### PR TITLE
fix: specify mkdirp version for plugin-file-manager

### DIFF
--- a/packages/plugin-file-manager/package.json
+++ b/packages/plugin-file-manager/package.json
@@ -8,6 +8,7 @@
     "aws-sdk": "^2.2.32",
     "koa-static": "^5.0.0",
     "mime-match": "^1.0.2",
+    "mkdirp": "^1.0.4",
     "multer": "^1.4.2",
     "multer-aliyun-oss": "1.1.1",
     "multer-s3": "^2.10.0"


### PR DESCRIPTION
使用 `create-nocobase-app` 创建项目后上传文件报错：
```
[0] TypeError: Cannot read properties of undefined (reading 'then')
[0]     at DiskStorage.destination [as getDestination] (/Users/sin/github/test/nocobase-test/node_modules/@nocobase/plugin-file-manager/lib/storages/local.js:154:36)
[0]     at DiskStorage._handleFile (/Users/sin/github/test/nocobase-test/node_modules/multer/storage/disk.js:31:8)
[0]     at /Users/sin/github/test/nocobase-test/node_modules/multer/lib/make-middleware.js:144:17
[0]     at /Users/sin/github/test/nocobase-test/node_modules/@nocobase/plugin-file-manager/lib/actions/upload.js:133:5
[0]     at wrappedFileFilter (/Users/sin/github/test/nocobase-test/node_modules/multer/index.js:44:7)
[0]     at Busboy.<anonymous> (/Users/sin/github/test/nocobase-test/node_modules/multer/lib/make-middleware.js:114:7)
[0]     at Busboy.emit (node:events:390:28)
[0]     at Busboy.emit (/Users/sin/github/test/nocobase-test/node_modules/busboy/lib/main.js:38:33)
[0]     at PartStream.<anonymous> (/Users/sin/github/test/nocobase-test/node_modules/busboy/lib/types/multipart.js:213:13)
[0]     at PartStream.emit (node:events:390:28)
```
疑似 local drive 里 mkdirp 未在 package.json 指定依赖，运行时用了 0.5 的版本，使用 1.x 后问题解决。