### PR TITLE
fix(core/client): 构建client库时加入less和woff2文件

### DIFF
--- a/packages/core/client/package.json
+++ b/packages/core/client/package.json
@@ -59,12 +59,13 @@
   },
   "scripts": {
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --project tsconfig.build.json",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm"
+    "build:cjs": "tsc --project tsconfig.build.json && copyfiles -u 1  \"./src/**/*.less\" \"./src/**/*.woff2\" ./lib",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm && copyfiles -u 1  \"./src/**/*.less\" \"./src/**/*.woff2\" ./esm"
   },
   "devDependencies": {
     "@types/marked": "^4.0.1",
-    "axios-mock-adapter": "^1.20.0"
+    "axios-mock-adapter": "^1.20.0",
+    "copyfiles": "^2.4.1"
   },
   "gitHead": "a00b45a2686695c5f4824d074ac5e1aff210793a"
 }


### PR DESCRIPTION
`@nocobase/client` 无法被直接引用使用：

```
yarn start
yarn run v1.22.17
$ umi dev
Starting the development server...

✖ Webpack
  Compiled with some errors in 31.26s

 ERROR  Failed to compile with 11 errors                                                                                         

These relative modules were not found:

* ../../../board/style.less in ./node_modules/@nocobase/client/esm/schema-component/antd/kanban/Kanban.js, ./node_modules/@nocobase/client/esm/schema-component/antd/kanban-v2/Kanban.js
* ./global.less in ./node_modules/@nocobase/client/esm/index.js
* ./index.less in ./node_modules/@nocobase/client/esm/schema-component/antd/index.js, ./node_modules/@nocobase/client/esm/schema-component/antd/kanban-v2/Kanban.js and 1 other
* ./style.less in ./node_modules/@nocobase/client/esm/schema-component/antd/calendar/Calendar.js, ./node_modules/@nocobase/client/esm/schema-component/antd/calendar-v2/index.js and 3 others
```

因为源文件中的`*.less`和`*.woff2`没有复制到 build 后的文件目录中去。

我修改了 packages.json，增加了 build 后复制相关文件的命令。

