### PR TITLE
fix(plugin-cm): fix unique option default value to update

### DIFF
--- a/packages/plugins/collection-manager/src/__tests__/field-options/indexes.test.ts
+++ b/packages/plugins/collection-manager/src/__tests__/field-options/indexes.test.ts
@@ -23,6 +23,36 @@ describe('field indexes', () => {
     await app.destroy();
   });
 
+  it('create unique constraint after added dulplicated records', async () => {
+    const tableName = 'test1';
+    // create an field with unique constraint
+    const field = await agent
+      .resource('collections.fields', tableName)
+      .create({
+        values: {
+          name: 'title',
+          type: 'string'
+        },
+      });
+
+    // create a record
+    const response1 = await agent.resource(tableName).create({
+      values: { title: 't1' }
+    });
+    // create another same record
+    const response2 = await agent.resource(tableName).create({
+      values: { title: 't1' }
+    });
+
+    const response3 = await agent.resource('fields').update({
+      filterByTk: field.id,
+      values: {
+        unique: true
+      }
+    });
+    expect(response3.status).toBe(400);
+  });
+
   it('field value cannot be duplicated with unique index', async () => {
     const tableName = 'test1';
     // create an field with unique constraint

--- a/packages/plugins/collection-manager/src/server.ts
+++ b/packages/plugins/collection-manager/src/server.ts
@@ -77,9 +77,9 @@ export class CollectionManagerPlugin extends Plugin {
 
     this.app.db.on('fields.afterUpdate', async (model: FieldModel, { context, transaction }) => {
       if (context) {
-        const prev = model.previous('options')?.unique;
-        const next = model.get('options')?.unique;
-        if (lodash.isBoolean(prev) && lodash.isBoolean(next) && prev !== next) {
+        const { unique: prev } = model.previous('options');
+        const { unique: next } = model.get('options');
+        if (Boolean(prev) !== Boolean(next)) {
           await model.migrate({ transaction });
         }
       }
@@ -180,7 +180,9 @@ export class CollectionManagerPlugin extends Plugin {
 
     const errorHandlerPlugin = <PluginErrorHandler>this.app.getPlugin('@nocobase/plugin-error-handler');
     errorHandlerPlugin.errorHandler.register(
-      (err) => err instanceof UniqueConstraintError,
+      (err) => {
+        return err instanceof UniqueConstraintError;
+      },
       (err, ctx) => {
         return ctx.throw(400, ctx.t(`The value of ${Object.keys(err.fields)} field duplicated`));
       },


### PR DESCRIPTION
Default value of `unique` of a field will be `undefined`, and when update it to `true`, should do migrate.