### PR TITLE
fix: field component options appears in non-association interface

### DIFF
--- a/packages/core/client/src/schema-component/hooks/useFieldComponentOptions.ts
+++ b/packages/core/client/src/schema-component/hooks/useFieldComponentOptions.ts
@@ -11,7 +11,12 @@ export const useFieldComponentOptions = () => {
   const { t } = useTranslation();
 
   const fieldComponentOptions = useMemo(() => {
-    if (!collectionField?.interface) return;
+    if (
+      !['o2o', 'oho', 'obo', 'o2m', 'linkTo', 'm2o', 'm2m']
+        .includes(collectionField.interface)
+    )
+      return;
+
     switch (collectionField.interface) {
       case 'o2m':
         return [


### PR DESCRIPTION
现在所有使用到 FormItem.Designer 的地方都会出现 FieldComponent 这个选项