### PR TITLE
docs: update G2Plot example url

### DIFF
--- a/docs/en-US/manual/blocks-guide/charts.md
+++ b/docs/en-US/manual/blocks-guide/charts.md
@@ -1,6 +1,6 @@
 # Charts
 
-Currently, chart blocks in NocoBase need to be implemented via a configuration file or by writing code. The chart library uses [g2plot](https://g2plot.antv.vision/en/examples/gallery), which theoretically supports all charts on [https://g2plot.antv.vision/en/examples/gallery](https://g2plot.antv.vision/en/examples/gallery). The currently configurable charts include
+Currently, chart blocks in NocoBase need to be implemented via a configuration file or by writing code. The chart library uses [g2plot](https://g2plot.antv.vision/en/examples), which theoretically supports all charts on [https://g2plot.antv.vision/en/examples](https://g2plot.antv.vision/en/examples). The currently configurable charts include
 
 - Column charts
 - Bar charts
@@ -183,7 +183,7 @@ https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9
 
 ### More charts
 
-Theoretically supports all charts on [https://g2plot.antv.vision/en/examples/gallery](https://g2plot.antv.vision/en/examples/gallery)
+Theoretically supports all charts on [https://g2plot.antv.vision/en/examples](https://g2plot.antv.vision/en/examples)
 
 https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4
 

--- a/docs/tr-TR/manual/blocks-guide/charts.md
+++ b/docs/tr-TR/manual/blocks-guide/charts.md
@@ -1,6 +1,6 @@
 # Charts
 
-Currently, chart blocks in NocoBase need to be implemented via a configuration file or by writing code. The chart library uses [g2plot](https://g2plot.antv.vision/en/examples/gallery), which theoretically supports all charts on [https://g2plot.antv.vision/en/examples/gallery](https://g2plot.antv.vision/en/examples/gallery). The currently configurable charts include
+Currently, chart blocks in NocoBase need to be implemented via a configuration file or by writing code. The chart library uses [g2plot](https://g2plot.antv.vision/en/examples), which theoretically supports all charts on [https://g2plot.antv.vision/en/examples](https://g2plot.antv.vision/en/examples). The currently configurable charts include
 
 - Column charts
 - Bar charts
@@ -183,7 +183,7 @@ https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9
 
 ### More charts
 
-Theoretically supports all charts on [https://g2plot.antv.vision/en/examples/gallery](https://g2plot.antv.vision/en/examples/gallery)
+Theoretically supports all charts on [https://g2plot.antv.vision/en/examples](https://g2plot.antv.vision/en/examples)
 
 https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4
 

--- a/docs/zh-CN/manual/blocks-guide/charts.md
+++ b/docs/zh-CN/manual/blocks-guide/charts.md
@@ -1,6 +1,6 @@
 # 图表
 
-目前，NocoBase 图表区块需要通过配置文件或编写代码来实现。图表库使用的是 [g2plot](https://g2plot.antv.vision/en/examples/gallery)，理论上支持 https://g2plot.antv.vision/en/examples/gallery 上的所有图表。目前可以配置的图表包括：
+目前，NocoBase 图表区块需要通过配置文件或编写代码来实现。图表库使用的是 [g2plot](https://g2plot.antv.vision/en/examples)，理论上支持 https://g2plot.antv.vision/en/examples 上的所有图表。目前可以配置的图表包括：
 
 - 柱状图
 - 条形图
@@ -186,7 +186,7 @@ https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9
 
 
 ### 更多图表
-理论上支持 https://g2plot.antv.vision/en/examples/gallery 上的所有图表
+理论上支持 https://g2plot.antv.vision/en/examples 上的所有图表
 
 https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4
 


### PR DESCRIPTION
It displays 404 when opening [https://g2plot.antv.antgroup.com/en/examples/gallery](https://g2plot.antv.antgroup.com/en/examples/gallery).