### PR TITLE
fix(docker-hub): assign platform, to support Apple M1 clip

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -56,6 +56,6 @@ jobs:
           file: Dockerfile
           build-args: | 
             VERDACCIO_URL=http://localhost:4873/
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
- 系统信息：
  型号名称：MacBook Pro
  芯片：Apple M1 Pro

- 问题
  使用 docker 方式启动项目时会出现不支持当前操作系统的提示， 在 `DockerHub` 上确实有缺少该平台的镜像

![image](https://user-images.githubusercontent.com/9244211/215982865-d1df6bfa-0bba-45e7-b8fb-7244a29a4090.png)

- 解决方法
首先在 DockerHub 上发现了之前构建的镜像存在 `linux/arm64` 平台的，于是将代码中 `/docker/app-mysql/docker-compose.yml` 下的 

``` diff
services:
  app:
-   image: nocobase/nocobase:main
+   image: nocobase/nocobase:latest
    networks:
      - nocobase
```
就能跑起来了

然后去 github  的 action 去看了下 docker-hub.yml 发现把 platform 相关的给注释了，所以就把这行代码放开了