### PR TITLE
docs: transform video link to video tag

### DIFF
--- a/docs/en-US/manual/blocks-guide/charts.md
+++ b/docs/en-US/manual/blocks-guide/charts.md
@@ -176,16 +176,23 @@ app.resourcer.registerActionHandlers({
 ## Video
 
 ### Static data
-https://user-images.githubusercontent.com/1267426/198877269-1c56562b-167a-4808-ada3-578f0872bce1.mp4
+
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877269-1c56562b-167a-4808-ada3-578f0872bce1.mp4" type="video/mp4">
+</video>
 
 ### Dynamic data
-https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9442-8045717cc7b0.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9442-8045717cc7b0.mp4" type="video/mp4">
+</video>
 
 ### More charts
 
 Theoretically supports all charts on [https://g2plot.antv.vision/en/examples](https://g2plot.antv.vision/en/examples)
 
-https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4" type="video/mp4">
+</video>
 
 ## JS Expressions
 
@@ -197,5 +204,7 @@ Syntax
 }
 ```
 
-https://user-images.githubusercontent.com/1267426/198877361-808a51cc-6c91-429f-8cfc-8ad7f747645a.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877361-808a51cc-6c91-429f-8cfc-8ad7f747645a.mp4" type="video/mp4">
+</video>
 

--- a/docs/tr-TR/manual/blocks-guide/charts.md
+++ b/docs/tr-TR/manual/blocks-guide/charts.md
@@ -176,16 +176,22 @@ app.resourcer.registerActionHandlers({
 ## Video
 
 ### Static data
-https://user-images.githubusercontent.com/1267426/198877269-1c56562b-167a-4808-ada3-578f0872bce1.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877269-1c56562b-167a-4808-ada3-578f0872bce1.mp4" type="video/mp4">
+</video>
 
 ### Dynamic data
-https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9442-8045717cc7b0.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9442-8045717cc7b0.mp4" type="video/mp4">
+</video>
 
 ### More charts
 
 Theoretically supports all charts on [https://g2plot.antv.vision/en/examples](https://g2plot.antv.vision/en/examples)
 
-https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4" type="video/mp4">
+</video>
 
 ## JS Expressions
 
@@ -197,5 +203,7 @@ Syntax
 }
 ```
 
-https://user-images.githubusercontent.com/1267426/198877361-808a51cc-6c91-429f-8cfc-8ad7f747645a.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877361-808a51cc-6c91-429f-8cfc-8ad7f747645a.mp4" type="video/mp4">
+</video>
 

--- a/docs/zh-CN/manual/blocks-guide/charts.md
+++ b/docs/zh-CN/manual/blocks-guide/charts.md
@@ -177,18 +177,24 @@ app.resourcer.registerActionHandlers({
 
 ### 静态数据
 
-https://user-images.githubusercontent.com/1267426/198877269-1c56562b-167a-4808-ada3-578f0872bce1.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877269-1c56562b-167a-4808-ada3-578f0872bce1.mp4" type="video/mp4">
+</video>
 
 
 ### 动态数据
 
-https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9442-8045717cc7b0.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877336-6bd85f0b-17c5-40a5-9442-8045717cc7b0.mp4" type="video/mp4">
+</video>
 
 
 ### 更多图表
 理论上支持 https://g2plot.antv.vision/en/examples 上的所有图表
 
-https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877347-7fc2544c-b938-4e34-8a83-721b3f62525e.mp4" type="video/mp4">
+</video>
 
 ## JS 表达式
 
@@ -200,5 +206,7 @@ Syntax
 }
 ```
 
-https://user-images.githubusercontent.com/1267426/198877361-808a51cc-6c91-429f-8cfc-8ad7f747645a.mp4
+<video width="100%" height="440" controls>
+  <source src="https://user-images.githubusercontent.com/1267426/198877361-808a51cc-6c91-429f-8cfc-8ad7f747645a.mp4" type="video/mp4">
+</video>
 


### PR DESCRIPTION
- 问题
现在的文档 https://docs.nocobase.com/manual/blocks-guide/charts#video 下的视频需要点开链接，然后打开新的标签页查看视频，比较麻烦

- 解决办法
其实 Markdown 支持 HTML 语法，所以可以直接在 md 中插入 video 标签就可以实现在当前文档中查看视频