### PR TITLE
fix(table): make td overflow behavior right (#1392)

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -235,7 +235,7 @@ export const Table: any = observer((props: any) => {
               css`
                 max-width: 300px;
                 white-space: nowrap;
-                overflow: hidden;
+                overflow-x: scroll;
                 .nb-read-pretty-input-number {
                   text-align: right;
                 }

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -235,6 +235,7 @@ export const Table: any = observer((props: any) => {
               css`
                 max-width: 300px;
                 white-space: nowrap;
+                overflow: hidden;
                 .nb-read-pretty-input-number {
                   text-align: right;
                 }


### PR DESCRIPTION
fix #1392 

Before:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/38434641/216218153-2ccb095c-69e2-4187-9066-3e5d3ca97a5d.png">


After:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/38434641/216217846-95a01504-73f8-4f56-87ed-49c698098ca2.png">