### PR TITLE
fix(Calendar): ensur to get correct gridInitializer when adding a new…

### DIFF
--- a/packages/core/client/src/schema-initializer/buttons/TabPaneInitializers.tsx
+++ b/packages/core/client/src/schema-initializer/buttons/TabPaneInitializers.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@formily/react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { SchemaComponent, useActionContext, useDesignable, useRecordIndex } from '../..';
 
 export const TabPaneInitializers = (props?: any) => {
@@ -46,69 +46,67 @@ export const TabPaneInitializers = (props?: any) => {
       },
     };
   };
-  return (
-    <SchemaComponent
-      schema={{
-        type: 'void',
-        properties: {
-          action1: {
-            type: 'void',
-            'x-component': 'Action',
-            'x-component-props': {
-              icon: 'PlusOutlined',
-              style: {
-                borderColor: 'rgb(241, 139, 98)',
-                color: 'rgb(241, 139, 98)',
-              },
-              type: 'dashed',
+  const schema = useMemo(() => {
+    return {
+      type: 'void',
+      properties: {
+        action1: {
+          type: 'void',
+          'x-component': 'Action',
+          'x-component-props': {
+            icon: 'PlusOutlined',
+            style: {
+              borderColor: 'rgb(241, 139, 98)',
+              color: 'rgb(241, 139, 98)',
             },
-            title: '{{t("Add tab")}}',
-            properties: {
-              drawer1: {
-                'x-decorator': 'Form',
-                'x-component': 'Action.Modal',
-                'x-component-props': {
-                  width: 520,
+            type: 'dashed',
+          },
+          title: '{{t("Add tab")}}',
+          properties: {
+            drawer1: {
+              'x-decorator': 'Form',
+              'x-component': 'Action.Modal',
+              'x-component-props': {
+                width: 520,
+              },
+              type: 'void',
+              title: '{{t("Add tab")}}',
+              properties: {
+                title: {
+                  title: '{{t("Tab name")}}',
+                  required: true,
+                  'x-component': 'Input',
+                  'x-decorator': 'FormItem',
                 },
-                type: 'void',
-                title: '{{t("Add tab")}}',
-                properties: {
-                  title: {
-                    title: '{{t("Tab name")}}',
-                    required: true,
-                    'x-component': 'Input',
-                    'x-decorator': 'FormItem',
-                  },
-                  icon: {
-                    title: '{{t("Icon")}}',
-                    'x-component': 'IconPicker',
-                    'x-decorator': 'FormItem',
-                  },
-                  footer: {
-                    'x-component': 'Action.Modal.Footer',
-                    type: 'void',
-                    properties: {
-                      cancel: {
-                        title: '{{t("Cancel")}}',
-                        'x-component': 'Action',
-                        'x-component-props': {
-                          useAction: () => {
-                            const ctx = useActionContext();
-                            return {
-                              async run() {
-                                ctx.setVisible(false);
-                              },
-                            };
-                          },
+                icon: {
+                  title: '{{t("Icon")}}',
+                  'x-component': 'IconPicker',
+                  'x-decorator': 'FormItem',
+                },
+                footer: {
+                  'x-component': 'Action.Modal.Footer',
+                  type: 'void',
+                  properties: {
+                    cancel: {
+                      title: '{{t("Cancel")}}',
+                      'x-component': 'Action',
+                      'x-component-props': {
+                        useAction: () => {
+                          const ctx = useActionContext();
+                          return {
+                            async run() {
+                              ctx.setVisible(false);
+                            },
+                          };
                         },
                       },
-                      submit: {
-                        title: '{{t("Submit")}}',
-                        'x-component': 'Action',
-                        'x-component-props': {
-                          type: 'primary',
-                          useAction: useSubmitAction,
-                        },
+                    },
+                    submit: {
+                      title: '{{t("Submit")}}',
+                      'x-component': 'Action',
+                      'x-component-props': {
+                        type: 'primary',
+                        useAction: useSubmitAction,
                       },
                     },
                   },
@@ -117,9 +115,10 @@ export const TabPaneInitializers = (props?: any) => {
             },
           },
         },
-      }}
-    />
-  );
+      },
+    };
+  }, []);
+  return <SchemaComponent schema={schema} />;
 };
 
 export const TabPaneInitializersForCreateFormBlock = (props) => {

--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -983,6 +983,9 @@ export const createCalendarBlockSchema = (options) => {
                     'x-component': 'Tabs',
                     'x-component-props': {},
                     'x-initializer': 'TabPaneInitializers',
+                    'x-initializer-props': {
+                      gridInitializer: 'RecordBlockInitializers',
+                    },
                     properties: {
                       tab1: {
                         type: 'void',


### PR DESCRIPTION
… tab (#1241)

fix #1241 

导致 #1241 的原因是因为 ```TabPaneInitializers``` 在其内部错误的设置了 ```initializer``` 的值为 ```CreateFormBlockInitializers``` ，在当前情况下正确的值应该是 ```RecordBlockInitializers```。
https://github.com/nocobase/nocobase/blob/7bfd8ea05b43cc9b262c0d36e5d738a9b543c5f9/packages/core/client/src/schema-initializer/buttons/TabPaneInitializers.tsx#L14-L22

我在 ```createCalendarBlockSchema``` 中设置 ```gridInitializer``` 的值为 ```RecordBlockInitializers``` 以修复此问题。

Before:

![image](https://user-images.githubusercontent.com/38434641/216751829-d7d71586-6e4c-4344-abd5-4febde88cbcb.png)


After:

![image](https://user-images.githubusercontent.com/38434641/216751695-ec469844-060b-414b-9532-ab87c58bfa16.png)
