### PR TITLE
fix(excel-formula): should update the options for Expression when dat…

### DIFF
--- a/packages/core/client/src/formula/Expression.tsx
+++ b/packages/core/client/src/formula/Expression.tsx
@@ -63,8 +63,15 @@ const renderExp = (exp: string, scope = {}) => {
   });
 };
 
-export const Expression = (props) => {
-  const { evaluate, value, supports, useCurrentFields } = props;
+export const Expression = (props: {
+  value: string;
+  onChange: (value: string) => void;
+  supports: string[];
+  useCurrentFields: () => any[];
+  dataType: string;
+  evaluate: (value: string, scope: any) => any;
+}) => {
+  const { evaluate, value, supports, useCurrentFields, dataType } = props;
   const field = useField<Field>();
   const { t } = useTranslation();
   const fields = useCurrentFields();
@@ -79,7 +86,7 @@ export const Expression = (props) => {
   const numColumns = new Map<string, string>();
   const scope = {};
   fields
-    .filter((field) => supports.includes(field.interface))
+    .filter((field) => supports.includes(field.interface) && field.interface === dataType)
     .forEach((field) => {
       numColumns.set(field.name, field.uiSchema.title);
       scope[field.name] = 1;

--- a/packages/plugins/excel-formula-field/src/client/excel-formula.ts
+++ b/packages/plugins/excel-formula-field/src/client/excel-formula.ts
@@ -32,7 +32,7 @@ export const excelFormula: IField = {
       'x-decorator': 'FormItem',
       default: 'number',
       'x-disabled': '{{ !createOnly }}',
-      "x-reactions": [
+      'x-reactions': [
         {
           target: 'uiSchema.x-component-props.step',
           fulfill: {
@@ -40,7 +40,7 @@ export const excelFormula: IField = {
               display: '{{$self.value !== "string" ? "visible" : "none"}}',
             },
           },
-        }
+        },
       ],
       enum: [
         { value: 'string', label: '{{t("String")}}' },
@@ -74,6 +74,18 @@ export const excelFormula: IField = {
         supports: ['number', 'percent', 'integer', 'string'],
         useCurrentFields: '{{ useCurrentFields }}',
       },
+      'x-reactions': [
+        {
+          dependencies: ['dataType'],
+          fulfill: {
+            state: {
+              componentProps: {
+                dataType: '{{$deps[0]}}',
+              },
+            },
+          },
+        },
+      ],
     },
   },
   filterable: {


### PR DESCRIPTION
…aType changed (#1376)

Fix #1376 

使用 Formily 的[联动逻辑](https://formilyjs.org/zh-CN/guide/advanced/linkages)实现当 ```dataType``` 变更时更新 ```Expression``` 的选项列表。

![image](https://user-images.githubusercontent.com/38434641/217128023-2061281f-e477-4176-b616-d28d19b41f1c.png)
