### PR TITLE
fix: fix the test does not work properly in windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
         "runtimeArgs": [
           "run",
           "--inspect-brk",
-          "test",
+          "win:test",
           "--runInBand",
           "/${fileBasename}"
         ],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "nocobase start",
     "build": "nocobase build",
     "test": "nocobase test",
+    "win:test": "jest",
     "doc": "nocobase doc",
     "postinstall": "nocobase postinstall",
     "lint": "eslint .",


### PR DESCRIPTION
## 解决的问题
- [x] 修复在 Windows 中运行测试时，如果有测试在 beforeEach 中使用了 async 函数，则测试不会等待该 async 函数返回的 Promise 被 resolve 就开始执行测试用例的问题

## 未解决的问题
- 使用 Windows 在本地运行 `yarn test` 依然会有大量测试用例报错