### PR TITLE
fix: plugin-manage and designable-switch add tooltip

### DIFF
--- a/packages/core/client/src/pm/PluginManagerLink.tsx
+++ b/packages/core/client/src/pm/PluginManagerLink.tsx
@@ -1,5 +1,5 @@
 import { ApiOutlined, SettingOutlined } from '@ant-design/icons';
-import { Button, Dropdown, Menu } from 'antd';
+import { Button, Dropdown, Menu, Tooltip } from 'antd';
 import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
@@ -11,13 +11,15 @@ export const PluginManagerLink = () => {
   const { t } = useTranslation();
   const history = useHistory();
   return (
-    <Button
-      icon={<ApiOutlined />}
-      title={t('Plugin manager')}
-      onClick={() => {
-        history.push('/admin/pm/list');
-      }}
-    />
+    <Tooltip title={t('Plugin manager')}>
+      <Button
+        icon={<ApiOutlined />}
+        title={t('Plugin manager')}
+        onClick={() => {
+          history.push('/admin/pm/list');
+        }}
+      />
+    </Tooltip>
   );
 };
 

--- a/packages/core/client/src/schema-component/core/DesignableSwitch.tsx
+++ b/packages/core/client/src/schema-component/core/DesignableSwitch.tsx
@@ -1,5 +1,5 @@
 import { HighlightOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
+import { Button, Tooltip } from 'antd';
 import React from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
@@ -17,15 +17,17 @@ export const DesignableSwitch = () => {
   useHotkeys('Ctrl+Shift+U', () => setDesignable(!designable), [designable]);
 
   return (
-    <Button
-      // selected={designable}
-      icon={<HighlightOutlined />}
-      title={t('UI Editor')}
-      // subtitle={'Ctrl+Shift+U'}
-      style={style}
-      onClick={() => {
-        setDesignable(!designable);
-      }}
-    />
+    <Tooltip title={t('UI Editor')}>
+      <Button
+        // selected={designable}
+        icon={<HighlightOutlined />}
+        title={t('UI Editor')}
+        // subtitle={'Ctrl+Shift+U'}
+        style={style}
+        onClick={() => {
+          setDesignable(!designable);
+        }}
+      />
+    </Tooltip>
   );
 };


### PR DESCRIPTION
When mouse hover on the plugin-manage Button and designable-switch Button, it shows title tooltip