### PR TITLE
fix: fix Menu dismiss on Drag&Drop

### DIFF
--- a/packages/core/client/src/schema-component/antd/menu/Menu.tsx
+++ b/packages/core/client/src/schema-component/antd/menu/Menu.tsx
@@ -363,7 +363,7 @@ Menu.Item = observer((props) => {
       eventKey={schema.name}
       schema={schema}
     >
-      <SortableItem className={designerCss}>
+      <SortableItem className={designerCss} removeParentsIfNoChildren={false}>
         <Icon type={icon} />
         <span
           className={css`
@@ -402,7 +402,7 @@ Menu.URL = observer((props) => {
         window.open(props.href, '_blank');
       }}
     >
-      <SortableItem className={designerCss}>
+      <SortableItem className={designerCss} removeParentsIfNoChildren={false}>
         <Icon type={icon} />
         <span
           className={css`
@@ -441,7 +441,7 @@ Menu.SubMenu = observer((props) => {
       key={schema.name}
       eventKey={schema.name}
       title={
-        <SortableItem className={subMenuDesignerCss}>
+        <SortableItem className={subMenuDesignerCss} removeParentsIfNoChildren={false}>
           <Icon type={icon} />
           {field.title}
           <Designer />

--- a/packages/core/client/src/schema-component/common/dnd-context/index.tsx
+++ b/packages/core/client/src/schema-component/common/dnd-context/index.tsx
@@ -19,6 +19,7 @@ const useDragEnd = (props?: any) => {
     const breakRemoveOn = over?.data?.current?.breakRemoveOn;
     const wrapSchema = over?.data?.current?.wrapSchema;
     const onSuccess = over?.data?.current?.onSuccess;
+    const removeParentsIfNoChildren = over.data.current.removeParentsIfNoChildren ?? true;
 
     if (!activeSchema || !overSchema) {
       props?.onDragEnd?.(event);
@@ -49,7 +50,7 @@ const useDragEnd = (props?: any) => {
       dn.insertAdjacent(insertAdjacent, activeSchema, {
         wrap: wrapSchema,
         breakRemoveOn,
-        removeParentsIfNoChildren: true,
+        removeParentsIfNoChildren,
         onSuccess,
       });
       props?.onDragEnd?.(event);

--- a/packages/core/client/src/schema-component/common/sortable-item/SortableItem.tsx
+++ b/packages/core/client/src/schema-component/common/sortable-item/SortableItem.tsx
@@ -57,8 +57,9 @@ const useSortableItemId = (props) => {
 
 export const SortableItem: React.FC<any> = observer((props) => {
   const { schema, id, ...others } = useSortableItemProps(props);
+  const removeParentsIfNoChildren = others.removeParentsIfNoChildren ?? true;
   return (
-    <SortableProvider id={id} data={{ insertAdjacent: 'afterEnd', schema: schema }}>
+    <SortableProvider id={id} data={{ insertAdjacent: 'afterEnd', schema: schema, removeParentsIfNoChildren }}>
       <Sortable {...others}>{props.children}</Sortable>
     </SortableProvider>
   );


### PR DESCRIPTION
When drag&drop a menu-item, if its parent only have one child, it will remove parent
To fix it, add a param about whether remove its parent

当移动 menu-item 的时候，如果父菜单只有一个元素，移动走了会导致父菜单被删除
加了一个参数判断是否需要删除