### PR TITLE
feat(core client Marddown): markdown support template with handlebars in detail

### DIFF
--- a/packages/core/client/package.json
+++ b/packages/core/client/package.json
@@ -23,6 +23,7 @@
     "cron-parser": "^4.6.0",
     "cronstrue": "^2.11.0",
     "file-saver": "^2.0.5",
+    "handlebars": "^4.7.7",
     "i18next": "^22.4.9",
     "i18next-http-backend": "^2.1.1",
     "json-templates": "^4.2.0",

--- a/packages/core/client/src/schema-component/antd/markdown/Markdown.Void.tsx
+++ b/packages/core/client/src/schema-component/antd/markdown/Markdown.Void.tsx
@@ -3,6 +3,7 @@ import { Button, Input as AntdInput, Space, Spin } from 'antd';
 import cls from 'classnames';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import handlebars from 'handlebars';
 import { useDesignable } from '../../hooks/useDesignable';
 import { MarkdownVoidDesigner } from './Markdown.Void.Designer';
 import { useParseMarkdown } from './util';
@@ -47,8 +48,16 @@ export const MarkdownVoid: any = observer((props: any) => {
   const schema = useFieldSchema();
   const { dn } = useDesignable();
   const { onSave, onCancel } = props;
-  const { html, loading } = useParseMarkdown(content);
-  if (loading) {
+  const markDown = useParseMarkdown(content);
+  let html = markDown.html;
+  if (field?.form?.values) {
+    try {
+      html = handlebars.compile(html)(field.form.values);
+    } catch {
+      console.log('templat解析错误');
+    }
+  }
+  if (markDown.loading) {
     return <Spin />;
   }
   return field?.editable ? (


### PR DESCRIPTION
You can use all the syntax of handlebars
[https://handlebarsjs.com/](https://handlebarsjs.com/)
![image](https://user-images.githubusercontent.com/26764888/234753723-e3cd0324-4c68-48c9-afcb-ab9f60f1b2c1.png)
![image](https://user-images.githubusercontent.com/26764888/234753750-5891ed8d-96ac-4b8c-944d-88a089358886.png)
