### PR TITLE
fix(RecordSelector): should keep read-pretty when change component

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-select/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-select/AssociationSelect.tsx
@@ -357,6 +357,7 @@ AssociationSelect.Designer = function Designer() {
                 ...collectionField?.uiSchema?.['x-component-props'],
                 ...fieldSchema['x-component-props'],
               },
+              'x-read-pretty': field.readPretty,
             };
 
             interfaceConfig?.schemaInitialize?.(schema, {

--- a/packages/core/client/src/schema-component/antd/remote-select/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/remote-select/ReadPretty.tsx
@@ -1,17 +1,21 @@
 import { observer, useField, useFieldSchema } from '@formily/react';
 import React from 'react';
-import { getValues } from './shared';
-import { Select, defaultFieldNames } from '../select';
 import { useRequest } from '../../../api-client';
+import { useCollectionManager } from '../../../collection-manager';
 import { useRecord } from '../../../record-provider';
 import { useActionContext } from '../action';
+import { Select, defaultFieldNames } from '../select';
+import { getValues } from './shared';
 
-export const ReadPretty = observer((props: any) => {
+export const ReadPretty = observer((props: any = {}) => {
+  const { service } = props;
   const fieldNames = { ...defaultFieldNames, ...props.fieldNames };
   const field = useField<any>();
   const fieldSchema = useFieldSchema();
   const record = useRecord();
   const { snapshot } = useActionContext();
+  const { getCollectionJoinField } = useCollectionManager();
+  const collectionField = getCollectionJoinField(fieldSchema?.['x-collection-field']);
 
   const { data } = useRequest(
     snapshot
@@ -21,6 +25,7 @@ export const ReadPretty = observer((props: any) => {
       : {
           action: 'list',
           ...props.service,
+          resource: service?.resource || collectionField?.target,
           params: {
             paginate: false,
             filter: {

--- a/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ResourceActionOptions, useRequest } from '../../../api-client';
 import { mergeFilter } from '../../../block-provider/SharedFilterProvider';
-import { useCollection, useCollectionManager } from '../../../collection-manager';
+import { useCollectionManager } from '../../../collection-manager';
 import { Select, defaultFieldNames } from '../select';
 import { ReadPretty } from './ReadPretty';
 
@@ -39,9 +39,9 @@ const InternalRemoteSelect = connect(
     const firstRun = useRef(false);
     const fieldSchema = useFieldSchema();
     const field = useField();
-    const { getField } = useCollection();
     const { getCollectionJoinField, getInterface } = useCollectionManager();
-    const collectionField = getField(fieldSchema.name);
+    const collectionField = getCollectionJoinField(fieldSchema?.['x-collection-field']);
+
     const targetField =
       _targetField ||
       (collectionField?.target &&
@@ -115,6 +115,7 @@ const InternalRemoteSelect = connect(
       {
         action: 'list',
         ...service,
+        resource: service?.resource || collectionField?.target,
         params: {
           pageSize: 200,
           ...service?.params,


### PR DESCRIPTION
- [x]  问题一：字段切换 component 的时候，read-pretty 的状态没有没有保持

![20230510065550_rec_](https://github.com/nocobase/nocobase/assets/38434641/64255742-5341-46cb-92c7-e90cfb2d3e3d)

- [x]  问题二：切换成 AssociationSelect 组件的时候请求接口会报错，具体情况可以参考上面的图片中，最后的部分。

### 修复之后的情况
![20230510070025_rec_](https://github.com/nocobase/nocobase/assets/38434641/3a692862-d6ec-4a68-a5a6-8c07d941df01)
