### PR TITLE
fix(plugin-workflow): remove useless context option

### DIFF
--- a/packages/plugins/workflow/src/server/instructions/query.ts
+++ b/packages/plugins/workflow/src/server/instructions/query.ts
@@ -10,9 +10,6 @@ export default {
     const options = processor.getParsedValue(params);
     const result = await (multiple ? repo.find : repo.findOne).call(repo, {
       ...options,
-      context: {
-        executionId: processor.execution.id,
-      },
       transaction: processor.transaction,
     });
 


### PR DESCRIPTION
# Description (Bug描述）

Remove useless code.

## Steps to reproduce (复现步骤)   

None.

## Expected behavior (预期行为)  

No changes.

## Actual behavior (实际行为)

No changes.

## Related issues (相关issue)

None.

# Reason (原因）

Query node does not use any `executionId` to avoid duplicated triggers.

# Solution (解决方案)

Remove useless code.