### PR TITLE
fix(acl): issue with repeated createdById field

### DIFF
--- a/packages/core/acl/src/__tests__/acl.test.ts
+++ b/packages/core/acl/src/__tests__/acl.test.ts
@@ -1,3 +1,4 @@
+import { Context } from '@nocobase/actions';
 import { ACL } from '..';
 
 describe('acl', () => {
@@ -353,5 +354,27 @@ describe('acl', () => {
         'posts:create': {},
       },
     });
+  });
+
+  it('should clone can result deeply', () => {
+    jest.spyOn(acl, 'can').mockReturnValue({
+      role: 'root',
+      resource: 'Test',
+      action: 'test',
+      params: {
+        fields: [],
+      },
+    });
+    const newConext = () => ({
+      state: {},
+      action: {},
+      throw: () => {},
+    });
+    const ctx1 = newConext() as Context;
+    const ctx2 = newConext() as Context;
+    acl.getActionParams(ctx1);
+    acl.getActionParams(ctx2);
+    ctx1.permission.can.params.fields.push('createdById');
+    expect(ctx2.permission.can.params.fields).toEqual([]);
   });
 });

--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -376,7 +376,11 @@ export class ACL extends EventEmitter {
     const { resourceName, actionName } = ctx.action;
 
     ctx.can = (options: Omit<CanArgs, 'role'>) => {
-      return this.can({ role: roleName, ...options });
+      const can = this.can({ role: roleName, ...options });
+      if (!can) {
+        return null;
+      }
+      return lodash.cloneDeep(can);
     };
 
     ctx.permission = {


### PR DESCRIPTION
# Description (Bug描述）

## Steps to reproduce (复现步骤)   
向服务端多次请求。
![img_v2_10f41d2b-8ba5-4782-aab6-6d16295c758g](https://github.com/nocobase/nocobase/assets/3250534/09de7587-2c7f-42a9-b02f-1f6f6cff6aa6)


## Expected behavior (预期行为)  
只有一个`createdById`字段

## Actual behavior (实际行为)
每次请求都添加了一个`createdById`字段

# Reason (原因）
[Explain what caused the bug to occur.   ](https://github.com/nocobase/nocobase/blob/5930218811013718cb79bc4d7dba09cd03366954/packages/plugins/acl/src/server.ts#L509)

`acl.can` 的返回结果直接赋值给了上下文，不同上下文访问的是同一个对象。

# Solution (解决方案)
对 `acl.can` 返回的结果做深拷贝。
```TypeScript
ctx.can = (options: Omit<CanArgs, 'role'>) => {
   const can = this.can({ role: roleName, ...options });
   if (!can) {
     return null;
   }
   return lodash.cloneDeep(can);
};
```
