### PR TITLE
fix(plugin-workflow): fix trigger title when workflow not loaded

### DIFF
--- a/packages/plugins/workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/workflow/src/client/triggers/index.tsx
@@ -143,7 +143,9 @@ export const TriggerConfig = () => {
   const [editingTitle, setEditingTitle] = useState<string>('');
   const [editingConfig, setEditingConfig] = useState(false);
   useEffect(() => {
-    setEditingTitle(workflow.title ?? typeTitle);
+    if (workflow) {
+      setEditingTitle(workflow.title ?? typeTitle);
+    }
   }, [workflow]);
 
   if (!workflow || !workflow.type) {


### PR DESCRIPTION
# Description (Bug描述）

![image](https://github.com/nocobase/nocobase/assets/525658/a76fdfbd-31f6-4f05-b90e-5b74e63c1d2d)

## Steps to reproduce (复现步骤)

1. Click "View" workflow on workflows list.

## Expected behavior (预期行为)

Should not throw error.

## Actual behavior (实际行为)

```
RefferenceError: Cannot access 'typeTitle' before initialization
```

## Related issues (相关issue)

None.

# Reason (原因）

Maybe workflow not fully loaded.

# Solution (解决方案)

Check `workflow` variable first before use.