### PR TITLE
fix(Data-template): fix bug when deleting fields

### DIFF
--- a/packages/core/client/src/locale/en_US.ts
+++ b/packages/core/client/src/locale/en_US.ts
@@ -708,4 +708,5 @@ export default {
   "Render Failed": "Render Failed",
   "Feedback": "Feedback",
   "Try again": "Try again",
+  "Data template": "Data template",
 };

--- a/packages/core/client/src/locale/en_US.ts
+++ b/packages/core/client/src/locale/en_US.ts
@@ -709,4 +709,5 @@ export default {
   "Feedback": "Feedback",
   "Try again": "Try again",
   "Data template": "Data template",
+  "Template fields have been removed and need to be reconfigured": "Template fields have been removed and need to be reconfigured",
 };

--- a/packages/core/client/src/locale/es_ES.ts
+++ b/packages/core/client/src/locale/es_ES.ts
@@ -686,5 +686,6 @@ export default {
     "UpdatedAt": "Registro del último usuario actualizado de una fila",
     "Column width": "Ancho de columna",
     "Sortable": "Clasificable",
-    "Enable link": "Activar enlace"
+    "Enable link": "Activar enlace",
+    "Data template": "Plantilla de datos",
  };

--- a/packages/core/client/src/locale/es_ES.ts
+++ b/packages/core/client/src/locale/es_ES.ts
@@ -688,4 +688,5 @@ export default {
     "Sortable": "Clasificable",
     "Enable link": "Activar enlace",
     "Data template": "Plantilla de datos",
+    "Template fields have been removed and need to be reconfigured": "Los campos de la plantilla se han eliminado y deben reconfigurarse",
  };

--- a/packages/core/client/src/locale/ja_JP.ts
+++ b/packages/core/client/src/locale/ja_JP.ts
@@ -617,4 +617,5 @@ export default {
   'Add template': 'テンプレートを追加',
   'Display data template selector': 'データテンプレートセレクターを表示',
   'Form data templates': 'フォームデータテンプレート',
+  "Data template": "データテンプレート",
 }

--- a/packages/core/client/src/locale/ja_JP.ts
+++ b/packages/core/client/src/locale/ja_JP.ts
@@ -618,4 +618,5 @@ export default {
   'Display data template selector': 'データテンプレートセレクターを表示',
   'Form data templates': 'フォームデータテンプレート',
   "Data template": "データテンプレート",
+  "Template fields have been removed and need to be reconfigured": "テンプレートフィールドが削除されました。再設定する必要があります",
 }

--- a/packages/core/client/src/locale/pt_BR.ts
+++ b/packages/core/client/src/locale/pt_BR.ts
@@ -667,4 +667,5 @@ export default {
   'Add template': 'Adicionar modelo',
   'Display data template selector': 'Exibir seletor de modelo de dados',
   'Form data templates': 'Modelos de dados do formulário',
+  "Data template": "Modelo de dados",
 };

--- a/packages/core/client/src/locale/pt_BR.ts
+++ b/packages/core/client/src/locale/pt_BR.ts
@@ -668,4 +668,5 @@ export default {
   'Display data template selector': 'Exibir seletor de modelo de dados',
   'Form data templates': 'Modelos de dados do formulário',
   "Data template": "Modelo de dados",
+  "Template fields have been removed and need to be reconfigured": "Os campos do modelo foram removidos e precisam ser reconfigurados",
 };

--- a/packages/core/client/src/locale/ru_RU.ts
+++ b/packages/core/client/src/locale/ru_RU.ts
@@ -521,4 +521,5 @@ export default {
   'Add template': "Добавить шаблон",
   'Display data template selector': "Отображать селектор шаблона данных",
   'Form data templates': "Шаблоны данных формы",
+  "Data template": "Шаблон данных",
 }

--- a/packages/core/client/src/locale/ru_RU.ts
+++ b/packages/core/client/src/locale/ru_RU.ts
@@ -522,4 +522,5 @@ export default {
   'Display data template selector': "Отображать селектор шаблона данных",
   'Form data templates': "Шаблоны данных формы",
   "Data template": "Шаблон данных",
+  "Template fields have been removed and need to be reconfigured": "Поля шаблона были удалены и требуют повторной настройки",
 }

--- a/packages/core/client/src/locale/tr_TR.ts
+++ b/packages/core/client/src/locale/tr_TR.ts
@@ -520,4 +520,5 @@ export default {
   'Add template': 'Şablon ekle',
   'Display data template selector': 'Veri şablonu seçicisini görüntüle',
   'Form data templates': 'Form veri şablonları',
+  "Data template": "Veri şablonu",
 }

--- a/packages/core/client/src/locale/tr_TR.ts
+++ b/packages/core/client/src/locale/tr_TR.ts
@@ -521,4 +521,5 @@ export default {
   'Display data template selector': 'Veri şablonu seçicisini görüntüle',
   'Form data templates': 'Form veri şablonları',
   "Data template": "Veri şablonu",
+  "Template fields have been removed and need to be reconfigured": "Şablon alanları kaldırıldı ve yeniden yapılandırılması gerekiyor",
 }

--- a/packages/core/client/src/locale/zh_CN.ts
+++ b/packages/core/client/src/locale/zh_CN.ts
@@ -786,4 +786,5 @@ export default {
   "Allows to reboot application": "允许重启应用",
   'The will interrupt service, it may take a few seconds to restart. Are you sure to continue?': '重启将会中断当前服务，这个过程可能需要一点时间，确定要继续吗？',
   'Reboot': '重启',
+  "Template fields have been removed and need to be reconfigured": "模板字段已被删除，需要重新配置",
 }

--- a/packages/core/client/src/locale/zh_CN.ts
+++ b/packages/core/client/src/locale/zh_CN.ts
@@ -777,6 +777,7 @@ export default {
   'Add template': '添加模板',
   'Display data template selector': '显示数据模板选择框',
   'Form data templates': '表单数据模板',
+  'Data template': '数据模板',
 
   'Reload Application': '重载应用',
   'The application is reloading, please do not close the page.': '应用正在重新加载，请勿关闭页面。',

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -1,5 +1,5 @@
 import { useFieldSchema } from '@formily/react';
-import { forEach } from '@nocobase/utils/client';
+import { forEach, showToast } from '@nocobase/utils/client';
 import { Select } from 'antd';
 import _ from 'lodash';
 import React, { useCallback, useEffect } from 'react';
@@ -25,12 +25,28 @@ const useDataTemplates = () => {
   const fieldSchema = useFieldSchema();
   const { t } = useTranslation();
   const { items = [], display = true } = findDataTemplates(fieldSchema);
+  const { getCollectionJoinField } = useCollectionManager();
+
+  // 过滤掉已经被删除的字段
+  items.forEach((item) => {
+    item.fields = item.fields
+      .map((field) => {
+        const joinField = getCollectionJoinField(`${item.collection}.${field}`);
+        if (joinField) {
+          return field;
+        }
+        return '';
+      })
+      .filter(Boolean);
+  });
+
   const templates: any = [
     {
       key: 'none',
       title: t('None'),
     },
   ].concat(items.map<any>((t, i) => ({ key: i, ...t })));
+
   const defaultTemplate = items.find((item) => item.default);
   return {
     templates,
@@ -42,14 +58,13 @@ const useDataTemplates = () => {
 
 export const Templates = ({ style = {}, form }) => {
   const { templates, display, enabled, defaultTemplate } = useDataTemplates();
-  const { getCollectionField } = useCollectionManager();
   const [value, setValue] = React.useState(defaultTemplate?.key || 'none');
   const api = useAPIClient();
   const { t } = useTranslation();
 
   useEffect(() => {
     if (defaultTemplate) {
-      fetchTemplateData(api, defaultTemplate)
+      fetchTemplateData(api, defaultTemplate, t)
         .then((data) => {
           if (form) {
             forEach(data, (value, key) => {
@@ -58,6 +73,7 @@ export const Templates = ({ style = {}, form }) => {
               }
             });
           }
+          return data;
         })
         .catch((err) => {
           console.error(err);
@@ -68,15 +84,20 @@ export const Templates = ({ style = {}, form }) => {
   const handleChange = useCallback(async (value, option) => {
     setValue(value);
     if (option.key !== 'none') {
-      fetchTemplateData(api, option).then((data) => {
-        if (form) {
-          forEach(data, (value, key) => {
-            if (value) {
-              form.values[key] = value;
-            }
-          });
-        }
-      });
+      fetchTemplateData(api, option, t)
+        .then((data) => {
+          if (form) {
+            forEach(data, (value, key) => {
+              if (value) {
+                form.values[key] = value;
+              }
+            });
+          }
+          return data;
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     } else {
       form?.reset();
     }
@@ -110,7 +131,10 @@ function findDataTemplates(fieldSchema): ITemplate {
   return {} as ITemplate;
 }
 
-async function fetchTemplateData(api, template: { collection: string; dataId: number; fields: string[] }) {
+async function fetchTemplateData(api, template: { collection: string; dataId: number; fields: string[] }, t) {
+  if (template.fields.length === 0) {
+    return showToast(t('Template fields have been removed and need to be reconfigured'));
+  }
   return api
     .resource(template.collection)
     .get({

--- a/packages/core/utils/src/client.ts
+++ b/packages/core/utils/src/client.ts
@@ -3,10 +3,12 @@ export * from './common';
 export * from './date';
 export * from './forEach';
 export * from './getValuesByPath';
+export * from './json-templates';
 export * from './merge';
+export * from './notification';
 export * from './number';
 export * from './parse-filter';
 export * from './registry';
 // export * from './toposort';
 export * from './uid';
-export * from './json-templates';
+

--- a/packages/core/utils/src/notification.ts
+++ b/packages/core/utils/src/notification.ts
@@ -1,0 +1,8 @@
+import { notification } from 'antd';
+
+export const showToast = (message, type = 'info', duration = 5000) => {
+  notification[type]({
+    message,
+    duration,
+  });
+};


### PR DESCRIPTION
## Description (Bug 描述)
- 数据模板创建后，删除关系字段后无法正常使用报错

### Steps to reproduce (复现步骤)
1. 先选择关系字段中的关系字段，保存
2. 再去数据表中删除关系字段中的关系字段
<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
- 没有报错，如果模板中的字段已被删除干净，则需要告知用户原因

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
- 有错误信息
<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
- 因用户删除了对应的字段，导致后端查询不到该字段而产生错误。
<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)
1. 前端请求模板数据之前会检查一下模板中的字段是否已被删除
2. 如果已经被删除则会被过滤掉
3. 如果字段已被删除干净，则告知用户需要重新配置模板
<!-- Describe solution to the bug clearly and consciously. -->
