### PR TITLE
fix(plugin-formula): use read-pretty component in result

### DIFF
--- a/packages/plugins/formula-field/src/client/components/Formula/Result.tsx
+++ b/packages/plugins/formula-field/src/client/components/Formula/Result.tsx
@@ -1,5 +1,5 @@
 import { onFormValuesChange } from '@formily/core';
-import { useFieldSchema, useFormEffects } from '@formily/react';
+import { useFieldSchema, useFormEffects, useForm } from '@formily/react';
 import { Checkbox, DatePicker, InputNumber, Input as InputString, useCollection } from '@nocobase/client';
 import { Evaluator, evaluators } from '@nocobase/evaluators/client';
 import { Registry, toFixedByStep } from '@nocobase/utils/client';
@@ -44,6 +44,10 @@ export const Result = (props) => {
   });
   const Component = TypedComponents[dataType] ?? InputString;
   return <Component {...others} value={dataType === 'double' ? toFixedByStep(value, props.step) : value} />;
+};
+
+Result.ReadPretty = function ReadPretty(props) {
+  return props.value ?? null;
 };
 
 export default Result;

--- a/packages/plugins/formula-field/src/client/components/Formula/index.tsx
+++ b/packages/plugins/formula-field/src/client/components/Formula/index.tsx
@@ -1,4 +1,4 @@
-import { connect } from '@formily/react';
+import { connect, mapReadPretty } from '@formily/react';
 
 import Expression from './Expression';
 import Result from './Result';
@@ -6,6 +6,6 @@ import Result from './Result';
 export const Formula = () => null;
 
 Formula.Expression = Expression;
-Formula.Result = connect(Result);
+Formula.Result = connect(Result, mapReadPretty(Result.ReadPretty));
 
 export default Formula;


### PR DESCRIPTION
## Description (Bug 描述)

#1805

## Reason (原因)

Using dynamic result calculating in all collection including all associating ones.

## Solution (解决方案)

Change `Formula.Result` component to use only value (read-pretty) in associating collection views.
