### PR TITLE
feat(data-template): support to set data scope and title field

### DIFF
--- a/packages/core/client/src/collection-manager/Configuration/CollectionFields.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/CollectionFields.tsx
@@ -74,7 +74,7 @@ const CurrentFields = (props) => {
   const { resource, targetKey } = props.collectionResource || {};
   const { [targetKey]: filterByTk, titleField } = useRecord();
   const [loadingRecord, setLoadingRecord] = React.useState<any>(null);
-  const { updateCollection, refreshCM } = useCollectionManager();
+  const { refreshCM } = useCollectionManager();
 
   const columns: TableColumnProps<any>[] = [
     {
@@ -180,7 +180,7 @@ const InheritFields = (props) => {
   const { [targetKey]: filterByTk, titleField, name } = useRecord();
   const [loadingRecord, setLoadingRecord] = React.useState(null);
   const { t } = useTranslation();
-  const { updateCollection, refreshCM } = useCollectionManager();
+  const { refreshCM } = useCollectionManager();
 
   const columns: TableColumnProps<any>[] = [
     {
@@ -265,7 +265,7 @@ const InheritFields = (props) => {
   );
 };
 
-export const CollectionFields = (props) => {
+export const CollectionFields = () => {
   const compile = useCompile();
   const field = useField<Field>();
   const { name } = useRecord();

--- a/packages/core/client/src/schema-component/antd/association-select/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-select/AssociationSelect.tsx
@@ -160,7 +160,7 @@ AssociationSelect.Designer = function Designer() {
     readOnlyMode = 'read-pretty';
   }
 
-  const fieldSchemaWithoutRequired = _.omit(fieldSchema,'required')
+  const fieldSchemaWithoutRequired = _.omit(fieldSchema, 'required');
 
   return (
     <GeneralSchemaDesigner>

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -35,7 +35,7 @@ const useDataTemplates = () => {
   items.forEach((item) => {
     try {
       item.fields = item.fields
-        .map((field) => {
+        ?.map((field) => {
           const joinField = getCollectionJoinField(`${item.collection}.${field}`);
           if (joinField) {
             return field;

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -9,6 +9,10 @@ import { findFormBlock } from '../../../block-provider';
 import { useCollectionManager } from '../../../collection-manager';
 
 export interface ITemplate {
+  /** 设置的数据范围 */
+  filter?: any;
+  /** 设置的标题字段 */
+  titleField?: string;
   items: {
     key: string;
     title: string;
@@ -16,10 +20,6 @@ export interface ITemplate {
     dataId: number;
     fields: string[];
     default?: boolean;
-    /** 设置的数据范围 */
-    filter?: any;
-    /** 设置的标题字段 */
-    titleField?: string;
   }[];
   /** 是否在 Form 区块显示模板选择器 */
   display: boolean;

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -61,7 +61,7 @@ const useDataTemplates = () => {
     templates,
     display,
     defaultTemplate,
-    enabled: items.length > 0,
+    enabled: items.length > 0 && items.every((item) => item.dataId !== undefined),
   };
 };
 
@@ -72,7 +72,7 @@ export const Templates = ({ style = {}, form }) => {
   const { t } = useTranslation();
 
   useEffect(() => {
-    if (defaultTemplate) {
+    if (enabled && defaultTemplate) {
       fetchTemplateData(api, defaultTemplate, t)
         .then((data) => {
           if (form && data) {

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -9,10 +9,14 @@ import { findFormBlock } from '../../../block-provider';
 import { useCollectionManager } from '../../../collection-manager';
 
 export interface ITemplate {
-  /** 设置的数据范围 */
-  filter?: any;
-  /** 设置的标题字段 */
-  titleField?: string;
+  config?: {
+    [key: string]: {
+      /** 设置的数据范围 */
+      filter?: any;
+      /** 设置的标题字段 */
+      titleField?: string;
+    };
+  };
   items: {
     key: string;
     title: string;

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -8,7 +8,7 @@ import { useAPIClient } from '../../../api-client';
 import { findFormBlock } from '../../../block-provider';
 import { useCollectionManager } from '../../../collection-manager';
 
-interface ITemplate {
+export interface ITemplate {
   items: {
     key: string;
     title: string;
@@ -16,6 +16,10 @@ interface ITemplate {
     dataId: number;
     fields: string[];
     default?: boolean;
+    /** 设置的数据范围 */
+    filter?: any;
+    /** 设置的标题字段 */
+    titleField?: string;
   }[];
   /** 是否在 Form 区块显示模板选择器 */
   display: boolean;

--- a/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
@@ -10,6 +10,8 @@ import { useCollection, useCollectionManager } from '../../../collection-manager
 import { Select, defaultFieldNames } from '../select';
 import { ReadPretty } from './ReadPretty';
 
+const EMPTY = 'N/A';
+
 export type RemoteSelectProps<P = any> = SelectProps<P, any> & {
   objectValue?: boolean;
   onChange?: (v: any) => void;
@@ -90,13 +92,13 @@ const InternalRemoteSelect = connect(
 
               if (mapOptions) {
                 return mapOptions({
-                  [fieldNames.label]: label,
+                  [fieldNames.label]: label || EMPTY,
                   [fieldNames.value]: option[fieldNames.value],
                 });
               }
               return {
                 ...option,
-                [fieldNames.label]: label || option[fieldNames.value],
+                [fieldNames.label]: label || EMPTY,
                 [fieldNames.value]: option[fieldNames.value],
               };
             })

--- a/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
@@ -7,7 +7,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ResourceActionOptions, useRequest } from '../../../api-client';
 import { mergeFilter } from '../../../block-provider/SharedFilterProvider';
 import { useCollection, useCollectionManager } from '../../../collection-manager';
-import { useCompile } from '../../hooks';
 import { Select, defaultFieldNames } from '../select';
 import { ReadPretty } from './ReadPretty';
 
@@ -35,7 +34,6 @@ const InternalRemoteSelect = connect(
       targetField: _targetField,
       ...others
     } = props;
-    const compile = useCompile();
     const firstRun = useRef(false);
     const fieldSchema = useFieldSchema();
     const field = useField();
@@ -58,49 +56,51 @@ const InternalRemoteSelect = connect(
     const mapOptionsToTags = useCallback(
       (options) => {
         try {
-          return options.map((option) => {
-            let label = option[fieldNames.label];
+          return options
+            .map((option) => {
+              let label = option[fieldNames.label];
 
-            if (targetField?.uiSchema?.enum) {
-              if (Array.isArray(label)) {
-                label = label
-                  .map((item, index) => {
-                    const option = targetField.uiSchema.enum.find((i) => i.value === item);
-                    if (option) {
-                      return (
-                        <Tag key={index} color={option.color} style={{ marginRight: 3 }}>
-                          {option?.label || item}
-                        </Tag>
-                      );
-                    } else {
-                      return <Tag>{item}</Tag>;
-                    }
-                  })
-                  .reverse();
-              } else {
-                const item = targetField.uiSchema.enum.find((i) => i.value === label);
-                if (item) {
-                  label = <Tag color={item.color}>{item.label}</Tag>;
+              if (targetField?.uiSchema?.enum) {
+                if (Array.isArray(label)) {
+                  label = label
+                    .map((item, index) => {
+                      const option = targetField.uiSchema.enum.find((i) => i.value === item);
+                      if (option) {
+                        return (
+                          <Tag key={index} color={option.color} style={{ marginRight: 3 }}>
+                            {option?.label || item}
+                          </Tag>
+                        );
+                      } else {
+                        return <Tag key={item}>{item}</Tag>;
+                      }
+                    })
+                    .reverse();
+                } else {
+                  const item = targetField.uiSchema.enum.find((i) => i.value === label);
+                  if (item) {
+                    label = <Tag color={item.color}>{item.label}</Tag>;
+                  }
                 }
               }
-            }
 
-            if (targetField?.type === 'date') {
-              label = moment(label).format('YYYY-MM-DD');
-            }
+              if (targetField?.type === 'date') {
+                label = moment(label).format('YYYY-MM-DD');
+              }
 
-            if (mapOptions) {
-              return mapOptions({
-                [fieldNames.label]: label,
+              if (mapOptions) {
+                return mapOptions({
+                  [fieldNames.label]: label,
+                  [fieldNames.value]: option[fieldNames.value],
+                });
+              }
+              return {
+                ...option,
+                [fieldNames.label]: label || option[fieldNames.value],
                 [fieldNames.value]: option[fieldNames.value],
-              });
-            }
-            return {
-              ...option,
-              [fieldNames.label]: label || option[fieldNames.value],
-              [fieldNames.value]: option[fieldNames.value],
-            };
-          });
+              };
+            })
+            .filter(Boolean);
         } catch (err) {
           console.error(err);
           return options;

--- a/packages/core/client/src/schema-component/core/SchemaComponentProvider.tsx
+++ b/packages/core/client/src/schema-component/core/SchemaComponentProvider.tsx
@@ -35,7 +35,7 @@ export const SchemaComponentProvider: React.FC<ISchemaComponentProvider> = (prop
   const { designable, components, children } = props;
   const [, setUid] = useState(uid());
   const [formId, setFormId] = useState(uid());
-  const form = props.form || useMemo(() => createForm(), [formId]);
+  const form = useMemo(() => props.form || createForm(), [formId]);
   const { t } = useTranslation();
   const scope = { ...props.scope, t, randomString };
   const [active, setActive] = useCookieState('useCookieDesignable', {

--- a/packages/core/client/src/schema-items/GeneralSchemaItems.tsx
+++ b/packages/core/client/src/schema-items/GeneralSchemaItems.tsx
@@ -1,9 +1,8 @@
 import { Field } from '@formily/core';
-import { ISchema, useField, useFieldSchema,observer } from '@formily/react';
-import _ from 'lodash';
-import { useTranslation } from 'react-i18next';
+import { ISchema, observer, useField, useFieldSchema } from '@formily/react';
 import React from 'react';
-import { useCollectionManager, useCollection } from '../collection-manager';
+import { useTranslation } from 'react-i18next';
+import { useCollection, useCollectionManager } from '../collection-manager';
 import { useDesignable } from '../schema-component';
 import { SchemaSettings } from '../schema-settings';
 
@@ -18,7 +17,6 @@ export const GeneralSchemaItems: React.FC<{
   const { t } = useTranslation();
   const { dn, refresh } = useDesignable();
   const collectionField = getField(fieldSchema['name']) || getCollectionJoinField(fieldSchema['x-collection-field']);
-console.log(field,field.decoratorProps )
   return (
     <>
       {collectionField && (

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -72,7 +72,6 @@ export const FormDataTemplates = observer((props: any) => {
       getFieldNames,
       getFilter,
       getResource,
-      getMapOptions,
       collectionName,
     }),
     [],
@@ -141,7 +140,7 @@ export const FormDataTemplates = observer((props: any) => {
                       objectValue: false,
                       manual: false,
                       targetField: '{{ getTargetField($self.componentProps.service.resource) }}',
-                      mapOptions: '{{ getMapOptions(getFieldNames($self.componentProps.service.resource)) }}',
+                      mapOptions: getMapOptions(),
                       fieldNames: '{{ getFieldNames($self.componentProps.service.resource) }}',
                     },
                     'x-reactions': [
@@ -244,16 +243,10 @@ export function getLabel(titleField) {
   return titleField || 'label';
 }
 
-function getMapOptions(fieldNames: { label: string; value: string }) {
+function getMapOptions() {
   return (option) => {
-    if (option?.id == null) {
+    if (option?.id === undefined) {
       return null;
-    }
-    if (option[fieldNames.label] == null) {
-      return {
-        ...option,
-        id: 'N/A',
-      };
     }
     return option;
   };

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -2,6 +2,7 @@ import { connect, mapProps, observer } from '@formily/react';
 import { Tree as AntdTree } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { mergeFilter } from '../../block-provider';
 import { useCollectionManager } from '../../collection-manager';
 import { AssociationSelect, SchemaComponent, SchemaComponentContext } from '../../schema-component';
 import { AsDefaultTemplate } from './components/AsDefaultTemplate';
@@ -34,6 +35,7 @@ export const FormDataTemplates = observer((props: any) => {
       getLabel,
       getFieldNames,
       getCollectionField,
+      mergeFilter,
       collection,
       collectionName,
       items: defaultValues?.items || [],

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -1,14 +1,21 @@
 import { connect, mapProps, observer } from '@formily/react';
 import { observable } from '@formily/reactive';
 import { Tree as AntdTree } from 'antd';
+import _ from 'lodash';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { mergeFilter } from '../../block-provider';
 import { useCollectionManager } from '../../collection-manager';
-import { AssociationSelect, SchemaComponent, SchemaComponentContext } from '../../schema-component';
+import {
+  AssociationSelect,
+  SchemaComponent,
+  SchemaComponentContext,
+  removeNullCondition,
+} from '../../schema-component';
 import { ITemplate } from '../../schema-component/antd/form-v2/Templates';
 import { AsDefaultTemplate } from './components/AsDefaultTemplate';
 import { ArrayCollapse } from './components/DataTemplateTitle';
-import { Designer } from './components/Designer';
+import { Designer, getSelectedIdFilter } from './components/Designer';
 import { useCollectionState } from './hooks/useCollectionState';
 
 const Tree = connect(
@@ -34,13 +41,11 @@ export const FormDataTemplates = observer((props: any) => {
   const scope = useMemo(
     () => ({
       getEnableFieldTree,
-      getMapOptions,
-      getLabel,
-      getFieldNames,
-      getCollectionField,
-      collection,
-      collectionName,
-      items: defaultValues?.items || [],
+      isEmpty: _.isEmpty,
+      removeNullCondition,
+      mergeFilter,
+      getSelectedIdFilter,
+      activeData,
     }),
     [],
   );
@@ -100,7 +105,13 @@ export const FormDataTemplates = observer((props: any) => {
                       service: {
                         resource: collectionName,
                         params: {
-                          filter: activeData?.filter,
+                          filter: `{{
+                                isEmpty(activeData?.filter)
+                                ? {}
+                                : removeNullCondition(
+                                    mergeFilter([activeData?.filter, getSelectedIdFilter($self.value)], '$or'),
+                                  )
+                              }}`,
                         },
                       },
                       action: 'list',

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -1,4 +1,5 @@
 import { connect, mapProps, observer } from '@formily/react';
+import { observable } from '@formily/reactive';
 import { Tree as AntdTree } from 'antd';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +28,8 @@ export const FormDataTemplates = observer((props: any) => {
   const { getCollection, getCollectionField } = useCollectionManager();
   const collection = getCollection(collectionName);
   const { t } = useTranslation();
+
+  const activeData = useMemo(() => observable(defaultValues), [defaultValues]);
   const components = useMemo(() => ({ ArrayCollapse }), []);
   const scope = useMemo(
     () => ({
@@ -47,7 +50,7 @@ export const FormDataTemplates = observer((props: any) => {
       properties: {
         items: {
           type: 'array',
-          default: '{{ items }}',
+          default: activeData?.items,
           'x-component': 'ArrayCollapse',
           'x-decorator': 'FormItem',
           'x-component-props': {
@@ -88,17 +91,16 @@ export const FormDataTemplates = observer((props: any) => {
                     'x-designer': Designer,
                     'x-designer-props': {
                       formSchema,
-                      data: defaultValues,
+                      data: activeData,
                       collectionName,
                     },
-                    'x-data': '{{ $index }}',
                     'x-decorator': 'FormItem',
                     'x-component': AssociationSelect,
                     'x-component-props': {
                       service: {
                         resource: collectionName,
                         params: {
-                          filter: defaultValues?.filter,
+                          filter: activeData?.filter,
                         },
                       },
                       action: 'list',
@@ -106,10 +108,10 @@ export const FormDataTemplates = observer((props: any) => {
                       objectValue: false,
                       manual: false,
                       targetField: getCollectionField(
-                        `${collectionName}.${defaultValues?.titleField || collection?.titleField || 'id'}`,
+                        `${collectionName}.${activeData?.titleField || collection?.titleField || 'id'}`,
                       ),
                       mapOptions: getMapOptions(),
-                      fieldNames: getFieldNames(defaultValues, collection),
+                      fieldNames: getFieldNames(activeData, collection),
                     },
                     'x-reactions': [
                       {
@@ -191,7 +193,7 @@ export const FormDataTemplates = observer((props: any) => {
         display: {
           type: 'boolean',
           'x-content': '{{ t("Display data template selector") }}',
-          default: defaultValues?.display !== false,
+          default: activeData?.display !== false,
           'x-decorator': 'FormItem',
           'x-component': 'Checkbox',
         },

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -21,7 +21,8 @@ const Tree = connect(
 
 export const FormDataTemplates = observer((props: any) => {
   const { useProps, formSchema, designerCtx } = props;
-  const { defaultValues, collectionName } = useProps();
+  // defaultValues 加个默认值，防止没有数据时，无法渲染 Designer
+  const { defaultValues = { items: [{}] }, collectionName } = useProps();
   const { collectionList, getEnableFieldTree, onLoadData, onCheck } = useCollectionState(collectionName);
   const { getCollection, getCollectionField } = useCollectionManager();
   const collection = getCollection(collectionName);

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -124,7 +124,6 @@ export const FormDataTemplates = observer((props: any) => {
                     'x-designer-props': {
                       formSchema,
                       data: activeData,
-                      collectionName,
                     },
                     'x-decorator': 'FormItem',
                     'x-component': AssociationSelect,

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -1,3 +1,4 @@
+import { Field } from '@formily/core';
 import { connect, mapProps, observer } from '@formily/react';
 import { observable } from '@formily/reactive';
 import { Tree as AntdTree } from 'antd';
@@ -70,6 +71,8 @@ export const FormDataTemplates = observer((props: any) => {
       getTargetField,
       getFieldNames,
       getFilter,
+      getResource,
+      collectionName,
     }),
     [],
   );
@@ -104,7 +107,7 @@ export const FormDataTemplates = observer((props: any) => {
                     title: '{{ t("Collection") }}',
                     required: true,
                     description: t('If collection inherits, choose inherited collections as templates'),
-                    default: collectionName,
+                    default: '{{ collectionName }}',
                     'x-display': collectionList.length > 1 ? 'visible' : 'hidden',
                     'x-decorator': 'FormItem',
                     'x-component': 'Select',
@@ -127,7 +130,7 @@ export const FormDataTemplates = observer((props: any) => {
                     'x-component': AssociationSelect,
                     'x-component-props': {
                       service: {
-                        resource: collectionName,
+                        resource: '{{ $record.collection || collectionName }}',
                         params: {
                           filter: '{{ getFilter($self.componentProps.service.resource, $self.value) }}',
                         },
@@ -148,7 +151,7 @@ export const FormDataTemplates = observer((props: any) => {
                             disabled: '{{ !$deps[0] }}',
                             componentProps: {
                               service: {
-                                resource: '{{ $deps[0] }}',
+                                resource: '{{ getResource($deps[0], $self) }}',
                               },
                             },
                           },
@@ -247,4 +250,12 @@ function getMapOptions() {
     }
     return option;
   };
+}
+
+function getResource(resource: string, field: Field) {
+  if (resource !== field.componentProps.service.resource) {
+    // 切换 collection 后，之前选中的其它 collection 的数据就没有意义了，需要清空
+    field.value = undefined;
+  }
+  return resource;
 }

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -1,6 +1,6 @@
 import { connect, mapProps, observer } from '@formily/react';
 import { Tree as AntdTree } from 'antd';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCollectionManager } from '../../collection-manager';
 import { AssociationSelect, SchemaComponent, SchemaComponentContext } from '../../schema-component';
@@ -27,7 +27,6 @@ export const FormDataTemplates = observer((props: any) => {
   const { getCollection, getCollectionField } = useCollectionManager();
   const collection = getCollection(collectionName);
   const { t } = useTranslation();
-  const field = getCollectionField(`${collectionName}.${collection?.titleField || 'id'}`);
   const components = useMemo(() => ({ ArrayCollapse }), []);
   const scope = useMemo(
     () => ({
@@ -35,7 +34,9 @@ export const FormDataTemplates = observer((props: any) => {
       getMapOptions,
       getLabel,
       getFieldNames,
+      getCollectionField,
       collection,
+      collectionName,
       items: defaultValues?.items || [],
     }),
     [],
@@ -104,7 +105,8 @@ export const FormDataTemplates = observer((props: any) => {
                       multiple: false,
                       objectValue: false,
                       manual: false,
-                      targetField: field,
+                      targetField:
+                        '{{ getCollectionField(`${collectionName}.${$record.titleField || collection?.titleField || "id"}`) }}',
                       mapOptions: '{{ getMapOptions($record, collection) }}',
                       fieldNames: '{{ getFieldNames($record, collection) }}',
                     },
@@ -205,7 +207,7 @@ export const FormDataTemplates = observer((props: any) => {
 });
 
 export function getLabel(titleField) {
-  return !titleField || titleField === 'id' ? 'label' : titleField;
+  return !titleField ? 'label' : titleField;
 }
 
 function getMapOptions(record: ITemplate['items'][0], collection) {

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -72,6 +72,7 @@ export const FormDataTemplates = observer((props: any) => {
       getFieldNames,
       getFilter,
       getResource,
+      getMapOptions,
       collectionName,
     }),
     [],
@@ -140,7 +141,7 @@ export const FormDataTemplates = observer((props: any) => {
                       objectValue: false,
                       manual: false,
                       targetField: '{{ getTargetField($self.componentProps.service.resource) }}',
-                      mapOptions: getMapOptions(),
+                      mapOptions: '{{ getMapOptions(getFieldNames($self.componentProps.service.resource)) }}',
                       fieldNames: '{{ getFieldNames($self.componentProps.service.resource) }}',
                     },
                     'x-reactions': [
@@ -243,10 +244,16 @@ export function getLabel(titleField) {
   return titleField || 'label';
 }
 
-function getMapOptions() {
+function getMapOptions(fieldNames: { label: string; value: string }) {
   return (option) => {
-    if (option?.id === undefined) {
+    if (option?.id == null) {
       return null;
+    }
+    if (option[fieldNames.label] == null) {
+      return {
+        ...option,
+        id: 'N/A',
+      };
     }
     return option;
   };

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCollectionManager } from '../../collection-manager';
 import { AssociationSelect, SchemaComponent, SchemaComponentContext } from '../../schema-component';
-import { ITemplate } from '../../schema-component/antd/form-v2/Templates';
 import { AsDefaultTemplate } from './components/AsDefaultTemplate';
 import { ArrayCollapse } from './components/DataTemplateTitle';
 import { Designer } from './components/Designer';
@@ -107,7 +106,7 @@ export const FormDataTemplates = observer((props: any) => {
                       manual: false,
                       targetField:
                         '{{ getCollectionField(`${collectionName}.${$record.titleField || collection?.titleField || "id"}`) }}',
-                      mapOptions: '{{ getMapOptions($record, collection) }}',
+                      mapOptions: '{{ getMapOptions() }}',
                       fieldNames: '{{ getFieldNames($record, collection) }}',
                     },
                     'x-reactions': [
@@ -210,25 +209,12 @@ export function getLabel(titleField) {
   return !titleField ? 'label' : titleField;
 }
 
-function getMapOptions(record: ITemplate['items'][0], collection) {
+function getMapOptions() {
   return (option) => {
-    try {
-      if (option?.id === undefined) {
-        return null;
-      }
-
-      const label = getLabel(record.titleField || collection?.titleField || 'id');
-      option[label] = (
-        <>
-          #{option.id} {option[label]}
-        </>
-      );
-
-      return option;
-    } catch (error) {
-      console.error(error);
+    if (option?.id === undefined) {
       return null;
     }
+    return option;
   };
 }
 

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -29,14 +29,15 @@ const Tree = connect(
 
 export const FormDataTemplates = observer((props: any) => {
   const { useProps, formSchema, designerCtx } = props;
-  // defaultValues 加个默认值，防止没有数据时，无法渲染 Designer
-  const { defaultValues = {}, collectionName } = useProps();
+  const { defaultValues = { items: [], titleField: '', filter: {}, display: true }, collectionName } = useProps();
   const { collectionList, getEnableFieldTree, onLoadData, onCheck } = useCollectionState(collectionName);
   const { getCollection, getCollectionField } = useCollectionManager();
   const collection = getCollection(collectionName);
   const { t } = useTranslation();
 
-  const activeData = useMemo(() => observable(defaultValues), [defaultValues]);
+  // 不要在后面的数组中依赖 defaultValues，否则会因为 defaultValues 的变化导致 activeData 响应性丢失
+  const activeData = useMemo(() => observable(defaultValues), []);
+
   const components = useMemo(() => ({ ArrayCollapse }), []);
   const scope = useMemo(
     () => ({

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -1,10 +1,10 @@
 import { connect, mapProps, observer } from '@formily/react';
 import { Tree as AntdTree } from 'antd';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { mergeFilter } from '../../block-provider';
 import { useCollectionManager } from '../../collection-manager';
 import { AssociationSelect, SchemaComponent, SchemaComponentContext } from '../../schema-component';
+import { ITemplate } from '../../schema-component/antd/form-v2/Templates';
 import { AsDefaultTemplate } from './components/AsDefaultTemplate';
 import { ArrayCollapse } from './components/DataTemplateTitle';
 import { Designer } from './components/Designer';
@@ -22,7 +22,7 @@ const Tree = connect(
 export const FormDataTemplates = observer((props: any) => {
   const { useProps, formSchema, designerCtx } = props;
   // defaultValues 加个默认值，防止没有数据时，无法渲染 Designer
-  const { defaultValues = { items: [{}] }, collectionName } = useProps();
+  const { defaultValues = {}, collectionName } = useProps();
   const { collectionList, getEnableFieldTree, onLoadData, onCheck } = useCollectionState(collectionName);
   const { getCollection, getCollectionField } = useCollectionManager();
   const collection = getCollection(collectionName);
@@ -35,7 +35,6 @@ export const FormDataTemplates = observer((props: any) => {
       getLabel,
       getFieldNames,
       getCollectionField,
-      mergeFilter,
       collection,
       collectionName,
       items: defaultValues?.items || [],
@@ -99,17 +98,18 @@ export const FormDataTemplates = observer((props: any) => {
                       service: {
                         resource: collectionName,
                         params: {
-                          filter: '{{ $record.filter }}',
+                          filter: defaultValues?.filter,
                         },
                       },
                       action: 'list',
                       multiple: false,
                       objectValue: false,
                       manual: false,
-                      targetField:
-                        '{{ getCollectionField(`${collectionName}.${$record.titleField || collection?.titleField || "id"}`) }}',
-                      mapOptions: '{{ getMapOptions() }}',
-                      fieldNames: '{{ getFieldNames($record, collection) }}',
+                      targetField: getCollectionField(
+                        `${collectionName}.${defaultValues?.titleField || collection?.titleField || 'id'}`,
+                      ),
+                      mapOptions: getMapOptions(),
+                      fieldNames: getFieldNames(defaultValues, collection),
                     },
                     'x-reactions': [
                       {
@@ -220,9 +220,9 @@ function getMapOptions() {
   };
 }
 
-function getFieldNames(record, collection) {
+function getFieldNames(data: ITemplate, collection) {
   return {
-    label: getLabel(record.titleField || collection?.titleField || 'id'),
+    label: getLabel(data?.titleField || collection?.titleField || 'id'),
     value: 'id',
   };
 }

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -22,8 +22,6 @@ export const Designer = observer(() => {
   const compile = useCompile();
   const { formSchema, data } = fieldSchema['x-designer-props'] as {
     formSchema: ISchema;
-    index: number;
-    collectionName: string;
     data?: ITemplate;
   };
 
@@ -101,7 +99,7 @@ export const Designer = observer(() => {
               };
             });
           } catch (err) {
-            console.error(err);
+            error(err);
           }
           formSchema['x-data-templates'] = data;
           dn.emit('patch', {

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -90,6 +90,10 @@ export const Designer = observer(() => {
           try {
             // 不仅更新当前模板，也更新同级的其它模板
             field.query('fieldReaction.items.*.layout.dataId').forEach((item) => {
+              if (item.componentProps.service.resource !== collectionName) {
+                return;
+              }
+
               item.componentProps.service.params = {
                 filter: _.isEmpty(filter)
                   ? {}
@@ -120,6 +124,10 @@ export const Designer = observer(() => {
           try {
             // 不仅更新当前模板，也更新同级的其它模板
             field.query('fieldReaction.items.*.layout.dataId').forEach((item) => {
+              if (item.componentProps.service.resource !== collectionName) {
+                return;
+              }
+
               item.componentProps.fieldNames.label = label;
               item.componentProps.targetField = getCollectionField(
                 `${collectionName}.${label || collection?.titleField || 'id'}`,

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -3,6 +3,7 @@ import { ISchema, useField, useFieldSchema } from '@formily/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GeneralSchemaDesigner, SchemaSettings } from '../..';
+import { mergeFilter } from '../../../block-provider';
 import { useCollectionFilterOptions, useCollectionManager } from '../../../collection-manager';
 import { isTitleField } from '../../../collection-manager/Configuration/CollectionFields';
 import { removeNullCondition, useCompile, useDesignable } from '../../../schema-component';
@@ -65,7 +66,8 @@ export const Designer = () => {
         }
         onSubmit={({ filter }) => {
           filter = removeNullCondition(filter);
-          item.filter = filter || {};
+          item.filter = mergeFilter([filter, getSelectedIdFilter(field.value)], '$or');
+
           try {
             field.componentProps.service.params = { filter: item.filter };
           } catch (err) {
@@ -112,3 +114,13 @@ export const Designer = () => {
     </GeneralSchemaDesigner>
   );
 };
+
+function getSelectedIdFilter(selectedId) {
+  return selectedId
+    ? {
+        id: {
+          $eq: selectedId,
+        },
+      }
+    : null;
+}

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -1,6 +1,7 @@
 import { Field } from '@formily/core';
 import { ISchema, observer, useField, useFieldSchema } from '@formily/react';
 import { Select } from 'antd';
+import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GeneralSchemaDesigner, SchemaSettings } from '../..';
@@ -62,13 +63,16 @@ export const Designer = observer(() => {
           } as ISchema
         }
         onSubmit={({ filter }) => {
-          filter = removeNullCondition(filter);
-          data.filter = mergeFilter([filter, getSelectedIdFilter(field.value)], '$or');
+          data.filter = removeNullCondition(filter);
 
           try {
             // 不仅更新当前模板，也更新同级的其它模板
             field.query('fieldReaction.items.*.layout.dataId').forEach((item) => {
-              item.componentProps.service.params = { filter: data.filter };
+              item.componentProps.service.params = {
+                filter: _.isEmpty(filter)
+                  ? {}
+                  : removeNullCondition(mergeFilter([filter, getSelectedIdFilter(field.value)], '$or')),
+              };
             });
           } catch (err) {
             console.error(err);
@@ -118,7 +122,7 @@ export const Designer = observer(() => {
   );
 });
 
-function getSelectedIdFilter(selectedId) {
+export function getSelectedIdFilter(selectedId) {
   return selectedId
     ? {
         id: {

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -1,5 +1,5 @@
 import { Field } from '@formily/core';
-import { ISchema, useField, useFieldSchema } from '@formily/react';
+import { ISchema, observer, useField, useFieldSchema } from '@formily/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GeneralSchemaDesigner, SchemaSettings } from '../..';
@@ -10,7 +10,7 @@ import { removeNullCondition, useCompile, useDesignable } from '../../../schema-
 import { ITemplate } from '../../../schema-component/antd/form-v2/Templates';
 import { FilterDynamicComponent } from '../../../schema-component/antd/table-v2/FilterDynamicComponent';
 
-export const Designer = () => {
+export const Designer = observer(() => {
   const { getCollectionFields, getCollectionField, getCollection } = useCollectionManager();
   const field = useField<Field>();
   const fieldSchema = useFieldSchema();
@@ -66,7 +66,10 @@ export const Designer = () => {
           data.filter = mergeFilter([filter, getSelectedIdFilter(field.value)], '$or');
 
           try {
-            field.componentProps.service.params = { filter: data.filter };
+            // 不仅更新当前模板，也更新同级的其它模板
+            field.query('fieldReaction.items.*.layout.dataId').forEach((item) => {
+              item.componentProps.service.params = { filter: data.filter };
+            });
           } catch (err) {
             console.error(err);
           }
@@ -88,10 +91,13 @@ export const Designer = () => {
         onChange={(label) => {
           data.titleField = label;
           try {
-            field.componentProps.fieldNames.label = label;
-            field.componentProps.targetField = getCollectionField(
-              `${collectionName}.${label || collection?.titleField || 'id'}`,
-            );
+            // 不仅更新当前模板，也更新同级的其它模板
+            field.query('fieldReaction.items.*.layout.dataId').forEach((item) => {
+              item.componentProps.fieldNames.label = label;
+              item.componentProps.targetField = getCollectionField(
+                `${collectionName}.${label || collection?.titleField || 'id'}`,
+              );
+            });
           } catch (err) {
             console.error(err);
           }
@@ -110,7 +116,7 @@ export const Designer = () => {
       />
     </GeneralSchemaDesigner>
   );
-};
+});
 
 function getSelectedIdFilter(selectedId) {
   return selectedId

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -67,7 +67,7 @@ export const Designer = () => {
           filter = removeNullCondition(filter);
           item.filter = filter || {};
           try {
-            field.componentProps.service.params.filter = item.filter;
+            field.componentProps.service.params = { filter: item.filter };
           } catch (err) {
             console.error(err);
           }

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -1,0 +1,111 @@
+import { Field } from '@formily/core';
+import { ISchema, useField, useFieldSchema } from '@formily/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { GeneralSchemaDesigner, SchemaSettings } from '../..';
+import { useCollectionFilterOptions, useCollectionManager } from '../../../collection-manager';
+import { isTitleField } from '../../../collection-manager/Configuration/CollectionFields';
+import { removeNullCondition, useCompile, useDesignable } from '../../../schema-component';
+import { ITemplate } from '../../../schema-component/antd/form-v2/Templates';
+import { FilterDynamicComponent } from '../../../schema-component/antd/table-v2/FilterDynamicComponent';
+
+export const Designer = () => {
+  const { getCollectionFields, getCollection } = useCollectionManager();
+  const field = useField<Field>();
+  const fieldSchema = useFieldSchema();
+  const { t } = useTranslation();
+  const { dn } = useDesignable();
+  const compile = useCompile();
+  const { formSchema, data, collectionName } = fieldSchema['x-designer-props'] as {
+    formSchema: ISchema;
+    index: number;
+    collectionName: string;
+    data?: ITemplate;
+  };
+  const index = field.data;
+
+  const collection = getCollection(collectionName);
+  const collectionFields = getCollectionFields(collectionName);
+  const dataSource = useCollectionFilterOptions(collectionName);
+
+  const item = data?.items?.[index];
+
+  if (!item) {
+    return null;
+  }
+
+  const options = collectionFields
+    .filter((field) => isTitleField(field))
+    .map((field) => ({
+      value: field?.name,
+      label: compile(field?.uiSchema?.title) || field?.name,
+    }));
+
+  return (
+    <GeneralSchemaDesigner draggable={false}>
+      <SchemaSettings.ModalItem
+        title={t('Set the data scope')}
+        scope={{ item }}
+        schema={
+          {
+            type: 'object',
+            title: t('Set the data scope'),
+            properties: {
+              filter: {
+                default: '{{ item.filter }}',
+                // title: '数据范围',
+                enum: dataSource,
+                'x-component': 'Filter',
+                'x-component-props': {
+                  dynamicComponent: (props) => FilterDynamicComponent({ ...props }),
+                },
+              },
+            },
+          } as ISchema
+        }
+        onSubmit={({ filter }) => {
+          filter = removeNullCondition(filter);
+          item.filter = filter || {};
+          try {
+            field.componentProps.service.params.filter = item.filter;
+          } catch (err) {
+            console.error(err);
+          }
+          formSchema['x-data-templates'] = data;
+          dn.emit('patch', {
+            schema: {
+              ['x-uid']: formSchema['x-uid'],
+              ['x-data-templates']: data,
+            },
+          });
+          dn.refresh();
+        }}
+      />
+      <SchemaSettings.SelectItem
+        key="title-field"
+        title={t('Title field')}
+        options={options}
+        value={item.titleField || collection?.titleField || 'id'}
+        onChange={(label) => {
+          item.titleField = label;
+          try {
+            field.componentProps.fieldNames.label = label;
+          } catch (err) {
+            console.error(err);
+          }
+          formSchema['x-data-templates'] = data;
+
+          const schema = {
+            ['x-uid']: formSchema['x-uid'],
+            ['x-data-templates']: data,
+          };
+
+          dn.emit('patch', {
+            schema,
+          });
+          dn.refresh();
+        }}
+      />
+    </GeneralSchemaDesigner>
+  );
+};

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -23,15 +23,12 @@ export const Designer = () => {
     collectionName: string;
     data?: ITemplate;
   };
-  const index = field.data;
 
   const collection = getCollection(collectionName);
   const collectionFields = getCollectionFields(collectionName);
   const dataSource = useCollectionFilterOptions(collectionName);
 
-  const item = data?.items?.[index];
-
-  if (!item) {
+  if (!data) {
     return null;
   }
 
@@ -46,14 +43,14 @@ export const Designer = () => {
     <GeneralSchemaDesigner draggable={false}>
       <SchemaSettings.ModalItem
         title={t('Set the data scope')}
-        scope={{ item }}
+        scope={{ data }}
         schema={
           {
             type: 'object',
             title: t('Set the data scope'),
             properties: {
               filter: {
-                default: '{{ item.filter }}',
+                default: '{{ data.filter }}',
                 // title: '数据范围',
                 enum: dataSource,
                 'x-component': 'Filter',
@@ -66,10 +63,10 @@ export const Designer = () => {
         }
         onSubmit={({ filter }) => {
           filter = removeNullCondition(filter);
-          item.filter = mergeFilter([filter, getSelectedIdFilter(field.value)], '$or');
+          data.filter = mergeFilter([filter, getSelectedIdFilter(field.value)], '$or');
 
           try {
-            field.componentProps.service.params = { filter: item.filter };
+            field.componentProps.service.params = { filter: data.filter };
           } catch (err) {
             console.error(err);
           }
@@ -87,9 +84,9 @@ export const Designer = () => {
         key="title-field"
         title={t('Title field')}
         options={options}
-        value={item.titleField || collection?.titleField || 'id'}
+        value={data.titleField || collection?.titleField || 'id'}
         onChange={(label) => {
-          item.titleField = label;
+          data.titleField = label;
           try {
             field.componentProps.fieldNames.label = label;
             field.componentProps.targetField = getCollectionField(

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -3,7 +3,7 @@ import { ISchema, observer, useField, useFieldSchema } from '@formily/react';
 import { error } from '@nocobase/utils/client';
 import { Select } from 'antd';
 import _ from 'lodash';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GeneralSchemaDesigner, SchemaSettings } from '../..';
 import { mergeFilter } from '../../../block-provider';
@@ -26,15 +26,13 @@ export const Designer = observer(() => {
     collectionName: string;
     data?: ITemplate;
   };
+
+  // 在这里读取 resource 的值，当 resource 变化时，会触发该组件的更新
   const collectionName = field.componentProps.service.resource;
+
   const collection = getCollection(collectionName);
   const collectionFields = getCollectionFields(collectionName);
   const dataSource = useCollectionFilterOptions(collectionName);
-
-  // 切换 collection 后，之前选中的其它 collection 的数据就没有意义了，需要清空
-  useEffect(() => {
-    field.reset();
-  }, [collectionName]);
 
   if (!data) {
     error('data is required');
@@ -44,7 +42,7 @@ export const Designer = observer(() => {
   const getFilter = () => data.config?.[collectionName]?.filter || {};
   const setFilter = (filter) => {
     try {
-      data.config[collectionName].filter = removeNullCondition(filter);
+      _.set(data, `config.${collectionName}.filter`, removeNullCondition(filter));
     } catch (err) {
       error(err);
     }
@@ -52,7 +50,7 @@ export const Designer = observer(() => {
   const getTitleFIeld = () => data.config?.[collectionName]?.titleField || collection?.titleField || 'id';
   const setTitleField = (titleField) => {
     try {
-      data.config[collectionName].titleField = titleField;
+      _.set(data, `config.${collectionName}.titleField`, titleField);
     } catch (err) {
       error(err);
     }

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -10,7 +10,7 @@ import { ITemplate } from '../../../schema-component/antd/form-v2/Templates';
 import { FilterDynamicComponent } from '../../../schema-component/antd/table-v2/FilterDynamicComponent';
 
 export const Designer = () => {
-  const { getCollectionFields, getCollection } = useCollectionManager();
+  const { getCollectionFields, getCollectionField, getCollection } = useCollectionManager();
   const field = useField<Field>();
   const fieldSchema = useFieldSchema();
   const { t } = useTranslation();
@@ -90,6 +90,9 @@ export const Designer = () => {
           item.titleField = label;
           try {
             field.componentProps.fieldNames.label = label;
+            field.componentProps.targetField = getCollectionField(
+              `${collectionName}.${label || collection?.titleField || 'id'}`,
+            );
           } catch (err) {
             console.error(err);
           }

--- a/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/Designer.tsx
@@ -1,5 +1,6 @@
 import { Field } from '@formily/core';
 import { ISchema, observer, useField, useFieldSchema } from '@formily/react';
+import { Select } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GeneralSchemaDesigner, SchemaSettings } from '../..';
@@ -23,7 +24,6 @@ export const Designer = observer(() => {
     collectionName: string;
     data?: ITemplate;
   };
-
   const collection = getCollection(collectionName);
   const collectionFields = getCollectionFields(collectionName);
   const dataSource = useCollectionFilterOptions(collectionName);
@@ -83,7 +83,7 @@ export const Designer = observer(() => {
           dn.refresh();
         }}
       />
-      <SchemaSettings.SelectItem
+      <SelectItem
         key="title-field"
         title={t('Title field')}
         options={options}
@@ -126,4 +126,24 @@ function getSelectedIdFilter(selectedId) {
         },
       }
     : null;
+}
+
+function SelectItem(props) {
+  const { title, options, value, onChange, ...others } = props;
+
+  return (
+    <SchemaSettings.Item {...others}>
+      <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
+        {title}
+        <Select
+          bordered={false}
+          value={value}
+          onChange={onChange}
+          options={options}
+          style={{ textAlign: 'right', minWidth: 100 }}
+          {...others}
+        />
+      </div>
+    </SchemaSettings.Item>
+  );
 }

--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -1059,7 +1059,7 @@ SchemaSettings.DataTemplates = function DataTemplates(props) {
     [templateData],
   );
   const onSubmit = useCallback((v) => {
-    const data = v.fieldReaction || {};
+    const data = { ...(formSchema['x-data-templates'] || {}), ...v.fieldReaction };
 
     // 当 Tree 组件开启 checkStrictly 属性时，会导致 checkedKeys 的值是一个对象，而不是数组，所以这里需要转换一下以支持旧版本
     data.items.forEach((item) => {

--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -31,6 +31,7 @@ import {
   FormProvider,
   RemoteSchemaComponent,
   SchemaComponent,
+  SchemaComponentContext,
   SchemaComponentOptions,
   createDesignable,
   findFormBlock,
@@ -1011,8 +1012,15 @@ SchemaSettings.LinkageRules = function LinkageRules(props) {
   );
 };
 
-export const useDataTemplates = () => {
+export const useDataTemplates = (schema?: Schema) => {
   const fieldSchema = useFieldSchema();
+
+  if (schema) {
+    return {
+      templateData: _.cloneDeep(schema['x-data-templates']),
+    };
+  }
+
   const formSchema = findFormBlock(fieldSchema) || fieldSchema;
   return {
     templateData: _.cloneDeep(formSchema?.['x-data-templates']),
@@ -1020,6 +1028,7 @@ export const useDataTemplates = () => {
 };
 
 SchemaSettings.DataTemplates = function DataTemplates(props) {
+  const designerCtx = useContext(SchemaComponentContext);
   const { collectionName } = props;
   const fieldSchema = useFieldSchema();
   const { dn } = useDesignable();
@@ -1035,6 +1044,8 @@ SchemaSettings.DataTemplates = function DataTemplates(props) {
         fieldReaction: {
           'x-component': FormDataTemplates,
           'x-component-props': {
+            designerCtx,
+            formSchema,
             useProps: () => {
               return {
                 defaultValues: templateData,

--- a/packages/core/client/src/schema-settings/hooks/useIsShowMultipleSwitch.ts
+++ b/packages/core/client/src/schema-settings/hooks/useIsShowMultipleSwitch.ts
@@ -9,7 +9,9 @@ export function useIsShowMultipleSwitch() {
   const fieldSchema = useFieldSchema();
   const { getCollectionField } = useCollectionManager();
 
-  const collectionField = getCollectionField(fieldSchema['x-collection-field']);
+  const collectionField = fieldSchema['x-collection-field']
+    ? getCollectionField(fieldSchema['x-collection-field'])
+    : null;
   const uiSchema = collectionField?.uiSchema || fieldSchema;
   const hasMultiple = uiSchema['x-component-props']?.multiple === true;
 

--- a/packages/core/client/src/schema-templates/BlockTemplateDetails.tsx
+++ b/packages/core/client/src/schema-templates/BlockTemplateDetails.tsx
@@ -1,4 +1,4 @@
-import { Input, PageHeader as AntdPageHeader, Spin } from 'antd';
+import { PageHeader as AntdPageHeader, Input, Spin } from 'antd';
 import React, { useContext, useState } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { useAPIClient, useRequest, useSchemaTemplateManager } from '..';


### PR DESCRIPTION
# Description (需求描述)
- 如下图所示，在 `数据模板` 中支持 `设置数据范围` 和 `设置标题字段`。

![image](https://github.com/nocobase/nocobase/assets/38434641/16472960-ec73-4c74-b5ab-70f56f764f13)


# Motivation (需求背景)
- 模板数据列表可能会有很多数据，不利于用户选择。
- 在数据表管理页面配置 `标题字段` 不方便，并且如果要在某些特定的区块使用其它 `标题字段` 则无法实现。

# Key changes (关键改动）

- Frontend (前端)
  - 新增一个 Designer 组件，与普通表单区块类似。
  - 新增的 Designer 组件不可拖动和新增其它字段。
- Backend (后端)
  - 无改动
# Test plan (测试计划)
## Suggestions (测试建议)
Provide any suggestions or recommendations for improvements in the testing plan.

## Underlying risk (潜在风险)

- 暂时没有发现潜在危险。
- 该功能为新增功能，不会对原来的功能造成影响。
# Showcase (结果展示）

![20230524094729_rec_](https://github.com/nocobase/nocobase/assets/38434641/7ec1250b-0078-4fad-bc48-33c5a943bbab)
