### PR TITLE
chore: when using association field by picker mode, its open size can…

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Drawer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Drawer.tsx
@@ -20,6 +20,8 @@ export const ActionDrawer: ComposedActionDrawer = observer((props) => {
   const { visible, setVisible, openSize = 'middle' } = useActionContext();
   const schema = useFieldSchema();
   const field = useField();
+  const openSizeFromParent = schema.parent?.['x-component-props']?.['openSize'];
+  const finalOpenSize = openSizeFromParent || openSize;
   const footerSchema = schema.reduceProperties((buf, s) => {
     if (s['x-component'] === footerNodeName) {
       return s;
@@ -35,7 +37,7 @@ export const ActionDrawer: ComposedActionDrawer = observer((props) => {
           }}
         >
           <Drawer
-            width={openSizeWidthMap.get(openSize)}
+            width={openSizeWidthMap.get(finalOpenSize)}
             title={field.title}
             {...others}
             destroyOnClose

--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -32,6 +32,7 @@ import { FilterDynamicComponent } from '../table-v2/FilterDynamicComponent';
 import { isInvariable } from '../variable';
 import { FilterFormDesigner } from './FormItem.FilterFormDesigner';
 import { useEnsureOperatorsValid } from './SchemaSettingOptions';
+import { Select } from 'antd';
 
 const defaultInputStyle = css`
   & > .nb-form-item {
@@ -173,6 +174,10 @@ FormItem.Designer = function Designer() {
   });
 
   const fieldSchemaWithoutRequired = _.omit(fieldSchema, 'required');
+
+  const isPickerMode = fieldSchema['x-component-props'].mode === 'Picker';
+  const showFieldMode = isAssociationField && fieldModeOptions && !isTableField;
+  const showModeSelect = showFieldMode && isPickerMode;
 
   return (
     <GeneralSchemaDesigner>
@@ -559,7 +564,7 @@ FormItem.Designer = function Designer() {
           }}
         />
       )}
-      {isAssociationField && fieldModeOptions && !isTableField && (
+      {showFieldMode && (
         <SchemaSettings.SelectItem
           key="field-mode"
           title={t('Field mode')}
@@ -585,7 +590,37 @@ FormItem.Designer = function Designer() {
           }}
         />
       )}
-
+      {showModeSelect && (
+        <SchemaSettings.Item>
+          <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
+            {t('Popup size')}
+            <Select
+              bordered={false}
+              options={[
+                { label: t('Small'), value: 'small' },
+                { label: t('Middle'), value: 'middle' },
+                { label: t('Large'), value: 'large' },
+              ]}
+              value={
+                fieldSchema?.['x-component-props']?.['openSize'] ??
+                (fieldSchema?.['x-component-props']?.['openMode'] == 'modal' ? 'large' : 'middle')
+              }
+              onChange={(value) => {
+                field.componentProps.openSize = value;
+                fieldSchema['x-component-props'] = field.componentProps;
+                dn.emit('patch', {
+                  schema: {
+                    'x-uid': fieldSchema['x-uid'],
+                    'x-component-props': fieldSchema['x-component-props'],
+                  },
+                });
+                dn.refresh();
+              }}
+              style={{ textAlign: 'right', minWidth: 100 }}
+            />
+          </div>
+        </SchemaSettings.Item>
+      )}
       {!field.readPretty && isAssociationField && ['Select', 'Picker'].includes(fieldMode) && (
         <SchemaSettings.SwitchItem
           key="allowAddNew"


### PR DESCRIPTION
… be changed

## Description (Bug 描述)
Data picker 窗口需可配置尺寸
### Steps to reproduce (复现步骤)
为操作按钮配置抽屉尺寸为 small，在抽屉里的关系字段选择 data picker 组件，打开二级抽屉，尺寸默认是 middle，应该在 data picker 配置项下面增加一个配置项，允许配置抽屉（弹窗）尺寸
<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
为操作按钮配置抽屉尺寸为 small，在抽屉里的关系字段选择 data picker 组件，打开二级抽屉，尺寸默认是 middle，应该在 data picker 配置项下面增加一个配置项，允许配置抽屉（弹窗）尺寸
<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
没有可配置抽屉弹窗尺寸的select
<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
<img width="397" alt="image" src="https://github.com/nocobase/nocobase/assets/33344293/9be3cd12-04a4-42be-9c85-65ab7b954452">
