### PR TITLE
fix(data-template): fix title input prevented proper data switching

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -100,6 +100,9 @@ export const Templates = ({ style = {}, form }) => {
       fetchTemplateData(api, option, t)
         .then((data) => {
           if (form && data) {
+            // 切换之前先把之前的数据清空
+            form.reset();
+
             forEach(data, (value, key) => {
               if (value) {
                 form.values[key] = value;

--- a/packages/core/client/src/schema-settings/DataTemplates/components/DataTemplateTitle.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/DataTemplateTitle.tsx
@@ -9,7 +9,7 @@ import { clone } from 'lodash';
 import React, { Fragment, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const DataTemplateTitle = observer<{ index: number }>((props) => {
+const DataTemplateTitle = observer<{ index: number; item: any }>((props) => {
   const array = ArrayBase.useArray();
   const index = ArrayBase.useIndex(props.index);
   const { t } = useTranslation();

--- a/packages/core/client/src/schema-settings/DataTemplates/components/DataTemplateTitle.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/components/DataTemplateTitle.tsx
@@ -9,7 +9,7 @@ import { clone } from 'lodash';
 import React, { Fragment, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const DataTemplateTitle = (props) => {
+const DataTemplateTitle = observer<{ index: number }>((props) => {
   const array = ArrayBase.useArray();
   const index = ArrayBase.useIndex(props.index);
   const { t } = useTranslation();
@@ -22,17 +22,18 @@ const DataTemplateTitle = (props) => {
       value.title = `${t('Template name')} ${array?.field?.value?.length}`;
     }
   }, []);
+
   return (
     <Input.TextArea
       value={value.title}
       placeholder={t('Template name')}
       onChange={(ev) => {
         ev.stopPropagation();
-        array.field.value.splice(index, 1, { ...value, title: ev.target.value });
+        value.title = ev.target.value;
       }}
       onBlur={(ev) => {
         ev.stopPropagation();
-        array.field.value.splice(index, 1, { ...value, title: ev.target.value });
+        value.title = ev.target.value;
       }}
       autoSize
       style={{ width: '70%', border: 'none' }}
@@ -41,7 +42,7 @@ const DataTemplateTitle = (props) => {
       }}
     />
   );
-};
+});
 
 export interface IArrayCollapseProps extends CollapseProps {
   defaultOpenPanelCount?: number;


### PR DESCRIPTION
## Description (Bug 描述)
如下图所示，如果先输入 `模板标题` 会导致其它选项异常。

![img_v2_f03814af-6a79-426d-88d8-00a6c5c85e4g](https://github.com/nocobase/nocobase/assets/38434641/a8a0c312-482b-4fcd-a49e-ea0bb58574a6)


### Steps to reproduce (复现步骤)
1. 打开设置数据模板弹窗
2. 先输入 `模板标题`
3. 再切换 `数据表`
4. 会发现 `模板数据` 还是保持原样，并没有跟着 `数据表` 切换

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
- 无论是否是先输入 `模板标题` 都不影响其它选项的正常使用
<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
- 参考上面的 `复现步骤`
<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
- 在修改 `模板标题` 的时候破环了原有数据的响应性，导致数据变更之后 UI 没有刷新
<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)
- 在 `DataTemplateTitle` 组件中修改 `onChange` 和 `onBlur` 的监听方法，防止破环数据的响应性。

具体变动请看：https://github.com/nocobase/nocobase/pull/1937/files?diff=split&w=0
<!-- Describe solution to the bug clearly and consciously. -->
