### PR TITLE
fix(useAssociationNames): undefined mode in useAssociationNames

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -1121,7 +1121,7 @@ export const useAssociationNames = (collection) => {
         if (['Nester', 'SubTable'].includes(s['x-component-props']?.mode)) {
           associationValues.push(s.name);
         }
-        if (s['x-component-props'].mode === 'Nester') {
+        if (s['x-component-props']?.mode === 'Nester') {
           return getAssociationAppends(s, buf);
         }
         return buf;


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)
表格中添加bulk edit -> Form-> 添加关系字段
<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
正常使用
<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
报错，cant not read properties of undefined (read mode) 

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
schema的‘x-compoent-props'不一定有mode属性

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)
schema['x-component-props'].?mode==='Nester'
使用可选链操作符（Optional Chaining Operator）?.。这样，如果 mode 存在，表达式将返回 mode 的值；如果 mode 不存在，则整个表达式的结果为 undefined。

<!-- Describe solution to the bug clearly and consciously. -->
