### PR TITLE
fix(plugin-formula): fix read-pretty component when used in association field

### DIFF
--- a/packages/plugins/formula-field/src/client/components/Formula/index.tsx
+++ b/packages/plugins/formula-field/src/client/components/Formula/index.tsx
@@ -6,6 +6,6 @@ import Result from './Result';
 export const Formula = () => null;
 
 Formula.Expression = Expression;
-Formula.Result = connect(Result, mapReadPretty(Result.ReadPretty));
+Formula.Result = connect(Result);
 
 export default Formula;

--- a/packages/plugins/formula-field/src/client/interfaces/formula.tsx
+++ b/packages/plugins/formula-field/src/client/interfaces/formula.tsx
@@ -67,7 +67,7 @@ export default {
     type: 'formula',
     // name,
     uiSchema: {
-      type: 'number',
+      type: 'string',
       // title,
       'x-component': 'Formula.Result',
       'x-component-props': {


### PR DESCRIPTION
## Description (Bug 描述)

公式字段在表格中展示时间格式有误，未按照 DatePicker 组件的格式展示。

> 公式日期字段，只选择了日期格式，没有选时间，刚升级版本后就这样了
> 
> <img width="385" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/48127588-042d-4261-b538-d35eae1ec450">

### Steps to reproduce (复现步骤)

1. 公式字段选择存储类型为 `Datetime`，格式为“年-月-日”。
2. 表达式填入“创建时间”变量。
3. 在表格中插入数据。
4. 查看公式结果列。

### Expected behavior (预期行为)

按照选择的时间格式展示。

### Actual behavior (实际行为)

未按照 DatePicker 组件的格式展示。

## Related issues (相关 issue)

#1911 #1805

## Reason (原因)

#1911 中修改了 `Formula.Result` 组件的 read-pretty 格式引入。

## Solution (解决方案)

恢复到 #1911 之前，但为解决 #1805，重新处理关系字段的配置读取问题。

## 其他影响

由于当前表格的关系字段展示选择标题列未对任意组件适配，所以暂时不支持从关系字段展示关系数据标题列为公式的结果组件渲染优化，会造成以此种方式展示日期类型公式结果时显示为 ISOString。但可以通过直接引用关系字段的字段绕过，可正常显示。

相关代码未来需要改进：

https://github.com/nocobase/nocobase/blob/3f4cd86465512e71bdb8776858d7215408b317c0/packages/core/client/src/schema-component/antd/association-field/util.ts#L44