### PR TITLE
fix(form-item): data scope and sorting rule config should only display in association field

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -130,7 +130,7 @@ FormItem.Designer = function Designer() {
     ? getCollectionFields(collectionField?.target)
     : getCollectionFields(collectionField?.targetCollection) ?? [];
   const fieldModeOptions = useFieldModeOptions();
-  const isAssociationField = ['belongsTo', 'hasOne', 'hasMany', 'belongsToMany'].includes(collectionField?.type);
+  const isAssociationField = ['obo', 'oho', 'o2o', 'o2m', 'm2m', 'm2o'].includes(collectionField?.interface);
   const isTableField = fieldSchema['x-component'] === 'TableField';
   const isFileField = isFileCollection(targetCollection);
   const initialValue = {
@@ -179,7 +179,6 @@ FormItem.Designer = function Designer() {
   const isPickerMode = fieldSchema['x-component-props']?.mode === 'Picker';
   const showFieldMode = isAssociationField && fieldModeOptions && !isTableField;
   const showModeSelect = showFieldMode && isPickerMode;
-
   return (
     <GeneralSchemaDesigner>
       <GeneralSchemaItems />

--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -160,7 +160,7 @@ FormItem.Designer = function Designer() {
   const sortFields = useSortFields(collectionField?.target);
   const defaultSort = field.componentProps?.service?.params?.sort || [];
   const fieldMode = field?.componentProps?.['mode'] || (isFileField ? 'FileManager' : 'Select');
-  const isSelectFieldMode = fieldMode === 'Select';
+  const isSelectFieldMode = isAssociationField && fieldMode === 'Select';
   const sort = defaultSort?.map((item: string) => {
     return item?.startsWith('-')
       ? {

--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -662,7 +662,7 @@ FormItem.Designer = function Designer() {
           }}
         />
       )}
-      {IsShowMultipleSwitch() ? (
+      {isAssociationField && IsShowMultipleSwitch() ? (
         <SchemaSettings.SwitchItem
           key="multiple"
           title={t('Allow multiple')}


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)
![img_v2_c7e494e7-6f48-4a38-9e92-1ed6b0ed2d2g](https://github.com/nocobase/nocobase/assets/25933040/ef4be0ed-2a75-4465-9038-2946859f2d86)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
普通字段不应该有 数据范围和排序规则
<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
应该通过interface来判断关系字段而不是通过type来判断关系字段，行政区划 和附件字段虽然也是关系字段但不应该出现范围配置等关系字段配置

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
