### PR TITLE
fix: treeCollection config in detail block

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/TableBlockDesigner.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/TableBlockDesigner.tsx
@@ -16,7 +16,7 @@ import { FilterDynamicComponent } from './FilterDynamicComponent';
 
 export const TableBlockDesigner = () => {
   const { name, title, sortable } = useCollection();
-  const { getCollectionField } = useCollectionManager();
+  const { getCollectionField, getCollection } = useCollectionManager();
   const field = useField();
   const fieldSchema = useFieldSchema();
   const dataSource = useCollectionFilterOptions(name);
@@ -43,7 +43,9 @@ export const TableBlockDesigner = () => {
   const template = useSchemaTemplate();
   const collection = useCollection();
   const { dragSort, resource } = field.decoratorProps;
-  const treeChildren = resource?.includes('.') ? getCollectionField(resource)?.treeChildren : !!collection?.tree;
+  const treeCollection = resource?.includes('.')
+    ? getCollection(getCollectionField(resource)?.target)?.tree
+    : !!collection?.tree;
   const dataScopeSchema = useMemo(() => {
     return {
       type: 'object',
@@ -90,7 +92,7 @@ export const TableBlockDesigner = () => {
         <SchemaSettings.SwitchItem
           title={t('Tree table')}
           defaultChecked={true}
-          checked={treeChildren ? field.decoratorProps.treeTable !== false : false}
+          checked={treeCollection ? field.decoratorProps.treeTable !== false : false}
           onChange={(flag) => {
             field.decoratorProps.treeTable = flag;
             fieldSchema['x-decorator-props'].treeTable = flag;


### PR DESCRIPTION
## Description (Bug 描述)
详情区块中，关系字段树表配置开启后，再次打开配置失效
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
应该判断关系字段的target表是否是树表
<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)
resource -> field -> field.target -> 判断 field.target 是不是树表

<!-- Describe solution to the bug clearly and consciously. -->
