### PR TITLE
fix(charts): fields undefined bug

### DIFF
--- a/packages/plugins/charts/src/client/hooks/index.ts
+++ b/packages/plugins/charts/src/client/hooks/index.ts
@@ -8,7 +8,7 @@ const useFieldsById = (queryId: number) => {
     const chartQueryList = ctx?.data;
     if (chartQueryList && Array.isArray(chartQueryList)) {
       const currentQuery = chartQueryList.find((chartQuery) => chartQuery.id === queryId);
-      setFields(currentQuery?.fields);
+      setFields(currentQuery?.fields || []);
     }
   }, [queryId]);
   return {


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

创建图表数据源>正常添加图表>删除数据源>图表右上角编辑图表

### Expected behavior (预期行为)

页面正常

### Actual behavior (实际行为)

页面报错

<img width="1421" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/5ca5ce03-4594-4ac4-9048-b90fb9299553">

## Reason (原因)

设计器弹窗前会从数据源中获取当前数据源中存在的字段，删除数据源后 `fields`变量值可能为 `undefined`

## Solution (解决方案)

当 `fields` 为 `undefined`时，使用空数组`[]`赋值。

页面正常显示

<img width="1220" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/9fec1ed1-a190-4b47-bf8d-1d48791c3eea">

