### PR TITLE
fix: fix default value is invalid in subform

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
@@ -36,7 +36,7 @@ export const AssociationFieldProvider = observer((props) => {
       // Nester 子表单时，如果没数据初始化一个 [null] 的占位
       if (currentMode === 'Nester' && Array.isArray(field.value)) {
         if (field.value.length === 0 && ['belongsToMany', 'hasMany'].includes(collectionField.type)) {
-          field.value = [null];
+          field.value = [{}];
         }
       }
       setLoading(false);
@@ -46,7 +46,7 @@ export const AssociationFieldProvider = observer((props) => {
       if (['belongsTo', 'hasOne'].includes(collectionField.type)) {
         field.value = {};
       } else if (['belongsToMany', 'hasMany'].includes(collectionField.type)) {
-        field.value = [null];
+        field.value = [{}];
       }
     }
     setLoading(false);

--- a/packages/core/client/src/schema-component/antd/association-field/Nester.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/Nester.tsx
@@ -60,7 +60,7 @@ const ToManyNester = observer((props) => {
                           startIndex: index + 1,
                           insertCount: 1,
                         });
-                        field.value.splice(index + 1, 0, null);
+                        field.value.splice(index + 1, 0, {});
                         return field.onInput(field.value);
                       });
                     }}

--- a/packages/core/client/src/schema-component/common/utils/uitls.tsx
+++ b/packages/core/client/src/schema-component/common/utils/uitls.tsx
@@ -1,6 +1,7 @@
 import flat from 'flat';
-import _, { every, findIndex, some, isArray } from 'lodash';
+import _, { every, findIndex, isArray, some } from 'lodash';
 import moment from 'moment';
+import { useMemo } from 'react';
 import { useCurrentUserContext } from '../../../user';
 import jsonLogic from '../../common/utils/logic';
 
@@ -13,12 +14,14 @@ type VariablesCtx = {
 export const useVariablesCtx = (): VariablesCtx => {
   const { data } = useCurrentUserContext() || {};
 
-  return {
-    $user: data?.data || {},
-    $date: {
-      now: () => moment().toISOString(),
-    },
-  };
+  return useMemo(() => {
+    return {
+      $user: data?.data || {},
+      $date: {
+        now: () => moment().toISOString(),
+      },
+    };
+  }, [data]);
 };
 
 export const isVariable = (str: unknown) => {
@@ -63,7 +66,7 @@ const getFieldValue = (fieldPath, values) => {
   const regex = new RegExp('^' + v + '\\..+\\.' + h + '$'); // 构建匹配的正则表达式
   const matchedValues = [];
   const data = flat.flatten(values, { maxDepth: 3 });
-  for (var key in data) {
+  for (const key in data) {
     if (regex.test(key)) {
       matchedValues.push(data[key]);
     }


### PR DESCRIPTION
## Description (Bug 描述)
用户反馈，在子表单中设置的默认值不生效：

![20230606143639_rec_](https://github.com/nocobase/nocobase/assets/38434641/67f6a5e4-db37-4d5f-b73b-07c4221f5afa)


### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->
1. 新增一个 `对多` 关系字段
2. 修改成 `子表单` 模式
3. 在子表单中增加一个字段，然后设置默认值
4. 关闭弹窗再打开会发现刚才设置的默认值没有显示

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->
设置的默认值应该正常显示
### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->
默认值没有显示
## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->
主要是 null 值导致的字段默认值失效


## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
把占位作用的 `null` 修改成一个空对象
