### PR TITLE
fix(display-title): display on even after the title configuration is turned off

### DIFF
--- a/packages/core/client/src/schema-items/GeneralSchemaItems.tsx
+++ b/packages/core/client/src/schema-items/GeneralSchemaItems.tsx
@@ -56,7 +56,7 @@ export const GeneralSchemaItems: React.FC<{
           />
         )}
         <SchemaSettings.SwitchItem
-          checked={fieldSchema['x-decorator-props'] ?? true}
+          checked={field.decoratorProps.showTitle ?? true}
           title={t('Display title')}
           onChange={(checked) => {
             fieldSchema['x-decorator-props'] = fieldSchema['x-decorator-props'] || {};


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)
标题字段关闭后，配置里的标题字段仍显示ka开启
![img_v2_c96f3b99-21a8-478b-b2e6-c5d9843a1c8g](https://github.com/nocobase/nocobase/assets/25933040/920765c1-d3f7-4b5c-8b2c-af6c97689d89)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
标题隐藏同时标题配置关闭
<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
标题隐藏而标题配置中却是开启的

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
标题字段配置项取值不对

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
