### PR TITLE
fix: editing and details should have no default values setting

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -169,6 +169,8 @@ FormItem.Designer = function Designer() {
   const isPickerMode = fieldSchema['x-component-props']?.mode === 'Picker';
   const showFieldMode = isAssociationField && fieldModeOptions && !isTableField;
   const showModeSelect = showFieldMode && isPickerMode;
+  const formContext = useFormBlockContext();
+  const isAddNewForm = !formContext.action;
   return (
     <GeneralSchemaDesigner>
       <GeneralSchemaItems />
@@ -335,6 +337,7 @@ FormItem.Designer = function Designer() {
         />
       )}
       {form &&
+        isAddNewForm &&
         !form?.readPretty &&
         isShowDefaultValue(collectionField, getInterface) &&
         !isPatternDisabled(fieldSchema) && (

--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -421,6 +421,7 @@ FormItem.Designer = function Designer() {
               };
               if (field.value !== v.default) {
                 field.value = parseVariables(v.default, variablesCtx);
+                field.initialValue = parseVariables(v.default, variablesCtx);
               }
               fieldSchema.default = v.default;
               schema.default = v.default;

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -78,7 +78,6 @@ export const Templates = ({ style = {}, form }) => {
   const [value, setValue] = React.useState(defaultTemplate?.key || 'none');
   const api = useAPIClient();
   const { t } = useTranslation();
-  form.__initValues = JSON.parse(JSON.stringify(form?.initialValues));
   useEffect(() => {
     if (enabled && defaultTemplate) {
       form.__template = true;
@@ -122,7 +121,6 @@ export const Templates = ({ style = {}, form }) => {
         });
     } else {
       form?.reset();
-      form.setValues(form.__initValues, 'overwrite');
     }
   }, []);
 

--- a/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Templates.tsx
@@ -78,7 +78,7 @@ export const Templates = ({ style = {}, form }) => {
   const [value, setValue] = React.useState(defaultTemplate?.key || 'none');
   const api = useAPIClient();
   const { t } = useTranslation();
-
+  form.__initValues = JSON.parse(JSON.stringify(form?.initialValues));
   useEffect(() => {
     if (enabled && defaultTemplate) {
       form.__template = true;
@@ -122,6 +122,7 @@ export const Templates = ({ style = {}, form }) => {
         });
     } else {
       form?.reset();
+      form.setValues(form.__initValues, 'overwrite');
     }
   }, []);
 

--- a/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
+++ b/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
@@ -217,7 +217,7 @@ export const CreateAction = observer(
               onClick?.(collection.name);
             }}
             style={{
-              display: !designable && field?.data?.hidden && 'none',
+              display: !designable && field?.data?.hidden ? 'none' : 'flex',
               opacity: designable && field?.data?.hidden && 0.1,
             }}
           >

--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -683,6 +683,7 @@ export const useCurrentSchema = (action: string, key: string, find = findSchema,
   const { remove } = useDesignable();
   const schema = find(fieldSchema, key, action);
   const ctx = useContext(BlockRequestContext);
+  const form = useForm();
 
   return {
     schema,
@@ -693,6 +694,7 @@ export const useCurrentSchema = (action: string, key: string, find = findSchema,
         ctx.field.data.activeFields = ctx.field.data.activeFields || new Set();
         ctx.field.data.activeFields.delete(schema.name);
       }
+      form.clearFormGraph(schema.name);
       schema && rm(schema, remove);
     },
   };
@@ -1064,9 +1066,6 @@ export const createGridCardBlockSchema = (options) => {
       ...others,
     },
     'x-component': 'BlockItem',
-    'x-component-props': {
-      useProps: '{{ useGridCardBlockItemProps }}',
-    },
     'x-designer': 'GridCard.Designer',
     properties: {
       actionBar: {
@@ -1084,7 +1083,7 @@ export const createGridCardBlockSchema = (options) => {
         type: 'array',
         'x-component': 'GridCard',
         'x-component-props': {
-          useProps: '{{ useGridCardBlockProps }}',
+          props: '{{ useGridCardBlockProps }}',
         },
         properties: {
           item: {
@@ -1326,6 +1325,8 @@ export const createTableBlockSchema = (options) => {
     TableBlockDesigner,
     blockType,
     pageSize = 20,
+    // 当前filter 不需要在 "设置数据范围" 表单里初始化，只需要在查询的时候合并到查询条件 filter中
+    crypticFilter = {},
     ...others
   } = options;
   const schema: ISchema = {
@@ -1338,6 +1339,7 @@ export const createTableBlockSchema = (options) => {
       action: 'list',
       params: {
         pageSize,
+        filter: crypticFilter,
       },
       rowKey,
       showIndex: true,


### PR DESCRIPTION
## Description (Bug 描述)
1创建表单时、子表单添加时才有默认值，编辑和详情无默认值
2.实时配置状态下，字段配置了默认值后，删掉字段，再次添加该字段，默认值还在（需要刷新页面才好），必输属性类似
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
