### PR TITLE
fix(select):  default value for multiple select cannot be set

### DIFF
--- a/packages/core/client/src/schema-component/antd/select/Select.tsx
+++ b/packages/core/client/src/schema-component/antd/select/Select.tsx
@@ -88,7 +88,10 @@ const InternalSelect = connect(
     }
     const toValue = (v) => {
       if (['tags', 'multiple'].includes(props.mode) || props.multiple) {
-        return toArr(v);
+        if (v) {
+          return toArr(v);
+        }
+        return undefined;
       }
       return v;
     };


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)
多选字段的默认值无法设置
<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

Close T-284
