### PR TITLE
fix(Varaible): fix option is disabled

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -218,7 +218,7 @@ export function Input(props) {
           if (i === 0) {
             prevOption = options.find((item) => item.value === key);
           } else {
-            if (prevOption.loadChildren) {
+            if (prevOption.loadChildren && !prevOption.children?.length) {
               await prevOption.loadChildren(prevOption);
             }
             prevOption = prevOption.children.find((item) => item.value === key);

--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -152,18 +152,20 @@ export function Input(props) {
 
   const { component: ConstantComponent, ...constantOption }: VariableOptions & { component?: React.FC<any> } =
     useMemo(() => {
-      return children
-        ? {
-            value: '',
-            label: '{{t("Constant")}}',
-          }
-        : useTypedConstant
-        ? getTypedConstantOption(type, useTypedConstant)
-        : {
-            value: '',
-            label: '{{t("Null")}}',
-            component: ConstantTypes.null.component,
-          };
+      if (children) {
+        return {
+          value: '',
+          label: '{{t("Constant")}}',
+        };
+      }
+      if (useTypedConstant) {
+        return getTypedConstantOption(type, useTypedConstant);
+      }
+      return {
+        value: '',
+        label: '{{t("Null")}}',
+        component: ConstantTypes.null.component,
+      };
     }, [type, useTypedConstant]);
 
   const options: VariableOptions[] = useMemo(

--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -14,6 +14,23 @@ import { Option } from '../../../schema-settings/VariableInput/type';
 import { XButton } from './XButton';
 
 const JT_VALUE_RE = /^\s*{{\s*([^{}]+)\s*}}\s*$/;
+const groupClass = css`
+  width: auto;
+  display: flex !important;
+  .ant-input-disabled {
+    .ant-tag {
+      color: #bfbfbf;
+      border-color: #d9d9d9;
+    }
+  }
+  .ant-input.null-value {
+    width: 4em;
+    min-width: 4em;
+  }
+`;
+const userSelectNone = css`
+  user-select: 'none';
+`;
 
 function parseValue(value: any): string | string[] {
   if (value == null) {
@@ -133,14 +150,6 @@ export function Input(props) {
 
   const [variableText, setVariableText] = React.useState('');
 
-  const loadData = (selectedOptions: Option[]) => {
-    const option = selectedOptions[selectedOptions.length - 1];
-    if (option.loadChildren) {
-      // 需要保证 selectedOptions 是一个响应式对象，这样才能触发重新渲染
-      option.loadChildren(option);
-    }
-  };
-
   const { component: ConstantComponent, ...constantOption }: VariableOptions & { component?: React.FC<any> } =
     useMemo(() => {
       return children
@@ -161,6 +170,13 @@ export function Input(props) {
     () => compile([constantOption, ...variableOptions]),
     [constantOption, variableOptions],
   );
+
+  const loadData = async (selectedOptions: Option[]) => {
+    const option = selectedOptions[selectedOptions.length - 1];
+    if (option.loadChildren) {
+      await option.loadChildren(option);
+    }
+  };
 
   const onSwitch = useCallback(
     (next) => {
@@ -215,27 +231,7 @@ export function Input(props) {
   const disabled = props.disabled || form.disabled;
 
   return (
-    <AntInput.Group
-      compact
-      style={style}
-      className={classNames(
-        className,
-        css`
-          width: auto;
-          display: flex !important;
-          .ant-input-disabled {
-            .ant-tag {
-              color: #bfbfbf;
-              border-color: #d9d9d9;
-            }
-          }
-          .ant-input.null-value {
-            width: 4em;
-            min-width: 4em;
-          }
-        `,
-      )}
-    >
+    <AntInput.Group compact style={style} className={classNames(className, groupClass)}>
       {variable ? (
         <div
           className={css`
@@ -282,12 +278,7 @@ export function Input(props) {
           </div>
           {!disabled ? (
             <span
-              className={cx(
-                'ant-select-clear',
-                css`
-                  user-select: 'none';
-                `,
-              )}
+              className={cx('ant-select-clear', userSelectNone)}
               // eslint-disable-next-line react/no-unknown-property
               unselectable="on"
               aria-hidden

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
@@ -1,146 +1,148 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export const useDateVariable = ({ operator, schema }) => {
+  const { t } = useTranslation();
   const operatorValue = operator?.value || '';
   const disabled = !['DatePicker', 'DatePicker.RangePicker'].includes(schema?.['x-component']);
   const dateOptions = [
     {
       key: 'now',
       value: 'now',
-      label: `{{t("Now")}}`,
+      label: t('Now'),
       disabled: schema?.['x-component'] !== 'DatePicker' || operatorValue === '$dateBetween',
     },
     {
       key: 'yesterday',
       value: 'yesterday',
-      label: `{{t("Yesterday")}}`,
+      label: t('Yesterday'),
       disabled,
     },
     {
       key: 'today',
       value: 'today',
-      label: `{{t("Today")}}`,
+      label: t('Today'),
       disabled,
     },
     {
       key: 'tomorrow',
       value: 'tomorrow',
-      label: `{{t("Tomorrow")}}`,
+      label: t('Tomorrow'),
       disabled,
     },
     {
       key: 'lastIsoWeek',
       value: 'lastIsoWeek',
-      label: `{{t("Last week")}}`,
+      label: t('Last week'),
       disabled,
     },
     {
       key: 'thisIsoWeek',
       value: 'thisIsoWeek',
-      label: `{{t("This week")}}`,
+      label: t('This week'),
       disabled,
     },
     {
       key: 'nextIsoWeek',
       value: 'nextIsoWeek',
-      label: `{{t("Next week")}}`,
+      label: t('Next week'),
       disabled,
     },
     {
       key: 'lastMonth',
       value: 'lastMonth',
-      label: `{{t("Last month")}}`,
+      label: t('Last month'),
       disabled,
     },
     {
       key: 'thisMonth',
       value: 'thisMonth',
-      label: `{{t("This month")}}`,
+      label: t('This month'),
       disabled,
     },
     {
       key: 'nextMonth',
       value: 'nextMonth',
-      label: `{{t("Next month")}}`,
+      label: t('Next month'),
       disabled,
     },
     {
       key: 'lastQuarter',
       value: 'lastQuarter',
-      label: `{{t("Last quarter")}}`,
+      label: t('Last quarter'),
       disabled,
     },
     {
       key: 'thisQuarter',
       value: 'thisQuarter',
-      label: `{{t("This quarter")}}`,
+      label: t('This quarter'),
       disabled,
     },
     {
       key: 'nextQuarter',
       value: 'nextQuarter',
-      label: `{{t("Next quarter")}}`,
+      label: t('Next quarter'),
       disabled,
     },
     {
       key: 'lastYear',
       value: 'lastYear',
-      label: `{{t("Last year")}}`,
+      label: t('Last year'),
       disabled,
     },
     {
       key: 'thisYear',
       value: 'thisYear',
-      label: `{{t("This year")}}`,
+      label: t('This year'),
       disabled,
     },
     {
       key: 'nextYear',
       value: 'nextYear',
-      label: `{{t("Next year")}}`,
+      label: t('Next year'),
       disabled,
     },
     {
       key: 'last7Days',
       value: 'last7Days',
-      label: `{{t("Last 7 days")}}`,
+      label: t('Last 7 days'),
       disabled,
     },
     {
       key: 'next7Days',
       value: 'next7Days',
-      label: `{{t("Next 7 days")}}`,
+      label: t('Next 7 days'),
       disabled,
     },
     {
       key: 'last30Days',
       value: 'last30Days',
-      label: `{{t("Last 30 days")}}`,
+      label: t('Last 30 days'),
       disabled,
     },
     {
       key: 'next30Days',
       value: 'next30Days',
-      label: `{{t("Next 30 days")}}`,
+      label: t('Next 30 days'),
       disabled,
     },
     {
       key: 'last90Days',
       value: 'last90Days',
-      label: `{{t("Last 90 days")}}`,
+      label: t('Last 90 days'),
       disabled,
     },
     {
       key: 'next90Days',
       value: 'next90Days',
-      label: `{{t("Next 90 days")}}`,
+      label: t('Next 90 days'),
       disabled,
     },
   ];
 
   const result = useMemo(() => {
     return {
-      label: `{{t("Date variables")}}`,
+      label: t('Date variables'),
       value: '$date',
       key: '$date',
       disabled: dateOptions.every((option) => option.disabled),

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
@@ -1,18 +1,14 @@
-import { useCompile } from '../../../schema-component';
+import { useMemo } from 'react';
 
 export const useDateVariable = ({ operator, schema }) => {
-  const compile = useCompile();
   const operatorValue = operator?.value || '';
-
-  if (!operator || !schema) return null;
-
-  const disabled = !['DatePicker', 'DatePicker.RangePicker'].includes(schema['x-component']);
+  const disabled = !['DatePicker', 'DatePicker.RangePicker'].includes(schema?.['x-component']);
   const dateOptions = [
     {
       key: 'now',
       value: 'now',
       label: `{{t("Now")}}`,
-      disabled: schema['x-component'] !== 'DatePicker' || operatorValue === '$dateBetween',
+      disabled: schema?.['x-component'] !== 'DatePicker' || operatorValue === '$dateBetween',
     },
     {
       key: 'yesterday',
@@ -142,11 +138,17 @@ export const useDateVariable = ({ operator, schema }) => {
     },
   ];
 
-  return compile({
-    label: `{{t("Date variables")}}`,
-    value: '$date',
-    key: '$date',
-    disabled: dateOptions.every((option) => option.disabled),
-    children: dateOptions,
-  });
+  const result = useMemo(() => {
+    return {
+      label: `{{t("Date variables")}}`,
+      value: '$date',
+      key: '$date',
+      disabled: dateOptions.every((option) => option.disabled),
+      children: dateOptions,
+    };
+  }, [schema?.['x-component']]);
+
+  if (!operator || !schema) return null;
+
+  return result;
 };

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useUserVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useUserVariable.ts
@@ -1,5 +1,6 @@
 import { error } from '@nocobase/utils/client';
 import { useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useCompile, useGetFilterOptions } from '../../../schema-component';
 import { FieldOption, Option } from '../type';
 
@@ -46,6 +47,7 @@ const getChildren = (options: FieldOption[], { schema, depth, maxDepth, loadChil
 };
 
 export const useUserVariable = ({ schema, maxDepth = 3 }: { schema: any; maxDepth?: number }) => {
+  const { t } = useTranslation();
   const compile = useCompile();
   const getFilterOptions = useGetFilterOptions();
   const schemaRef = useRef(schema);
@@ -80,7 +82,7 @@ export const useUserVariable = ({ schema, maxDepth = 3 }: { schema: any; maxDept
 
   const result = useMemo(() => {
     return {
-      label: `{{t("Current user")}}`,
+      label: t('Current user'),
       value: '$user',
       key: '$user',
       children: [],

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useUserVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useUserVariable.ts
@@ -72,6 +72,11 @@ export const useUserVariable = ({ schema, maxDepth = 3 }: { schema: any; maxDept
             loadChildren,
           }) || [];
 
+        if (children.length === 0) {
+          option.disabled = true;
+          resolve(void 0);
+          return;
+        }
         option.children = compile(children);
         resolve(void 0);
 

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useUserVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useUserVariable.ts
@@ -1,4 +1,3 @@
-import { observable } from '@formily/reactive';
 import { error } from '@nocobase/utils/client';
 import { useMemo, useRef } from 'react';
 import { useCompile, useGetFilterOptions } from '../../../schema-component';
@@ -80,7 +79,7 @@ export const useUserVariable = ({ schema, maxDepth = 3 }: { schema: any; maxDept
   };
 
   const result = useMemo(() => {
-    return compile({
+    return {
       label: `{{t("Current user")}}`,
       value: '$user',
       key: '$user',
@@ -91,9 +90,8 @@ export const useUserVariable = ({ schema, maxDepth = 3 }: { schema: any; maxDept
       },
       depth: 0,
       loadChildren,
-    } as Option);
-  }, []);
+    } as Option;
+  }, [schema?.['x-component']]);
 
-  // 必须使用 observable 包一下，使其变成响应式对象，不然 children 加载后不会更新 UI
-  return observable(result);
+  return result;
 };

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useVariableOptions.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useVariableOptions.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useValues } from '../../../schema-component/antd/filter/useValues';
 import { useDateVariable } from './useDateVariable';
 import { useUserVariable } from './useUserVariable';
@@ -7,7 +8,9 @@ export const useVariableOptions = () => {
   const userVariable = useUserVariable({ maxDepth: 3, schema });
   const dateVariable = useDateVariable({ operator, schema });
 
+  const result = useMemo(() => [userVariable, dateVariable], [dateVariable, userVariable]);
+
   if (!operator || !schema) return [];
 
-  return [userVariable, dateVariable];
+  return result;
 };


### PR DESCRIPTION
### Steps to reproduce (复现步骤)
如视频所示，在字段由 `ID` 改成 `昵称` 的时候，变量 `昵称` 选项被禁用了，这是错误的。

https://github.com/nocobase/nocobase/assets/38434641/ddeae922-40e0-4745-8ed9-1399ae76a855



<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->
不应该禁用掉 `昵称` 选项。
### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->
`昵称` 选项被禁用掉了。
## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->
在 #1880 中 `useCompile` 被修改成具有缓存的功能，以获得更好的性能，但直接导致 `options` 数据一直是之前的老数据，其 `loadChildren` 函数不是最新的，所以才会出现这个 BUG。


## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
1. 重写 `useUserVariable` ，放弃使用 `响应式对象` 方案
2. 因为 `compile` 每次返回的都是同一个对象，所以需要手动更新 `loadChildren` 的值
3. 在每次数据变更时，调用 `setOptions` 用以刷新页面