### PR TITLE
fix: enable tab and deleting tab page  will result in an error

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/Page.tsx
+++ b/packages/core/client/src/schema-component/antd/page/Page.tsx
@@ -139,7 +139,7 @@ export const Page = (props) => {
   const [loading, setLoading] = useState(false);
   const [activeKey, setActiveKey] = useState(() => {
     // @ts-ignore
-    return location?.query?.tab || Object.keys(fieldSchema.properties).shift();
+    return location?.query?.tab || Object.keys(fieldSchema.properties || {}).shift();
   });
 
   const [height, setHeight] = useState(0);


### PR DESCRIPTION
## Description (Bug 描述)
页面启用选项卡后删除掉选项页面，刷新浏览器白屏
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
Object.keys(fieldSchema.properties)方法报错，删掉唯一标签页后，fieldSchema.properties为null
<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
