### PR TITLE
fix(dnd): block disappears when dragged over its parent

### DIFF
--- a/packages/core/client/src/schema-component/common/dnd-context/index.tsx
+++ b/packages/core/client/src/schema-component/common/dnd-context/index.tsx
@@ -31,6 +31,11 @@ const useDragEnd = (props?: any) => {
       return;
     }
 
+    if (activeSchema.parent === overSchema && insertAdjacent === 'beforeEnd') {
+      props?.onDragEnd?.(event);
+      return;
+    }
+
     const dn = createDesignable({
       t,
       api,


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

创建两个有高度差的区块，拖拽成一行两列的布局，将较矮的区块向下拖拽，但不超出较高区块的范围，较矮的区块会消失。

![20230614183754_rec_](https://github.com/nocobase/nocobase/assets/3250534/5c9467d6-f16e-4f37-bb90-834c4e21009b)

### Expected behavior (预期行为)

布局不发生变化。

### Actual behavior (实际行为)

较矮的区块消失了。

## Reason (原因)

当前父组件下只有一个组件，由于拖拽移除了当前组件，导致父组件下面没有组件，父组件被移除。

`packages/core/client/src/schema-component/hooks/useDesignable.tsx` - `L492`

```
 schema.parent.removeProperty(schema.name);
 if (removeParentsIfNoChildren) {
    opts['removed'] = this.recursiveRemoveIfNoChildren(schema.parent, { breakRemoveOn });
 }
```


## Solution (解决方案)

`packages/core/client/src/schema-component/common/dnd-context/index.tsx`

```
if (activeSchema.parent === overSchema && insertAdjacent === 'beforeEnd') {
    props?.onDragEnd?.(event);
    return;
}
```

拖拽时判断落点位置组件为父组件且插入位置为`beforeEnd`时，不处理。