### PR TITLE
fix: fix default value of optional field

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -112,6 +112,10 @@ FormItem.Designer = function Designer() {
   const IsShowMultipleSwitch = useIsShowMultipleSwitch();
 
   const collectionField = getField(fieldSchema['name']) || getCollectionJoinField(fieldSchema['x-collection-field']);
+  const targetField = getCollectionJoinField(
+    `${collectionField?.target}.${fieldSchema['x-component-props'].fieldNames?.label}`,
+  );
+
   const targetCollection = getCollection(collectionField?.target);
   const interfaceConfig = getInterface(collectionField?.interface);
   const validateSchema = interfaceConfig?.['validateSchema']?.(fieldSchema);
@@ -347,12 +351,13 @@ FormItem.Designer = function Designer() {
                 type: 'object',
                 title: t('Set default value'),
                 properties: {
-                  default: isInvariable(interfaceConfig)
+                  [fieldSchema.name]: isInvariable(interfaceConfig)
                     ? {
                         ...(fieldSchemaWithoutRequired || {}),
                         'x-decorator': 'FormItem',
                         'x-component-props': {
                           ...fieldSchema['x-component-props'],
+                          targetField,
                           component:
                             collectionField?.target && collectionField?.interface !== 'chinaRegion'
                               ? 'AssociationSelect'
@@ -377,6 +382,7 @@ FormItem.Designer = function Designer() {
                         'x-component': 'VariableInput',
                         'x-component-props': {
                           ...(fieldSchema?.['x-component-props'] || {}),
+                          targetField,
                           collectionName: collectionField?.collectionName,
                           schema: collectionField?.uiSchema,
                           className: defaultInputStyle,

--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -351,7 +351,7 @@ FormItem.Designer = function Designer() {
                 type: 'object',
                 title: t('Set default value'),
                 properties: {
-                  [fieldSchema.name]: isInvariable(interfaceConfig)
+                  default: isInvariable(interfaceConfig)
                     ? {
                         ...(fieldSchemaWithoutRequired || {}),
                         'x-decorator': 'FormItem',


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)
见下方视频：


https://github.com/nocobase/nocobase/assets/38434641/c48e3459-e9b6-4c4e-8e24-a48573b44cdf


<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->
![image](https://github.com/nocobase/nocobase/assets/38434641/f853bab9-7bd2-4796-9fe7-18d02e2f63bd)


### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->
![image](https://github.com/nocobase/nocobase/assets/38434641/9be479bf-fb39-4891-bb53-d3921a99d54b)


## Reason (原因)

<!-- Explain what caused the bug to occur. -->
- 缺少 `targetField` 参数

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
从外面传进来一个 `targetField` 参数

## 其它
close T-471
