### PR TITLE
fix(file-manager): do not delete the selected records

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/FileManager.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/FileManager.tsx
@@ -112,6 +112,7 @@ const InternalFileManager = (props) => {
     association: {
       target: collectionField?.target,
     },
+    options,
     onChange: props?.onChange,
     selectedRows,
     setSelectedRows,


### PR DESCRIPTION
## Description (Bug 描述)
文章表多对多文件表，文件字段 select 文件之后，不应该把之前已选的文件给移除了
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
