### PR TITLE
fix(Data-template): fix field cannot be expanded

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -1,15 +1,15 @@
-import { ISchema, useField, useFieldSchema, connect, mapProps } from '@formily/react';
+import { ISchema, connect, mapProps, useField, useFieldSchema } from '@formily/react';
 import { isValid, uid } from '@formily/shared';
-import { Menu, Tree as AntdTree } from 'antd';
+import { Tree as AntdTree, Menu } from 'antd';
 import { cloneDeep } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDesignable } from '../..';
-import { useCollection, useCollectionManager, useCollectionFieldsOptions } from '../../../collection-manager';
+import { useCollection, useCollectionFieldsOptions, useCollectionManager } from '../../../collection-manager';
 import { OpenModeSchemaItems } from '../../../schema-items';
 import { GeneralSchemaDesigner, SchemaSettings } from '../../../schema-settings';
-import { useLinkageAction } from './hooks';
 import { useCollectionState } from '../../../schema-settings/DataTemplates/hooks/useCollectionState';
+import { useLinkageAction } from './hooks';
 import { requestSettingsSchema } from './utils';
 
 const Tree = connect(
@@ -70,7 +70,7 @@ export const ActionDesigner = (props) => {
   const isDelete = fieldSchema?.parent['x-component'] === 'CollectionField';
   const isDraggable = fieldSchema?.parent['x-component'] !== 'CollectionField';
   const isDuplicateAction = fieldSchema['x-action'] === 'duplicate';
-  const { collectionList, getEnableFieldTree, onLoadData, onCheck } = useCollectionState(name);
+  const { collectionList, getEnableFieldTree, getOnLoadData, getOnCheck } = useCollectionState(name);
   const duplicateValues = cloneDeep(fieldSchema['x-component-props'].duplicateFields || []);
   const options = useCollectionFieldsOptions(name, 1, ['id']);
   useEffect(() => {
@@ -236,11 +236,11 @@ export const ActionDesigner = (props) => {
             />
           )}
         {isLinkageAction && <SchemaSettings.LinkageRules collectionName={name} />}
-        {isDuplicateAction && [
+        {isDuplicateAction && (
           <SchemaSettings.ModalItem
             title={t('Duplicate mode')}
             components={{ Tree }}
-            scope={{ getEnableFieldTree, collectionName: name }}
+            scope={{ getEnableFieldTree, collectionName: name, getOnLoadData, getOnCheck }}
             schema={
               {
                 type: 'object',
@@ -283,8 +283,8 @@ export const ActionDesigner = (props) => {
                       checkable: true,
                       checkStrictly: true,
                       selectable: false,
-                      loadData: onLoadData,
-                      onCheck,
+                      loadData: '{{ getOnLoadData($self) }}',
+                      onCheck: '{{ getOnCheck($self) }}',
                       rootStyle: {
                         padding: '8px 0',
                         border: '1px solid #d9d9d9',
@@ -328,8 +328,8 @@ export const ActionDesigner = (props) => {
               });
               dn.refresh();
             }}
-          />,
-        ]}
+          />
+        )}
         <OpenModeSchemaItems openMode={isPopupAction} openSize={isPopupAction}></OpenModeSchemaItems>
         {isUpdateModePopupAction && (
           <SchemaSettings.SelectItem

--- a/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
+++ b/packages/core/client/src/schema-settings/DataTemplates/FormDataTemplates.tsx
@@ -24,7 +24,6 @@ const Tree = connect(
   mapProps({
     value: 'checkedKeys',
     dataSource: 'treeData',
-    // onInput: 'onCheck',
   }),
 );
 
@@ -32,7 +31,7 @@ export const FormDataTemplates = observer(
   (props: any) => {
     const { useProps, formSchema, designerCtx } = props;
     const { defaultValues, collectionName } = useProps();
-    const { collectionList, getEnableFieldTree, onLoadData, onCheck } = useCollectionState(collectionName);
+    const { collectionList, getEnableFieldTree, getOnLoadData, getOnCheck } = useCollectionState(collectionName);
     const { getCollection, getCollectionField } = useCollectionManager();
     const { t } = useTranslation();
 
@@ -73,6 +72,8 @@ export const FormDataTemplates = observer(
         getFieldNames,
         getFilter,
         getResource,
+        getOnLoadData,
+        getOnCheck,
         collectionName,
       }),
       [],
@@ -171,8 +172,8 @@ export const FormDataTemplates = observer(
                         checkable: true,
                         checkStrictly: true,
                         selectable: false,
-                        loadData: onLoadData,
-                        onCheck,
+                        loadData: '{{ getOnLoadData($self) }}',
+                        onCheck: '{{ getOnCheck($self) }}',
                         rootStyle: {
                           padding: '8px 0',
                           border: '1px solid #d9d9d9',


### PR DESCRIPTION
## Description (Bug 描述)
表现为当设置多个 数据模板 时，有些本该可以被展开的字段无法被展开，只有一条模板数据时没有这个问题。

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->
1. 创建两个数据模板
2. 会发现第二个是正常的
3. 而第一个是有问题的，也就是某些字段无法展开

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->
正常展开

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->
没有展开

## Reason (原因)

<!-- Explain what caused the bug to occur. -->
发现之前就有这个问题。
是由于获取的 `fields` 数据错误，导致所有 `fields` 值都是最后一个模板的。

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
1. `onLoadData` 和 `onCheck` 方法改名为 `getOnLoadData` 和 `getOnCheck`
2. 接受当前模板的 `$self` 作为参数（也就是上面说的 fields 的值）
3. 返回一个和之前一样的函数，其 `fields` 的闭包指向参数中传入的值

## 其他
close T-512