### PR TITLE
fix: association field cannot enable link in table column

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/FileManager.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/FileManager.tsx
@@ -161,6 +161,7 @@ const InternalFileManager = (props) => {
           modalProps: {
             getContainer: others?.getContainer,
           },
+          formValueChanged: false,
         }}
       >
         <RecordPickerProvider {...pickerProps}>

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Designer.tsx
@@ -136,7 +136,7 @@ export const TableColumnDesigner = (props) => {
         collectionField?.interface,
       ) &&
         !isFileField &&
-        field.readPrety && (
+        readOnlyMode === 'read-pretty' && (
           <SchemaSettings.SwitchItem
             title={t('Enable link')}
             checked={fieldSchema['x-component-props']?.enableLink !== false}


### PR DESCRIPTION
## Description (Bug 描述)
关系字段在表格中无法配置启用链接
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
