### PR TITLE
refactor(db): add batch logic to update for better performance

### DIFF
--- a/packages/core/database/src/__tests__/repository.test.ts
+++ b/packages/core/database/src/__tests__/repository.test.ts
@@ -411,7 +411,7 @@ describe('repository.update', () => {
     await db.close();
   });
 
-  it('update1', async () => {
+  it('update with filterByTk and with associations', async () => {
     const user = await User.model.create<any>({
       name: 'user1',
     });
@@ -454,7 +454,7 @@ describe('repository.update', () => {
     expect(updated2.posts.length).toBe(2);
   });
 
-  it('update2', async () => {
+  it('update with filterByTk', async () => {
     const user = await User.model.create<any>({
       name: 'user1',
     });
@@ -463,6 +463,9 @@ describe('repository.update', () => {
       name: 'user2',
     });
 
+    const hook = jest.fn();
+    db.on('users.afterUpdate', hook);
+
     await User.repository.update({
       filterByTk: user.id,
       values: {
@@ -470,12 +473,69 @@ describe('repository.update', () => {
       },
     });
 
+    expect(hook).toBeCalledTimes(1);
+
     const updated = await User.model.findByPk(user.id);
 
     expect(updated.get('name')).toEqual('user11');
 
     const u2 = await User.model.findByPk(user2.id);
     expect(u2.get('name')).toEqual('user2');
+  });
+
+  it('update with filter one by one when individualHooks is not set', async () => {
+    const u1 = await User.repository.create({ values: { name: 'u1' } });
+
+    const p1 = await Post.repository.create({ values: { name: 'p1', userId: u1.id } });
+    const p2 = await Post.repository.create({ values: { name: 'p2', userId: u1.id } });
+    const p3 = await Post.repository.create({ values: { name: 'p3' } });
+
+    const hook = jest.fn();
+    db.on('posts.afterUpdate', hook);
+
+    await Post.repository.update({
+      filter: {
+        userId: u1.id,
+      },
+      values: {
+        name: 'pp',
+      },
+    });
+
+    const postsAfterUpdated = await Post.repository.find({ order: [['id', 'ASC']] });
+    expect(postsAfterUpdated[0].name).toBe('pp');
+    expect(postsAfterUpdated[1].name).toBe('pp');
+    expect(postsAfterUpdated[2].name).toBe('p3');
+
+    expect(hook).toBeCalledTimes(2);
+  });
+
+  it('update in batch when individualHooks is false', async () => {
+    const u1 = await User.repository.create({ values: { name: 'u1' } });
+
+    const p1 = await Post.repository.create({ values: { name: 'p1', userId: u1.id } });
+    const p2 = await Post.repository.create({ values: { name: 'p2', userId: u1.id } });
+    const p3 = await Post.repository.create({ values: { name: 'p3' } });
+
+    const hook = jest.fn();
+    db.on('posts.afterUpdate', hook);
+
+    await Post.repository.update({
+      filter: {
+        userId: u1.id,
+      },
+      values: {
+        name: 'pp',
+      },
+      individualHooks: false,
+    });
+
+    const postsAfterUpdated = await Post.repository.find({ order: [['id', 'ASC']] });
+    expect(postsAfterUpdated[0].name).toBe('pp');
+    expect(postsAfterUpdated[1].name).toBe('pp');
+    expect(postsAfterUpdated[2].name).toBe('p3');
+
+    expect(hook).toBeCalledTimes(0);
   });
 });
 

--- a/packages/core/database/src/__tests__/repository.test.ts
+++ b/packages/core/database/src/__tests__/repository.test.ts
@@ -557,10 +557,10 @@ describe('repository.update', () => {
 
     expect(r1).toEqual(1);
 
-    const updatedP1 = await Post.repository.findOne({
+    const p1Updated = await Post.repository.findOne({
       filterByTk: p1.id,
     });
-    expect(updatedP1.userId).toBe(u2.id);
+    expect(p1Updated.userId).toBe(u2.id);
 
     const r2 = await Post.repository.update({
       filter: {
@@ -574,10 +574,27 @@ describe('repository.update', () => {
 
     expect(r2).toEqual(1);
 
-    const updatedP2 = await Post.repository.findOne({
+    const p2Updated = await Post.repository.findOne({
       filterByTk: p2.id,
     });
-    expect(updatedP2.userId).toBe(null);
+    expect(p2Updated.userId).toBe(null);
+
+    const r3 = await Post.repository.update({
+      filter: {
+        id: p1.id,
+      },
+      values: {
+        user: { id: u1.id },
+      },
+      individualHooks: false,
+    });
+
+    expect(r3).toEqual(1);
+
+    const p1Updated2 = await Post.repository.findOne({
+      filterByTk: p1.id,
+    });
+    expect(p1Updated2.userId).toBe(u1.id);
   });
 });
 

--- a/packages/core/database/src/__tests__/update-guard.test.ts
+++ b/packages/core/database/src/__tests__/update-guard.test.ts
@@ -370,6 +370,7 @@ describe('One2One Association', () => {
         uid: 1,
         name: '123',
       },
+      userId: 1,
     };
 
     const guard = new UpdateGuard();
@@ -381,6 +382,7 @@ describe('One2One Association', () => {
       user: {
         uid: 1,
       },
+      userId: 1,
     });
 
     guard.setAssociationKeysToBeUpdate(['user']);

--- a/packages/core/database/src/update-guard.ts
+++ b/packages/core/database/src/update-guard.ts
@@ -146,7 +146,7 @@ export class UpdateGuard {
 
       if (associationObj.associationType === 'BelongsTo') {
         if (typeof associationValues === 'object' && associationValues !== null) {
-          if (associationValues[(associationObj as any).targetKey]) {
+          if (associationValues[(associationObj as any).targetKey] != null) {
             values[(associationObj as any).foreignKey] = associationValues[(associationObj as any).targetKey];
           }
         } else {

--- a/packages/core/database/src/update-guard.ts
+++ b/packages/core/database/src/update-guard.ts
@@ -144,11 +144,14 @@ export class UpdateGuard {
       // set association values to sanitized value
       values[association] = associationValues;
 
-      if (
-        associationObj.associationType === 'BelongsTo' &&
-        (typeof associationValues !== 'object' || associationValues === null)
-      ) {
-        values[(associationObj as any).foreignKey] = associationValues;
+      if (associationObj.associationType === 'BelongsTo') {
+        if (typeof associationValues === 'object' && associationValues !== null) {
+          if (associationValues[(associationObj as any).targetKey]) {
+            values[(associationObj as any).foreignKey] = associationValues[(associationObj as any).targetKey];
+          }
+        } else {
+          values[(associationObj as any).foreignKey] = associationValues;
+        }
       }
     });
 

--- a/packages/core/database/src/update-guard.ts
+++ b/packages/core/database/src/update-guard.ts
@@ -93,6 +93,8 @@ export class UpdateGuard {
     Object.keys(associationsValues).forEach((association) => {
       let associationValues = associationsValues[association];
 
+      const associationObj = associations[association];
+
       const filterAssociationToBeUpdate = (value) => {
         if (value === null) {
           return value;
@@ -103,8 +105,6 @@ export class UpdateGuard {
         if (associationKeysToBeUpdate.includes(association)) {
           return value;
         }
-
-        const associationObj = associations[association];
 
         const associationKeyName =
           associationObj.associationType == 'BelongsTo' || associationObj.associationType == 'HasOne'
@@ -143,6 +143,13 @@ export class UpdateGuard {
 
       // set association values to sanitized value
       values[association] = associationValues;
+
+      if (
+        associationObj.associationType === 'BelongsTo' &&
+        (typeof associationValues !== 'object' || associationValues === null)
+      ) {
+        values[(associationObj as any).foreignKey] = associationValues;
+      }
     });
 
     if (values instanceof Model) {

--- a/packages/plugins/workflow/src/client/locale/zh-CN.ts
+++ b/packages/plugins/workflow/src/client/locale/zh-CN.ts
@@ -171,6 +171,13 @@ export default {
   'Update record': '更新数据',
   'Update records of a collection. You can use variables from upstream nodes as query conditions and field values.':
     '更新一个数据表中的数据。可以使用上游节点里的变量作为查询条件和数据值。',
+  'Update mode': '更新模式',
+  'Update in a batch': '批量更新',
+  'Update one by one': '逐条更新',
+  'Update all eligible data at one time, which has better performance when the amount of data is large. But the updated data will not trigger other workflows, and will not record audit logs.':
+    '一次性更新所有符合条件的数据，在数据量较大时有比较好的性能；但被更新的数据不会触发其他工作流，也不会记录更新日志。',
+  'The updated data can trigger other workflows, and the audit log will also be recorded. But it is usually only applicable to several or dozens of pieces of data, otherwise there will be performance problems.':
+    '被更新的数据可以再次触发其他工作流，也会记录更新日志；但通常只适用于数条或数十条数据，否则会有性能问题。',
   'Query record': '查询数据',
   'Query records from a collection. You can use variables from upstream nodes as query conditions.':
     '查询一个数据表中的数据。可以使用上游节点里的变量作为查询条件。',

--- a/packages/plugins/workflow/src/client/nodes/update.tsx
+++ b/packages/plugins/workflow/src/client/nodes/update.tsx
@@ -1,11 +1,43 @@
+import React from 'react';
+import { onFieldInputValueChange } from '@formily/core';
+import { useForm, useField } from '@formily/react';
+
 import { useCollectionDataSource } from '@nocobase/client';
 
 import { FilterDynamicComponent } from '../components/FilterDynamicComponent';
-import CollectionFieldset from '../components/CollectionFieldset';
+import CollectionFieldset, { useCollectionUIFields } from '../components/CollectionFieldset';
 
 import { isValidFilter } from '../utils';
 import { NAMESPACE } from '../locale';
 import { collection, filter, values } from '../schemas/collection';
+import { RadioWithTooltip } from '../components/RadioWithTooltip';
+
+function IndividualHooksRadioWithTooltip({ onChange, ...props }) {
+  const form = useForm();
+  const { collection } = form.values;
+  const fields = useCollectionUIFields(collection);
+  const field = useField<any>();
+
+  function onValueChange({ target }) {
+    const valuesField = field.query('.values').take();
+    if (!valuesField) {
+      return;
+    }
+    const filteredValues = fields.reduce((result, item) => {
+      if (
+        item.name in valuesField.value &&
+        (target.value || !['hasOne', 'hasMany', 'belongsToMany'].includes(item.type))
+      ) {
+        result[item.name] = valuesField.value[item.name];
+      }
+      return result;
+    }, {});
+    form.setValuesIn('params.values', filteredValues);
+
+    onChange(target.value);
+  }
+  return <RadioWithTooltip {...props} onChange={onValueChange} />;
+}
 
 export default {
   title: `{{t("Update record", { ns: "${NAMESPACE}" })}}`,
@@ -17,6 +49,27 @@ export default {
     params: {
       type: 'object',
       properties: {
+        individualHooks: {
+          type: 'boolean',
+          title: `{{t("Update mode", { ns: "${NAMESPACE}" })}}`,
+          'x-decorator': 'FormItem',
+          'x-component': 'IndividualHooksRadioWithTooltip',
+          'x-component-props': {
+            options: [
+              {
+                label: `{{t("Update in a batch", { ns: "${NAMESPACE}" })}}`,
+                value: false,
+                tooltip: `{{t("Update all eligible data at one time, which has better performance when the amount of data is large. But the updated data will not trigger other workflows, and will not record audit logs.", { ns: "${NAMESPACE}" })}}`,
+              },
+              {
+                label: `{{t("Update one by one", { ns: "${NAMESPACE}" })}}`,
+                value: true,
+                tooltip: `{{t("The updated data can trigger other workflows, and the audit log will also be recorded. But it is usually only applicable to several or dozens of pieces of data, otherwise there will be performance problems.", { ns: "${NAMESPACE}" })}}`,
+              },
+            ],
+          },
+          default: false,
+        },
         filter: {
           ...filter,
           title: `{{t("Only update records matching conditions", { ns: "${NAMESPACE}" })}}`,
@@ -24,7 +77,14 @@ export default {
             return isValidFilter(value) ? '' : `{{t("Please add at least one condition", { ns: "${NAMESPACE}" })}}`;
           },
         },
-        values,
+        values: {
+          ...values,
+          'x-component-props': {
+            filter(this, field) {
+              return this.params?.individualHooks || !['hasOne', 'hasMany', 'belongsToMany'].includes(field.type);
+            },
+          },
+        },
       },
     },
   },
@@ -35,5 +95,6 @@ export default {
   components: {
     FilterDynamicComponent,
     CollectionFieldset,
+    IndividualHooksRadioWithTooltip,
   },
 };

--- a/packages/plugins/workflow/src/server/Plugin.ts
+++ b/packages/plugins/workflow/src/server/Plugin.ts
@@ -201,8 +201,9 @@ export default class WorkflowPlugin extends Plugin {
 
     this.events.push([workflow, context, options]);
 
-    this.getLogger(workflow.id).debug(`new event triggered, now events: ${this.events.length}`, {
-      data: workflow.config,
+    this.getLogger(workflow.id).info(`new event triggered, now events: ${this.events.length}`);
+    this.getLogger(workflow.id).debug(`event data:`, {
+      data: context,
     });
 
     if (this.events.length > 1) {

--- a/packages/plugins/workflow/src/server/__tests__/instructions/update.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/instructions/update.test.ts
@@ -18,7 +18,6 @@ describe('workflow > instructions > update', () => {
     PostRepo = db.getCollection('posts').repository;
 
     workflow = await WorkflowModel.create({
-      title: 'test workflow',
       enabled: true,
       type: 'collection',
       config: {
@@ -54,51 +53,137 @@ describe('workflow > instructions > update', () => {
 
       const [execution] = await workflow.getExecutions();
       const [job] = await execution.getJobs();
-      expect(job.result.published).toBe(true);
+      expect(job.result).toBe(1);
 
       const updatedPost = await PostRepo.findById(post.id);
       expect(updatedPost.published).toBe(true);
     });
+
+    it('params: from job of node', async () => {
+      const n1 = await workflow.createNode({
+        type: 'query',
+        config: {
+          collection: 'posts',
+          params: {
+            filter: {
+              title: 'test',
+            },
+          },
+        },
+      });
+
+      const n2 = await workflow.createNode({
+        type: 'update',
+        config: {
+          collection: 'posts',
+          params: {
+            filter: {
+              id: `{{$jobsMapByNodeId.${n1.id}.id}}`,
+            },
+            values: {
+              title: 'changed',
+            },
+          },
+        },
+        upstreamId: n1.id,
+      });
+
+      await n1.setDownstream(n2);
+
+      // NOTE: the result of post immediately created will not be changed by workflow
+      const { id } = await PostRepo.create({ values: { title: 'test' } });
+
+      await sleep(500);
+
+      // should get from db
+      const post = await PostRepo.findById(id);
+      expect(post.title).toBe('changed');
+    });
   });
 
-  it('params: from job of node', async () => {
-    const n1 = await workflow.createNode({
-      type: 'query',
-      config: {
-        collection: 'posts',
-        params: {
-          filter: {
-            title: 'test',
+  describe('update batch', () => {
+    it('individualHooks off should not trigger other workflow', async () => {
+      const w2 = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 2,
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await workflow.createNode({
+        type: 'update',
+        config: {
+          collection: 'posts',
+          params: {
+            filter: {
+              id: '{{$context.data.id}}',
+            },
+            values: {
+              published: true,
+            },
+            individualHooks: false,
           },
         },
-      },
+      });
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+      expect(post.published).toBe(false);
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      const [job] = await execution.getJobs();
+      expect(job.result).toBe(1);
+
+      const updatedPost = await PostRepo.findById(post.id);
+      expect(updatedPost.published).toBe(true);
+
+      const w2Exes = await w2.getExecutions();
+      expect(w2Exes.length).toBe(0);
     });
 
-    const n2 = await workflow.createNode({
-      type: 'update',
-      config: {
-        collection: 'posts',
-        params: {
-          filter: {
-            id: `{{$jobsMapByNodeId.${n1.id}.id}}`,
-          },
-          values: {
-            title: 'changed',
+    it('individualHooks on should trigger other workflow', async () => {
+      const w2 = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 2,
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await workflow.createNode({
+        type: 'update',
+        config: {
+          collection: 'posts',
+          params: {
+            filter: {
+              id: '{{$context.data.id}}',
+            },
+            values: {
+              published: true,
+            },
+            individualHooks: true,
           },
         },
-      },
-      upstreamId: n1.id,
+      });
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+      expect(post.published).toBe(false);
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      const [job] = await execution.getJobs();
+      expect(job.result).toBe(1);
+
+      const updatedPost = await PostRepo.findById(post.id);
+      expect(updatedPost.published).toBe(true);
+
+      const w2Exes = await w2.getExecutions();
+      expect(w2Exes.length).toBe(1);
     });
-
-    await n1.setDownstream(n2);
-
-    // NOTE: the result of post immediately created will not be changed by workflow
-    const { id } = await PostRepo.create({ values: { title: 'test' } });
-
-    await sleep(500);
-
-    // should get from db
-    const post = await PostRepo.findById(id);
-    expect(post.title).toBe('changed');
   });
 });

--- a/packages/plugins/workflow/src/server/instructions/update.ts
+++ b/packages/plugins/workflow/src/server/instructions/update.ts
@@ -4,7 +4,7 @@ import { JOB_STATUS } from '../constants';
 
 export default {
   async run(node: FlowNodeModel, input, processor: Processor) {
-    const { collection, multiple = false, params = {} } = node.config;
+    const { collection, params = {} } = node.config;
 
     const repo = (<typeof FlowNodeModel>node.constructor).database.getRepository(collection);
     const options = processor.getParsedValue(params, node);
@@ -17,7 +17,7 @@ export default {
     });
 
     return {
-      result: multiple ? result : result[0] || null,
+      result: result.length ?? result,
       status: JOB_STATUS.RESOLVED,
     };
   },


### PR DESCRIPTION
# Description (需求描述)

add batch logic to `repository.update` for better performance.

# Motivation (需求背景)

Before this PR, `repository.update` only update rows one by one (DB IO), mostly for triggering single model events. But when used on large quantity of data, it will be very slow.

So, we need better performance in such scenario, which only send one IO to DB for multiple records updating, and not triggering single model events.

# Key changes (关键改动）

- Frontend (前端)
  - Add `individualHooks` in update node configuration in workflow.
  - Add linkage for values in update node configuration to skip non-belongsTo association values.
- Backend (后端)
  - Add branch logic on `individualHooks` is exact `false` to perform batch updating.
  - Fix result value of update node to only numbers.

# Test plan (测试计划)

## Suggestions (测试建议)

* Unit cases.
* Benchmark.

## Underlying risk (潜在风险)

Not support `hasOne`, `hasMany` and `belongsToMany` values in batch updating.

# Showcase (结果展示）

![53732540-fec5-473b-abb8-fcb599405582](https://github.com/nocobase/nocobase/assets/525658/281ce4c1-90b8-465a-adf4-eacaa03ed977)

Only spent about 400ms for updating 20000 records in workflow, instead of minutes which reported by client.
