### PR TITLE
fix(client): fix onchange mistake

### DIFF
--- a/packages/core/client/src/schema-component/antd/input/Json.tsx
+++ b/packages/core/client/src/schema-component/antd/input/Json.tsx
@@ -42,7 +42,6 @@ export const Json = React.forwardRef<typeof Input.TextArea, JSONTextAreaProps>(
             field.setFeedback({});
             onChange?.(v);
           } catch (err) {
-            onChange?.(ev);
             field.setFeedback({
               type: 'error',
               code: 'JSONSyntaxError',


### PR DESCRIPTION
## Description (Bug 描述)

![img_v2_f9ed636c-c101-48ba-92f9-eb1b388148ag](https://github.com/nocobase/nocobase/assets/525658/30e24b59-d3be-4c45-a456-bb4eccb80a08)

### Steps to reproduce (复现步骤)

Any JSON field input.

### Expected behavior (预期行为)

Should represent correct JSON value.

### Actual behavior (实际行为)

Duplication of stringifying.

## Related issues (相关 issue)

## Reason (原因)

Should not invoke `onChange` in `catch` due to invalid.

## Solution (解决方案)

Remove `onChange` in `catch`.