### PR TITLE
fix(plugin-workflow): fix occasional error on enter workflow page

### DIFF
--- a/packages/plugins/workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/workflow/src/client/triggers/index.tsx
@@ -141,6 +141,7 @@ export const TriggerConfig = () => {
   const { workflow, refresh } = useFlowContext();
   const [editingTitle, setEditingTitle] = useState<string>('');
   const [editingConfig, setEditingConfig] = useState(false);
+  let typeTitle = '';
   useEffect(() => {
     if (workflow) {
       setEditingTitle(workflow.title ?? typeTitle);
@@ -151,7 +152,9 @@ export const TriggerConfig = () => {
     return null;
   }
   const { title, type, config, executed } = workflow;
-  const { title: typeTitle, fieldset, scope, components } = triggers.get(type);
+  const trigger = triggers.get(type);
+  const { fieldset, scope, components } = trigger;
+  typeTitle = trigger.title;
   const detailText = executed ? '{{t("View")}}' : '{{t("Configure")}}';
   const titleText = `${lang('Trigger')}: ${compile(typeTitle)}`;
 


### PR DESCRIPTION
## Description (Bug 描述)

<img width="971" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/ddbfaa9f-9364-416a-8409-2aa6928a3147">

### Steps to reproduce (复现步骤)

Occasionally, enter single workflow page.

### Expected behavior (预期行为)

No error.

### Actual behavior (实际行为)

Error occurs

## Related issues (相关 issue)

None.

## Reason (原因)

```
can't access lexical declaration `variable' before initialization
```

## Solution (解决方案)

Adjust variable definition.
