### PR TITLE
fix(plugin-verification): fix duplication of installation

### DIFF
--- a/packages/plugins/verification/src/server/Plugin.ts
+++ b/packages/plugins/verification/src/server/Plugin.ts
@@ -98,6 +98,12 @@ export default class VerificationPlugin extends Plugin {
       INIT_ALI_SMS_VERIFY_CODE_SIGN
     ) {
       const ProviderRepo = this.db.getRepository('verifications_providers');
+      const existed = await ProviderRepo.count({
+        filterByTk: DEFAULT_SMS_VERIFY_CODE_PROVIDER,
+      });
+      if (existed) {
+        return;
+      }
       await ProviderRepo.create({
         values: {
           id: DEFAULT_SMS_VERIFY_CODE_PROVIDER,


### PR DESCRIPTION
## Description (Bug 描述)

When using multi-app, creating sub-app with SMS environments, will produce duplication error.

### Steps to reproduce (复现步骤)

1. Set SMS environments in `.env`.
2. Activate multi-app plugin.
3. Add new sub-app, error will be thrown.

### Expected behavior (预期行为)

No error.

### Actual behavior (实际行为)

```
errors: [
  ValidationErrorItem {
    message: 'id must be unique',
    type: 'unique violation',
    path: 'id',
    value: 'alisms',
    origin: 'DB',
    instance: [verifications_providers],
    validatorKey: 'not_unique',
    validatorName: null,
    validatorArgs: []
  }
],
```

## Related issues (相关 issue)

None.

## Reason (原因)

Verification plugin is shared, installation will be processed when new app added.

## Solution (解决方案)

Check if provider existed before create default in installation.
