### PR TITLE
fix(plugin-workflow): fix job button style

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/workflow/src/client/nodes/index.tsx
@@ -240,7 +240,7 @@ function InnerJobButton({ job, ...props }) {
   const { icon, color } = JobStatusOptionsMap[job.status];
 
   return (
-    <Button {...props} shape="circle" className={nodeJobButtonClass}>
+    <Button {...props} shape="circle" className={cx(nodeJobButtonClass, props.className)}>
       <Tag color={color}>{icon}</Tag>
     </Button>
   );
@@ -292,7 +292,7 @@ export function JobButton() {
                   }
                 `}
               >
-                <span className={nodeJobButtonClass}>
+                <span className={cx(nodeJobButtonClass, 'inner')}>
                   <Tag color={color}>{icon}</Tag>
                 </span>
                 <time>{str2moment(job.updatedAt).format('YYYY-MM-DD HH:mm:ss')}</time>

--- a/packages/plugins/workflow/src/client/style.tsx
+++ b/packages/plugins/workflow/src/client/style.tsx
@@ -255,6 +255,10 @@ export const nodeJobButtonClass = css`
     border: none;
   }
 
+  &.inner{
+    position: static;
+  }
+
   .ant-tag {
     padding: 0;
     width: 100%;


### PR DESCRIPTION
## Description (Bug 描述)

![image](https://github.com/nocobase/nocobase/assets/525658/937006d7-a35c-4b76-81a4-51602145ec77)

### Steps to reproduce (复现步骤)

Use loop node and do a more than one loop.

### Expected behavior (预期行为)

Button icon should be on left side and not in absolute position.

### Actual behavior (实际行为)

Absolute position to right.

## Related issues (相关 issue)

None.

## Reason (原因)

Styles.

## Solution (解决方案)

Adjust style.
