### PR TITLE
fix(plugin-workflow): change to formv2 to avoid values updating issue

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-v2/Form.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Form.tsx
@@ -141,7 +141,7 @@ const WithForm = (props) => {
       form.removeEffects(id);
     };
   }, [linkageRules]);
-  return fieldSchema['x-decorator'] === 'Form' ? <FormDecorator {...props} /> : <FormComponent {...props} />;
+  return fieldSchema['x-decorator'] === 'FormV2' ? <FormDecorator {...props} /> : <FormComponent {...props} />;
 };
 
 const WithoutForm = (props) => {
@@ -159,7 +159,7 @@ const WithoutForm = (props) => {
       }),
     [],
   );
-  return fieldSchema['x-decorator'] === 'Form' ? (
+  return fieldSchema['x-decorator'] === 'FormV2' ? (
     <FormDecorator form={form} {...props} />
   ) : (
     <FormComponent form={form} {...props} />

--- a/packages/plugins/workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/workflow/src/client/WorkflowCanvas.tsx
@@ -52,12 +52,11 @@ export function WorkflowCanvas() {
     setTitle?.(`${lang('Workflow')}${title ? `: ${title}` : ''}`);
   }, [data?.data]);
 
-  if (!data?.data && !loading) {
-    return <div>{lang('Load failed')}</div>;
+  if (!data?.data) {
+    return <div>{loading ? lang('Loading') : lang('Load failed')}</div>;
   }
 
   const { nodes = [], revisions = [], ...workflow } = data?.data ?? {};
-
   linkNodes(nodes);
 
   const entry = nodes.find((item) => !item.upstream);

--- a/packages/plugins/workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/workflow/src/client/triggers/index.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { css, cx } from '@emotion/css';
+import { createForm } from '@formily/core';
 import { ISchema, useForm } from '@formily/react';
 import { Registry } from '@nocobase/utils/client';
 import { message, Tag, Alert, Button, Input } from 'antd';
-import { useTranslation } from 'react-i18next';
 import { InfoOutlined } from '@ant-design/icons';
 
 import {
@@ -13,7 +13,6 @@ import {
   useActionContext,
   useAPIClient,
   useCompile,
-  useRequest,
   useResourceActionContext,
 } from '@nocobase/client';
 
@@ -148,10 +147,19 @@ export const TriggerConfig = () => {
     }
   }, [workflow]);
 
+  const form = useMemo(
+    () =>
+      createForm({
+        values: workflow?.config,
+        disabled: workflow?.executed,
+      }),
+    [workflow],
+  );
+
   if (!workflow || !workflow.type) {
     return null;
   }
-  const { title, type, config, executed } = workflow;
+  const { title, type, executed } = workflow;
   const trigger = triggers.get(type);
   const { fieldset, scope, components } = trigger;
   typeTitle = trigger.title;
@@ -205,6 +213,7 @@ export const TriggerConfig = () => {
       <ActionContextProvider value={{ visible: editingConfig, setVisible: setEditingConfig }}>
         <SchemaComponent
           schema={{
+            name: `workflow-trigger-${workflow.id}`,
             type: 'void',
             properties: {
               config: {
@@ -220,18 +229,9 @@ export const TriggerConfig = () => {
                 type: 'void',
                 title: titleText,
                 'x-component': 'Action.Drawer',
-                'x-decorator': 'Form',
+                'x-decorator': 'FormV2',
                 'x-decorator-props': {
-                  disabled: workflow.executed,
-                  useValues(options) {
-                    return useRequest(
-                      () =>
-                        Promise.resolve({
-                          data: config,
-                        }),
-                      options,
-                    );
-                  },
+                  form,
                 },
                 properties: {
                   ...(executed

--- a/packages/plugins/workflow/src/client/triggers/schedule/ScheduleConfig.tsx
+++ b/packages/plugins/workflow/src/client/triggers/schedule/ScheduleConfig.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/css';
 
 import { SchemaComponent } from '@nocobase/client';
 
-import { collection } from '../../schemas/collection';
+import { appends, collection } from '../../schemas/collection';
 import { OnField } from './OnField';
 import { EndsByField } from './EndsByField';
 import { RepeatField } from './RepeatField';
@@ -140,6 +140,19 @@ const ModeFieldsets = {
         placeholder: `{{t("No limit", { ns: "${NAMESPACE}" })}}`,
         min: 0,
       },
+    },
+    appends: {
+      ...appends,
+      'x-reactions': [
+        {
+          dependencies: ['mode', 'collection'],
+          fulfill: {
+            state: {
+              visible: `{{$deps[0] === ${SCHEDULE_MODE.COLLECTION_FIELD} && $deps[1]}}`,
+            },
+          },
+        },
+      ],
     },
   },
 };

--- a/packages/plugins/workflow/src/client/triggers/schedule/index.tsx
+++ b/packages/plugins/workflow/src/client/triggers/schedule/index.tsx
@@ -5,7 +5,6 @@ import { SCHEDULE_MODE } from './constants';
 import { NAMESPACE, useWorkflowTranslation } from '../../locale';
 import { CollectionBlockInitializer } from '../../components/CollectionBlockInitializer';
 import { useCollectionFieldOptions } from '../../variable';
-import { appends } from '../../schemas/collection';
 import { FieldsSelect } from '../../components/FieldsSelect';
 
 export default {
@@ -16,19 +15,6 @@ export default {
       type: 'void',
       'x-component': 'ScheduleConfig',
       'x-component-props': {},
-    },
-    appends: {
-      ...appends,
-      'x-reactions': [
-        {
-          dependencies: ['mode', 'collection'],
-          fulfill: {
-            state: {
-              visible: `{{$deps[0] === ${SCHEDULE_MODE.COLLECTION_FIELD} && $deps[1]}}`,
-            },
-          },
-        },
-      ],
     },
   },
   scope: {


### PR DESCRIPTION
## Description (Bug 描述)

After re-enter workflow canvas page, the schedule trigger config is not same as submitted before. But after reload whole page it will be correct.

### Steps to reproduce (复现步骤)

1. Add a schedule type workflow.
2. Modify the trigger configurations and submit.
3. Re-open the trigger configurations panel: correct.
4. Go back to workflows list (browser history back).
5. Re-enter the workflow canvas page submitted before.
6. Open the trigger configurations panel: wrong.
7. Reload page, open the trigger configurations panel: correct.

### Expected behavior (预期行为)

After history go back and forward, the trigger config should be correct in panel as submitted.

### Actual behavior (实际行为)

The config remains as old.

## Related issues (相关 issue)

None.

## Reason (原因)

Legacy `Form` component in schema component does not handle values correctly.

## Solution (解决方案)

Migrate to `FormV2` to fix.
