### PR TITLE
fix(upload): fix the upload status not being updated if the upload was successful

### DIFF
--- a/packages/core/client/src/schema-component/antd/preview/Preview.tsx
+++ b/packages/core/client/src/schema-component/antd/preview/Preview.tsx
@@ -72,7 +72,7 @@ export const FileSelector = (props: Props) => {
               }
             };
             return (
-              <div key={file.id} className={'ant-upload-list-picture-card-container'}>
+              <div key={file.uid || file.id} className={'ant-upload-list-picture-card-container'}>
                 <div className="ant-upload-list-item ant-upload-list-item-done ant-upload-list-item-list-type-picture-card">
                   <div className={'ant-upload-list-item-info'}>
                     <span className="ant-upload-span">

--- a/packages/core/client/src/schema-component/antd/preview/Preview.tsx
+++ b/packages/core/client/src/schema-component/antd/preview/Preview.tsx
@@ -1,10 +1,9 @@
 import { DeleteOutlined, DownloadOutlined, PlusOutlined } from '@ant-design/icons';
 import { connect, mapReadPretty } from '@formily/react';
-import { Upload as AntdUpload, Button, Progress, Space } from 'antd';
+import { Upload as AntdUpload, Button, Progress, Space, UploadFile } from 'antd';
 import cls from 'classnames';
-import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Lightbox from 'react-image-lightbox';
 import 'react-image-lightbox/style.css'; // This only needs to be imported once in your app
@@ -33,12 +32,15 @@ export const FileSelector = (props: Props) => {
   const [photoIndex, setPhotoIndex] = useState(0);
   const [visible, setVisible] = useState(false);
   const { t } = useTranslation();
+  const internalFileList = useRef([]);
 
   // 兼容旧版本
   const showSelectButton = selectFile === undefined && quickUpload === undefined;
 
   useEffect(() => {
-    setFileList(toFileList(value));
+    const fileList = toFileList(value);
+    setFileList(fileList);
+    internalFileList.current = fileList;
   }, [value]);
 
   const handleRemove = (file) => {
@@ -114,6 +116,7 @@ export const FileSelector = (props: Props) => {
                           icon={<DeleteOutlined />}
                           onClick={() => {
                             handleRemove(file);
+                            internalFileList.current = internalFileList.current.filter((item) => item.uid !== file.uid);
                           }}
                         />
                       )}
@@ -166,9 +169,14 @@ export const FileSelector = (props: Props) => {
                   showUploadList={false}
                   onRemove={handleRemove}
                   onChange={(info) => {
+                    // info.fileList 有 BUG，会导致上传状态一直是 uploading
+                    // 所以这里仿照 antd 源码，自己维护一个 fileList
+                    const list = updateFileList(info.file, internalFileList.current);
+                    internalFileList.current = list;
+
                     // 如果不在这里 setFileList 的话，会导致 onChange 只会执行一次
-                    setFileList([...info.fileList]);
-                    uploadProps.onChange?.(info);
+                    setFileList(toFileList(list));
+                    uploadProps.onChange?.({ fileList: list });
                   }}
                 >
                   <div
@@ -250,3 +258,14 @@ export const FileSelector = (props: Props) => {
 };
 
 export default Preview;
+
+function updateFileList(file: UploadFile, fileList: (UploadFile | Readonly<UploadFile>)[]) {
+  const nextFileList = [...fileList];
+  const fileIndex = nextFileList.findIndex(({ uid }) => uid === file.uid);
+  if (fileIndex === -1) {
+    nextFileList.push(file);
+  } else {
+    nextFileList[fileIndex] = file;
+  }
+  return nextFileList;
+}

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -3,7 +3,6 @@ import { usePrefixCls } from '@formily/antd/esm/__builtins__';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { Upload as AntdUpload, Button, Progress, Space, Modal } from 'antd';
 import cls from 'classnames';
-import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -64,7 +63,7 @@ Upload.Attachment = connect((props: UploadProps) => {
               }
             };
             return (
-              <div className={'ant-upload-list-picture-card-container'}>
+              <div key={file.uid || file.id} className={'ant-upload-list-picture-card-container'}>
                 <div className="ant-upload-list-item ant-upload-list-item-done ant-upload-list-item-list-type-picture-card">
                   <div className={'ant-upload-list-item-info'}>
                     <span className="ant-upload-span">

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -321,7 +321,7 @@ Upload.DraggerV2 = connect(
 
 export default Upload;
 
-export function updateFileList(file: UploadFile, fileList: (UploadFile | Readonly<UploadFile>)[]) {
+function updateFileList(file: UploadFile, fileList: (UploadFile | Readonly<UploadFile>)[]) {
   const nextFileList = [...fileList];
   const fileIndex = nextFileList.findIndex(({ uid }) => uid === file.uid);
   if (fileIndex === -1) {

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -3,6 +3,7 @@ import { usePrefixCls } from '@formily/antd/esm/__builtins__';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { Upload as AntdUpload, Button, Progress, Space, Modal } from 'antd';
 import cls from 'classnames';
+import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -63,7 +64,7 @@ Upload.Attachment = connect((props: UploadProps) => {
               }
             };
             return (
-              <div key={file.uid || file.id} className={'ant-upload-list-picture-card-container'}>
+              <div className={'ant-upload-list-picture-card-container'}>
                 <div className="ant-upload-list-item ant-upload-list-item-done ant-upload-list-item-list-type-picture-card">
                   <div className={'ant-upload-list-item-info'}>
                     <span className="ant-upload-span">
@@ -140,29 +141,12 @@ Upload.Attachment = connect((props: UploadProps) => {
                 listType={'picture-card'}
                 fileList={fileList}
                 onChange={(info) => {
-                  // ----------------------------------------------
-                  // 使用 info.fileList 会导致一直显示 Uploading 的问题
-                  // 注意：此方法依然不能保证一定不会出现 Uploading 的问题，但相比之前有很大改善，具体原因不明
-                  let list = fileList;
-                  if (!list.find((file) => file.uid === info.file.uid)) {
-                    list.push({ ...info.file });
-                  }
-                  list = list.map((file) => {
-                    if (file.uid === info.file.uid) {
-                      return { ...info.file };
-                    }
-                    return file;
-                  });
-                  // ----------------------------------------------
-
-                  console.log(info.file.uid, info.file.status);
-
                   setSync(false);
                   if (multiple) {
                     if (info.file.status === 'done') {
-                      onChange(toValue(list));
+                      onChange(toValue(info.fileList));
                     }
-                    setFileList(list.map(toItem));
+                    setFileList(info.fileList.map(toItem));
                   } else {
                     if (info.file.status === 'done') {
                       // TODO(BUG): object 的联动有问题，不响应，折中的办法先置空再赋值

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -2,7 +2,6 @@ import { Field } from '@formily/core';
 import { useField } from '@formily/react';
 import { reaction } from '@formily/reactive';
 import { isArr, isValid, toArr as toArray } from '@formily/shared';
-import { UploadChangeParam } from 'antd/es/upload';
 import { UploadFile } from 'antd/es/upload/interface';
 import { useEffect } from 'react';
 import { useAPIClient } from '../../../api-client';
@@ -167,7 +166,7 @@ export const useUploadValidator = (serviceErrorMessage = 'Upload Service Error')
 
 export function useUploadProps<T extends IUploadProps = UploadProps>({ serviceErrorMessage, ...props }: T) {
   useUploadValidator(serviceErrorMessage);
-  const onChange = (param: UploadChangeParam<UploadFile>) => {
+  const onChange = (param: { fileList: any[] }) => {
     props.onChange?.(normalizeFileList([...param.fileList]));
   };
 

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -212,7 +212,10 @@ export function useUploadProps<T extends IUploadProps = UploadProps>({ serviceEr
 
 export const toItem = (file) => {
   if (file?.response?.data) {
-    file = file.response.data;
+    file = {
+      uid: file.uid,
+      ...file.response.data,
+    };
   }
   return {
     ...file,

--- a/packages/core/client/src/schema-component/antd/upload/style.less
+++ b/packages/core/client/src/schema-component/antd/upload/style.less
@@ -40,7 +40,7 @@
     background: rgba(0, 0, 0, 0.5);
   }
   .ant-upload-list-picture-card-container {
-    // margin-bottom: 28px;
+    margin-bottom: 28px;
   }
 }
 


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)
1. 批量上传多张图片
2. 会发现样式问题

![image](https://github.com/nocobase/nocobase/assets/38434641/c7dfa533-e714-4d5d-9607-fea68633c0a3)


<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->
- 图片的名字不应该被下面的图片盖住
- 图片上传成功后应该更新状态并显示已上传的图片

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->
- 图片的名字被盖住
- 某些图片上传成功了，但是依然显示 `uploading` 

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->
#1862 
https://github.com/ant-design/ant-design/issues/2423

## Reason (原因)

<!-- Explain what caused the bug to occur. -->
- #1862 修改了样式，导致图片名称被覆盖
- 一直显示 `uploading` 的问题是因为 antd 的 BUG，导致 `onChange` 方法的 `fileList` 参数的值没有及时的更新，需要 antd 团队修复该问题
- 这个功能之前是好的，现在出问题，怀疑可能跟最近的 `React` 升级到 18 版本有关（未验证）

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
- 回退样式
- 关于一直显示 `uploading` 的问题
  - 首先，使用官方推荐的[方法](https://github.com/ant-design/ant-design/issues/2423#issuecomment-233523579)不能解决这里遇到的问题
  - 经测试发现 `onChange` 的 `file` 参数是正确的，所以可以根据 `file` 实时的计算出 `fileList` 的值
  - 计算出的 `fileList` 需要通过一个 `useRef` 保存，如果使用 `useState` 同样会有问题
  - 在删除图片的时候，同时需要删除 `Ref` 中的值

## 修复后的样子

![image](https://github.com/nocobase/nocobase/assets/38434641/8bbd8001-1221-49c3-b52f-050eaba1669a)


## 其它
close T-650