### PR TITLE
fix(client): fix field initializer in detail block

### DIFF
--- a/packages/core/client/src/schema-initializer/buttons/ReadPrettyFormItemInitializers.tsx
+++ b/packages/core/client/src/schema-initializer/buttons/ReadPrettyFormItemInitializers.tsx
@@ -39,7 +39,7 @@ export const ReadPrettyFormItemInitializers = (props: any) => {
     });
   }
   associationFields.length > 0 &&
-    fieldItems.push([
+    fieldItems.push(
       {
         type: 'divider',
       },
@@ -48,7 +48,7 @@ export const ReadPrettyFormItemInitializers = (props: any) => {
         title: t('Display association fields'),
         children: associationFields,
       },
-    ]);
+    );
 
   fieldItems.push(
     {


### PR DESCRIPTION
## Description (Bug 描述)

Association field initializers in detail block not showing.

### Steps to reproduce (复现步骤)

1. Create detail block.
2. Hover to "Configure fields".
3. No association field initializers menu.

### Expected behavior (预期行为)

Association field initializers should show up.

### Actual behavior (实际行为)

No Association field initializers.

## Related issues (相关 issue)

None.

## Reason (原因)

`push([item1, item2])` => `push(item1, item2)`.

## Solution (解决方案)

As above.
