### PR TITLE
fix:  association fields cannot config in table

### DIFF
--- a/packages/core/client/src/schema-initializer/buttons/TableColumnInitializers.tsx
+++ b/packages/core/client/src/schema-initializer/buttons/TableColumnInitializers.tsx
@@ -1,14 +1,14 @@
+import { useField, useFieldSchema } from '@formily/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useCompile } from '../../schema-component';
 import { SchemaInitializer } from '../SchemaInitializer';
 import {
   itemsMerge,
   useAssociatedTableColumnInitializerFields,
-  useTableColumnInitializerFields,
   useInheritsTableColumnInitializerFields,
+  useTableColumnInitializerFields,
 } from '../utils';
-import { useCompile } from '../../schema-component';
-import { useField, useFieldSchema } from '@formily/react';
 
 // 表格列配置
 export const TableColumnInitializers = (props: any) => {
@@ -42,7 +42,7 @@ export const TableColumnInitializers = (props: any) => {
         );
     });
   }
-  if (associatedFields?.length > 0 && field.readPretty) {
+  if (associatedFields?.length > 0 && (!isSubTable || field.readPretty)) {
     fieldItems.push(
       {
         type: 'divider',


### PR DESCRIPTION
## Description (Bug 描述)
表格区块无法配置 【显示关联表的字段】
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
表格区块和详情里的子表格支持配置【显示关联表的字段】,表单中的子表格不支持配置

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
