### PR TITLE
fix(utils): avoid to use default value for null in json-templates

### DIFF
--- a/packages/core/utils/src/json-templates.ts
+++ b/packages/core/utils/src/json-templates.ts
@@ -92,15 +92,20 @@ const parseString = (() => {
         return matches.reduce((result, match, i) => {
           const parameter = parameters[i];
           let value = objectPath.get(context, parameter.key);
-          if (value == null) {
+          const type = typeof value;
+
+          if (type === 'undefined') {
+            if (typeof parameter.defaultValue === 'undefined') {
+              return value;
+            }
             value = parameter.defaultValue;
           }
 
-          if (typeof value === 'function') {
+          if (type === 'function') {
             value = value();
           }
 
-          if (typeof value === 'object') {
+          if (type === 'object') {
             return value;
           }
 


### PR DESCRIPTION
## Description (Bug 描述)

Null value becomes `undefined` and cause comparison failure.

### Steps to reproduce (复现步骤)

1. Create a condition node in workflow.
2. Assign left operand as a nullable variable.
3. Assign right operand as null constant.
4. Use "Equal" method.
5. Submit data contains the null variable (field).
6. Condition result is `false` and workflow fails.

### Expected behavior (预期行为)

Condition result should be `true`.

### Actual behavior (实际行为)

Condition result is `false`.

## Related issues (相关 issue)

None.

## Reason (原因)

The logic of default assign for `null` value in json-templates is not correct.

## Solution (解决方案)

Use different way to deal with `undefined` and `null`.
