### PR TITLE
fix(plugin-workflow): fix cancel action on trigger config

### DIFF
--- a/packages/plugins/workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/workflow/src/client/triggers/index.tsx
@@ -150,6 +150,7 @@ export const TriggerConfig = () => {
   const form = useMemo(
     () =>
       createForm({
+        initialValues: workflow?.config,
         values: workflow?.config,
         disabled: workflow?.executed,
       }),


### PR DESCRIPTION
## Description (Bug 描述)

The config form of workflow trigger will be empty after clicked cancel button, and remains empty after reopen.

### Steps to reproduce (复现步骤)

1. Open trigger config (with data).
2. Click "Cancel" button.
3. Reopen trigger config.

### Expected behavior (预期行为)

Showing all configuration data.

### Actual behavior (实际行为)

Showing empty form.

## Related issues (相关 issue)

None.

## Reason (原因)

No `initialValue` provided to the form.

## Solution (解决方案)

Add `initialValue`.
