### PR TITLE
fix(plugin-workflow): fix data scope on todo table block

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/manual/WorkflowTodo.tsx
+++ b/packages/plugins/workflow/src/client/nodes/manual/WorkflowTodo.tsx
@@ -580,7 +580,7 @@ function Drawer() {
   );
 }
 
-function Decorator({ children }) {
+function Decorator({ params = {}, children }) {
   const { collections, ...cm } = useCollectionManager();
   const blockProps = {
     collection: 'users_jobs',
@@ -589,6 +589,7 @@ function Decorator({ children }) {
     params: {
       pageSize: 20,
       sort: ['-createdAt'],
+      ...params,
       appends: ['user', 'node', 'workflow'],
       except: ['node.config', 'workflow.config'],
     },


### PR DESCRIPTION
## Description (Bug 描述)

Data scope settings not works on workflow todo list.

### Steps to reproduce (复现步骤)

1. Set a data scope on workflow todo list block, such as current user.
2. Reload the list.

### Expected behavior (预期行为)

Todo data should be filtered by the data scope set.

### Actual behavior (实际行为)

Not filtered.

## Related issues (相关 issue)

None.

## Reason (原因)

`WorkflowTodo.Decorator` not applies `params`.

## Solution (解决方案)

Add `params`.
