### PR TITLE
fix(utils): fix json-template type checking logic

### DIFF
--- a/packages/core/utils/src/json-templates.ts
+++ b/packages/core/utils/src/json-templates.ts
@@ -92,20 +92,21 @@ const parseString = (() => {
         return matches.reduce((result, match, i) => {
           const parameter = parameters[i];
           let value = objectPath.get(context, parameter.key);
-          const type = typeof value;
 
-          if (type === 'undefined') {
-            if (typeof parameter.defaultValue === 'undefined') {
-              return value;
-            }
+          if (typeof value === 'undefined') {
             value = parameter.defaultValue;
           }
 
-          if (type === 'function') {
+          if (typeof value === 'function') {
             value = value();
           }
 
-          if (type === 'object') {
+          if (typeof value === 'object' && value !== null) {
+            return value;
+          }
+
+          // Accommodate numbers as values.
+          if (matches.length === 1 && str.startsWith('{{') && str.endsWith('}}')) {
             return value;
           }
 


### PR DESCRIPTION
## Description (Bug 描述)

Fixed type checking based on test cases from original `json-templates`.

### Steps to reproduce (复现步骤)

Test cases.

### Expected behavior (预期行为)

Pass all.

### Actual behavior (实际行为)

String template cases with multiple variables not pass.

## Related issues (相关 issue)

#2165.

## Reason (原因)

`undefined` value should be directly returned.

## Solution (解决方案)

Handle `undefined` in single/multiple variables branches.
