### PR TITLE
refactor(plugin-workflow): refactor nodes variable option api

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/aggregate.tsx
+++ b/packages/plugins/workflow/src/client/nodes/aggregate.tsx
@@ -30,7 +30,6 @@ function AssociatedConfig({ value, onChange, ...props }): JSX.Element {
   const { setValuesIn } = useForm();
   const compile = useCompile();
   const { getCollection } = useCollectionManager();
-  const current = useNodeContext();
   const options = [nodesOptions, triggerOptions].map((item) => {
     const children = item.useOptions({ types: [matchToManyField] })?.filter(Boolean);
     return {
@@ -300,16 +299,17 @@ export default {
     ValueBlock,
     AssociatedConfig,
   },
-  useVariables(current, { types }) {
+  useVariables({ id, title }, { types }) {
     if (
       types &&
       !types.some((type) => type in BaseTypeSets || Object.values(BaseTypeSets).some((set) => set.has(type)))
     ) {
       return null;
     }
-    return [
-      // { key: '', value: '', label: lang('Calculation result') }
-    ];
+    return {
+      value: `${id}`,
+      label: title,
+    };
   },
   useInitializers(node): SchemaInitializerItemOptions | null {
     if (!node.config.collection) {

--- a/packages/plugins/workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/workflow/src/client/nodes/calculation.tsx
@@ -18,15 +18,19 @@ function useDynamicExpressionCollectionFieldMatcher(field): boolean {
     return false;
   }
 
+  if (this.getCollection(field.collectionName)?.template === 'expression') {
+    return true;
+  }
+
   const fields = this.getCollectionFields(field.target);
   return fields.some((f) => f.interface === 'expression');
 }
 
 const DynamicConfig = ({ value, onChange }) => {
   const { t } = useTranslation();
-  const { getCollectionFields } = useCollectionManager();
+  const { getCollectionFields, getCollection } = useCollectionManager();
   const scope = useWorkflowVariableOptions({
-    types: [useDynamicExpressionCollectionFieldMatcher.bind({ getCollectionFields })],
+    types: [useDynamicExpressionCollectionFieldMatcher.bind({ getCollectionFields, getCollection })],
   });
 
   return (
@@ -189,7 +193,7 @@ export default {
     RadioWithTooltip,
     DynamicConfig,
   },
-  useVariables(current, options) {
+  useVariables({ id, title }, options) {
     const { types } = options ?? {};
     if (
       types &&
@@ -197,9 +201,10 @@ export default {
     ) {
       return null;
     }
-    return [
-      // { key: '', value: '', label: lang('Calculation result') }
-    ];
+    return {
+      value: id,
+      label: title,
+    };
   },
   useInitializers(node): SchemaInitializerItemOptions {
     return {

--- a/packages/plugins/workflow/src/client/nodes/create.tsx
+++ b/packages/plugins/workflow/src/client/nodes/create.tsx
@@ -40,22 +40,34 @@ export default {
     CollectionFieldset,
     FieldsSelect,
   },
-  useVariables({ config }, options) {
+  useVariables({ id, title, config }, options) {
     const compile = useCompile();
     const { getCollectionFields } = useCollectionManager();
     // const depth = config?.params?.appends?.length
     //   ? config?.params?.appends.reduce((max, item) => Math.max(max, item.split('.').length), 1)
     //   : 0;
-    const result = getCollectionFieldOptions({
-      collection: config.collection,
+    const name = `${id}`;
+    const [result] = getCollectionFieldOptions({
+      // collection: config.collection,
       ...options,
+      fields: [
+        {
+          collectionName: config.collection,
+          name,
+          type: 'hasOne',
+          target: config.collection,
+          uiSchema: {
+            title,
+          },
+        },
+      ],
       // depth: options?.depth ?? depth,
-      appends: config.params?.appends,
+      appends: [name, ...(config.params?.appends?.map((item) => `${name}.${item}`) || [])],
       compile,
       getCollectionFields,
     });
 
-    return result?.length ? result : null;
+    return result;
   },
   useInitializers(node): SchemaInitializerItemOptions | null {
     if (!node.config.collection) {

--- a/packages/plugins/workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/workflow/src/client/nodes/index.tsx
@@ -38,7 +38,7 @@ import aggregate from './aggregate';
 import { JobStatusOptionsMap } from '../constants';
 import { NAMESPACE, lang } from '../locale';
 import request from './request';
-import { VariableOptions } from '../variable';
+import { VariableOption, VariableOptions } from '../variable';
 import { NodeDescription } from '../components/NodeDescription';
 
 export interface Instruction {
@@ -53,7 +53,7 @@ export interface Instruction {
   components?: { [key: string]: any };
   component?(props): JSX.Element;
   endding?: boolean;
-  useVariables?(node, options?): VariableOptions;
+  useVariables?(node, options?): VariableOption;
   useScopeVariables?(node, options?): VariableOptions;
   useInitializers?(node): SchemaInitializerItemOptions | null;
   initializers?: { [key: string]: any };

--- a/packages/plugins/workflow/src/client/nodes/manual/index.tsx
+++ b/packages/plugins/workflow/src/client/nodes/manual/index.tsx
@@ -85,7 +85,7 @@ export default {
     ModeConfig,
     AssigneesSelect,
   },
-  useVariables({ config }, { types }) {
+  useVariables({ id, title, config }, { types }) {
     const compile = useCompile();
     const { getCollectionFields } = useCollectionManager();
     const formKeys = Object.keys(config.forms ?? {});
@@ -97,27 +97,33 @@ export default {
       .map((formKey) => {
         const form = config.forms[formKey];
 
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const options = getCollectionFieldOptions({
+        const fieldsOptions = getCollectionFieldOptions({
           fields: form.collection?.fields,
           collection: form.collection,
           types,
           compile,
           getCollectionFields,
         });
-        return options.length
+        const label = compile(form.title) || formKey;
+        return fieldsOptions.length
           ? {
               key: formKey,
               value: formKey,
-              label: form.title || formKey,
-              title: form.title || formKey,
-              children: options,
+              label,
+              title: label,
+              children: fieldsOptions,
             }
           : null;
       })
       .filter(Boolean);
 
-    return options.length ? options : null;
+    return options.length
+      ? {
+          value: `${id}`,
+          label: title,
+          children: options,
+        }
+      : null;
   },
   useInitializers(node): SchemaInitializerItemOptions | null {
     const { getCollection } = useCollectionManager();

--- a/packages/plugins/workflow/src/client/nodes/query.tsx
+++ b/packages/plugins/workflow/src/client/nodes/query.tsx
@@ -43,22 +43,34 @@ export default {
     FilterDynamicComponent,
     FieldsSelect,
   },
-  useVariables({ config }, options) {
+  useVariables({ id, title, config }, options) {
     const compile = useCompile();
     const { getCollectionFields } = useCollectionManager();
     // const depth = config?.params?.appends?.length
     //   ? config?.params?.appends.reduce((max, item) => Math.max(max, item.split('.').length), 1)
     //   : 0;
-    const result = getCollectionFieldOptions({
-      collection: config.collection,
+    const name = `${id}`;
+    const [result] = getCollectionFieldOptions({
+      // collection: config.collection,
       ...options,
+      fields: [
+        {
+          collectionName: config.collection,
+          name,
+          type: 'hasOne',
+          target: config.collection,
+          uiSchema: {
+            title,
+          },
+        },
+      ],
       // depth: options?.depth ?? depth,
-      appends: config.params?.appends,
+      appends: [name, ...(config.params?.appends?.map((item) => `${name}.${item}`) || [])],
       compile,
       getCollectionFields,
     });
 
-    return result?.length ? result : null;
+    return result;
   },
   useInitializers(node): SchemaInitializerItemOptions | null {
     if (!node.config.collection || node.config.multiple) {

--- a/packages/plugins/workflow/src/client/variable.tsx
+++ b/packages/plugins/workflow/src/client/variable.tsx
@@ -22,14 +22,9 @@ export const nodesOptions = {
     const result: VariableOption[] = [];
     upstreams.forEach((node) => {
       const instruction = instructions.get(node.type);
-      const subOptions = instruction.useVariables?.(node, options);
-      if (subOptions) {
-        result.push({
-          key: node.id.toString(),
-          value: node.id.toString(),
-          label: node.title ?? `#${node.id}`,
-          children: subOptions,
-        });
+      const subOption = instruction.useVariables?.(node, options);
+      if (subOption) {
+        result.push(subOption);
       }
     });
     return result;


### PR DESCRIPTION
## Description (Bug 描述)

Can not select dynamic expression from directly loaded expression record from query node.

### Steps to reproduce (复现步骤)

1. Add a query node.
2. Use an expression collection to query.
3. Add a calculation node as downstream.
4. Select dynamic expression.

### Expected behavior (预期行为)

Query result should be in dynamic expression options list.

### Actual behavior (实际行为)

Not showing.

## Related issues (相关 issue)

#2157.

## Reason (原因)

Type filter hard to handle raw node result as fields.

## Solution (解决方案)

Refactor `useVariables` API for all instructions, each could define and export correct node option on its own (could be with fake collection).
