### PR TITLE
fix: optional fields of the child collection cannot be displayed correctly in  parent collection

### DIFF
--- a/packages/core/client/src/collection-manager/CollectionFieldProvider.tsx
+++ b/packages/core/client/src/collection-manager/CollectionFieldProvider.tsx
@@ -1,5 +1,6 @@
 import { SchemaKey, useFieldSchema } from '@formily/react';
 import React from 'react';
+import { useRecord } from '../record-provider';
 import { CollectionFieldContext } from './context';
 import { useCollection, useCollectionManager } from './hooks';
 import { CollectionFieldOptions } from './types';
@@ -12,8 +13,11 @@ export const CollectionFieldProvider: React.FC<{
   const { name, field, children, fallback = null } = props;
   const fieldSchema = useFieldSchema();
   const { getField } = useCollection();
+  const { __collection } = useRecord();
   const { getCollectionJoinField } = useCollectionManager();
-  const value = field || getField(field?.name || name) || getCollectionJoinField(fieldSchema?.['x-collection-field']);
+  const value = __collection
+    ? getCollectionJoinField(`${__collection}.${name}`)
+    : field || getField(field?.name || name) || getCollectionJoinField(fieldSchema?.['x-collection-field']);
   if (!value) {
     return fallback;
   }


### PR DESCRIPTION
## Description (Bug 描述)
子表重写了父表的可选项字段（select）,子表的数据在父表中显示时该可选项字段无法正常显示（没有显示label）
### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->
