### PR TITLE
fix(plugin-workflow): try to avoid occasionally duplicated executions

### DIFF
--- a/packages/plugins/workflow/src/server/Plugin.ts
+++ b/packages/plugins/workflow/src/server/Plugin.ts
@@ -309,7 +309,7 @@ export default class WorkflowPlugin extends Plugin {
         filter: {
           status: EXECUTION_STATUS.QUEUEING,
         },
-        appends: ['workflow.enabled'],
+        appends: ['workflow'],
         sort: 'createdAt',
       })) as ExecutionModel;
       if (execution && execution.workflow.enabled) {

--- a/packages/plugins/workflow/src/server/__tests__/instructions/delay.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/instructions/delay.test.ts
@@ -171,7 +171,7 @@ describe('workflow > instructions > delay', () => {
       await sleep(2000);
 
       await app.start();
-      await sleep(500);
+      await sleep(1000);
 
       const [e2] = await workflow.getExecutions();
       expect(e2.status).toEqual(EXECUTION_STATUS.RESOLVED);

--- a/packages/plugins/workflow/src/server/__tests__/instructions/delay.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/instructions/delay.test.ts
@@ -171,7 +171,7 @@ describe('workflow > instructions > delay', () => {
       await sleep(2000);
 
       await app.start();
-      await sleep(1000);
+      await sleep(500);
 
       const [e2] = await workflow.getExecutions();
       expect(e2.status).toEqual(EXECUTION_STATUS.RESOLVED);

--- a/packages/plugins/workflow/src/server/__tests__/instructions/request.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/instructions/request.test.ts
@@ -32,7 +32,7 @@ describe('workflow > instructions > request', () => {
         ctx.withoutDataWrapping = true;
         ctx.body = {
           meta: { title: ctx.query.title },
-          data: { title: ctx.request.body.title },
+          data: { title: ctx.request.body['title'] },
         };
       }
       next();


### PR DESCRIPTION
## Description (Bug 描述)

Execution run duplicated occasionally.

### Steps to reproduce (复现步骤)

Not reproduced.

### Expected behavior (预期行为)

No duplicated executions.

### Actual behavior (实际行为)

Duplicated.

## Related issues (相关 issue)

None.

## Reason (原因)

Need `await` to get one unexecuted execution, and on that moment once another `dispatch()` happens, will do same thing.

## Solution (解决方案)

Change the `executing` flag logic.
