### PR TITLE
fix(client): fix variable component for preload label based on value

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -232,7 +232,7 @@ export function Input(props) {
 
   useEffect(() => {
     const run = async () => {
-      if (!variable || !options.length) {
+      if (!variable || options.length <= 1) {
         return;
       }
       let prevOption: DefaultOptionType = null;

--- a/packages/core/client/src/schema-initializer/components/assigned-field/AssignedField.tsx
+++ b/packages/core/client/src/schema-initializer/components/assigned-field/AssignedField.tsx
@@ -45,9 +45,9 @@ const InternalField: React.FC = (props) => {
     setFieldProps('title', uiSchema.title);
     setFieldProps('description', uiSchema.description);
     setFieldProps('initialValue', uiSchema.default);
-    if (!field.validator && uiSchema['x-validator']) {
-      field.validator = uiSchema['x-validator'];
-    }
+    // if (!field.validator && uiSchema['x-validator']) {
+    //   field.validator = uiSchema['x-validator'];
+    // }
     if (fieldSchema['x-disabled'] === true) {
       field.disabled = true;
     }


### PR DESCRIPTION
## Description (Bug 描述)

Variable labels not rendering correctly in AssignedField.

### Steps to reproduce (复现步骤)

1. Add a custom save button in add button form.
2. Go to custom save button assign field value settings.
3. Add a field, and use some variable, save.
4. Reopen the assign field value settings, variable labels is empty.

### Expected behavior (预期行为)

Variable labels should showing.

### Actual behavior (实际行为)

Empty labels.

## Related issues (相关 issue)

#2157.

## Reason (原因)

Preload condition is not correct.

## Solution (解决方案)

Revert the condition.

Link T-869.