### PR TITLE
fix(db): fix `$date.now` variable

### DIFF
--- a/packages/core/server/src/middlewares/parse-variables.ts
+++ b/packages/core/server/src/middlewares/parse-variables.ts
@@ -44,9 +44,6 @@ export const parseVariables = async (ctx, next) => {
       return ctx.db.getFieldByPath(`${resourceName}.${fieldPath}`);
     },
     vars: {
-      $system: {
-        now: new Date().toISOString(),
-      },
       $date: getDateVars(),
       $user: getUser(ctx),
     },

--- a/packages/core/utils/src/parse-filter.ts
+++ b/packages/core/utils/src/parse-filter.ts
@@ -267,6 +267,7 @@ const toDays = (offset: number) => {
 
 export function getDateVars() {
   return {
+    now: new Date().toISOString(),
     today: toUnit('day'),
     yesterday: toUnit('day', -1),
     tomorrow: toUnit('day', 1),


### PR DESCRIPTION
## Description (Bug 描述)

By using `$date.now` as variable in filter cause server error.

### Steps to reproduce (复现步骤)

1. Set one field to equal to `$date.now` in any data scope settings.
2. Refresh list.

### Expected behavior (预期行为)

Filtered as configured conditions.

### Actual behavior (实际行为)

Showing error.

## Related issues (相关 issue)

None.

## Reason (原因)

`$date.now` not implemented in proper place.

## Solution (解决方案)

Move deprecated `$system.now` to `$date.now`.
