### PR TITLE
fix(plugin-fm): adjust upload file size to 1GB which same as default on server side

### DIFF
--- a/packages/plugins/file-manager/src/client/hooks/useUploadFiles.ts
+++ b/packages/plugins/file-manager/src/client/hooks/useUploadFiles.ts
@@ -4,7 +4,7 @@ import { useContext } from 'react';
 import { useFmTranslation } from '../locale';
 
 // 限制上传文件大小为 10M
-export const FILE_LIMIT_SIZE = 10 * 1024 * 1024;
+export const FILE_LIMIT_SIZE = 1024 * 1024 * 1024;
 
 export const useUploadFiles = () => {
   const { service } = useBlockRequestContext();


### PR DESCRIPTION
# Description (需求描述)

Adjust file size limit on frontend to 1GB, which is default limit on server side.

# Motivation (需求背景)

Frontend upload file size limit is 10MB, not same as on server side.

# Key changes (关键改动）

- Frontend (前端)
  - Constant on frontend
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

Test file size.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

