### PR TITLE
fix(plugin-workflow): fix job button style

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/workflow/src/client/nodes/index.tsx
@@ -235,7 +235,7 @@ function InnerJobButton({ job, ...props }) {
   const { icon, color } = JobStatusOptionsMap[job.status];
 
   return (
-    <Button {...props} shape="circle" className={cx(nodeJobButtonClass, props.className)}>
+    <Button {...props} shape="circle" size="small" className={cx(nodeJobButtonClass, props.className)}>
       <Tag color={color}>{icon}</Tag>
     </Button>
   );
@@ -279,6 +279,7 @@ export function JobButton() {
               <div
                 className={css`
                   display: flex;
+                  align-items: center;
                   gap: 0.5em;
 
                   time {

--- a/packages/plugins/workflow/src/client/style.tsx
+++ b/packages/plugins/workflow/src/client/style.tsx
@@ -241,14 +241,10 @@ export const nodeCardClass = css`
 export const nodeJobButtonClass = css`
   display: flex;
   position: absolute;
-  top: 1.25em;
-  right: 1.25em;
-  width: 1.25rem;
-  height: 1.25rem;
-  min-width: 1.25rem;
+  top: calc(1em - 1px);
+  right: 1em;
   justify-content: center;
   align-items: center;
-  font-size: 0.8em;
   color: #fff;
 
   &[type='button'] {
@@ -261,8 +257,9 @@ export const nodeJobButtonClass = css`
 
   .ant-tag {
     padding: 0;
-    width: 100%;
-    line-height: 18px;
+    width: 24px;
+    height: 24px;
+    line-height: 22px;
     margin-right: 0;
     border-radius: 50%;
     text-align: center;

--- a/packages/plugins/workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/workflow/src/client/triggers/index.tsx
@@ -83,6 +83,7 @@ function TriggerExecution() {
         'x-component-props': {
           title: <InfoOutlined />,
           shape: 'circle',
+          size: 'small',
           className: nodeJobButtonClass,
           type: 'primary',
         },


### PR DESCRIPTION
## Description (Bug 描述)

Job button in workflow canvas became wider after ant design upgraded to v5.

### Steps to reproduce (复现步骤)

Any job button.

### Expected behavior (预期行为)

Width should equal to height.

### Actual behavior (实际行为)

Wider.

## Related issues (相关 issue)

None.

## Reason (原因)

CSS priority changed in ant design v5, wrapped with `where` selector.

## Solution (解决方案)

Change CSS.