### PR TITLE
refactor(client): change `isTitleField` check to interface property `titleUsable`

### DIFF
--- a/packages/core/client/src/collection-manager/Configuration/CollectionFields.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/CollectionFields.tsx
@@ -57,14 +57,11 @@ const tableContainer = css`
 `;
 
 const titlePrompt = 'Default title for each record';
-// 只有下面类型的字段才可以设置为标题字段
-const expectTypes = ['string', 'integer', 'bigInt', 'float', 'double', 'decimal', 'date', 'dateonly', 'time'];
-const excludeInterfaces = ['icon'];
 
 // 是否可以作为标题字段
 export const isTitleField = (field) => {
-  if (!field) return false;
-  return !field.isForeignKey && expectTypes.includes(field.type) && !excludeInterfaces.includes(field.interface);
+  const { getInterface } = useCollectionManager();
+  return !field.isForeignKey && getInterface(field.interface)?.titleUsable;
 };
 
 const CurrentFields = (props) => {

--- a/packages/core/client/src/collection-manager/interfaces/createdAt.ts
+++ b/packages/core/client/src/collection-manager/interfaces/createdAt.ts
@@ -28,4 +28,5 @@ export const createdAt: IField = {
   filterable: {
     operators: operators.datetime,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/datetime.ts
+++ b/packages/core/client/src/collection-manager/interfaces/datetime.ts
@@ -37,4 +37,5 @@ export const datetime: IField = {
   filterable: {
     operators: operators.datetime,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/email.ts
+++ b/packages/core/client/src/collection-manager/interfaces/email.ts
@@ -28,6 +28,7 @@ export const email: IField = {
   filterable: {
     operators: operators.string,
   },
+  titleUsable: true,
   schemaInitialize(schema: ISchema, { block }) {
     if (['Table', 'Kanban'].includes(block)) {
       schema['x-component-props'] = schema['x-component-props'] || {};

--- a/packages/core/client/src/collection-manager/interfaces/id.ts
+++ b/packages/core/client/src/collection-manager/interfaces/id.ts
@@ -45,4 +45,5 @@ export const id: IField = {
   filterable: {
     operators: operators.id,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/input.ts
+++ b/packages/core/client/src/collection-manager/interfaces/input.ts
@@ -27,6 +27,7 @@ export const input: IField = {
   filterable: {
     operators: operators.string,
   },
+  titleUsable: true,
   schemaInitialize(schema: ISchema, { block }) {
     if (['Table', 'Kanban'].includes(block)) {
       schema['x-component-props'] = schema['x-component-props'] || {};

--- a/packages/core/client/src/collection-manager/interfaces/integer.ts
+++ b/packages/core/client/src/collection-manager/interfaces/integer.ts
@@ -38,6 +38,7 @@ export const integer: IField = {
   filterable: {
     operators: operators.number,
   },
+  titleUsable: true,
   validateSchema(fieldSchema) {
     return {
       maximum: {

--- a/packages/core/client/src/collection-manager/interfaces/number.ts
+++ b/packages/core/client/src/collection-manager/interfaces/number.ts
@@ -46,6 +46,7 @@ export const number: IField = {
   filterable: {
     operators: operators.number,
   },
+  titleUsable: true,
   validateSchema(fieldSchema) {
     return {
       maximum: {

--- a/packages/core/client/src/collection-manager/interfaces/percent.ts
+++ b/packages/core/client/src/collection-manager/interfaces/percent.ts
@@ -99,6 +99,7 @@ export const percent: IField = {
   filterable: {
     operators: operators.number,
   },
+  titleUsable: true,
   validateSchema(fieldSchema) {
     return {
       maxValue: {

--- a/packages/core/client/src/collection-manager/interfaces/phone.ts
+++ b/packages/core/client/src/collection-manager/interfaces/phone.ts
@@ -30,4 +30,5 @@ export const phone: IField = {
   filterable: {
     operators: operators.string,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/radioGroup.ts
+++ b/packages/core/client/src/collection-manager/interfaces/radioGroup.ts
@@ -26,4 +26,5 @@ export const radioGroup: IField = {
   filterable: {
     operators: operators.enumType,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/select.ts
+++ b/packages/core/client/src/collection-manager/interfaces/select.ts
@@ -28,6 +28,7 @@ export const select: IField = {
   filterable: {
     operators: operators.enumType,
   },
+  titleUsable: true,
   schemaInitialize(schema: ISchema, { block }) {
     const props = (schema['x-component-props'] = schema['x-component-props'] || {});
     props.style = {

--- a/packages/core/client/src/collection-manager/interfaces/time.ts
+++ b/packages/core/client/src/collection-manager/interfaces/time.ts
@@ -41,4 +41,5 @@ export const time: IField = {
   filterable: {
     operators: operators.time,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/types.ts
+++ b/packages/core/client/src/collection-manager/interfaces/types.ts
@@ -12,5 +12,7 @@ export interface IField extends ISchema {
   filterable?: any;
   /** 不支持使用变量的值进行设置 */
   invariable?: boolean;
+  // NOTE: set to `true` means field could be used as a title field
+  titleUsable?: boolean;
   [key: string]: any;
 }

--- a/packages/core/client/src/collection-manager/interfaces/updatedAt.ts
+++ b/packages/core/client/src/collection-manager/interfaces/updatedAt.ts
@@ -28,4 +28,5 @@ export const updatedAt: IField = {
   filterable: {
     operators: operators.datetime,
   },
+  titleUsable: true,
 };

--- a/packages/core/client/src/collection-manager/interfaces/url.ts
+++ b/packages/core/client/src/collection-manager/interfaces/url.ts
@@ -19,4 +19,5 @@ export const url: IField = {
   properties: {
     ...defaultProps,
   },
+  titleUsable: true,
 };

--- a/packages/plugins/formula-field/src/client/interfaces/formula.tsx
+++ b/packages/plugins/formula-field/src/client/interfaces/formula.tsx
@@ -197,4 +197,5 @@ export default {
   filterable: {
     operators: operators.number,
   },
+  titleUsable: true,
 } as IField;

--- a/packages/plugins/sequence-field/src/client/sequence.tsx
+++ b/packages/plugins/sequence-field/src/client/sequence.tsx
@@ -280,6 +280,10 @@ export const sequence: IField = {
     },
   },
   hasDefaultValue: false,
+  filterable: {
+    operators: interfacesProperties.operators.string,
+  },
+  titleUsable: true,
   schemaInitialize(schema: ISchema, { block, field }) {
     if (block === 'Form') {
       Object.assign(schema['x-component-props'], {
@@ -404,8 +408,5 @@ export const sequence: IField = {
         },
       },
     },
-  },
-  filterable: {
-    operators: interfacesProperties.operators.string,
   },
 };


### PR DESCRIPTION
# Description (需求描述)

Field/interface extended by plugin should be able to be set as title field.

# Motivation (需求背景)

* Formula field (result)
* Sequence field

# Key changes (关键改动）

- Frontend (前端)
  - Add `titleUsable` property to interface type.
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

* Fields configuration in collection
* Association field as select
* FormItem designers

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

<img width="768" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/b8c2b119-d9fb-44e5-9ba5-15159dff11e7">

