### PR TITLE
fix(plugin-workflow): fix request node error in loop

### DIFF
--- a/packages/plugins/workflow/src/server/__tests__/instructions/request.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/instructions/request.test.ts
@@ -213,5 +213,35 @@ describe('workflow > instructions > request', () => {
       expect(job.status).toEqual(JOB_STATUS.RESOLVED);
       expect(job.result.data).toEqual({ title });
     });
+
+    it('request inside loop',async () => {
+      const n1 = await workflow.createNode({
+        type: 'loop',
+        config: {
+          target: 2,
+        },
+      });
+
+      const n2 = await workflow.createNode({
+        type: 'request',
+        upstreamId: n1.id,
+        branchIndex: 0,
+        config: {
+          url: URL_DATA,
+          method: 'GET',
+        }
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toEqual(EXECUTION_STATUS.RESOLVED);
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.length).toBe(3);
+      expect(jobs.map(item => item.status)).toEqual(Array(3).fill(JOB_STATUS.RESOLVED));
+      expect(jobs[0].result).toBe(2);
+    });
   });
 });

--- a/packages/plugins/workflow/src/server/instructions/request.ts
+++ b/packages/plugins/workflow/src/server/instructions/request.ts
@@ -45,10 +45,11 @@ async function request(config) {
 export default class implements Instruction {
   constructor(public plugin) {}
 
-  async run(node: FlowNodeModel, input, processor: Processor) {
+  async run(node: FlowNodeModel, prevJob, processor: Processor) {
     const job = await processor.saveJob({
       status: JOB_STATUS.PENDING,
       nodeId: node.id,
+      upstreamId: prevJob?.id ?? null,
     });
 
     const config = processor.getParsedValue(node.config, node) as RequestConfig;


### PR DESCRIPTION
## Description (Bug 描述)

Loop will error when request node inside.

### Steps to reproduce (复现步骤)

1. Create a loop node, set target as a number.
2. Create a request node inside the loop.
3. Trigger the workflow.

### Expected behavior (预期行为)

Process normally to end with `RESOLVED` status.

### Actual behavior (实际行为)

Error occurred in loop node.

## Related issues (相关 issue)

https://github.com/nocobase/nocobase/discussions/2235

## Reason (原因)

No `upstreamId` set in pending request running phase.

## Solution (解决方案)

Add `upstreamId` to save the pending job.
