### PR TITLE
feat: add minio S3 as file storage

### DIFF
--- a/packages/plugins/file-manager/src/client/StorageOptions.tsx
+++ b/packages/plugins/file-manager/src/client/StorageOptions.tsx
@@ -119,6 +119,39 @@ const schema = {
       },
     },
   },
+  minio: {
+    properties: {
+      region: {
+        title: `{{t("Region", { ns: "${NAMESPACE}" })}}`,
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input',
+        required: true,
+        default: 'us-east-1',
+      },
+      accessKeyId: {
+        title: `{{t("AccessKey ID", { ns: "${NAMESPACE}" })}}`,
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input',
+        required: true,
+      },
+      secretAccessKey: {
+        title: `{{t("AccessKey Secret", { ns: "${NAMESPACE}" })}}`,
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'Password',
+        required: true,
+      },
+      bucket: {
+        title: `{{t("Bucket", { ns: "${NAMESPACE}" })}}`,
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'Input',
+        required: true,
+      },
+    },
+  },
 };
 
 export const StorageOptions = observer(

--- a/packages/plugins/file-manager/src/client/schemas/storage.ts
+++ b/packages/plugins/file-manager/src/client/schemas/storage.ts
@@ -41,6 +41,7 @@ const collection = {
           { label: `{{t("Local storage", { ns: "${NAMESPACE}" })}}`, value: 'local' },
           { label: `{{t("Aliyun OSS", { ns: "${NAMESPACE}" })}}`, value: 'ali-oss' },
           { label: `{{t("Amazon S3", { ns: "${NAMESPACE}" })}}`, value: 's3' },
+          { label: `{{t("Minio S3", { ns: "${NAMESPACE}" })}}`, value: 'minio' },
           { label: `{{t("Tencent COS", { ns: "${NAMESPACE}" })}}`, value: 'tx-cos' },
         ],
       } as ISchema,

--- a/packages/plugins/file-manager/src/server/__tests__/storages/minio.test.ts
+++ b/packages/plugins/file-manager/src/server/__tests__/storages/minio.test.ts
@@ -1,0 +1,126 @@
+import path from 'path';
+import { MockServer } from '@nocobase/test';
+import minioStorage from '../../storages/minio';
+import { FILE_FIELD_NAME } from '../../constants';
+import { getApp, requestFile } from '..';
+import Database from '@nocobase/database';
+
+const itif = process.env.MINIO_SECRET_ACCESS_KEY ? it : it.skip;
+
+describe('storage:s3', () => {
+  let app: MockServer;
+  let agent;
+  let db: Database;
+  let AttachmentRepo;
+  let StorageRepo;
+  let storage;
+
+  beforeEach(async () => {
+    app = await getApp();
+    agent = app.agent();
+    db = app.db;
+
+    AttachmentRepo = db.getCollection('attachments').repository;
+    StorageRepo = db.getCollection('storages').repository;
+
+    storage = await StorageRepo.create({
+      values: {
+        ...minioStorage.defaults(),
+        name: 's3',
+        default: true,
+        path: 'test/path',
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  describe('direct attachment', () => {
+    itif('upload file should be ok', async () => {
+      const { body } = await agent.resource('attachments').create({
+        [FILE_FIELD_NAME]: path.resolve(__dirname, '../files/text.txt'),
+      });
+
+      const attachment = await AttachmentRepo.findOne({
+        filterByTk: body.data.id,
+        appends: ['storage'],
+      });
+
+      const matcher = {
+        title: 'text',
+        extname: '.txt',
+        path: 'test/path',
+        size: 13,
+        mimetype: 'text/plain',
+        meta: {},
+        storageId: storage.id,
+      };
+
+      // 文件上传和解析是否正常
+      expect(body.data).toMatchObject(matcher);
+      // 文件的 url 是否正常生成
+      expect(body.data.url).toBe(`${attachment.storage.baseUrl}/${body.data.path}/${body.data.filename}`);
+      // 文件的数据是否正常保存
+      expect(attachment).toMatchObject(matcher);
+
+      // 通过 url 是否能正确访问
+      const content = await requestFile(attachment.url, agent);
+      expect(content.text).toBe('Hello world!\n');
+    });
+  });
+
+  describe('destroy', () => {
+    itif('destroy record should also delete file', async () => {
+      const { body } = await agent.resource('attachments').create({
+        [FILE_FIELD_NAME]: path.resolve(__dirname, '../files/text.txt'),
+      });
+      // 通过 url 是否能正确访问
+      const content1 = await requestFile(body.data.url, agent);
+      expect(content1.text).toBe('Hello world!\n');
+
+      const res = await agent.resource('attachments').destroy({
+        filterByTk: body.data.id,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const count = await AttachmentRepo.count();
+      expect(count).toBe(0);
+
+      const content2 = await requestFile(body.data.url, agent);
+      console.log(content2.status, body.data.url);
+      expect(content2.status).toBe(403);
+    });
+
+    itif('destroy record should not delete file when paranoid', async () => {
+      const paranoidStorage = await StorageRepo.create({
+        values: {
+          ...minioStorage.defaults(),
+          name: 's3-2',
+          path: 'test/nocobase',
+          paranoid: true,
+          default: true,
+        },
+      });
+
+      const { body } = await agent.resource('attachments').create({
+        [FILE_FIELD_NAME]: path.resolve(__dirname, '../files/text.txt'),
+      });
+      // 通过 url 是否能正确访问
+      const content1 = await requestFile(body.data.url, agent);
+      expect(content1.text).toBe('Hello world!\n');
+
+      const res = await agent.resource('attachments').destroy({
+        filterByTk: body.data.id,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const count = await AttachmentRepo.count();
+      expect(count).toBe(0);
+
+      const content2 = await requestFile(body.data.url, agent);
+      expect(content2.status).toBe(200);
+    });
+  });
+});

--- a/packages/plugins/file-manager/src/server/constants.ts
+++ b/packages/plugins/file-manager/src/server/constants.ts
@@ -5,4 +5,5 @@ export const DEFAULT_MAX_FILE_SIZE = 1024 * 1024 * 1024;
 export const STORAGE_TYPE_LOCAL = 'local';
 export const STORAGE_TYPE_ALI_OSS = 'ali-oss';
 export const STORAGE_TYPE_S3 = 's3';
+export const STORAGE_TYPE_MINIO = 'minio';
 export const STORAGE_TYPE_TX_COS = 'tx-cos';

--- a/packages/plugins/file-manager/src/server/storages/index.ts
+++ b/packages/plugins/file-manager/src/server/storages/index.ts
@@ -5,9 +5,10 @@ import { Registry } from '@nocobase/utils';
 import local from './local';
 import oss from './ali-oss';
 import s3 from './s3';
+import minio from './minio';
 import cos from './tx-cos';
 
-import { STORAGE_TYPE_LOCAL, STORAGE_TYPE_ALI_OSS, STORAGE_TYPE_S3, STORAGE_TYPE_TX_COS } from '../constants';
+import { STORAGE_TYPE_LOCAL, STORAGE_TYPE_ALI_OSS, STORAGE_TYPE_S3, STORAGE_TYPE_MINIO, STORAGE_TYPE_TX_COS } from '../constants';
 
 export interface StorageModel {
   title: string;
@@ -37,6 +38,7 @@ const storageTypes = new Registry<IStorage>();
 storageTypes.register(STORAGE_TYPE_LOCAL, local);
 storageTypes.register(STORAGE_TYPE_ALI_OSS, oss);
 storageTypes.register(STORAGE_TYPE_S3, s3);
+storageTypes.register(STORAGE_TYPE_MINIO, minio);
 storageTypes.register(STORAGE_TYPE_TX_COS, cos);
 
 export function getStorageConfig(key: string): IStorage {

--- a/packages/plugins/file-manager/src/server/storages/minio.ts
+++ b/packages/plugins/file-manager/src/server/storages/minio.ts
@@ -1,0 +1,70 @@
+import { AttachmentModel } from '.';
+import { STORAGE_TYPE_MINIO } from '../constants';
+import { cloudFilenameGetter } from '../utils';
+
+export default {
+  filenameKey: 'key',
+  make(storage) {
+    const { S3Client } = require('@aws-sdk/client-s3');
+    const multerS3 = require('multer-s3');
+    const { baseUrl } = storage;
+    const { accessKeyId, secretAccessKey, bucket, acl = 'public-read', ...options } = storage.options;
+
+    const s3 = new S3Client({
+      ...options,
+      endpoint: baseUrl,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    });
+    return multerS3({
+      s3,
+      bucket,
+      acl,
+      contentType(req, file, cb) {
+        if (file.mimetype) {
+          cb(null, file.mimetype);
+          return;
+        }
+
+        multerS3.AUTO_CONTENT_TYPE(req, file, cb);
+      },
+      key: cloudFilenameGetter(storage),
+    });
+  },
+  defaults() {
+    return {
+      title: 'MinIO S3',
+      name: 'minio-s3',
+      type: STORAGE_TYPE_MINIO,
+      baseUrl: process.env.MINIO_S3_STORAGE_BASE_URL,
+      options: {
+        region: process.env.MINIO_S3_REGION,
+        accessKeyId: process.env.MINIO_ACCESS_KEY_ID,
+        secretAccessKey: process.env.MINIO_SECRET_ACCESS_KEY,
+        bucket: process.env.MINIO_S3_BUCKET,
+      },
+    };
+  },
+  async delete(storage, records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {
+    const { DeleteObjectsCommand } = require('@aws-sdk/client-s3');
+    const { s3 } = this.make(storage);
+    const { Deleted } = await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: storage.options.bucket,
+        Delete: {
+          Objects: records.map((record) => ({ Key: `${record.path}/${record.filename}` })),
+        },
+      }),
+    );
+
+    return [
+      Deleted.length,
+      records.filter(
+        (record) =>
+          !Deleted.find((item) => item.Key === `${record.path}/${record.filename}` || item.Key === record.filename),
+      ),
+    ];
+  },
+};


### PR DESCRIPTION
> **Note**
> This is a template for submitting a new feature. Use the bug fix template if you're submitting a bug fix pull request by adding `template=bug_fix.md` to your pull request URL.

# Description (需求描述)
One more file storage added - Minio S3
It is slightly changed AWS S3 which wasn't working with Minio S3.

# Motivation (需求背景)
Additional file storage.

# Key changes (关键改动）
Provide a technically detailed description of the key changes made.
- Frontend (前端)
  added "Minio S3" option
- Backend (后端)
  copied `s3` to a `minio` and changed to work with Minio installation
  changes from s3 to minio are
  - "baseUrl" should be taken from storage object and put to `endpoint` parameter
  - on object delete minio sends only filename
  

# Test plan (测试计划)
## Suggestions (测试建议)
No

## Underlying risk (潜在风险)
No

# Showcase (结果展示）
No
