### PR TITLE
fix(bi): eliminate redundancy queries

### DIFF
--- a/packages/plugins/data-visualization/src/client/block/ChartBlock.tsx
+++ b/packages/plugins/data-visualization/src/client/block/ChartBlock.tsx
@@ -1,21 +1,23 @@
 import { SchemaInitializerButtonContext, useDesignable } from '@nocobase/client';
 import React, { useState } from 'react';
+import { ChartRendererProvider } from '../renderer';
 import { ChartConfigContext, ChartConfigCurrent, ChartConfigure } from './ChartConfigure';
 
 export const ChartV2Block: React.FC = (props) => {
   const { insertAdjacent } = useDesignable();
   const [visible, setVisible] = useState(false);
   const [current, setCurrent] = useState<ChartConfigCurrent>({} as any);
-  const [data, setData] = useState<string | any[]>([]);
   const [initialVisible, setInitialVisible] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   return (
     <SchemaInitializerButtonContext.Provider
       value={{ visible: initialVisible, setVisible: setInitialVisible, searchValue, setSearchValue }}
     >
-      <ChartConfigContext.Provider value={{ visible, setVisible, current, setCurrent, data, setData }}>
+      <ChartConfigContext.Provider value={{ visible, setVisible, current, setCurrent }}>
         {props.children}
-        <ChartConfigure insert={(schema, options) => insertAdjacent('beforeEnd', schema, options)} />
+        <ChartRendererProvider {...current.field?.decoratorProps}>
+          <ChartConfigure insert={(schema, options) => insertAdjacent('beforeEnd', schema, options)} />
+        </ChartRendererProvider>
       </ChartConfigContext.Provider>
     </SchemaInitializerButtonContext.Provider>
   );

--- a/packages/plugins/data-visualization/src/client/block/ChartBlockInitializer.tsx
+++ b/packages/plugins/data-visualization/src/client/block/ChartBlockInitializer.tsx
@@ -13,7 +13,7 @@ const ConfigureButton = itemWrap((props) => {
     <SchemaInitializer.Item
       {...props}
       onClick={() => {
-        setCurrent({ schema: {}, field: null, collection: props.item?.name, service: null });
+        setCurrent({ schema: {}, field: null, collection: props.item?.name, service: null, data: undefined });
         setVisible(true);
       }}
     />

--- a/packages/plugins/data-visualization/src/client/block/ChartBlockInitializer.tsx
+++ b/packages/plugins/data-visualization/src/client/block/ChartBlockInitializer.tsx
@@ -8,13 +8,12 @@ import { ChartConfigContext } from './ChartConfigure';
 
 const itemWrap = SchemaInitializer.itemWrap;
 const ConfigureButton = itemWrap((props) => {
-  const { setVisible, setCurrent, setData } = useContext(ChartConfigContext);
+  const { setVisible, setCurrent } = useContext(ChartConfigContext);
   return (
     <SchemaInitializer.Item
       {...props}
       onClick={() => {
-        setCurrent({ schema: {}, field: null, collection: props.item?.name });
-        setData([]);
+        setCurrent({ schema: {}, field: null, collection: props.item?.name, service: null });
         setVisible(true);
       }}
     />

--- a/packages/plugins/data-visualization/src/client/block/ChartConfigure.tsx
+++ b/packages/plugins/data-visualization/src/client/block/ChartConfigure.tsx
@@ -132,9 +132,6 @@ export const ChartConfigure: React.FC<{
           onFieldChange('config.chartType', () => initChart(true));
           onFormInit(() => {
             queryReact(form);
-            // if (!service.loading) {
-            //   service.run(collection, form.values.query);
-            // }
           });
         },
       });
@@ -182,6 +179,7 @@ export const ChartConfigure: React.FC<{
           current.service?.run(collection, query);
           queryRef.current.scrollTop = 0;
           configRef.current.scrollTop = 0;
+          service.mutate(undefined);
         };
         const rendererProps = {
           query,
@@ -337,7 +335,7 @@ ChartConfigure.Query = function Query() {
       collection: value,
       service: current.service,
     });
-    service.mutate([]);
+    service.mutate(undefined);
   };
   const FromSql = () => (
     <Text code>

--- a/packages/plugins/data-visualization/src/client/block/ChartConfigure.tsx
+++ b/packages/plugins/data-visualization/src/client/block/ChartConfigure.tsx
@@ -127,7 +127,7 @@ export const ChartConfigure: React.FC<{
     () => {
       const chartType = chartTypes[0]?.children?.[0]?.value;
       return createForm({
-        values: { config: { chartType }, ...field?.decoratorProps, collection, data: '' },
+        values: { config: { chartType }, ...field?.decoratorProps, collection },
         effects: (form) => {
           onFieldChange('config.chartType', () => initChart(true));
           onFormInit(() => {
@@ -138,7 +138,7 @@ export const ChartConfigure: React.FC<{
     },
     // visible, collection added here to re-initialize form when visible, collection change
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [field, collection],
+    [field, visible, collection],
   );
 
   const RunButton: React.FC = () => (
@@ -214,6 +214,7 @@ export const ChartConfigure: React.FC<{
             setVisible(false);
             queryRef.current.scrollTop = 0;
             configRef.current.scrollTop = 0;
+            service.mutate(undefined);
           },
         });
       }}

--- a/packages/plugins/data-visualization/src/client/block/ChartConfigure.tsx
+++ b/packages/plugins/data-visualization/src/client/block/ChartConfigure.tsx
@@ -32,7 +32,7 @@ import {
 } from '../hooks';
 import { useChartsTranslation } from '../locale';
 import { ChartRenderer, ChartRendererContext, useChartTypes, useCharts } from '../renderer';
-import { createRendererSchema, getField, getSelectedFields } from '../utils';
+import { createRendererSchema, getField, getSelectedFields, processData } from '../utils';
 import { getConfigSchema, querySchema, transformSchema } from './schemas/configure';
 const { Paragraph, Text } = Typography;
 
@@ -432,10 +432,11 @@ ChartConfigure.Transform = function Transform() {
 };
 
 ChartConfigure.Data = function Data() {
+  const { t } = useChartsTranslation();
   const { current } = useContext(ChartConfigContext);
   const { service } = useContext(ChartRendererContext);
   const fields = useFieldsWithAssociation();
-  const data = service?.data || current?.service?.data || [];
+  const data = processData(fields, service?.data || current?.service?.data || [], { t });
   const error = service?.error;
   return !error ? (
     <div

--- a/packages/plugins/data-visualization/src/client/renderer/ChartLibrary.tsx
+++ b/packages/plugins/data-visualization/src/client/renderer/ChartLibrary.tsx
@@ -90,6 +90,11 @@ export const useChartTypes = (): {
     }, []);
 };
 
+export const useDefaultChartType = () => {
+  const chartTypes = useChartTypes();
+  return chartTypes[0]?.children?.[0]?.value;
+};
+
 export const useToggleChartLibrary = () => {
   const ctx = useContext(ChartLibraryContext);
   return {

--- a/packages/plugins/data-visualization/src/client/renderer/ChartRenderer.tsx
+++ b/packages/plugins/data-visualization/src/client/renderer/ChartRenderer.tsx
@@ -88,7 +88,7 @@ ChartRenderer.Designer = function Designer() {
       <SchemaSettings.Item
         key="configure"
         onClick={() => {
-          setCurrent({ schema, field, collection: name, service });
+          setCurrent({ schema, field, collection: name, service, data: service?.data });
           setVisible(true);
         }}
       >

--- a/packages/plugins/data-visualization/src/client/renderer/ChartRenderer.tsx
+++ b/packages/plugins/data-visualization/src/client/renderer/ChartRenderer.tsx
@@ -1,107 +1,34 @@
 import { useField, useFieldSchema } from '@formily/react';
 import {
   GeneralSchemaDesigner,
-  gridRowColWrap,
   SchemaSettings,
+  gridRowColWrap,
   useAPIClient,
   useCollection,
   useDesignable,
-  useRequest,
 } from '@nocobase/client';
-import { Empty, Result, Typography } from 'antd';
-import React, { useContext, useEffect, useState } from 'react';
+import { Empty, Result, Spin, Typography } from 'antd';
+import React, { useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ChartConfigContext } from '../block';
-import { useFieldsWithAssociation, useFieldTransformer } from '../hooks';
+import { useFieldTransformer, useFieldsWithAssociation } from '../hooks';
 import { useChartsTranslation } from '../locale';
-import { createRendererSchema, getField, parseField, processData } from '../utils';
+import { createRendererSchema, getField, processData } from '../utils';
 import { useCharts } from './ChartLibrary';
-import { ChartRendererContext, DimensionProps, MeasureProps, QueryProps } from './ChartRendererProvider';
+import { ChartRendererContext } from './ChartRendererProvider';
 const { Paragraph, Text } = Typography;
 
-export const ChartRenderer: React.FC<{
-  configuring?: boolean;
-  runQuery?: any;
-}> & {
+export const ChartRenderer: React.FC & {
   Designer: React.FC;
 } = (props) => {
   const { t } = useChartsTranslation();
-  const { setData: setQueryData, current } = useContext(ChartConfigContext);
-  const { query, config, collection, transform } = useContext(ChartRendererContext);
-  const { configuring, runQuery } = props;
+  const ctx = useContext(ChartRendererContext);
+  const { config, transform, collection, service, data: _data } = ctx;
+  const fields = useFieldsWithAssociation(collection);
+  const data = processData(fields, service?.data || _data || [], { t });
   const general = config?.general || {};
   const advanced = config?.advanced || {};
-  const schema = useFieldSchema();
-  const currentSchema = schema || current?.schema;
-  const fields = useFieldsWithAssociation(collection);
   const api = useAPIClient();
-  const [data, setData] = useState<any[]>([]);
-  const { runAsync } = useRequest(
-    (query) =>
-      api
-        .request({
-          url: 'charts:query',
-          method: 'POST',
-          data: {
-            uid: currentSchema?.['x-uid'],
-            collection,
-            ...query,
-            dimensions: (query?.dimensions || []).map((item: DimensionProps) => {
-              const dimension = { ...item };
-              if (item.format && !item.alias) {
-                const { alias } = parseField(item.field);
-                dimension.alias = alias;
-              }
-              return dimension;
-            }),
-            measures: (query?.measures || []).map((item: MeasureProps) => {
-              const measure = { ...item };
-              if (item.aggregation && !item.alias) {
-                const { alias } = parseField(item.field);
-                measure.alias = alias;
-              }
-              return measure;
-            }),
-          },
-        })
-        .then((res) => {
-          const data = res?.data?.data || [];
-          return processData(fields, data, { t });
-        }),
-    {
-      manual: true,
-      onSuccess: (data) => {
-        setData(data);
-      },
-      onFinally(params, data, error: any) {
-        if (!configuring) {
-          return;
-        }
-        if (error) {
-          const message = error?.response?.data?.errors?.map?.((error: any) => error.message).join('\n');
-          setQueryData(message || error.message);
-          return;
-        }
-        setQueryData(data);
-      },
-    },
-  );
-
-  useEffect(() => {
-    setData([]);
-    const run = async (query: QueryProps) => {
-      if (
-        query?.measures?.length
-        // || (query?.sql?.fields && query?.sql?.clauses)
-      ) {
-        await runAsync(query);
-      }
-    };
-    if (runQuery) {
-      runQuery.current = run;
-    }
-    run(query);
-  }, [query, runAsync, runQuery]);
 
   const charts = useCharts();
   const chart = charts[config?.chartType];
@@ -137,16 +64,21 @@ export const ChartRenderer: React.FC<{
       <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('Please configure chart')} />
     );
 
-  return data && data.length ? (
-    <C />
-  ) : (
-    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('Please configure and run query')} />
-  );
+  if (service.loading) {
+    return <Spin />;
+  }
+
+  if (!(data && data.length)) {
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('Please configure and run query')} />;
+  }
+
+  return <C />;
 };
 
 ChartRenderer.Designer = function Designer() {
   const { t } = useChartsTranslation();
   const { setVisible, setCurrent } = useContext(ChartConfigContext);
+  const { service } = useContext(ChartRendererContext);
   const field = useField();
   const schema = useFieldSchema();
   const { insertAdjacent } = useDesignable();
@@ -156,7 +88,7 @@ ChartRenderer.Designer = function Designer() {
       <SchemaSettings.Item
         key="configure"
         onClick={() => {
-          setCurrent({ schema, field, collection: name });
+          setCurrent({ schema, field, collection: name, service });
           setVisible(true);
         }}
       >

--- a/packages/plugins/data-visualization/src/client/renderer/library/G2PlotLibrary.tsx
+++ b/packages/plugins/data-visualization/src/client/renderer/library/G2PlotLibrary.tsx
@@ -181,7 +181,7 @@ export const G2PlotLibrary: Charts = {
                 'x-reactions': '{{ useChartFields }}',
                 'x-component-props': {
                   style: {
-                    'min-width': '200px',
+                    minWidth: '200px',
                   },
                 },
                 required: true,


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

![20230718235445_rec_](https://github.com/nocobase/nocobase/assets/3250534/fec2a066-1c24-4a9d-8267-1442e50b0719)

### Expected behavior (预期行为)

请求只与当前区块相关，没有多余请求

### Actual behavior (实际行为)

拖拽，配置改变会使当前页面的所有图表区块重新请求

## Reason (原因)

数据请求和图表渲染组件杂糅，而配置和展示共用图表渲染组件，请求判断有问题，导致每次组件重新渲染，都会重复请求。

## Solution (解决方案)

将请求和图表渲染拆分，优化请求方式。

Close T-786
