### PR TITLE
fix(client): using component as action title

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -21,6 +21,7 @@ import { ActionContextProvider } from './context';
 import { useA } from './hooks';
 import { ComposedAction } from './types';
 import { linkageAction } from './utils';
+import { lodash } from '@nocobase/utils';
 
 export const actionDesignerCss = css`
   position: relative;
@@ -99,6 +100,8 @@ export const Action: ComposedAction = observer(
     const { designable } = useDesignable();
     const tarComponent = useComponent(component) || component;
     const { modal } = App.useApp();
+    let actionTitle = title || compile(fieldSchema.title);
+    actionTitle = lodash.isString(actionTitle) ? t(actionTitle) : actionTitle;
 
     useEffect(() => {
       field.linkageProperty = {};
@@ -148,7 +151,7 @@ export const Action: ComposedAction = observer(
           className={classnames(actionDesignerCss, className)}
           type={props.type === 'danger' ? undefined : props.type}
         >
-          {t(title || compile(fieldSchema.title))}
+          {actionTitle}
           <Designer {...designerProps} />
         </SortableItem>
       );


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

工作流 - 执行记录 - 查看
![97cfe48e-757b-4c02-b319-1e80b1e87559](https://github.com/nocobase/nocobase/assets/3250534/16fdd772-ceee-4c06-bce3-0bdcf047a99c)


### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

能正常显示icon
<img width="296" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/f83fdea2-79e1-49ba-b2cf-5d66fadf3ee4">


### Actual behavior (实际行为)

显示`[object Object]`

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

多语言需要修改了`title`为`{t(title || compile(fieldSchema.title))}`

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

增加title是否为字符串的判断。

Close T-1077
