### PR TITLE
fix(bi): orderBy bug under MySQL

### DIFF
--- a/packages/plugins/data-visualization/src/server/__tests__/api.test.ts
+++ b/packages/plugins/data-visualization/src/server/__tests__/api.test.ts
@@ -41,8 +41,8 @@ describe('api', () => {
     const repo = db.getRepository('chart_test');
     await repo.create({
       values: [
-        { price: 1, count: 1, title: 'title1' },
-        { price: 2, count: 2, title: 'title2' },
+        { price: 1, count: 1, title: 'title1', createdAt: '2023-02-02' },
+        { price: 2, count: 2, title: 'title2', createdAt: '2023-01-01' },
       ],
     });
   });
@@ -51,55 +51,52 @@ describe('api', () => {
     await db.close();
   });
 
-  test('query', () => {
-    expect.assertions(1);
-    return expect(
-      queryData({ db } as any, {
-        collection: 'chart_test',
-        measures: [
-          {
-            field: ['price'],
-            alias: 'Price',
-          },
-          {
-            field: ['count'],
-            alias: 'Count',
-          },
-        ],
-        dimensions: [
-          {
-            field: ['title'],
-            alias: 'Title',
-          },
-        ],
-      }),
-    ).resolves.toBeDefined();
+  test('query', async () => {
+    const result = await queryData({ db } as any, {
+      collection: 'chart_test',
+      measures: [
+        {
+          field: ['price'],
+          alias: 'Price',
+        },
+        {
+          field: ['count'],
+          alias: 'Count',
+        },
+      ],
+      dimensions: [
+        {
+          field: ['title'],
+          alias: 'Title',
+        },
+      ],
+    });
+    expect(result).toBeDefined();
   });
 
-  test('query with sort', () => {
-    expect.assertions(1);
-    return expect(
-      queryData({ db } as any, {
-        collection: 'chart_test',
-        measures: [
-          {
-            field: ['price'],
-            aggregation: 'sum',
-            alias: 'Price',
-          },
-        ],
-        dimensions: [
-          {
-            field: ['title'],
-            alias: 'Title',
-          },
-          {
-            field: ['createdAt'],
-            format: 'YYYY',
-          },
-        ],
-        orders: [{ field: 'createdAt', order: 'asc' }],
-      }),
-    ).resolves.toBeDefined();
+  test('query with sort', async () => {
+    const result = await queryData({ db } as any, {
+      collection: 'chart_test',
+      measures: [
+        {
+          field: ['price'],
+          aggregation: 'sum',
+          alias: 'Price',
+        },
+      ],
+      dimensions: [
+        {
+          field: ['title'],
+          alias: 'Title',
+        },
+        {
+          field: ['createdAt'],
+          format: 'YYYY-MM',
+        },
+      ],
+      orders: [{ field: 'createdAt', order: 'asc' }],
+    });
+    expect(result).toBeDefined();
+    expect(result).toMatchObject([{ createdAt: '2023-01' }, { createdAt: '2023-02' }]);
   });
 });

--- a/packages/plugins/data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/data-visualization/src/server/actions/query.ts
@@ -161,7 +161,12 @@ export const parseBuilder = (ctx: Context, builder: QueryParams) => {
   });
 
   orders.forEach((item: OrderProps) => {
-    const name = hasAgg ? sequelize.literal(`\`${item.alias}\``) : sequelize.col(item.field as string);
+    const dialect = sequelize.getDialect();
+    let alias = `"${item.alias}"`;
+    if (dialect === 'mysql') {
+      alias = `\`${item.alias}\``;
+    }
+    const name = hasAgg ? sequelize.literal(alias) : sequelize.col(item.field as string);
     order.push([name, item.order || 'ASC']);
   });
 

--- a/packages/plugins/data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/data-visualization/src/server/actions/query.ts
@@ -161,7 +161,7 @@ export const parseBuilder = (ctx: Context, builder: QueryParams) => {
   });
 
   orders.forEach((item: OrderProps) => {
-    const name = hasAgg ? sequelize.literal(`"${item.alias}"`) : sequelize.col(item.field as string);
+    const name = hasAgg ? sequelize.literal(`\`${item.alias}\``) : sequelize.col(item.field as string);
     order.push([name, item.order || 'ASC']);
   });
 


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

使用MySQL，在图表中对日期字段做排序。

### Expected behavior (预期行为)

返回数据按配置排序

### Actual behavior (实际行为)

返回数据没有正常排序

## Reason (原因)

处理`orderBy`别名时使用双引号`"`, 在MySQL中被认为是字符串。
https://stackoverflow.com/questions/61467696/why-does-using-or-doesnt-sort-column-aliases-via-order-by-in-mysql

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

MySQL处理别名时使用<code>`</code>

Close T-1095
