### PR TITLE
fix(plugin-workflow): workflow collections should not appear in blocks

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/manual/WorkflowTodo.tsx
+++ b/packages/plugins/workflow/src/client/nodes/manual/WorkflowTodo.tsx
@@ -593,16 +593,10 @@ function Decorator({ params = {}, children }) {
     dragSort: false,
   };
 
-  [nodeCollection, workflowCollection, todoCollection].forEach((collection) => {
-    if (!collections.find((item) => item.name === collection.name)) {
-      collections.push(collection);
-    }
-  });
-
   return (
     <CollectionManagerProvider
       {...cm}
-      collections={[...collections]}
+      collections={[...collections, nodeCollection, workflowCollection, todoCollection]}
     >
       <TableBlockProvider {...blockProps}>{children}</TableBlockProvider>
     </CollectionManagerProvider>


### PR DESCRIPTION
## Description (Bug 描述)

Workflow collection appears in block initializers.

### Steps to reproduce (复现步骤)

1. Create block via table... etc., 3 collection "Task"/"Workflow"/"Todo" appears in list.

### Expected behavior (预期行为)

No workflow collections.

### Actual behavior (实际行为)

Exposed.

## Related issues (相关 issue)

#2225.

## Reason (原因)

Should not use `push` to add to collection manager.

## Solution (解决方案)

Revert relative code back.
