### PR TITLE
fix(plugin-workflow): fix schedule duplicated triggering in multi-apps

### DIFF
--- a/packages/plugins/workflow/src/server/triggers/schedule.ts
+++ b/packages/plugins/workflow/src/server/triggers/schedule.ts
@@ -424,6 +424,10 @@ export default class ScheduleTrigger extends Trigger {
   }
 
   init() {
+    if (this.plugin.app.name !== 'main') {
+      return;
+    }
+
     if (this.timer) {
       return;
     }
@@ -435,7 +439,7 @@ export default class ScheduleTrigger extends Trigger {
       this.run,
       // NOTE:
       //  try to align to system time on each second starts,
-      //  after at least 1 second initialized for anything to get ready.
+      //  after at least 1 second initialized for everything to get ready.
       //  so jobs in 2 seconds will be missed at first start.
       1_000 - now.getMilliseconds(),
     );


### PR DESCRIPTION
## Description (Bug 描述)

Schedule workflow will be triggered multiple times in multi-apps.

### Steps to reproduce (复现步骤)

1. Add a schedule workflow.
2. Add a sub app.
3. Wait to time for triggering.

### Expected behavior (预期行为)

Only trigger once.

### Actual behavior (实际行为)

Workflow will be triggered once in each app.

## Related issues (相关 issue)

None.

## Reason (原因)

Schedule manager will start in each app.

## Solution (解决方案)

Disable timer if app is not main.
