### PR TITLE
refactor(plugin-workflow): allow system values to be assigned in create and update node

### DIFF
--- a/packages/plugins/workflow/src/client/components/CollectionFieldset.tsx
+++ b/packages/plugins/workflow/src/client/components/CollectionFieldset.tsx
@@ -32,14 +32,6 @@ function AssociationInput(props) {
   return <Input {...props} value={value} onChange={onChange} />;
 }
 
-export function useCollectionUIFields(collection) {
-  const { getCollectionFields } = useCollectionManager();
-
-  return getCollectionFields(collection).filter(
-    (field) => !field.hidden && (field.uiSchema ? !field.uiSchema['x-read-pretty'] : false),
-  );
-}
-
 // NOTE: observer for watching useProps
 const CollectionFieldSet = observer(
   ({ value, disabled, onChange, filter }: any) => {
@@ -47,11 +39,11 @@ const CollectionFieldSet = observer(
     const { t } = useTranslation();
     const compile = useCompile();
     const form = useForm();
-    const { getCollection } = useCollectionManager();
+    const { getCollection, getCollectionFields } = useCollectionManager();
     const scope = useWorkflowVariableOptions();
     const { values: config } = form;
     const collectionName = config?.collection;
-    const collectionFields = useCollectionUIFields(collectionName);
+    const collectionFields = getCollectionFields(collectionName);
     const fields = filter ? collectionFields.filter(filter.bind(config)) : collectionFields;
 
     const unassignedFields = useMemo(() => fields.filter((field) => !value || !(field.name in value)), [fields, value]);

--- a/packages/plugins/workflow/src/client/nodes/update.tsx
+++ b/packages/plugins/workflow/src/client/nodes/update.tsx
@@ -1,20 +1,21 @@
+import { useField, useForm } from '@formily/react';
 import React from 'react';
-import { useForm, useField } from '@formily/react';
 
-import { useCollectionDataSource } from '@nocobase/client';
+import { useCollectionDataSource, useCollectionManager } from '@nocobase/client';
 
+import CollectionFieldset from '../components/CollectionFieldset';
 import { FilterDynamicComponent } from '../components/FilterDynamicComponent';
-import CollectionFieldset, { useCollectionUIFields } from '../components/CollectionFieldset';
 
-import { isValidFilter } from '../utils';
+import { RadioWithTooltip } from '../components/RadioWithTooltip';
 import { NAMESPACE, lang } from '../locale';
 import { collection, filter, values } from '../schemas/collection';
-import { RadioWithTooltip } from '../components/RadioWithTooltip';
+import { isValidFilter } from '../utils';
 
 function IndividualHooksRadioWithTooltip({ onChange, ...props }) {
+  const { getCollectionFields } = useCollectionManager();
   const form = useForm();
   const { collection } = form.values;
-  const fields = useCollectionUIFields(collection);
+  const fields = getCollectionFields(collection);
   const field = useField<any>();
 
   function onValueChange({ target }) {


### PR DESCRIPTION
# Description (需求描述)

Allow system field values to be assigned in create and update node.

# Motivation (需求背景)

`createdBy`, `updatedBy` etc. fields should be able to be assigned.

# Key changes (关键改动）

- Frontend (前端)
  - Use full fields in values assigning in create and update node configuration.
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

Test system fields.

## Underlying risk (潜在风险)

`id`, `createdAt` and `updatedAt` can be assigned too.

# Showcase (结果展示）

None.
