### PR TITLE
refactor(plugin-workflow): change strict equal and not equal to non-strict

### DIFF
--- a/packages/plugins/workflow/src/server/instructions/condition.ts
+++ b/packages/plugins/workflow/src/server/instructions/condition.ts
@@ -11,11 +11,11 @@ export const calculators = new Registry<Comparer>();
 
 // built-in functions
 function equal(a, b) {
-  return a === b;
+  return a == b;
 }
 
 function notEqual(a, b) {
-  return a !== b;
+  return a != b;
 }
 
 function gt(a, b) {
@@ -41,8 +41,8 @@ calculators.register('gte', gte);
 calculators.register('lt', lt);
 calculators.register('lte', lte);
 
-calculators.register('===', equal);
-calculators.register('!==', notEqual);
+calculators.register('==', equal);
+calculators.register('!=', notEqual);
 calculators.register('>', gt);
 calculators.register('>=', gte);
 calculators.register('<', lt);


### PR DESCRIPTION
# Description (需求描述)

Change `equal` and `not equal` operators to non-strict.

# Motivation (需求背景)

Strict equal/not equal are hard to use in no-code mode. Non-strict will be more useful in common scenarios.

# Key changes (关键改动）

- Frontend (前端)
- Backend (后端)
  - Condition instruction calculators.

# Test plan (测试计划)

## Suggestions (测试建议)

Via cases.

## Underlying risk (潜在风险)

Some strict equal and not equal usage break.

# Showcase (结果展示）

None.