### PR TITLE
fix(bi): issue of parsing label of region & file field

### DIFF
--- a/packages/plugins/data-visualization/src/client/__tests__/hooks.test.ts
+++ b/packages/plugins/data-visualization/src/client/__tests__/hooks.test.ts
@@ -64,6 +64,18 @@ describe('hooks', () => {
             },
           ],
         }[name]),
+      getInterface: (i: string) => {
+        switch (i) {
+          case 'm2o':
+            return {
+              filterable: {
+                nested: true,
+              },
+            };
+          default:
+            return {};
+        }
+      },
     } as any);
   });
 


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

在图表中选择 `所属地区(行政区划) / 省市区名称 `或 `公司近照(附件) / 文件名` 字段


### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

数据展示使用标签名

<img width="426" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/59203289-f5bf-4279-86af-c10d4e36437b">

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

<img width="438" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/04c458bf-cee2-4060-b9e2-741db3508a73">

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

获取级联关系时只考虑了关系字段，直接从目标中进行获取。而行政区划字段、文件字段的级联字段在`interface.filterable.children`中

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

从目标表和`interface.filterable.children`中获取级联字段

Close T-784
