### PR TITLE
feat(plugin-workflow): add reload for multi-app

### DIFF
--- a/packages/plugins/workflow/src/client/WorkflowProvider.tsx
+++ b/packages/plugins/workflow/src/client/WorkflowProvider.tsx
@@ -3,8 +3,9 @@ import {
   PluginManagerContext,
   SchemaComponent,
   SettingsCenterProvider,
+  useResourceContext,
 } from '@nocobase/client';
-import { Card } from 'antd';
+import { Card, message } from 'antd';
 import React, { useContext } from 'react';
 import { ExecutionLink } from './ExecutionLink';
 import { ExecutionResourceProvider } from './ExecutionResourceProvider';
@@ -15,6 +16,7 @@ import { lang } from './locale';
 import { instructions } from './nodes';
 import { workflowSchema } from './schemas/workflows';
 import { triggers } from './triggers';
+import { useTranslation } from 'react-i18next';
 
 // registerField(expressionField.group, 'expression', expressionField);
 
@@ -24,11 +26,25 @@ export function useWorkflowContext() {
   return useContext(WorkflowContext);
 }
 
+function useWorkflowReloadAction() {
+  const { t } = useTranslation();
+  const { resource } = useResourceContext();
+  return {
+    async run() {
+      await resource.reload();
+      message.success(t('Operation succeeded'));
+    },
+  };
+}
+
 function WorkflowPane() {
   return (
     <Card bordered={false}>
       <SchemaComponent
         schema={workflowSchema}
+        scope={{
+          useWorkflowReloadAction,
+        }}
         components={{
           WorkflowLink,
           ExecutionResourceProvider,

--- a/packages/plugins/workflow/src/client/schemas/workflows.ts
+++ b/packages/plugins/workflow/src/client/schemas/workflows.ts
@@ -113,18 +113,6 @@ export const workflowSchema: ISchema = {
             },
           },
           properties: {
-            delete: {
-              type: 'void',
-              title: '{{t("Delete")}}',
-              'x-component': 'Action',
-              'x-component-props': {
-                useAction: '{{ cm.useBulkDestroyAction }}',
-                confirm: {
-                  title: "{{t('Delete record')}}",
-                  content: "{{t('Are you sure you want to delete it?')}}",
-                },
-              },
-            },
             create: {
               type: 'void',
               title: '{{t("Add new")}}',
@@ -178,6 +166,26 @@ export const workflowSchema: ISchema = {
                       },
                     },
                   },
+                },
+              },
+            },
+            reload: {
+              type: 'void',
+              title: `{{t("Reload", { ns: "${NAMESPACE}" })}}`,
+              'x-component': 'Action',
+              'x-component-props': {
+                useAction: '{{ useWorkflowReloadAction }}',
+              },
+            },
+            delete: {
+              type: 'void',
+              title: '{{t("Delete")}}',
+              'x-component': 'Action',
+              'x-component-props': {
+                useAction: '{{ cm.useBulkDestroyAction }}',
+                confirm: {
+                  title: "{{t('Delete record')}}",
+                  content: "{{t('Are you sure you want to delete it?')}}",
                 },
               },
             },

--- a/packages/plugins/workflow/src/locale/zh-CN.ts
+++ b/packages/plugins/workflow/src/locale/zh-CN.ts
@@ -2,6 +2,7 @@ export default {
   Workflow: '工作流',
   'Execution history': '执行历史',
   Executed: '已执行',
+  Reload: '重载',
   'Trigger type': '触发方式',
   Status: '状态',
   On: '启用',
@@ -244,5 +245,5 @@ export default {
 
   'SQL action': 'SQL 操作',
   'Execute a SQL statement in database': '在数据库中执行一个 SQL 语句',
-  'Usage of SQL query result is not supported yet.': 'SQL 执行的结果暂不支持使用。'
+  'Usage of SQL query result is not supported yet.': 'SQL 执行的结果暂不支持使用。',
 };

--- a/packages/plugins/workflow/src/server/actions/workflows.ts
+++ b/packages/plugins/workflow/src/server/actions/workflows.ts
@@ -176,3 +176,22 @@ export async function revision(context: Context, next) {
 
   await next();
 }
+
+export async function reload(context: Context, next) {
+  const plugin = context.app.getPlugin('workflow');
+  const repository = utils.getRepositoryFromParams(context);
+  const { filterByTk, filter = {} } = context.action.params;
+
+  const workflows = await repository.find({
+    filterByTk,
+    filter,
+  });
+
+  workflows.forEach((workflow) => {
+    plugin.toggle(workflow);
+  });
+
+  context.status = 205;
+
+  await next();
+}


### PR DESCRIPTION
# Description (需求描述)

Add manually reload action for synchronization issues of workflows in multi-app.

# Motivation (需求背景)

Toggle any workflows will not be synchronized to other sub-apps.

# Key changes (关键改动）

- Frontend (前端)
  - Add a global action button for reloading all workflows.
- Backend (后端)
  - Add a reload action for workflow resource.

# Test plan (测试计划)

## Suggestions (测试建议)

* Multi-app workflows toggle on/off.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

None.
