### PR TITLE
fix(plugin-workflow): fix manual assignee select variable type filter

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/manual/AssigneesSelect.tsx
+++ b/packages/plugins/workflow/src/client/nodes/manual/AssigneesSelect.tsx
@@ -2,8 +2,15 @@ import { RemoteSelect, Variable } from '@nocobase/client';
 import React from 'react';
 import { useWorkflowVariableOptions } from '../../variable';
 
+function isUserKeyField(field) {
+  if (field.isForeignKey) {
+    return field.target === 'users';
+  }
+  return field.collectionName === 'users' && field.name === 'id';
+}
+
 export function AssigneesSelect({ multiple = false, value = [], onChange }) {
-  const scope = useWorkflowVariableOptions({ types: [{ type: 'reference', options: { collection: 'users' } }] });
+  const scope = useWorkflowVariableOptions({ types: [isUserKeyField] });
 
   return (
     <Variable.Input

--- a/packages/plugins/workflow/src/client/variable.tsx
+++ b/packages/plugins/workflow/src/client/variable.tsx
@@ -15,12 +15,12 @@ export type VariableOption = {
 export type VariableOptions = VariableOption[] | null;
 
 export type VariableDataType =
-  string |
-  {
-    type: string;
-    options?: { entity?: boolean; collection?: string }
-  } |
-  ((field: any, appends?: string[]) => boolean);
+  | string
+  | {
+      type: string;
+      options?: { entity?: boolean; collection?: string };
+    }
+  | ((field: any, appends?: string[]) => boolean);
 
 export type OptionsOfUseVariableOptions = {
   types?: VariableDataType[];
@@ -29,7 +29,7 @@ export type OptionsOfUseVariableOptions = {
     value?: string;
     children?: string;
   };
-}
+};
 
 export const defaultFieldNames = { label: 'label', value: 'value', children: 'children' } as const;
 
@@ -283,7 +283,15 @@ async function loadChildren(option) {
 }
 
 export function getCollectionFieldOptions(options): VariableOption[] {
-  const { fields, collection, types, appends = [], compile, getCollectionFields, fieldNames = defaultFieldNames } = options;
+  const {
+    fields,
+    collection,
+    types,
+    appends = [],
+    compile,
+    getCollectionFields,
+    fieldNames = defaultFieldNames,
+  } = options;
   const normalizedFields = getNormalizedFields(collection, { compile, getCollectionFields });
   const computedFields = fields ?? normalizedFields;
   const boundLoadChildren = loadChildren.bind({ compile, getCollectionFields, fieldNames });


### PR DESCRIPTION
## Description (Bug 描述)

Can not select result of query node which collection target is users.

### Steps to reproduce (复现步骤)

1. Add a query node, set collection to users.
2. Add a manual node as downstream, try to select assignee from node variables, the query node result is not available.

### Expected behavior (预期行为)

Could select the query node and ID field.

### Actual behavior (实际行为)

Not available.

## Related issues (相关 issue)

#2192.

## Reason (原因)

Type filter not match.

## Solution (解决方案)

Change to custom type filter.
