### PR TITLE
feat(plugin-workflow): add execution dropdown for quick navigating

### DIFF
--- a/packages/plugins/workflow/src/client/components/StatusIcon.tsx
+++ b/packages/plugins/workflow/src/client/components/StatusIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Tag } from 'antd';
+import classnames from 'classnames';
+
+import { createStyles } from '@nocobase/client';
+
+import { JobStatusOptionsMap } from '../constants';
+
+const useStyles = createStyles(({ css, token }) => ({
+  statusIconClass: css`
+    padding: 0;
+    width: ${token.sizeLG}px;
+    height: ${token.sizeLG}px;
+    line-height: ${token.sizeLG}px;
+    margin-right: 0;
+    border-radius: 50%;
+    text-align: center;
+  `,
+}));
+
+export function StatusIcon(props) {
+  const { icon, color } = JobStatusOptionsMap[props.status];
+  const { styles } = useStyles();
+
+  return (
+    <Tag color={color} className={classnames(styles.statusIconClass, props.className)}>
+      {icon}
+    </Tag>
+  );
+}

--- a/packages/plugins/workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/workflow/src/client/nodes/index.tsx
@@ -36,6 +36,7 @@ import query from './query';
 import request from './request';
 import sql from './sql';
 import update from './update';
+import { StatusIcon } from '../components/StatusIcon';
 
 export interface Instruction {
   title: string;
@@ -238,11 +239,10 @@ export function RemoveButton() {
 
 function InnerJobButton({ job, ...props }) {
   const { styles } = useStyles();
-  const { icon, color } = JobStatusOptionsMap[job.status];
 
   return (
     <Button {...props} shape="circle" size="small" className={cx(styles.nodeJobButtonClass, props.className)}>
-      <Tag color={color}>{icon}</Tag>
+      <StatusIcon status={job.status} />
     </Button>
   );
 }
@@ -280,7 +280,6 @@ export function JobButton() {
     <Dropdown
       menu={{
         items: jobs.map((job) => {
-          const { icon, color } = JobStatusOptionsMap[job.status];
           return {
             key: job.id,
             label: (
@@ -296,9 +295,7 @@ export function JobButton() {
                   }
                 `}
               >
-                <span className={cx(styles.nodeJobButtonClass, 'inner')}>
-                  <Tag color={color}>{icon}</Tag>
-                </span>
+                <StatusIcon status={job.status} />
                 <time>{str2moment(job.updatedAt).format('YYYY-MM-DD HH:mm:ss')}</time>
               </div>
             ),

--- a/packages/plugins/workflow/src/client/style.tsx
+++ b/packages/plugins/workflow/src/client/style.tsx
@@ -85,6 +85,29 @@ const useStyles = createStyles(({ css, token }) => {
       }
     `,
 
+    executionsDropdownRowClass: css`
+      .row {
+        display: flex;
+        align-items: baseline;
+
+        &.current {
+          font-weight: bold;
+        }
+
+        .id {
+          flex-grow: 1;
+          text-align: right;
+        }
+
+        time {
+          width: 12em;
+          margin-left: 0.5rem;
+          color: ${token.colorText};
+          font-size: 80%;
+        }
+      }
+    `,
+
     branchBlockClass: css`
       display: flex;
       position: relative;
@@ -258,20 +281,6 @@ const useStyles = createStyles(({ css, token }) => {
 
       &[type='button'] {
         border: none;
-      }
-
-      &.inner {
-        position: static;
-      }
-
-      .ant-tag {
-        padding: 0;
-        width: ${token.sizeLG}px;
-        height: ${token.sizeLG}px;
-        line-height: ${token.sizeLG}px;
-        margin-right: 0;
-        border-radius: 50%;
-        text-align: center;
       }
     `,
 


### PR DESCRIPTION
# Description (需求描述)

Add execution dropdown for quick navigating

# Motivation (需求背景)

In execution page, hard to navigate to previous and newer executions in history.

# Key changes (关键改动）

- Frontend (前端)
  - Add dropdown to breadcrumb in execution page.
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

None.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

<img width="376" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/af743151-46aa-4c62-b583-9529f5e86177">
