### PR TITLE
fix(plugin-workflow): fix assign attachment value in nodes

### DIFF
--- a/packages/plugins/workflow/src/client/variable.tsx
+++ b/packages/plugins/workflow/src/client/variable.tsx
@@ -126,7 +126,7 @@ export const BaseTypeSets = {
 // { type: 'reference', options: { collection: 'attachments', multiple: false } }
 // { type: 'reference', options: { collection: 'myExpressions', entity: false } }
 
-function matchFieldType(field, type, appends): boolean {
+function matchFieldType(field, type, appends?: string[]): boolean {
   const inputType = typeof type;
   if (inputType === 'string') {
     return BaseTypeSets[type]?.has(field.interface);
@@ -264,10 +264,11 @@ function getNormalizedFields(collectionName, { compile, getCollectionFields }) {
 }
 
 async function loadChildren(option) {
+  const appends = getNextAppends(option.field, option.appends);
   const result = getCollectionFieldOptions({
     collection: option.field.target,
     types: option.types,
-    appends: getNextAppends(option.field, option.appends),
+    appends,
     ...this,
   });
   option.loadChildren = null;
@@ -275,7 +276,7 @@ async function loadChildren(option) {
     option.children = result;
   } else {
     option.isLeaf = true;
-    const matchingType = option.types?.some((type) => matchFieldType(option.field, type, 0));
+    const matchingType = option.types ? option.types.some((type) => matchFieldType(option.field, type, appends)) : true;
     if (!matchingType) {
       option.disabled = true;
     }


### PR DESCRIPTION
## Description (Bug 描述)

Attachment field can not be selected when assigning value from variables in create/update node.

### Steps to reproduce (复现步骤)

1. Add a posts collection with a cover attachment field.
2. Create a workflow which triggered when posts collection create, and an update node against posts collection.
3. Set update mode to one by one.
4. Set values in update nodes, try to use cover field in trigger context data.

### Expected behavior (预期行为)

Could set attachment field.

### Actual behavior (实际行为)

Attachment field is disabled.

## Related issues (相关 issue)

None.

## Reason (原因)

Should allow all fields when no types defined.

## Solution (解决方案)

Change the types matching logic.