### PR TITLE
fix(client): fix select button height in variable textarea

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -357,6 +357,10 @@ export function TextArea(props) {
               }
             }
           }
+
+          > .x-button {
+            height: min-content;
+          }
         `,
       )}
     >


### PR DESCRIPTION
## Description (Bug 描述)

Can not open variable list when line wrapping in Variable.TextArea.

### Steps to reproduce (复现步骤)

1. Create a formula field.
2. Input any expression content more than 1 line.
3. Click "x" button on bottom half.

### Expected behavior (预期行为)

Variable list should open.

### Actual behavior (实际行为)

Not open.

## Related issues (相关 issue)

## Reason (原因)

After upgrade to Ant Design v5, `Button` in `Compact` got a `height: auto` style, which is not correct in `Variable.TextArea` component.

## Solution (解决方案)

Add another height style to override.
