### PR TITLE
fix(plugin-workflow): fix fields filter in value assignment nodes

### DIFF
--- a/packages/plugins/workflow/src/client/components/CollectionFieldset.tsx
+++ b/packages/plugins/workflow/src/client/components/CollectionFieldset.tsx
@@ -43,7 +43,7 @@ const CollectionFieldSet = observer(
     const scope = useWorkflowVariableOptions();
     const { values: config } = form;
     const collectionName = config?.collection;
-    const collectionFields = getCollectionFields(collectionName);
+    const collectionFields = getCollectionFields(collectionName).filter((field) => field.uiSchema);
     const fields = filter ? collectionFields.filter(filter.bind(config)) : collectionFields;
 
     const unassignedFields = useMemo(() => fields.filter((field) => !value || !(field.name in value)), [fields, value]);


### PR DESCRIPTION
## Description (Bug 描述)

Some hidden field which has no `uiSchema` showing up in value assignment fields list of create/update node.

### Steps to reproduce (复现步骤)

1. Use create record node.
2. Select "User" collection.
3. Hover to "Add field", check the fields list.

### Expected behavior (预期行为)

No `appLang`, `systemSettings` etc fields.

### Actual behavior (实际行为)

Hidden fields showing.

## Related issues (相关 issue)

None.

## Reason (原因)

Should do filtering.

## Solution (解决方案)

Add a filter.
