### PR TITLE
fix(plugin-workflow): fix form trigger data bug

### DIFF
--- a/packages/plugins/workflow/src/server/triggers/form.ts
+++ b/packages/plugins/workflow/src/server/triggers/form.ts
@@ -5,6 +5,7 @@ import Plugin from '..';
 import { WorkflowModel } from '../types';
 import { Model, modelAssociationByKey } from '@nocobase/database';
 import { BelongsTo, HasOne } from 'sequelize';
+import { toJSON } from '../utils';
 
 export default class FormTrigger extends Trigger {
   constructor(plugin: Plugin) {
@@ -85,7 +86,7 @@ export default class FormTrigger extends Trigger {
               appends,
             });
           }
-          this.plugin.trigger(workflow, { data: payload });
+          this.plugin.trigger(workflow, { data: toJSON(payload) });
         });
       } else {
         this.plugin.trigger(workflow, { data: trigger[1] ? get(values, trigger[1]) : values });


### PR DESCRIPTION
## Description (Bug 描述)

When use form trigger, and bind workflow to default submit button, trigger data is present in execution but some properties can not be access.

### Steps to reproduce (复现步骤)

Not sure.

### Expected behavior (预期行为)

Fields of form data could be access.

### Actual behavior (实际行为)

Fields values in trigger's data but can not access from nodes.

## Related issues (相关 issue)

None.

## Reason (原因)

Should do `toJSON()` to the model before triggering.

## Solution (解决方案)

Add `toJSON()`.
