### PR TITLE
feat(plugin-workflow): add user variable to form trigger context

### DIFF
--- a/packages/plugins/workflow/src/client/triggers/form.tsx
+++ b/packages/plugins/workflow/src/client/triggers/form.tsx
@@ -65,12 +65,21 @@ export default {
           title: lang('Trigger data'),
         },
       },
+      {
+        collectionName: 'users',
+        name: 'user',
+        type: 'hasOne',
+        target: 'users',
+        uiSchema: {
+          title: lang('User submitted form'),
+        },
+      },
     ];
     const result = getCollectionFieldOptions({
       // depth,
       ...options,
       fields: rootFields,
-      appends: ['data', ...(config.appends?.map((item) => `data.${item}`) || [])],
+      appends: ['data', 'user', ...(config.appends?.map((item) => `data.${item}`) || [])],
       compile,
       getCollectionFields,
     });

--- a/packages/plugins/workflow/src/locale/zh-CN.ts
+++ b/packages/plugins/workflow/src/locale/zh-CN.ts
@@ -33,6 +33,7 @@ export default {
   'Form data model': '表单数据模型',
   'Use a collection to match form data.': '使用一个数据表来匹配表单数据。',
   'Associations to use': '待使用的关系数据',
+  'User submitted form': '提交表单的用户',
   'Bind workflows': '绑定工作流',
   'Workflow will be triggered after submitting succeeded.': '提交成功后触发工作流。',
   'Workflow will be triggered after saving succeeded.': '保存成功后触发工作流。',

--- a/packages/plugins/workflow/src/server/__tests__/triggers/form.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/triggers/form.test.ts
@@ -180,6 +180,29 @@ describe('workflow > triggers > form', () => {
       expect(e1[0].status).toBe(EXECUTION_STATUS.RESOLVED);
       expect(e1[0].context.data).toHaveProperty('createdBy');
     });
+
+    it('user submitted form', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'form',
+        config: {
+          collection: 'posts',
+        },
+      });
+
+      const res1 = await userAgents[0].resource('posts').create({
+        values: { title: 't1' },
+        triggerWorkflows: `${workflow.key}`,
+      });
+      expect(res1.status).toBe(200);
+
+      await sleep(500);
+
+      const [e1] = await workflow.getExecutions();
+      expect(e1.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(e1.context.user).toBeDefined();
+      expect(e1.context.user.id).toBe(users[0].id);
+    });
   });
 
   describe('update', () => {
@@ -262,6 +285,30 @@ describe('workflow > triggers > form', () => {
       const [e2] = await w2.getExecutions();
       expect(e2.status).toBe(EXECUTION_STATUS.RESOLVED);
       expect(e2.context.data).toMatchObject({ title: 't1' });
+    });
+
+    it('user submitted form', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'form',
+        config: {
+          collection: 'posts',
+          appends: ['createdBy'],
+        },
+      });
+
+      const res1 = await userAgents[0].resource('posts').create({
+        values: { title: 't1' },
+        triggerWorkflows: `${workflow.key}`,
+      });
+      expect(res1.status).toBe(200);
+
+      await sleep(500);
+
+      const [e1] = await workflow.getExecutions();
+      expect(e1.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(e1.context.user).toBeDefined();
+      expect(e1.context.user.id).toBe(users[0].id);
     });
   });
 

--- a/packages/plugins/workflow/src/server/triggers/form.ts
+++ b/packages/plugins/workflow/src/server/triggers/form.ts
@@ -48,6 +48,8 @@ export default class FormTrigger extends Trigger {
       return;
     }
 
+    const { currentUser } = context.state;
+
     const triggers = triggerWorkflows.split(',').map((trigger) => trigger.split('!'));
     const workflowRepo = this.plugin.db.getRepository('workflows');
     const workflows = await workflowRepo.find({
@@ -86,10 +88,14 @@ export default class FormTrigger extends Trigger {
               appends,
             });
           }
-          this.plugin.trigger(workflow, { data: toJSON(payload) });
+          this.plugin.trigger(workflow, { data: payload, user: currentUser });
         });
       } else {
-        this.plugin.trigger(workflow, { data: trigger[1] ? get(values, trigger[1]) : values });
+        const data = trigger[1] ? get(values, trigger[1]) : values;
+        this.plugin.trigger(workflow, {
+          data,
+          user: currentUser,
+        });
       }
     });
   }


### PR DESCRIPTION
# Description (需求描述)

Add user variable to form trigger context, allow to use user which submitted form in nodes.

# Motivation (需求背景)

We could use `createdBy`/`updatedBy` in common forms, but can not use them in "directly trigger workflow" button.

# Key changes (关键改动）

- Frontend (前端)
  - Add user to form trigger context variable select.
- Backend (后端)
  - Add current user as `user` to trigger context.

# Test plan (测试计划)

## Suggestions (测试建议)

Try "User submitted form" variable in form event.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

<img width="426" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/008baf28-2075-481f-8ad7-8d9e3c8f94ae">

