### PR TITLE
fix(plugin-workflow): fix variable type check

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/aggregate.tsx
+++ b/packages/plugins/workflow/src/client/nodes/aggregate.tsx
@@ -20,8 +20,9 @@ import { BaseTypeSets, defaultFieldNames, nodesOptions, triggerOptions } from '.
 function matchToManyField(field, appends): boolean {
   const fieldPrefix = `${field.name}.`;
   return (
-    ['hasMany', 'belongsToMany'].includes(field.type) &&
-    (appends ? appends.includes(field.name) || appends.some((item) => item.startsWith(fieldPrefix)) : true)
+    (['hasOne', 'belongsTo'].includes(field.type) &&
+      (appends ? appends.includes(field.name) || appends.some((item) => item.startsWith(fieldPrefix)) : true)) ||
+    ['hasMany', 'belongsToMany'].includes(field.type)
   );
 }
 

--- a/packages/plugins/workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/workflow/src/client/nodes/index.tsx
@@ -265,6 +265,8 @@ export function JobButton() {
             border: 2px solid #d9d9d9;
             border-radius: 50%;
             cursor: not-allowed;
+            width: 24px;
+            height: 24px;
           `,
         )}
       />

--- a/packages/plugins/workflow/src/client/variable.tsx
+++ b/packages/plugins/workflow/src/client/variable.tsx
@@ -165,28 +165,25 @@ function getNextAppends(field, appends: string[]) {
 
 function filterTypedFields({ fields, types, appends, compile, getCollectionFields }) {
   return fields.filter((field) => {
-    const match = types?.length ? types.some((type) => matchFieldType(field, type, appends)) : true;
+    if (types?.length) {
+      return types.some((type) => matchFieldType(field, type, appends));
+    }
     if (isAssociationField(field)) {
       const nextAppends = getNextAppends(field, appends);
       const included = appends.includes(field.name);
-      if (match) {
-        return included;
-      } else {
-        return (
-          (nextAppends.length || included) &&
-          filterTypedFields({
-            fields: getNormalizedFields(field.target, { compile, getCollectionFields }),
-            types,
-            // depth: depth - 1,
-            appends: nextAppends,
-            compile,
-            getCollectionFields,
-          }).length
-        );
-      }
-    } else {
-      return match;
+      return (
+        (nextAppends.length || included) &&
+        filterTypedFields({
+          fields: getNormalizedFields(field.target, { compile, getCollectionFields }),
+          types,
+          // depth: depth - 1,
+          appends: nextAppends,
+          compile,
+          getCollectionFields,
+        }).length
+      );
     }
+    return true;
   });
 }
 


### PR DESCRIPTION
## Description (Bug 描述)

Can not select next to-many field (which is not in appends) in aggregate association mode.

### Steps to reproduce (复现步骤)

1. Add posts, categories tables, posts belongs to categories, categories has many posts.
2. Add workflow trigger by posts collection creation, appends category.
3. Add an aggregate node, select association field collection mode.
4. Try to select "Trigger variables / Trigger data / category / posts".

### Expected behavior (预期行为)

Could select to "... / posts".

### Actual behavior (实际行为)

Could not.

## Related issues (相关 issue)

None.

## Reason (原因)

Types check in variables not only rely on types options, but also checked by next associations.

## Solution (解决方案)

If provide types option, only rely on types. Otherwise will be checked by next associations.
