### PR TITLE
fix(plugin-workflow): fix loop scope variable parsing

### DIFF
--- a/packages/plugins/workflow/src/server/Processor.ts
+++ b/packages/plugins/workflow/src/server/Processor.ts
@@ -318,7 +318,8 @@ export default class Processor {
     return null;
   }
 
-  public getScope(node?) {
+  public getScope(sourceNodeId: number) {
+    const node = this.nodesMap.get(sourceNodeId);
     const systemFns = {};
     const scope = {
       execution: this.execution,
@@ -329,12 +330,10 @@ export default class Processor {
     }
 
     const $scopes = {};
-    if (node) {
-      for (let n = this.findBranchParentNode(node); n; n = this.findBranchParentNode(n)) {
-        const instruction = this.options.plugin.instructions.get(n.type);
-        if (typeof instruction.getScope === 'function') {
-          $scopes[n.id] = instruction.getScope(n, this.jobsMapByNodeId[n.id], this);
-        }
+    for (let n = this.findBranchParentNode(node); n; n = this.findBranchParentNode(n)) {
+      const instruction = this.options.plugin.instructions.get(n.type);
+      if (typeof instruction.getScope === 'function') {
+        $scopes[n.id] = instruction.getScope(n, this.jobsMapByNodeId[n.id], this);
       }
     }
 
@@ -346,9 +345,9 @@ export default class Processor {
     };
   }
 
-  public getParsedValue(value, node?, additionalScope?: object) {
+  public getParsedValue(value, sourceNodeId: number, additionalScope?: object) {
     const template = parse(value);
-    const scope = Object.assign(this.getScope(node), additionalScope);
+    const scope = Object.assign(this.getScope(sourceNodeId), additionalScope);
     template.parameters.forEach(({ key }) => {
       appendArrayColumn(scope, key);
     });

--- a/packages/plugins/workflow/src/server/instructions/aggregate.ts
+++ b/packages/plugins/workflow/src/server/instructions/aggregate.ts
@@ -15,12 +15,12 @@ const aggregators = {
 export default {
   async run(node: FlowNodeModel, input, processor: Processor) {
     const { aggregator, associated, collection, association = {}, params = {} } = node.config;
-    const options = processor.getParsedValue(params);
+    const options = processor.getParsedValue(params, node.id);
     const { database } = <typeof FlowNodeModel>node.constructor;
     const repo = associated
       ? database.getRepository<HasManyRepository | BelongsToManyRepository>(
           `${association?.associatedCollection}.${association.name}`,
-          processor.getParsedValue(association?.associatedKey),
+          processor.getParsedValue(association?.associatedKey, node.id),
         )
       : database.getRepository(collection);
 

--- a/packages/plugins/workflow/src/server/instructions/condition.ts
+++ b/packages/plugins/workflow/src/server/instructions/condition.ts
@@ -125,8 +125,8 @@ export default {
 
     try {
       result = evaluator
-        ? evaluator(expression, processor.getScope())
-        : logicCalculate(processor.getParsedValue(calculation, node));
+        ? evaluator(expression, processor.getScope(node.id))
+        : logicCalculate(processor.getParsedValue(calculation, node.id));
     } catch (e) {
       return {
         result: e.toString(),

--- a/packages/plugins/workflow/src/server/instructions/create.ts
+++ b/packages/plugins/workflow/src/server/instructions/create.ts
@@ -7,7 +7,7 @@ export default {
     const { collection, params: { appends = [], ...params } = {} } = node.config;
 
     const { repository, model } = (<typeof FlowNodeModel>node.constructor).database.getCollection(collection);
-    const options = processor.getParsedValue(params, node);
+    const options = processor.getParsedValue(params, node.id);
     const created = await repository.create({
       ...options,
       context: {

--- a/packages/plugins/workflow/src/server/instructions/destroy.ts
+++ b/packages/plugins/workflow/src/server/instructions/destroy.ts
@@ -6,7 +6,7 @@ export default {
     const { collection, params = {} } = node.config;
 
     const repo = (<typeof FlowNodeModel>node.constructor).database.getRepository(collection);
-    const options = processor.getParsedValue(params, node);
+    const options = processor.getParsedValue(params, node.id);
     const result = await repo.destroy({
       ...options,
       context: {

--- a/packages/plugins/workflow/src/server/instructions/loop.ts
+++ b/packages/plugins/workflow/src/server/instructions/loop.ts
@@ -19,7 +19,7 @@ function getTargetLength(target) {
 export default {
   async run(node: FlowNodeModel, prevJob: JobModel, processor: Processor) {
     const [branch] = processor.getBranches(node);
-    const target = processor.getParsedValue(node.config.target, node);
+    const target = processor.getParsedValue(node.config.target, node.id);
     const length = getTargetLength(target);
 
     if (!branch || !length) {
@@ -61,7 +61,7 @@ export default {
 
     const nextIndex = result + 1;
 
-    const target = processor.getParsedValue(loop.config.target, node);
+    const target = processor.getParsedValue(loop.config.target, node.id);
     // branchJob.status === JOB_STATUS.RESOLVED means branchJob is done, try next loop or exit as resolved
     if (branchJob.status > JOB_STATUS.PENDING) {
       job.set({ result: nextIndex });
@@ -83,7 +83,7 @@ export default {
   },
 
   getScope(node, index, processor) {
-    const target = processor.getParsedValue(node.config.target, node);
+    const target = processor.getParsedValue(node.config.target, node.id);
     const targets = (Array.isArray(target) ? target : [target]).filter((t) => t != null);
     const length = getTargetLength(target);
     const item = typeof target === 'number' ? index : targets[index];

--- a/packages/plugins/workflow/src/server/instructions/manual/forms/update.ts
+++ b/packages/plugins/workflow/src/server/instructions/manual/forms/update.ts
@@ -10,7 +10,7 @@ export default async function (this: ManualInstruction, instance, { collection, 
   const { _, ...form } = instance.result;
   const [values] = Object.values(form);
   await repo.update({
-    filter: processor.getParsedValue(filter),
+    filter: processor.getParsedValue(filter, instance.nodeId),
     values: {
       ...((values as { [key: string]: any }) ?? {}),
       updatedBy: instance.userId,

--- a/packages/plugins/workflow/src/server/instructions/manual/index.ts
+++ b/packages/plugins/workflow/src/server/instructions/manual/index.ts
@@ -2,7 +2,7 @@ import actions from '@nocobase/actions';
 import { HandlerType } from '@nocobase/resourcer';
 import { Registry } from '@nocobase/utils';
 
-import Plugin from '../..';
+import Plugin, { Processor } from '../..';
 import { JOB_STATUS } from '../../constants';
 import { Instruction } from '..';
 import jobsCollection from './collecions/jobs';
@@ -124,9 +124,9 @@ export default class implements Instruction {
     initFormTypes(this);
   }
 
-  async run(node, prevJob, processor) {
+  async run(node, prevJob, processor: Processor) {
     const { mode, ...config } = node.config as ManualConfig;
-    const assignees = [...new Set(processor.getParsedValue(config.assignees) || [])];
+    const assignees = [...new Set(processor.getParsedValue(config.assignees, node.id) || [])];
 
     const job = await processor.saveJob({
       status: JOB_STATUS.PENDING,
@@ -154,7 +154,7 @@ export default class implements Instruction {
     return job;
   }
 
-  async resume(node, job, processor) {
+  async resume(node, job, processor: Processor) {
     // NOTE: check all users jobs related if all done then continue as parallel
     const { assignees = [], mode } = node.config as ManualConfig;
 

--- a/packages/plugins/workflow/src/server/instructions/query.ts
+++ b/packages/plugins/workflow/src/server/instructions/query.ts
@@ -15,7 +15,7 @@ export default {
       pageSize = DEFAULT_PER_PAGE,
       sort = [],
       ...options
-    } = processor.getParsedValue(params, node);
+    } = processor.getParsedValue(params, node.id);
     const appends = options.appends
       ? Array.from(
           options.appends.reduce((set, field) => {

--- a/packages/plugins/workflow/src/server/instructions/request.ts
+++ b/packages/plugins/workflow/src/server/instructions/request.ts
@@ -52,7 +52,7 @@ export default class implements Instruction {
       upstreamId: prevJob?.id ?? null,
     });
 
-    const config = processor.getParsedValue(node.config, node) as RequestConfig;
+    const config = processor.getParsedValue(node.config, node.id) as RequestConfig;
 
     // eslint-disable-next-line promise/catch-or-return
     request(config)

--- a/packages/plugins/workflow/src/server/instructions/sql.ts
+++ b/packages/plugins/workflow/src/server/instructions/sql.ts
@@ -4,11 +4,11 @@ import type { FlowNodeModel } from '../types';
 export default {
   async run(node: FlowNodeModel, input, processor: Processor) {
     const { sequelize } = (<typeof FlowNodeModel>node.constructor).database;
-    const sql = processor.getParsedValue(node.config.sql ?? '', node).trim();
+    const sql = processor.getParsedValue(node.config.sql ?? '', node.id).trim();
     if (!sql) {
       return {
         status: JOB_STATUS.RESOLVED,
-      }
+      };
     }
 
     const result = await sequelize.query(sql, {

--- a/packages/plugins/workflow/src/server/instructions/update.ts
+++ b/packages/plugins/workflow/src/server/instructions/update.ts
@@ -7,7 +7,7 @@ export default {
     const { collection, params = {} } = node.config;
 
     const repo = (<typeof FlowNodeModel>node.constructor).database.getRepository(collection);
-    const options = processor.getParsedValue(params, node);
+    const options = processor.getParsedValue(params, node.id);
     const result = await repo.update({
       ...options,
       context: {


### PR DESCRIPTION
## Description (Bug 描述)

Some nodes' variables are not parsed in loop.

### Steps to reproduce (复现步骤)

1. Add a loop.
2. Add an aggregate, use conditions with loop scope variable.

### Expected behavior (预期行为)

Condition will be parsed to be with loop scope variable.

### Actual behavior (实际行为)

Not parsed

## Related issues (相关 issue)

#2496.

## Reason (原因)

Processor API should force to use source node as parameter.

## Solution (解决方案)

Change Processor API invoking.
