### PR TITLE
fix(plugin-fm): fix error when add attachment field to manual form assigned values

### DIFF
--- a/packages/plugins/file-manager/src/client/interfaces/attachment.ts
+++ b/packages/plugins/file-manager/src/client/interfaces/attachment.ts
@@ -27,6 +27,9 @@ export const attachment: IField = {
       schema['x-component-props']['size'] = 'small';
     }
 
+    if (!schema['x-component-props']) {
+      schema['x-component-props'] = {};
+    }
     schema['x-component-props']['action'] = `${field.target}:create${
       field.storage ? `?attachementField=${field.collectionName}.${field.name}` : ''
     }`;


### PR DESCRIPTION
## Description (Bug 描述)

Error happens when add attachment field to manual form assigned values

### Steps to reproduce (复现步骤)

1. Add a posts collection with an attachment field.
2. Add a manual node in workflow, add a create form of posts in user interface configuration.
3. Open "Assign field values" from "Continue the process" button settings.
4. Add the attachment field.

### Expected behavior (预期行为)

Attachment field added.

### Actual behavior (实际行为)

Error.

## Related issues (相关 issue)

None.

## Reason (原因)

No fallback when add deep field schema properties.

## Solution (解决方案)

Add fallback code.
