### PR TITLE
fix(auth): basic-auth compatibility issue

### DIFF
--- a/packages/plugins/auth/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/auth/src/server/__tests__/actions.test.ts
@@ -147,5 +147,26 @@ describe('actions', () => {
       });
       expect(res.statusCode).toEqual(403);
     });
+
+    it('should compitible with old api', async () => {
+      // Create a user without username
+      const userRepo = db.getRepository('users');
+      const email = 'test2@nocobase.com';
+      const password = '1234567';
+      await userRepo.create({
+        values: {
+          email,
+          password,
+        },
+      });
+      const res = await agent.post('/auth:signIn').set({ 'X-Authenticator': 'basic' }).send({
+        email: 'test@nocobase.com',
+        password: '123456',
+      });
+      expect(res.statusCode).toEqual(200);
+      const data = res.body.data;
+      const token = data.token;
+      expect(token).toBeDefined();
+    });
   });
 });

--- a/packages/plugins/auth/src/server/basic-auth.ts
+++ b/packages/plugins/auth/src/server/basic-auth.ts
@@ -22,10 +22,13 @@ export class BasicAuth extends BaseAuth {
     if (!account && !email) {
       ctx.throw(400, ctx.t('Please enter your username or email', { ns: namespace }));
     }
+    const filter = email
+      ? { email }
+      : {
+          $or: [{ username: account }, { email: account }],
+        };
     const user = await this.userRepository.findOne({
-      filter: {
-        $or: [{ username: account || null }, { email: account || email }],
-      },
+      filter,
     });
 
     if (!user) {


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

1. Use Nocobase of old version that has some users do not have username.
2. Request api `auth:signIn` use old parameters `email` and `password`.

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

Auth successfully with correct email and password.

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

Get `password is incorrect` error message.

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

#2505 
Close T-1533

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

![img_v2_44b3dc70-f50f-420f-97de-c040d90925ag](https://github.com/nocobase/nocobase/assets/3250534/11f5a530-e413-4da2-b11a-04d630a735eb)


## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

![d047cf22-28c7-4822-8455-667447c1d5a1](https://github.com/nocobase/nocobase/assets/3250534/34bf7830-3d50-4ee9-80ef-89c1ac490a14)

