### PR TITLE
fix(plugin-workflow): fix duplicated downstream executions after condition

### DIFF
--- a/packages/plugins/workflow/src/server/__tests__/instructions/condition.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/instructions/condition.test.ts
@@ -35,7 +35,6 @@ describe('workflow > instructions > condition', () => {
   describe('single calculation', () => {
     it('calculation to true downstream', async () => {
       const n1 = await workflow.createNode({
-        title: 'condition',
         type: 'condition',
         config: {
           engine: 'math.js',
@@ -44,18 +43,23 @@ describe('workflow > instructions > condition', () => {
       });
 
       const n2 = await workflow.createNode({
-        title: 'true to echo',
         type: 'echo',
         branchIndex: BRANCH_INDEX.ON_TRUE,
         upstreamId: n1.id,
       });
 
       const n3 = await workflow.createNode({
-        title: 'false to echo',
         type: 'echo',
         branchIndex: BRANCH_INDEX.ON_FALSE,
         upstreamId: n1.id,
       });
+
+      const n4 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+
+      await n1.setDownstream(n4);
 
       const post = await PostRepo.create({ values: { title: 't1' } });
 
@@ -64,9 +68,12 @@ describe('workflow > instructions > condition', () => {
       const [execution] = await workflow.getExecutions();
       expect(execution.status).toEqual(EXECUTION_STATUS.RESOLVED);
 
-      const jobs = await execution.getJobs();
-      expect(jobs.length).toEqual(2);
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.length).toEqual(3);
       expect(jobs[1].result).toEqual(true);
+      expect(jobs[1].nodeId).toEqual(n2.id);
+      expect(jobs[2].result).toEqual(true);
+      expect(jobs[2].nodeId).toEqual(n4.id);
     });
 
     it('calculation to false downstream', async () => {

--- a/packages/plugins/workflow/src/server/instructions/condition.ts
+++ b/packages/plugins/workflow/src/server/instructions/condition.ts
@@ -3,7 +3,7 @@ import { Registry } from '@nocobase/utils';
 import { Instruction } from '.';
 import { Processor } from '..';
 import { JOB_STATUS } from '../constants';
-import type { FlowNodeModel } from '../types';
+import type { FlowNodeModel, JobModel } from '../types';
 
 type Comparer = (a: any, b: any) => boolean;
 
@@ -157,16 +157,20 @@ export default {
 
     const savedJob = await processor.saveJob(job);
 
-    return processor.run(branchNode, savedJob);
+    await processor.run(branchNode, savedJob);
+
+    return null;
   },
 
-  async resume(node: FlowNodeModel, branchJob, processor: Processor) {
+  async resume(node: FlowNodeModel, branchJob: JobModel, processor: Processor) {
+    const job = processor.findBranchParentJob(branchJob, node) as JobModel;
+
     if (branchJob.status === JOB_STATUS.RESOLVED) {
       // return to continue node.downstream
-      return branchJob;
+      return job;
     }
 
     // pass control to upper scope by ending current scope
-    return processor.end(node, branchJob);
+    return processor.exit(branchJob.status);
   },
 } as Instruction;


### PR DESCRIPTION
## Description (Bug 描述)

Downstream nodes of condition node duplicately executed.

### Steps to reproduce (复现步骤)

1. Add a condition node on branch mode.
2. Add any node in each branch.
3. Add any node after branch.
4. Trigger the workflow.

### Expected behavior (预期行为)

Node after branch should only be executed once.

### Actual behavior (实际行为)

Twice.

## Related issues (相关 issue)

#2510.

## Reason (原因)

End logic of condition instruction is not correct.

## Solution (解决方案)

Adjust end logic.
