### PR TITLE
refactor(plugin-workflow): hide unused form in manual ui after done

### DIFF
--- a/packages/plugins/workflow/src/client/nodes/manual/FormBlockProvider.tsx
+++ b/packages/plugins/workflow/src/client/nodes/manual/FormBlockProvider.tsx
@@ -47,7 +47,7 @@ export function FormBlockProvider(props) {
   const resource = api.resource(props.collection);
   const __parent = useContext(BlockRequestContext);
 
-  return (
+  return !userJob.status || values ? (
     <CollectionProvider collection={props.collection}>
       <RecordProvider record={values} parent={false}>
         <BlockRequestContext.Provider value={{ block: 'form', props, field, service, resource, __parent }}>
@@ -71,5 +71,5 @@ export function FormBlockProvider(props) {
         </BlockRequestContext.Provider>
       </RecordProvider>
     </CollectionProvider>
-  );
+  ) : null;
 }

--- a/packages/plugins/workflow/src/client/nodes/manual/forms/custom.tsx
+++ b/packages/plugins/workflow/src/client/nodes/manual/forms/custom.tsx
@@ -40,7 +40,7 @@ function CustomFormBlockProvider(props) {
     [values],
   );
 
-  return (
+  return !userJob.status || values ? (
     <CollectionProvider
       collection={{
         ...props.collection,
@@ -59,7 +59,7 @@ function CustomFormBlockProvider(props) {
         </FormBlockContext.Provider>
       </RecordProvider>
     </CollectionProvider>
-  );
+  ) : null;
 }
 
 function CustomFormBlockInitializer({ insert, ...props }) {
@@ -104,10 +104,6 @@ function CustomFormBlockInitializer({ insert, ...props }) {
                   'x-component': 'ActionBar',
                   'x-component-props': {
                     layout: 'one-column',
-                    style: {
-                      marginTop: '1.5em',
-                      flexWrap: 'wrap',
-                    },
                   },
                   'x-initializer': 'AddActionButton',
                   properties: {


### PR DESCRIPTION
# Description (需求描述)

Hide unused form in manual ui after done.

# Motivation (需求背景)

If multiple forms configured in manual UI, after assignee submitted one of them, others are uselessly to be shown.

# Key changes (关键改动）

- Frontend (前端)
  - `FormBlockProvider` in manual node
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

UI.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

None.