### PR TITLE
fix(plugin-cm): fix life cycle

### DIFF
--- a/packages/plugins/collection-manager/src/server/server.ts
+++ b/packages/plugins/collection-manager/src/server/server.ts
@@ -214,7 +214,7 @@ export class CollectionManagerPlugin extends Plugin {
       await this.app.db.getRepository<CollectionRepository>('collections').load();
     };
 
-    this.app.on('afterStart', loadCollections);
+    this.app.on('beforeStart', loadCollections);
     this.app.on('beforeUpgrade', async () => {
       const syncOptions = {
         alter: {

--- a/packages/plugins/workflow/package.json
+++ b/packages/plugins/workflow/package.json
@@ -34,6 +34,8 @@
     "@nocobase/database": "0.x",
     "@nocobase/evaluators": "0.x",
     "@nocobase/logger": "0.x",
+    "@nocobase/plugin-collection-manager": "0.x",
+    "@nocobase/plugin-error-handler": "0.x",
     "@nocobase/plugin-users": "0.x",
     "@nocobase/resourcer": "0.x",
     "@nocobase/server": "0.x",

--- a/packages/plugins/workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/workflow/src/server/__tests__/triggers/collection.test.ts
@@ -13,7 +13,9 @@ describe('workflow > triggers > collection', () => {
   let WorkflowModel;
 
   beforeEach(async () => {
-    app = await getApp();
+    app = await getApp({
+      plugins: ['error-handler', 'collection-manager'],
+    });
 
     db = app.db;
     WorkflowModel = db.getCollection('workflows').model;
@@ -49,6 +51,51 @@ describe('workflow > triggers > collection', () => {
 
       const executions = await workflow.getExecutions();
       expect(executions.length).toBe(0);
+    });
+
+    it('restart server and listen a collection managed by collection-manager', async () => {
+      await db.getRepository('collections').create({
+        values: {
+          name: 'temp',
+          title: 'Temp',
+        },
+        // to trigger collection sync to db.collections
+        context: {},
+      });
+
+      const workflow = await WorkflowModel.create({
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'temp',
+        },
+        enabled: true,
+      });
+
+      await db.getRepository('temp').create({ values: {} });
+
+      await sleep(500);
+
+      const e1 = await workflow.getExecutions();
+      expect(e1.length).toBe(1);
+
+      await app.destroy();
+
+      app = await getApp({
+        plugins: ['error-handler', 'collection-manager'],
+        database: {
+          tablePrefix: db.options.tablePrefix,
+        },
+      });
+
+      db = app.db;
+
+      await db.getRepository('temp').create({ values: {} });
+
+      await sleep(500);
+
+      const e2 = await db.getModel('executions').findAll();
+      expect(e2.length).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Description (Bug 描述)

After server started, enabled workflows will not be triggered unless toggle off and on again manually.

### Steps to reproduce (复现步骤)

1. Add and enable a workflow with collection event.
2. Stop server.
3. Start server.
4. Trigger the collection event by some creation.

### Expected behavior (预期行为)

Workflow triggered.

### Actual behavior (实际行为)

Not triggered.

## Related issues (相关 issue)

None.

## Reason (原因)

Collection manager plugin load managed collections in "afterStart" life cycle of application, this makes other plugins like workflow hard to listen all collection events in "beforeStart" life cycle.

## Solution (解决方案)

Change collection manager plugin to load managed collections in "beforeStart" life cycle.
