### PR TITLE
fix(themeEditor): should allow all roles to use

### DIFF
--- a/packages/plugins/theme-editor/src/server/plugin.ts
+++ b/packages/plugins/theme-editor/src/server/plugin.ts
@@ -28,6 +28,7 @@ export class ThemeEditorPlugin extends Plugin {
         },
       ],
     });
+    this.app.acl.allow('themeConfig', '*');
   }
 
   async install(options?: InstallOptions) {


### PR DESCRIPTION
## Description (Bug 描述)
普通权限的用户无法获取到主题的配置数据。
### Steps to reproduce (复现步骤)
1. 新建一个普通权限的用户
2. 开启主题插件
3. 刷新页面会报权限错误
<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
默认情况下所有权限的用户都可以使用主题
<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
普通权限的用户使用主题会报权限错误
<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)
#2228 
<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
没有处理权限问题
<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)
允许所有权限用户使用主题接口
<!-- Describe solution to the bug clearly and consciously. -->

## 其它
close T-1540