### PR TITLE
fix: fix collapsed panels not working when clicked

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -1,5 +1,5 @@
 import { observer, RecursionField, useField, useFieldSchema, useForm } from '@formily/react';
-import { App, Button } from 'antd';
+import { App, Button, Popover } from 'antd';
 import classnames from 'classnames';
 import lodash from 'lodash';
 import React, { useEffect, useState } from 'react';
@@ -11,7 +11,6 @@ import { useRecord } from '../../../record-provider';
 import { SortableItem } from '../../common';
 import { useCompile, useComponent, useDesigner } from '../../hooks';
 import { useProps } from '../../hooks/useProps';
-import { Popover } from '../popover';
 import ActionContainer from './Action.Container';
 import { ActionDesigner } from './Action.Designer';
 import { ActionDrawer } from './Action.Drawer';

--- a/packages/core/client/src/schema-component/antd/association-field/InternalPopoverNester.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalPopoverNester.tsx
@@ -4,7 +4,7 @@ import { observer } from '@formily/react';
 import React, { useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActionContext, ActionContextProvider } from '../action/context';
-import { Popover } from '../popover';
+import { PopoverWithStopPropagation } from '../popover';
 import { InternalNester } from './InternalNester';
 import { ReadPrettyInternalViewer } from './InternalViewer';
 import { useAssociationFieldContext } from './hooks';
@@ -46,7 +46,7 @@ export const InternaPopoverNester = observer(
     };
     return (
       <ActionContextProvider value={{ ...ctx, modalProps }}>
-        <Popover
+        <PopoverWithStopPropagation
           overlayStyle={{ padding: '0px' }}
           content={content}
           trigger="click"
@@ -65,7 +65,7 @@ export const InternaPopoverNester = observer(
             </div>
             <EditOutlined style={{ display: 'inline-flex', marginLeft: '5px' }} />
           </span>
-        </Popover>
+        </PopoverWithStopPropagation>
         {visible && (
           <div
             onClick={() => setVisible(false)}

--- a/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
@@ -8,7 +8,7 @@ import { FormProvider, SchemaComponent } from '../../core';
 import { useDesignable } from '../../hooks';
 import { useProps } from '../../hooks/useProps';
 import { Action } from '../action';
-import { Popover } from '../popover';
+import { PopoverWithStopPropagation } from '../popover';
 
 export const FilterActionContext = createContext<any>(null);
 
@@ -27,7 +27,7 @@ export const FilterAction = observer(
 
     return (
       <FilterActionContext.Provider value={{ field, fieldSchema, designable, dn }}>
-        <Popover
+        <PopoverWithStopPropagation
           destroyTooltipOnHide
           placement={'bottomLeft'}
           open={visible}
@@ -88,7 +88,7 @@ export const FilterAction = observer(
           }
         >
           <Action {...others} title={field.title} />
-        </Popover>
+        </PopoverWithStopPropagation>
       </FilterActionContext.Provider>
     );
   },

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -6,7 +6,7 @@ import { Button, Input } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, hasIcon, icons } from '../../../icon';
-import { Popover } from '../popover';
+import { PopoverWithStopPropagation } from '../popover';
 
 function IconField(props: any) {
   const layout = useFormLayout();
@@ -16,7 +16,7 @@ function IconField(props: any) {
   return (
     <div>
       <Input.Group compact>
-        <Popover
+        <PopoverWithStopPropagation
           placement={'bottom'}
           open={visible}
           onOpenChange={(val) => {
@@ -47,7 +47,7 @@ function IconField(props: any) {
           <Button size={layout.size as any} disabled={disabled}>
             {hasIcon(value) ? <Icon type={value} /> : t('Select icon')}
           </Button>
-        </Popover>
+        </PopoverWithStopPropagation>
         {value && !disabled && (
           <Button
             size={layout.size as any}

--- a/packages/core/client/src/schema-component/antd/input/EllipsisWithTooltip.tsx
+++ b/packages/core/client/src/schema-component/antd/input/EllipsisWithTooltip.tsx
@@ -1,5 +1,5 @@
+import { Popover } from 'antd';
 import React, { CSSProperties, forwardRef, useImperativeHandle, useRef, useState } from 'react';
-import { Popover } from '../popover';
 
 const getContentWidth = (element) => {
   if (element) {

--- a/packages/core/client/src/schema-component/antd/popover/Popover.tsx
+++ b/packages/core/client/src/schema-component/antd/popover/Popover.tsx
@@ -1,7 +1,7 @@
 import { Popover as AntdPopover, PopoverProps } from 'antd';
 import React, { useCallback } from 'react';
 
-export const Popover = (props: PopoverProps) => {
+export const PopoverWithStopPropagation = (props: PopoverProps) => {
   // 参见：https://github.com/ant-design/ant-design/issues/44119
   // fix T-1508
   const avoidClose = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {

--- a/packages/core/client/src/schema-component/antd/quick-edit/QuickEdit.tsx
+++ b/packages/core/client/src/schema-component/antd/quick-edit/QuickEdit.tsx
@@ -4,7 +4,7 @@ import { Field, createForm } from '@formily/core';
 import { FormContext, RecursionField, observer, useField, useFieldSchema } from '@formily/react';
 import React, { useMemo, useRef } from 'react';
 import { useCollectionManager } from '../../../collection-manager';
-import { Popover } from '../popover';
+import { PopoverWithStopPropagation } from '../popover';
 
 export const Editable = observer((props) => {
   const field: any = useField();
@@ -42,7 +42,7 @@ export const Editable = observer((props) => {
 
   return (
     <FormItem {...props} labelStyle={{ display: 'none' }}>
-      <Popover
+      <PopoverWithStopPropagation
         content={
           <div style={{ width: '100%', height: '100%', minWidth: 500 }}>
             <div ref={containerRef}>{modifiedChildren}</div>
@@ -62,7 +62,7 @@ export const Editable = observer((props) => {
             <RecursionField schema={schema} name={fieldSchema.name} />
           </FormContext.Provider>
         </div>
-      </Popover>
+      </PopoverWithStopPropagation>
     </FormItem>
   );
 });

--- a/packages/plugins/charts/src/client/select/CustomSelect.tsx
+++ b/packages/plugins/charts/src/client/select/CustomSelect.tsx
@@ -1,7 +1,7 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { isValid } from '@formily/shared';
-import { Icon, Popover, css } from '@nocobase/client';
+import { Icon, PopoverWithStopPropagation, css } from '@nocobase/client';
 import type { SelectProps } from 'antd';
 import { Select as AntdSelect } from 'antd';
 import React from 'react';
@@ -36,7 +36,7 @@ const InternalSelect = connect(
         <OptGroup label={lang('Basic charts')}>
           {group1.map((option) => (
             <Option key={option.key} value={option.key} label={lang(option.title)}>
-              <Popover
+              <PopoverWithStopPropagation
                 placement={'right'}
                 zIndex={99999999999}
                 content={() => (
@@ -60,14 +60,14 @@ const InternalSelect = connect(
                     {lang(option.title)}
                   </span>
                 </div>
-              </Popover>
+              </PopoverWithStopPropagation>
             </Option>
           ))}
         </OptGroup>
         <OptGroup label={lang('More charts')}>
           {group2.map((option) => (
             <Option key={option.key} value={option.key} label={lang(option.title)}>
-              <Popover
+              <PopoverWithStopPropagation
                 placement={'right'}
                 zIndex={99999999999}
                 content={() => (
@@ -91,7 +91,7 @@ const InternalSelect = connect(
                     {lang(option.title)}
                   </span>
                 </div>
-              </Popover>
+              </PopoverWithStopPropagation>
             </Option>
           ))}
         </OptGroup>

--- a/packages/plugins/graph-collection-manager/src/client/GraphDrawPage.tsx
+++ b/packages/plugins/graph-collection-manager/src/client/GraphDrawPage.tsx
@@ -21,7 +21,7 @@ import {
   CollectionManagerContext,
   CollectionManagerProvider,
   CurrentAppInfoContext,
-  Popover,
+  PopoverWithStopPropagation,
   SchemaComponent,
   SchemaComponentOptions,
   Select,
@@ -1140,7 +1140,7 @@ export const GraphDrawPage = React.memo(() => {
                                     </div>
                                   );
                                   return (
-                                    <Popover
+                                    <PopoverWithStopPropagation
                                       content={content}
                                       autoAdjustOverflow
                                       placement="bottomRight"
@@ -1155,7 +1155,7 @@ export const GraphDrawPage = React.memo(() => {
                                       <Button>
                                         <MenuOutlined />
                                       </Button>
-                                    </Popover>
+                                    </PopoverWithStopPropagation>
                                   );
                                 },
                                 'x-component-props': {
@@ -1239,7 +1239,7 @@ export const GraphDrawPage = React.memo(() => {
                                     </div>
                                   );
                                   return (
-                                    <Popover
+                                    <PopoverWithStopPropagation
                                       content={content}
                                       autoAdjustOverflow
                                       placement="bottomRight"
@@ -1254,7 +1254,7 @@ export const GraphDrawPage = React.memo(() => {
                                       <Button>
                                         <ShareAltOutlined />
                                       </Button>
-                                    </Popover>
+                                    </PopoverWithStopPropagation>
                                   );
                                 },
                                 'x-component-props': {
@@ -1315,7 +1315,7 @@ export const GraphDrawPage = React.memo(() => {
                                     </div>
                                   );
                                   return (
-                                    <Popover
+                                    <PopoverWithStopPropagation
                                       content={content}
                                       autoAdjustOverflow
                                       placement="bottomRight"
@@ -1330,7 +1330,7 @@ export const GraphDrawPage = React.memo(() => {
                                       <Button>
                                         <LineHeightOutlined />
                                       </Button>
-                                    </Popover>
+                                    </PopoverWithStopPropagation>
                                   );
                                 },
                               },

--- a/packages/plugins/graph-collection-manager/src/client/components/Entity.tsx
+++ b/packages/plugins/graph-collection-manager/src/client/components/Entity.tsx
@@ -5,7 +5,7 @@ import { uid } from '@formily/shared';
 import {
   CollectionCategroriesContext,
   CollectionProvider,
-  Popover,
+  PopoverWithStopPropagation,
   SchemaComponent,
   SchemaComponentProvider,
   Select,
@@ -218,7 +218,7 @@ const PopoverContent = React.memo((props: any) => {
     }
   };
   return (
-    <Popover
+    <PopoverWithStopPropagation
       content={CollectionConten(property)}
       getPopupContainer={getPopupContainer}
       mouseLeaveDelay={0}
@@ -252,7 +252,7 @@ const PopoverContent = React.memo((props: any) => {
         <div className={`type  field_type`}>{compile(getInterface(property.interface)?.title)}</div>
         {isHovered && <OperationButton property={property} {...operatioBtnProps} />}
       </div>
-    </Popover>
+    </PopoverWithStopPropagation>
   );
 });
 

--- a/packages/plugins/localization-management/src/client/Localization.tsx
+++ b/packages/plugins/localization-management/src/client/Localization.tsx
@@ -4,7 +4,7 @@ import { Field, useField, useForm } from '@formily/react';
 import {
   FormProvider,
   Input,
-  Popover,
+  PopoverWithStopPropagation,
   Radio,
   SchemaComponent,
   locale,
@@ -115,7 +115,7 @@ const Sync = () => {
   };
 
   return (
-    <Popover
+    <PopoverWithStopPropagation
       placement="bottomRight"
       content={
         <>
@@ -158,7 +158,7 @@ const Sync = () => {
       >
         {t('Sync')}
       </Button>
-    </Popover>
+    </PopoverWithStopPropagation>
   );
 };
 

--- a/packages/plugins/theme-editor/src/client/antd-token-previewer/token-panel-pro/TokenContent.tsx
+++ b/packages/plugins/theme-editor/src/client/antd-token-previewer/token-panel-pro/TokenContent.tsx
@@ -1,5 +1,5 @@
 import { CaretRightOutlined, ExpandOutlined, QuestionCircleOutlined } from '@ant-design/icons';
-import { Popover } from '@nocobase/client';
+import { PopoverWithStopPropagation } from '@nocobase/client';
 import { Button, Checkbox, Collapse, ConfigProvider, Switch, Tooltip, Typography } from 'antd';
 import type { ThemeConfig } from 'antd/es/config-provider/context';
 import seed from 'antd/es/theme/themes/seed';
@@ -304,7 +304,7 @@ const SeedTokenPreview: FC<SeedTokenProps> = ({ theme, tokenName, disabled, alph
         </Typography.Link>
       </div>
       {tokenName.startsWith('color') && (
-        <Popover
+        <PopoverWithStopPropagation
           trigger="click"
           placement="bottomRight"
           overlayInnerStyle={{ padding: 0 }}
@@ -326,7 +326,7 @@ const SeedTokenPreview: FC<SeedTokenProps> = ({ theme, tokenName, disabled, alph
             />
             <div className="token-panel-pro-token-collapse-seed-block-sample-card-value">{tokenValue}</div>
           </div>
-        </Popover>
+        </PopoverWithStopPropagation>
       )}
       {['fontSize', 'sizeUnit', 'sizeStep', 'borderRadius'].includes(tokenName) && (
         <InputNumberPlus


### PR DESCRIPTION
## Description (Bug 描述)
- 折叠面板筛选区块，点击无效

### Steps to reproduce (复现步骤)
1. 新建一个 `折叠面板筛选区块`
2. 新建一个 `表格区块`
3. 连接两个区块
4. 点击 `折叠面板筛选区块` 的一个选项，会发现不起作用

https://github.com/nocobase/nocobase/assets/38434641/0faeac5d-7c40-41db-9853-50fd9aa58d19
<!-- Clear steps to reproduce the bug. -->

### Expected behavior (预期行为)
点击 `折叠面板筛选区块` 选项可以有效进行筛选

https://github.com/nocobase/nocobase/assets/38434641/ca819baf-0e42-40fe-87fd-78fb9853fd93


<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

### Actual behavior (实际行为)
点击无效
<!-- Describe what actually happens when the code is executed with the bug. -->

## Related issues (相关 issue)
#2586 
<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)
 `折叠面板筛选区块` 的每一项会被渲染成 `EllipsisWithTooltip` 组件，而 `EllipsisWithTooltip` 组件中使用到了 `Popover`，之前为了解决 #2586 重构了 `Popover` （主要是在外面包一层 div 阻止点击事件向上冒泡），导致这里的点击事件也被阻止向上冒泡，表现出的行为就是点击选项无效。
https://github.com/nocobase/nocobase/blob/4812cc5692675986e95ef92e4f2218b0ffa37ca5/packages/core/client/src/schema-component/antd/association-filter/AssociationFilter.Item.tsx#L143-L149
<!-- Explain what caused the bug to occur. -->

## Solution (解决方案)
替换为原生的 antd 的 `Popover` 组件，重命名自定义的 `Popover` 为 `PopoverWithStopPropagation`，这样易于区分，防止出错。同时自查可能出问题的点，并进行了修改。
<!-- Describe solution to the bug clearly and consciously. -->

## 其它
close T-1806