### PR TITLE
fix(plugin-workflow): fix scope variable in loop

### DIFF
--- a/packages/plugins/workflow/src/client/variable.tsx
+++ b/packages/plugins/workflow/src/client/variable.tsx
@@ -260,7 +260,7 @@ function getNormalizedFields(collectionName, { compile, getCollectionFields }) {
   return otherFields.filter((field) => field.interface && !field.hidden);
 }
 
-async function loadChildren(option) {
+function loadChildren(option) {
   const appends = getNextAppends(option.field, option.appends);
   const result = getCollectionFieldOptions({
     collection: option.field.target,


### PR DESCRIPTION
## Description (Bug 描述)

Cannot select properties of collection variable in loop scope.

### Steps to reproduce (复现步骤)

1. Add a collection workflow.
2. Add a loop node, target as trigger data.
3. Add any node in loop, try to use scope variable as any field of the trigger data.

### Expected behavior (预期行为)

Could select the fields.

### Actual behavior (实际行为)

Could not.

## Related issues (相关 issue)

#2622.

## Reason (原因)

Scope variables not include lazy load variables.

## Solution (解决方案)

Add lazy load logic to loop node.
