### PR TITLE
fix: fix quarter variables

### DIFF
--- a/packages/core/utils/src/__tests__/parse-date.test.ts
+++ b/packages/core/utils/src/__tests__/parse-date.test.ts
@@ -21,8 +21,11 @@ describe('parse date', () => {
 
   it('should parse quarter', async () => {
     expectDate('2023Q1').toEqual(['2023-01-01T00:00:00.000Z', '2023-04-01T00:00:00.000Z']);
+    expectDate('2023Q2').toEqual(['2023-04-01T00:00:00.000Z', '2023-07-01T00:00:00.000Z']);
     expectDate('2023Q1+08:00').toEqual(['2022-12-31T16:00:00.000Z', '2023-03-31T16:00:00.000Z']);
+    expectDate('2023Q2+08:00').toEqual(['2023-03-31T16:00:00.000Z', '2023-06-30T16:00:00.000Z']);
     expectDate('2023Q1', { timezone: '+08:00' }).toEqual(['2022-12-31T16:00:00.000Z', '2023-03-31T16:00:00.000Z']);
+    expectDate('2023Q2', { timezone: '+08:00' }).toEqual(['2023-03-31T16:00:00.000Z', '2023-06-30T16:00:00.000Z']);
   });
 
   it('should parse iso week', async () => {

--- a/packages/core/utils/src/parse-date.ts
+++ b/packages/core/utils/src/parse-date.ts
@@ -26,10 +26,11 @@ function parseYear(value) {
 }
 
 function parseQuarter(value) {
-  if (/^\d\d\d\d\Q\d$/.test(value)) {
+  if (/^\d\d\d\dQ\d$/.test(value)) {
+    const [year, q] = value.split('Q');
     return {
       unit: 'quarter',
-      start: dayjs(value, 'YYYY[Q]Q').format('YYYY-MM-DD HH:mm:ss'),
+      start: dayjs(year, 'YYYY').quarter(q).format('YYYY-MM-DD HH:mm:ss'),
     };
   }
 }


### PR DESCRIPTION
修复在数据范围中使用日期的 `季度` 相关的变量时筛选结果不对的问题。

![image](https://github.com/nocobase/nocobase/assets/38434641/91b68979-0673-401e-91e6-ec1dd66a9ca8)

link T-1832