### PR TITLE
fix(auth): change password issue of basic auth

### DIFF
--- a/packages/core/client/src/user/ChangePassword.tsx
+++ b/packages/core/client/src/user/ChangePassword.tsx
@@ -26,7 +26,7 @@ const useSaveCurrentUserValues = () => {
   return {
     async run() {
       await form.submit();
-      await api.resource('users').changePassword({
+      await api.resource('auth').changePassword({
         values: form.values,
       });
       await form.reset();

--- a/packages/core/resourcer/src/__tests__/resourcer.test.ts
+++ b/packages/core/resourcer/src/__tests__/resourcer.test.ts
@@ -713,4 +713,36 @@ describe('resourcer', () => {
 
     expect(context.arr).toEqual([2, 9, 10, 3]);
   });
+
+  it('add action', async () => {
+    const resourcer = new Resourcer();
+    resourcer.define({
+      name: 'test',
+      middleware: require('./middlewares/demo1'),
+      actions: {
+        list: {
+          handler: require('./actions/demo1'),
+        },
+      },
+    });
+    resourcer.getResource('test').addAction('new', async function (ctx, next) {
+      ctx.arr.push(100);
+      await next();
+      ctx.arr.push(101);
+    });
+
+    const context = {
+      arr: [],
+    };
+
+    await resourcer.execute(
+      {
+        resource: 'test',
+        action: 'new',
+      },
+      context,
+    );
+
+    expect(context.arr).toEqual([2, 100, 101, 3]);
+  });
 });

--- a/packages/core/resourcer/src/resource.ts
+++ b/packages/core/resourcer/src/resource.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Action, { ActionName, ActionType } from './action';
 import Middleware, { MiddlewareType } from './middleware';
-import { Resourcer } from './resourcer';
+import { HandlerType, Resourcer } from './resourcer';
 
 export type ResourceType = 'single' | 'hasOne' | 'hasMany' | 'belongsTo' | 'belongsToMany';
 
@@ -86,6 +86,20 @@ export class Resource {
 
   getExcept() {
     return this.except;
+  }
+
+  addAction(name: ActionName, handler: HandlerType) {
+    if (this.except.includes(name)) {
+      throw new Error(`${name} action is not allowed`);
+    }
+    if (this.actions.has(name)) {
+      throw new Error(`${name} action already exists`);
+    }
+    const action = new Action(handler);
+    action.setName(name);
+    action.setResource(this);
+    action.middlewares.unshift(...this.middlewares);
+    this.actions.set(name, action);
   }
 
   getAction(action: ActionName) {

--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
@@ -168,5 +168,36 @@ describe('actions', () => {
       const token = data.token;
       expect(token).toBeDefined();
     });
+
+    it('should change password', async () => {
+      // Create a user without email
+      const userRepo = db.getRepository('users');
+      const user = await userRepo.create({
+        values: {
+          username: 'test',
+          password: '12345',
+        },
+      });
+      const res = await agent.login(user).post('/auth:changePassword').set({ 'X-Authenticator': 'basic' }).send({
+        oldPassword: '12345',
+        newPassword: '123456',
+        confirmPassword: '123456',
+      });
+      expect(res.statusCode).toEqual(200);
+
+      // Create a user without username
+      const user1 = await userRepo.create({
+        values: {
+          username: 'test2',
+          password: '12345',
+        },
+      });
+      const res2 = await agent.login(user1).post('/auth:changePassword').set({ 'X-Authenticator': 'basic' }).send({
+        oldPassword: '12345',
+        newPassword: '123456',
+        confirmPassword: '123456',
+      });
+      expect(res2.statusCode).toEqual(200);
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-auth/src/server/basic-auth.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/basic-auth.ts
@@ -124,9 +124,15 @@ export class BasicAuth extends BaseAuth {
     if (!currentUser) {
       ctx.throw(401);
     }
+    let key: string;
+    if (currentUser.username) {
+      key = 'username';
+    } else {
+      key = 'email';
+    }
     const user = await this.userRepository.findOne({
       where: {
-        email: currentUser.email,
+        [key]: currentUser[key],
       },
     });
     const pwd = this.userCollection.getField<PasswordField>('password');

--- a/packages/plugins/@nocobase/plugin-auth/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/plugin.ts
@@ -50,8 +50,8 @@ export class AuthPlugin extends Plugin {
       title: 'Password',
     });
     // Register actions
-    Object.entries(authActions).forEach(([action, handler]) =>
-      this.app.resourcer.registerAction(`auth:${action}`, handler),
+    Object.entries(authActions).forEach(
+      ([action, handler]) => this.app.resourcer.getResource('auth')?.addAction(action, handler),
     );
     Object.entries(authenticatorsActions).forEach(([action, handler]) =>
       this.app.resourcer.registerAction(`authenticators:${action}`, handler),

--- a/packages/plugins/@nocobase/plugin-auth/src/swagger/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/swagger/index.ts
@@ -318,6 +318,58 @@ export default {
         },
       },
     },
+    '/auth:changePassword': {
+      post: {
+        description: 'Change password',
+        tags: ['Basic auth'],
+        security: [],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  oldPassword: {
+                    type: 'string',
+                    description: '旧密码',
+                  },
+                  newPassword: {
+                    type: 'string',
+                    description: '新密码',
+                  },
+                  confirmPassword: {
+                    type: 'string',
+                    description: '确认密码',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/user',
+                },
+              },
+            },
+          },
+          401: {
+            description: 'Unauthorized',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/error',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     'authenticators:listTypes': {
       get: {
         description: 'List authenticator types',


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

创建一个新用户，修改密码

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

正常修改密码

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

401， 密码不正确

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

#2634
Close T-1893

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

切换为用户名注册以后，新用户没有邮箱，旧的changePassword接口仍使用原来的用邮箱查找用户的方式，导致查找不到正确用户。

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

优先使用用户名查找用户，用户名不存在再用邮箱。
