### PR TITLE
fix(auth): user role not found

### DIFF
--- a/packages/core/client/src/api-client/APIClient.ts
+++ b/packages/core/client/src/api-client/APIClient.ts
@@ -39,6 +39,20 @@ export class APIClient extends APIClientSDK {
     });
     super.interceptors();
     this.useNotificationMiddleware();
+    this.axios.interceptors.response.use(
+      (response) => {
+        return response;
+      },
+      (error) => {
+        const errs = error?.response?.data?.errors || [{ message: 'Server error' }];
+        // Hard code here temporarily
+        // TODO(yangqia): improve error code and message
+        if (errs.find((error: { code?: string }) => error.code === 'ROLE_NOT_FOUND_ERR')) {
+          this.auth.setRole(null);
+        }
+        throw error;
+      },
+    );
   }
 
   useNotificationMiddleware() {

--- a/packages/core/client/src/api-client/__tests__/APIClient.test.tsx
+++ b/packages/core/client/src/api-client/__tests__/APIClient.test.tsx
@@ -23,4 +23,40 @@ describe('APIClient', () => {
       expect(apiClient.axios).toBe(instance);
     });
   });
+
+  test('should reset role when role is not found', async () => {
+    const instance = axios.create();
+    instance.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        error = {
+          response: {
+            data: {
+              errors: [
+                {
+                  code: 'ROLE_NOT_FOUND_ERR',
+                },
+              ],
+            },
+          },
+        };
+        throw error;
+      },
+    );
+    const apiClient = new APIClient(instance);
+    apiClient.app = {} as any;
+    apiClient.auth.setRole('not-found');
+    expect(apiClient.auth.role).toBe('not-found');
+    try {
+      await apiClient.request({
+        method: 'GET',
+        url: '/api/test',
+      });
+    } catch (err) {
+      console.log(err);
+      expect(err).toBeDefined();
+      expect(err.response.data.errors[0].code).toBe('ROLE_NOT_FOUND_ERR');
+    }
+    expect(apiClient.auth.role).toBeFalsy();
+  });
 });

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/setCurrentRole.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/setCurrentRole.test.ts
@@ -67,7 +67,7 @@ describe('role', () => {
     const throwFn = jest.fn();
     ctx.throw = throwFn;
     await setCurrentRole(ctx, () => {});
-    expect(throwFn).lastCalledWith(401, 'User role not found');
+    expect(throwFn).lastCalledWith(401, { code: 'ROLE_NOT_FOUND_ERR', message: 'The user role does not exist.' });
     expect(ctx.state.currentRole).not.toBeDefined();
   });
 

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/users.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/users.test.ts
@@ -94,7 +94,7 @@ describe('actions', () => {
     const rolesCheckResponse2 = (await loggedAgent.set('Accept', 'application/json').get('/roles:check')) as any;
 
     expect(rolesCheckResponse2.status).toEqual(401);
-    expect(rolesCheckResponse2.body.errors[0].message).toEqual('User role not found');
+    expect(rolesCheckResponse2.body.errors[0].code).toEqual('ROLE_NOT_FOUND_ERR');
   });
 
   it('should destroy through table record when destroy role', async () => {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/setCurrentRole.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/setCurrentRole.ts
@@ -28,7 +28,7 @@ export async function setCurrentRole(ctx: Context, next) {
   }
 
   if (!ctx.state.currentRole) {
-    return ctx.throw(401, 'User role not found');
+    return ctx.throw(401, { code: 'ROLE_NOT_FOUND_ERR', message: 'The user role does not exist.' });
   }
 
   await next();


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

1. 登录一个用户，选择一个角色，比如root，注销后，登录一个没有所选择角色权限的用户，提示"User role not found"，无法登录
2. 登录一个用户，选择一个角色，删除角色，提示"User role not found"

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

1. 可以正常登录
2. 操作不报错

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

报错后，无法再操作

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

Close T-1798
Close T-1835

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

上一个用户角色遗留在LocalStorage中，没有清除

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

客户端判断`ROLE_NOT_FOUND_ERR`的错误码，删除LocalStorage中的角色
