### PR TITLE
fix(plugin-workflow): fix parallel bug in loop

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -306,13 +306,18 @@ export default class Processor {
     return null;
   }
 
-  findBranchLastJob(node: FlowNodeModel): JobModel | null {
+  findBranchLastJob(node: FlowNodeModel, job: JobModel): JobModel | null {
+    const allJobs = Array.from(this.jobsMap.values());
+    const branchJobs = [];
     for (let n = this.findBranchEndNode(node); n && n !== node.upstream; n = n.upstream) {
-      const jobs = Array.from(this.jobsMap.values())
-        .filter((item) => item.nodeId === n.id)
-        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
-      if (jobs.length) {
-        return jobs[jobs.length - 1];
+      branchJobs.push(...allJobs.filter((item) => item.nodeId === n.id));
+    }
+    branchJobs.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    for (let i = branchJobs.length - 1; i >= 0; i -= 1) {
+      for (let j = branchJobs[i]; j && j.id !== job.id; j = this.jobsMap.get(j.upstreamId)) {
+        if (j.upstreamId === job.id) {
+          return branchJobs[i];
+        }
       }
     }
     return null;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/parallel.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/parallel.ts
@@ -81,7 +81,7 @@ export default {
           await processor.run(branch, job);
 
           // find last job of the branch
-          return processor.findBranchLastJob(branch);
+          return processor.findBranchLastJob(branch, job);
         }),
       Promise.resolve(),
     );


### PR DESCRIPTION
## Description (Bug 描述)

Looped parallel will return wrong status when one of nodes failed in branch.

### Steps to reproduce (复现步骤)

1. Add a loop for 2.
2. Add a parallel in loop.
3. Add a condition (`{{$scopes.1.item}} < 1`) as first branch in parallel.
4. Add a query as downstream of condition.
5. Add another copy branch of condition above for parallel.

### Expected behavior (预期行为)

Workflow fails on second loop due to both conditions fails.

### Actual behavior (实际行为)

Second parallel passed as succeeded.

## Related issues (相关 issue)

#2687.

## Reason (原因)

Logic of `findBranchLastJob` not perfect.

## Solution (解决方案)

Fix logic of `findBranchLastJob` method.
