### PR TITLE
fix(plugin-workflow): fix exporting types

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/index.ts
@@ -1,5 +1,5 @@
 export * from './constants';
-// export * from './instructions';
+export type * from './instructions';
 export { Trigger } from './triggers';
 export { default as Processor } from './Processor';
 export { default } from './Plugin';

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/index.ts
@@ -7,13 +7,13 @@ import Processor from '../Processor';
 
 import type { FlowNodeModel } from '../types';
 
-export type Job = {
+export interface IJob {
   status: number;
   result?: unknown;
   [key: string]: unknown;
-} | null;
+}
 
-export type InstructionResult = Job | Promise<Job>;
+export type InstructionResult = IJob | Promise<IJob> | null;
 
 export type Runner = (node: FlowNodeModel, input: any, processor: Processor) => InstructionResult;
 


### PR DESCRIPTION
## Description (Bug 描述)

Exporting types lead to building errors.

### Steps to reproduce (复现步骤)

```
yarn build
```

### Expected behavior (预期行为)

No error.

### Actual behavior (实际行为)

```
error TS2614: Module '"@nocobase/plugin-workflow"' has no exported member 'Instruction'. Did you mean to use 'import Instruction from "@nocobase/plugin-workflow"' instead?
```

## Related issues (相关 issue)

None.

## Reason (原因)

Types.

## Solution (解决方案)

Fix types.
