### PR TITLE
fix(plugin-workflow): fix assignees and aggregate variable

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/aggregate.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/aggregate.tsx
@@ -17,19 +17,20 @@ import { NAMESPACE, lang } from '../locale';
 import { collection, filter } from '../schemas/collection';
 import { BaseTypeSets, defaultFieldNames, nodesOptions, triggerOptions } from '../variable';
 
-function matchToManyField(field, appends): boolean {
-  const fieldPrefix = `${field.name}.`;
-  return (
-    (['hasOne', 'belongsTo'].includes(field.type) &&
-      (appends ? appends.includes(field.name) || appends.some((item) => item.startsWith(fieldPrefix)) : true)) ||
-    ['hasMany', 'belongsToMany'].includes(field.type)
-  );
+function matchToManyField(field): boolean {
+  // const fieldPrefix = `${field.name}.`;
+  return ['hasMany', 'belongsToMany'].includes(field.type);
 }
 
 function useAssociatedFields() {
   const compile = useCompile();
   return [nodesOptions, triggerOptions].map((item) => {
-    const children = item.useOptions({ types: [matchToManyField] })?.filter(Boolean);
+    const children = item
+      .useOptions({
+        types: [matchToManyField],
+        appends: null,
+      })
+      ?.filter(Boolean);
     return {
       label: compile(item.label),
       value: item.value,
@@ -100,6 +101,9 @@ function AssociatedConfig({ value, onChange, ...props }): JSX.Element {
 
       // const associationFieldName = path.pop();
       const { field } = option.pop();
+      if (!field || !['hasMany', 'belongsToMany'].includes(field.type)) {
+        return;
+      }
       // need to get:
       // * source collection (from node.config)
       // * target collection (from field name)
@@ -242,6 +246,9 @@ export default {
                   title: `{{t("Data of associated collection", { ns: "${NAMESPACE}" })}}`,
                   'x-decorator': 'FormItem',
                   'x-component': 'AssociatedConfig',
+                  'x-component-props': {
+                    changeOnSelect: true,
+                  },
                   'x-reactions': [
                     {
                       dependencies: ['associated'],

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
@@ -53,6 +53,8 @@ export default {
     const name = `${id}`;
     const [result] = getCollectionFieldOptions({
       // collection: config.collection,
+      // depth: options?.depth ?? depth,
+      appends: [name, ...(config.params?.appends?.map((item) => `${name}.${item}`) || [])],
       ...options,
       fields: [
         {
@@ -65,8 +67,6 @@ export default {
           },
         },
       ],
-      // depth: options?.depth ?? depth,
-      appends: [name, ...(config.params?.appends?.map((item) => `${name}.${item}`) || [])],
       compile,
       getCollectionFields,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/query.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/query.tsx
@@ -98,6 +98,8 @@ export default {
     const name = `${id}`;
     const [result] = getCollectionFieldOptions({
       // collection: config.collection,
+      // depth: options?.depth ?? depth,
+      appends: [name, ...(config.params?.appends?.map((item) => `${name}.${item}`) || [])],
       ...options,
       fields: [
         {
@@ -110,8 +112,6 @@ export default {
           },
         },
       ],
-      // depth: options?.depth ?? depth,
-      appends: [name, ...(config.params?.appends?.map((item) => `${name}.${item}`) || [])],
       compile,
       getCollectionFields,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/collection.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/collection.tsx
@@ -170,9 +170,9 @@ export default {
     //   : 1;
     const result = getCollectionFieldOptions({
       // depth,
+      appends: ['data', ...(config.appends?.map((item) => `data.${item}`) || [])],
       ...options,
       fields: rootFields,
-      appends: ['data', ...(config.appends?.map((item) => `data.${item}`) || [])],
       compile,
       getCollectionFields,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/form.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/form.tsx
@@ -77,9 +77,9 @@ export default {
     ];
     const result = getCollectionFieldOptions({
       // depth,
+      appends: ['data', 'user', ...(config.appends?.map((item) => `data.${item}`) || [])],
       ...options,
       fields: rootFields,
-      appends: ['data', 'user', ...(config.appends?.map((item) => `data.${item}`) || [])],
       compile,
       getCollectionFields,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/schedule/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/schedule/index.tsx
@@ -43,6 +43,7 @@ export default {
     if (config.mode === SCHEDULE_MODE.COLLECTION_FIELD) {
       const [fieldOption] = getCollectionFieldOptions({
         // depth,
+        appends: ['data', ...(config.appends?.map((item) => `data.${item}`) || [])],
         ...opts,
         fields: [
           {
@@ -55,7 +56,6 @@ export default {
             },
           },
         ],
-        appends: ['data', ...(config.appends?.map((item) => `data.${item}`) || [])],
         compile,
         getCollectionFields,
       });


### PR DESCRIPTION
## Description (Bug 描述)

In manual node, assignees cannot use variable.

### Steps to reproduce (复现步骤)

1. Add a collection trigger workflow.
2. Select any collection in trigger config.
3. Add manual node, try to use trigger variable in assignees field.

### Expected behavior (预期行为)

Could use `createdBy` field.

### Actual behavior (实际行为)

No variable to use.

## Related issues (相关 issue)

#2492.

## Reason (原因)

Variable type filter logic no completed.

## Solution (解决方案)

Fix the filter logic.