### PR TITLE
fix(plugin-workflow): fix context data of form trigger

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/form.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/form.ts
@@ -88,7 +88,7 @@ export default class FormTrigger extends Trigger {
               appends,
             });
           }
-          this.plugin.trigger(workflow, { data: payload, user: currentUser });
+          this.plugin.trigger(workflow, { data: toJSON(payload), user: toJSON(currentUser) });
         });
       } else {
         const data = trigger[1] ? get(values, trigger[1]) : values;


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

1. Create a form trigger workflow.
2. Add append association to preload.
3. Try to use the variable field of appended association.

### Expected behavior (预期行为)

Could get correct variable value.

### Actual behavior (实际行为)

`undefined`.

## Related issues (相关 issue)

None.

## Reason (原因)

Need `toJSON` for execution context variables when result is Model type.

## Solution (解决方案)

Add `toJSON`.
