### PR TITLE
style: fix PageHeader

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/style.ts
+++ b/packages/core/client/src/schema-component/antd/page/style.ts
@@ -41,9 +41,9 @@ export const useStyles = genStyleHook('nb-page', (token) => {
 
       '.pageHeaderCss': {
         backgroundColor: token.colorBgContainer,
+        paddingInline: token.paddingLG,
         '&.ant-page-header-has-footer': {
           paddingTop: token.paddingSM,
-          paddingInline: token.paddingLG,
           paddingBottom: '0',
           '.ant-page-header-heading-left': {},
           '.ant-page-header-footer': { marginBlockStart: '0' },


### PR DESCRIPTION
# 问题
没有标签页的时候，标题的上下左右空间调紧凑了，有标签页的没调，导致不统一。

![img_v2_f1a4e0e2-ad54-4cd4-b8ea-903d30759d6g](https://github.com/nocobase/nocobase/assets/38434641/f85e8a07-6375-47d6-9f01-4d58ce8a174a)
![img_v2_c952fb0b-79c2-45be-96cf-9a283bc2ce4g](https://github.com/nocobase/nocobase/assets/38434641/ddaf8838-3233-43b3-aa38-cbc4b4f31ca7)

close T-2128
