### PR TITLE
fix(client): fix rerendering cause range bug

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -213,7 +213,7 @@ export function TextArea(props) {
     if (!changed) {
       setRange([-1, 0, -1, 0]);
     }
-  }, [value, keyLabelMap]);
+  }, [value]);
 
   useEffect(() => {
     const { current } = inputRef;


### PR DESCRIPTION
## Description (Bug 描述)

Cursor jump to start when insert variable into expression input.

### Steps to reproduce (复现步骤)

1. Add collection workflow.
2. Select a collection in trigger config.
3. Add a calculation node.
4. Input "1+", then select trigger variable to insert.

### Expected behavior (预期行为)

Showing: "1+{{trigger/...}}".

### Actual behavior (实际行为)

Showing: "{{trigger/...}}1+"

## Related issues (相关 issue)

#2157.

## Reason (原因)

https://github.com/nocobase/nocobase/commit/c9b726916ce2f5d699674075e2f7d47098184d77#diff-1e4902f03f04232eab38873797c9729ec3139bc455afaf0bd16eadc9fce13fdaR214

Rerendering happened when update `keyLabelMap`.

## Solution (解决方案)

Remove `keyLabelMap` from use effect dependency.
