### PR TITLE
fix(client): fix rendering cause range bug

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -222,7 +222,7 @@ export function TextArea(props) {
     }
     const nextRange = new Range();
     if (changed) {
-      setChanged(false);
+      // setChanged(false);
       if (range.join() === '-1,0,-1,0') {
         return;
       }


### PR DESCRIPTION
## Description (Bug 描述)

Cursor jump to start when insert variable into expression input.

### Steps to reproduce (复现步骤)

1. Add collection workflow.
2. Select a collection in trigger config.
3. Add a calculation node.
4. Input "1+", then select trigger variable to insert.

### Expected behavior (预期行为)

Showing: "1+{{trigger/...}}".

### Actual behavior (实际行为)

Showing: "{{trigger/...}}1+"

## Related issues (相关 issue)

#2157.

## Reason (原因)

https://github.com/nocobase/nocobase/blob/main/packages/core/client/src/schema-component/antd/variable/TextArea.tsx#L225

Rerendering happened when update `keyLabelMap`, but `setChanged(true)` always invoked when rendering.

## Solution (解决方案)

Comment `setChanged(true)` out.
