### PR TITLE
fix(client): fix action component warning

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -38,6 +38,8 @@ export const Action: ComposedAction = observer(
       icon,
       title,
       onClick,
+      style,
+      openSize,
       ...others
     } = useProps(props);
     const { wrapSSR, componentCls, hashId } = useStyles();
@@ -54,7 +56,6 @@ export const Action: ComposedAction = observer(
     const designerProps = fieldSchema['x-designer-props'];
     const openMode = fieldSchema?.['x-component-props']?.['openMode'];
     const disabled = form.disabled || field.disabled || field.data?.disabled || props.disabled;
-    const openSize = fieldSchema?.['x-component-props']?.['openSize'];
     const linkageRules = fieldSchema?.['x-linkage-rules'] || [];
     const { designable } = useDesignable();
     const tarComponent = useComponent(component) || component;
@@ -111,10 +112,10 @@ export const Action: ComposedAction = observer(
 
     const buttonStyle = useMemo(() => {
       return {
-        ...others.style,
+        ...style,
         opacity: designable && field?.data?.hidden && 0.1,
       };
-    }, [designable, field?.data?.hidden, others.style]);
+    }, [designable, field?.data?.hidden, style]);
 
     const renderButton = () => {
       if (!designable && field?.data?.hidden) {


### PR DESCRIPTION
## Description (Bug 描述)

Warning in console.

### Steps to reproduce (复现步骤)

1. Use "Add new" popup
2. Add a form.

### Expected behavior (预期行为)

No warning.

### Actual behavior (实际行为)

Warning on `openSize`.

## Related issues (相关 issue)

None.

## Reason (原因)

Passing all props to children.

## Solution (解决方案)

Pick props.
