### PR TITLE
feat(auth): add global auth token provider

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/client/AuthPluginProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/AuthPluginProvider.tsx
@@ -1,0 +1,41 @@
+import {
+  OptionsComponentProvider,
+  SettingsCenterProvider,
+  SigninPageProvider,
+  SignupPageProvider,
+} from '@nocobase/client';
+import React, { FC } from 'react';
+import { Authenticator } from './settings/Authenticator';
+import SigninPage from './basic/SigninPage';
+import { presetAuthType } from '../preset';
+import SignupPage from './basic/SignupPage';
+import { useAuthTranslation } from './locale';
+import { Options } from './basic/Options';
+
+export const AuthPluginProvider: FC = (props) => {
+  const { t } = useAuthTranslation();
+  return (
+    <SettingsCenterProvider
+      settings={{
+        auth: {
+          title: t('Authentication'),
+          icon: 'LoginOutlined',
+          tabs: {
+            authenticators: {
+              title: t('Authenticators'),
+              component: () => <Authenticator />,
+            },
+          },
+        },
+      }}
+    >
+      <OptionsComponentProvider authType={presetAuthType} component={Options}>
+        <SigninPageProvider authType={presetAuthType} tabTitle={t('Sign in via password')} component={SigninPage}>
+          <SignupPageProvider authType={presetAuthType} component={SignupPage}>
+            {props.children}
+          </SignupPageProvider>
+        </SigninPageProvider>
+      </OptionsComponentProvider>
+    </SettingsCenterProvider>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx
@@ -1,41 +1,19 @@
-import {
-  OptionsComponentProvider,
-  SettingsCenterProvider,
-  SigninPageProvider,
-  SignupPageProvider,
-} from '@nocobase/client';
-import React, { FC } from 'react';
-import { Authenticator } from './settings/Authenticator';
-import SigninPage from './basic/SigninPage';
-import { presetAuthType } from '../preset';
-import SignupPage from './basic/SignupPage';
-import { useAuthTranslation } from './locale';
-import { Options } from './basic/Options';
+import { useAPIClient } from '@nocobase/client';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
-export const AuthProvider: FC = (props) => {
-  const { t } = useAuthTranslation();
-  return (
-    <SettingsCenterProvider
-      settings={{
-        auth: {
-          title: t('Authentication'),
-          icon: 'LoginOutlined',
-          tabs: {
-            authenticators: {
-              title: t('Authenticators'),
-              component: () => <Authenticator />,
-            },
-          },
-        },
-      }}
-    >
-      <OptionsComponentProvider authType={presetAuthType} component={Options}>
-        <SigninPageProvider authType={presetAuthType} tabTitle={t('Sign in via password')} component={SigninPage}>
-          <SignupPageProvider authType={presetAuthType} component={SignupPage}>
-            {props.children}
-          </SignupPageProvider>
-        </SigninPageProvider>
-      </OptionsComponentProvider>
-    </SettingsCenterProvider>
-  );
+export const AuthProvider: React.FC = (props) => {
+  const location = useLocation();
+  const api = useAPIClient();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const authenticator = params.get('authenticator');
+    const token = params.get('token');
+    if (token) {
+      api.auth.setToken(token);
+      api.auth.setAuthenticator(authenticator);
+    }
+  });
+  return <>{props.children}</>;
 };

--- a/packages/plugins/@nocobase/plugin-auth/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/index.tsx
@@ -1,9 +1,11 @@
 import { Plugin } from '@nocobase/client';
+import { AuthPluginProvider } from './AuthPluginProvider';
 import { AuthProvider } from './AuthProvider';
 
 export class AuthPlugin extends Plugin {
   async load() {
-    this.app.use(AuthProvider);
+    this.app.providers.unshift([AuthProvider, {}]);
+    this.app.use(AuthPluginProvider);
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-cas/src/client/SigninPage.tsx
+++ b/packages/plugins/@nocobase/plugin-cas/src/client/SigninPage.tsx
@@ -1,4 +1,4 @@
-import { Authenticator, useAPIClient, useRedirect, useCurrentUserContext } from '@nocobase/client';
+import { Authenticator, useRedirect } from '@nocobase/client';
 import React, { useEffect } from 'react';
 import { LoginOutlined } from '@ant-design/icons';
 import { Button, Space, message } from 'antd';
@@ -6,10 +6,8 @@ import { useLocation } from 'react-router-dom';
 import { getSubAppName } from '@nocobase/sdk';
 
 export const SigninPage = (props: { authenticator: Authenticator }) => {
-  const api = useAPIClient();
   const redirect = useRedirect();
   const location = useLocation();
-  const { refreshAsync: refresh } = useCurrentUserContext();
 
   const authenticator = props.authenticator;
 
@@ -21,7 +19,6 @@ export const SigninPage = (props: { authenticator: Authenticator }) => {
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const token = params.get('token');
     const name = params.get('authenticator');
     const error = params.get('error');
     if (name !== authenticator.name) {
@@ -29,14 +26,6 @@ export const SigninPage = (props: { authenticator: Authenticator }) => {
     }
     if (error) {
       message.error(error);
-      return;
-    }
-    if (token) {
-      api.auth.setToken(token);
-      api.auth.setAuthenticator(name);
-      refresh()
-        .then(() => redirect())
-        .catch((err) => console.log(err));
       return;
     }
   });

--- a/packages/plugins/@nocobase/plugin-cas/src/server/actions/service.ts
+++ b/packages/plugins/@nocobase/plugin-cas/src/server/actions/service.ts
@@ -16,7 +16,7 @@ export const service = async (ctx: Context, next: Next) => {
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as CASAuth;
   try {
     const { token } = await auth.signIn();
-    ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&token=${token}`);
+    ctx.redirect(`${prefix}/admin?authenticator=${authenticator}&token=${token}`);
   } catch (error) {
     ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&error=${error.message}`);
   }

--- a/packages/plugins/@nocobase/plugin-oidc/src/client/OIDCButton.tsx
+++ b/packages/plugins/@nocobase/plugin-oidc/src/client/OIDCButton.tsx
@@ -1,5 +1,5 @@
 import { LoginOutlined } from '@ant-design/icons';
-import { Authenticator, css, useAPIClient, useCurrentUserContext, useRedirect } from '@nocobase/client';
+import { Authenticator, css, useAPIClient } from '@nocobase/client';
 import { Button, Space, message } from 'antd';
 import React, { useEffect } from 'react';
 import { useOidcTranslation } from './locale';
@@ -13,9 +13,7 @@ export interface OIDCProvider {
 export const OIDCButton = ({ authenticator }: { authenticator: Authenticator }) => {
   const { t } = useOidcTranslation();
   const api = useAPIClient();
-  const redirect = useRedirect();
   const location = useLocation();
-  const { refreshAsync: refresh } = useCurrentUserContext();
 
   const login = async () => {
     const response = await api.request({
@@ -32,7 +30,6 @@ export const OIDCButton = ({ authenticator }: { authenticator: Authenticator }) 
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const token = params.get('token');
     const name = params.get('authenticator');
     const error = params.get('error');
     if (name !== authenticator.name) {
@@ -40,14 +37,6 @@ export const OIDCButton = ({ authenticator }: { authenticator: Authenticator }) 
     }
     if (error) {
       message.error(t(error));
-      return;
-    }
-    if (token) {
-      api.auth.setToken(token);
-      api.auth.setAuthenticator(name);
-      refresh()
-        .then(() => redirect())
-        .catch((err) => console.log(err));
       return;
     }
   });

--- a/packages/plugins/@nocobase/plugin-oidc/src/server/actions/redirect.ts
+++ b/packages/plugins/@nocobase/plugin-oidc/src/server/actions/redirect.ts
@@ -19,7 +19,7 @@ export const redirect = async (ctx: Context, next: Next) => {
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as OIDCAuth;
   try {
     const { token } = await auth.signIn();
-    ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&token=${token}`);
+    ctx.redirect(`${prefix}/admin?authenticator=${authenticator}&token=${token}`);
   } catch (error) {
     ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&error=${error.message}`);
   }

--- a/packages/plugins/@nocobase/plugin-saml/src/client/SAMLButton.tsx
+++ b/packages/plugins/@nocobase/plugin-saml/src/client/SAMLButton.tsx
@@ -1,5 +1,5 @@
 import { LoginOutlined } from '@ant-design/icons';
-import { Authenticator, css, useAPIClient, useCurrentUserContext, useRedirect } from '@nocobase/client';
+import { Authenticator, css, useAPIClient } from '@nocobase/client';
 import { Button, Space, message } from 'antd';
 import React, { useEffect } from 'react';
 import { useSamlTranslation } from './locale';
@@ -8,9 +8,7 @@ import { useLocation } from 'react-router-dom';
 export const SAMLButton = ({ authenticator }: { authenticator: Authenticator }) => {
   const { t } = useSamlTranslation();
   const api = useAPIClient();
-  const redirect = useRedirect();
   const location = useLocation();
-  const { refreshAsync: refresh } = useCurrentUserContext();
 
   const login = async () => {
     const response = await api.request({
@@ -27,7 +25,6 @@ export const SAMLButton = ({ authenticator }: { authenticator: Authenticator }) 
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const token = params.get('token');
     const name = params.get('authenticator');
     const error = params.get('error');
     if (name !== authenticator.name) {
@@ -35,14 +32,6 @@ export const SAMLButton = ({ authenticator }: { authenticator: Authenticator }) 
     }
     if (error) {
       message.error(error);
-      return;
-    }
-    if (token) {
-      api.auth.setToken(token);
-      api.auth.setAuthenticator(name);
-      refresh()
-        .then(() => redirect())
-        .catch((err) => console.log(err));
       return;
     }
   });

--- a/packages/plugins/@nocobase/plugin-saml/src/server/actions/redirect.ts
+++ b/packages/plugins/@nocobase/plugin-saml/src/server/actions/redirect.ts
@@ -14,7 +14,7 @@ export const redirect = async (ctx: Context, next: Next) => {
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as SAMLAuth;
   try {
     const { token } = await auth.signIn();
-    ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&token=${token}`);
+    ctx.redirect(`${prefix}/admin?authenticator=${authenticator}&token=${token}`);
   } catch (error) {
     ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&error=${error.message}`);
   }


### PR DESCRIPTION
# Description (需求描述)

Use a global Provider to handle the `token` and `authenticator` parameters, writing them to LocalStorage when the router contains these parameters.

# Motivation (需求背景)
Write the token to LocalStorage directly after a successful sign-in, without redirecting to `/signin` first.

# Key changes (关键改动）
Provide a technically detailed description of the key changes made.
- Frontend (前端)
   - Add `AuthProvider`
- Backend (后端)
  - Navigate to `/admin` directly if sign in successfully

Close T-2227