### PR TITLE
fix(plugin-sequence): avoid invalid value from `ArrayTable.useRecord()`

### DIFF
--- a/packages/plugins/@nocobase/plugin-sequence-field/src/client/sequence.tsx
+++ b/packages/plugins/@nocobase/plugin-sequence-field/src/client/sequence.tsx
@@ -40,9 +40,11 @@ function RuleTypeSelect(props) {
 }
 
 function RuleOptions() {
-  const { type, options } = ArrayTable.useRecord();
-  const ruleType = RuleTypes[type];
   const compile = useCompile();
+  const { values } = useForm();
+  const index = ArrayTable.useIndex();
+  const { type, options } = values.patterns[index];
+  const ruleType = RuleTypes[type];
   return (
     <div
       className={css`
@@ -210,9 +212,9 @@ export function RuleConfigForm() {
   const { t } = useTranslation();
   const compile = useCompile();
   const schemaOptions = useContext(SchemaOptionsContext);
-  const form = useForm();
-  const { type, options } = ArrayTable.useRecord();
+  const { values, setValuesIn } = useForm();
   const index = ArrayTable.useIndex();
+  const { type, options } = values.patterns[index];
   const ruleType = RuleTypes[type];
   return ruleType?.fieldset ? (
     <Button
@@ -252,7 +254,7 @@ export function RuleConfigForm() {
             initialValues: options,
           })
           .then((values) => {
-            form.setValuesIn(`patterns.${index}`, { type, options: { ...values } });
+            setValuesIn(`patterns.${index}`, { type, options: { ...values } });
           })
           .catch((err) => {
             error(err);


### PR DESCRIPTION
## Description (Bug 描述)

Add sequence field pattern throwing error.

### Steps to reproduce (复现步骤)

1. Add sequence field.
2. Add pattern row.

### Expected behavior (预期行为)

Pattern row added.

### Actual behavior (实际行为)

Error thrown.

## Related issues (相关 issue)

None.

## Reason (原因)

The result of `ArrayTable.useRecord()` is `undefined`, not reasonable.

## Solution (解决方案)

Use `form.values` instead.
