### PR TITLE
fix(client): fix varaible textarea setRange bug

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -229,19 +229,21 @@ export function TextArea(props) {
       const sel = window.getSelection?.();
       if (sel) {
         const children = Array.from(current.childNodes) as HTMLElement[];
-        if (range[0] === -1) {
-          if (range[1]) {
-            nextRange.setStartAfter(children[range[1] - 1]);
+        if (children.length) {
+          if (range[0] === -1) {
+            if (range[1]) {
+              nextRange.setStartAfter(children[range[1] - 1]);
+            }
+          } else {
+            nextRange.setStart(children[range[0]], range[1]);
           }
-        } else {
-          nextRange.setStart(children[range[0]], range[1]);
-        }
-        if (range[2] === -1) {
-          if (range[3]) {
-            nextRange.setEndAfter(children[range[3] - 1]);
+          if (range[2] === -1) {
+            if (range[3]) {
+              nextRange.setEndAfter(children[range[3] - 1]);
+            }
+          } else {
+            nextRange.setEnd(children[range[2]], range[3]);
           }
-        } else {
-          nextRange.setEnd(children[range[2]], range[3]);
         }
         nextRange.collapse(true);
         sel.removeAllRanges();


### PR DESCRIPTION
## Description (Bug 描述)

After modified expression then save formula field, error thrown.

### Steps to reproduce (复现步骤)

1. Add formula field.
2. Modify expression.
3. Save field.

### Expected behavior (预期行为)

To show normal fields list.

### Actual behavior (实际行为)

Error thrown.

## Related issues (相关 issue)

#2785.

## Reason (原因)

`changed` branch logic should avoid new empty value to cause setting range.

## Solution (解决方案)

Add `children.length` check.