### PR TITLE
refactor(plugin-workflow): add property to determine workflow type triggerable on ui

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
@@ -11,11 +11,17 @@ import { ExecutionPage } from './ExecutionPage';
 import { WorkflowPage } from './WorkflowPage';
 import { WorkflowProvider } from './WorkflowProvider';
 import { DynamicExpression } from './components/DynamicExpression';
+import { triggers, useTrigger, getTriggersOptions } from './triggers';
+import { instructions } from './nodes';
 import { WorkflowTodo } from './nodes/manual/WorkflowTodo';
 import { WorkflowTodoBlockInitializer } from './nodes/manual/WorkflowTodoBlockInitializer';
 import { useTriggerWorkflowsActionProps } from './triggers/form';
 
 export class WorkflowPlugin extends Plugin {
+  triggers = triggers;
+  getTriggersOptions = getTriggersOptions;
+  instructions = instructions;
+
   async load() {
     this.addRoutes();
     this.addScopes();

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/form.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/form.tsx
@@ -101,6 +101,7 @@ export default {
     };
   },
   initializers: {},
+  actionTriggerable: true,
 };
 
 function getFormValues({

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/index.tsx
@@ -61,6 +61,7 @@ export interface Trigger {
   components?: { [key: string]: any };
   useInitializers?(config): SchemaInitializerItemOptions | null;
   initializers?: any;
+  actionTriggerable?: boolean;
 }
 
 export const triggers = new Registry<Trigger>();
@@ -311,9 +312,10 @@ export function useTrigger() {
 }
 
 export function getTriggersOptions() {
-  return Array.from(triggers.getEntities()).map(([value, { title }]) => ({
+  return Array.from(triggers.getEntities()).map(([value, { title, ...options }]) => ({
     value,
     label: title,
     color: 'gold',
+    options,
   }));
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
@@ -196,3 +196,7 @@ export async function sync(context: Context, next) {
 
   await next();
 }
+
+export async function trigger(context: Context, next) {
+  return next();
+}

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/index.ts
@@ -1,3 +1,4 @@
+export * from './utils';
 export * from './constants';
 export type * from './instructions';
 export { Trigger } from './triggers';

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/form.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/form.ts
@@ -12,12 +12,9 @@ export default class FormTrigger extends Trigger {
     super(plugin);
 
     plugin.app.resourcer.use(this.middleware);
-    plugin.app.actions({
-      ['workflows:trigger']: this.triggerAction,
-    });
   }
 
-  triggerAction = async (context, next) => {
+  async triggerAction(context, next) {
     const { triggerWorkflows } = context.action.params;
 
     if (!triggerWorkflows) {
@@ -28,21 +25,26 @@ export default class FormTrigger extends Trigger {
     await next();
 
     this.trigger(context);
-  };
+  }
 
   middleware = async (context, next) => {
-    await next();
-
     const {
       resourceName,
       actionName,
       params: { triggerWorkflows },
     } = context.action;
+
+    if (resourceName === 'workflows' && actionName === 'trigger') {
+      return this.triggerAction(context, next);
+    }
+
+    await next();
+
     if (!triggerWorkflows) {
       return;
     }
 
-    if ((resourceName === 'workflows' && actionName === 'trigger') || !['create', 'update'].includes(actionName)) {
+    if (!['create', 'update'].includes(actionName)) {
       return;
     }
 


### PR DESCRIPTION
# Description (需求描述)

Add `actionTriggerable` property for trigger configurations.

# Motivation (需求背景)

Combine any types workflow support `actionTriggerable: true` in UI.

# Key changes (关键改动）

- Frontend (前端)
  - Trigger type definition.
  - Bind workflow UI logic.
- Backend (后端)
  - Form trigger middleware logic.

# Test plan (测试计划)

## Suggestions (测试建议)

* UI

## Underlying risk (潜在风险)

Compatible with configured binding action.

# Showcase (结果展示）

None.