### PR TITLE
fix(plugin-workflow): fix cycling association stackoverflow

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/aggregate.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/aggregate.tsx
@@ -29,6 +29,7 @@ function useAssociatedFields() {
       .useOptions({
         types: [matchToManyField],
         appends: null,
+        depth: 4,
       })
       ?.filter(Boolean);
     return {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -30,6 +30,7 @@ export type OptionsOfUseVariableOptions = {
     children?: string;
   };
   appends?: string[] | null;
+  depth?: number;
 };
 
 export const defaultFieldNames = { label: 'label', value: 'value', children: 'children' } as const;
@@ -167,17 +168,20 @@ function getNextAppends(field, appends: string[] | null): string[] | null {
   return appends.filter((item) => item.startsWith(fieldPrefix)).map((item) => item.replace(fieldPrefix, ''));
 }
 
-function filterTypedFields({ fields, types, appends, compile, getCollectionFields }) {
+function filterTypedFields({ fields, types, appends, depth = 1, compile, getCollectionFields }) {
   return fields.filter((field) => {
     const match = types?.length ? types.some((type) => matchFieldType(field, type)) : true;
     if (isAssociationField(field)) {
       if (appends === null) {
+        if (!depth) {
+          return false;
+        }
         return (
           match ||
           filterTypedFields({
             fields: getNormalizedFields(field.target, { compile, getCollectionFields }),
             types,
-            // depth: depth - 1,
+            depth: depth - 1,
             appends,
             compile,
             getCollectionFields,
@@ -286,6 +290,7 @@ function loadChildren(option) {
     collection: option.field.target,
     types: option.types,
     appends,
+    depth: option.depth - 1,
     ...this,
   });
   option.loadChildren = null;
@@ -306,6 +311,7 @@ export function getCollectionFieldOptions(options): VariableOption[] {
     collection,
     types,
     appends = [],
+    depth = 1,
     compile,
     getCollectionFields,
     fieldNames = defaultFieldNames,
@@ -317,7 +323,7 @@ export function getCollectionFieldOptions(options): VariableOption[] {
   const result: VariableOption[] = filterTypedFields({
     fields: computedFields,
     types,
-    // depth,
+    depth,
     appends,
     compile,
     getCollectionFields,
@@ -335,7 +341,7 @@ export function getCollectionFieldOptions(options): VariableOption[] {
       isLeaf,
       loadChildren: isLeaf ? null : boundLoadChildren,
       field,
-      // depth,
+      depth,
       appends,
       types,
     };


### PR DESCRIPTION
## Description (Bug 描述)

When there are cycling associations, switch aggregate mode to association will cause stack overflow.

### Steps to reproduce (复现步骤)

1. Add posts collection (has `createdBy`).
2. Add posts association to users.
3. Add a workflow with collection trigger on new post.
4. Add an aggregate node and switch to association type target.

### Expected behavior (预期行为)

Could continue to select field.

### Actual behavior (实际行为)

Dead cycle cause stack overflow.

## Related issues (相关 issue)

Also fix T-1509.

## Reason (原因)

Cycling association.

## Solution (解决方案)

Add `depth` to not to detect possible types of variable.
