### PR TITLE
fix(plugin-workflow): fix schedule workflow under normal multi-apps

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/schedule.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/schedule.ts
@@ -424,7 +424,7 @@ export default class ScheduleTrigger extends Trigger {
   }
 
   init() {
-    if (this.plugin.app.name !== 'main') {
+    if (this.plugin.app.getPlugin('multi-app-share-collection').enabled && this.plugin.app.name !== 'main') {
       return;
     }
 


### PR DESCRIPTION
## Description (Bug 描述)

Schedule workflow is disabled under sub apps.

### Steps to reproduce (复现步骤)

1. Enable multi-app plugin and add a sub app.
2. Add a schedule workflow to the sub app on some time, wait for triggering.

### Expected behavior (预期行为)

Schedule workflow in sub app should be triggered.

### Actual behavior (实际行为)

Not triggered.

## Related issues (相关 issue)

None.

## Reason (原因)

Schedule workflows in sub apps are restricted.

## Solution (解决方案)

Change condition to restrict only when multi-app-share-collection plugin enabled.
