### PR TITLE
refactor(plugin-workflow): change to use node key for variables

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
@@ -32,6 +32,7 @@ function attachJobs(nodes, jobs: any[] = []): void {
     node.jobs.push(item);
     item.node = {
       id: node.id,
+      key: node.key,
       title: node.title,
       type: node.type,
     };

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/ValueBlock.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/ValueBlock.tsx
@@ -32,7 +32,7 @@ function Initializer({ node, resultTitle, insert, ...props }) {
               'x-component': 'ValueBlock.Result',
               'x-component-props': {
                 // NOTE: as same format as other reference for migration of revision
-                dataSource: `{{$jobsMapByNodeId.${node.id}}}`,
+                dataSource: `{{$jobsMapByNodeKey.${node.key}}}`,
               },
             },
           },
@@ -49,7 +49,10 @@ function Result({ dataSource }) {
     return field.title;
   }
   const result = parse(dataSource)({
-    $jobsMapByNodeId: (execution.jobs ?? []).reduce((map, job) => Object.assign(map, { [job.nodeId]: job.result }), {}),
+    $jobsMapByNodeKey: (execution.jobs ?? []).reduce(
+      (map, job) => Object.assign(map, { [job.nodeId]: job.result }),
+      {},
+    ),
   });
 
   return (

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/aggregate.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/aggregate.tsx
@@ -346,7 +346,7 @@ export default {
     ValueBlock,
     AssociatedConfig,
   },
-  useVariables({ id, title }, { types, fieldNames = defaultFieldNames }) {
+  useVariables({ key, title }, { types, fieldNames = defaultFieldNames }) {
     if (
       types &&
       !types.some((type) => type in BaseTypeSets || Object.values(BaseTypeSets).some((set) => set.has(type)))
@@ -354,7 +354,7 @@ export default {
       return null;
     }
     return {
-      [fieldNames.value]: `${id}`,
+      [fieldNames.value]: key,
       [fieldNames.label]: title,
     };
   },

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
@@ -1,11 +1,9 @@
 import { FormItem, FormLayout } from '@formily/antd-v5';
 import { SchemaInitializerItemOptions, Variable, css, defaultFieldNames, useCollectionManager } from '@nocobase/client';
 import { Evaluator, evaluators, getOptions } from '@nocobase/evaluators/client';
-import { parse } from '@nocobase/utils/client';
 import { Radio } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useFlowContext } from '../FlowContext';
 import { RadioWithTooltip } from '../components/RadioWithTooltip';
 import { ValueBlock } from '../components/ValueBlock';
 import { renderEngineReference } from '../components/renderEngineReference';
@@ -167,32 +165,11 @@ export default {
       });
       return <Variable.Input scope={scope} {...props} />;
     },
-    CalculationResult({ dataSource }) {
-      const { execution } = useFlowContext();
-      if (!execution) {
-        return lang('Calculation result');
-      }
-      const result = parse(dataSource)({
-        $jobsMapByNodeKey: (execution.jobs ?? []).reduce((map, job) => {
-          Object.assign(map, { [job.node.key]: job.result });
-          return map;
-        }, {}),
-      });
-
-      return (
-        <pre
-          className={css`
-            margin: 0;
-          `}
-        >
-          {JSON.stringify(result, null, 2)}
-        </pre>
-      );
-    },
     RadioWithTooltip,
     DynamicConfig,
+    ValueBlock,
   },
-  useVariables({ id, title }, { types, fieldNames = defaultFieldNames }) {
+  useVariables({ key, title }, { types, fieldNames = defaultFieldNames }) {
     if (
       types &&
       !types.some((type) => type in BaseTypeSets || Object.values(BaseTypeSets).some((set) => set.has(type)))
@@ -200,7 +177,7 @@ export default {
       return null;
     }
     return {
-      [fieldNames.value]: `${id}`,
+      [fieldNames.value]: key,
       [fieldNames.label]: title,
     };
   },

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
@@ -173,10 +173,10 @@ export default {
         return lang('Calculation result');
       }
       const result = parse(dataSource)({
-        $jobsMapByNodeId: (execution.jobs ?? []).reduce(
-          (map, job) => Object.assign(map, { [job.nodeId]: job.result }),
-          {},
-        ),
+        $jobsMapByNodeKey: (execution.jobs ?? []).reduce((map, job) => {
+          Object.assign(map, { [job.node.key]: job.result });
+          return map;
+        }, {}),
       });
 
       return (

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
@@ -83,7 +83,7 @@ export default {
       title: node.title ?? `#${node.id}`,
       component: CollectionBlockInitializer,
       collection: node.config.collection,
-      dataSource: `{{$jobsMapByNodeId.${node.id}}}`,
+      dataSource: `{{$jobsMapByNodeKey.${node.key}}}`,
     };
   },
   initializers: {},

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
@@ -44,13 +44,12 @@ export default {
   components: {
     CollectionFieldset,
   },
-  useVariables({ id, title, config }, options) {
+  useVariables({ key: name, title, config }, options) {
     const compile = useCompile();
     const { getCollectionFields } = useCollectionManager();
     // const depth = config?.params?.appends?.length
     //   ? config?.params?.appends.reduce((max, item) => Math.max(max, item.split('.').length), 1)
     //   : 0;
-    const name = `${id}`;
     const [result] = getCollectionFieldOptions({
       // collection: config.collection,
       // depth: options?.depth ?? depth,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
@@ -199,7 +199,7 @@ export function RemoveButton() {
 
       const template = parse(node.config);
       const refs = template.parameters.filter(
-        ({ key }) => key.startsWith(`$jobsMapByNodeId.${current.id}.`) || key === `$jobsMapByNodeId.${current.id}`,
+        ({ key }) => key.startsWith(`$jobsMapByNodeKey.${current.key}.`) || key === `$jobsMapByNodeKey.${current.key}`,
       );
       return refs.length;
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
@@ -13,7 +13,7 @@ import {
   useResourceActionContext,
 } from '@nocobase/client';
 import { Registry, parse, str2moment } from '@nocobase/utils/client';
-import { App, Button, Dropdown, Input, Tag, message } from 'antd';
+import { App, Button, Dropdown, Input, Tag, Tooltip, message } from 'antd';
 import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AddButton } from '../AddButton';
@@ -371,7 +371,33 @@ export function NodeDefaultView(props) {
                 },
                 [`${instruction.type}_${data.id}`]: {
                   type: 'void',
-                  title: data.title,
+                  title: (
+                    <div
+                      className={css`
+                        display: flex;
+                        justify-content: space-between;
+
+                        strong {
+                          font-weight: bold;
+                        }
+
+                        .ant-tag {
+                          margin-inline-end: 0;
+                        }
+
+                        code {
+                          font-weight: normal;
+                        }
+                      `}
+                    >
+                      <strong>{data.title}</strong>
+                      <Tooltip title={lang('Variable key of node')}>
+                        <Tag>
+                          <code>{data.key}</code>
+                        </Tag>
+                      </Tooltip>
+                    </div>
+                  ),
                   'x-component': 'Action.Drawer',
                   'x-decorator': 'Form',
                   'x-decorator-props': {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/loop.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/loop.tsx
@@ -118,7 +118,7 @@ export default {
     // const current = useNodeContext();
     // const upstreams = useAvailableUpstreams(current);
     // find target data model by path described in `config.target`
-    // 1. get options from $context/$jobsMapByNodeId
+    // 1. get options from $context/$jobsMapByNodeKey
     // 2. route to sub-options and use as loop target options
     let targetOption: VariableOption = {
       key: 'item',

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/DetailsBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/DetailsBlockProvider.tsx
@@ -13,12 +13,17 @@ import { useFlowContext } from '../../FlowContext';
 import { parse } from '@nocobase/utils/client';
 
 function useFlowContextData(dataSource) {
-  const { execution } = useFlowContext();
+  const { execution, nodes } = useFlowContext();
+
+  const nodesKeyMap = useMemo(() => {
+    return nodes.reduce((map, node) => Object.assign(map, { [node.id]: node.key }), {});
+  }, [nodes]);
+
   const data = useMemo(
     () => ({
       $context: execution?.context,
       $jobsMapByNodeKey: (execution?.jobs ?? []).reduce(
-        (map, job) => Object.assign(map, { [job.node.key]: job.result }),
+        (map, job) => Object.assign(map, { [nodesKeyMap[job.nodeId]]: job.result }),
         {},
       ),
     }),

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/DetailsBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/DetailsBlockProvider.tsx
@@ -17,8 +17,8 @@ function useFlowContextData(dataSource) {
   const data = useMemo(
     () => ({
       $context: execution?.context,
-      $jobsMapByNodeId: (execution?.jobs ?? []).reduce(
-        (map, job) => Object.assign(map, { [job.nodeId]: job.result }),
+      $jobsMapByNodeKey: (execution?.jobs ?? []).reduce(
+        (map, job) => Object.assign(map, { [job.node.key]: job.result }),
         {},
       ),
     }),

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/index.tsx
@@ -143,7 +143,7 @@ export default {
               title: form.title ?? formKey,
               component: CollectionBlockInitializer,
               collection: form.collection,
-              dataSource: `{{$jobsMapByNodeId.${node.id}.${formKey}}}`,
+              dataSource: `{{$jobsMapByNodeKey.${node.key}.${formKey}}}`,
             } as SchemaInitializerItemOptions)
           : null;
       })

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/index.tsx
@@ -85,7 +85,7 @@ export default {
     ModeConfig,
     AssigneesSelect,
   },
-  useVariables({ id, title, config }, { types, fieldNames = defaultFieldNames }) {
+  useVariables({ key, title, config }, { types, fieldNames = defaultFieldNames }) {
     const compile = useCompile();
     const { getCollectionFields } = useCollectionManager();
     const formKeys = Object.keys(config.forms ?? {});
@@ -119,7 +119,7 @@ export default {
 
     return options.length
       ? {
-          [fieldNames.value]: `${id}`,
+          [fieldNames.value]: key,
           [fieldNames.label]: title,
           [fieldNames.children]: options,
         }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/query.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/query.tsx
@@ -89,13 +89,12 @@ export default {
     FilterDynamicComponent,
     SchemaComponentContext,
   },
-  useVariables({ id, title, config }, options) {
+  useVariables({ key: name, title, config }, options) {
     const compile = useCompile();
     const { getCollectionFields } = useCollectionManager();
     // const depth = config?.params?.appends?.length
     //   ? config?.params?.appends.reduce((max, item) => Math.max(max, item.split('.').length), 1)
     //   : 0;
-    const name = `${id}`;
     const [result] = getCollectionFieldOptions({
       // collection: config.collection,
       // depth: options?.depth ?? depth,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/query.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/query.tsx
@@ -128,7 +128,7 @@ export default {
       title: node.title ?? `#${node.id}`,
       component: CollectionBlockInitializer,
       collection: node.config.collection,
-      dataSource: `{{$jobsMapByNodeId.${node.id}}}`,
+      dataSource: `{{$jobsMapByNodeKey.${node.key}}}`,
     };
   },
   initializers: {},

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -76,8 +76,8 @@ export const scopeOptions = {
       const subOptions = instruction.useScopeVariables?.(node, options);
       if (subOptions) {
         result.push({
-          key: node.id.toString(),
-          [fieldNames.value]: node.id.toString(),
+          key: node.key,
+          [fieldNames.value]: node.key,
           [fieldNames.label]: node.title ?? `#${node.id}`,
           [fieldNames.children]: subOptions,
         });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -37,7 +37,7 @@ export const defaultFieldNames = { label: 'label', value: 'value', children: 'ch
 
 export const nodesOptions = {
   label: `{{t("Node result", { ns: "${NAMESPACE}" })}}`,
-  value: '$jobsMapByNodeId',
+  value: '$jobsMapByNodeKey',
   useOptions(options: OptionsOfUseVariableOptions) {
     const current = useNodeContext();
     const upstreams = useAvailableUpstreams(current);

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.ts
@@ -89,6 +89,7 @@ export default {
   Advanced: '高级模式',
   End: '结束',
   'Node result': '节点数据',
+  'Variable key of node': '节点变量标识',
   Calculator: '运算',
   'Calculate an expression based on a calculation engine and obtain a value as the result. Variables in the upstream nodes can be used in the expression. The expression can be static or dynamic one from an expression collections.':
     '基于计算引擎对一个表达式进行计算，并获得一个值作为结果。表达式中可以使用上游节点里的变量。表达式可以是静态的，也可以是表达式表中的动态表达式。',

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/aggregate.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/aggregate.test.ts
@@ -248,7 +248,7 @@ describe('workflow > instructions > aggregate', () => {
           associated: true,
           association: {
             name: 'posts',
-            associatedKey: `{{$jobsMapByNodeId.${n1.id}.id}}`,
+            associatedKey: `{{$jobsMapByNodeKey.${n1.key}.id}}`,
             associatedCollection: 'tags',
           },
           params: {
@@ -266,7 +266,7 @@ describe('workflow > instructions > aggregate', () => {
           associated: true,
           association: {
             name: 'posts',
-            associatedKey: `{{$jobsMapByNodeId.${n1.id}.id}}`,
+            associatedKey: `{{$jobsMapByNodeKey.${n1.key}.id}}`,
             associatedCollection: 'tags',
           },
           params: {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/calculation.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/calculation.test.ts
@@ -88,7 +88,7 @@ describe('workflow > instructions > calculation', () => {
       expect(job.result).toBe(2);
     });
 
-    it('$jobsMapByNodeId', async () => {
+    it('$jobsMapByNodeKey', async () => {
       const n1 = await workflow.createNode({
         type: 'echo',
       });
@@ -97,7 +97,7 @@ describe('workflow > instructions > calculation', () => {
         type: 'calculation',
         config: {
           engine: 'math.js',
-          expression: `{{$jobsMapByNodeId.${n1.id}.data.read}} + 1`,
+          expression: `{{$jobsMapByNodeKey.${n1.key}.data.read}} + 1`,
         },
         upstreamId: n1.id,
       });
@@ -231,7 +231,7 @@ describe('workflow > instructions > calculation', () => {
       const n2 = await workflow.createNode({
         type: 'calculation',
         config: {
-          dynamic: `{{$jobsMapByNodeId.${n1.id}}}`,
+          dynamic: `{{$jobsMapByNodeKey.${n1.key}}}`,
           scope: '{{$context.data}}',
         },
         upstreamId: n1.id,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/manual.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/manual.test.ts
@@ -867,7 +867,7 @@ describe('workflow > instructions > manual', () => {
         type: 'calculation',
         config: {
           engine: 'math.js',
-          expression: `{{$jobsMapByNodeId.${n1.id}.f1.number}} + 1`,
+          expression: `{{$jobsMapByNodeKey.${n1.key}.f1.number}} + 1`,
         },
         upstreamId: n1.id,
       });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/query.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/query.test.ts
@@ -130,7 +130,7 @@ describe('workflow > instructions > query', () => {
           collection: 'posts',
           params: {
             filter: {
-              title: `{{$jobsMapByNodeId.${n1.id}.data.title}}`,
+              title: `{{$jobsMapByNodeKey.${n1.key}.data.title}}`,
             },
           },
         },

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/update.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/update.test.ts
@@ -78,7 +78,7 @@ describe('workflow > instructions > update', () => {
           collection: 'posts',
           params: {
             filter: {
-              id: `{{$jobsMapByNodeId.${n1.id}.id}}`,
+              id: `{{$jobsMapByNodeKey.${n1.key}.id}}`,
             },
             values: {
               title: 'changed',

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/collections/flow_nodes.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/collections/flow_nodes.ts
@@ -6,6 +6,10 @@ export default {
   name: 'flow_nodes',
   fields: [
     {
+      type: 'uid',
+      name: 'key',
+    },
+    {
       type: 'string',
       name: 'title',
     },

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/index.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { requireModule } from '@nocobase/utils';
+import { Transactionable } from '@nocobase/database';
 
 import Plugin from '..';
 import Processor from '../Processor';
@@ -25,7 +26,9 @@ export interface Instruction {
   // for start node in main flow (or branch) to resume when manual sub branch triggered
   resume?: Runner;
 
-  getScope?: (node: FlowNodeModel, job: any, processor: Processor) => any;
+  getScope?: (node: FlowNodeModel, data: any, processor: Processor) => any;
+
+  duplicateConfig?: (node: FlowNodeModel, options: Transactionable) => object | Promise<object>;
 }
 
 type InstructionConstructor<T> = { new (p: Plugin): T };

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20230221162902-jsonb-to-json.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20230221162902-jsonb-to-json.ts
@@ -30,22 +30,6 @@ export default class extends Migration {
         },
         { transaction },
       );
-      await queryInterface.changeColumn(
-        db.getCollection('executions').model.getTableName(),
-        'context',
-        {
-          type: DataTypes.JSON,
-        },
-        { transaction },
-      );
-      await queryInterface.changeColumn(
-        db.getCollection('jobs').model.getTableName(),
-        'result',
-        {
-          type: DataTypes.JSON,
-        },
-        { transaction },
-      );
     });
   }
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20230809113132-workflow-options.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20230809113132-workflow-options.ts
@@ -2,12 +2,12 @@ import { Migration } from '@nocobase/server';
 
 export default class extends Migration {
   async up() {
-    const match = await this.app.version.satisfies('<0.11.0-alpha.2');
+    const match = await this.app.version.satisfies('<0.14.0-alpha.8');
     if (!match) {
       return;
     }
     const { db } = this.context;
-    const WorkflowRepo = db.getRepository('flow_nodes');
+    const WorkflowRepo = db.getRepository('workflows');
     await db.sequelize.transaction(async (transaction) => {
       const workflows = await WorkflowRepo.find({
         transaction,
@@ -16,6 +16,9 @@ export default class extends Migration {
       await workflows.reduce(
         (promise, workflow) =>
           promise.then(() => {
+            if (!workflow.useTransaction) {
+              return;
+            }
             workflow.set('options', {
               useTransaction: workflow.get('useTransaction'),
             });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
@@ -26,6 +26,8 @@ export default class extends Migration {
       return;
     }
     const { db } = this.context;
+    await db.getCollection('flow_nodes').sync();
+
     const NodeRepo = db.getRepository('flow_nodes');
     await db.sequelize.transaction(async (transaction) => {
       const nodes = await NodeRepo.find({
@@ -34,7 +36,7 @@ export default class extends Migration {
 
       const nodesMap = nodes.reduce((map, node) => {
         map[node.id] = node;
-        if (!node.key) {
+        if (!node.get('key')) {
           node.set('key', uid());
         }
         return map;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
@@ -1,0 +1,57 @@
+import { Migration } from '@nocobase/server';
+import { uid } from '@nocobase/utils';
+
+function migrateNodeConfig(config = {}, nodesMap) {
+  Object.keys(config).forEach((key) => {
+    const valueType = typeof config[key];
+    if (valueType === 'string') {
+      config[key] = config[key]
+        .replace(/{{\s*\$jobsMapByNodeId\.(\d+)(\.[^}]+)?\s*}}/g, (matched, id, path) => {
+          return `{{$jobsMapByNodeKey.${nodesMap[id].key}${path || ''}}}`;
+        })
+        .replace(/{{\s*\$scopes\.(\d+)(\.[^}]+)?\s*}}/g, (matched, id, path) => {
+          return `{{$scopes.${nodesMap[id].key}${path || ''}}}`;
+        });
+    } else if (valueType === 'object' && config[key]) {
+      migrateNodeConfig(config[key], nodesMap);
+    }
+  });
+  return config;
+}
+
+export default class extends Migration {
+  async up() {
+    const match = await this.app.version.satisfies('<0.14.0-alpha.8');
+    if (!match) {
+      return;
+    }
+    const { db } = this.context;
+    const NodeRepo = db.getRepository('flow_nodes');
+    await db.sequelize.transaction(async (transaction) => {
+      const nodes = await NodeRepo.find({
+        transaction,
+      });
+
+      const nodesMap = nodes.reduce((map, node) => {
+        map[node.id] = node;
+        if (!node.key) {
+          node.set('key', uid());
+        }
+        return map;
+      }, {});
+
+      await nodes.reduce(
+        (promise, node) =>
+          promise.then(() => {
+            node.set('config', migrateNodeConfig(node.config, nodesMap));
+            node.changed('config', true);
+            return node.save({
+              silent: true,
+              transaction,
+            });
+          }),
+        Promise.resolve(),
+      );
+    });
+  }
+}

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
@@ -1,3 +1,4 @@
+import { DataTypes } from 'sequelize';
 import { Migration } from '@nocobase/server';
 import { uid } from '@nocobase/utils';
 
@@ -26,10 +27,15 @@ export default class extends Migration {
       return;
     }
     const { db } = this.context;
-    await db.getCollection('flow_nodes').sync();
 
     const NodeRepo = db.getRepository('flow_nodes');
+    const { key } = await this.queryInterface.describeTable('flow_nodes');
     await db.sequelize.transaction(async (transaction) => {
+      if (!key) {
+        await this.queryInterface.addColumn('flow_nodes', 'key', DataTypes.STRING, {
+          transaction,
+        });
+      }
       const nodes = await NodeRepo.find({
         transaction,
       });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
@@ -1,5 +1,7 @@
-import { requireModule } from '@nocobase/utils';
 import path from 'path';
+
+import { requireModule } from '@nocobase/utils';
+import { Transactionable } from '@nocobase/database';
 
 import Plugin from '..';
 import type { WorkflowModel } from '../types';
@@ -8,6 +10,7 @@ export abstract class Trigger {
   constructor(public readonly plugin: Plugin) {}
   abstract on(workflow: WorkflowModel): void;
   abstract off(workflow: WorkflowModel): void;
+  duplicateConfig?(workflow: WorkflowModel, options: Transactionable): object | Promise<object>;
 }
 
 export default function <T extends Trigger>(plugin, more: { [key: string]: { new (p: Plugin): T } } = {}) {


### PR DESCRIPTION
# Description (需求描述)

Change `$jobsMapByNodeId` to `$jobsMapByNodeKey` in variable context.

# Motivation (需求背景)

If use `uiSchemaStorage` to persist UI configuration, then change the variable references when duplicating workflow will be very tedious.

# Key changes (关键改动）

- Frontend (前端)
  - Variables in workflow context.
- Backend (后端)
  - Variables in workflow context.
  - Migrations.

# Test plan (测试计划)

## Suggestions (测试建议)

* Migrations.
* Revision.
* Manual node.

## Underlying risk (潜在风险)

Migrations.

# Showcase (结果展示）

None.
