### PR TITLE
fix(plugin-workflow): fix migration

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20231024172342-add-node-key.ts
@@ -28,11 +28,12 @@ export default class extends Migration {
     }
     const { db } = this.context;
 
-    const NodeRepo = db.getRepository('flow_nodes');
-    const { key } = await this.queryInterface.describeTable('flow_nodes');
+    const NodeCollection = db.getCollection('flow_nodes');
+    const NodeRepo = NodeCollection.repository;
+    const tableName = NodeCollection.getTableNameWithSchema();
     await db.sequelize.transaction(async (transaction) => {
-      if (!key) {
-        await this.queryInterface.addColumn('flow_nodes', 'key', DataTypes.STRING, {
+      if (!(await NodeCollection.getField('key').existsInDb())) {
+        await this.queryInterface.addColumn(tableName, 'key', DataTypes.STRING, {
           transaction,
         });
       }


### PR DESCRIPTION
## Description (Bug 描述)

Migration for adding `key` field to `flow_nodes` cause error.

### Steps to reproduce (复现步骤)

1. Use table prefix in `.env`.

### Expected behavior (预期行为)

Migrated.

### Actual behavior (实际行为)

Error thrown.

## Related issues (相关 issue)

#2909.

## Reason (原因)

Not considered table prefix.

## Solution (解决方案)

Fix table prefix logic.
