### PR TITLE
fix(plugin-workflow): fix canvas style

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/CanvasContent.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/CanvasContent.tsx
@@ -27,7 +27,14 @@ export function CanvasContent({ entry }) {
         >
           <div className={styles.branchClass}>
             {workflow?.executed ? (
-              <Alert type="warning" message={lang('Executed workflow cannot be modified')} showIcon />
+              <Alert
+                type="warning"
+                message={lang('Executed workflow cannot be modified')}
+                showIcon
+                className={css`
+                  margin-bottom: 1em;
+                `}
+              />
             ) : null}
             <TriggerConfig />
             <div


### PR DESCRIPTION
## Description (Bug 描述)

Miss margin between alert and trigger card in workflow canvas.

### Steps to reproduce (复现步骤)

1. Open an executed workflow.

### Expected behavior (预期行为)

There should be a little distance between alert bar and trigger card.

### Actual behavior (实际行为)

They are clinging.

## Related issues (相关 issue)

#2951.

## Reason (原因)

No margin.

## Solution (解决方案)

Add margin.