### PR TITLE
fix(plugin-workflow): fix node form values when closed

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useForm } from '@formily/react';
 import { Input } from 'antd';
 import { cloneDeep } from 'lodash';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import sanitizeHTML from 'sanitize-html';
 
 import { error } from '@nocobase/utils/client';
@@ -228,26 +228,30 @@ export function TextArea(props) {
       }
       const sel = window.getSelection?.();
       if (sel) {
-        const children = Array.from(current.childNodes) as HTMLElement[];
-        if (children.length) {
-          if (range[0] === -1) {
-            if (range[1]) {
-              nextRange.setStartAfter(children[range[1] - 1]);
+        try {
+          const children = Array.from(current.childNodes) as HTMLElement[];
+          if (children.length) {
+            if (range[0] === -1) {
+              if (range[1]) {
+                nextRange.setStartAfter(children[range[1] - 1]);
+              }
+            } else {
+              nextRange.setStart(children[range[0]], range[1]);
             }
-          } else {
-            nextRange.setStart(children[range[0]], range[1]);
-          }
-          if (range[2] === -1) {
-            if (range[3]) {
-              nextRange.setEndAfter(children[range[3] - 1]);
+            if (range[2] === -1) {
+              if (range[3]) {
+                nextRange.setEndAfter(children[range[3] - 1]);
+              }
+            } else {
+              nextRange.setEnd(children[range[2]], range[3]);
             }
-          } else {
-            nextRange.setEnd(children[range[2]], range[3]);
           }
+          nextRange.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(nextRange);
+        } catch (ex) {
+          // console.error(ex);
         }
-        nextRange.collapse(true);
-        sel.removeAllRanges();
-        sel.addRange(nextRange);
       }
     } else {
       const { lastChild } = current;
@@ -262,39 +266,45 @@ export function TextArea(props) {
     }
   }, [html]);
 
-  function onInsert(paths: string[]) {
-    const variable: string[] = paths.filter((key) => Boolean(key.trim()));
-    const { current } = inputRef;
-    if (!current || !variable) {
-      return;
-    }
+  const onInsert = useCallback(
+    function (paths: string[]) {
+      const variable: string[] = paths.filter((key) => Boolean(key.trim()));
+      const { current } = inputRef;
+      if (!current || !variable) {
+        return;
+      }
 
-    current.focus();
+      current.focus();
 
-    const content = createVariableTagHTML(variable.join('.'), keyLabelMap);
-    pasteHTML(current, content, {
-      range,
-    });
+      const content = createVariableTagHTML(variable.join('.'), keyLabelMap);
+      pasteHTML(current, content, {
+        range,
+      });
 
-    setChanged(true);
-    setRange(getCurrentRange(current));
-    onChange(getValue(current));
-  }
+      setChanged(true);
+      setRange(getCurrentRange(current));
+      onChange(getValue(current));
+    },
+    [keyLabelMap, onChange, range],
+  );
 
-  function onInput({ currentTarget }) {
-    if (ime) {
-      return;
-    }
-    setChanged(true);
+  const onInput = useCallback(
+    function ({ currentTarget }) {
+      if (ime) {
+        return;
+      }
+      setChanged(true);
+      setRange(getCurrentRange(currentTarget));
+      onChange(getValue(currentTarget));
+    },
+    [ime, onChange],
+  );
+
+  const onBlur = useCallback(function ({ currentTarget }) {
     setRange(getCurrentRange(currentTarget));
-    onChange(getValue(currentTarget));
-  }
+  }, []);
 
-  function onBlur({ currentTarget }) {
-    setRange(getCurrentRange(currentTarget));
-  }
-
-  function onKeyDown(ev) {
+  const onKeyDown = useCallback(function (ev) {
     if (ev.key === 'Enter') {
       ev.preventDefault();
     }
@@ -305,37 +315,40 @@ export function TextArea(props) {
     // if (ev.key === 'Alt') {
     //   console.debug(getCurrentRange(ev.currentTarget));
     // }
-  }
+  }, []);
 
-  function onPaste(ev) {
-    ev.preventDefault();
-    const input = ev.clipboardData.getData('text/html') || ev.clipboardData.getData('text');
-    const sanitizedHTML = sanitizeHTML(input, {
-      allowedTags: ['span'],
-      allowedAttributes: {
-        span: ['data-variable', 'contenteditable'],
-      },
-      allowedClasses: {
-        span: ['ant-tag', 'ant-tag-*'],
-      },
-      transformTags: {
-        span(tagName, attribs) {
-          return attribs['data-variable']
-            ? {
-                tagName: tagName,
-                attribs,
-              }
-            : {};
+  const onPaste = useCallback(
+    function (ev) {
+      ev.preventDefault();
+      const input = ev.clipboardData.getData('text/html') || ev.clipboardData.getData('text');
+      const sanitizedHTML = sanitizeHTML(input, {
+        allowedTags: ['span'],
+        allowedAttributes: {
+          span: ['data-variable', 'contenteditable'],
         },
-      },
-    }).replace(/\n/g, ' ');
-    // ev.clipboardData.setData('text/html', sanitizedHTML);
-    // console.log(input, sanitizedHTML);
-    setChanged(true);
-    pasteHTML(ev.currentTarget, sanitizedHTML);
-    setRange(getCurrentRange(ev.currentTarget));
-    onChange(getValue(ev.currentTarget));
-  }
+        allowedClasses: {
+          span: ['ant-tag', 'ant-tag-*'],
+        },
+        transformTags: {
+          span(tagName, attribs) {
+            return attribs['data-variable']
+              ? {
+                  tagName: tagName,
+                  attribs,
+                }
+              : {};
+          },
+        },
+      }).replace(/\n/g, ' ');
+      // ev.clipboardData.setData('text/html', sanitizedHTML);
+      // console.log(input, sanitizedHTML);
+      setChanged(true);
+      pasteHTML(ev.currentTarget, sanitizedHTML);
+      setRange(getCurrentRange(ev.currentTarget));
+      onChange(getValue(ev.currentTarget));
+    },
+    [onChange],
+  );
 
   const disabled = props.disabled || form.disabled;
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/SchemaConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/SchemaConfig.tsx
@@ -520,7 +520,9 @@ export function SchemaConfigButton(props) {
       <Button type="primary" onClick={() => setVisible(true)}>
         {workflow.executed ? lang('View user interface') : lang('Configure user interface')}
       </Button>
-      <ActionContextProvider value={{ visible, setVisible }}>{props.children}</ActionContextProvider>
+      <ActionContextProvider value={{ visible, setVisible, formValueChanged: false }}>
+        {props.children}
+      </ActionContextProvider>
     </>
   );
 }


### PR DESCRIPTION
## Description (Bug 描述)

When closed node configuration form without save, the values remains when reopen.

### Steps to reproduce (复现步骤)

1. Modify a node field in configuration form.
2. Click outside the drawer to close it.
3. Confirm not to save.
4. Reopen the node configuration drawer.

### Expected behavior (预期行为)

Fields are reset to original values.

### Actual behavior (实际行为)

Modified and unsaved values remains.

## Related issues (相关 issue)

#2955.

## Reason (原因)

Variable `form` in `<SchemaComponent />` not updated.

## Solution (解决方案)

Add `<FormProvider />` to wrap it.

Also need fix `Variable.TextArea` to avoid error.
