### PR TITLE
fix(plugin-workflow): fix loop scope variable

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/loop.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/loop.tsx
@@ -8,7 +8,14 @@ import { Branch } from '../Branch';
 import { useFlowContext } from '../FlowContext';
 import { NAMESPACE, lang } from '../locale';
 import useStyles from '../style';
-import { VariableOption, WorkflowVariableInput, defaultFieldNames, nodesOptions, triggerOptions } from '../variable';
+import {
+  VariableOption,
+  WorkflowVariableInput,
+  defaultFieldNames,
+  nodesOptions,
+  scopeOptions,
+  triggerOptions,
+} from '../variable';
 
 function findOption(options: VariableOption[], paths: string[]) {
   let opts = options;
@@ -121,8 +128,8 @@ export default {
         .split('.')
         .map((path) => path.trim());
 
-      const targetOptions = [nodesOptions, triggerOptions].map((item: any) => {
-        const opts = item.useOptions(options).filter(Boolean);
+      const targetOptions = [scopeOptions, nodesOptions, triggerOptions].map((item: any) => {
+        const opts = item.useOptions({ ...options, current: node }).filter(Boolean);
         return {
           [fieldNames.label]: compile(item.label),
           [fieldNames.value]: item.value,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -34,6 +34,7 @@ export type OptionsOfUseVariableOptions = {
   };
   appends?: string[] | null;
   depth?: number;
+  current?: any;
 };
 
 export const defaultFieldNames = { label: 'label', value: 'value', children: 'children' } as const;
@@ -70,9 +71,10 @@ export const scopeOptions = {
   label: `{{t("Scope variables", { ns: "${NAMESPACE}" })}}`,
   value: '$scopes',
   useOptions(options: OptionsOfUseVariableOptions) {
-    const { fieldNames = defaultFieldNames } = options;
-    const current = useNodeContext();
-    const scopes = useUpstreamScopes(current);
+    const { fieldNames = defaultFieldNames, current } = options;
+    const source = useNodeContext();
+    const from = current ?? source;
+    const scopes = useUpstreamScopes(from);
     const result: VariableOption[] = [];
     scopes.forEach((node) => {
       const instruction = instructions.get(node.type);


### PR DESCRIPTION
## Description (Bug 描述)

Can not use collection variable from inner loop target.

### Steps to reproduce (复现步骤)

1. Add 3 collections as A --(hasMany)-> B --(hasMany)-> C.
2. Add collection workflow and use collection A to trigger, append association B and B.C.
3. Add a loop(1) with target as `A.B`.
4. Add another loop(2) inside loop(1) with target as `{loop1.target}.C`.
5. Add a calculation node inside loop(2).
6. Try to select `{loop2.target.someField}`.

### Expected behavior (预期行为)

Could select `C.field` from `loop2.target`.

### Actual behavior (实际行为)

No sub-list for `{loop2.target}` fields.

## Related issues (相关 issue)

None.

## Reason (原因)

Need recursive loop variable options.

## Solution (解决方案)

Add recursive loop variable options.
