### PR TITLE
refactor(plugin-workflow): change `actionTriggerable` to function `useActionTriggerable`

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -762,7 +762,11 @@ function WorkflowConfig() {
   const fieldSchema = useFieldSchema();
   const { name: collection } = useCollection();
   const workflowPlugin = usePlugin('workflow') as any;
-  const workflowTypes = workflowPlugin.getTriggersOptions().filter((item) => item.options.actionTriggerable);
+  const workflowTypes = workflowPlugin.getTriggersOptions().filter((item) => {
+    return typeof item.options.useActionTriggerable === 'function'
+      ? item.options.useActionTriggerable()
+      : item.options.useActionTriggerable;
+  });
   const description = {
     submit: t('Workflow will be triggered after submitting succeeded.', { ns: 'workflow' }),
     'customize:save': t('Workflow will be triggered after saving succeeded.', { ns: 'workflow' }),

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/form.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/form.tsx
@@ -101,7 +101,7 @@ export default {
     };
   },
   initializers: {},
-  actionTriggerable: true,
+  useActionTriggerable: true,
 };
 
 function getFormValues({

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/index.tsx
@@ -63,7 +63,7 @@ export interface Trigger {
   components?: { [key: string]: any };
   useInitializers?(config): SchemaInitializerItemOptions | null;
   initializers?: any;
-  actionTriggerable?: boolean;
+  useActionTriggerable?: boolean | (() => boolean);
 }
 
 export const triggers = new Registry<Trigger>();


### PR DESCRIPTION
# Description (需求描述)

Add extensibility to triggers to bind in action buttons.

# Motivation (需求背景)

Some triggers can only be bound to action conditionally.

# Key changes (关键改动）

- Frontend (前端)
  - Workflow section in `Action.Designer`.
  - Trigger option.
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

None.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

None.
