### PR TITLE
fix(plugin-workflow): fix configuration drawer close logic

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
@@ -274,7 +274,7 @@ export function JobButton() {
   );
 }
 
-function useNodeFormProps() {
+function useFormProviderProps() {
   return { form: useForm() };
 }
 
@@ -379,7 +379,7 @@ export function NodeDefaultView(props) {
             <SchemaComponent
               scope={{
                 ...instruction.scope,
-                useNodeFormProps,
+                useFormProviderProps,
               }}
               components={instruction.components}
               schema={{
@@ -427,7 +427,7 @@ export function NodeDefaultView(props) {
                     'x-decorator': 'FormV2',
                     'x-decorator-props': {
                       // form,
-                      useProps: '{{ useNodeFormProps }}',
+                      useProps: '{{ useFormProviderProps }}',
                     },
                     'x-component': 'Action.Drawer',
                     properties: {


### PR DESCRIPTION
## Description (Bug 描述)

When changed some field value in trigger or node configuration and close without save, the values changed remain in the drawer when reopened.

### Steps to reproduce (复现步骤)

1. Add a collection workflow.
2. Open trigger configuration.
3. Select some collection.
4. Close drawer without saving.
5. Reopen the configuration.

### Expected behavior (预期行为)

The collection field should be empty as not selected.

### Actual behavior (实际行为)

Collection has value.

## Related issues (相关 issue)

#2978.

## Reason (原因)

Reset logic not completed.

## Solution (解决方案)

Fix the form and reset logic.
