### PR TITLE
fix(plugin-workflow): fix workflow title in binding workflow configuration not showing

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -715,6 +715,7 @@ function RemoveButton(
 }
 
 function WorkflowSelect({ types, ...props }) {
+  const { t } = useTranslation();
   const index = ArrayTable.useIndex();
   const { setValuesIn } = useForm();
   const baseCollection = useCollection();
@@ -740,7 +741,12 @@ function WorkflowSelect({ types, ...props }) {
 
   return (
     <RemoteSelect
-      {...props}
+      manual={false}
+      placeholder={t('Select workflow', { ns: 'workflow' })}
+      fieldNames={{
+        label: 'title',
+        value: 'key',
+      }}
       service={{
         resource: 'workflows',
         action: 'list',
@@ -752,6 +758,7 @@ function WorkflowSelect({ types, ...props }) {
           },
         },
       }}
+      {...props}
     />
   );
 }
@@ -847,11 +854,6 @@ function WorkflowConfig() {
                         'x-decorator': 'FormItem',
                         'x-component': 'WorkflowSelect',
                         'x-component-props': {
-                          placeholder: t('Select workflow', { ns: 'workflow' }),
-                          fieldNames: {
-                            label: 'title',
-                            value: 'key',
-                          },
                           types: workflowTypes.map((item) => item.value),
                         },
                         required: true,


### PR DESCRIPTION
## Description (Bug 描述)

Workflow title in binding workflow configuration not showing

### Steps to reproduce (复现步骤)

1. Add a form workflow with a collection and enabled it.
2. Add binding workflow to the form of the collection.
3. Reopen the binding configuration.

### Expected behavior (预期行为)

Workflow configured should show title.

### Actual behavior (实际行为)

Not showing.

## Related issues (相关 issue)

None.

## Reason (原因)

Usage of `RemoteSelect` component.

## Solution (解决方案)

Add `manual={false}`.