### PR TITLE
fix(plugin-fm): fix error log

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -228,7 +228,7 @@ export const toItem = (file) => {
 };
 
 export const toFileList = (fileList: any) => {
-  return toArr(fileList?.filter(Boolean)).map(toItem);
+  return toArr(fileList).filter(Boolean).map(toItem);
 };
 
 export const toValue = (fileList: any) => {

--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/error-handler.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/error-handler.ts
@@ -18,10 +18,6 @@ export class ErrorHandler {
         },
       ],
     };
-
-    if (ctx.status === 500) {
-      console.error(err);
-    }
   }
 
   middleware() {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -78,6 +78,7 @@ async function multipart(ctx: Context, next: Next) {
     if (err.name === 'MulterError') {
       return ctx.throw(400, err);
     }
+    ctx.logger.error(err);
     return ctx.throw(500);
   }
 


### PR DESCRIPTION
## Description (Bug 描述)

No error when upload file failed.

### Steps to reproduce (复现步骤)

1. Configure an Ali-oss storage with wrong key pair.
2. Upload a file to the storage.

### Expected behavior (预期行为)

Can not upload, but notify in backend error message.

### Actual behavior (实际行为)

No error message.

## Related issues (相关 issue)

#2947.

## Reason (原因)

No logging for uncaught error.

## Solution (解决方案)

Add logging.
