### PR TITLE
fix(plugin-workflow): client minor fixes

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -41,6 +41,7 @@ export const Action: ComposedAction = observer(
       onClick,
       style,
       openSize,
+      disabled: propsDisabled,
       ...others
     } = useProps(props);
     const { wrapSSR, componentCls, hashId } = useStyles();
@@ -56,7 +57,7 @@ export const Action: ComposedAction = observer(
     const record = useRecord();
     const designerProps = fieldSchema['x-designer-props'];
     const openMode = fieldSchema?.['x-component-props']?.['openMode'];
-    const disabled = form.disabled || field.disabled || field.data?.disabled || props.disabled;
+    const disabled = form.disabled || field.disabled || field.data?.disabled || propsDisabled;
     const linkageRules = fieldSchema?.['x-linkage-rules'] || [];
     const { designable } = useDesignable();
     const tarComponent = useComponent(component) || component;

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -2,7 +2,7 @@ import { CloseOutlined, LoadingOutlined } from '@ant-design/icons';
 import { useFormLayout } from '@formily/antd-v5';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { isValid } from '@formily/shared';
-import { Button, Input } from 'antd';
+import { Button, Input, Space } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, hasIcon, icons } from '../../../icon';
@@ -15,7 +15,7 @@ function IconField(props: any) {
   const { t } = useTranslation();
   return (
     <div>
-      <Input.Group compact>
+      <Space.Compact>
         <PopoverWithStopPropagation
           placement={'bottom'}
           open={visible}
@@ -57,7 +57,7 @@ function IconField(props: any) {
             }}
           ></Button>
         )}
-      </Input.Group>
+      </Space.Compact>
     </div>
   );
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
@@ -9,7 +9,7 @@ import {
   useResourceActionContext,
 } from '@nocobase/client';
 import { str2moment } from '@nocobase/utils/client';
-import { Breadcrumb, Dropdown, Space, Tag } from 'antd';
+import { Breadcrumb, Dropdown, Result, Space, Spin, Tag } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { CanvasContent } from './CanvasContent';
@@ -58,7 +58,7 @@ function JobModal() {
         schema={{
           type: 'void',
           properties: {
-            [`${job?.id}-modal`]: {
+            [`${job?.id}-${job?.updatedAt}-modal`]: {
               type: 'void',
               'x-decorator': 'Form',
               'x-decorator-props': {
@@ -218,10 +218,9 @@ export function ExecutionCanvas() {
 
   if (!data?.data) {
     if (loading) {
-      return <div>{lang('Loading')}</div>;
-    } else {
-      return <div>{lang('Load failed')}</div>;
+      return <Spin />;
     }
+    return <Result status="404" title="Not found" />;
   }
 
   const { jobs = [], workflow: { nodes = [], revisions = [], ...workflow } = {}, ...execution } = data?.data ?? {};

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -10,7 +10,7 @@ import {
   useResourceContext,
 } from '@nocobase/client';
 import { str2moment } from '@nocobase/utils/client';
-import { App, Breadcrumb, Button, Dropdown, Switch, message } from 'antd';
+import { App, Breadcrumb, Button, Dropdown, Result, Spin, Switch, message } from 'antd';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
@@ -60,7 +60,10 @@ export function WorkflowCanvas() {
   }, [data?.data]);
 
   if (!data?.data) {
-    return <div>{loading ? lang('Loading') : lang('Load failed')}</div>;
+    if (loading) {
+      return <Spin />;
+    }
+    return <Result status="404" title="Not found" />;
   }
 
   const { nodes = [], revisions = [], ...workflow } = data?.data ?? {};

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/SchemaConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/SchemaConfig.tsx
@@ -522,7 +522,7 @@ export function SchemaConfigButton(props) {
   const [visible, setVisible] = useState(false);
   return (
     <>
-      <Button type="primary" onClick={() => setVisible(true)}>
+      <Button type="primary" onClick={() => setVisible(true)} disabled={false}>
         {workflow.executed ? lang('View user interface') : lang('Configure user interface')}
       </Button>
       <ActionContextProvider value={{ visible, setVisible, formValueChanged: false }}>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/WorkflowTodoBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/manual/WorkflowTodoBlockInitializer.tsx
@@ -25,4 +25,4 @@ export const WorkflowTodoBlockInitializer: FC<any> = ({ insert, ...rest }) => {
       }}
     />
   );
-}
+};


### PR DESCRIPTION
## Description (Bug 描述)

Manual node view configuration button should not be disabled after executed.

### Steps to reproduce (复现步骤)

1. Add manual node.
2. Trigger the workflow.
3. Reopen the workflow and the manual node configuration.

### Expected behavior (预期行为)

Could view UI configurations via "View configurations" button.

### Actual behavior (实际行为)

Can not.

## Related issues (相关 issue)

None.

## Reason (原因)

All form are disabled because workflow executed.

## Solution (解决方案)

Add `disabled` property to the button.
