### PR TITLE
fix(client): fix variable input style when disabled

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -332,25 +332,24 @@ export function Input(props) {
           )}
         </div>
       )}
-      {options.length > 1 && !disabled ? (
-        <Cascader
-          options={options}
-          value={variable ?? ['', ...(children || !constantOption.children?.length ? [] : [type])]}
-          onChange={onSwitch}
-          loadData={loadData as any}
-          changeOnSelect={changeOnSelect}
-          fieldNames={fieldNames}
-        >
-          {button ?? (
-            <XButton
-              className={css(`
-                margin-left: -1px;
-              `)}
-              type={variable ? 'primary' : 'default'}
-            />
-          )}
-        </Cascader>
-      ) : null}
+      <Cascader
+        options={options}
+        value={variable ?? ['', ...(children || !constantOption.children?.length ? [] : [type])]}
+        onChange={onSwitch}
+        loadData={loadData as any}
+        changeOnSelect={changeOnSelect}
+        fieldNames={fieldNames}
+        disabled={disabled}
+      >
+        {button ?? (
+          <XButton
+            className={css(`
+              margin-left: -1px;
+            `)}
+            type={variable ? 'primary' : 'default'}
+          />
+        )}
+      </Cascader>
     </Space.Compact>,
   );
 }


### PR DESCRIPTION
## Description (Bug 描述)

`<Variable.Input />` showing no `border-radius` on right side when disabled.

### Steps to reproduce (复现步骤)

1. Make a field with variable disabled.

### Expected behavior (预期行为)

Should show same `border-radius` as left side.

### Actual behavior (实际行为)

Rectangle.

## Related issues (相关 issue)

None.

## Reason (原因)

Hidden "x" button under `<Space.Compact>`.

## Solution (解决方案)

Show "x" button when disabled.
