### PR TITLE
fix(cm): sql collection creation issue

### DIFF
--- a/packages/core/client/src/collection-manager/templates/components/sql-collection/FieldsConfigure.tsx
+++ b/packages/core/client/src/collection-manager/templates/components/sql-collection/FieldsConfigure.tsx
@@ -9,9 +9,7 @@ import { useCompile } from '../../../../schema-component';
 import { useCollectionManager } from '../../../hooks';
 import dayjs from 'dayjs';
 import { FieldOptions } from '@nocobase/database';
-import { ResourceActionContext, useResourceContext } from '../../../ResourceActionProvider';
-import { useRecord } from '../../../../record-provider';
-import { last } from 'lodash';
+import { ResourceActionContext } from '../../../ResourceActionProvider';
 
 const inferInterface = (field: string, value: any) => {
   if (field.toLowerCase().includes('id')) {
@@ -24,7 +22,7 @@ const inferInterface = (field: string, value: any) => {
     return 'number';
   }
   if (typeof value === 'boolean') {
-    return 'boolean';
+    return 'checkbox';
   }
   if (dayjs(value).isValid()) {
     return 'datetime';


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

1. New sql collection
2. Enter a SQL statement that select a boolean field. E.g. `select * from users left join roles_users on users.id=roles_users.user_id left join roles on roles.name=roles_users.role_name`
3. Submit

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

Submitted successfully.

### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

It occurred error "field type null is not supported".

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

Close T-2618

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

The field interface inference was wrong.

```ts
  if (typeof value === 'boolean') {
    return 'boolean';
  }
```

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

```ts
  if (typeof value === 'boolean') {
    return 'checkbox';
  }
```
