### PR TITLE
fix(client): allow match query case insensitive

### DIFF
--- a/packages/core/client/src/schema-component/antd/collection-select/CollectionSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/collection-select/CollectionSelect.tsx
@@ -52,7 +52,10 @@ export const CollectionSelect = connect(
         popupMatchSelectWidth={false}
         {...others}
         showSearch
-        filterOption={(input, option) => (option?.label ?? '').includes(input)}
+        filterOption={(input, option) =>
+          (option?.label.toLowerCase() ?? '').includes(input.toLocaleLowerCase()) ||
+          (option?.value.toString().toLowerCase() ?? '').includes(input.toLocaleLowerCase())
+        }
         options={options}
       />
     );


### PR DESCRIPTION
## Description (Bug 描述)

Could not filter collection when letters case not match.

### Steps to reproduce (复现步骤)

1. Create a collection workflow.
2. Select a created collection with name.

### Expected behavior (预期行为)

Input `post` could match `Post` as name.

### Actual behavior (实际行为)

Could not.

## Related issues (相关 issue)

None.

## Reason (原因)

Case sensitive in component filter.

## Solution (解决方案)

Add `.toLowerCase()`.
