### PR TITLE
fix(plugin-workflow): fix condition branch node finding logic (fix #3082)

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/condition.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/condition.ts
@@ -149,7 +149,9 @@ export default {
       upstreamId: (prevJob && prevJob.id) || null,
     };
 
-    const branchNode = processor.nodes.find((item) => item.upstream === node && Boolean(item.branchIndex) === result);
+    const branchNode = processor.nodes.find(
+      (item) => item.upstreamId === node.id && item.branchIndex != null && Boolean(item.branchIndex) === result,
+    );
 
     if (!branchNode) {
       return job;


### PR DESCRIPTION
## Description (Bug 描述)

Nested condition branches will be jumped.

### Steps to reproduce (复现步骤)

1. Use PG@11.
2. Add a condition node (1) with `1 = 0` (to `false`).
3. Add another condition in falsy branch of node (1), with falsy calculation too.
4. Add any node as direct downstream of node (1).

### Expected behavior (预期行为)

Node (2) should be executed.

### Actual behavior (实际行为)

Node (2) is not executed.

## Related issues (相关 issue)

#3082.

## Reason (原因)

Logic of `branchIndex` goes to `null`.

## Solution (解决方案)

Fix `branchIndex` logic.
