### PR TITLE
fix(plugin-workflow): fix destroy node locale

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/destroy.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/destroy.tsx
@@ -3,7 +3,7 @@ import { useCollectionDataSource } from '@nocobase/client';
 import { FilterDynamicComponent } from '../components/FilterDynamicComponent';
 import { collection, filter } from '../schemas/collection';
 import { isValidFilter } from '../utils';
-import { NAMESPACE } from '../locale';
+import { NAMESPACE, lang } from '../locale';
 
 export default {
   title: '{{t("Delete record")}}',
@@ -18,7 +18,7 @@ export default {
         filter: {
           ...filter,
           ['x-validator'](value) {
-            return isValidFilter(value) ? '' : `{{t("Please add at least one condition", { ns: "${NAMESPACE}" })}}`;
+            return isValidFilter(value) ? '' : lang('Please add at least one condition');
           },
         },
       },


### PR DESCRIPTION
## Description (Bug 描述)

Locale of destroy node not rendering correctly.

### Steps to reproduce (复现步骤)

1. Add a destroy node in workflow.
2. Open destroy node configuration panel and then submit without any input.

### Expected behavior (预期行为)

Validation error showing correctly.

### Actual behavior (实际行为)

Filter validation error is not translated.

## Related issues (相关 issue)

None.

## Reason (原因)

Should not use uncompiled raw string in validation.

## Solution (解决方案)

Use `lang()` instead.
