### PR TITLE
fix(plugin-workflow-manual): fix initializer

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/index.ts
@@ -16,6 +16,8 @@ export default class extends Plugin {
 
   // You can get and modify the app instance here
   async load() {
+    this.addComponents();
+
     // this.app.addProvider(Provider);
     const workflow = this.app.pm.get('workflow') as WorkflowPlugin;
     const manualInstruction = new Manual();


### PR DESCRIPTION
## Description (Bug 描述)

Workflow todo initializer missed.

### Steps to reproduce (复现步骤)

Open block initializer and try to find "Workflow todos".

### Expected behavior (预期行为)

Should be in initializers menu.

### Actual behavior (实际行为)

Not exists.

## Related issues (相关 issue)

#3115.

## Reason (原因)

Forgot to add components.

## Solution (解决方案)

Add components.
