### PR TITLE
feat: the $anyof and $noneOf operators should support non-array values

### DIFF
--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -23,7 +23,8 @@
     "qs": "^6.11.2",
     "semver": "^7.3.7",
     "sequelize": "^6.26.0",
-    "umzug": "^3.1.1"
+    "umzug": "^3.1.1",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/packages/core/database/src/__tests__/operator/array-operator.test.ts
+++ b/packages/core/database/src/__tests__/operator/array-operator.test.ts
@@ -195,6 +195,7 @@ describe('array field operator', function () {
     expect(filter3[0].get('name')).toEqual(t2.get('name'));
   });
 
+  // fix https://nocobase.height.app/T-2803
   test('$anyOf with string', async () => {
     const filter3 = await Test.repository.find({
       filter: {
@@ -220,6 +221,18 @@ describe('array field operator', function () {
     const filter = await Test.repository.find({
       filter: {
         'selected.$noneOf': ['aa'],
+      },
+    });
+
+    expect(filter.length).toEqual(1);
+    expect(filter[0].get('name')).toEqual(t1.get('name'));
+  });
+
+  // fix https://nocobase.height.app/T-2803
+  test('$noneOf with string', async () => {
+    const filter = await Test.repository.find({
+      filter: {
+        'selected.$noneOf': 'aa',
       },
     });
 

--- a/packages/core/database/src/__tests__/operator/array-operator.test.ts
+++ b/packages/core/database/src/__tests__/operator/array-operator.test.ts
@@ -1,5 +1,5 @@
-import { mockDatabase } from '../index';
 import Database from '../../database';
+import { mockDatabase } from '../index';
 
 describe('array field operator', function () {
   let db: Database;
@@ -188,6 +188,17 @@ describe('array field operator', function () {
     const filter3 = await Test.repository.find({
       filter: {
         'selected.$anyOf': ['aa'],
+      },
+    });
+
+    expect(filter3.length).toEqual(1);
+    expect(filter3[0].get('name')).toEqual(t2.get('name'));
+  });
+
+  test('$anyOf with string', async () => {
+    const filter3 = await Test.repository.find({
+      filter: {
+        'selected.$anyOf': 'aa',
       },
     });
 

--- a/packages/core/database/src/operators/array.ts
+++ b/packages/core/database/src/operators/array.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Op, Sequelize } from 'sequelize';
 import { isMySQL, isPg } from './utils';
 
@@ -87,6 +88,7 @@ export default {
 
   $anyOf(value, ctx) {
     const fieldName = getFieldName(ctx);
+    value = _.castArray(value);
 
     if (isPg(ctx)) {
       const name = ctx.fullName === fieldName ? `"${ctx.model.name}"."${fieldName}"` : `"${fieldName}"`;
@@ -111,6 +113,7 @@ export default {
 
   $noneOf(value, ctx) {
     let where;
+    value = _.castArray(value);
 
     if (isPg(ctx)) {
       const fieldName = getFieldName(ctx);


### PR DESCRIPTION
close T-2803

**需求：$anyOf 和 $noneOf 需要支持非数组的值。**

比如下图中的一个多选字段，选择的操作符为**包含**（$anyOf），要匹配包含**当前角色**，而当前角色是一个字符串，这样设置其实是合理的，但是现在会报错。
![img_v3_026b_4be1dce0-ef8f-4529-b0e7-b2b9ad65aceg](https://github.com/nocobase/nocobase/assets/38434641/69b9ef7e-fef1-46ab-af65-aa432da4400e)
![image](https://github.com/nocobase/nocobase/assets/38434641/aeb25f33-6b03-42e8-95af-7aa3fffc1463)


解决方法就是：把值都转换为数组之后再进行处理。