### PR TITLE
refactor(client): allow fixed layout table and action link class

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Link.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Link.tsx
@@ -1,11 +1,14 @@
 import { observer } from '@formily/react';
 import React from 'react';
+import classnames from 'classnames';
 import Action from './Action';
 import { ComposedAction } from './types';
 
 export const ActionLink: ComposedAction = observer(
   (props: any) => {
-    return <Action {...props} component={props.component || 'a'} className={'nb-action-link'} />;
+    return (
+      <Action {...props} component={props.component || 'a'} className={classnames('nb-action-link', props.className)} />
+    );
   },
   { displayName: 'ActionLink' },
 );

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -538,6 +538,7 @@ export const Table: any = observer(
             ref={tableSizeRefCallback}
             rowKey={rowKey ?? defaultRowKey}
             dataSource={dataSource}
+            tableLayout="auto"
             {...others}
             {...restProps}
             pagination={paginationProps}
@@ -547,7 +548,6 @@ export const Table: any = observer(
             }}
             onRow={onRow}
             rowClassName={(record) => (selectedRow.includes(record[rowKey]) ? highlightRow : '')}
-            tableLayout={'auto'}
             scroll={scroll}
             columns={columns}
             expandable={{


### PR DESCRIPTION
# Description (需求描述)

Refactor components:

1. `TableV2`: allow to use fixed layout for column width.
2. `Action.Link`: Allow pass `className` in.

# Motivation (需求背景)

1. Column in `Table` need fixed width.
2. `Action.Link` need custom style.

# Key changes (关键改动）

- Frontend (前端)
  - TableV2
  - Action.Link
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

Table column width when `tableLayout` passed to Table component.

## Underlying risk (潜在风险)

Uncertain.

# Showcase (结果展示）

None.
