### PR TITLE
fix(plugin-workflow-dynamic-calculation): fix missed component

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/index.ts
@@ -15,14 +15,11 @@ export default class extends Plugin {
   // You can get and modify the app instance here
   async load() {
     this.app.addProvider(Provider);
-    const workflow = this.app.pm.get('workflow') as WorkflowPlugin;
-    const dynamicCalculation = new DynamicCalculation();
-    workflow.instructions.register(dynamicCalculation.type, dynamicCalculation);
-  }
-
-  addComponents() {
     this.app.addComponents({
       DynamicExpression,
     });
+    const workflow = this.app.pm.get('workflow') as WorkflowPlugin;
+    const dynamicCalculation = new DynamicCalculation();
+    workflow.instructions.register(dynamicCalculation.type, dynamicCalculation);
   }
 }


### PR DESCRIPTION
## Description (Bug 描述)

Page crash when add expression field in expression collection form.

### Steps to reproduce (复现步骤)

1. Add an expression collection.
2. Add a form for the collection.
3. Add expression field to the form.

### Expected behavior (预期行为)

Expression field added.

### Actual behavior (实际行为)

Page crash.

## Related issues (相关 issue)

None.

## Reason (原因)

Missed component when split plugins.

## Solution (解决方案)

Add missed component.
