### PR TITLE
feat(plugin-workflow): add space control to RadioWithTooltip

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/RadioWithTooltip.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/RadioWithTooltip.tsx
@@ -1,6 +1,6 @@
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { css, useCompile } from '@nocobase/client';
-import { Radio, Tooltip } from 'antd';
+import { Radio, Space, Tooltip } from 'antd';
 import React from 'react';
 
 export interface RadioWithTooltipOption {
@@ -10,29 +10,31 @@ export interface RadioWithTooltipOption {
 }
 
 export function RadioWithTooltip(props) {
-  const { options = [], ...other } = props;
+  const { options = [], direction, ...other } = props;
   const compile = useCompile();
 
   return (
     <Radio.Group {...other}>
-      {options.map((option) => (
-        <Radio key={option.value} value={option.value}>
-          <span
-            className={css`
-              & + .anticon {
-                margin-left: 0.25em;
-              }
-            `}
-          >
-            {compile(option.label)}
-          </span>
-          {option.tooltip && (
-            <Tooltip title={compile(option.tooltip)}>
-              <QuestionCircleOutlined style={{ color: '#666' }} />
-            </Tooltip>
-          )}
-        </Radio>
-      ))}
+      <Space direction={direction}>
+        {options.map((option) => (
+          <Radio key={option.value} value={option.value}>
+            <span
+              className={css`
+                & + .anticon {
+                  margin-left: 0.25em;
+                }
+              `}
+            >
+              {compile(option.label)}
+            </span>
+            {option.tooltip && (
+              <Tooltip title={compile(option.tooltip)}>
+                <QuestionCircleOutlined style={{ color: '#666' }} />
+              </Tooltip>
+            )}
+          </Radio>
+        ))}
+      </Space>
     </Radio.Group>
   );
 }


### PR DESCRIPTION
# Description (需求描述)

Add space control to `RadioWithTooltip`.

# Motivation (需求背景)

When text is too long, should be able to be placed vertically.

# Key changes (关键改动）

- Frontend (前端)
  - Workflow component.
- Backend (后端)

# Test plan (测试计划)

## Suggestions (测试建议)

None.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

None.
