### PR TITLE
fix(plugin-workflow): queueing execution of disabled workflow block dispatching

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -398,6 +398,7 @@ export default class WorkflowPlugin extends Plugin {
         const execution = (await this.db.getRepository('executions').findOne({
           filter: {
             status: EXECUTION_STATUS.QUEUEING,
+            'workflow.enabled': true,
             'workflow.id': {
               [Op.not]: null,
             },
@@ -405,7 +406,7 @@ export default class WorkflowPlugin extends Plugin {
           appends: ['workflow'],
           sort: 'createdAt',
         })) as ExecutionModel;
-        if (execution && execution.workflow.enabled) {
+        if (execution) {
           this.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
           next = [execution];
         }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -2,7 +2,6 @@ import { MockServer } from '@nocobase/test';
 import Database from '@nocobase/database';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { EXECUTION_STATUS } from '../constants';
-import a from 'packages/core/database/src/__tests__/fixtures/c0/a';
 
 describe('workflow > Plugin', () => {
   let app: MockServer;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -2,6 +2,7 @@ import { MockServer } from '@nocobase/test';
 import Database from '@nocobase/database';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { EXECUTION_STATUS } from '../constants';
+import a from 'packages/core/database/src/__tests__/fixtures/c0/a';
 
 describe('workflow > Plugin', () => {
   let app: MockServer;
@@ -356,10 +357,8 @@ describe('workflow > Plugin', () => {
       const p1 = await PostRepo.create({ values: { title: 't1' } });
 
       const ExecutionModel = db.getCollection('executions').model;
-      const e1 = await ExecutionModel.create({
-        workflowId: w1.id,
+      const e1 = await w1.createExecution({
         key: w1.key,
-        useTransaction: w1.useTransaction,
         context: {
           data: p1.get(),
         },
@@ -378,10 +377,25 @@ describe('workflow > Plugin', () => {
 
       await db.reconnect();
 
-      const e2 = await ExecutionModel.create({
-        workflowId: w1.id,
+      const e2 = await w1.createExecution({
         key: w1.key,
-        useTransaction: w1.useTransaction,
+        context: {
+          data: p1.get(),
+        },
+        createdAt: p1.createdAt,
+      });
+
+      const w2 = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      const e3 = await w2.createExecution({
+        key: w2.key,
         context: {
           data: p1.get(),
         },
@@ -393,6 +407,10 @@ describe('workflow > Plugin', () => {
 
       await e2.reload();
       expect(e2.status).toBe(EXECUTION_STATUS.QUEUEING);
+
+      // queueing execution of disabled workflow should not effect other executions
+      await e3.reload();
+      expect(e3.status).toBe(EXECUTION_STATUS.RESOLVED);
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/collections/executions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/collections/executions.ts
@@ -14,11 +14,6 @@ export default {
       name: 'key',
     },
     {
-      type: 'boolean',
-      name: 'useTransaction',
-      defaultValue: false,
-    },
-    {
       type: 'hasMany',
       name: 'jobs',
       onDelete: 'CASCADE',


### PR DESCRIPTION
## Description (Bug 描述)

Occasionally workflow dispatch stops.

### Steps to reproduce (复现步骤)

1. Make multiple triggering of multiple workflows.
2. Disable some workflow which has queueing executions.

### Expected behavior (预期行为)

All queueing executions of enabled workflows should be dispatched and processed.

### Actual behavior (实际行为)

The queueing executions block all processing.

## Related issues (相关 issue)

#3221.

## Reason (原因)

Enabled checking logic bug.

## Solution (解决方案)

Fix enabled checking.
