### PR TITLE
fix(plugin-workflow): defend unimplemented trigger type

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -235,6 +235,10 @@ export default class WorkflowPlugin extends Plugin {
   toggle(workflow: WorkflowModel, enable?: boolean) {
     const type = workflow.get('type');
     const trigger = this.triggers.get(type);
+    if (!trigger) {
+      this.getLogger(workflow.id).error(`trigger type ${workflow.type} of workflow ${workflow.id} is not implemented`);
+      return;
+    }
     if (typeof enable !== 'undefined' ? enable : workflow.get('enabled')) {
       // NOTE: remove previous listener if config updated
       const prev = workflow.previous();


### PR DESCRIPTION
## Description (Bug 描述)

Unimplemented trigger type throwing error which blocking app start.

### Steps to reproduce (复现步骤)

1. Some dirty data with not enabled trigger plugin (form trigger).

### Expected behavior (预期行为)

Trigger not works but app goes on.

### Actual behavior (实际行为)

App stuck.

## Related issues (相关 issue)

#3191.

## Reason (原因)

Dirty data.

## Solution (解决方案)

Defend unknown types.
