### PR TITLE
fix: z-index should be the same value

### DIFF
--- a/packages/core/app/client/public/global.css
+++ b/packages/core/app/client/public/global.css
@@ -61,3 +61,9 @@ body a:active {
 .ant-btn-link:active {
   color: var(--colorPrimaryTextActive);
 }
+
+/* fix https://nocobase.height.app/T-2838 */
+/* antd 组件的层级有问题，有的弹窗是 1000 有的是 1200，会导致弹窗被覆盖的问题。弹窗这里应该使用同一个值，是比较合理的 */
+.ant-modal-wrap, .ant-modal-mask {
+  z-index: 1000 !important;
+}


### PR DESCRIPTION
close T-2838

antd 组件的层级有问题，有的弹窗是 1000 有的是 1200，会导致弹窗被覆盖的问题。弹窗这里使用同一个值是比较合理的。