### PR TITLE
chore(vscode): add inspect argument for attaching to debug port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,16 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
+      "address": "localhost",
+      "localRoot": "${workspaceFolder}",
+      "name": "Attach to debug server (remote)",
+      "port": 9229,
+      "remoteRoot": "${workspaceFolder}",
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Debug Tests",

--- a/packages/core/cli/src/commands/dev.js
+++ b/packages/core/cli/src/commands/dev.js
@@ -15,6 +15,7 @@ module.exports = (cli) => {
     .option('--client')
     .option('--server')
     .option('--db-sync')
+    .option('--inspect [port]')
     .allowUnknownOption()
     .action(async (opts) => {
       promptForTs();
@@ -33,7 +34,7 @@ module.exports = (cli) => {
         return;
       }
 
-      const { port, client, server } = opts;
+      const { port, client, server, inspect } = opts;
 
       if (port) {
         process.env.APP_PORT = opts.port;
@@ -59,8 +60,13 @@ module.exports = (cli) => {
       if (server || !client) {
         console.log('starting server', serverPort);
 
+        const filteredArgs = process.argv.filter(
+          (item, i) => !item.startsWith('--inspect') && !(process.argv[i - 1] === '--inspect' && Number.parseInt(item)),
+        );
+
         const argv = [
           'watch',
+          ...(inspect ? [`--inspect=${inspect === true ? 9229 : inspect}`] : []),
           '--ignore=./storage/plugins/**',
           '--tsconfig',
           SERVER_TSCONFIG_PATH,
@@ -68,7 +74,7 @@ module.exports = (cli) => {
           'tsconfig-paths/register',
           `${APP_PACKAGE_ROOT}/src/index.ts`,
           'start',
-          ...process.argv.slice(3),
+          ...filteredArgs.slice(3),
           `--port=${serverPort}`,
         ];
 


### PR DESCRIPTION
# Description (需求描述)

Add inspect argument for attaching to debug port.

# Motivation (需求背景)

When using VSCode developing over remote development server, need the server running under debug mode (with `--inspect`), and could use VSCode to attach to the debug port.

# Key changes (关键改动）

* `.vscode/launch.json`
* `dev.js`

# Test plan (测试计划)

## Suggestions (测试建议)

None.

## Underlying risk (潜在风险)

None.

# Showcase (结果展示）

None.
