### PR TITLE
fix(bi): axis numbers are out of order when the database returns numeric values as strings

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
@@ -46,35 +46,26 @@ type QueryParams = Partial<{
 }>;
 
 export const postProcess = async (ctx: Context, next: Next) => {
-  const { sequelize } = ctx.db;
-  const dialect = sequelize.getDialect();
   const { data, fieldMap } = ctx.action.params.values as {
     data: any[];
     fieldMap: { [source: string]: { type?: string } };
   };
-  switch (dialect) {
-    case 'postgres':
-      // https://github.com/sequelize/sequelize/issues/4550
-      ctx.body = data.map((record) => {
-        const result = {};
-        Object.entries(record).forEach(([key, value]) => {
-          const { type } = fieldMap[key] || {};
-          switch (type) {
-            case 'bigInt':
-            case 'integer':
-            case 'float':
-            case 'double':
-              value = Number(value);
-              break;
-          }
-          result[key] = value;
-        });
-        return result;
-      });
-      break;
-    default:
-      ctx.body = data;
-  }
+  ctx.body = data.map((record) => {
+    const result = {};
+    Object.entries(record).forEach(([key, value]) => {
+      const { type } = fieldMap[key] || {};
+      switch (type) {
+        case 'bigInt':
+        case 'integer':
+        case 'float':
+        case 'double':
+          value = Number(value);
+          break;
+      }
+      result[key] = value;
+    });
+    return result;
+  });
   await next();
 };
 


### PR DESCRIPTION
## Description (Bug 描述)

### Steps to reproduce (复现步骤)

<!-- Clear steps to reproduce the bug. -->

1. 使用 MySQL 数据库
2. 新增图表，使用整数类型字段作为度量，并选择求和作为聚合方式
3. 配置折线图

### Expected behavior (预期行为)

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

<img width="520" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/acb3b7ff-49c1-4e6c-aef5-a0e61f40780b">


### Actual behavior (实际行为)

<!-- Describe what actually happens when the code is executed with the bug. -->

<img width="431" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/90f879bd-1d9c-4318-958a-2ac1b895d9ae">

## Related issues (相关 issue)

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason (原因)

<!-- Explain what caused the bug to occur. -->

MySQL 将聚合后的 `bigInt` 字段返回成了 `string`

## Solution (解决方案)

<!-- Describe solution to the bug clearly and consciously. -->

对数字字段统一处理类型
