### PR TITLE
test: mysql version bug

### DIFF
--- a/.github/workflows/nocobase-test-backend.yml
+++ b/.github/workflows/nocobase-test-backend.yml
@@ -136,7 +136,7 @@ jobs:
     container: node:${{ matrix.node_version }}
     services:
       mysql:
-        image: mysql:8
+        image: mysql:8.2 # >= 8.3 will meet unsolved error: https://github.com/nocobase/nocobase/actions/runs/7581141593/job/20653828990?pr=3383
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: nocobase

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
@@ -97,7 +97,7 @@ describe('workflow > instructions > delay', () => {
       const n2 = await workflow.createNode({
         type: 'create',
         config: {
-          collection: 'comment',
+          collection: 'comments',
           params: {
             values: {
               status: 'should be number but use string to raise an error',

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
@@ -86,7 +86,7 @@ describe('workflow > instructions > delay', () => {
       expect(j2.status).toBe(JOB_STATUS.FAILED);
     });
 
-    it('delay to resolve and rollback in downstream node', async () => {
+    it('delay to resolve and downstream node error', async () => {
       const n1 = await workflow.createNode({
         type: 'delay',
         config: {
@@ -122,8 +122,8 @@ describe('workflow > instructions > delay', () => {
       const [e2] = await workflow.getExecutions();
       expect(e2.status).toEqual(EXECUTION_STATUS.ERROR);
       const [j2, j3] = await e2.getJobs({ order: [['id', 'ASC']] });
-      expect(j2.status).toBe(JOB_STATUS.RESOLVED);
-      expect(j3.status).toBe(JOB_STATUS.ERROR);
+      expect(j2.status).toBe(JOB_STATUS.ERROR);
+      expect(j3.status).toBe(JOB_STATUS.RESOLVED);
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/__tests__/instruction.test.ts
@@ -97,11 +97,9 @@ describe('workflow > instructions > delay', () => {
       const n2 = await workflow.createNode({
         type: 'create',
         config: {
-          collection: 'comments',
+          collection: 'notExistsTable',
           params: {
-            values: {
-              status: 'should be number but use string to raise an error',
-            },
+            values: {},
           },
         },
         upstreamId: n1.id,
@@ -122,8 +120,8 @@ describe('workflow > instructions > delay', () => {
       const [e2] = await workflow.getExecutions();
       expect(e2.status).toEqual(EXECUTION_STATUS.ERROR);
       const [j2, j3] = await e2.getJobs({ order: [['id', 'ASC']] });
-      expect(j2.status).toBe(JOB_STATUS.ERROR);
-      expect(j3.status).toBe(JOB_STATUS.RESOLVED);
+      expect(j2.status).toBe(JOB_STATUS.RESOLVED);
+      expect(j3.status).toBe(JOB_STATUS.ERROR);
     });
   });
 


### PR DESCRIPTION
## Description (Bug 描述)

MySQL 8.3 (used in CI image as '8', update at Jan 19, 2024 at 3:03 pm on docker hub) cause some test cases failed with error:

~~~
Cannot create a JSON value from a string with CHARACTER SET 'binary'. Cannot create a JSON value from a string with CHARACTER SET 'binary'.

sql:

INSERT INTO `jobs` (`id`,`createdAt`,`updatedAt`,`executionId`,`nodeId`,`nodeKey`,`upstreamId`,`status`,`result`) VALUES (DEFAULT,?,?,?,?,?,?,?,?);
~~~

### Steps to reproduce (复现步骤)

Run test of these files:

* packages/plugins/@nocobase/plugin-workflow-delay/src/server/\_\_tests\_\_/instruction.test.ts
* packages/plugins/@nocobase/plugin-workflow-manual/src/server/\_\_tests\_\_/instruction.test.ts

### Expected behavior (预期行为)

Could pass.

### Actual behavior (实际行为)

Throw error about JSON field.

## Related issues (相关 issue)

None.

## Reason (原因)

Not sure for now. Only happens in the cases, can not make a simple small reproduction.

## Solution (解决方案)

Limit CI MySQL version to 8.2.
