### PR TITLE
feat: collection table management adds uid automatic generation with logic switch function

### DIFF
--- a/packages/core/client/src/collection-manager/CollectionManageSetting.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSetting.tsx
@@ -36,10 +36,11 @@ const useSaveSystemSettingsValues = () => {
         method: 'post',
         data: values,
         params: {
-          filterByTk: 2,
+          filter: { packageName: '@nocobase/plugin-collection-manager' },
         },
       });
       message.success(t('Saved successfully'));
+      window.location.reload();
     },
   };
 };

--- a/packages/core/client/src/collection-manager/CollectionManageSetting.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSetting.tsx
@@ -1,0 +1,102 @@
+import { ISchema, useForm } from '@formily/react';
+import { uid } from '@formily/shared';
+import { Card, message } from 'antd';
+import cloneDeep from 'lodash/cloneDeep';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCollectionManageSetting, CollectionManageSettingProvider } from './CollectionManageSettingProvider';
+import { useAPIClient, useRequest } from '..';
+import { SchemaComponent, useActionContext } from '../schema-component';
+
+const useSystemSettingsValues = (options) => {
+  const { visible } = useActionContext();
+  const result = useCollectionManageSetting();
+  return useRequest(() => Promise.resolve(result.data), {
+    ...options,
+    refreshDeps: [visible],
+  });
+};
+
+const useSaveSystemSettingsValues = () => {
+  const form = useForm();
+  const api = useAPIClient();
+  const { t } = useTranslation();
+  return {
+    async run() {
+      await form.submit();
+      const values = cloneDeep(form.values);
+      localStorage.setItem('RANDOM_UID_BLACKLIST', values?.options?.randomUidBlacklist);
+      await api.request({
+        url: 'applicationPlugins:update',
+        method: 'post',
+        data: values,
+        params: {
+          filterByTk: 2,
+        },
+      });
+      message.success(t('Saved successfully'));
+    },
+  };
+};
+
+const schema: ISchema = {
+  type: 'object',
+  properties: {
+    [uid()]: {
+      'x-decorator': 'Form',
+      'x-decorator-props': {
+        useValues: '{{ useSystemSettingsValues }}',
+      },
+      'x-component': 'div',
+      type: 'void',
+      title: '{{t("System settings")}}',
+      properties: {
+        'options.randomUidBlacklist': {
+          type: 'string',
+          title: '{{t("auto generate uid")}}',
+          'x-component': 'Checkbox.Group',
+          'x-component-props': {
+            options: [
+              { label: '{{t("Table name")}}', value: 'TABLE_NAME' },
+              { label: '{{t("Table field name")}}', value: 'TABLE_FIELD' },
+              { label: '{{t("Foreign key")}}', value: 'FOREIGN_KEY' },
+              { label: '{{t("Table select option")}}', value: 'SELECT_OPTION' },
+            ],
+          },
+          'x-decorator': 'FormItem',
+          'x-decorator-props': {
+            tooltip: '{{t("auto generate uid switch")}}',
+          },
+        },
+        footer1: {
+          type: 'void',
+          'x-component': 'ActionBar',
+          'x-component-props': {
+            layout: 'one-column',
+          },
+          properties: {
+            submit: {
+              title: '{{t("Submit")}}',
+              'x-component': 'Action',
+              'x-component-props': {
+                type: 'primary',
+                htmlType: 'submit',
+                useAction: '{{ useSaveSystemSettingsValues }}',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const CollectionManageSetting = () => {
+  return (
+    <Card bordered={false}>
+      <CollectionManageSettingProvider>
+        <SchemaComponent scope={{ useSaveSystemSettingsValues, useSystemSettingsValues }} schema={schema} />
+      </CollectionManageSettingProvider>
+    </Card>
+  );
+};

--- a/packages/core/client/src/collection-manager/CollectionManageSetting.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSetting.tsx
@@ -30,11 +30,7 @@ const useSaveSystemSettingsValues = () => {
     async run() {
       await form.submit();
       const values = cloneDeep(form.values);
-      localStorage.setItem(CONSTANT.RANDOM_UID_OPTIONS, values?.options?.randomUidBlacklist);
-      values.options = {
-        ...values.options,
-        type: values?.options?.randomUidBlacklist?.length === 0 ? CONSTANT.ALL_SELECTED_EMPTY : '',
-      };
+      localStorage.setItem(CONSTANT.RANDOM_UID_BLACKLIST, values?.options?.randomUidBlacklist);
       await api.request({
         url: 'applicationPlugins:update',
         method: 'post',
@@ -62,14 +58,14 @@ const schema: ISchema = {
       properties: {
         'options.randomUidBlacklist': {
           type: 'string',
-          title: '{{t("auto generate uid")}}',
+          title: '{{t("Do not generate related identifiers randomly")}}',
           'x-component': 'Checkbox.Group',
           'x-component-props': {
             options: [
-              { label: '{{t("Table name")}}', value: ERandomUidType.TABLE_NAME },
-              { label: '{{t("Table field name")}}', value: ERandomUidType.TABLE_FIELD },
-              { label: '{{t("Foreign key")}}', value: ERandomUidType.FOREIGN_KEY },
-              { label: '{{t("Table select option")}}', value: ERandomUidType.SELECT_OPTION },
+              { label: '{{t("Collection name")}}', value: ERandomUidType.TABLE_NAME },
+              { label: '{{t("Collection field name")}}', value: ERandomUidType.TABLE_FIELD },
+              { label: '{{t("Association fields foreign key")}}', value: ERandomUidType.FOREIGN_KEY },
+              { label: '{{t("Option value for choice-type fields")}}', value: ERandomUidType.SELECT_OPTION },
             ],
           },
           'x-decorator': 'FormItem',

--- a/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
@@ -12,7 +12,11 @@ export const useCollectionManageSetting = () => {
 export const CollectionManageSettingProvider: React.FC<{ children?: ReactNode }> = (props) => {
   const { render } = useAppSpin();
   const result = useRequest({
-    url: 'applicationPlugins:get/1?filterByTk=2',
+    resource: 'applicationPlugins',
+    action: 'get',
+    params: {
+      filter: { packageName: '@nocobase/plugin-collection-manager' },
+    },
   });
 
   useEffect(() => {

--- a/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, ReactNode, useContext, useEffect } from 'react';
+import { Result } from 'ahooks/es/useRequest/src/types';
+import { useRequest } from '../api-client';
+import { useAppSpin } from '../application/hooks/useAppSpin';
+
+export const CollectionManageSettingContext = createContext<Result<any, any>>(null);
+
+export const useCollectionManageSetting = () => {
+  return useContext(CollectionManageSettingContext);
+};
+
+export const CollectionManageSettingProvider: React.FC<{ children?: ReactNode }> = (props) => {
+  const { render } = useAppSpin();
+  const result = useRequest({
+    url: 'applicationPlugins:get/1?filterByTk=2',
+  });
+  useEffect(() => {
+    const data = (result as any)?.data?.data?.options?.randomUidBlacklist;
+    localStorage.setItem('RANDOM_UID_BLACKLIST', data);
+  }, [result]);
+  if (result.loading) {
+    return render();
+  }
+
+  return (
+    <CollectionManageSettingContext.Provider value={result}>{props.children}</CollectionManageSettingContext.Provider>
+  );
+};
+
+/** 随机UId生成的类型 */
+export enum ERandomUidType {
+  /** 数据表标识 */
+  TABLE_NAME = 'TABLE_NAME',
+  /** 数据表字段 */
+  TABLE_FIELD = 'TABLE_FIELD',
+  /** 表格下拉枚举 */
+  SELECT_OPTION = 'SELECT_OPTION',
+  /** 外键 */
+  FOREIGN_KEY = 'FOREIGN_KEY',
+}
+
+/** 获取uid黑名单 */
+export const useRandomUidBlacklist = () => {
+  const { data } = useCollectionManageSetting();
+  const randomUidBlacklist = data?.data?.options?.randomUidBlacklist;
+  return randomUidBlacklist;
+};
+
+/** 获取是否通过uid生成的name */
+export const getRandomUidName = (data: any, type: ERandomUidType, name: string) => {
+  return !data.includes(type) ? '' : name;
+};

--- a/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
@@ -1,6 +1,6 @@
-import React, { createContext, ReactNode, useContext, useEffect } from 'react';
+import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import { Result } from 'ahooks/es/useRequest/src/types';
-import { useRequest } from '../api-client';
+import { useRequest, useAPIClient } from '../api-client';
 import { useAppSpin } from '../application/hooks/useAppSpin';
 
 export const CollectionManageSettingContext = createContext<Result<any, any>>(null);
@@ -11,17 +11,51 @@ export const useCollectionManageSetting = () => {
 
 export const CollectionManageSettingProvider: React.FC<{ children?: ReactNode }> = (props) => {
   const { render } = useAppSpin();
+  const api = useAPIClient();
   const result = useRequest({
     url: 'applicationPlugins:get/1?filterByTk=2',
   });
+
+  const data = (result as any)?.data?.data?.options;
+  console.log('data:', data);
+  const update = async () => {
+    const allSelected: any = [
+      ERandomUidType.TABLE_NAME,
+      ERandomUidType.TABLE_FIELD,
+      ERandomUidType.SELECT_OPTION,
+      ERandomUidType.FOREIGN_KEY,
+    ];
+
+    await api
+      .request({
+        url: 'applicationPlugins:update',
+        method: 'post',
+        data: {
+          options: {
+            randomUidBlacklist: allSelected,
+          },
+        },
+        params: {
+          filterByTk: 2,
+        },
+      })
+      .then(() => {
+        localStorage.setItem(CONSTANT.RANDOM_UID_OPTIONS, allSelected);
+        result.run();
+      });
+  };
+
+  useRequest(() => update(), {
+    ready: data !== undefined && data?.randomUidBlacklist.length === 0 && data?.type !== CONSTANT.ALL_SELECTED_EMPTY,
+  });
+
   useEffect(() => {
     const data = (result as any)?.data?.data?.options?.randomUidBlacklist;
-    localStorage.setItem('RANDOM_UID_BLACKLIST', data);
+    localStorage.setItem(CONSTANT.RANDOM_UID_OPTIONS, data);
   }, [result]);
   if (result.loading) {
     return render();
   }
-
   return (
     <CollectionManageSettingContext.Provider value={result}>{props.children}</CollectionManageSettingContext.Provider>
   );
@@ -38,6 +72,14 @@ export enum ERandomUidType {
   /** 外键 */
   FOREIGN_KEY = 'FOREIGN_KEY',
 }
+
+/** 常量 */
+export const CONSTANT = {
+  /** 随机uid选项 */
+  RANDOM_UID_OPTIONS: 'RANDOM_UID_OPTIONS',
+  /** 所有选择为空 */
+  ALL_SELECTED_EMPTY: 'ALL_SELECTED_EMPTY',
+};
 
 /** 获取uid黑名单 */
 export const useRandomUidBlacklist = () => {

--- a/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManageSettingProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import { Result } from 'ahooks/es/useRequest/src/types';
-import { useRequest, useAPIClient } from '../api-client';
+import { useRequest } from '../api-client';
 import { useAppSpin } from '../application/hooks/useAppSpin';
 
 export const CollectionManageSettingContext = createContext<Result<any, any>>(null);
@@ -11,47 +11,13 @@ export const useCollectionManageSetting = () => {
 
 export const CollectionManageSettingProvider: React.FC<{ children?: ReactNode }> = (props) => {
   const { render } = useAppSpin();
-  const api = useAPIClient();
   const result = useRequest({
     url: 'applicationPlugins:get/1?filterByTk=2',
   });
 
-  const data = (result as any)?.data?.data?.options;
-  console.log('data:', data);
-  const update = async () => {
-    const allSelected: any = [
-      ERandomUidType.TABLE_NAME,
-      ERandomUidType.TABLE_FIELD,
-      ERandomUidType.SELECT_OPTION,
-      ERandomUidType.FOREIGN_KEY,
-    ];
-
-    await api
-      .request({
-        url: 'applicationPlugins:update',
-        method: 'post',
-        data: {
-          options: {
-            randomUidBlacklist: allSelected,
-          },
-        },
-        params: {
-          filterByTk: 2,
-        },
-      })
-      .then(() => {
-        localStorage.setItem(CONSTANT.RANDOM_UID_OPTIONS, allSelected);
-        result.run();
-      });
-  };
-
-  useRequest(() => update(), {
-    ready: data !== undefined && data?.randomUidBlacklist.length === 0 && data?.type !== CONSTANT.ALL_SELECTED_EMPTY,
-  });
-
   useEffect(() => {
     const data = (result as any)?.data?.data?.options?.randomUidBlacklist;
-    localStorage.setItem(CONSTANT.RANDOM_UID_OPTIONS, data);
+    localStorage.setItem(CONSTANT.RANDOM_UID_BLACKLIST, data);
   }, [result]);
   if (result.loading) {
     return render();
@@ -76,19 +42,17 @@ export enum ERandomUidType {
 /** 常量 */
 export const CONSTANT = {
   /** 随机uid选项 */
-  RANDOM_UID_OPTIONS: 'RANDOM_UID_OPTIONS',
-  /** 所有选择为空 */
-  ALL_SELECTED_EMPTY: 'ALL_SELECTED_EMPTY',
+  RANDOM_UID_BLACKLIST: 'RANDOM_UID_BLACKLIST',
 };
 
 /** 获取uid黑名单 */
 export const useRandomUidBlacklist = () => {
   const { data } = useCollectionManageSetting();
-  const randomUidBlacklist = data?.data?.options?.randomUidBlacklist;
+  const randomUidBlacklist = data?.data?.options?.randomUidBlacklist ?? [];
   return randomUidBlacklist;
 };
 
 /** 获取是否通过uid生成的name */
 export const getRandomUidName = (data: any, type: ERandomUidType, name: string) => {
-  return !data.includes(type) ? '' : name;
+  return data?.includes(type) ? '' : name;
 };

--- a/packages/core/client/src/collection-manager/CollectionManagerSchemaComponentProvider.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManagerSchemaComponentProvider.tsx
@@ -6,6 +6,7 @@ import {
   CollectionProvider,
   ResourceActionProvider,
   useDataSourceFromRAC,
+  CollectionManageSettingProvider,
 } from './';
 import * as hooks from './action-hooks';
 import { DataSourceProvider, ds, SubFieldDataSourceProvider } from './sub-table';
@@ -21,6 +22,7 @@ export const CollectionManagerSchemaComponentProvider: React.FC = (props) => {
         CollectionFieldProvider,
         CollectionProvider,
         ResourceActionProvider,
+        CollectionManageSettingProvider,
       }}
     >
       {props.children}

--- a/packages/core/client/src/collection-manager/CollectionManagerShortcut.tsx
+++ b/packages/core/client/src/collection-manager/CollectionManagerShortcut.tsx
@@ -51,6 +51,7 @@ const schema2: ISchema = {
   properties: {
     [uid()]: {
       // 'x-decorator': 'CollectionCategroriesProvider',
+      'x-decorator': 'CollectionManageSettingProvider',
       'x-component': 'ConfigurationTable',
     },
   },

--- a/packages/core/client/src/collection-manager/Configuration/AddCollectionAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddCollectionAction.tsx
@@ -15,8 +15,9 @@ import { useCollectionManager } from '../hooks';
 import * as components from './components';
 import { TemplateSummary } from './components/TemplateSummary';
 import { templateOptions } from './templates';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
-const getSchema = (schema, category, compile): ISchema => {
+const getSchema = (schema, category, compile, data): ISchema => {
   if (!schema) {
     return;
   }
@@ -28,15 +29,17 @@ const getSchema = (schema, category, compile): ISchema => {
     properties['defaultValue']['title'] = compile('{{ t("Default value") }}');
     properties['defaultValue']['x-decorator'] = 'FormItem';
   }
+  const name = getRandomUidName(data, ERandomUidType.TABLE_NAME, `t_${uid()}`);
   const initialValue: any = {
-    name: `t_${uid()}`,
+    name,
     template: schema.name,
     view: schema.name === 'view',
     category,
     ...cloneDeep(schema.default),
   };
   if (initialValue.reverseField) {
-    initialValue.reverseField.name = `f_${uid()}`;
+    const name = getRandomUidName(data, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
+    initialValue.reverseField.name = name;
   }
   return {
     type: 'object',
@@ -267,6 +270,7 @@ export const AddCollectionAction = (props) => {
   const {
     state: { category },
   } = useResourceActionContext();
+  const randomUidBlacklist = useRandomUidBlacklist();
   const menu = useMemo<MenuProps>(() => {
     return {
       style: {
@@ -274,7 +278,7 @@ export const AddCollectionAction = (props) => {
         overflow: 'auto',
       },
       onClick: (info) => {
-        const schema = getSchema(getTemplate(info.key), category, compile);
+        const schema = getSchema(getTemplate(info.key), category, compile, randomUidBlacklist);
         setSchema(schema);
         setVisible(true);
       },

--- a/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
@@ -16,8 +16,9 @@ import useDialect from '../hooks/useDialect';
 import { IField } from '../interfaces/types';
 import * as components from './components';
 import { getOptions } from './interfaces';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
-const getSchema = (schema: IField, record: any, compile) => {
+const getSchema = (schema: IField, record: any, compile, data) => {
   if (!schema) {
     return;
   }
@@ -48,13 +49,15 @@ const getSchema = (schema: IField, record: any, compile) => {
       },
     };
   }
+  const name = getRandomUidName(data, ERandomUidType.TABLE_NAME, `f_${uid()}`);
   const initialValue: any = {
-    name: `f_${uid()}`,
+    name,
     ...cloneDeep(schema.default),
     interface: schema.name,
   };
   if (initialValue.reverseField) {
-    initialValue.reverseField.name = `f_${uid()}`;
+    const name = getRandomUidName(data, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
+    initialValue.reverseField.name = name;
   }
   // initialValue.uiSchema.title = schema.title;
   return {
@@ -285,6 +288,7 @@ export const AddFieldAction = (props) => {
       })
       .filter((v) => v?.children?.length);
   }, [getFieldOptions]);
+  const randomUidBlacklist = useRandomUidBlacklist();
   const menu = useMemo<MenuProps>(() => {
     return {
       style: {
@@ -295,7 +299,7 @@ export const AddFieldAction = (props) => {
         //@ts-ignore
         const targetScope = e.item.props['data-targetScope'];
         targetScope && setTargetScope(targetScope);
-        const schema = getSchema(getInterface(e.key), record, compile);
+        const schema = getSchema(getInterface(e.key), record, compile, randomUidBlacklist);
         if (schema) {
           setSchema(schema);
           setVisible(true);

--- a/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
@@ -49,14 +49,14 @@ const getSchema = (schema: IField, record: any, compile, data) => {
       },
     };
   }
-  const name = getRandomUidName(data, ERandomUidType.TABLE_NAME, `f_${uid()}`);
+  const name = getRandomUidName(data, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
   const initialValue: any = {
     name,
     ...cloneDeep(schema.default),
     interface: schema.name,
   };
   if (initialValue.reverseField) {
-    const name = getRandomUidName(data, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
+    const name = getRandomUidName(data, ERandomUidType.FOREIGN_KEY, `f_${uid()}`);
     initialValue.reverseField.name = name;
   }
   // initialValue.uiSchema.title = schema.title;

--- a/packages/core/client/src/collection-manager/Configuration/AddSubFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddSubFieldAction.tsx
@@ -13,14 +13,16 @@ import { useCollectionManager } from '../hooks';
 import { useOptions } from '../hooks/useOptions';
 import { IField } from '../interfaces/types';
 import * as components from './components';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
-const getSchema = (schema: IField): ISchema => {
+const getSchema = (schema: IField, data): ISchema => {
   if (!schema) {
     return;
   }
   const properties = cloneDeep(schema.properties) as any;
+  const name = getRandomUidName(data, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
   const initialValue = {
-    name: `f_${uid()}`,
+    name,
     ...cloneDeep(schema.default),
     interface: schema.name,
   };
@@ -113,6 +115,7 @@ export const AddSubFieldAction = () => {
       };
     });
   }, [options]);
+  const randomUidBlacklist = useRandomUidBlacklist();
   const menu = useMemo<MenuProps>(() => {
     return {
       style: {
@@ -120,7 +123,7 @@ export const AddSubFieldAction = () => {
         overflow: 'auto',
       },
       onClick: (info) => {
-        const schema = getSchema(getInterface(info.key));
+        const schema = getSchema(getInterface(info.key), randomUidBlacklist);
         setSchema(schema);
         setVisible(true);
       },

--- a/packages/core/client/src/collection-manager/Configuration/ConfigurationTable.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/ConfigurationTable.tsx
@@ -18,7 +18,7 @@ import { EditSubFieldAction } from './EditSubFieldAction';
 import { FieldSummary } from './components/FieldSummary';
 import { TemplateSummary } from './components/TemplateSummary';
 import { collectionSchema } from './schemas/collections';
-import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '@nocobase/client';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
 /**
  * @param service

--- a/packages/core/client/src/collection-manager/Configuration/ConfigurationTable.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/ConfigurationTable.tsx
@@ -18,6 +18,7 @@ import { EditSubFieldAction } from './EditSubFieldAction';
 import { FieldSummary } from './components/FieldSummary';
 import { TemplateSummary } from './components/TemplateSummary';
 import { collectionSchema } from './schemas/collections';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '@nocobase/client';
 
 /**
  * @param service
@@ -78,7 +79,9 @@ const useCurrentFields = () => {
 };
 
 const useNewId = (prefix) => {
-  return `${prefix || ''}${uid()}`;
+  const data = useRandomUidBlacklist();
+  const name = getRandomUidName(data, ERandomUidType.FOREIGN_KEY, `${prefix || ''}${uid()}`);
+  return name;
 };
 
 export const ConfigurationTable = () => {

--- a/packages/core/client/src/collection-manager/Configuration/OverridingCollectionField.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/OverridingCollectionField.tsx
@@ -13,6 +13,7 @@ import { useCollectionManager } from '../hooks';
 import { IField } from '../interfaces/types';
 import { useResourceActionContext, useResourceContext } from '../ResourceActionProvider';
 import * as components from './components';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
 const getSchema = (schema: IField, record: any, compile, getContainer): ISchema => {
   if (!schema) {
@@ -160,6 +161,7 @@ export const OverridingFieldAction = (props) => {
       };
     });
   }, []);
+  const randomUidBlacklist = useRandomUidBlacklist();
   return (
     <RecordProvider record={{ ...record, collectionName: record.__parent.name }}>
       <ActionContextProvider value={{ visible, setVisible }}>
@@ -178,7 +180,8 @@ export const OverridingFieldAction = (props) => {
               if (!defaultValues?.reverseField) {
                 defaultValues.autoCreateReverseField = false;
                 defaultValues.reverseField = interfaceConf.default?.reverseField;
-                set(defaultValues.reverseField, 'name', `f_${uid()}`);
+                const data = getRandomUidName(randomUidBlacklist, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
+                set(defaultValues.reverseField, 'name', data);
                 set(defaultValues.reverseField, 'uiSchema.title', record.__parent.title);
               }
               const schema = getSchema(

--- a/packages/core/client/src/collection-manager/Configuration/SyncFieldsAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/SyncFieldsAction.tsx
@@ -16,8 +16,9 @@ import { IField } from '../interfaces/types';
 import { PreviewFields } from '../templates/components/PreviewFields';
 import { PreviewTable } from '../templates/components/PreviewTable';
 import * as components from './components';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
-const getSchema = (schema: IField, record: any, compile) => {
+const getSchema = (schema: IField, record: any, compile, data) => {
   if (!schema) {
     return;
   }
@@ -29,13 +30,15 @@ const getSchema = (schema: IField, record: any, compile) => {
     properties['defaultValue']['title'] = compile('{{ t("Default value") }}');
     properties['defaultValue']['x-decorator'] = 'FormItem';
   }
+  const name = getRandomUidName(data, ERandomUidType.TABLE_NAME, `f_${uid()}`);
   const initialValue: any = {
-    name: `f_${uid()}`,
+    name,
     ...cloneDeep(schema.default),
     interface: schema.name,
   };
   if (initialValue.reverseField) {
-    initialValue.reverseField.name = `f_${uid()}`;
+    const name = getRandomUidName(data, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
+    initialValue.reverseField.name = name;
   }
   // initialValue.uiSchema.title = schema.title;
   return {
@@ -163,6 +166,7 @@ export const SyncFieldsActionCom = (props) => {
   const [schema, setSchema] = useState({});
   const compile = useCompile();
   const { t } = useTranslation();
+  const randomUidBlacklist = useRandomUidBlacklist();
   return (
     record.template === 'view' && (
       <RecordProvider record={record}>
@@ -171,7 +175,7 @@ export const SyncFieldsActionCom = (props) => {
             <Button
               icon={<PlusOutlined />}
               onClick={(e) => {
-                const schema = getSchema({}, record, compile);
+                const schema = getSchema({}, record, compile, randomUidBlacklist);
                 if (schema) {
                   setSchema(schema);
                   setVisible(true);

--- a/packages/core/client/src/collection-manager/Configuration/ViewInheritedField.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/ViewInheritedField.tsx
@@ -11,6 +11,7 @@ import { ActionContextProvider, SchemaComponent, useCompile } from '../../schema
 import { useCollectionManager } from '../hooks';
 import { IField } from '../interfaces/types';
 import * as components from './components';
+import { ERandomUidType, getRandomUidName, useRandomUidBlacklist } from '../CollectionManageSettingProvider';
 
 const getSchema = (schema: IField, record: any, compile, getContainer): ISchema => {
   if (!schema) {
@@ -89,6 +90,7 @@ export const ViewFieldAction = (props) => {
       };
     });
   }, []);
+  const randomUidBlacklist = useRandomUidBlacklist();
   return (
     <RecordProvider record={record}>
       <ActionContextProvider value={{ visible, setVisible }}>
@@ -104,7 +106,8 @@ export const ViewFieldAction = (props) => {
             if (!defaultValues?.reverseField) {
               defaultValues.autoCreateReverseField = false;
               defaultValues.reverseField = interfaceConf.default?.reverseField;
-              set(defaultValues.reverseField, 'name', `f_${uid()}`);
+              const name = getRandomUidName(randomUidBlacklist, ERandomUidType.TABLE_FIELD, `f_${uid()}`);
+              set(defaultValues.reverseField, 'name', name);
               set(defaultValues.reverseField, 'uiSchema.title', record.__parent.title);
             }
             const schema = getSchema(

--- a/packages/core/client/src/collection-manager/index.tsx
+++ b/packages/core/client/src/collection-manager/index.tsx
@@ -22,3 +22,5 @@ export * from './templates/types';
 export * from './types';
 export * from './CollectionHistoryProvider';
 export * from './interfaces/properties';
+export * from './CollectionManageSetting';
+export * from './CollectionManageSettingProvider';

--- a/packages/core/client/src/collection-manager/interfaces/m2m.tsx
+++ b/packages/core/client/src/collection-manager/interfaces/m2m.tsx
@@ -2,6 +2,12 @@ import { ISchema } from '@formily/react';
 import { uid } from '@formily/shared';
 import { defaultProps, relationshipType, reverseFieldProperties } from './properties';
 import { IField } from './types';
+import { ERandomUidType, CONSTANT } from '../CollectionManageSettingProvider';
+
+const getThroughIsRequired = () => {
+  const randomUidBlacklist = localStorage.getItem(CONSTANT.RANDOM_UID_BLACKLIST);
+  return randomUidBlacklist.includes(ERandomUidType.TABLE_FIELD);
+};
 
 export const m2m: IField = {
   name: 'm2m',
@@ -109,6 +115,7 @@ export const m2m: IField = {
                 through: {
                   type: 'string',
                   title: '{{t("Through collection")}}',
+                  required: getThroughIsRequired(),
                   description: '{{ t("Generated automatically if left blank") }}',
                   'x-decorator': 'FormItem',
                   'x-disabled': '{{ !createOnly }}',

--- a/packages/core/client/src/collection-manager/interfaces/m2m.tsx
+++ b/packages/core/client/src/collection-manager/interfaces/m2m.tsx
@@ -6,7 +6,7 @@ import { ERandomUidType, CONSTANT } from '../CollectionManageSettingProvider';
 
 const getThroughIsRequired = () => {
   const randomUidBlacklist = localStorage.getItem(CONSTANT.RANDOM_UID_BLACKLIST);
-  return randomUidBlacklist.includes(ERandomUidType.TABLE_FIELD);
+  return randomUidBlacklist?.includes(ERandomUidType.TABLE_FIELD);
 };
 
 export const m2m: IField = {

--- a/packages/core/client/src/collection-manager/interfaces/properties/index.ts
+++ b/packages/core/client/src/collection-manager/interfaces/properties/index.ts
@@ -249,7 +249,7 @@ export const dataSource: ISchema = {
             'x-component': 'Input',
             'x-reactions': (field: Field) => {
               if (!field.initialValue) {
-                const randomUidBlacklist = localStorage.getItem(CONSTANT.RANDOM_UID_OPTIONS);
+                const randomUidBlacklist = localStorage.getItem(CONSTANT.RANDOM_UID_BLACKLIST);
                 const data = getRandomUidName(randomUidBlacklist, ERandomUidType.SELECT_OPTION, uid());
                 field.initialValue = data;
               }

--- a/packages/core/client/src/collection-manager/interfaces/properties/index.ts
+++ b/packages/core/client/src/collection-manager/interfaces/properties/index.ts
@@ -2,6 +2,7 @@ import { Field } from '@formily/core';
 import { ISchema } from '@formily/react';
 import { uid } from '@formily/shared';
 export * as operators from './operators';
+import { ERandomUidType, getRandomUidName } from '../../CollectionManageSettingProvider';
 
 export const type: ISchema = {
   type: 'string',
@@ -248,7 +249,9 @@ export const dataSource: ISchema = {
             'x-component': 'Input',
             'x-reactions': (field: Field) => {
               if (!field.initialValue) {
-                field.initialValue = uid();
+                const randomUidBlacklist = localStorage.getItem('RANDOM_UID_BLACKLIST');
+                const data = getRandomUidName(randomUidBlacklist, ERandomUidType.SELECT_OPTION, uid());
+                field.initialValue = data;
               }
             },
           },

--- a/packages/core/client/src/collection-manager/interfaces/properties/index.ts
+++ b/packages/core/client/src/collection-manager/interfaces/properties/index.ts
@@ -249,7 +249,7 @@ export const dataSource: ISchema = {
             'x-component': 'Input',
             'x-reactions': (field: Field) => {
               if (!field.initialValue) {
-                const randomUidBlacklist = localStorage.getItem('RANDOM_UID_BLACKLIST');
+                const randomUidBlacklist = localStorage.getItem('RANDOM_UID_OPTIONS');
                 const data = getRandomUidName(randomUidBlacklist, ERandomUidType.SELECT_OPTION, uid());
                 field.initialValue = data;
               }

--- a/packages/core/client/src/collection-manager/interfaces/properties/index.ts
+++ b/packages/core/client/src/collection-manager/interfaces/properties/index.ts
@@ -2,7 +2,7 @@ import { Field } from '@formily/core';
 import { ISchema } from '@formily/react';
 import { uid } from '@formily/shared';
 export * as operators from './operators';
-import { ERandomUidType, getRandomUidName } from '../../CollectionManageSettingProvider';
+import { ERandomUidType, getRandomUidName, CONSTANT } from '../../CollectionManageSettingProvider';
 
 export const type: ISchema = {
   type: 'string',
@@ -249,7 +249,7 @@ export const dataSource: ISchema = {
             'x-component': 'Input',
             'x-reactions': (field: Field) => {
               if (!field.initialValue) {
-                const randomUidBlacklist = localStorage.getItem('RANDOM_UID_OPTIONS');
+                const randomUidBlacklist = localStorage.getItem(CONSTANT.RANDOM_UID_OPTIONS);
                 const data = getRandomUidName(randomUidBlacklist, ERandomUidType.SELECT_OPTION, uid());
                 field.initialValue = data;
               }

--- a/packages/core/client/src/locale/en_US.json
+++ b/packages/core/client/src/locale/en_US.json
@@ -780,5 +780,10 @@
   "Automatically drop objects that depend on the collection (such as views), and in turn all objects that depend on those objects": "Automatically drop objects that depend on the collection (such as views), and in turn all objects that depend on those objects",
   "Sign in with another account": "Sign in with another account",
   "Return to the main application": "Return to the main application",
-  "Permission deined": "Permission denied"
+  "Permission deined": "Permission denied",
+  "Table field name": "Table field name",
+  "Table select option": "Table select option",
+  "Table name": "Table name",
+  "auto generate uid": "auto generate uid",
+  "auto generate uid switch": "auto generate uid switch"
 }

--- a/packages/core/client/src/locale/en_US.json
+++ b/packages/core/client/src/locale/en_US.json
@@ -781,9 +781,9 @@
   "Sign in with another account": "Sign in with another account",
   "Return to the main application": "Return to the main application",
   "Permission deined": "Permission denied",
-  "Table field name": "Table field name",
-  "Table select option": "Table select option",
-  "Table name": "Table name",
-  "auto generate uid": "auto generate uid",
-  "auto generate uid switch": "auto generate uid switch"
+  "Option value for choice-type fields": "Option value for choice-type fields",
+  "auto generate uid switch": "auto generate uid switch",
+  "Do not generate related identifiers randomly": "Do not generate related identifiers randomly",
+  "Collection field name": "Collection field name",
+  "Association fields foreign key": "Association fields foreign key"
 }

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -843,9 +843,10 @@
   "Permission denied": "没有权限",
   "Allow add new":"允许新增",
   "Allow selection of existing records":"允许选择已有数据",
-  "Table field name": "字段标识",
-  "Table select option": "选项值",
-  "Table name": "数据表标识",
+  "Collection field name": "数据表字段标识",
+  "Option value for choice-type fields": "选择类型字段选项值",
   "auto generate uid": "自动生成uid",
-  "auto generate uid switch": "uid的自动生成逻辑开关控制"
+  "auto generate uid switch": "自动生成逻辑开关控制",
+  "Do not generate related identifiers randomly": "不随机生成相关标识",
+  "Association fields foreign key": "关系字段外键"
 }

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -842,5 +842,10 @@
   "Return to the main application": "返回主应用",
   "Permission denied": "没有权限",
   "Allow add new":"允许新增",
-  "Allow selection of existing records":"允许选择已有数据"
+  "Allow selection of existing records":"允许选择已有数据",
+  "Table field name": "字段标识",
+  "Table select option": "选项值",
+  "Table name": "数据表标识",
+  "auto generate uid": "自动生成uid",
+  "auto generate uid switch": "uid的自动生成逻辑开关控制"
 }

--- a/packages/core/client/src/pm/index.tsx
+++ b/packages/core/client/src/pm/index.tsx
@@ -4,7 +4,7 @@ import { PluginManagerLink, SettingsCenterDropdown } from './PluginManagerLink';
 import { AdminSettingsLayout } from './PluginSetting';
 import { PluginManager } from './PluginManager';
 import { ACLPane } from '../acl/ACLShortcut';
-import { CollectionManagerPane } from '../collection-manager';
+import { CollectionManagerPane, CollectionManageSetting } from '../collection-manager';
 import { BlockTemplatesPane } from '../schema-templates';
 import { SystemSettingsPane } from '../system-settings';
 import { ADMIN_SETTINGS_PATH } from '../application';
@@ -49,6 +49,11 @@ export class PMPlugin extends Plugin {
     this.app.pluginSettingsManager.add('collection-manager.collections', {
       title: '{{t("Collections & Fields")}}',
       Component: CollectionManagerPane,
+    });
+
+    this.app.pluginSettingsManager.add('collection-manager.settings', {
+      title: '{{t("Setting")}}',
+      Component: CollectionManageSetting,
     });
   }
 

--- a/packages/core/client/src/pm/index.tsx
+++ b/packages/core/client/src/pm/index.tsx
@@ -52,7 +52,7 @@ export class PMPlugin extends Plugin {
     });
 
     this.app.pluginSettingsManager.add('collection-manager.settings', {
-      title: '{{t("Setting")}}',
+      title: '{{t("Settings")}}',
       Component: CollectionManageSetting,
     });
   }


### PR DESCRIPTION
<!-- Note -->
<!-- This is a template for submitting a new feature. 
Use the bug fix template if you're submitting a bug fix pull request by adding `template=bug_fix.md` to your pull request URL. -->

# Description (需求描述)
需要在数据表管理中做到uid自动生成逻辑开关功能

# Motivation (需求背景)
在数据表管理中系统随机生成的uid不利于维护，表达的含义不清晰，需要做到开关可配置

# Key changes (关键改动）
- Frontend (前端)
在【数据表管理】中增加设置，控制uid自动生成的逻辑。为多选的形式【数据表标识】【字段标识】【选项值】【外键】
- Backend (后端)

# Test plan (测试计划)
## Suggestions (测试建议)
<!-- Provide any suggestions or recommendations for improvements in the testing plan. -->

## Underlying risk (潜在风险)
<!-- Identify any potential risks or issues that may arise from the new feature or modification. -->

# Showcase (结果展示）
<!-- Including any screenshots of the new feature or modification. -->
