### PR TITLE
fix(plugin-workflow): fix sync collection trigger transaction

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -85,17 +85,23 @@ async function handler(this: CollectionTrigger, workflow: WorkflowModel, data: M
   // TODO: `result.toJSON()` throws error
   const json = toJSON(result);
 
-  const promise = this.workflow.trigger(
-    workflow,
-    { data: json },
-    {
-      context,
-      transaction,
-    },
-  );
-
   if (workflow.sync) {
-    await promise;
+    await this.workflow.trigger(
+      workflow,
+      { data: json },
+      {
+        context,
+        transaction,
+      },
+    );
+  } else {
+    this.workflow.trigger(
+      workflow,
+      { data: json },
+      {
+        context,
+      },
+    );
   }
 }
 


### PR DESCRIPTION
## Description (Bug 描述)

Should not pass transaction to sync trigger.

### Steps to reproduce (复现步骤)

None.

### Expected behavior (预期行为)

No transaction in async triggering.

### Actual behavior (实际行为)

Reusing committed transaction.

## Related issues (相关 issue)

None.

## Reason (原因)

Mistaken using transaction.

## Solution (解决方案)

Do not use transaction in async triggering.
