### PR TITLE
fix(client): fix cron locale when DOM and DOW both present

### DIFF
--- a/packages/core/client/src/locale/cron/zh_CN.json
+++ b/packages/core/client/src/locale/cron/zh_CN.json
@@ -19,7 +19,7 @@
   "prefixMonths": "的",
   "prefixMonthDays": "的",
   "prefixWeekDays": "的",
-  "prefixWeekDaysForMonthAndYearPeriod": "并且",
+  "prefixWeekDaysForMonthAndYearPeriod": "或者",
   "prefixHours": "的",
   "prefixMinutes": ":",
   "prefixMinutesForHourPeriod": "的",

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/schedule/locale/Cron.zh-CN.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/schedule/locale/Cron.zh-CN.ts
@@ -19,7 +19,7 @@ export default {
   prefixMonths: '的',
   prefixMonthDays: '的',
   prefixWeekDays: '的',
-  prefixWeekDaysForMonthAndYearPeriod: '并且',
+  prefixWeekDaysForMonthAndYearPeriod: '或者',
   prefixHours: '的',
   prefixMinutes: ':',
   prefixMinutesForHourPeriod: '的',


### PR DESCRIPTION
## Description (Bug 描述)

Locale of Cron component is wrong when DOM and DOW both present.

### Steps to reproduce (复现步骤)

1. Use advance repeat mode in schedule workflow configuration.

### Expected behavior (预期行为)

Show "或者" in Chinese.

### Actual behavior (实际行为)

Showing "并且".

## Related issues (相关 issue)

None.

## Reason (原因)

None.

## Solution (解决方案)

Change language in locale.
