### PR TITLE
fix(plugin-workflow): fix collection cycling triggering

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/triggers.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/triggers.ts
@@ -4,10 +4,16 @@ export default {
     on() {}
     off() {}
     sync = true;
+    validateEvent() {
+      return true;
+    }
   },
   asyncTrigger: class {
     constructor(public readonly workflow) {}
     on() {}
     off() {}
+    validateEvent() {
+      return true;
+    }
   },
 };

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -233,52 +233,6 @@ describe('workflow > Plugin', () => {
     });
   });
 
-  describe('cycling trigger', () => {
-    it('trigger should not be triggered more than once in same execution', async () => {
-      const workflow = await WorkflowModel.create({
-        enabled: true,
-        type: 'collection',
-        config: {
-          mode: 1,
-          collection: 'posts',
-        },
-      });
-
-      const n1 = await workflow.createNode({
-        type: 'create',
-        config: {
-          collection: 'posts',
-          params: {
-            values: {
-              title: 't2',
-            },
-          },
-        },
-      });
-
-      const post = await PostRepo.create({ values: { title: 't1' } });
-
-      await sleep(500);
-
-      const posts = await PostRepo.find();
-      expect(posts.length).toBe(2);
-
-      const [execution] = await workflow.getExecutions();
-      expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
-
-      // NOTE: second trigger to ensure no skipped event
-      const p3 = await PostRepo.create({ values: { title: 't2' } });
-
-      await sleep(500);
-
-      const posts2 = await PostRepo.find();
-      expect(posts2.length).toBe(4);
-
-      const [execution2] = await workflow.getExecutions({ order: [['createdAt', 'DESC']] });
-      expect(execution2.status).toBe(EXECUTION_STATUS.RESOLVED);
-    });
-  });
-
   describe('dispatcher', () => {
     it('multiple triggers in same event', async () => {
       const w1 = await WorkflowModel.create({

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -371,6 +371,113 @@ describe('workflow > triggers > collection', () => {
     });
   });
 
+  describe('cycling trigger', () => {
+    it('trigger should not be triggered more than once in same execution', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await workflow.createNode({
+        type: 'create',
+        config: {
+          collection: 'posts',
+          params: {
+            values: {
+              title: 't2',
+            },
+          },
+        },
+      });
+
+      const p1 = await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(500);
+
+      const posts = await PostRepo.find();
+      expect(posts.length).toBe(2);
+
+      const e1s = await workflow.getExecutions();
+      expect(e1s.length).toBe(1);
+      expect(e1s[0].status).toBe(EXECUTION_STATUS.RESOLVED);
+
+      // NOTE: second trigger to ensure no skipped event
+      const p3 = await PostRepo.create({ values: { title: 't3' } });
+
+      await sleep(500);
+
+      const posts2 = await PostRepo.find();
+      expect(posts2.length).toBe(4);
+
+      const e2s = await workflow.getExecutions({ order: [['createdAt', 'DESC']] });
+      expect(e2s.length).toBe(2);
+      expect(e2s[1].status).toBe(EXECUTION_STATUS.RESOLVED);
+    });
+
+    it('multiple cycling trigger should not trigger more than once', async () => {
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await w1.createNode({
+        type: 'create',
+        config: {
+          collection: 'categories',
+          params: {
+            values: {
+              title: 'c1',
+            },
+          },
+        },
+      });
+
+      const w2 = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'categories',
+        },
+      });
+
+      const n2 = await w2.createNode({
+        type: 'create',
+        config: {
+          collection: 'posts',
+          params: {
+            values: {
+              title: 't2',
+            },
+          },
+        },
+      });
+
+      const p1 = await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(500);
+
+      const posts = await PostRepo.find();
+      expect(posts.length).toBe(2);
+
+      const e1s = await w1.getExecutions();
+      expect(e1s.length).toBe(1);
+      expect(e1s[0].status).toBe(EXECUTION_STATUS.RESOLVED);
+
+      const e2s = await w2.getExecutions();
+      expect(e2s.length).toBe(1);
+      expect(e2s[0].status).toBe(EXECUTION_STATUS.RESOLVED);
+    });
+  });
+
   describe('sync', () => {
     it('sync collection trigger', async () => {
       const workflow = await WorkflowModel.create({

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/CreateInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/CreateInstruction.ts
@@ -13,7 +13,7 @@ export class CreateInstruction extends Instruction {
     const created = await repository.create({
       ...options,
       context: {
-        executionId: processor.execution.id,
+        stack: Array.from(new Set((processor.execution.context.stack ?? []).concat(processor.execution.id))),
       },
       transaction: processor.transaction,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/DestroyInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/DestroyInstruction.ts
@@ -12,7 +12,7 @@ export class DestroyInstruction extends Instruction {
     const result = await repo.destroy({
       ...options,
       context: {
-        executionId: processor.execution.id,
+        stack: Array.from(new Set((processor.execution.context.stack ?? []).concat(processor.execution.id))),
       },
       transaction: processor.transaction,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/UpdateInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/UpdateInstruction.ts
@@ -12,7 +12,7 @@ export class UpdateInstruction extends Instruction {
     const result = await repo.update({
       ...options,
       context: {
-        executionId: processor.execution.id,
+        stack: Array.from(new Set((processor.execution.context.stack ?? []).concat(processor.execution.id))),
       },
       transaction: processor.transaction,
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -1,4 +1,4 @@
-import { Collection, Model } from '@nocobase/database';
+import { Collection, Model, Transactionable } from '@nocobase/database';
 import Trigger from '.';
 import { toJSON } from '../utils';
 import type { WorkflowModel } from '../types';
@@ -153,5 +153,34 @@ export default class CollectionTrigger extends Trigger {
         }
       }
     }
+  }
+
+  async validateEvent(
+    workflow: WorkflowModel,
+    context: any,
+    options: { context?: { stack?: number[] } } & Transactionable,
+  ): Promise<boolean> {
+    if (options.context?.stack) {
+      const existed = await workflow.countExecutions({
+        where: {
+          id: options.context.stack,
+        },
+        transaction: options.transaction,
+      });
+
+      if (existed) {
+        this.workflow
+          .getLogger(workflow.id)
+          .warn(
+            `workflow ${workflow.id} has already been triggered in stack executions (${options.context.stack}), and newly triggering will be skipped.`,
+          );
+
+        return false;
+      }
+
+      context.stack = options.context.stack;
+    }
+
+    return true;
   }
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
@@ -6,6 +6,9 @@ export abstract class Trigger {
   constructor(public readonly workflow: Plugin) {}
   abstract on(workflow: WorkflowModel): void;
   abstract off(workflow: WorkflowModel): void;
+  validateEvent(workflow: WorkflowModel, context: any, options: Transactionable): boolean | Promise<boolean> {
+    return true;
+  }
   duplicateConfig?(workflow: WorkflowModel, options: Transactionable): object | Promise<object>;
   sync?: boolean;
 }


### PR DESCRIPTION
## Description (Bug 描述)

Cycling triggering cause dead loop between collection events.

### Steps to reproduce (复现步骤)

1. Create event on collection1 with a create node to create data on collection2;
2. Create event on collection2 with a create node to create data on collection1;
3. Trigger one of events.

### Expected behavior (预期行为)

Only trigger once for each event.

### Actual behavior (实际行为)

Dead loop.

## Related issues (相关 issue)

None.

## Reason (原因)

Not considered cycling event on different collections.

## Solution (解决方案)

Add stack to check event validity.
