### PR TITLE
fix(plugin-workflow): fix end logic when success

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
@@ -200,8 +200,7 @@ const useStyles = createStyles(({ css, token }) => {
         align-items: center;
         justify-content: center;
         width: 0;
-        height: 4em;
-        padding: 1em 0;
+        height: 6em;
         border-left: 1px dashed ${token.colorBgLayout};
 
         .anticon {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/end.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/instructions/end.test.ts
@@ -35,12 +35,20 @@ describe('workflow > instructions > end', () => {
         },
       });
 
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+
+      await n1.setDownstream(n2);
+
       await plugin.trigger(workflow, {});
 
       const [execution] = await workflow.getExecutions();
       expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
-      const [job] = await execution.getJobs();
-      expect(job.status).toBe(JOB_STATUS.RESOLVED);
+      const jobs = await execution.getJobs();
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
     });
 
     it('failed', async () => {
@@ -51,12 +59,20 @@ describe('workflow > instructions > end', () => {
         },
       });
 
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+
+      await n1.setDownstream(n2);
+
       await plugin.trigger(workflow, {});
 
       const [execution] = await workflow.getExecutions();
       expect(execution.status).toBe(EXECUTION_STATUS.FAILED);
-      const [job] = await execution.getJobs();
-      expect(job.status).toBe(JOB_STATUS.FAILED);
+      const jobs = await execution.getJobs();
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].status).toBe(JOB_STATUS.FAILED);
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/EndInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/EndInstruction.ts
@@ -9,9 +9,14 @@ interface Config {
 
 export default class extends Instruction {
   async run(node: FlowNodeModel, prevJob, processor: Processor) {
-    const { endStatus } = <Config>node.config;
-    return {
-      status: endStatus ?? JOB_STATUS.RESOLVED,
-    };
+    const { endStatus = JOB_STATUS.RESOLVED } = <Config>node.config;
+    await processor.saveJob({
+      status: endStatus,
+      nodeId: node.id,
+      nodeKey: node.key,
+      upstreamId: prevJob?.id ?? null,
+    });
+
+    return processor.exit(endStatus);
   }
 }


### PR DESCRIPTION
## Description (Bug 描述)

End node doesn't end process when set to success.

### Steps to reproduce (复现步骤)

1. Add any node (1).
2. Add end node (2) before the node (1).
3. Trigger the workflow.

### Expected behavior (预期行为)

Node 1 should not be executed.

### Actual behavior (实际行为)

Node 1 executed.

## Related issues (相关 issue)

None.

## Reason (原因)

Exit logic is not completed.

## Solution (解决方案)

Fix exit logic.
