### PR TITLE
fix(plugin-workflow): fix processor options to pass any context

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -484,16 +484,12 @@ export default class PluginWorkflowServer extends Plugin {
     })();
   }
 
-  private async process(
-    execution: ExecutionModel,
-    job?: JobModel,
-    { transaction }: Transactionable = {},
-  ): Promise<Processor> {
+  private async process(execution: ExecutionModel, job?: JobModel, options: Transactionable = {}): Promise<Processor> {
     if (execution.status === EXECUTION_STATUS.QUEUEING) {
-      await execution.update({ status: EXECUTION_STATUS.STARTED }, { transaction });
+      await execution.update({ status: EXECUTION_STATUS.STARTED }, { transaction: options.transaction });
     }
 
-    const processor = this.createProcessor(execution, { transaction });
+    const processor = this.createProcessor(execution, options);
 
     this.getLogger(execution.workflowId).info(`execution (${execution.id}) ${job ? 'resuming' : 'starting'}...`);
 


### PR DESCRIPTION
## Description (Bug 描述)

Context should be passed into processor instance.

### Steps to reproduce (复现步骤)

1. Trigger workflow with specific context object.
2. To use the context object from `processor.options.xxx` in instructions.

### Expected behavior (预期行为)

Could access `xxx`.

### Actual behavior (实际行为)

Throws error.

## Related issues (相关 issue)

None.

## Reason (原因)

Not passed the instance to `createProcessor`.

## Solution (解决方案)

Pass the instance.
