### PR TITLE
fix(bi): parse issue of date variables

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/utils.ts
@@ -154,7 +154,7 @@ export const transformValue = (value: any, props: any) => {
       start = start.startOf('day');
       end = end.endOf('day');
     }
-    return [moment2str(start, props), moment2str(end, props)];
+    return [start.toISOString(), end.toISOString()];
   }
   return value;
 };


### PR DESCRIPTION
## Description

### Steps to reproduce

<!-- Clear steps to reproduce the bug. -->

1. Create a chart block
2. Add filter block of chart block
3. Add a field with type of date
4. Set default value of the field as "Today" variable 

### Expected behavior

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

The default value of the field is `YYYY-MM-DDT00:00:00.000Z` to `YYYY-MM-DDT23:59:59.000Z`

### Actual behavior

<!-- Describe what actually happens when the code is executed with the bug. -->

The default value of the field is `YYYY-MM-DDT00:00:00.000Z` to `YYYY-MM-DDT00:00:00.000Z`

## Related issues

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason

<!-- Explain what caused the bug to occur. -->

Conversion error

## Solution

<!-- Describe solution to the bug clearly and consciously. -->

use `toISOString()`
