### PR TITLE
fix(client): fix filter default value

### DIFF
--- a/packages/core/client/src/schema-component/antd/filter/Filter.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/Filter.tsx
@@ -27,8 +27,10 @@ export const Filter: any = observer(
     });
 
     useEffect(() => {
-      field.initialValue = fieldSchema.defaultValue;
-    }, []);
+      if (fieldSchema.defaultValue) {
+        field.initialValue = fieldSchema.defaultValue;
+      }
+    }, [fieldSchema.defaultValue]);
     return (
       <div className={className}>
         <FilterContext.Provider


### PR DESCRIPTION
## Description

Filter field value of nodes cleared after open and just close drawer.

### Steps to reproduce

1. Add a query or update node.
2. Add a filter and save.
3. Reopen the node configuration drawer.
4. Close it.
5. Reopen it.

### Expected behavior

Filter value should be persisted in UI.

### Actual behavior

Filter value disappeared.

## Related issues

#3529.

## Reason

Undefined `defaultValue` assigned to `initialValue` in filter component.

## Solution

Check if undefined.
