### PR TITLE
fix(plugin-workflow): fix off static schedule trigger

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
@@ -218,6 +218,33 @@ describe('workflow > triggers > schedule > static mode', () => {
     });
   });
 
+  describe('status', () => {
+    it('should not trigger after turned off', async () => {
+      const start = await sleepToEvenSecond();
+      const future = new Date();
+      future.setSeconds(future.getSeconds() + 2);
+
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'schedule',
+        config: {
+          mode: 0,
+          startsOn: future.toISOString(),
+          repeat: 1000,
+        },
+      });
+
+      await sleep(1000);
+
+      await workflow.update({ enabled: false });
+
+      await sleep(3000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(0);
+    });
+  });
+
   describe('dispatch', () => {
     it('missed non-repeated scheduled time should not be triggered', async () => {
       await sleepToEvenSecond();

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
@@ -78,8 +78,8 @@ export default class StaticScheduleTrigger {
   }
 
   schedule(workflow, nextTime, toggle = true) {
-    const key = `${workflow.id}@${nextTime}`;
     if (toggle) {
+      const key = `${workflow.id}@${nextTime}`;
       if (!this.timers.has(key)) {
         const interval = Math.max(nextTime - Date.now(), 0);
         if (interval > MAX_SAFE_INTERVAL) {
@@ -95,9 +95,12 @@ export default class StaticScheduleTrigger {
         }
       }
     } else {
-      const timer = this.timers.get(key);
-      clearTimeout(timer);
-      this.timers.delete(key);
+      for (const [key, timer] of this.timers.entries()) {
+        if (key.startsWith(`${workflow.id}@`)) {
+          clearTimeout(timer);
+          this.timers.delete(key);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Event not removed when turn off static schedule trigger.

### Steps to reproduce

1. Add a static time trigger workflow which starts on some future time.
2. Turn on the workflow.
3. Turn off the workflow.

### Expected behavior

Not triggering.

### Actual behavior

Triggered.

## Related issues

#3594.

## Reason

Not cleared scheduled timers.

## Solution

Clear all the timers related to the workflow.
