### PR TITLE
fix(client): fix mistaken changed api

### DIFF
--- a/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
@@ -12,7 +12,7 @@ export type AppendsTreeSelectProps = {
   multiple?: boolean;
   filter?(field): boolean;
   collection?: string;
-  useCollection_deprecated?(props: Pick<AppendsTreeSelectProps, 'collection'>): string;
+  useCollection?(props: Pick<AppendsTreeSelectProps, 'collection'>): string;
   rootOption?: {
     label: string;
     value: string;
@@ -78,7 +78,7 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
     value: propsValue,
     onChange,
     collection,
-    useCollection_deprecated = usePropsCollection,
+    useCollection = usePropsCollection,
     filter = trueFilter,
     rootOption,
     loadData: propsLoadData,
@@ -88,7 +88,7 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
   const compile = useCompile();
   const { t } = useTranslation();
   const [optionsMap, setOptionsMap] = useState({});
-  const baseCollection = useCollection_deprecated({ collection });
+  const baseCollection = useCollection({ collection });
   const treeData = Object.values(optionsMap);
   const value: string | DefaultOptionType[] = useMemo(() => {
     if (props.multiple) {
@@ -99,7 +99,7 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
 
   const loadData = useCallback(
     async (option) => {
-      if (propsLoadData !== null) {
+      if (propsLoadData != null) {
         return propsLoadData(option);
       }
       if (!option.isLeaf && option.loadChildren) {

--- a/packages/plugins/@nocobase/plugin-snapshot-field/src/client/interface.ts
+++ b/packages/plugins/@nocobase/plugin-snapshot-field/src/client/interface.ts
@@ -176,7 +176,7 @@ export class SnapshotFieldInterface extends CollectionFieldInterface {
       'x-component': 'AppendsTreeSelect',
       'x-component-props': {
         multiple: true,
-        useCollection_deprecated: useRecordCollection,
+        useCollection: useRecordCollection,
       },
       'x-reactions': [
         {

--- a/packages/plugins/@nocobase/plugin-workflow-form-trigger/src/client/FormTrigger.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-form-trigger/src/client/FormTrigger.tsx
@@ -44,7 +44,7 @@ export default class extends Trigger {
       'x-component-props': {
         title: 'Preload associations',
         multiple: true,
-        useCollection_deprecated() {
+        useCollection() {
           const { values } = useForm();
           return values?.collection;
         },

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/schemas/collection.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/schemas/collection.ts
@@ -174,7 +174,7 @@ export const appends = {
   'x-component-props': {
     title: 'Preload associations',
     multiple: true,
-    useCollection_deprecated() {
+    useCollection() {
       const { values } = useForm();
       return values?.collection;
     },


### PR DESCRIPTION
## Description

Can not select deep appends in workflow triggers.

### Steps to reproduce

1. Create a collection trigger workflow with any collection.
2. Try to select appends field under "Created by" field.

### Expected behavior

Could show the sub-tree and select.

### Actual behavior

Not showing.

## Related issues

None.

## Reason

`useCollection` API mistaken changed.

## Solution

Change the API back.
