### PR TITLE
fix(plugin-workflow): fix schedule repeat logic

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
@@ -119,7 +119,8 @@ describe('workflow > triggers > schedule > static mode', () => {
     });
 
     it('start before now and repeat every 2 seconds after created and limit 1', async () => {
-      const start = await sleepToEvenSecond();
+      await sleepToEvenSecond();
+      const start = new Date();
       start.setMilliseconds(0);
 
       const workflow = await WorkflowModel.create({

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
@@ -27,7 +27,6 @@ export default class StaticScheduleTrigger {
 
   inspect(workflows) {
     const now = new Date();
-    now.setMilliseconds(0);
 
     workflows.forEach((workflow) => {
       const nextTime = this.getNextTime(workflow, now);
@@ -65,7 +64,8 @@ export default class StaticScheduleTrigger {
         const next = interval.next();
         return next.getTime();
       } else if (typeof config.repeat === 'number') {
-        return timestamp + ((timestamp - startTime) % config.repeat);
+        const next = timestamp + config.repeat - ((timestamp - startTime) % config.repeat);
+        return next;
       } else {
         return null;
       }


### PR DESCRIPTION
## Description

Repeat as number in schedule trigger works not correctly.

### Steps to reproduce

1. Create a schedule trigger with repeat as 10min.

### Expected behavior

Triggers every 10min from start time.

### Actual behavior

Triggers time is in chaos.

## Related issues

#3594.

## Reason

Calculation of repeat time is not correct.

## Solution

Fix repeat calculation.
