### PR TITLE
fix(plugin-workflow-action-trigger): fix appends loading

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/__tests__/trigger.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/__tests__/trigger.test.ts
@@ -358,11 +358,17 @@ describe('workflow > action-trigger', () => {
       const w1 = await WorkflowModel.create({
         enabled: true,
         type: 'action',
+        config: {
+          collection: 'posts',
+        },
       });
 
       const w2 = await WorkflowModel.create({
         enabled: true,
         type: 'action',
+        config: {
+          collection: 'posts',
+        },
       });
 
       const res1 = await userAgents[0].resource('workflows').trigger({
@@ -412,6 +418,9 @@ describe('workflow > action-trigger', () => {
       const workflow = await WorkflowModel.create({
         enabled: true,
         type: 'action',
+        config: {
+          collection: 'posts',
+        },
       });
 
       const res1 = await userAgents[0].resource('workflows').trigger({
@@ -431,6 +440,9 @@ describe('workflow > action-trigger', () => {
       const workflow = await WorkflowModel.create({
         enabled: true,
         type: 'action',
+        config: {
+          collection: 'posts',
+        },
       });
 
       const res1 = await userAgents[0].resource('workflows').trigger({
@@ -452,6 +464,9 @@ describe('workflow > action-trigger', () => {
       const w1 = await WorkflowModel.create({
         enabled: true,
         type: 'action',
+        config: {
+          collection: 'posts',
+        },
       });
 
       const res1 = await userAgents[0].resource('workflows').trigger({


### PR DESCRIPTION
## Description

Record trigger workflow with appends not loaded.

### Steps to reproduce

1. Add action workflow with appends data (like createdBy).
2. Use "Submit to workflow" button in data table action column.
3. Check context data in triggered workflow.

### Expected behavior

Appends data should be in context data as a full record.

### Actual behavior

Not exists as a full record.

## Related issues

#3657.

## Reason

Not loaded in "Submit to workflow" trigger mode.

## Solution

Add load logic.
