### PR TITLE
fix(plugin-workflow): remove string template in condition calculation

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
@@ -355,7 +355,7 @@ export default class extends Instruction {
       'x-component-props': {
         options: [
           ['basic', { label: `{{t("Basic", { ns: "${NAMESPACE}" })}}` }],
-          ...Array.from(evaluators.getEntities()),
+          ...Array.from(evaluators.getEntities()).filter(([key]) => ['math.js', 'formula.js'].includes(key)),
         ].reduce((result: RadioWithTooltipOption[], [value, options]: any) => result.concat({ value, ...options }), []),
       },
       required: true,


### PR DESCRIPTION
## Description

Should not use string template engine for calculation in condition node.

### Steps to reproduce

1. Add a condition node.
2. Check calculation engines.

### Expected behavior

String template should not be present.

### Actual behavior

String template is present.

## Related issues

None.

## Reason

String result is not related to logic checking.

## Solution

Remove it.
