### PR TITLE
fix(plugin-workflow): fix duplicated triggering schedule event

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
@@ -358,7 +358,7 @@ export default class ScheduleTrigger {
     }
 
     const { collection } = workflow.config;
-    const event = `${collection}.afterSave`;
+    const event = `${collection}.afterSaveWithAssociations`;
     const name = getHookId(workflow, event);
     if (this.events.has(name)) {
       const listener = this.events.get(name);


### PR DESCRIPTION
## Description

Occasionally duplicated triggering on schedule workflow.

### Steps to reproduce

1. Add a date field based schedule workflow and enable it.
2. Disable it and enable again.

### Expected behavior

Only trigger once on one time.

### Actual behavior

Triggered twice.

## Related issues

#3594.

## Reason

Event is not match to the add one when remove.

## Solution

Fix event key.
