### PR TITLE
feat: supports subdirectory deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,6 @@ APP_ENV=development
 APP_PORT=13000
 APP_KEY=test-key
 
-APP_PUBLIC_PATH=/nocobase/
 API_BASE_PATH=/api/
 API_BASE_URL=
 

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ APP_ENV=development
 APP_PORT=13000
 APP_KEY=test-key
 
+APP_PUBLIC_PATH=/nocobase/
 API_BASE_PATH=/api/
 API_BASE_URL=
 

--- a/docker/nocobase/Dockerfile
+++ b/docker/nocobase/Dockerfile
@@ -30,7 +30,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && apt-get update && apt-get install -y nginx
 
 RUN rm -rf /etc/nginx/sites-enabled/default
-COPY ./nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
 COPY --from=builder /app/nocobase.tar.gz /app/nocobase.tar.gz
 
 WORKDIR /app/nocobase

--- a/docker/nocobase/docker-entrypoint.sh
+++ b/docker/nocobase/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+cd /app/nocobase && yarn nocobase create-nginx-conf
+rm -rf /etc/nginx/sites-enabled/nocobase.conf
+ln -s /app/nocobase/storage/nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
+
 nginx
 echo 'nginx started';
 
@@ -14,9 +18,6 @@ if [ ! -f "/app/nocobase/package.json" ]; then
   touch /app/nocobase/node_modules/@nocobase/app/dist/client/index.html
 fi
 
-cd /app/nocobase && yarn nocobase create-nginx-conf
-rm -rf /etc/nginx/sites-enabled/nocobase.conf
-ln -s /app/nocobase/storage/nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
 cd /app/nocobase && yarn start --quickstart
 
 # Run command with node if the first argument contains a "-" or is not a system command. The last

--- a/docker/nocobase/docker-entrypoint.sh
+++ b/docker/nocobase/docker-entrypoint.sh
@@ -14,6 +14,9 @@ if [ ! -f "/app/nocobase/package.json" ]; then
   touch /app/nocobase/node_modules/@nocobase/app/dist/client/index.html
 fi
 
+cd /app/nocobase && yarn nocobase create-nginx-conf
+rm -rf /etc/nginx/sites-enabled/nocobase.conf
+ln -s /app/nocobase/storage/nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
 cd /app/nocobase && yarn start --quickstart
 
 # Run command with node if the first argument contains a "-" or is not a system command. The last

--- a/docker/nocobase/docker-entrypoint.sh
+++ b/docker/nocobase/docker-entrypoint.sh
@@ -1,13 +1,6 @@
 #!/bin/sh
 set -e
 
-cd /app/nocobase && yarn nocobase create-nginx-conf
-rm -rf /etc/nginx/sites-enabled/nocobase.conf
-ln -s /app/nocobase/storage/nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
-
-nginx
-echo 'nginx started';
-
 if [ ! -d "/app/nocobase" ]; then
   mkdir nocobase
 fi
@@ -17,6 +10,13 @@ if [ ! -f "/app/nocobase/package.json" ]; then
   tar -zxf /app/nocobase.tar.gz --absolute-names -C /app/nocobase
   touch /app/nocobase/node_modules/@nocobase/app/dist/client/index.html
 fi
+
+cd /app/nocobase && yarn nocobase create-nginx-conf
+rm -rf /etc/nginx/sites-enabled/nocobase.conf
+ln -s /app/nocobase/storage/nocobase.conf /etc/nginx/sites-enabled/nocobase.conf
+
+nginx
+echo 'nginx started';
 
 cd /app/nocobase && yarn start --quickstart
 

--- a/docker/nocobase/nocobase.conf
+++ b/docker/nocobase/nocobase.conf
@@ -36,14 +36,14 @@ server {
       add_header Cache-Control "public";
     }
 
-    location /nocobase/storage/uploads/ {
+    location /storage/uploads/ {
         alias /app/nocobase/storage/uploads/;
         add_header Cache-Control "public";
         access_log off;
         autoindex off;
     }
 
-    location /nocobase/ {
+    location / {
         root /app/nocobase/node_modules/@nocobase/app/dist/client;
         try_files $uri $uri/ /index.html;
         add_header Last-Modified $date_gmt;
@@ -53,8 +53,8 @@ server {
         etag off;
     }
 
-    location ^~ /nocobase/api/ {
-        proxy_pass http://127.0.0.1:13000/nocobase/api/;
+    location ^~ /api/ {
+        proxy_pass http://127.0.0.1:13000/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -66,8 +66,8 @@ server {
         send_timeout 600;
     }
 
-    location ^~ /nocobase/static/plugins/ {
-        proxy_pass http://127.0.0.1:13000/nocobase/static/plugins/;
+    location ^~ /static/plugins/ {
+        proxy_pass http://127.0.0.1:13000/static/plugins/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -79,8 +79,8 @@ server {
         send_timeout 600;
     }
 
-    location /nocobase/ws {
-      proxy_pass http://127.0.0.1:13000/nocobase/ws;
+    location /ws {
+      proxy_pass http://127.0.0.1:13000/ws;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";

--- a/docker/nocobase/nocobase.conf
+++ b/docker/nocobase/nocobase.conf
@@ -36,14 +36,14 @@ server {
       add_header Cache-Control "public";
     }
 
-    location /storage/uploads/ {
+    location /nocobase/storage/uploads/ {
         alias /app/nocobase/storage/uploads/;
         add_header Cache-Control "public";
         access_log off;
         autoindex off;
     }
 
-    location / {
+    location /nocobase/ {
         root /app/nocobase/node_modules/@nocobase/app/dist/client;
         try_files $uri $uri/ /index.html;
         add_header Last-Modified $date_gmt;
@@ -53,8 +53,8 @@ server {
         etag off;
     }
 
-    location ^~ /api/ {
-        proxy_pass http://127.0.0.1:13000/api/;
+    location ^~ /nocobase/api/ {
+        proxy_pass http://127.0.0.1:13000/nocobase/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -66,8 +66,8 @@ server {
         send_timeout 600;
     }
 
-    location ^~ /static/plugins/ {
-        proxy_pass http://127.0.0.1:13000/static/plugins/;
+    location ^~ /nocobase/static/plugins/ {
+        proxy_pass http://127.0.0.1:13000/nocobase/static/plugins/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -79,8 +79,8 @@ server {
         send_timeout 600;
     }
 
-    location /ws {
-      proxy_pass http://127.0.0.1:13000/ws;
+    location /nocobase/ws {
+      proxy_pass http://127.0.0.1:13000/nocobase/ws;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";

--- a/packages/core/app/client/.umirc.ts
+++ b/packages/core/app/client/.umirc.ts
@@ -16,19 +16,21 @@ const outputPluginPath = path.join(__dirname, 'src', '.plugins');
 const indexGenerator = new IndexGenerator(outputPluginPath, pluginDirs);
 indexGenerator.generate();
 
+const publicPath = process.env.APP_PUBLIC_PATH || '/';
+
 export default defineConfig({
   title: 'Loading...',
   devtool: process.env.NODE_ENV === 'development' ? 'source-map' : false,
-  favicons: ['/favicon/favicon.ico'],
+  favicons: [`${publicPath}favicon/favicon.ico`],
   metas: [{ name: 'viewport', content: 'initial-scale=0.1' }],
   links: [
-    { rel: 'apple-touch-icon', size: '180x180', ref: '/favicon/apple-touch-icon.png' },
-    { rel: 'icon', type: 'image/png', size: '32x32', ref: '/favicon/favicon-32x32.png' },
-    { rel: 'icon', type: 'image/png', size: '16x16', ref: '/favicon/favicon-16x16.png' },
-    { rel: 'manifest', href: '/favicon/site.webmanifest' },
-    { rel: 'stylesheet', href: '/global.css' },
+    { rel: 'apple-touch-icon', size: '180x180', ref: `${publicPath}favicon/apple-touch-icon.png` },
+    { rel: 'icon', type: 'image/png', size: '32x32', ref: `${publicPath}favicon/favicon-32x32.png` },
+    { rel: 'icon', type: 'image/png', size: '16x16', ref: `${publicPath}favicon/favicon-16x16.png` },
+    { rel: 'manifest', href: `${publicPath}favicon/site.webmanifest` },
+    { rel: 'stylesheet', href: `${publicPath}global.css` },
   ],
-  headScripts: ['/browser-checker.js'],
+  headScripts: [`${publicPath}browser-checker.js`],
   outputPath: path.resolve(__dirname, '../dist/client'),
   hash: true,
   alias: {
@@ -41,6 +43,7 @@ export default defineConfig({
   proxy: {
     ...umiConfig.proxy,
   },
+  publicPath,
   fastRefresh: false, // 热更新会导致 Context 丢失，不开启
   mfsu: false,
   esbuildMinifyIIFE: true,

--- a/packages/core/app/client/.umirc.ts
+++ b/packages/core/app/client/.umirc.ts
@@ -17,20 +17,26 @@ const indexGenerator = new IndexGenerator(outputPluginPath, pluginDirs);
 indexGenerator.generate();
 
 const publicPath = process.env.APP_PUBLIC_PATH || '/';
-
 export default defineConfig({
   title: 'Loading...',
   devtool: process.env.NODE_ENV === 'development' ? 'source-map' : false,
-  favicons: [`${publicPath}favicon/favicon.ico`],
+  favicons: [`{{publicPath}}favicon/favicon.ico`],
   metas: [{ name: 'viewport', content: 'initial-scale=0.1' }],
   links: [
-    { rel: 'apple-touch-icon', size: '180x180', ref: `${publicPath}favicon/apple-touch-icon.png` },
-    { rel: 'icon', type: 'image/png', size: '32x32', ref: `${publicPath}favicon/favicon-32x32.png` },
-    { rel: 'icon', type: 'image/png', size: '16x16', ref: `${publicPath}favicon/favicon-16x16.png` },
-    { rel: 'manifest', href: `${publicPath}favicon/site.webmanifest` },
-    { rel: 'stylesheet', href: `${publicPath}global.css` },
+    { rel: 'apple-touch-icon', size: '180x180', ref: `{{publicPath}}favicon/apple-touch-icon.png` },
+    { rel: 'icon', type: 'image/png', size: '32x32', ref: `{{publicPath}}favicon/favicon-32x32.png` },
+    { rel: 'icon', type: 'image/png', size: '16x16', ref: `{{publicPath}}favicon/favicon-16x16.png` },
+    { rel: 'manifest', href: `{{publicPath}}favicon/site.webmanifest` },
+    { rel: 'stylesheet', href: `{{publicPath}}global.css` },
   ],
-  headScripts: [`${publicPath}browser-checker.js`],
+  headScripts: [
+    {
+      src: `{{publicPath}}browser-checker.js`,
+    },
+    {
+      content: `window['__webpack_public_path__'] = '{{publicPath}}';`,
+    },
+  ],
   outputPath: path.resolve(__dirname, '../dist/client'),
   hash: true,
   alias: {
@@ -43,7 +49,7 @@ export default defineConfig({
   proxy: {
     ...umiConfig.proxy,
   },
-  publicPath,
+  publicPath: 'auto',
   fastRefresh: false, // 热更新会导致 Context 丢失，不开启
   mfsu: false,
   esbuildMinifyIIFE: true,

--- a/packages/core/app/client/.umirc.ts
+++ b/packages/core/app/client/.umirc.ts
@@ -16,25 +16,30 @@ const outputPluginPath = path.join(__dirname, 'src', '.plugins');
 const indexGenerator = new IndexGenerator(outputPluginPath, pluginDirs);
 indexGenerator.generate();
 
-const publicPath = process.env.APP_PUBLIC_PATH || '/';
 export default defineConfig({
   title: 'Loading...',
   devtool: process.env.NODE_ENV === 'development' ? 'source-map' : false,
-  favicons: [`{{publicPath}}favicon/favicon.ico`],
+  favicons: [`{{env.APP_PUBLIC_PATH}}favicon/favicon.ico`],
   metas: [{ name: 'viewport', content: 'initial-scale=0.1' }],
   links: [
-    { rel: 'apple-touch-icon', size: '180x180', ref: `{{publicPath}}favicon/apple-touch-icon.png` },
-    { rel: 'icon', type: 'image/png', size: '32x32', ref: `{{publicPath}}favicon/favicon-32x32.png` },
-    { rel: 'icon', type: 'image/png', size: '16x16', ref: `{{publicPath}}favicon/favicon-16x16.png` },
-    { rel: 'manifest', href: `{{publicPath}}favicon/site.webmanifest` },
-    { rel: 'stylesheet', href: `{{publicPath}}global.css` },
+    { rel: 'apple-touch-icon', size: '180x180', ref: `{{env.APP_PUBLIC_PATH}}favicon/apple-touch-icon.png` },
+    { rel: 'icon', type: 'image/png', size: '32x32', ref: `{{env.APP_PUBLIC_PATH}}favicon/favicon-32x32.png` },
+    { rel: 'icon', type: 'image/png', size: '16x16', ref: `{{env.APP_PUBLIC_PATH}}favicon/favicon-16x16.png` },
+    { rel: 'manifest', href: `{{env.APP_PUBLIC_PATH}}favicon/site.webmanifest` },
+    { rel: 'stylesheet', href: `{{env.APP_PUBLIC_PATH}}global.css` },
   ],
   headScripts: [
     {
-      src: `{{publicPath}}browser-checker.js`,
+      src: `{{env.APP_PUBLIC_PATH}}browser-checker.js`,
     },
     {
-      content: `window['__webpack_public_path__'] = '{{publicPath}}';`,
+      content: `
+        window['__webpack_public_path__'] = '{{env.APP_PUBLIC_PATH}}';
+        window['__nocobase_api_base_url__'] = '{{env.API_BASE_URL}}';
+        window['__nocobase_public_path__'] = '{{env.APP_PUBLIC_PATH}}';
+        window['__nocobase_ws_url__'] = '{{env.WS_URL}}';
+        window['__nocobase_ws_path__'] = '{{env.WS_PATH}}';
+      `,
     },
   ],
   outputPath: path.resolve(__dirname, '../dist/client'),

--- a/packages/core/app/client/src/pages/index.tsx
+++ b/packages/core/app/client/src/pages/index.tsx
@@ -4,13 +4,17 @@ import devDynamicImport from '../.plugins/index';
 
 export const app = new Application({
   apiClient: {
-    baseURL: process.env.API_BASE_URL,
+    // @ts-ignore
+    baseURL: window['__nocobase_api_base_url__'] || '/api/',
   },
-  publicPath: process.env.APP_PUBLIC_PATH,
+  // @ts-ignore
+  publicPath: window['__nocobase_public_path__'] || '/',
   plugins: [NocoBaseClientPresetPlugin],
   ws: {
-    url: process.env.WEBSOCKET_URL,
-    basename: process.env.WS_PATH || '/ws',
+    // @ts-ignore
+    url: window['__nocobase_ws_url__'] || '',
+    // @ts-ignore
+    basename: window['__nocobase_ws_path__'] || '/ws',
   },
   loadRemotePlugins: true,
   devDynamicImport,

--- a/packages/core/app/client/src/pages/index.tsx
+++ b/packages/core/app/client/src/pages/index.tsx
@@ -6,8 +6,12 @@ export const app = new Application({
   apiClient: {
     baseURL: process.env.API_BASE_URL,
   },
+  publicPath: process.env.APP_PUBLIC_PATH,
   plugins: [NocoBaseClientPresetPlugin],
-  ws: true,
+  ws: {
+    url: process.env.WEBSOCKET_URL,
+    basename: process.env.WS_PATH || '/ws',
+  },
   loadRemotePlugins: true,
   devDynamicImport,
 });

--- a/packages/core/cli/bin/index.js
+++ b/packages/core/cli/bin/index.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 const chalk = require('chalk');
-const { initEnv, genTsConfigPaths } = require('../src/util');
+const { initEnv, genTsConfigPaths, buildIndexHtml } = require('../src/util');
 
 initEnv();
 genTsConfigPaths();
+buildIndexHtml();
 
 if (require('semver').satisfies(process.version, '<16')) {
   console.error(chalk.red('[nocobase cli]: Node.js version must be >= 16'));

--- a/packages/core/cli/bin/index.js
+++ b/packages/core/cli/bin/index.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
 const chalk = require('chalk');
-const { initEnv, genTsConfigPaths, buildIndexHtml } = require('../src/util');
+const { initEnv, genTsConfigPaths } = require('../src/util');
 
 initEnv();
 genTsConfigPaths();
-buildIndexHtml();
 
 if (require('semver').satisfies(process.version, '<16')) {
   console.error(chalk.red('[nocobase cli]: Node.js version must be >= 16'));

--- a/packages/core/cli/nocobase.conf.tpl
+++ b/packages/core/cli/nocobase.conf.tpl
@@ -44,7 +44,7 @@ server {
     }
 
     location {{publicPath}} {
-        alias {{cwd}}/node_modules/@nocobase/app/dist/client;
+        alias {{cwd}}/node_modules/@nocobase/app/dist/client/;
         try_files $uri $uri/ /index.html;
         add_header Last-Modified $date_gmt;
         add_header Cache-Control 'no-store, no-cache';

--- a/packages/core/cli/nocobase.conf.tpl
+++ b/packages/core/cli/nocobase.conf.tpl
@@ -1,0 +1,89 @@
+log_format apm '"$time_local" client=$remote_addr '
+               'method=$request_method request="$request" '
+               'request_length=$request_length '
+               'status=$status bytes_sent=$bytes_sent '
+               'body_bytes_sent=$body_bytes_sent '
+               'referer=$http_referer '
+               'user_agent="$http_user_agent" '
+               'upstream_addr=$upstream_addr '
+               'upstream_status=$upstream_status '
+               'request_time=$request_time '
+               'upstream_response_time=$upstream_response_time '
+               'upstream_connect_time=$upstream_connect_time '
+               'upstream_header_time=$upstream_header_time';
+
+server {
+    listen 80;
+    server_name _;
+    root {{cwd}}/node_modules/@nocobase/app/dist/client;
+    index index.html;
+    client_max_body_size 1000M;
+    access_log /var/log/nginx/nocobase.log apm;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # 不缓存 HTML 文件
+    # location ~ \.html$ {
+    #   if_modified_since off;
+    #   expires off;
+    #   etag off;
+    # }
+
+    # # 缓存 JavaScript 和 CSS 文件
+    # location ~* \.(js|css)$ {
+    #   expires 365d;
+    #   add_header Cache-Control "public";
+    # }
+
+    location {{publicPath}}storage/uploads/ {
+        alias {{cwd}}/storage/uploads/;
+        add_header Cache-Control "public";
+        access_log off;
+        autoindex off;
+    }
+
+    location {{publicPath}} {
+        alias {{cwd}}/node_modules/@nocobase/app/dist/client;
+        try_files $uri $uri/ /index.html;
+        add_header Last-Modified $date_gmt;
+        add_header Cache-Control 'no-store, no-cache';
+        if_modified_since off;
+        expires off;
+        etag off;
+    }
+
+    location ^~ {{publicPath}}api/ {
+        proxy_pass http://127.0.0.1:{{apiPort}}{{publicPath}}api/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
+    }
+
+    location ^~ {{publicPath}}static/plugins/ {
+        proxy_pass http://127.0.0.1:{{apiPort}}{{publicPath}}static/plugins/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
+    }
+
+    location {{publicPath}}ws {
+      proxy_pass http://127.0.0.1:{{apiPort}}{{publicPath}}ws;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header Host $host;
+    }
+}

--- a/packages/core/cli/src/commands/build.js
+++ b/packages/core/cli/src/commands/build.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 const { Command } = require('commander');
-const { run, nodeCheck, isPackageValid } = require('../util');
+const { run, nodeCheck, isPackageValid, buildIndexHtml } = require('../util');
 
 /**
  *
@@ -31,5 +31,6 @@ module.exports = (cli) => {
         !options.dts ? '--no-dts' : '',
         options.sourcemap ? '--sourcemap' : '',
       ]);
+      buildIndexHtml();
     });
 };

--- a/packages/core/cli/src/commands/build.js
+++ b/packages/core/cli/src/commands/build.js
@@ -31,6 +31,6 @@ module.exports = (cli) => {
         !options.dts ? '--no-dts' : '',
         options.sourcemap ? '--sourcemap' : '',
       ]);
-      buildIndexHtml();
+      buildIndexHtml(true);
     });
 };

--- a/packages/core/cli/src/commands/create-nginx-conf.js
+++ b/packages/core/cli/src/commands/create-nginx-conf.js
@@ -1,0 +1,21 @@
+const { resolve } = require('path');
+const { Command } = require('commander');
+const { readFileSync, writeFileSync } = require('fs');
+
+/**
+ *
+ * @param {Command} cli
+ */
+module.exports = (cli) => {
+  cli.command('create-nginx-conf').action(async (name, options) => {
+    const file = resolve(__dirname, '../../nocobase.conf.tpl');
+    const data = readFileSync(file, 'utf-8');
+    const replaced = data
+      .replace(/\{\{cwd\}\}/g, '/app/nocobase')
+      .replace(/\{\{publicPath\}\}/g, process.env.APP_PUBLIC_PATH)
+      .replace(/\{\{apiPort\}\}/g, process.env.APP_PORT);
+
+    const targetFile = resolve(process.cwd(), 'storage', 'nocobase.conf');
+    writeFileSync(targetFile, replaced);
+  });
+};

--- a/packages/core/cli/src/commands/index.js
+++ b/packages/core/cli/src/commands/index.js
@@ -8,6 +8,7 @@ const { isPackageValid, generateAppDir } = require('../util');
 module.exports = (cli) => {
   generateAppDir();
   require('./global')(cli);
+  require('./create-nginx-conf')(cli);
   require('./build')(cli);
   require('./tar')(cli);
   require('./dev')(cli);

--- a/packages/core/cli/src/util.js
+++ b/packages/core/cli/src/util.js
@@ -280,7 +280,10 @@ exports.initEnv = function initEnv() {
     PLAYWRIGHT_AUTH_FILE: resolve(process.cwd(), 'storage/playwright/.auth/admin.json'),
     CACHE_DEFAULT_STORE: 'memory',
     CACHE_MEMORY_MAX: 2000,
+    PLUGIN_STATICS_PATH: '/static/plugins',
     LOGGER_BASE_PATH: 'storage/logs',
+    APP_SERVER_BASE_URL: '',
+    APP_PUBLIC_PATH: '/',
   };
 
   if (
@@ -318,5 +321,17 @@ exports.initEnv = function initEnv() {
     if (!process.env[key]) {
       process.env[key] = env[key];
     }
+  }
+
+  if (process.env.APP_PUBLIC_PATH) {
+    const publicPath = process.env.APP_PUBLIC_PATH.replace(/\/$/g, '');
+    const keys = ['API_BASE_PATH', 'WS_PATH', 'PLUGIN_STATICS_PATH'];
+    for (const key of keys) {
+      process.env[key] = publicPath + process.env[key];
+    }
+  }
+
+  if (process.env.APP_SERVER_BASE_URL && !process.env.API_BASE_URL) {
+    process.env.API_BASE_URL = process.env.APP_SERVER_BASE_URL + process.env.API_BASE_PATH;
   }
 };

--- a/packages/core/cli/src/util.js
+++ b/packages/core/cli/src/util.js
@@ -257,6 +257,18 @@ function parseEnv(name) {
   }
 }
 
+exports.buildIndexHtml = function buildIndexHtml() {
+  const file = `${process.env.APP_PACKAGE_ROOT}/dist/client/index.html`;
+  if (!fs.existsSync(file)) {
+    return;
+  }
+  const data = fs.readFileSync(file, 'utf-8');
+  const replacedData = data
+    .replace(/\{\{publicPath\}\}/g, process.env.APP_PUBLIC_PATH)
+    .replace('src="/umi.', `src="${process.env.APP_PUBLIC_PATH}umi.`);
+  fs.writeFileSync(file, replacedData, 'utf-8');
+};
+
 exports.initEnv = function initEnv() {
   const env = {
     APP_ENV: 'development',
@@ -280,7 +292,7 @@ exports.initEnv = function initEnv() {
     PLAYWRIGHT_AUTH_FILE: resolve(process.cwd(), 'storage/playwright/.auth/admin.json'),
     CACHE_DEFAULT_STORE: 'memory',
     CACHE_MEMORY_MAX: 2000,
-    PLUGIN_STATICS_PATH: '/static/plugins',
+    PLUGIN_STATICS_PATH: '/static/plugins/',
     LOGGER_BASE_PATH: 'storage/logs',
     APP_SERVER_BASE_URL: '',
     APP_PUBLIC_PATH: '/',

--- a/packages/core/cli/src/util.js
+++ b/packages/core/cli/src/util.js
@@ -278,7 +278,7 @@ function buildIndexHtml(force = false) {
     .replace(/\{\{env.WS_PATH\}\}/g, process.env.WS_PATH)
     .replace('src="/umi.', `src="${process.env.APP_PUBLIC_PATH}umi.`);
   fs.writeFileSync(file, replacedData, 'utf-8');
-};
+}
 
 exports.buildIndexHtml = buildIndexHtml;
 

--- a/packages/core/client/src/api-client/APIClient.ts
+++ b/packages/core/client/src/api-client/APIClient.ts
@@ -39,7 +39,8 @@ export class APIClient extends APIClientSDK {
   interceptors() {
     this.axios.interceptors.request.use((config) => {
       config.headers['X-With-ACL-Meta'] = true;
-      const match = location.pathname.match(/^\/apps\/([^/]*)\//);
+      const pattern = `^${this.app.getPublicPath()}apps/([^/]*)/`;
+      const match = location.pathname.match(new RegExp(pattern));
       if (match) {
         config.headers['X-App'] = match[1];
       }

--- a/packages/core/client/src/api-client/APIClient.ts
+++ b/packages/core/client/src/api-client/APIClient.ts
@@ -1,4 +1,4 @@
-import { APIClient as APIClientSDK } from '@nocobase/sdk';
+import { APIClient as APIClientSDK, getSubAppName } from '@nocobase/sdk';
 import { Result } from 'ahooks/es/useRequest/src/types';
 import { notification } from 'antd';
 import React from 'react';
@@ -39,10 +39,9 @@ export class APIClient extends APIClientSDK {
   interceptors() {
     this.axios.interceptors.request.use((config) => {
       config.headers['X-With-ACL-Meta'] = true;
-      const pattern = `^${this.app.getPublicPath()}apps/([^/]*)/`;
-      const match = location.pathname.match(new RegExp(pattern));
-      if (match) {
-        config.headers['X-App'] = match[1];
+      const appName = this.app ? getSubAppName(this.app.getPublicPath()) : null;
+      if (appName) {
+        config.headers['X-App'] = appName;
       }
       return config;
     });

--- a/packages/core/client/src/application/RouterManager.tsx
+++ b/packages/core/client/src/application/RouterManager.tsx
@@ -1,4 +1,4 @@
-import { set, get } from 'lodash';
+import { get, set } from 'lodash';
 import React, { ComponentType } from 'react';
 import {
   BrowserRouter,
@@ -10,8 +10,8 @@ import {
   RouteObject,
   useRoutes,
 } from 'react-router-dom';
-import { BlankComponent, RouterContextCleaner } from './components';
 import { Application } from './Application';
+import { BlankComponent, RouterContextCleaner } from './components';
 
 export interface BrowserRouterOptions extends Omit<BrowserRouterProps, 'children'> {
   type?: 'browser';
@@ -96,6 +96,10 @@ export class RouterManager {
 
   setType(type: RouterOptions['type']) {
     this.options.type = type;
+  }
+
+  getBasename() {
+    return this.options.basename;
   }
 
   setBasename(basename: string) {

--- a/packages/core/client/src/nocobase-buildin-plugin/index.tsx
+++ b/packages/core/client/src/nocobase-buildin-plugin/index.tsx
@@ -10,6 +10,7 @@ import { useAPIClient } from '../api-client';
 import { Application } from '../application';
 import { Plugin } from '../application/Plugin';
 import { BlockSchemaComponentPlugin } from '../block-provider';
+import { CollectionPlugin } from '../collection-manager';
 import { RemoteDocumentTitlePlugin } from '../document-title';
 import { PinnedListPlugin } from '../plugin-manager';
 import { PMPlugin } from '../pm';
@@ -22,7 +23,6 @@ import { BlockTemplateDetails, BlockTemplatePage } from '../schema-templates';
 import { SystemSettingsPlugin } from '../system-settings';
 import { CurrentUserProvider, CurrentUserSettingsMenuProvider } from '../user';
 import { LocalePlugin } from './plugins/LocalePlugin';
-import { CollectionPlugin } from '../collection-manager';
 
 const AppSpin = () => {
   return (
@@ -36,7 +36,7 @@ const useErrorProps = (app: Application, error: any) => {
     return {};
   }
   const err = error?.response?.data?.errors?.[0] || error;
-  const subApp = getSubAppName();
+  const subApp = getSubAppName(app.getPublicPath());
   switch (err.code) {
     case 'USER_HAS_NO_ROLES_ERR':
       return {

--- a/packages/core/devtools/umiConfig.js
+++ b/packages/core/devtools/umiConfig.js
@@ -37,6 +37,7 @@ function getUmiConfig() {
       return memo;
     }, {}),
     define: {
+      'process.env.APP_PUBLIC_PATH': process.env.APP_PUBLIC_PATH,
       'process.env.WS_PATH': process.env.WS_PATH,
       'process.env.API_BASE_URL': API_BASE_URL || API_BASE_PATH,
       'process.env.APP_ENV': process.env.APP_ENV,

--- a/packages/core/sdk/src/APIClient.ts
+++ b/packages/core/sdk/src/APIClient.ts
@@ -48,7 +48,7 @@ export class Auth {
     if (typeof window === 'undefined') {
       return;
     }
-    const appName = getSubAppName();
+    const appName = getSubAppName(this.api['app'] ? this.api['app'].getPublicPath() : '/');
     if (!appName) {
       return;
     }

--- a/packages/core/sdk/src/getSubAppName.ts
+++ b/packages/core/sdk/src/getSubAppName.ts
@@ -1,10 +1,11 @@
 const getSubAppName = (publicPath = '/') => {
-  const pattern = `^${publicPath}apps/([^/]*)/`;
-  const match = window.location.pathname.match(pattern);
-  if (!match) {
-    return '';
+  const prefix = `${publicPath}apps/`;
+  if (!window.location.pathname.startsWith(prefix)) {
+    return;
   }
-  return match[1];
+  const pathname = window.location.pathname.substring(prefix.length);
+  const args = pathname.split('/', 1);
+  return args[0] || '';
 };
 
 export default getSubAppName;

--- a/packages/core/sdk/src/getSubAppName.ts
+++ b/packages/core/sdk/src/getSubAppName.ts
@@ -1,5 +1,6 @@
-const getSubAppName = () => {
-  const match = window.location.pathname.match(/^\/apps\/([^/]*)\/?/);
+const getSubAppName = (publicPath = '/') => {
+  const pattern = `^${publicPath}apps/([^/]*)/`;
+  const match = window.location.pathname.match(pattern);
   if (!match) {
     return '';
   }

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -1,3 +1,3 @@
 export * from './APIClient';
-export { default as getSubAppName } from './getSubAppName';
 
+export { default as getSubAppName } from './getSubAppName';

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -15,7 +15,7 @@ import handler from 'serve-handler';
 import { parse } from 'url';
 import { AppSupervisor } from '../app-supervisor';
 import { ApplicationOptions } from '../application';
-import { PLUGIN_STATICS_PATH, getPackageDirByExposeUrl, getPackageNameByExposeUrl } from '../plugin-manager';
+import { getPackageDirByExposeUrl, getPackageNameByExposeUrl } from '../plugin-manager';
 import { applyErrorWithArgs, getErrorWithCode } from './errors';
 import { IPCSocketClient } from './ipc-socket-client';
 import { IPCSocketServer } from './ipc-socket-server';
@@ -168,6 +168,7 @@ export class Gateway extends EventEmitter {
 
   async requestHandler(req: IncomingMessage, res: ServerResponse) {
     const { pathname } = parse(req.url);
+    const { PLUGIN_STATICS_PATH, APP_PUBLIC_PATH } = process.env;
 
     if (pathname === '/__umi/api/bundle-status') {
       res.statusCode = 200;
@@ -175,7 +176,8 @@ export class Gateway extends EventEmitter {
       return;
     }
 
-    if (pathname.startsWith('/storage/uploads/')) {
+    if (pathname.startsWith(APP_PUBLIC_PATH + 'storage/uploads/')) {
+      req.url = req.url.replace(new RegExp(`^${APP_PUBLIC_PATH}`), '/');
       await compress(req, res);
       return handler(req, res, {
         public: resolve(process.cwd()),
@@ -203,7 +205,8 @@ export class Gateway extends EventEmitter {
       });
     }
 
-    if (!pathname.startsWith('/api')) {
+    if (!pathname.startsWith(process.env.API_BASE_PATH)) {
+      req.url = req.url.replace(new RegExp(`^${APP_PUBLIC_PATH}`), '/');
       await compress(req, res);
       return handler(req, res, {
         public: `${process.env.APP_PACKAGE_ROOT}/dist/client`,

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -170,7 +170,7 @@ export class Gateway extends EventEmitter {
     const { pathname } = parse(req.url);
     const { PLUGIN_STATICS_PATH, APP_PUBLIC_PATH } = process.env;
 
-    if (pathname === '/__umi/api/bundle-status') {
+    if (pathname.endsWith('/__umi/api/bundle-status')) {
       res.statusCode = 200;
       res.end('ok');
       return;

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -177,7 +177,7 @@ export class Gateway extends EventEmitter {
     }
 
     if (pathname.startsWith(APP_PUBLIC_PATH + 'storage/uploads/')) {
-      req.url = req.url.replace(new RegExp(`^${APP_PUBLIC_PATH}`), '/');
+      req.url = req.url.substring(APP_PUBLIC_PATH.length - 1);
       await compress(req, res);
       return handler(req, res, {
         public: resolve(process.cwd()),
@@ -206,7 +206,7 @@ export class Gateway extends EventEmitter {
     }
 
     if (!pathname.startsWith(process.env.API_BASE_PATH)) {
-      req.url = req.url.replace(new RegExp(`^${APP_PUBLIC_PATH}`), '/');
+      req.url = req.url.substring(APP_PUBLIC_PATH.length - 1);
       await compress(req, res);
       return handler(req, res, {
         public: `${process.env.APP_PACKAGE_ROOT}/dist/client`,

--- a/packages/core/server/src/plugin-manager/clientStaticUtils.ts
+++ b/packages/core/server/src/plugin-manager/clientStaticUtils.ts
@@ -36,7 +36,7 @@ export function getPackageFilePathWithExistCheck(packageName: string, filePath: 
 }
 
 export function getExposeUrl(packageName: string, filePath: string) {
-  return `${PLUGIN_STATICS_PATH}${packageName}/${filePath}`;
+  return `${process.env.PLUGIN_STATICS_PATH}${packageName}/${filePath}`;
 }
 
 export function getExposeReadmeUrl(packageName: string, lang: string) {
@@ -63,7 +63,7 @@ export function getExposeChangelogUrl(packageName: string) {
  * getPluginNameByClientStaticUrl('/static/plugins/@nocobase/foo/README.md') => '@nocobase/foo'
  */
 export function getPackageNameByExposeUrl(pathname: string) {
-  pathname = pathname.replace(PLUGIN_STATICS_PATH, '');
+  pathname = pathname.replace(process.env.PLUGIN_STATICS_PATH, '');
   const pathArr = pathname.split('/');
   if (pathname.startsWith('@')) {
     return pathArr.slice(0, 2).join('/');

--- a/packages/core/server/src/plugin-manager/options/resource.ts
+++ b/packages/core/server/src/plugin-manager/options/resource.ts
@@ -5,7 +5,6 @@ import Application from '../../application';
 import { getExposeUrl } from '../clientStaticUtils';
 import PluginManager from '../plugin-manager';
 //@ts-ignore
-import { version } from '../../../package.json';
 
 export default {
   name: 'pm',
@@ -131,7 +130,10 @@ export default {
           try {
             return {
               ...item.toJSON(),
-              url: `${getExposeUrl(item.packageName, PLUGIN_CLIENT_ENTRY_FILE)}?version=${item.version}`,
+              url: `${process.env.APP_SERVER_BASE_URL}${getExposeUrl(
+                item.packageName,
+                PLUGIN_CLIENT_ENTRY_FILE,
+              )}?version=${item.version}`,
             };
           } catch {
             return false;

--- a/packages/plugins/@nocobase/plugin-api-doc/src/client/Document.tsx
+++ b/packages/plugins/@nocobase/plugin-api-doc/src/client/Document.tsx
@@ -1,4 +1,5 @@
-import { css, useAPIClient, useRequest } from '@nocobase/client';
+import { css, useAPIClient, useApp, useRequest } from '@nocobase/client';
+import { getSubAppName } from '@nocobase/sdk';
 import { Select, Space, Spin, Typography } from 'antd';
 import React, { useEffect, useRef, useState } from 'react';
 import SwaggerUIBundle from 'swagger-ui-dist/swagger-ui-bundle';
@@ -13,11 +14,12 @@ const Documentation = () => {
   const { t } = useTranslation();
   const swaggerUIRef = useRef();
   const { data: urls } = useRequest<{ data: { name: string; url: string }[] }>({ url: 'swagger:getUrls' });
+  const app = useApp();
   const requestInterceptor = (req) => {
     if (!req.headers['Authorization']) {
-      const match = location.pathname.match(/^\/apps\/([^/]*)\//);
-      if (match?.[1]) {
-        req.headers['X-App'] = match?.[1];
+      const appName = getSubAppName(app.getPublicPath());
+      if (appName) {
+        req.headers['X-App'] = appName;
       }
       req.headers['Authorization'] = `Bearer ${apiClient.auth.getToken()}`;
     }

--- a/packages/plugins/@nocobase/plugin-api-doc/src/server/swagger/index.ts
+++ b/packages/plugins/@nocobase/plugin-api-doc/src/server/swagger/index.ts
@@ -1,10 +1,10 @@
 import APIDocPlugin from '../server';
 import baseSwagger from './base-swagger';
+import collectionToSwaggerObject from './collections';
 import { SchemaTypeMapping } from './constants';
 import { createDefaultActionSwagger, getInterfaceCollection } from './helpers';
 import { getPluginsSwagger, getSwaggerDocument, loadSwagger } from './loader';
 import { merge } from './merge';
-import collectionToSwaggerObject from './collections';
 
 export class SwaggerManager {
   private plugin: APIDocPlugin;
@@ -81,6 +81,10 @@ export class SwaggerManager {
     return merge(await this.getBaseSwagger(), await loadSwagger('@nocobase/server'));
   }
 
+  getURL(pathname: string) {
+    return process.env.API_BASE_PATH + pathname;
+  }
+
   async getUrls() {
     const plugins = await getPluginsSwagger(this.db)
       .then((res) => {
@@ -88,7 +92,7 @@ export class SwaggerManager {
           const schema = res[name];
           return {
             name: schema.info?.title || name,
-            url: `/api/swagger:get?ns=${encodeURIComponent(`plugins/${name}`)}`,
+            url: this.getURL(`swagger:get?ns=${encodeURIComponent(`plugins/${name}`)}`),
           };
         });
       })
@@ -102,25 +106,25 @@ export class SwaggerManager {
     return [
       {
         name: 'NocoBase API',
-        url: '/api/swagger:get',
+        url: this.getURL('swagger:get'),
       },
       {
         name: 'NocoBase API - Core',
-        url: '/api/swagger:get?ns=core',
+        url: this.getURL('swagger:get?ns=core'),
       },
       {
         name: 'NocoBase API - All plugins',
-        url: '/api/swagger:get?ns=plugins',
+        url: this.getURL('swagger:get?ns=plugins'),
       },
       {
         name: 'NocoBase API - Custom collections',
-        url: '/api/swagger:get?ns=collections',
+        url: this.getURL('swagger:get?ns=collections'),
       },
       ...plugins,
       ...collections.map((collection) => {
         return {
           name: `Collection API - ${collection.title}`,
-          url: `/api/swagger:get?ns=${encodeURIComponent('collections/' + collection.name)}`,
+          url: this.getURL(`swagger:get?ns=${encodeURIComponent('collections/' + collection.name)}`),
         };
       }),
     ];

--- a/packages/plugins/@nocobase/plugin-cas/src/client/SigninPage.tsx
+++ b/packages/plugins/@nocobase/plugin-cas/src/client/SigninPage.tsx
@@ -1,19 +1,23 @@
-import React, { useEffect } from 'react';
 import { LoginOutlined } from '@ant-design/icons';
-import { Button, Space, message } from 'antd';
-import { useLocation } from 'react-router-dom';
-import { getSubAppName } from '@nocobase/sdk';
+import { useApp } from '@nocobase/client';
 import { Authenticator } from '@nocobase/plugin-auth/client';
+import { getSubAppName } from '@nocobase/sdk';
+import { Button, Space, message } from 'antd';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 export const SigninPage = (props: { authenticator: Authenticator }) => {
   const authenticator = props.authenticator;
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const redirect = params.get('redirect');
+  const app = useApp();
 
-  const app = getSubAppName() || 'main';
+  const appName = getSubAppName(app.getPublicPath()) || 'main';
   const login = async () => {
-    window.location.replace(`/api/cas:login?authenticator=${authenticator.name}&__appName=${app}&redirect=${redirect}`);
+    window.location.replace(
+      `/api/cas:login?authenticator=${authenticator.name}&__appName=${appName}&redirect=${redirect}`,
+    );
   };
 
   useEffect(() => {

--- a/packages/plugins/@nocobase/plugin-cas/src/server/actions/service.ts
+++ b/packages/plugins/@nocobase/plugin-cas/src/server/actions/service.ts
@@ -9,7 +9,7 @@ export const service = async (ctx: Context, next: Next) => {
   if (appName && appName !== 'main') {
     const appSupervisor = AppSupervisor.getInstance();
     if (appSupervisor?.runningMode !== 'single') {
-      prefix = `/apps/${appName}`;
+      prefix = process.env.APP_PUBLIC_PATH + `apps/${appName}`;
     }
   }
 

--- a/packages/plugins/@nocobase/plugin-cas/src/server/auth.ts
+++ b/packages/plugins/@nocobase/plugin-cas/src/server/auth.ts
@@ -19,7 +19,7 @@ export class CASAuth extends BaseAuth {
     const opts = this.options || {};
     return {
       ...opts,
-      serviceUrl: `${opts.serviceDomain}/api/cas:service`,
+      serviceUrl: `${opts.serviceDomain}${process.env.API_BASE_PATH}cas:service`,
     };
   }
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/FileModel.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/FileModel.ts
@@ -10,6 +10,9 @@ export class FileModel extends Model {
       if (!json['thumbnailRule'] && storage?.type === 'ali-oss') {
         json['thumbnailRule'] = '?x-oss-process=image/auto-orient,1/resize,m_fill,w_94,h_94/quality,q_90';
       }
+      if (storage?.type === 'local' && process.env.APP_PUBLIC_PATH) {
+        json['url'] = process.env.APP_PUBLIC_PATH.replace(/\/$/g, '') + json.url;
+      }
     }
     return json;
   }

--- a/packages/plugins/@nocobase/plugin-iframe-block/src/client/Iframe.tsx
+++ b/packages/plugins/@nocobase/plugin-iframe-block/src/client/Iframe.tsx
@@ -1,5 +1,5 @@
 import { observer, useField } from '@formily/react';
-import { useAPIClient } from '@nocobase/client';
+import { useAPIClient, useApp } from '@nocobase/client';
 import { Card } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,13 +22,16 @@ export const Iframe: any = observer(
     const { t } = useTranslation();
     const api = useAPIClient();
     const field = useField();
+    const app = useApp();
 
     const src = React.useMemo(() => {
       if (mode === 'html') {
-        return `/api/iframeHtml:getHtml/${htmlId}?token=${api.auth.getToken()}&v=${field.data?.v || ''}`;
+        const options = app.getOptions();
+        const apiBaseURL: string = options?.apiClient?.['baseURL'];
+        return `${apiBaseURL}iframeHtml:getHtml/${htmlId}?token=${api.auth.getToken()}&v=${field.data?.v || ''}`;
       }
       return url;
-    }, [url, mode, htmlId, field.data?.v]);
+    }, [app, url, mode, htmlId, field.data?.v]);
 
     if ((mode === 'url' && !url) || (mode === 'html' && !htmlId)) {
       return <Card style={{ marginBottom: 24 }}>{t('Please fill in the iframe URL')}</Card>;

--- a/packages/plugins/@nocobase/plugin-mobile-client/src/client/configuration/App.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile-client/src/client/configuration/App.tsx
@@ -1,18 +1,14 @@
+import { useApp } from '@nocobase/client';
 import { Card, Form, Input } from 'antd';
 import React, { useMemo } from 'react';
 import { useTranslation } from '../locale';
-import { useLocation } from 'react-router-dom';
 
 export const AppConfiguration = () => {
+  const app = useApp();
   const { t } = useTranslation();
-  const location = useLocation();
   const targetUrl = useMemo(() => {
-    let baseUrl = '/mobile';
-    if (location.pathname.startsWith('/apps')) {
-      baseUrl = location.pathname.split('/').slice(0, 3).join('/');
-    }
-    return baseUrl;
-  }, [location.pathname]);
+    return app.getRouteUrl('/mobile');
+  }, [app]);
   return (
     <Card
       style={{

--- a/packages/plugins/@nocobase/plugin-mobile-client/src/client/router/OpenInNewTab.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile-client/src/client/router/OpenInNewTab.tsx
@@ -1,20 +1,15 @@
+import { LinkOutlined } from '@ant-design/icons';
+import { css, useApp } from '@nocobase/client';
+import { Button } from 'antd';
 import React from 'react';
 import { useTranslation } from '../locale';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { css } from '@nocobase/client';
-import { Button } from 'antd';
-import { LinkOutlined } from '@ant-design/icons';
 
 export const OpenInNewTab = () => {
-  const location = useLocation();
   const { t } = useTranslation();
+  const app = useApp();
 
   const onOpenInNewTab = () => {
-    let baseUrl = window.origin;
-    if (window.location.pathname.startsWith('/apps')) {
-      baseUrl = window.origin + window.location.pathname.split('/').slice(0, 3).join('/');
-    }
-    window.open(`${baseUrl}${location.pathname}${location.search}`);
+    window.open(app.getRouteUrl('/mobile'));
   };
 
   return (

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/AppManager.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/AppManager.tsx
@@ -1,4 +1,4 @@
-import { SchemaComponent, useRecord } from '@nocobase/client';
+import { SchemaComponent, useApp, useRecord } from '@nocobase/client';
 import { Card } from 'antd';
 import React from 'react';
 import { schema } from './settings/schemas/applications';
@@ -6,10 +6,11 @@ import { usePluginUtils } from './utils';
 
 const useLink = () => {
   const record = useRecord();
+  const app = useApp();
   if (record.options?.standaloneDeployment && record.cname) {
     return `//${record.cname}`;
   }
-  return `/apps/${record.name}/admin/`;
+  return app.getRouteUrl(`/apps/${record.name}/admin/`);
 };
 
 const AppVisitor = () => {

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/AppNameInput.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/AppNameInput.tsx
@@ -1,10 +1,12 @@
 import { connect, mapReadPretty } from '@formily/react';
+import { useApp } from '@nocobase/client';
 import { Input as AntdInput } from 'antd';
 import React from 'react';
 
 const ReadPretty = (props) => {
+  const app = useApp();
   const content = props.value && (
-    <a target={'_blank'} href={`/apps/${props.value}/admin`} rel="noreferrer">
+    <a target={'_blank'} href={app.getRouteUrl(`/apps/${props.value}/admin`)} rel="noreferrer">
       {props.value}
     </a>
   );

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/MultiAppManagerProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/MultiAppManagerProvider.tsx
@@ -20,10 +20,10 @@ const MultiAppManager = () => {
     },
   );
   const { t } = usePluginUtils();
-  const app = useApp();
+  const instance = useApp();
   const items = [
     ...(data?.data || []).map((app) => {
-      let link = `/apps/${app.name}/admin/`;
+      let link = instance.getRouteUrl(`/apps/${app.name}/admin/`);
       if (app.options?.standaloneDeployment && app.cname) {
         link = `//${app.cname}`;
       }
@@ -38,7 +38,9 @@ const MultiAppManager = () => {
     }),
     {
       key: '.manager',
-      label: <Link to={app.pluginSettingsManager.getRoutePath('multi-app-manager')}>{t('Manage applications')}</Link>,
+      label: (
+        <Link to={instance.pluginSettingsManager.getRoutePath('multi-app-manager')}>{t('Manage applications')}</Link>
+      ),
     },
   ];
   return (

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/server/server.ts
@@ -115,7 +115,7 @@ const defaultAppOptionsFactory = (appName: string, mainApp: Application) => {
     },
     plugins: ['nocobase'],
     resourcer: {
-      prefix: '/api',
+      prefix: process.env.API_BASE_PATH,
     },
   };
 };

--- a/packages/plugins/@nocobase/plugin-multi-app-share-collection/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-multi-app-share-collection/src/server/plugin.ts
@@ -274,7 +274,7 @@ export class MultiAppShareCollectionPlugin extends Plugin {
         }),
         plugins: plugins.includes('nocobase') ? ['nocobase'] : plugins,
         resourcer: {
-          prefix: '/api',
+          prefix: process.env.API_BASE_PATH,
         },
         logger: {
           ...mainApp.options.logger,

--- a/packages/plugins/@nocobase/plugin-oidc/src/client/Options.tsx
+++ b/packages/plugins/@nocobase/plugin-oidc/src/client/Options.tsx
@@ -1,9 +1,9 @@
 import { CopyOutlined } from '@ant-design/icons';
 import { ArrayItems, FormTab } from '@formily/antd-v5';
 import { observer } from '@formily/react';
-import { FormItem, Input, SchemaComponent } from '@nocobase/client';
+import { FormItem, Input, SchemaComponent, useApp } from '@nocobase/client';
 import { Card, Space, message } from 'antd';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { lang, useOidcTranslation } from './locale';
 
 const schema = {
@@ -327,9 +327,16 @@ const schema = {
 const Usage = observer(
   () => {
     const { t } = useOidcTranslation();
+    const app = useApp();
 
-    const { protocol, host } = window.location;
-    const url = `${protocol}//${host}/api/oidc:redirect`;
+    const url = useMemo(() => {
+      const options = app.getOptions();
+      const apiBaseURL: string = options?.apiClient?.['baseURL'];
+      const { protocol, host } = window.location;
+      return apiBaseURL.startsWith('http')
+        ? `${apiBaseURL}oidc:redirect`
+        : `${protocol}//${host}${apiBaseURL}oidc:redirect`;
+    }, [app]);
 
     const copy = (text: string) => {
       navigator.clipboard.writeText(text);

--- a/packages/plugins/@nocobase/plugin-oidc/src/server/actions/redirect.ts
+++ b/packages/plugins/@nocobase/plugin-oidc/src/server/actions/redirect.ts
@@ -1,6 +1,6 @@
 import { Context, Next } from '@nocobase/actions';
-import { OIDCAuth } from '../oidc-auth';
 import { AppSupervisor } from '@nocobase/server';
+import { OIDCAuth } from '../oidc-auth';
 
 export const redirect = async (ctx: Context, next: Next) => {
   const {
@@ -14,7 +14,7 @@ export const redirect = async (ctx: Context, next: Next) => {
   if (appName && appName !== 'main') {
     const appSupervisor = AppSupervisor.getInstance();
     if (appSupervisor?.runningMode !== 'single') {
-      prefix = `/apps/${appName}`;
+      prefix = process.env.APP_PUBLIC_PATH + `apps/${appName}`;
     }
   }
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as OIDCAuth;

--- a/packages/plugins/@nocobase/plugin-oidc/src/server/oidc-auth.ts
+++ b/packages/plugins/@nocobase/plugin-oidc/src/server/oidc-auth.ts
@@ -1,7 +1,7 @@
 import { AuthConfig, BaseAuth } from '@nocobase/auth';
+import { AuthModel } from '@nocobase/plugin-auth';
 import { Issuer } from 'openid-client';
 import { cookieName } from '../constants';
-import { AuthModel } from '@nocobase/plugin-auth';
 
 export class OIDCAuth extends BaseAuth {
   constructor(config: AuthConfig) {
@@ -17,7 +17,7 @@ export class OIDCAuth extends BaseAuth {
     const { http, port } = this.getOptions();
     const protocol = http ? 'http' : 'https';
     const host = port ? `${ctx.hostname}${port ? `:${port}` : ''}` : ctx.host;
-    return `${protocol}://${host}/api/oidc:redirect`;
+    return `${protocol}://${host}${process.env.API_BASE_PATH}oidc:redirect`;
   }
 
   getOptions() {

--- a/packages/plugins/@nocobase/plugin-saml/src/client/Options.tsx
+++ b/packages/plugins/@nocobase/plugin-saml/src/client/Options.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { SchemaComponent } from '@nocobase/client';
-import { Card, message } from 'antd';
 import { CopyOutlined } from '@ant-design/icons';
 import { observer, useForm } from '@formily/react';
-import { useRecord, FormItem, Input } from '@nocobase/client';
-import { lang, useSamlTranslation } from './locale';
+import { FormItem, Input, SchemaComponent, useApp, useRecord } from '@nocobase/client';
 import { getSubAppName } from '@nocobase/sdk';
+import { Card, message } from 'antd';
+import React from 'react';
+import { lang, useSamlTranslation } from './locale';
 
 const schema = {
   type: 'object',
@@ -74,10 +73,11 @@ const Usage = observer(
     const record = useRecord();
     const { t } = useSamlTranslation();
 
-    const app = getSubAppName() || 'main';
+    const app = useApp();
+    const appName = getSubAppName(app.getPublicPath()) || 'main';
     const name = form.values.name ?? record.name;
     const { protocol, host } = window.location;
-    const url = `${protocol}//${host}/api/saml:redirect?authenticator=${name}&__appName=${app}`;
+    const url = `${protocol}//${host}/api/saml:redirect?authenticator=${name}&__appName=${appName}`;
 
     const copy = (text: string) => {
       navigator.clipboard.writeText(text);

--- a/packages/plugins/@nocobase/plugin-saml/src/server/actions/redirect.ts
+++ b/packages/plugins/@nocobase/plugin-saml/src/server/actions/redirect.ts
@@ -1,6 +1,6 @@
 import { Context, Next } from '@nocobase/actions';
-import { SAMLAuth } from '../saml-auth';
 import { AppSupervisor } from '@nocobase/server';
+import { SAMLAuth } from '../saml-auth';
 
 export const redirect = async (ctx: Context, next: Next) => {
   const { authenticator, __appName: appName } = ctx.action.params || {};
@@ -9,7 +9,7 @@ export const redirect = async (ctx: Context, next: Next) => {
   if (appName && appName !== 'main') {
     const appSupervisor = AppSupervisor.getInstance();
     if (appSupervisor?.runningMode !== 'single') {
-      prefix = `/apps/${appName}`;
+      prefix = process.env.APP_PUBLIC_PATH + `apps/${appName}`;
     }
   }
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as SAMLAuth;

--- a/packages/plugins/@nocobase/plugin-saml/src/server/saml-auth.ts
+++ b/packages/plugins/@nocobase/plugin-saml/src/server/saml-auth.ts
@@ -24,7 +24,7 @@ export class SAMLAuth extends BaseAuth {
     const name = this.authenticator.get('name');
     const protocol = http ? 'http' : 'https';
     return {
-      callbackUrl: `${protocol}://${ctx.host}/api/saml:redirect?authenticator=${name}&__appName=${ctx.app.name}`,
+      callbackUrl: `${protocol}://${ctx.host}${process.env.API_BASE_PATH}saml:redirect?authenticator=${name}&__appName=${ctx.app.name}`,
       entryPoint: ssoUrl,
       issuer: name,
       cert: certificate,

--- a/packages/presets/nocobase/src/client/index.ts
+++ b/packages/presets/nocobase/src/client/index.ts
@@ -1,4 +1,4 @@
-import { NocoBaseBuildInPlugin, Plugin } from '@nocobase/client';
+import { Application, NocoBaseBuildInPlugin, Plugin } from '@nocobase/client';
 
 const getCurrentTimezone = () => {
   const timezoneOffset = new Date().getTimezoneOffset() / -60;
@@ -6,15 +6,17 @@ const getCurrentTimezone = () => {
   return (timezoneOffset > 0 ? '+' : '-') + timezone;
 };
 
-function getBasename() {
-  const match = location.pathname.match(/^\/apps\/([^/]*)\//);
-  return match ? match[0] : '/';
+function getBasename(app: Application) {
+  const publicPath = app.getPublicPath();
+  const pattern = `^${publicPath}apps/([^/]*)/`;
+  const match = location.pathname.match(new RegExp(pattern));
+  return match ? match[0] : publicPath;
 }
 
 export class NocoBaseClientPresetPlugin extends Plugin {
   async afterAdd() {
     this.router.setType('browser');
-    this.router.setBasename(getBasename());
+    this.router.setBasename(getBasename(this.app));
     this.app.apiClient.axios.interceptors.request.use((config) => {
       config.headers['X-Hostname'] = window?.location?.hostname;
       config.headers['X-Timezone'] = getCurrentTimezone();

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -2,3 +2,4 @@
 tmp
 app.watch.ts
 /e2e
+nocobase.conf


### PR DESCRIPTION
新增 `APP_PUBLIC_PATH` 环境变量，用于支持子路径部署，代码必须重新编译

1. 主子应用
2. 本地存储文件
3. mobile 端页面
4. SSO 认证跳转，包括主子应用
5. ws 的路径
6. API 文档
7. iframe 区块的 html 方式