### PR TITLE
fixing timezone header when it is negative value

### DIFF
--- a/packages/presets/nocobase/src/client/index.ts
+++ b/packages/presets/nocobase/src/client/index.ts
@@ -2,7 +2,7 @@ import { NocoBaseBuildInPlugin, Plugin } from '@nocobase/client';
 
 const getCurrentTimezone = () => {
   const timezoneOffset = new Date().getTimezoneOffset() / -60;
-  const timezone = String(timezoneOffset).padStart(2, '0') + ':00';
+  const timezone = String(Math.abs(timezoneOffset)).padStart(2, '0') + ':00';
   return (timezoneOffset > 0 ? '+' : '-') + timezone;
 };
 


### PR DESCRIPTION
The issue related is: https://github.com/nocobase/nocobase/issues/3721

When timezone is negative, like Brazilian (UTC -3), the header `X-Timezone` is `--3:00`.

This fix solve the issue ensuring the variable is positive before pad `0` and append `-`
