### PR TITLE
fix: issues/3746 fix error: unknown command 'restore'

### DIFF
--- a/packages/plugins/@nocobase/plugin-backup-restore/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-backup-restore/src/server/server.ts
@@ -1,5 +1,6 @@
 import { Plugin } from '@nocobase/server';
 import backupFilesResourcer from './resourcers/backup-files';
+import addRestoreCommand from './commands/restore-command';
 
 export default class Duplicator extends Plugin {
   beforeLoad() {
@@ -7,6 +8,8 @@ export default class Duplicator extends Plugin {
       name: `pm.${this.name}`,
       actions: ['backupFiles:*'],
     });
+
+    addRestoreCommand(this.app);
   }
 
   async load() {


### PR DESCRIPTION
## Description

### Steps to reproduce

1. create a backup
2. restore the backup

### Expected behavior

The backup is restored successfully

### Actual behavior

see error "unknown command 'restore'" in console log

## Related issues

https://github.com/nocobase/nocobase/issues/3746

## Reason

plugin-backup-restore forget to register the command 'restore'

## Solution

register the command 'restore' in beforeLoad event
