### PR TITLE
fix(auth): sso auth bug when deploying with subpath

### DIFF
--- a/packages/plugins/@nocobase/plugin-cas/src/server/actions/service.ts
+++ b/packages/plugins/@nocobase/plugin-cas/src/server/actions/service.ts
@@ -3,20 +3,25 @@ import { AppSupervisor } from '@nocobase/server';
 import { CASAuth } from '../auth';
 
 export const service = async (ctx: Context, next: Next) => {
-  const { authenticator, __appName: appName, redirect = '/admin' } = ctx.action.params;
+  const { authenticator, __appName: appName, redirect } = ctx.action.params;
 
-  let prefix = '';
+  let prefix = process.env.APP_PUBLIC_PATH || '';
   if (appName && appName !== 'main') {
     const appSupervisor = AppSupervisor.getInstance();
     if (appSupervisor?.runningMode !== 'single') {
-      prefix = process.env.APP_PUBLIC_PATH + `apps/${appName}`;
+      prefix += `apps/${appName}`;
     }
   }
 
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as CASAuth;
+
+  if (prefix.endsWith('/')) {
+    prefix = prefix.slice(0, -1);
+  }
+
   try {
     const { token } = await auth.signIn();
-    ctx.redirect(`${prefix}${redirect}?authenticator=${authenticator}&token=${token}`);
+    ctx.redirect(`${prefix}${redirect || '/admin'}?authenticator=${authenticator}&token=${token}`);
   } catch (error) {
     ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&error=${error.message}&redirect=${redirect}`);
   }

--- a/packages/plugins/@nocobase/plugin-oidc/src/server/actions/redirect.ts
+++ b/packages/plugins/@nocobase/plugin-oidc/src/server/actions/redirect.ts
@@ -10,14 +10,17 @@ export const redirect = async (ctx: Context, next: Next) => {
   const authenticator = search.get('name');
   const appName = search.get('app');
   const redirect = search.get('redirect') || '/admin';
-  let prefix = '';
+  let prefix = process.env.APP_PUBLIC_PATH || '';
   if (appName && appName !== 'main') {
     const appSupervisor = AppSupervisor.getInstance();
     if (appSupervisor?.runningMode !== 'single') {
-      prefix = process.env.APP_PUBLIC_PATH + `apps/${appName}`;
+      prefix += `apps/${appName}`;
     }
   }
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as OIDCAuth;
+  if (prefix.endsWith('/')) {
+    prefix = prefix.slice(0, -1);
+  }
   try {
     const { token } = await auth.signIn();
     ctx.redirect(`${prefix}${redirect}?authenticator=${authenticator}&token=${token}`);

--- a/packages/plugins/@nocobase/plugin-saml/src/server/actions/redirect.ts
+++ b/packages/plugins/@nocobase/plugin-saml/src/server/actions/redirect.ts
@@ -4,18 +4,21 @@ import { SAMLAuth } from '../saml-auth';
 
 export const redirect = async (ctx: Context, next: Next) => {
   const { authenticator, __appName: appName } = ctx.action.params || {};
-  const { RelayState: redirect = '/admin' } = ctx.action.params.values || {};
-  let prefix = '';
+  const { RelayState: redirect } = ctx.action.params.values || {};
+  let prefix = process.env.APP_PUBLIC_PATH || '';
   if (appName && appName !== 'main') {
     const appSupervisor = AppSupervisor.getInstance();
     if (appSupervisor?.runningMode !== 'single') {
-      prefix = process.env.APP_PUBLIC_PATH + `apps/${appName}`;
+      prefix += `/apps/${appName}`;
     }
   }
   const auth = (await ctx.app.authManager.get(authenticator, ctx)) as SAMLAuth;
+  if (prefix.endsWith('/')) {
+    prefix = prefix.slice(0, -1);
+  }
   try {
     const { token } = await auth.signIn();
-    ctx.redirect(`${prefix}${redirect}?authenticator=${authenticator}&token=${token}`);
+    ctx.redirect(`${prefix}${redirect || '/admin'}?authenticator=${authenticator}&token=${token}`);
   } catch (error) {
     ctx.redirect(`${prefix}/signin?authenticator=${authenticator}&error=${error.message}&redirect=${redirect}`);
   }


### PR DESCRIPTION
## Description

### Steps to reproduce

<!-- Clear steps to reproduce the bug. -->

1. Deploy NocoBase using subpath
2. Configure SSO auth and attempt to sign in

### Expected behavior

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

Sign in successfully.

### Actual behavior

<!-- Describe what actually happens when the code is executed with the bug. -->

Redirect URL missed subpath.

## Related issues

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason

<!-- Explain what caused the bug to occur. -->

Prefix of redirect URL is wrong.

## Solution

<!-- Describe solution to the bug clearly and consciously. -->

Add subpath to redirect URL.
