### PR TITLE
feat(plugin-user): add model method desensitize() to filter hidden field

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/server/__tests__/model.test.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/__tests__/model.test.ts
@@ -1,0 +1,27 @@
+import Database from '@nocobase/database';
+import { createMockServer, MockServer } from '@nocobase/test';
+import { UserModel } from '../models/UserModel';
+
+describe('models', () => {
+  let app: MockServer;
+  let db: Database;
+
+  beforeEach(async () => {
+    app = await createMockServer({
+      plugins: ['auth', 'users'],
+    });
+    db = app.db;
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+  });
+
+  it('model registeration', async () => {
+    const model = db.getModel('users');
+    const u1 = model.build({ nickname: 'test', password: '123' });
+    expect(u1).toBeInstanceOf(UserModel);
+    const n = u1.desensitize();
+    expect(n.password).toBeUndefined();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/server/models/UserModel.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/models/UserModel.ts
@@ -1,0 +1,15 @@
+import { Model } from '@nocobase/database';
+
+export class UserModel extends Model {
+  desensitize() {
+    const { fields } = (this.constructor as typeof UserModel).collection;
+    const result = (this.constructor as typeof UserModel).build({}, { isNewRecord: this.isNewRecord });
+    for (const [name, value] of Object.entries(this.get())) {
+      const field = fields.get(name);
+      if (field && !field.options.hidden) {
+        result.set(name, value);
+      }
+    }
+    return result;
+  }
+}

--- a/packages/plugins/@nocobase/plugin-users/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/server.ts
@@ -5,9 +5,13 @@ import { resolve } from 'path';
 
 import * as actions from './actions/users';
 import { Cache } from '@nocobase/cache';
+import { UserModel } from './models/UserModel';
 
 export default class PluginUsersServer extends Plugin {
   async beforeLoad() {
+    this.db.registerModels({
+      UserModel,
+    });
     this.db.registerOperators({
       $isCurrentUser(_, ctx) {
         return {
@@ -116,7 +120,6 @@ export default class PluginUsersServer extends Plugin {
 
   async load() {
     await this.importCollections(resolve(__dirname, 'collections'));
-
     this.db.addMigrations({
       namespace: 'users',
       directory: resolve(__dirname, 'migrations'),

--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
@@ -57,8 +57,9 @@ export default class extends Trigger {
     const { triggerWorkflows = '', values } = context.action.params;
 
     const { currentUser, currentRole } = context.state;
+    const { model: UserModel } = this.workflow.db.getCollection('users');
     const userInfo = {
-      user: toJSON(currentUser),
+      user: UserModel.build(currentUser).desensitize(),
       roleName: currentRole,
     };
 


### PR DESCRIPTION
# Description

Add model method `.desensitize()` to filter hidden field.

# Motivation

`password` and `resetToken` field should be hidden when output or save to cache.

# Key changes

- Frontend
- Backend
  - Add `UserModel` class and `.desensitize()` method.

# Test plan

## Suggestions

None.

## Underlying risk

None.

# Showcase

None.
