### PR TITLE
chore: add options for matching and ignoring test files in p-test

### DIFF
--- a/packages/core/cli/src/commands/e2e.js
+++ b/packages/core/cli/src/commands/e2e.js
@@ -243,6 +243,12 @@ module.exports = (cli) => {
     .option('--stop-on-error')
     .option('--build')
     .option('--concurrency [concurrency]', '', os.cpus().length)
+    .option(
+      '--match [match]',
+      'Only the files matching one of these patterns are executed as test files. Matching is performed against the absolute file path. Strings are treated as glob patterns.',
+      'packages/**/__e2e__/**/*.test.ts',
+    )
+    .option('--ignore [ignore]', 'Skip tests that match the pattern. Strings are treated as glob patterns.', undefined)
     .action(async (options) => {
       process.env.__E2E__ = true;
       if (options.build) {

--- a/packages/core/cli/src/commands/p-test.js
+++ b/packages/core/cli/src/commands/p-test.js
@@ -60,7 +60,8 @@ exports.pTest = async (options) => {
     fs.mkdirSync(dir, { recursive: true });
   }
 
-  const files = glob.sync('packages/**/__e2e__/**/*.test.ts', {
+  const files = glob.sync(options.match, {
+    ignore: options.ignore,
     root: process.cwd(),
   });
 


### PR DESCRIPTION
close T-3682

## 优化 E2E 并发模式参数
### 默认是运行所有 E2E 测试用例
```bash
yarn e2e p-test
```
### 该 PR 增加了 --match 和 --ignore 选项，便于本地调试
```bash
# 使用 --match 参数，实现只运行工作流相关的测试
yarn e2e p-test --match 'packages/**/{plugin-workflow,plugin-workflow-*}/**/__e2e__/**/*.test.ts'
```
```bash
# 使用 --ignore 参数，排除掉工作流相关的测试
yarn e2e p-test --ignore 'packages/**/{plugin-workflow,plugin-workflow-*}/**/__e2e__/**/*.test.ts'
```