### PR TITLE
fix(client): fix diabled in filter dynamic component

### DIFF
--- a/packages/core/client/src/schema-component/antd/filter/DynamicComponent.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/DynamicComponent.tsx
@@ -56,11 +56,12 @@ export const DynamicComponent = (props: Props) => {
             'x-read-pretty': false,
             'x-validator': undefined,
             'x-decorator': undefined,
+            'x-disabled': disabled,
           }}
         />
       </FieldContext.Provider>
     );
-  }, [props.schema]);
+  }, [props.schema, disabled]);
   return (
     <FormContext.Provider value={form}>
       {component


### PR DESCRIPTION
## Description

When use dynamic component in filter, the disabled property is not correct.

### Steps to reproduce

1. Create a query node in workflow with variable in a filter.
2. Trigger the workflow.
3. Reopen the query node in the executed workflow.
4. Check the filter.

### Expected behavior

All field in the filter should be disabled due to the workflow is executed.

### Actual behavior

The variable part is not disabled.

## Related issues

None.

## Reason

No disabled property control in `renderSchemaComponent()`.

## Solution

Add `x-disabled` to the dynamic component.
