### PR TITLE
fix(plugin-workflow-parallel): fix locale

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-parallel/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-parallel/src/locale/zh-CN.json
@@ -2,6 +2,7 @@
   "Parallel branch": "分支",
   "Run multiple branch processes in parallel.": "并行运行多个分支流程。",
   "Add branch": "增加分支",
+  "Mode": "执行模式",
   "All succeeded": "全部成功",
   "Any succeeded": "任意成功",
   "Any succeeded or failed": "任意成功或失败",


### PR DESCRIPTION
## Description

"Mode" is missed in locale file.

### Steps to reproduce

1. Add parallel node.
2. Change language to Chinese.

### Expected behavior

"Mode" should be translated.

### Actual behavior

Not translated.

## Related issues

None.

## Reason

Locale missed when split plugins.

## Solution

Add missed translation to plugin.
