### PR TITLE
Test/plugin error handler middleware

### DIFF
--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
@@ -41,12 +41,14 @@ describe('middleware', () => {
         ctx.body = {
           errors: [err.message],
         };
+
+        ctx.status = 400;
       },
     );
 
     app.use(
       (ctx, next) => {
-        ctx.throw(400, new CustomError('custom error'));
+        throw new CustomError('custom error');
       },
       { after: 'dataSource' },
     );

--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
@@ -1,0 +1,64 @@
+import { Database } from '@nocobase/database';
+import { MockServer, createMockServer } from '@nocobase/test';
+import Plugin from '..';
+
+describe('middleware', () => {
+  let app: MockServer;
+  beforeEach(async () => {
+    app = await createMockServer({
+      acl: false,
+      plugins: ['error-handler'],
+    });
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+  });
+
+  it('should handle not null error', async () => {
+    const collection = app.db.collection({
+      name: 'users',
+      fields: [
+        {
+          name: 'name',
+          type: 'string',
+        },
+      ],
+    });
+
+    await collection.sync();
+
+    class CustomError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+
+    (app.pm.get(Plugin) as Plugin).errorHandler.register(
+      (err) => err instanceof CustomError,
+      (err, ctx) => {
+        ctx.body = {
+          errors: [err.message],
+        };
+      },
+    );
+
+    app.use(
+      (ctx, next) => {
+        ctx.throw(400, new CustomError('custom error'));
+      },
+      { after: 'dataSource' },
+    );
+
+    const response = await app.agent().resource('users').create({
+      values: {},
+    });
+
+    expect(response.statusCode).toEqual(400);
+
+    expect(response.body).toEqual({
+      errors: ['custom error'],
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
@@ -41,14 +41,12 @@ describe('middleware', () => {
         ctx.body = {
           errors: [err.message],
         };
-
-        ctx.status = 400;
       },
     );
 
     app.use(
       (ctx, next) => {
-        throw new CustomError('custom error');
+        ctx.throw(400, new CustomError('custom error'));
       },
       { after: 'dataSource' },
     );

--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/error-handler.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/error-handler.ts
@@ -28,6 +28,10 @@ export class ErrorHandler {
       } catch (err) {
         ctx.log.error(err.message, { method: 'error-handler', err: err.stack });
 
+        if (err.statusCode) {
+          ctx.status = err.statusCode;
+        }
+
         for (const handler of self.handlers) {
           if (handler.guard(err)) {
             return handler.render(err, ctx);


### PR DESCRIPTION
## Description

### Steps to reproduce

As in case.

### Expected behavior

Throw error to client as `400` status.

### Actual behavior

`200`.

## Related issues

None.

## Reason

Middleware?

## Solution

None.
