### PR TITLE
fix(evaluators): fix array flatten

### DIFF
--- a/packages/core/evaluators/src/utils/__tests__/appendArrayColumn.test.ts
+++ b/packages/core/evaluators/src/utils/__tests__/appendArrayColumn.test.ts
@@ -1,0 +1,31 @@
+import { get } from 'lodash';
+
+import { appendArrayColumn } from '..';
+
+describe('evaluators > appendArrayColumn()', () => {
+  it('simple array', () => {
+    const scope = {
+      a: [{ b: 1 }, { b: 2 }],
+    };
+    appendArrayColumn(scope, 'a.b');
+    expect(get(scope, 'a.b')).toEqual([1, 2]);
+  });
+
+  it('nested array', () => {
+    const scope = {
+      a: [
+        {
+          b: [{ c: 1 }, { c: 2 }],
+        },
+        {
+          b: [{ c: 3 }, { c: 4 }],
+        },
+      ],
+    };
+    appendArrayColumn(scope, 'a.b.c');
+    const a_b: any = [{ c: 1 }, { c: 2 }, { c: 3 }, { c: 4 }];
+    a_b.c = [1, 2, 3, 4];
+    expect(get(scope, 'a.b')).toEqual(a_b);
+    expect(get(scope, 'a.b.c')).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/packages/core/evaluators/src/utils/index.ts
+++ b/packages/core/evaluators/src/utils/index.ts
@@ -11,7 +11,7 @@ export function appendArrayColumn(scope, key) {
     const path = paths[p];
     const isIndex = path.match(/^\d+$/);
     if (Array.isArray(data) && !isIndex && !data[path]) {
-      data[path] = data.map((item) => item[path]);
+      data[path] = data.map((item) => item[path]).flat();
     }
     data = data?.[path];
   }


### PR DESCRIPTION
## Description

Deep array should be flatten.

### Steps to reproduce

```
const scope = appendArrayColumn({ a: [{ b: [{ c: 1 }, { c: 2 }] }, { b: [{ c: 3 }, { c: 4 }] }] }, 'a.b.c');
get(scope, 'a.b.c');
```

### Expected behavior

```
[1, 2, 3, 4]
```

### Actual behavior


```
[{ b: [{ c: 1 }, { c: 2 }] }, { b: [{ c: 3 }, { c: 4 }] }]
```

## Related issues

None.

## Reason

Array not flatten.

## Solution

Flat array.
