### PR TITLE
fix(plugin-workflow): adjust locale

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -435,7 +435,7 @@ export function WorkflowConfig() {
       ns: 'workflow',
     }),
     'customize:triggerWorkflows': t(
-      'Workflow will be triggered directly once the button clicked, without data saving.',
+      'Workflow will be triggered directly once the button clicked, without data saving. Only supports "Post-action event" for now.',
       { ns: 'workflow' },
     ),
     destroy: t('Workflow will be triggered before deleting succeeded.', { ns: 'workflow' }),

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
@@ -38,7 +38,7 @@
 
   "Bind workflows": "绑定工作流",
   "Workflow will be triggered before or after submitting succeeded based on workflow type.": "工作流会基于其类型在提交成功之前或之后触发。",
-  "Workflow will be triggered directly once the button clicked, without data saving.": "按钮点击后直接触发工作流，但不会保存数据。",
+  "Workflow will be triggered directly once the button clicked, without data saving. Only supports \"Post-action event\" for now.": "按钮点击后直接触发工作流，但不会保存数据。目前仅支持“操作后事件”。",
   "Workflow will be triggered before deleting succeeded.": "删除成功之前触发工作流。",
   "Submit to workflow": "提交至工作流",
   "Add workflow": "添加工作流",


### PR DESCRIPTION
# Description

Adjust locale.

# Motivation

To explain "Submit to workflow" button can only be used for "Post-action event".

# Key changes

- Frontend
- Backend

# Test plan

## Suggestions

None.

## Underlying risk

None.

# Showcase

None.
