### PR TITLE
fix(auth): sign up page not found when entering with url directly

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/client/pages/AuthLayout.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/pages/AuthLayout.tsx
@@ -3,11 +3,16 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { useSystemSettings, PoweredBy, useRequest, useAPIClient } from '@nocobase/client';
 import { AuthenticatorsContext } from '../authenticator';
+import { Spin } from 'antd';
 
 export function AuthLayout(props: any) {
   const { data } = useSystemSettings();
   const api = useAPIClient();
-  const { data: authenticators = [], error } = useRequest(() =>
+  const {
+    data: authenticators = [],
+    error,
+    loading,
+  } = useRequest(() =>
     api
       .resource('authenticators')
       .publicList()
@@ -15,6 +20,10 @@ export function AuthLayout(props: any) {
         return res?.data?.data || [];
       }),
   );
+
+  if (loading) {
+    return <Spin />;
+  }
 
   if (error) {
     throw error;


### PR DESCRIPTION
## Description

### Steps to reproduce

<!-- Clear steps to reproduce the bug. -->

Enter `/signup?name=basic` with url directly

### Expected behavior

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

It shows up sign up page.

### Actual behavior

<!-- Describe what actually happens when the code is executed with the bug. -->

It shows up not found page.

## Related issues

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason

<!-- Explain what caused the bug to occur. -->

The request of `authenticators:publicList` is loading when the page showing up.

## Solution

<!-- Describe solution to the bug clearly and consciously. -->

Return `<Spin />` instead of the sign up page if the status of the request is loading.
