### PR TITLE
fix(server): `Cannot read properties of undefined (reading 'reqId')` error when using `runAsCLI` without `option` argument

### DIFF
--- a/packages/core/server/src/application.ts
+++ b/packages/core/server/src/application.ts
@@ -731,7 +731,7 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     if (this.activatedCommand) {
       return;
     }
-    if (options.reqId) {
+    if (options?.reqId) {
       this.context.reqId = options.reqId;
       this._logger = this._logger.child({ reqId: this.context.reqId });
     }


### PR DESCRIPTION
## Description
The runAsCLI function's argument: 'options' is an optional argument.
However, there were instances where it was being treated as a regular argument, which was causing errors.
I have changed it to be nullable.

### Steps to reproduce
yarn run:example app/single-app start

### Expected behavior
example starts.

### Actual behavior
error occurred.
```
TypeError: Cannot read properties of undefined (reading 'reqId')
    at AsyncEmitter.runAsCLI (c:\nocobase\packages\core\server\src\application.ts:734:17)
    at Database (c:\nocobase\examples\index.ts:9:7)
    at Object.<anonymous> (c:\nocobase\examples\index.ts:14:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Object.j (C:\nocobase\node_modules\@umijs\plugin-run\node_modules\tsx\dist\cjs\index.cjs:1:1197)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
```

## Related issues

## Reason
The runAsCLI function's argument: 'options' is an optional argument.
However, there were instances where it was being treated as a regular argument, which was causing errors.

## Solution
I have changed it to be nullable.
