### PR TITLE
chore(Theme): set the default font size of the Compact theme to 16

### DIFF
--- a/packages/plugins/@nocobase/plugin-theme-editor/src/server/builtinThemes.ts
+++ b/packages/plugins/@nocobase/plugin-theme-editor/src/server/builtinThemes.ts
@@ -28,6 +28,9 @@ export const compact: Omit<ThemeItem, 'id'> = {
     name: 'Compact',
     // @ts-ignore
     algorithm: 'compactAlgorithm',
+    token: {
+      fontSize: 16,
+    },
   },
   optional: true,
   isBuiltIn: true,

--- a/packages/plugins/@nocobase/plugin-theme-editor/src/server/builtinThemes.ts
+++ b/packages/plugins/@nocobase/plugin-theme-editor/src/server/builtinThemes.ts
@@ -44,6 +44,9 @@ export const compactDark: Omit<ThemeItem, 'id'> = {
     name: 'Compact dark',
     // @ts-ignore
     algorithm: ['compactAlgorithm', 'darkAlgorithm'],
+    token: {
+      fontSize: 16,
+    },
   },
   optional: true,
   isBuiltIn: true,


### PR DESCRIPTION
close T-4074

## 将`紧凑`和`暗黑紧凑`主题的默认 fonstSize 改为 16
实际表现是页面中的普通文字的字号会是 14。

![image](https://github.com/nocobase/nocobase/assets/38434641/69072367-56fe-4666-bc0c-caebbef9e154)
