### PR TITLE
fix(core): fix round bug in formula evaluator

### DIFF
--- a/packages/core/evaluators/src/server/__tests__/index.test.ts
+++ b/packages/core/evaluators/src/server/__tests__/index.test.ts
@@ -145,6 +145,16 @@ describe('evaluate', () => {
       const result = formulaEval('{{a.1a}}', { a: { '1a': 1 } });
       expect(result).toBe(1);
     });
+
+    it('number greater than 32bit integer', () => {
+      const result = formulaEval('{{a}}', { a: 1609459200000 });
+      expect(result).toBe(1609459200000);
+    });
+
+    it('ISO date string parsing by Date.parse', () => {
+      const result = formulaEval('Date.parse({{a}})', { a: '2021-01-01T00:00:00.000Z' });
+      expect(result).toBe(1609459200000);
+    });
   });
 
   describe('string', () => {

--- a/packages/core/evaluators/src/utils/formulajs.ts
+++ b/packages/core/evaluators/src/utils/formulajs.ts
@@ -1,4 +1,5 @@
 import * as functions from '@formulajs/formulajs';
+import { round } from 'mathjs';
 
 import { evaluate } from '.';
 
@@ -12,7 +13,7 @@ export default evaluate.bind(function (expression: string, scope = {}) {
     if (Number.isNaN(result) || !Number.isFinite(result)) {
       return null;
     }
-    return functions.ROUND(result, 9);
+    return round(result, 9);
   }
   return result;
 }, {});


### PR DESCRIPTION
## Description

### Steps to reproduce

1. Use a number greater than 32 bit integer in formula.js calculation.
2. Execute the calculation.

### Expected behavior

The number should be output as same input.

### Actual behavior

`NaN`.

## Related issues

None.

## Reason

`ROUND()` function in formula.js is not same function as `round()` in math.js, which produce `NaN`.

## Solution

Use `round()` in math.js instead.
