### PR TITLE
fix(associationBlock): get the correct association

### DIFF
--- a/packages/core/client/src/data-source/collection/AssociationProvider.tsx
+++ b/packages/core/client/src/data-source/collection/AssociationProvider.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, createContext, useContext } from 'react';
-import { CollectionFieldProvider, useCollectionField } from '../collection-field';
+import { CollectionFieldProvider } from '../collection-field';
 import { CollectionDeletedPlaceholder } from '../components/CollectionDeletedPlaceholder';
 import { Collection } from './Collection';
 import { useCollectionManager } from './CollectionManagerProvider';
@@ -40,9 +40,4 @@ export const AssociationProvider: FC<AssociationProviderProps> = (props) => {
       </ParentCollectionProvider>
     </CollectionProvider>
   );
-};
-
-export const useAssociationName = () => {
-  const field = useCollectionField();
-  return field ? `${field.collectionName}.${field.name}` : null;
 };

--- a/packages/core/client/src/data-source/data-block/DataBlockProvider.tsx
+++ b/packages/core/client/src/data-source/data-block/DataBlockProvider.tsx
@@ -4,6 +4,7 @@ import { ACLCollectionProvider } from '../../acl/ACLProvider';
 import { UseRequestOptions, UseRequestService } from '../../api-client';
 import { withDynamicSchemaProps } from '../../application/hoc';
 import { Designable, useDesignable } from '../../schema-component';
+import { PopupAssociationProvider } from '../../schema-component/antd/action/PopupAssociationProvider';
 import { AssociationProvider, CollectionManagerProvider, CollectionOptions, CollectionProvider } from '../collection';
 import { CollectionRecord } from '../collection-record';
 import { BlockRequestProvider } from './DataBlockRequestProvider';
@@ -149,7 +150,9 @@ export const DataBlockProvider: FC<DataBlockProviderProps & { children?: ReactNo
           <AssociationOrCollectionProvider collection={collection} association={association}>
             <ACLCollectionProvider>
               <DataBlockResourceProvider>
-                <BlockRequestProvider>{children}</BlockRequestProvider>
+                <PopupAssociationProvider association={association}>
+                  <BlockRequestProvider>{children}</BlockRequestProvider>
+                </PopupAssociationProvider>
               </DataBlockResourceProvider>
             </ACLCollectionProvider>
           </AssociationOrCollectionProvider>

--- a/packages/core/client/src/modules/blocks/data-blocks/details-single/RecordReadPrettyFormBlockInitializer.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/details-single/RecordReadPrettyFormBlockInitializer.tsx
@@ -2,10 +2,10 @@ import { FormOutlined } from '@ant-design/icons';
 import React, { useCallback } from 'react';
 import { SchemaInitializerItem, useSchemaInitializer, useSchemaInitializerItem } from '../../../../application';
 import { useCollection_deprecated } from '../../../../collection-manager';
+import { usePopupAssociation } from '../../../../schema-component/antd/action/PopupAssociationProvider';
 import { useRecordCollectionDataSourceItems } from '../../../../schema-initializer/utils';
 import { useSchemaTemplateManager } from '../../../../schema-templates';
 import { createDetailsUISchema } from './createDetailsUISchema';
-import { useAssociationName } from '../../../../data-source';
 
 export const RecordReadPrettyFormBlockInitializer = () => {
   const itemConfig = useSchemaInitializerItem();
@@ -27,7 +27,7 @@ export const RecordReadPrettyFormBlockInitializer = () => {
 export function useCreateSingleDetailsSchema() {
   const { insert } = useSchemaInitializer();
   const { getTemplateSchemaByMode } = useSchemaTemplateManager();
-  const association = useAssociationName();
+  const association = usePopupAssociation();
 
   const templateWrap = useCallback(
     (templateSchema, options) => {

--- a/packages/core/client/src/modules/blocks/data-blocks/form/CreateFormBlockInitializer.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/CreateFormBlockInitializer.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 import { SchemaInitializerItem, useSchemaInitializer, useSchemaInitializerItem } from '../../../../application';
 import { useCollection_deprecated } from '../../../../collection-manager';
+import { usePopupAssociation } from '../../../../schema-component/antd/action/PopupAssociationProvider';
 import { useRecordCollectionDataSourceItems } from '../../../../schema-initializer/utils';
 import { useSchemaTemplateManager } from '../../../../schema-templates';
 import { createCreateFormBlockUISchema } from './createCreateFormBlockUISchema';
-import { useAssociationName } from '../../../../data-source';
 
 // TODO: `SchemaInitializerItem` items
 export const CreateFormBlockInitializer = () => {
@@ -14,7 +14,7 @@ export const CreateFormBlockInitializer = () => {
   const { onCreateBlockSchema, componentType, createBlockSchema, ...others } = itemConfig;
   const { getTemplateSchemaByMode } = useSchemaTemplateManager();
   const { insert } = useSchemaInitializer();
-  const association = useAssociationName();
+  const association = usePopupAssociation();
   const collection = useCollection_deprecated();
   return (
     <SchemaInitializerItem

--- a/packages/core/client/src/modules/blocks/data-blocks/form/RecordFormBlockInitializer.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/RecordFormBlockInitializer.tsx
@@ -1,8 +1,8 @@
 import { FormOutlined } from '@ant-design/icons';
 import React, { useCallback } from 'react';
 import { SchemaInitializerItem, useSchemaInitializer, useSchemaInitializerItem } from '../../../../application';
-import { useAssociationName } from '../../../../data-source';
 import { useCollection_deprecated } from '../../../../collection-manager';
+import { usePopupAssociation } from '../../../../schema-component/antd/action/PopupAssociationProvider';
 import { useRecordCollectionDataSourceItems } from '../../../../schema-initializer/utils';
 import { useSchemaTemplateManager } from '../../../../schema-templates';
 import { createEditFormBlockUISchema } from './createEditFormBlockUISchema';
@@ -39,7 +39,7 @@ export const RecordFormBlockInitializer = () => {
 
 export function useCreateEditFormBlock() {
   const { insert } = useSchemaInitializer();
-  const association = useAssociationName();
+  const association = usePopupAssociation();
 
   const createEditFormBlock = useCallback(
     ({ item }) => {

--- a/packages/core/client/src/schema-component/antd/action/PopupAssociationProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/action/PopupAssociationProvider.tsx
@@ -1,0 +1,18 @@
+import React, { FC, createContext } from 'react';
+
+const PopupAssociationContext = createContext<string>(null);
+
+/**
+ * 专门用来为弹窗提供其创建区块所需要的 association 的值
+ * @param props
+ * @returns
+ */
+export const PopupAssociationProvider: FC<{ association: string }> = (props) => {
+  return (
+    <PopupAssociationContext.Provider value={props.association}>{props.children}</PopupAssociationContext.Provider>
+  );
+};
+
+export const usePopupAssociation = () => {
+  return React.useContext(PopupAssociationContext);
+};

--- a/packages/core/client/src/schema-component/antd/action/index.tsx
+++ b/packages/core/client/src/schema-component/antd/action/index.tsx
@@ -1,9 +1,10 @@
 export * from './Action';
+export * from './Action.Designer';
 export * from './ActionBar';
+export { usePopupAssociation } from './PopupAssociationProvider';
 export * from './context';
 export * from './hooks';
 export * from './hooks/useGetAriaLabelOfAction';
 export * from './hooks/useGetAriaLabelOfDrawer';
 export * from './hooks/useGetAriaLabelOfModal';
 export * from './hooks/useGetAriaLabelOfPopover';
-export * from './Action.Designer';

--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { RecordProvider, useAPIClient, useCollectionRecordData } from '../../../';
 import { isVariable } from '../../../variables/utils/isVariable';
 import { getInnermostKeyAndValue } from '../../common/utils/uitls';
+import { PopupAssociationProvider } from '../action/PopupAssociationProvider';
 import { RemoteSelect, RemoteSelectProps } from '../remote-select';
 import useServiceOptions, { useAssociationFieldContext } from './hooks';
 
@@ -135,14 +136,17 @@ const InternalAssociationSelect = observer(
 
           {(addMode === 'modalAdd' || isAllowAddNew) && (
             <RecordProvider isNew={true} record={null} parent={recordData}>
-              <RecursionField
-                onlyRenderProperties
-                basePath={field.address}
-                schema={fieldSchema}
-                filterProperties={(s) => {
-                  return s['x-component'] === 'Action';
-                }}
-              />
+              {/* 通过快捷添加按钮打开的弹窗中不应该存在 association，因为其创建的 form 区块永远不可能是一个关系区块 */}
+              <PopupAssociationProvider association={null}>
+                <RecursionField
+                  onlyRenderProperties
+                  basePath={field.address}
+                  schema={fieldSchema}
+                  filterProperties={(s) => {
+                    return s['x-component'] === 'Action';
+                  }}
+                />
+              </PopupAssociationProvider>
             </RecordProvider>
           )}
         </Space.Compact>

--- a/packages/core/client/src/schema-component/antd/association-field/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/ReadPretty.tsx
@@ -1,24 +1,25 @@
 import { observer } from '@formily/react';
 import React from 'react';
+import { PopupAssociationProvider } from '../action/PopupAssociationProvider';
 import { AssociationFieldProvider } from './AssociationFieldProvider';
 import { FileManageReadPretty } from './FileManager';
-import { useAssociationFieldContext } from './hooks';
 import { InternalNester } from './InternalNester';
 import { InternalSubTable } from './InternalSubTable';
 import { ReadPrettyInternalTag } from './InternalTag';
 import { ReadPrettyInternalViewer } from './InternalViewer';
+import { useAssociationFieldContext } from './hooks';
 
 const ReadPrettyAssociationField = observer(
   (props: any) => {
-    const { currentMode } = useAssociationFieldContext();
+    const { currentMode, options } = useAssociationFieldContext();
     return (
-      <>
+      <PopupAssociationProvider association={`${options.collectionName}.${options.name}`}>
         {['Select', 'Picker', 'CascadeSelect'].includes(currentMode) && <ReadPrettyInternalViewer {...props} />}
         {currentMode === 'Tag' && <ReadPrettyInternalTag {...props} />}
         {currentMode === 'Nester' && <InternalNester {...props} />}
         {currentMode === 'SubTable' && <InternalSubTable {...props} />}
         {currentMode === 'FileManager' && <FileManageReadPretty {...props} />}
-      </>
+      </PopupAssociationProvider>
     );
   },
   { displayName: 'ReadPrettyAssociationField' },

--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/CreateFormBulkEditBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/CreateFormBulkEditBlockInitializer.tsx
@@ -3,13 +3,13 @@ import {
   SchemaInitializerItem,
   createCreateFormBlockUISchema,
   useCollection_deprecated,
+  usePopupAssociation,
   useRecordCollectionDataSourceItems,
   useSchemaInitializer,
   useSchemaInitializerItem,
   useSchemaTemplateManager,
 } from '@nocobase/client';
 import React from 'react';
-import { usePopupAssociation } from '../../../../schema-component/antd/action/PopupAssociationProvider';
 import { createBulkEditBlockUISchema } from './createBulkEditBlockUISchema';
 
 export const CreateFormBulkEditBlockInitializer = () => {

--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/CreateFormBulkEditBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/CreateFormBulkEditBlockInitializer.tsx
@@ -7,9 +7,9 @@ import {
   useSchemaInitializer,
   useSchemaInitializerItem,
   useSchemaTemplateManager,
-  useAssociationName,
 } from '@nocobase/client';
 import React from 'react';
+import { usePopupAssociation } from '../../../../schema-component/antd/action/PopupAssociationProvider';
 import { createBulkEditBlockUISchema } from './createBulkEditBlockUISchema';
 
 export const CreateFormBulkEditBlockInitializer = () => {
@@ -17,7 +17,7 @@ export const CreateFormBulkEditBlockInitializer = () => {
   const { onCreateBlockSchema, componentType, createBlockSchema, ...others } = itemConfig;
   const { insert } = useSchemaInitializer();
   const { getTemplateSchemaByMode } = useSchemaTemplateManager();
-  const association = useAssociationName();
+  const association = usePopupAssociation();
   const collection = useCollection_deprecated();
   return (
     <SchemaInitializerItem

--- a/packages/plugins/@nocobase/plugin-snapshot-field/src/client/SnapshotBlock/SnapshotBlockInitializers/SnapshotBlockInitializersDetailItem.tsx
+++ b/packages/plugins/@nocobase/plugin-snapshot-field/src/client/SnapshotBlock/SnapshotBlockInitializers/SnapshotBlockInitializersDetailItem.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
 import { FormOutlined } from '@ant-design/icons';
-import {
-  useCollection_deprecated,
-  useSchemaTemplateManager,
-  useRecordCollectionDataSourceItems,
-  useBlockRequestContext,
-  useSchemaInitializer,
-  SchemaInitializerItem,
-  useSchemaInitializerItem,
-  useAssociationName,
-} from '@nocobase/client';
 import { ISchema } from '@formily/react';
 import { uid } from '@formily/shared';
+import {
+  SchemaInitializerItem,
+  useBlockRequestContext,
+  useCollection_deprecated,
+  usePopupAssociation,
+  useRecordCollectionDataSourceItems,
+  useSchemaInitializer,
+  useSchemaInitializerItem,
+  useSchemaTemplateManager,
+} from '@nocobase/client';
+import React from 'react';
 
 export const createSnapshotBlockSchema = (options) => {
   const {
@@ -73,7 +73,7 @@ export const SnapshotBlockInitializersDetailItem = () => {
   const { getTemplateSchemaByMode } = useSchemaTemplateManager();
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const collection = targetCollection || useCollection_deprecated();
-  const association = useAssociationName();
+  const association = usePopupAssociation();
   const { block } = useBlockRequestContext();
   const actionInitializers =
     block !== 'TableField' ? itemConfig.actionInitializers || 'details:configureActions' : null;


### PR DESCRIPTION
close T-4088

目前可以创建关系区块的途径一共就两个位置：
1. 点击 current record
2. 点击 associated fields

![img_v3_02a2_d2922571-f34b-433c-b3a7-c778fc6c483g](https://github.com/nocobase/nocobase/assets/38434641/983306de-22e0-448c-b0cc-2dc7402465d1)

点击 2 的时候 association 是本身就能获取到的，不需要再通过 hooks 获取。而点击 1 的时候需要从上下文中获取到 association 才能确定是否要创建成关系区块，如果上下文中没有提供 association 或者提供的为空那么就创建成普通区块。**通过 1 创建的是否是关系区块是通过上下文中是否提供 association 且其值是否为空决定的。**

所以我建议，新增一个名为 PopupAssociationProvider 的 Provider，用于为弹窗提供 association 上下文。这样只需要在需要提供 association 上下文的地方加上 AssociationValueProvider 就行，不需要就不加。这其中没有任何判断的逻辑。应该是最简单的。

## 可以打开弹窗的地方有哪些？
1. 查看和编辑等按钮（其弹窗中的 association 应该和区块的 association 相同）
2. 关系字段按钮（其弹窗中的 association 的值由关系字段的值拼接而成 field.collectionName + field.name）
4. Add new 按钮（分为两种）
  a. 快捷添加（此类按钮打开的弹窗中永远不要有 association）
  b. 数据选择器的 Add new（此类按钮打开的弹窗中永远不要有 association，但由于数据选择器区块本身不携带 association 所以也可以跟着区块的值走）
  c. Table、list、grid等区块的添加按钮（此类按钮打开的弹窗的 association 和其所在的区块的 association 相同）

## 弹窗中获取 association 的思路
1. 新增一个 `PopupAssociationProvider` 用来专门为弹窗提供 association 的值
2. 把 `PopupAssociationProvider` 分别放到 DataBlockProvider（解决 1 和 3.b、3.c）、关系字段（解决 2）、快捷添加按钮中（解决 3.a）
3. 然后在弹窗中通过 `usePopupAssociation` 获取到 association