### PR TITLE
perf: remove all Skeleton animation

### DIFF
--- a/packages/core/client/src/schema-component/antd/card-item/CardItem.tsx
+++ b/packages/core/client/src/schema-component/antd/card-item/CardItem.tsx
@@ -1,9 +1,9 @@
 import { useFieldSchema } from '@formily/react';
 import { Skeleton } from 'antd';
 import React from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useSchemaTemplate } from '../../../schema-templates';
 import { BlockItem } from '../block-item';
-import { useInView } from 'react-intersection-observer';
 import { BlockItemCard } from '../block-item/BlockItemCard';
 import { BlockItemError } from '../block-item/BlockItemError';
 import useStyles from './style';
@@ -33,7 +33,7 @@ export const CardItem = (props: Props) => {
     <BlockItemError>
       <BlockItem name={name} className={`${componentCls} ${hashId} noco-card-item`}>
         <BlockItemCard ref={ref} {...restProps}>
-          {inView ? props.children : <Skeleton active paragraph={{ rows: 4 }} />}
+          {inView ? props.children : <Skeleton paragraph={{ rows: 4 }} />}
         </BlockItemCard>
       </BlockItem>
     </BlockItemError>,

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -9,7 +9,7 @@ import { action } from '@formily/reactive';
 import { uid } from '@formily/shared';
 import { isPortalInBody } from '@nocobase/utils/client';
 import { useCreation, useDeepCompareEffect, useMemoizedFn } from 'ahooks';
-import { Table as AntdTable, TableColumnProps } from 'antd';
+import { Table as AntdTable, Skeleton, TableColumnProps } from 'antd';
 import { default as classNames, default as cls } from 'classnames';
 import _, { omit } from 'lodash';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -508,7 +508,7 @@ export const Table: any = withDynamicSchemaProps(
 
         return (
           <td {...props} ref={ref} className={classNames(props.className, cellClass)}>
-            {inView || isIndex ? props.children : null}
+            {inView || isIndex ? props.children : <Skeleton.Button />}
           </td>
         );
       },

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -14,6 +14,7 @@ import { default as classNames, default as cls } from 'classnames';
 import _, { omit } from 'lodash';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useInView } from 'react-intersection-observer';
 import { DndContext, useDesignable, useTableSize } from '../..';
 import {
   RecordIndexProvider,
@@ -494,13 +495,25 @@ export const Table: any = withDynamicSchemaProps(
       };
     }, [onRowDragEnd, field]);
 
-    const BodyCellComponent = useCallback((props) => {
-      return (
-        <td {...props} className={classNames(props.className, cellClass)}>
-          {props.children}
-        </td>
-      );
-    }, []);
+    const BodyCellComponent = useCallback(
+      (props) => {
+        const isIndex = props.className?.includes('selection-column');
+
+        const { ref, inView } = useInView({
+          threshold: 0,
+          triggerOnce: true,
+          initialInView: isIndex || !!process.env.__E2E__ || dataSource.length <= 10,
+          skip: isIndex || !!process.env.__E2E__,
+        });
+
+        return (
+          <td {...props} ref={ref} className={classNames(props.className, cellClass)}>
+            {inView || isIndex ? props.children : null}
+          </td>
+        );
+      },
+      [dataSource.length],
+    );
 
     const components = useMemo(() => {
       return {

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -9,12 +9,11 @@ import { action } from '@formily/reactive';
 import { uid } from '@formily/shared';
 import { isPortalInBody } from '@nocobase/utils/client';
 import { useCreation, useDeepCompareEffect, useMemoizedFn } from 'ahooks';
-import { Table as AntdTable, Skeleton, TableColumnProps } from 'antd';
+import { Table as AntdTable, TableColumnProps } from 'antd';
 import { default as classNames, default as cls } from 'classnames';
 import _, { omit } from 'lodash';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useInView } from 'react-intersection-observer';
 import { DndContext, useDesignable, useTableSize } from '../..';
 import {
   RecordIndexProvider,
@@ -495,25 +494,13 @@ export const Table: any = withDynamicSchemaProps(
       };
     }, [onRowDragEnd, field]);
 
-    const BodyCellComponent = useCallback(
-      (props) => {
-        const isIndex = props.className?.includes('selection-column');
-
-        const { ref, inView } = useInView({
-          threshold: 0,
-          triggerOnce: true,
-          initialInView: isIndex || !!process.env.__E2E__ || dataSource.length <= 10,
-          skip: isIndex || !!process.env.__E2E__,
-        });
-
-        return (
-          <td {...props} ref={ref} className={classNames(props.className, cellClass)}>
-            {inView || isIndex ? props.children : <Skeleton.Button active />}
-          </td>
-        );
-      },
-      [dataSource.length],
-    );
+    const BodyCellComponent = useCallback((props) => {
+      return (
+        <td {...props} className={classNames(props.className, cellClass)}>
+          {props.children}
+        </td>
+      );
+    }, []);
 
     const components = useMemo(() => {
       return {
@@ -527,7 +514,7 @@ export const Table: any = withDynamicSchemaProps(
           cell: BodyCellComponent,
         },
       };
-    }, [bodyWrapperComponent]);
+    }, [BodyCellComponent, bodyWrapperComponent]);
 
     const memoizedRowSelection = useMemo(() => rowSelection, [JSON.stringify(rowSelection)]);
 

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/Kanban.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/Kanban.tsx
@@ -9,7 +9,7 @@ import {
   useProps,
   withDynamicSchemaProps,
 } from '@nocobase/client';
-import { Spin, Tag, Card, Skeleton } from 'antd';
+import { Card, Skeleton, Spin, Tag } from 'antd';
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { Board } from './board';
@@ -155,7 +155,7 @@ export const Kanban: any = withDynamicSchemaProps(
                         <MemorizedRecursionField name={schemas.card.name} schema={schemas.card} />
                       ) : (
                         <Card bordered={false}>
-                          <Skeleton active paragraph={{ rows: 4 }} />
+                          <Skeleton paragraph={{ rows: 4 }} />
                         </Card>
                       )}
                     </div>


### PR DESCRIPTION
## 问题

> 页面地址：[https://main.test.nocobase.com/admin/4y6tv4btv0p](https://main.test.nocobase.com/admin/4y6tv4btv0p)

在页面渲染完成后，CPU 依然是满负荷状态，并且一直持续下去：

![image](https://github.com/nocobase/nocobase/assets/38434641/79f6e32d-8772-4b75-8355-11e9eec99528)

经过 Performance 面板分析后发现，页面一直在进行 `重新计算样式` 和 `绘制` 的过程，并且和动画有关。

![image](https://github.com/nocobase/nocobase/assets/38434641/07d20c19-7a47-46b2-a1e1-0828542186b7)

由于这里加的有 `骨架屏` 的效果，所以怀疑是骨架屏动画影响的。在去除骨架屏动画后，页面恢复正常：

![image](https://github.com/nocobase/nocobase/assets/38434641/3e338846-860a-4212-bb32-72287dd8a9ab)

![image](https://github.com/nocobase/nocobase/assets/38434641/428ea1d2-d84d-4d11-983b-d3bbfc706cca)

