### PR TITLE
fix(plugin-workflow-manual): allow pass node when no assignee

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/ManualInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/ManualInstruction.ts
@@ -96,12 +96,16 @@ export default class extends Instruction {
     const assignees = [...new Set(processor.getParsedValue(config.assignees, node.id).flat().filter(Boolean))];
 
     const job = await processor.saveJob({
-      status: JOB_STATUS.PENDING,
+      status: assignees.length ? JOB_STATUS.PENDING : JOB_STATUS.RESOLVED,
       result: mode ? [] : null,
       nodeId: node.id,
       nodeKey: node.key,
       upstreamId: prevJob?.id ?? null,
     });
+
+    if (!assignees.length) {
+      return job;
+    }
 
     // NOTE: batch create users jobs
     const UserJobModel = this.workflow.app.db.getModel('users_jobs');

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/assignees.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/assignees.test.ts
@@ -50,6 +50,32 @@ describe('workflow > instructions > manual > assignees', () => {
 
   afterEach(() => app.destroy());
 
+  describe('no', () => {
+    it('empty assignees', async () => {
+      const n1 = await workflow.createNode({
+        type: 'manual',
+        config: {
+          assignees: [],
+          forms: {
+            f1: {
+              actions: [{ status: JOB_STATUS.RESOLVED, key: 'resolve' }],
+            },
+          },
+        },
+      });
+
+      const post = await PostRepo.create({
+        values: { title: 't1', category: { title: 'c1' } },
+        context: { state: { currentUser: users[0] } },
+      });
+
+      await sleep(500);
+
+      const [pending] = await workflow.getExecutions();
+      expect(pending.status).toBe(EXECUTION_STATUS.RESOLVED);
+    });
+  });
+
   describe('multiple', () => {
     it('assignees from nested array', async () => {
       const n1 = await workflow.createNode({


### PR DESCRIPTION
## Description

Allow pass node when no assignee

### Steps to reproduce

1. Create manual node without assignee.
2. Trigger the workflow.

### Expected behavior

Execution should be resolved.

### Actual behavior

Pending.

## Related issues

None.

## Reason

Not skipped scenario of none assignee.

## Solution

Make the node as resolve when no assignee.
