### PR TITLE
feat(plugin-workflow): show workflow key as tooltip on title

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
@@ -275,7 +275,13 @@ export function ExecutionCanvas() {
           <Breadcrumb
             items={[
               { title: <Link to={app.pluginSettingsManager.getRoutePath('workflow')}>{lang('Workflow')}</Link> },
-              { title: <Link to={getWorkflowDetailPath(workflow.id)}>{workflow.title}</Link> },
+              {
+                title: (
+                  <Tooltip title={`Key: ${workflow.key}`}>
+                    <Link to={getWorkflowDetailPath(workflow.id)}>{workflow.title}</Link>
+                  </Tooltip>
+                ),
+              },
               { title: <ExecutionsDropdown /> },
             ]}
           />

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
-import { App, Breadcrumb, Button, Dropdown, Result, Spin, Switch, message } from 'antd';
+import { App, Breadcrumb, Button, Dropdown, Result, Spin, Switch, Tooltip, message } from 'antd';
 import { DownOutlined, EllipsisOutlined, RightOutlined } from '@ant-design/icons';
 import {
   ActionContextProvider,
@@ -155,7 +155,13 @@ export function WorkflowCanvas() {
           <Breadcrumb
             items={[
               { title: <Link to={app.pluginSettingsManager.getRoutePath('workflow')}>{lang('Workflow')}</Link> },
-              { title: <strong>{workflow.title}</strong> },
+              {
+                title: (
+                  <Tooltip title={`Key: ${workflow.key}`}>
+                    <strong>{workflow.title}</strong>
+                  </Tooltip>
+                ),
+              },
             ]}
           />
         </header>


### PR DESCRIPTION
# Description

Show workflow key as tooltip on title.

# Motivation

Workflow key will be useful when trigger workflow over HTTP API, administrator need to get it from UI.

# Key changes

- Frontend
  - Workflow canvas.
- Backend

# Test plan

## Suggestions

None.

## Underlying risk

None.

# Showcase

![工作流_key_查看方式](https://static-docs.nocobase.com/20240426135108.png)
