### PR TITLE
feat(plugin-workflow-request): support "application/x-www-form-urlencoded" type

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -385,17 +385,15 @@ export function TextArea(props) {
         componentCls,
         hashId,
         css`
-          &.ant-input-group.ant-input-group-compact {
-            display: flex;
-            .ant-input {
-              flex-grow: 1;
-              min-width: 200px;
-            }
-            .ant-input-disabled {
-              .ant-tag {
-                color: #bfbfbf;
-                border-color: #d9d9d9;
-              }
+          display: flex;
+          .ant-input {
+            flex-grow: 1;
+            min-width: 200px;
+          }
+          .ant-input-disabled {
+            .ant-tag {
+              color: #bfbfbf;
+              border-color: #d9d9d9;
             }
           }
 

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/locale/zh-CN.json
@@ -9,12 +9,13 @@
   "Add parameter": "添加参数",
   "Body": "请求体",
   "Use variable": "使用变量",
+  "Add key-value pairs": "添加键值对",
   "Format": "格式化",
   "Insert": "插入",
   "Timeout config": "超时设置",
   "ms": "毫秒",
   "Input request data": "输入请求数据",
   "Only support standard JSON data": "仅支持标准 JSON 数据",
-  "\"Content-Type\" only support \"application/json\", and no need to specify": "\"Content-Type\" 请求头仅支持 \"application/json\"，无需填写",
+  "\"Content-Type\" will be ignored from headers.": "请求头中配置的 \"Content-Type\" 将被忽略。",
   "Ignore failed request and continue workflow": "忽略失败的请求并继续工作流"
 }

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -58,8 +58,12 @@ async function request(config) {
     method,
     headers,
     params,
-    data: ContentTypeTransformers[contentType](data),
     timeout,
+    ...(method.toLowerCase() !== 'get' && data != null
+      ? {
+          data: ContentTypeTransformers[contentType](data),
+        }
+      : {}),
   });
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -18,14 +18,29 @@ export interface Header {
 
 export type RequestConfig = Pick<AxiosRequestConfig, 'url' | 'method' | 'params' | 'data' | 'timeout'> & {
   headers: Array<Header>;
+  contentType: string;
   ignoreFail: boolean;
+};
+
+const ContentTypeTransformers = {
+  'application/json'(data) {
+    return data;
+  },
+  'application/x-www-form-urlencoded'(data: { name: string; value: string }[]) {
+    return new URLSearchParams(
+      data.filter(({ name, value }) => name && typeof value !== 'undefined').map(({ name, value }) => [name, value]),
+    ).toString();
+  },
 };
 
 async function request(config) {
   // default headers
-  const { url, method = 'POST', data, timeout = 5000 } = config;
+  const { url, method = 'POST', contentType = 'application/json', data, timeout = 5000 } = config;
   const headers = (config.headers ?? []).reduce((result, header) => {
     if (header.name.toLowerCase() === 'content-type') {
+      // header.value = ['application/json', 'application/x-www-form-urlencoded'].includes(header.value)
+      //   ? header.value
+      //   : 'application/json';
       return result;
     }
     return Object.assign(result, { [header.name]: header.value });
@@ -36,14 +51,14 @@ async function request(config) {
   );
 
   // TODO(feat): only support JSON type for now, should support others in future
-  headers['Content-Type'] = 'application/json';
+  headers['Content-Type'] = contentType;
 
   return axios.request({
     url,
     method,
     headers,
     params,
-    data,
+    data: ContentTypeTransformers[contentType](data),
     timeout,
   });
 }

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/__tests__/instruction.test.ts
@@ -58,7 +58,7 @@ class MockAPI {
         await sleep(100);
         ctx.body = {
           meta: { title: ctx.query.title },
-          data: { title: ctx.request.body['title'] },
+          data: ctx.request.body,
         };
       }
       await next();
@@ -313,6 +313,54 @@ describe('workflow > instructions > request', () => {
       expect(jobs.length).toBe(3);
       expect(jobs.map((item) => item.status)).toEqual(Array(3).fill(JOB_STATUS.RESOLVED));
       expect(jobs[0].result).toBe(2);
+    });
+  });
+
+  describe('contentType', () => {
+    it('no contentType as "application/json"', async () => {
+      const n1 = await workflow.createNode({
+        type: 'request',
+        config: {
+          url: api.URL_DATA,
+          method: 'POST',
+          data: { a: '{{$context.data.title}}' },
+        },
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toEqual(EXECUTION_STATUS.RESOLVED);
+      const [job] = await execution.getJobs();
+      expect(job.status).toEqual(JOB_STATUS.RESOLVED);
+      expect(job.result.data).toEqual({ a: 't1' });
+    });
+
+    it('contentType as "application/x-www-form-urlencoded"', async () => {
+      const n1 = await workflow.createNode({
+        type: 'request',
+        config: {
+          url: api.URL_DATA,
+          method: 'POST',
+          data: [
+            { name: 'a', value: '{{$context.data.title}}' },
+            { name: 'a', value: '&=1' },
+          ],
+          contentType: 'application/x-www-form-urlencoded',
+        },
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toEqual(EXECUTION_STATUS.RESOLVED);
+      const [job] = await execution.getJobs();
+      expect(job.status).toEqual(JOB_STATUS.RESOLVED);
+      expect(job.result.data).toEqual({ a: ['t1', '&=1'] });
     });
   });
 


### PR DESCRIPTION
# Description

Support "application/x-www-form-urlencoded" for "Content-Type".

# Motivation

For legacy HTTP API services.

# Key changes

- Frontend
  - Add `contentType` option for request node.
  - Change `Variable.Input` to `Variable.TextArea` for values options.
- Backend
  - Support `contentType` option for request node.

# Test plan

## Suggestions

Through cases.

## Underlying risk

None.

# Showcase

<img width="717" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/5e72485b-3dbd-43b9-b76d-3d44053be7e2">

