### PR TITLE
fix(plugin-workflow-custom-action-trigger): fix locales

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -461,7 +461,7 @@ export function WorkflowConfig() {
     }),
     'customize:triggerWorkflows': t(
       'Workflow will be triggered directly once the button clicked, without data saving. Only supports to be bound with "Custom action event".',
-      { ns: 'workflow' },
+      { ns: '@nocobase/plugin-workflow-custom-action-trigger' },
     ),
     'customize:triggerWorkflows_deprecated': t(
       '"Submit to workflow" to "Post-action event" is deprecated, please use "Custom action event" instead.',

--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/client/ActionTrigger.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/client/ActionTrigger.tsx
@@ -124,7 +124,6 @@ export default class extends Trigger {
       'x-decorator': 'FormItem',
       'x-component': 'AppendsTreeSelect',
       'x-component-props': {
-        title: 'Preload associations',
         multiple: true,
         useCollection() {
           const { values } = useForm();


### PR DESCRIPTION
## Description

Fix locales.

### Steps to reproduce

Bind custom action trigger workflow.

### Expected behavior

Hint translated.

### Actual behavior

Not translated.

## Related issues

None.

## Reason

Wrong namespace.

## Solution

Fix namespace.
