### PR TITLE
fix(plugin-workflow-aggregate): fix association field select

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/AggregateInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/AggregateInstruction.tsx
@@ -132,7 +132,7 @@ function AssociatedConfig({ value, onChange, ...props }): JSX.Element {
       const collection = getCollection(collectionName, dataSourceKey);
       const primaryKeyField = collection.fields.find((f) => f.primaryKey);
 
-      setValuesIn('collection', `${dataSourceKey}:${target}`);
+      setValuesIn('collection', joinCollectionName(dataSourceKey, target));
 
       onChange({
         name,


### PR DESCRIPTION
## Description

Association field can not be selected in aggregate node.

### Steps to reproduce

1. Make 2 collection with many-to-many relationship.
2. Create a workflow and an aggregate node.
3. Select the association collection from one to another.
4. Select the association field to aggregate.

### Expected behavior

The association field could be selected.

### Actual behavior

The field list is empty.

## Related issues

None.

## Reason

Data source parsing incorrectly.

## Solution

Fix the data source parsing.
