### PR TITLE
fix(plugin-workflow-request): fix ignoreFail in sync mode

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -83,7 +83,7 @@ export default class extends Instruction {
         };
       } catch (error) {
         return {
-          status: JOB_STATUS.FAILED,
+          status: config.ignoreFail ? JOB_STATUS.RESOLVED : JOB_STATUS.FAILED,
           result: error.isAxiosError ? error.toJSON() : error.message,
         };
       }

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/__tests__/instruction.test.ts
@@ -448,8 +448,6 @@ describe('workflow > instructions > request', () => {
       const workflowPlugin = app.pm.get(PluginWorkflow) as PluginWorkflow;
       const processor = (await workflowPlugin.trigger(syncFlow, { data: { title: 't1' } })) as Processor;
 
-      await sleep(1000);
-
       const [execution] = await syncFlow.getExecutions();
       const [job] = await execution.getJobs();
       expect(job.status).toBe(JOB_STATUS.RESOLVED);


### PR DESCRIPTION
## Description

"Ignore failure" of request node not works in sync workflow.

### Steps to reproduce

1. Create a sync workflow.
2. Create a request node (1), point to a 404 URL, and enable "Ignore failure" option.
3. Create another node (2) as downstream of the request node.

### Expected behavior

Node (2) should be executed.

### Actual behavior

Not executed, and execution exited as failure.

## Related issues

#4333.

## Reason

`ignoreFail` not implemented in sync mode.

## Solution

Add implementation in sync mode.
