### PR TITLE
fix(plugin-workflow-request): fix value fields overflowing

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -389,6 +389,7 @@ export function TextArea(props) {
           .ant-input {
             flex-grow: 1;
             min-width: 200px;
+            word-break: break-all;
           }
           .ant-input-disabled {
             .ant-tag {
@@ -412,6 +413,7 @@ export function TextArea(props) {
         onPaste={onPaste}
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}
+        placeholder={props.placeholder}
         className={cx(
           hashId,
           'ant-input',
@@ -419,6 +421,11 @@ export function TextArea(props) {
           css`
             overflow: auto;
             white-space: ${multiline ? 'normal' : 'nowrap'};
+
+            &[placeholder]:empty::before {
+              content: attr(placeholder);
+              color: #ccc;
+            }
 
             .ant-tag {
               display: inline;

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/client/RequestInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/client/RequestInstruction.tsx
@@ -20,7 +20,7 @@ import {
 } from '@nocobase/plugin-workflow/client';
 
 import { NAMESPACE } from '../locale';
-import { SchemaComponent } from '@nocobase/client';
+import { SchemaComponent, css } from '@nocobase/client';
 
 const BodySchema = {
   'application/json': {
@@ -173,6 +173,18 @@ export default class extends Instruction {
           space: {
             type: 'void',
             'x-component': 'Space',
+            'x-component-props': {
+              style: {
+                flexWrap: 'nowrap',
+                maxWidth: '100%',
+              },
+              className: css`
+                & > .ant-space-item:first-child,
+                & > .ant-space-item:last-child {
+                  flex-shrink: 0;
+                }
+              `,
+            },
             properties: {
               name: {
                 type: 'string',
@@ -188,6 +200,7 @@ export default class extends Instruction {
                 'x-component': 'WorkflowVariableTextArea',
                 'x-component-props': {
                   useTypedConstant: true,
+                  placeholder: `{{t("Value")}}`,
                 },
               },
               remove: {
@@ -218,6 +231,18 @@ export default class extends Instruction {
           space: {
             type: 'void',
             'x-component': 'Space',
+            'x-component-props': {
+              style: {
+                flexWrap: 'nowrap',
+                maxWidth: '100%',
+              },
+              className: css`
+                & > .ant-space-item:first-child,
+                & > .ant-space-item:last-child {
+                  flex-shrink: 0;
+                }
+              `,
+            },
             properties: {
               name: {
                 type: 'string',
@@ -233,6 +258,7 @@ export default class extends Instruction {
                 'x-component': 'WorkflowVariableTextArea',
                 'x-component-props': {
                   useTypedConstant: true,
+                  placeholder: `{{t("Value")}}`,
                 },
               },
               remove: {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
@@ -82,8 +82,8 @@ export default class extends Instruction {
       return null;
     }
     return {
-      [fieldNames.value]: key,
-      [fieldNames.label]: title,
+      value: key,
+      label: title,
     };
   }
   useInitializers(node): SchemaInitializerItemType {


### PR DESCRIPTION
## Description

Value fields (header / params) overflowing when text too long.

### Steps to reproduce

1. Create a request node in workflow.
2. Add a header row and input a piece of long text in value field.

### Expected behavior

Text should wrap to new line.

### Actual behavior

Input box width overflowing.

## Related issues

#4334.

## Reason

Some component style not controlled well like `Variable.TextArea`.

## Solution

Fix the styles.
