### PR TITLE
fix(logger): should close log stream after destroying app

### DIFF
--- a/packages/core/logger/src/request-logger.ts
+++ b/packages/core/logger/src/request-logger.ts
@@ -8,7 +8,7 @@
  */
 
 import { getLoggerFilePath } from './config';
-import { LoggerOptions, createLogger } from './logger';
+import { Logger, LoggerOptions } from './logger';
 import { pick } from 'lodash';
 const defaultRequestWhitelist = [
   'action',
@@ -28,12 +28,7 @@ export interface RequestLoggerOptions extends LoggerOptions {
   responseWhitelist?: string[];
 }
 
-export const requestLogger = (appName: string, options?: RequestLoggerOptions) => {
-  const requestLogger = createLogger({
-    dirname: getLoggerFilePath(appName),
-    filename: 'request',
-    ...(options || {}),
-  });
+export const requestLogger = (appName: string, requestLogger: Logger, options?: RequestLoggerOptions) => {
   return async (ctx, next) => {
     const reqId = ctx.reqId;
     const path = /^\/api\/(.+):(.+)/.exec(ctx.path);

--- a/packages/core/logger/src/system-logger.ts
+++ b/packages/core/logger/src/system-logger.ts
@@ -86,6 +86,13 @@ class SystemLoggerTransport extends Transport {
     }
     callback(null, true);
   }
+
+  close() {
+    this.logger.close();
+    if (this.errorLogger) {
+      this.errorLogger.close();
+    }
+  }
 }
 
 function child(defaultRequestMetadata: any) {
@@ -108,8 +115,12 @@ function child(defaultRequestMetadata: any) {
 }
 
 export const createSystemLogger = (options: SystemLoggerOptions): SystemLogger => {
+  const transport = new SystemLoggerTransport(options);
+  transport.once('unpipe', () => {
+    transport.close();
+  });
   const logger = winston.createLogger({
-    transports: [new SystemLoggerTransport(options)],
+    transports: [transport],
   });
 
   // Since error.cause is not supported by child logger of winston

--- a/packages/core/server/src/application.ts
+++ b/packages/core/server/src/application.ts
@@ -15,6 +15,7 @@ import {
   createLogger,
   createSystemLogger,
   getLoggerFilePath,
+  Logger,
   LoggerOptions,
   RequestLoggerOptions,
   SystemLogger,
@@ -217,6 +218,13 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
   private _maintainingStatusBeforeCommand: MaintainingCommandStatus | null;
   private _actionCommand: Command;
 
+  /**
+   * @internal
+   */
+  public requestLogger: Logger;
+  private sqlLogger: Logger;
+  protected _logger: SystemLogger;
+
   constructor(public options: ApplicationOptions) {
     super();
     this.context.reqId = randomUUID();
@@ -226,9 +234,11 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     this._appSupervisor.addApp(this);
   }
 
-  protected _logger: SystemLogger;
-
   get logger() {
+    return this._logger;
+  }
+
+  get log() {
     return this._logger;
   }
 
@@ -354,10 +364,6 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
 
   get version() {
     return this._version;
-  }
-
-  get log() {
-    return this._logger;
   }
 
   get name() {
@@ -501,6 +507,8 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     if (this.telemetry.started) {
       await this.telemetry.shutdown();
     }
+
+    this.closeLogger();
 
     const oldDb = this.db;
 
@@ -862,6 +870,8 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     await this.emitAsync('afterDestroy', this, options);
 
     this.log.debug('finish destroy app', { method: 'destory' });
+
+    this.closeLogger();
   }
 
   async isInstalled() {
@@ -1043,19 +1053,38 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     return command;
   }
 
-  protected init() {
-    const options = this.options;
-
+  protected initLogger(options: AppLoggerOptions) {
     this._logger = createSystemLogger({
       dirname: getLoggerFilePath(this.name),
       filename: 'system',
       seperateError: true,
-      ...(options.logger?.system || {}),
+      ...(options?.system || {}),
     }).child({
       reqId: this.context.reqId,
       app: this.name,
       module: 'application',
     });
+    this.requestLogger = createLogger({
+      dirname: getLoggerFilePath(this.name),
+      filename: 'request',
+      ...(options?.request || {}),
+    });
+    this.sqlLogger = this.createLogger({
+      filename: 'sql',
+      level: 'debug',
+    });
+  }
+
+  protected closeLogger() {
+    this.log?.close();
+    this.requestLogger?.close();
+    this.sqlLogger?.close();
+  }
+
+  protected init() {
+    const options = this.options;
+
+    this.initLogger(options.logger);
 
     this.reInitEvents();
 
@@ -1144,10 +1173,6 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
   }
 
   protected createDatabase(options: ApplicationOptions) {
-    const sqlLogger = this.createLogger({
-      filename: 'sql',
-      level: 'debug',
-    });
     const logging = (msg: any) => {
       if (typeof msg === 'string') {
         msg = msg.replace(/[\r\n]/gm, '').replace(/\s+/g, ' ');
@@ -1155,7 +1180,7 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
       if (msg.includes('INSERT INTO')) {
         msg = msg.substring(0, 2000) + '...';
       }
-      sqlLogger.debug({ message: msg, app: this.name, reqId: this.context.reqId });
+      this.sqlLogger.debug({ message: msg, app: this.name, reqId: this.context.reqId });
     };
     const dbOptions = options.database instanceof Database ? options.database.options : options.database;
     const db = new Database({

--- a/packages/core/server/src/helper.ts
+++ b/packages/core/server/src/helper.ts
@@ -45,7 +45,7 @@ export function registerMiddlewares(app: Application, options: ApplicationOption
     await next();
   });
 
-  app.use(requestLogger(app.name, options.logger?.request), { tag: 'logger' });
+  app.use(requestLogger(app.name, app.requestLogger, options.logger?.request), { tag: 'logger' });
 
   app.use(
     cors({


### PR DESCRIPTION
After an app is destroyed, the opened log file streams should be closed. fix T-4302