### PR TITLE
feat(plugin-workflow-request): allow to use response variables

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-request/src/client/RequestInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/client/RequestInstruction.tsx
@@ -19,7 +19,7 @@ import {
   defaultFieldNames,
 } from '@nocobase/plugin-workflow/client';
 
-import { NAMESPACE } from '../locale';
+import { NAMESPACE, useLang } from '../locale';
 import { SchemaComponent, css } from '@nocobase/client';
 
 const BodySchema = {
@@ -319,10 +319,32 @@ export default class extends Instruction {
     WorkflowVariableTextArea,
     WorkflowVariableJSON,
   };
-  useVariables({ key, title }, { types, fieldNames = defaultFieldNames }) {
+  useVariables({ key, title, config }, { types }) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const statusCodeLabel = useLang('Status code');
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const dataLabel = useLang('Data');
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const headersLabel = useLang('Response headers');
     return {
-      [fieldNames.value]: key,
-      [fieldNames.label]: title,
+      [defaultFieldNames.value]: key,
+      [defaultFieldNames.label]: title,
+      [defaultFieldNames.children]: config.onlyData
+        ? null
+        : [
+            {
+              [defaultFieldNames.value]: 'status',
+              [defaultFieldNames.label]: statusCodeLabel,
+            },
+            {
+              [defaultFieldNames.value]: 'data',
+              [defaultFieldNames.label]: dataLabel,
+            },
+            {
+              [defaultFieldNames.value]: 'headers',
+              [defaultFieldNames.label]: headersLabel,
+            },
+          ],
     };
   }
 }

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -66,7 +66,7 @@ async function request(config) {
   });
 }
 
-function successResponse(response, onlyData = false) {
+function responseSuccess(response, onlyData = false) {
   return onlyData
     ? response.data
     : {
@@ -78,7 +78,7 @@ function successResponse(response, onlyData = false) {
       };
 }
 
-function failedResponse(error) {
+function responseFailure(error) {
   let result = {
     message: error.message,
     stack: error.stack,
@@ -111,7 +111,7 @@ export default class extends Instruction {
         const response = await request(config);
         return {
           status: JOB_STATUS.RESOLVED,
-          result: successResponse(response, config.onlyData),
+          result: responseSuccess(response, config.onlyData),
         };
       } catch (error) {
         return {
@@ -135,7 +135,7 @@ export default class extends Instruction {
 
         job.set({
           status: JOB_STATUS.RESOLVED,
-          result: successResponse(response, config.onlyData),
+          result: responseSuccess(response, config.onlyData),
         });
       })
       .catch((error) => {
@@ -153,7 +153,7 @@ export default class extends Instruction {
 
         job.set({
           status: JOB_STATUS.FAILED,
-          result: failedResponse(error),
+          result: responseFailure(error),
         });
       })
       .finally(() => {


### PR DESCRIPTION
# Description

Allow to use response variables:

- Status code
- Data payload
- Response headers

# Motivation

After unified response structure, status code will be very useful for checking logic in workflow (when `ignoreFail` configured).

# Key changes

- Frontend
  - Change `useVariable` in new request node (ignored legacy `onlyData`).
- Backend

# Test plan

## Suggestions

None.

## Underlying risk

None.

# Showcase

<img width="1440" alt="image" src="https://github.com/nocobase/nocobase/assets/525658/419d82c0-2a98-4e95-900e-3495da1f7dce">

