### PR TITLE
fix(plugin-workflow): fix empty value in create and update node association values

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/CollectionFieldset.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/CollectionFieldset.tsx
@@ -21,7 +21,7 @@ import {
   useToken,
 } from '@nocobase/client';
 import { Button, Dropdown, Form, Input, MenuProps } from 'antd';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { lang } from '../locale';
 import { useWorkflowVariableOptions } from '../variable';
@@ -36,10 +36,20 @@ function AssociationInput(props) {
   const { type } = fields.find((item) => item.name === fieldName);
 
   const value = Array.isArray(props.value) ? props.value.join(',') : props.value;
-  function onChange(ev) {
-    const trimed = ev.target.value.trim();
-    props.onChange(['belongsTo', 'hasOne'].includes(type) ? trimed : trimed.split(/[,\s]+/));
-  }
+  const onChange = useCallback(
+    (ev) => {
+      const trimed = ev.target.value.trim();
+      const next = ['belongsTo', 'hasOne'].includes(type)
+        ? trimed || null
+        : trimed
+            .split(',')
+            .map((item) => item.trim())
+            .filter((item) => item !== '');
+      props.onChange(next);
+    },
+    [props.onChange, type],
+  );
+
   return <Input {...props} value={value} onChange={onChange} />;
 }
 


### PR DESCRIPTION
## Description

### Steps to reproduce

1. Add a create or update node in workflow.
2. Add an association field (belong to) in value fields set.
3. Input anything, then clear content.
4. Save node.
5. Trigger the workflow.

### Expected behavior

Association field value updated to `null`.

### Actual behavior

Error thrown:

```json
{
  "message": "invalid input syntax for integer: \"\"",
  "stack": "Error\n    at Query.run (/app/nocobase/node_modules/sequelize/lib/dialects/postgres/query.js:50:25)\n    at /app/nocobase/node_modules/sequelize/lib/sequelize.js:315:28\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async PostgresQueryInterface.update (/app/nocobase/node_modules/sequelize/lib/dialects/abstract/query-interface.js:355:12)\n    at async model.save (/app/nocobase/node_modules/sequelize/lib/model.js:2490:35)\n    at async model.update (/app/nocobase/node_modules/sequelize/lib/model.js:2598:12)\n    at async updateModelByValues (/app/nocobase/node_modules/@nocobase/database/lib/update-associations.js:84:3)\n    at async _Repository.update (/app/nocobase/node_modules/@nocobase/database/lib/repository.js:412:7)\n    at async descriptor.value (/app/nocobase/node_modules/@nocobase/database/lib/decorators/transaction-decorator.js:66:29)\n    at async UpdateInstruction.run (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/instructions/UpdateInstruction.js:33:20)"
}
```

## Related issues

None.

## Reason

Empty string should not be used as association value.

## Solution

Use `null` instead.
