### PR TITLE
fix(plugin-workflow): fix condition node variable error

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/CanvasContent.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/CanvasContent.tsx
@@ -9,8 +9,9 @@
 
 import { Alert, Slider } from 'antd';
 import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
-import { cx, css } from '@nocobase/client';
+import { cx, css, ErrorFallback } from '@nocobase/client';
 
 import { Branch } from './Branch';
 import { useFlowContext } from './FlowContext';
@@ -25,41 +26,43 @@ export function CanvasContent({ entry }) {
 
   return (
     <div className="workflow-canvas-wrapper">
-      <div className="workflow-canvas" style={{ zoom: zoom / 100 }}>
-        <div
-          className={cx(
-            styles.branchBlockClass,
-            css`
-              margin-top: 0 !important;
-            `,
-          )}
-        >
-          <div className={styles.branchClass}>
-            {workflow?.executed ? (
-              <Alert
-                type="warning"
-                message={lang('Executed workflow cannot be modified. Could be copied to a new version to modify.')}
-                showIcon
-                className={css`
-                  margin-bottom: 1em;
-                `}
-              />
-            ) : null}
-            <TriggerConfig />
-            <div
-              className={cx(
-                styles.branchBlockClass,
-                css`
-                  margin-top: 0 !important;
-                `,
-              )}
-            >
-              <Branch entry={entry} />
+      <ErrorBoundary FallbackComponent={ErrorFallback} onError={console.error}>
+        <div className="workflow-canvas" style={{ zoom: zoom / 100 }}>
+          <div
+            className={cx(
+              styles.branchBlockClass,
+              css`
+                margin-top: 0 !important;
+              `,
+            )}
+          >
+            <div className={styles.branchClass}>
+              {workflow?.executed ? (
+                <Alert
+                  type="warning"
+                  message={lang('Executed workflow cannot be modified. Could be copied to a new version to modify.')}
+                  showIcon
+                  className={css`
+                    margin-bottom: 1em;
+                  `}
+                />
+              ) : null}
+              <TriggerConfig />
+              <div
+                className={cx(
+                  styles.branchBlockClass,
+                  css`
+                    margin-top: 0 !important;
+                  `,
+                )}
+              >
+                <Branch entry={entry} />
+              </div>
+              <div className={styles.terminalClass}>{lang('End')}</div>
             </div>
-            <div className={styles.terminalClass}>{lang('End')}</div>
           </div>
         </div>
-      </div>
+      </ErrorBoundary>
       <div className="workflow-canvas-zoomer">
         <Slider vertical reverse defaultValue={100} step={10} min={10} value={zoom} onChange={setZoom} />
       </div>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
@@ -12,7 +12,7 @@ import { css, cx, useCompile, Variable } from '@nocobase/client';
 import { evaluators } from '@nocobase/evaluators/client';
 import { Registry } from '@nocobase/utils/client';
 import { Button, Select } from 'antd';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Instruction, NodeDefaultView } from '.';
 import { Branch } from '../Branch';
@@ -149,7 +149,18 @@ function getGroupCalculators(group) {
 
 function Calculation({ calculator, operands = [], onChange }) {
   const compile = useCompile();
-  const options = useWorkflowVariableOptions();
+  const leftOptions = useWorkflowVariableOptions();
+  const rightOptions = useWorkflowVariableOptions();
+  const leftOperandOnChange = useCallback(
+    (v) => onChange({ calculator, operands: [v, operands[1]] }),
+    [calculator, onChange, operands],
+  );
+  const rightOperandOnChange = useCallback(
+    (v) => onChange({ calculator, operands: [operands[0], v] }),
+    [calculator, onChange, operands],
+  );
+  const operatorOnChange = useCallback((v) => onChange({ operands, calculator: v }), [onChange, operands]);
+
   return (
     <fieldset
       className={css`
@@ -159,18 +170,13 @@ function Calculation({ calculator, operands = [], onChange }) {
         flex-wrap: wrap;
       `}
     >
-      <Variable.Input
-        value={operands[0]}
-        onChange={(v) => onChange({ calculator, operands: [v, operands[1]] })}
-        scope={options}
-        useTypedConstant
-      />
+      <Variable.Input value={operands[0]} onChange={leftOperandOnChange} scope={leftOptions} useTypedConstant />
       <Select
         // @ts-ignore
         role="button"
         aria-label="select-operator-calc"
         value={calculator}
-        onChange={(v) => onChange({ operands, calculator: v })}
+        onChange={operatorOnChange}
         placeholder={lang('Operator')}
         popupMatchSelectWidth={false}
         className="auto-width"
@@ -187,12 +193,7 @@ function Calculation({ calculator, operands = [], onChange }) {
             </Select.OptGroup>
           ))}
       </Select>
-      <Variable.Input
-        value={operands[1]}
-        onChange={(v) => onChange({ calculator, operands: [operands[0], v] })}
-        scope={options}
-        useTypedConstant
-      />
+      <Variable.Input value={operands[1]} onChange={rightOperandOnChange} scope={rightOptions} useTypedConstant />
     </fieldset>
   );
 }


### PR DESCRIPTION
## Description

### Steps to reproduce

1. Add a condition node and use basic engine.
2. Add a trigger variable like data id as left operand.
3. Add a same variable as right operand.
4. Clear one of the operand.
5. Add the variable back.

### Expected behavior

Variable added as usual.

### Actual behavior

Error thrown.

## Related issues

#4431.

## Reason

Different `Variable.Input` using same options instance.

## Solution

Use independent options for each component.
