### PR TITLE
chore: avoid misoperation of date variables

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettingsDataScope.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDataScope.tsx
@@ -39,6 +39,7 @@ export const SchemaSettingsDataScope: FC<DataScopeProps> = function DataScopeCon
             {...props}
             form={form}
             record={record}
+            noDisabled={true}
             shouldChange={getShouldChange({
               collectionField: props.collectionField,
               variables,

--- a/packages/core/client/src/schema-settings/VariableInput/VariableInput.tsx
+++ b/packages/core/client/src/schema-settings/VariableInput/VariableInput.tsx
@@ -67,6 +67,10 @@ type Props = {
    * @returns
    */
   returnScope?: (scope: Option[]) => any[];
+  /**
+   * 不需要禁用选项，一般会在表达式中使用
+   */
+  noDisabled?: boolean;
 };
 
 /**
@@ -91,6 +95,7 @@ export const VariableInput = (props: Props) => {
     record,
     returnScope = _.identity,
     targetFieldSchema,
+    noDisabled,
   } = props;
   const { name: blockCollectionName } = useBlockCollection();
   const scope = useVariableScope();
@@ -103,6 +108,7 @@ export const VariableInput = (props: Props) => {
     operator,
     uiSchema,
     targetFieldSchema,
+    noDisabled,
   });
   const contextVariable = useContextAssociationFields({ schema, maxDepth: 2, contextCollectionName, collectionField });
   const { compatOldVariables } = useCompatOldVariables({

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
@@ -193,7 +193,7 @@ export const useDatetimeVariable = ({ operator, schema, noDisabled }: Props = {}
   const { t } = useTranslation();
   const datetimeSettings = useMemo(() => {
     const operatorValue = operator?.value || '';
-    const disabled = noDisabled ? false : !['DatePicker', 'DatePicker.RangePicker'].includes(schema?.['x-component']);
+    const disabled = noDisabled ? false : !['DatePicker.RangePicker'].includes(schema?.['x-component']);
     const dateOptions = [
       {
         key: 'now',

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useVariableOptions.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useVariableOptions.ts
@@ -11,7 +11,6 @@ import { Form } from '@formily/core';
 import { ISchema, Schema } from '@formily/react';
 import { useMemo } from 'react';
 import { CollectionFieldOptions_deprecated } from '../../../collection-manager';
-import { useBlockCollection } from './useBlockCollection';
 import { useDatetimeVariable } from './useDateVariable';
 import { useCurrentFormVariable } from './useFormVariable';
 import { useCurrentObjectVariable } from './useIterationVariable';
@@ -56,7 +55,6 @@ export const useVariableOptions = ({
   targetFieldSchema,
   record,
 }: Props) => {
-  const { name: blockCollectionName = record?.__collectionName } = useBlockCollection();
   const blockParentCollectionName = record?.__parent?.__collectionName;
   const { currentUserSettings } = useCurrentUserVariable({
     maxDepth: 3,


### PR DESCRIPTION
close T-4067

### Key Changes
- When setting default values for form fields, options that don't match will be disabled to prevent errors.
![image](https://github.com/nocobase/nocobase/assets/38434641/2694f616-aa06-4f25-966a-b81706591218)
- When setting the data scope, the date variable is not disabled to ensure it can be selected.
- The date variables in expressions remain unchanged.