### PR TITLE
feat: support linkage style in table and form

### DIFF
--- a/packages/core/client/src/locale/en_US.json
+++ b/packages/core/client/src/locale/en_US.json
@@ -426,6 +426,7 @@
   "Option value": "Option value",
   "Option label": "Option label",
   "Color": "Color",
+  "Background Color": "Background Color",
   "Add option": "Add option",
   "Related collection": "Related collection",
   "Allow linking to multiple records": "Allow linking to multiple records",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -447,6 +447,7 @@
   "Option value": "选项值",
   "Option label": "选项标签",
   "Color": "颜色",
+  "Background Color": "背景颜色",
   "Add option": "添加选项",
   "Related collection": "关系表",
   "Allow linking to multiple records": "允许关联多条记录",

--- a/packages/core/client/src/modules/blocks/data-blocks/form/fieldSettingsFormItem.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/fieldSettingsFormItem.tsx
@@ -6,7 +6,7 @@
  * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
-
+import React from 'react';
 import { ArrayCollapse, FormLayout } from '@formily/antd-v5';
 import { Field } from '@formily/core';
 import { ISchema, useField, useFieldSchema } from '@formily/react';
@@ -24,6 +24,7 @@ import { isPatternDisabled } from '../../../../schema-settings';
 import { ActionType } from '../../../../schema-settings/LinkageRules/type';
 import { SchemaSettingsDefaultValue } from '../../../../schema-settings/SchemaSettingsDefaultValue';
 import { useIsAllowToSetDefaultValue } from '../../../../schema-settings/hooks/useIsAllowToSetDefaultValue';
+import { SchemaSettingsLinkageRules } from '../../../../schema-settings';
 
 export const fieldSettingsFormItem = new SchemaSettings({
   name: 'fieldSettings:FormItem',
@@ -440,6 +441,25 @@ export const fieldSettingsFormItem = new SchemaSettings({
               const isFormReadPretty = useIsFormReadPretty();
               const validateSchema = useValidateSchema();
               return form && !isFormReadPretty && validateSchema;
+            },
+          },
+          {
+            name: 'style',
+            Component: (props) => {
+              const propsWithType = { ...props, type: 'style' };
+              return <SchemaSettingsLinkageRules {...propsWithType} />;
+            },
+            useVisible() {
+              const field: any = useField();
+              return field.readPretty;
+            },
+            useComponentProps() {
+              const { name } = useCollection_deprecated();
+              const { linkageRulesProps } = useSchemaToolbar();
+              return {
+                ...linkageRulesProps,
+                collectionName: name,
+              };
             },
           },
         ];

--- a/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
@@ -7,12 +7,13 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import React from 'react';
 import { ISchema } from '@formily/json-schema';
 import { useField, useFieldSchema } from '@formily/react';
 import { useTranslation } from 'react-i18next';
-import { useApp } from '../../../../application';
+import { useApp, useSchemaToolbar } from '../../../../application';
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
-import { useCollectionManager_deprecated } from '../../../../collection-manager';
+import { useCollection_deprecated, useCollectionManager_deprecated } from '../../../../collection-manager';
 import { useDesignable } from '../../../../schema-component';
 import { useAssociationFieldContext } from '../../../../schema-component/antd/association-field/hooks';
 import { useColumnSchema } from '../../../../schema-component/antd/table-v2/Table.Column.Decorator';
@@ -20,6 +21,7 @@ import { SchemaSettingsDefaultValue } from '../../../../schema-settings/SchemaSe
 import { useFieldComponentName } from './utils';
 import { isPatternDisabled } from '../../../../schema-settings/isPatternDisabled';
 import { useCollection } from '../../../../data-source';
+import { SchemaSettingsLinkageRules } from '../../../../schema-settings';
 
 export const tableColumnSettings = new SchemaSettings({
   name: 'fieldSettings:TableColumn',
@@ -44,7 +46,6 @@ export const tableColumnSettings = new SchemaSettings({
             const { t } = useTranslation();
             const columnSchema = useFieldSchema();
             const { dn } = useDesignable();
-
             return {
               title: t('Custom column title'),
               schema: {
@@ -76,6 +77,50 @@ export const tableColumnSettings = new SchemaSettings({
                 }
                 dn.refresh();
               },
+            };
+          },
+        },
+        {
+          name: 'style',
+          Component: (props) => {
+            const propsWithType = { ...props, type: 'style' };
+            return <SchemaSettingsLinkageRules {...propsWithType} />;
+          },
+          useVisible() {
+            const { uiSchema, fieldSchema } = useColumnSchema();
+            const field: any = useField();
+            const path = field.path?.splice(field.path?.length - 1, 1);
+            const isReadPretty = field.form.query(`${path.concat(`*.` + fieldSchema.name)}`).get('readPretty');
+            return isReadPretty;
+          },
+          useComponentProps() {
+            const { name } = useCollection_deprecated();
+            const { linkageRulesProps } = useSchemaToolbar();
+            return {
+              ...linkageRulesProps,
+              collectionName: name,
+            };
+          },
+        },
+        {
+          name: 'linkageRules',
+          Component: (props) => {
+            const propsWithType = { ...props };
+            return <SchemaSettingsLinkageRules {...propsWithType} />;
+          },
+          useVisible() {
+            const { uiSchema, fieldSchema } = useColumnSchema();
+            const field: any = useField();
+            const path = field.path?.splice(field.path?.length - 1, 1);
+            const isReadPretty = field.form.query(`${path.concat(`*.` + fieldSchema.name)}`).get('readPretty');
+            return isReadPretty;
+          },
+          useComponentProps() {
+            const { name } = useCollection_deprecated();
+            const { linkageRulesProps } = useSchemaToolbar();
+            return {
+              ...linkageRulesProps,
+              collectionName: name,
             };
           },
         },

--- a/packages/core/client/src/schema-settings/LinkageRules/LinkageRuleAction.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/LinkageRuleAction.tsx
@@ -184,3 +184,64 @@ export const FormButtonLinkageRuleAction = observer(
   },
   { displayName: 'FormButtonLinkageRuleAction' },
 );
+
+export const FormStyleLinkageRuleAction = observer(
+  (props: any) => {
+    const { value, options, collectionName } = props;
+    const { t } = useTranslation();
+    const compile = useCompile();
+    const remove = useContext(RemoveActionContext);
+    const { operator, setOperator, value: fieldValue, setValue } = useValues(options);
+    const operators = useMemo(
+      () =>
+        compile([
+          { label: t('Color'), value: ActionType.Color, schema: {} },
+          { label: t('Background Color'), value: ActionType.BackgroundColor, schema: {} },
+        ]),
+      [compile, t],
+    );
+    const schema = {
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'ColorSelect',
+    };
+
+    const onChange = useCallback(
+      (value) => {
+        setOperator(value);
+      },
+      [setOperator],
+    );
+
+    const closeStyle = useMemo(() => ({ color: '#bfbfbf' }), []);
+    return (
+      <div style={{ marginBottom: 8 }}>
+        <Space>
+          <Select
+            data-testid="select-linkage-properties"
+            popupMatchSelectWidth={false}
+            value={operator}
+            options={operators}
+            onChange={onChange}
+            placeholder={t('action')}
+          />
+          {[ActionType.Color, ActionType.BackgroundColor].includes(operator) && (
+            <ValueDynamicComponent
+              fieldValue={fieldValue}
+              schema={schema}
+              setValue={setValue}
+              collectionName={collectionName}
+              inputModes={['constant']}
+            />
+          )}
+          {!props.disabled && (
+            <a role="button" aria-label="icon-close">
+              <CloseCircleOutlined onClick={remove} style={closeStyle} />
+            </a>
+          )}
+        </Space>
+      </div>
+    );
+  },
+  { displayName: 'FormStyleLinkageRuleAction' },
+);

--- a/packages/core/client/src/schema-settings/LinkageRules/LinkageRuleActionGroup.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/LinkageRuleActionGroup.tsx
@@ -14,22 +14,27 @@ import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { withDynamicSchemaProps } from '../../hoc/withDynamicSchemaProps';
 import { useProps } from '../../schema-component/hooks/useProps';
-import { FormButtonLinkageRuleAction, FormFieldLinkageRuleAction } from './LinkageRuleAction';
+import {
+  FormButtonLinkageRuleAction,
+  FormFieldLinkageRuleAction,
+  FormStyleLinkageRuleAction,
+} from './LinkageRuleAction';
 import { RemoveActionContext } from './context';
 export const LinkageRuleActions = observer(
   (props: any): any => {
     const { type, linkageOptions } = props;
     const field = useField<ArrayFieldModel>();
+    const componentMap: {
+      [key in LinkageRuleActionGroupProps['type']]: any;
+    } = {
+      button: FormButtonLinkageRuleAction,
+      field: FormFieldLinkageRuleAction,
+      style: FormStyleLinkageRuleAction,
+    };
     return field?.value?.map((item, index) => {
       return (
         <RemoveActionContext.Provider key={index} value={() => field.remove(index)}>
-          <ObjectField
-            name={index}
-            component={[
-              type === 'button' ? FormButtonLinkageRuleAction : FormFieldLinkageRuleAction,
-              { ...props, options: linkageOptions },
-            ]}
-          />
+          <ObjectField name={index} component={[componentMap[type], { ...props, options: linkageOptions }]} />
         </RemoveActionContext.Provider>
       );
     });
@@ -37,8 +42,8 @@ export const LinkageRuleActions = observer(
   { displayName: 'LinkageRuleActions' },
 );
 
-interface LinkageRuleActionGroupProps {
-  type: 'button' | 'field';
+export interface LinkageRuleActionGroupProps {
+  type: 'button' | 'field' | 'style';
   linkageOptions: any;
   collectionName: string;
 }

--- a/packages/core/client/src/schema-settings/LinkageRules/ValueDynamicComponent.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/ValueDynamicComponent.tsx
@@ -19,15 +19,17 @@ import { DynamicComponent } from './DynamicComponent';
 
 const { Option } = Select;
 
+export type InputModeType = 'constant' | 'express' | 'empty';
 interface ValueDynamicComponentProps {
   fieldValue: any;
   schema: any;
   setValue: (value: any) => void;
   collectionName: string;
+  inputModes?: Array<InputModeType>;
 }
 
 export const ValueDynamicComponent = (props: ValueDynamicComponentProps) => {
-  const { fieldValue, schema, setValue, collectionName } = props;
+  const { fieldValue, schema, setValue, collectionName, inputModes } = props;
   const [mode, setMode] = useState(fieldValue?.mode || 'constant');
   const { t } = useTranslation();
   const { form } = useFormBlockContext();
@@ -111,6 +113,22 @@ export const ValueDynamicComponent = (props: ValueDynamicComponentProps) => {
     ),
   };
 
+  const isModeContained = (mode: InputModeType) => {
+    if (!inputModes) return true;
+    else {
+      return inputModes.indexOf(mode) > -1;
+    }
+  };
+
+  type Options = Array<{ value: InputModeType; label: string }>;
+
+  const options: Options = (
+    [
+      { value: 'constant', label: t('Constant value') },
+      { value: 'express', label: t('Expression') },
+      { value: 'empty', label: t('Empty') },
+    ] as const
+  ).filter((option) => isModeContained(option.value));
   return (
     <Input.Group compact>
       <Select
@@ -127,9 +145,11 @@ export const ValueDynamicComponent = (props: ValueDynamicComponentProps) => {
           });
         }}
       >
-        <Option value="constant">{t('Constant value')}</Option>
-        <Option value="express">{t('Expression')}</Option>
-        <Option value="empty">{t('Empty')}</Option>
+        {options.map((option) => (
+          <Option value={option.value} key={option.value}>
+            {option.label}
+          </Option>
+        ))}
       </Select>
       {modeMap[mode]}
     </Input.Group>

--- a/packages/core/client/src/schema-settings/LinkageRules/compute-rules.ts
+++ b/packages/core/client/src/schema-settings/LinkageRules/compute-rules.ts
@@ -1,0 +1,56 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ActionType } from './type';
+import { InputModeType } from './ValueDynamicComponent';
+import { conditionAnalyses } from '../../schema-component/common/utils/uitls';
+import { color } from '../../style/color';
+const getActionValue = (operator, value) => {
+  const getValueByMode = (value) => {
+    const mode = value?.mode as InputModeType;
+    if (mode === 'constant') {
+      return color[value.value];
+    } else return null;
+  };
+  switch (true) {
+    case [ActionType.Color, ActionType.BackgroundColor].includes(operator):
+      return getValueByMode(value);
+    default:
+      return null;
+      break;
+  }
+};
+
+const getSatisfiedActions = async ({ rules, variables, localVariables }) => {
+  const satisfiedRules = (
+    await Promise.all(
+      rules
+        .filter((k) => !k.disabled)
+        .map(async (rule) => {
+          if (await conditionAnalyses({ ruleGroup: rule.condition, variables, localVariables })) {
+            return rule;
+          } else return null;
+        }),
+    )
+  ).filter(Boolean);
+  return satisfiedRules.map((rule) => rule.actions).flat();
+};
+
+const getSatisfiedValues = async ({ rules, variables, localVariables }) => {
+  return (await getSatisfiedActions({ rules, variables, localVariables })).map((action) => ({
+    ...action,
+    value: getActionValue(action.operator, action.value),
+  }));
+};
+
+export const getSatisfiedValueMap = async ({ rules, variables, localVariables }) => {
+  const values = await getSatisfiedValues({ rules, variables, localVariables });
+  const valueMap = values.reduce((a, v) => ({ ...a, [v.operator]: v.value }), {});
+  return valueMap;
+};

--- a/packages/core/client/src/schema-settings/LinkageRules/type.ts
+++ b/packages/core/client/src/schema-settings/LinkageRules/type.ts
@@ -19,4 +19,11 @@ export enum ActionType {
   Disabled = 'disabled',
   Value = 'value',
   Active = 'enabled',
+  Color = 'color',
+  BackgroundColor = 'backgroundColor',
+}
+
+export enum LinkageRuleDataKey {
+  style = 'x-linkage-rules-style',
+  default = 'x-linkage-rules',
 }

--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -967,21 +967,46 @@ export const SchemaSettingsLinkageRules = function LinkageRules(props) {
   const localVariables = useLocalVariables();
   const record = useRecord();
   const { type: formBlockType } = useFormBlockType();
-  const type = props?.type || fieldSchema?.['x-action'] ? 'button' : 'field';
+  const type = props?.type ?? (['Action', 'Action.Link'].includes(fieldSchema['x-component']) ? 'button' : 'field');
   const gridSchema = findGridSchema(fieldSchema) || fieldSchema;
   const options = useLinkageCollectionFilterOptions(collectionName);
-  const linkageOptions = useLinkageCollectionFieldOptions(collectionName, readPretty);
+  const linkageOptions = useLinkageCollectionFieldOptions(collectionName, readPretty, type);
+  const titleMap = {
+    button: t('Linkage rules'),
+    field: t('Linkage rules'),
+    style: t('Style'),
+  };
+  const ruleKeyMap = useMemo(
+    () => ({
+      button: 'x-linkage-rules',
+      field: 'x-linkage-rules',
+      style: 'x-linkage-rules-style',
+    }),
+    [],
+  );
+  const getRules = useCallback(() => {
+    return gridSchema?.[ruleKeyMap[type]] || fieldSchema?.[ruleKeyMap[type]] || [];
+  }, [gridSchema, fieldSchema, ruleKeyMap, type]);
+
+  const setRules = useCallback(
+    (rules) => {
+      gridSchema[ruleKeyMap[type]] = rules;
+      fieldSchema[ruleKeyMap[type]] = rules;
+    },
+    [[gridSchema, fieldSchema, ruleKeyMap, type]],
+  );
+  const title = titleMap[type];
   const schema = useMemo<ISchema>(
     () => ({
       type: 'object',
-      title: t('Linkage rules'),
+      title,
       properties: {
         fieldReaction: {
           'x-component': FormLinkageRules,
           'x-use-component-props': () => {
             return {
               options,
-              defaultValues: gridSchema?.['x-linkage-rules'] || fieldSchema?.['x-linkage-rules'],
+              defaultValues: getRules(),
               type,
               linkageOptions,
               collectionName,
@@ -995,7 +1020,7 @@ export const SchemaSettingsLinkageRules = function LinkageRules(props) {
         },
       },
     }),
-    [collectionName, fieldSchema, form, gridSchema, localVariables, record, t, type, variables],
+    [collectionName, fieldSchema, form, gridSchema, localVariables, record, t, type, variables, getRules],
   );
   const components = useMemo(() => ({ ArrayCollapse, FormLayout }), []);
   const onSubmit = useCallback(
@@ -1009,25 +1034,18 @@ export const SchemaSettingsLinkageRules = function LinkageRules(props) {
       const schema = {
         ['x-uid']: uid,
       };
-
-      gridSchema['x-linkage-rules'] = rules;
-      schema['x-linkage-rules'] = rules;
+      gridSchema[ruleKeyMap[type]] = rules;
+      schema[ruleKeyMap[type]] = rules;
       dn.emit('patch', {
         schema,
       });
       dn.refresh();
     },
-    [dn, getTemplateById, gridSchema],
+    [dn, getTemplateById, gridSchema, setRules],
   );
 
   return (
-    <SchemaSettingsModalItem
-      title={t('Linkage rules')}
-      components={components}
-      width={770}
-      schema={schema}
-      onSubmit={onSubmit}
-    />
+    <SchemaSettingsModalItem title={title} components={components} width={770} schema={schema} onSubmit={onSubmit} />
   );
 };
 
@@ -1115,7 +1133,7 @@ export function SchemaSettingsEnableChildCollections(props) {
   const isAssocationAdd = fieldSchema?.parent?.['x-component'] === 'CollectionField';
   return (
     <SchemaSettingsModalItem
-      title={t('Enable child collections')}
+      title={title}
       components={{ ArrayItems, FormLayout }}
       scope={{ isAssocationAdd }}
       schema={

--- a/packages/core/client/src/style/color.ts
+++ b/packages/core/client/src/style/color.ts
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import {
+  red,
+  volcano,
+  orange,
+  gold,
+  yellow,
+  lime,
+  green,
+  cyan,
+  blue,
+  geekblue,
+  purple,
+  magenta,
+  grey,
+  gray,
+} from '@ant-design/colors';
+
+export const color = {
+  red: red.primary,
+  volcano: volcano.primary,
+  gold: gold.primary,
+  orange: orange.primary,
+  yellow: yellow.primary,
+  lime: lime.primary,
+  green: green.primary,
+  cyan: cyan.primary,
+  blue: blue.primary,
+  geekblue: geekblue.primary,
+  purple: purple.primary,
+  magenta: magenta.primary,
+  grey: grey.primary,
+  gray: gray.primary,
+  default: null,
+};


### PR DESCRIPTION
## 需求
支持Table和Form的Field使用联动规则框架配置color和backgroundColor样式
## 规则类型
样式联动规则与原有联动规则虽然框架是同一套，但是数据是隔离的，所以规则数据的存储应与`x-linkage-rules`分开，目前设计存储在`x-style-linkage-rules`下
同时，为联动规则增加类型字段
```ts
type RuleType = 'style' | 'default' // style-样式联动规则  default-普通联动规则
```
## 规则计算
增加规则计算函数, 可以计算规则中所有满足条件的action中的value

## 样式渲染
### Table
在BodyCellComponent组件中渲染联动样式，首先在columns在onCell函数将当前record作为props传递给BodyCellComponent
### Form
FormItem渲染样式，使用formilyJS的onFormValuesChange，当form数据有变动时执行规则计算逻辑