### PR TITLE
fix(client): fix Variable.TextArea style

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -13,6 +13,7 @@ import { Space } from 'antd';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { renderToString } from 'react-dom/server';
 import sanitizeHTML from 'sanitize-html';
+import useInputStyle from 'antd/es/input/style';
 
 import { error } from '@nocobase/utils/client';
 
@@ -219,6 +220,7 @@ export function TextArea(props) {
   const [html, setHtml] = useState(() => renderHTML(value ?? '', keyLabelMap));
   // NOTE: e.g. [startElementIndex, startOffset, endElementIndex, endOffset]
   const [range, setRange] = useState<[number, number, number, number]>([-1, 0, -1, 0]);
+  useInputStyle('ant-input');
 
   useEffect(() => {
     preloadOptions(scope, value)


### PR DESCRIPTION
## Description

Border and other style of Variable.TextArea disappeared.

![image](https://github.com/nocobase/nocobase/assets/525658/8c6bf5f5-2ed7-4e3b-a7fa-105249bed509)

### Steps to reproduce

1. Add a calculation node in workflow.
2. Open node configuration drawer.

### Expected behavior

The input text area should has border and other styles.

### Actual behavior

Styles disappeared.

## Related issues

None.

## Reason

https://github.com/nocobase/nocobase/commit/49d0082b16460768a5aeab7a457f7d42b4014ab7#diff-015b8e211b486e3d5847258410762fc9da59abfc28055848abf1bc9dde29003bR238

## Solution

Add `useInputStyle('ant-input')` for custom component.
