### PR TITLE
fix(plugin-workflow-request): fix locale

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-request/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/locale/zh-CN.json
@@ -17,5 +17,8 @@
   "Input request data": "输入请求数据",
   "Only support standard JSON data": "仅支持标准 JSON 数据",
   "\"Content-Type\" will be ignored from headers.": "请求头中配置的 \"Content-Type\" 将被忽略。",
-  "Ignore failed request and continue workflow": "忽略失败的请求并继续工作流"
+  "Ignore failed request and continue workflow": "忽略失败的请求并继续工作流",
+  "Status code": "状态码",
+  "Data": "数据",
+  "Response headers": "响应头"
 }


### PR DESCRIPTION
## Description

Variable label of request node not translated.

### Steps to reproduce

1. Add a request node.
2. Add a calculation node as after.
3. Try to add "Status code" of request result as a variable.

### Expected behavior

"Status code" and other variables should be translated.

### Actual behavior

Not translated.

## Related issues

None.

## Reason

Locale missed.

## Solution

Add the locales.
