### PR TITLE
fix(plugin-workflow): fix trigger workflow acl

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -233,9 +233,7 @@ export default class PluginWorkflowServer extends Plugin {
       actions: ['workflows:list'],
     });
 
-    this.app.acl.allow('workflows', ['trigger'], 'loggedIn');
-
-    await this.importCollections(path.resolve(__dirname, 'collections'));
+    this.app.acl.allow('*', ['trigger'], 'loggedIn');
 
     this.db.addMigrations({
       namespace: this.name,


### PR DESCRIPTION
## Description

### Steps to reproduce

1. Add a custom action trigger workflow, and add a button for it on a table block.
2. Add a user in member role.
3. Login from the user.
4. Click the trigger button from table click user.

### Expected behavior

Workflow successfully triggered.

### Actual behavior

Error with "No permission".

## Related issues

None.

## Reason

ACL not open for users.

## Solution

Open ACL for logged-in users.
