### PR TITLE
fix(utils): fix json-templates

### DIFF
--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -8,7 +8,6 @@
     "@hapi/topo": "^6.0.0",
     "@rc-component/mini-decimal": "^1.1.0",
     "dayjs": "^1.11.9",
-    "dedupe": "^3.0.2",
     "deepmerge": "^4.2.2",
     "flat-to-nested": "^1.1.1",
     "graphlib": "^2.1.8",

--- a/packages/core/utils/src/__tests__/json-templates.test.ts
+++ b/packages/core/utils/src/__tests__/json-templates.test.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { parse } from '../json-templates';
+
+describe('json-templates', () => {
+  it('parse json with string template', async () => {
+    const template = {
+      name: '{{id}}-{{name}}.',
+      age: 18,
+    };
+    const result = parse(template)({
+      name: 'test',
+      id: 1,
+    });
+    expect(result).toEqual({
+      name: '1-test.',
+      age: 18,
+    });
+  });
+});


### PR DESCRIPTION
## Description

Multiple variables in a string not parsed correctly.

### Steps to reproduce

```
parse({ str: '{{a}},{{b}}' })({ a: 'a', b: 'b' });
```

### Expected behavior

```
{ str: 'a,b' }
```

### Actual behavior

```
{ str: 'b' }
```

## Related issues

None.

## Reason

json-templates bug.

## Solution

Update code to latest version.
