### PR TITLE
fix(client): fix deep association select in AppendsTreeSelect component

### DIFF
--- a/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import {
   CollectionFieldOptions_deprecated,
   parseCollectionName,
+  useApp,
   useCollectionManager_deprecated,
   useCompile,
 } from '../../..';
@@ -66,8 +67,7 @@ function trueFilter(field) {
 }
 
 function getCollectionFieldOptions(this: CallScope, collection, parentNode?): TreeOptionType[] {
-  const [dataSourceName, collectionName] = parseCollectionName(collection);
-  const fields = this.getCollectionFields(collectionName, dataSourceName).filter(isAssociation);
+  const fields = this.getCollectionFields(collection).filter(isAssociation);
   const boundLoadChildren = loadChildren.bind(this);
   return fields.filter(this.filter).map((field) => {
     const key = parentNode ? `${parentNode.value ? `${parentNode.value}.` : ''}${field.name}` : field.name;
@@ -104,7 +104,9 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
   const [optionsMap, setOptionsMap] = useState({});
   const collectionString = useCollection({ collection });
   const [dataSourceName, collectionName] = parseCollectionName(collectionString);
-  const { getCollectionFields } = useCollectionManager_deprecated(dataSourceName);
+  const app = useApp();
+  const { collectionManager } = app.dataSourceManager.getDataSource(dataSourceName);
+  const getCollectionFields = collectionManager.getCollectionFields.bind(collectionManager);
   const treeData = Object.values(optionsMap);
   const value: string | DefaultOptionType[] = useMemo(() => {
     if (props.multiple) {
@@ -142,7 +144,7 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
     const tData =
       propsLoadData === null
         ? []
-        : getCollectionFieldOptions.call({ compile, getCollectionFields, filter }, collectionString, parentNode);
+        : getCollectionFieldOptions.call({ compile, getCollectionFields, filter }, collectionName, parentNode);
 
     const map = tData.reduce((result, item) => Object.assign(result, { [item.value]: item }), {});
     if (parentNode) {


### PR DESCRIPTION
## Description

Can not select deep associations in AppendsTreeSelect component.

### Steps to reproduce

1. Add an external PG datasource.
2. Add a collection workflow using collection from the datasource.
3. Try select associations more than 1 level for the preload associations select.

### Expected behavior

Could select.

### Actual behavior

Could not.

## Related issues

None.

## Reason

Legacy API does not support multiple data source.

## Solution

Migrate legacy API to new ones in the component.
