### PR TITLE
fix(plugin-map): add 'Set default zoom level' option for map fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-map/src/client/block/MapBlock.Settings.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/block/MapBlock.Settings.tsx
@@ -26,10 +26,51 @@ import {
   useDesignable,
   useFormBlockContext,
 } from '@nocobase/client';
-import lodash from 'lodash';
+import _ from 'lodash';
 import { useMapTranslation } from '../locale';
 import { useMapBlockContext } from './MapBlockProvider';
 import { findNestedOption } from './utils';
+
+export const defaultZoomLevel = {
+  name: 'defaultZoomLevel',
+  Component: SchemaSettingsModalItem,
+  useComponentProps() {
+    const { t } = useMapTranslation();
+    const fieldSchema = useFieldSchema();
+    const field = useField();
+    const { dn } = useDesignable();
+    const defaultZoom = fieldSchema?.['x-component-props']?.['zoom'] || 13;
+    return {
+      title: t('The default zoom level of the map'),
+      schema: {
+        type: 'object',
+        title: t('Set default zoom level'),
+        properties: {
+          zoom: {
+            title: t('Zoom'),
+            default: defaultZoom,
+            'x-component': 'InputNumber',
+            'x-decorator': 'FormItem',
+            'x-component-props': {
+              precision: 0,
+            },
+          },
+        },
+      } as ISchema,
+      onSubmit: ({ zoom }) => {
+        _.set(fieldSchema, 'x-component-props.zoom', zoom);
+        field.componentProps.zoom = zoom;
+        dn.emit('patch', {
+          schema: {
+            'x-uid': fieldSchema['x-uid'],
+            'x-component-props': fieldSchema['x-component-props'],
+          },
+        });
+        dn.refresh();
+      },
+    };
+  },
+};
 
 export const mapBlockSettings = new SchemaSettings({
   name: 'blockSettings:map',
@@ -136,46 +177,7 @@ export const mapBlockSettings = new SchemaSettings({
       },
     },
     setDataLoadingModeSettingsItem,
-    {
-      name: 'defaultZoomLevel',
-      Component: SchemaSettingsModalItem,
-      useComponentProps() {
-        const { t } = useMapTranslation();
-        const fieldSchema = useFieldSchema();
-        const field = useField();
-        const { dn } = useDesignable();
-        const defaultZoom = fieldSchema?.['x-component-props']?.['zoom'] || 13;
-        return {
-          title: t('The default zoom level of the map'),
-          schema: {
-            type: 'object',
-            title: t('Set default zoom level'),
-            properties: {
-              zoom: {
-                title: t('Zoom'),
-                default: defaultZoom,
-                'x-component': 'InputNumber',
-                'x-decorator': 'FormItem',
-                'x-component-props': {
-                  precision: 0,
-                },
-              },
-            },
-          } as ISchema,
-          onSubmit: ({ zoom }) => {
-            lodash.set(fieldSchema, 'x-component-props.zoom', zoom);
-            Object.assign(field.componentProps, fieldSchema['x-component-props']);
-            dn.emit('patch', {
-              schema: {
-                'x-uid': fieldSchema['x-uid'],
-                'x-component-props': field.componentProps,
-              },
-            });
-            dn.refresh();
-          },
-        };
-      },
-    },
+    defaultZoomLevel,
     {
       name: 'dataScope',
       Component: SchemaSettingsDataScope,

--- a/packages/plugins/@nocobase/plugin-map/src/client/components/AMap/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/components/AMap/Map.tsx
@@ -121,6 +121,12 @@ export const AMapComponent = React.forwardRef<AMapForwardedRefProps, AMapCompone
     ...overlayCommonOptions,
   });
 
+  useEffect(() => {
+    if (map.current) {
+      map.current.setZoom(zoom);
+    }
+  }, [zoom]);
+
   const toRemoveOverlay = useMemoizedFn(() => {
     if (overlay.current) {
       overlay.current.remove();

--- a/packages/plugins/@nocobase/plugin-map/src/client/components/GoogleMaps/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/components/GoogleMaps/Map.tsx
@@ -99,6 +99,12 @@ export const GoogleMapsComponent = React.forwardRef<GoogleMapForwardedRefProps, 
     const api = useAPIClient();
     const { modal } = App.useApp();
 
+    useEffect(() => {
+      if (map.current) {
+        map.current.setZoom(zoom);
+      }
+    }, [zoom]);
+
     const type = useMemo<MapEditorType>(() => {
       if (props.type) return props.type;
       const collectionField = getField(fieldSchema?.name);

--- a/packages/plugins/@nocobase/plugin-map/src/client/fields/fieldSettingsComponentMap.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client/fields/fieldSettingsComponentMap.ts
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ISchema, useField, useFieldSchema } from '@formily/react';
+import { SchemaSettings, SchemaSettingsModalItem, useDesignable } from '@nocobase/client';
+import _ from 'lodash';
+import { useMapTranslation } from '../locale';
+
+export const fieldSettingsComponentMap = new SchemaSettings({
+  name: 'fieldSettings:component:Map',
+  items: [
+    {
+      name: 'defaultZoomLevel',
+      Component: SchemaSettingsModalItem,
+      useComponentProps() {
+        const { t } = useMapTranslation();
+        const fieldSchema = useFieldSchema();
+        const field = useField();
+        const { dn } = useDesignable();
+        const defaultZoom = fieldSchema?.['x-component-props']?.['zoom'] || 13;
+        return {
+          title: t('The default zoom level of the map'),
+          schema: {
+            type: 'object',
+            title: t('Set default zoom level'),
+            properties: {
+              zoom: {
+                title: t('Zoom'),
+                default: defaultZoom,
+                'x-component': 'InputNumber',
+                'x-decorator': 'FormItem',
+                'x-component-props': {
+                  precision: 0,
+                },
+              },
+            },
+          } as ISchema,
+          onSubmit: ({ zoom }) => {
+            _.set(fieldSchema, 'x-component-props.zoom', zoom);
+            Object.assign(field.componentProps, fieldSchema['x-component-props']);
+            dn.emit('patch', {
+              schema: {
+                'x-uid': fieldSchema['x-uid'],
+                'x-component-props': field.componentProps,
+              },
+            });
+            dn.refresh();
+          },
+        };
+      },
+    },
+  ],
+});

--- a/packages/plugins/@nocobase/plugin-map/src/client/fields/fieldSettingsComponentMap.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client/fields/fieldSettingsComponentMap.ts
@@ -7,53 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { ISchema, useField, useFieldSchema } from '@formily/react';
-import { SchemaSettings, SchemaSettingsModalItem, useDesignable } from '@nocobase/client';
-import _ from 'lodash';
-import { useMapTranslation } from '../locale';
+import { SchemaSettings } from '@nocobase/client';
+import { defaultZoomLevel } from '../block/MapBlock.Settings';
 
 export const fieldSettingsComponentMap = new SchemaSettings({
   name: 'fieldSettings:component:Map',
-  items: [
-    {
-      name: 'defaultZoomLevel',
-      Component: SchemaSettingsModalItem,
-      useComponentProps() {
-        const { t } = useMapTranslation();
-        const fieldSchema = useFieldSchema();
-        const field = useField();
-        const { dn } = useDesignable();
-        const defaultZoom = fieldSchema?.['x-component-props']?.['zoom'] || 13;
-        return {
-          title: t('The default zoom level of the map'),
-          schema: {
-            type: 'object',
-            title: t('Set default zoom level'),
-            properties: {
-              zoom: {
-                title: t('Zoom'),
-                default: defaultZoom,
-                'x-component': 'InputNumber',
-                'x-decorator': 'FormItem',
-                'x-component-props': {
-                  precision: 0,
-                },
-              },
-            },
-          } as ISchema,
-          onSubmit: ({ zoom }) => {
-            _.set(fieldSchema, 'x-component-props.zoom', zoom);
-            Object.assign(field.componentProps, fieldSchema['x-component-props']);
-            dn.emit('patch', {
-              schema: {
-                'x-uid': fieldSchema['x-uid'],
-                'x-component-props': field.componentProps,
-              },
-            });
-            dn.refresh();
-          },
-        };
-      },
-    },
-  ],
+  items: [defaultZoomLevel],
 });

--- a/packages/plugins/@nocobase/plugin-map/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/index.tsx
@@ -12,10 +12,11 @@ import React from 'react';
 import { MapBlockOptions } from './block';
 import { mapActionInitializers, mapActionInitializers_deprecated } from './block/MapActionInitializers';
 import { mapBlockSettings } from './block/MapBlock.Settings';
+import { useMapBlockProps } from './block/MapBlockProvider';
 import { Configuration, Map } from './components';
 import { fields } from './fields';
+import { fieldSettingsComponentMap } from './fields/fieldSettingsComponentMap';
 import { NAMESPACE, generateNTemplate } from './locale';
-import { useMapBlockProps } from './block/MapBlockProvider';
 const MapProvider = React.memo((props) => {
   return (
     <SchemaComponentOptions components={{ Map }}>
@@ -39,6 +40,7 @@ export class PluginMapClient extends Plugin {
     this.app.schemaInitializerManager.add(mapActionInitializers_deprecated);
     this.app.schemaInitializerManager.add(mapActionInitializers);
     this.schemaSettingsManager.add(mapBlockSettings);
+    this.schemaSettingsManager.add(fieldSettingsComponentMap);
 
     const blockInitializers = this.app.schemaInitializerManager.get('page:addBlock');
     blockInitializers?.add('dataBlocks.map', {


### PR DESCRIPTION
close T-4358

- [ ] Add 'Set default zoom level' option for map fields.
- [ ] Extract the 'Set default zoom level' option.
- [ ] Should real-time map update after zoom changes.