### PR TITLE
fix(plugin-fm): fix delete file error of cos

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/storages/ali-oss.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/storages/ali-oss.test.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import { MockServer } from '@nocobase/test';
-import aliossStorage from '../../storages/ali-oss';
+import AliOSSStorage from '../../storages/ali-oss';
 import { FILE_FIELD_NAME } from '../../../constants';
 import { getApp, requestFile } from '..';
 import { Database } from '@nocobase/database';
@@ -23,6 +23,7 @@ describe('storage:ali-oss', () => {
   let AttachmentRepo;
   let StorageRepo;
   let storage;
+  const aliossStorage = new AliOSSStorage();
 
   beforeEach(async () => {
     app = await getApp();

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/storages/s3.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/storages/s3.test.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import { MockServer } from '@nocobase/test';
-import s3Storage from '../../storages/s3';
+import S3Storage from '../../storages/s3';
 import { FILE_FIELD_NAME } from '../../../constants';
 import { getApp, requestFile } from '..';
 import Database from '@nocobase/database';
@@ -23,6 +23,7 @@ describe('storage:s3', () => {
   let AttachmentRepo;
   let StorageRepo;
   let storage;
+  const s3Storage = new S3Storage();
 
   beforeEach(async () => {
     app = await getApp();

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/storages/tx-cos.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/storages/tx-cos.test.ts
@@ -9,7 +9,7 @@
 
 import path from 'path';
 import { MockServer } from '@nocobase/test';
-import txStorage from '../../storages/tx-cos';
+import TXCOSStorage from '../../storages/tx-cos';
 import { FILE_FIELD_NAME } from '../../../constants';
 import { getApp, requestFile } from '..';
 import { Database } from '@nocobase/database';
@@ -21,6 +21,7 @@ describe('storage:tx-cos', () => {
   let agent;
   let db: Database;
   let storage;
+  const txStorage = new TXCOSStorage();
 
   beforeEach(async () => {
     app = await getApp();

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -46,6 +46,7 @@ function getFileData(ctx: Context) {
   const extname = Path.extname(filename);
   const path = storage.path.replace(/^\/|\/$/g, '');
   const baseUrl = storage.baseUrl.replace(/\/+$/, '');
+  const pathname = [path, filename].filter(Boolean).join('/');
 
   return {
     title: Buffer.from(file.originalname, 'latin1').toString('utf8').replace(extname, ''),
@@ -55,7 +56,7 @@ function getFileData(ctx: Context) {
     path,
     size: file.size,
     // 直接缓存起来
-    url: `${baseUrl}/${path}/${filename}`,
+    url: `${baseUrl}/${pathname}`,
     mimetype: file.mimetype,
     // @ts-ignore
     meta: ctx.request.body,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -9,7 +9,7 @@
 
 import { Context, Next } from '@nocobase/actions';
 import { koaMulter as multer } from '@nocobase/utils';
-import path from 'path';
+import Path from 'path';
 
 import {
   FILE_SIZE_LIMIT_DEFAULT,
@@ -42,19 +42,20 @@ function getFileData(ctx: Context) {
   const storageConfig = ctx.app.pm.get(Plugin).storageTypes.get(storage.type);
   const { [storageConfig.filenameKey || 'filename']: name } = file;
   // make compatible filename across cloud service (with path)
-  const filename = path.basename(name);
-  const extname = path.extname(filename);
-  const urlPath = storage.path ? storage.path.replace(/^([^/])/, '/$1') : '';
+  const filename = Path.basename(name);
+  const extname = Path.extname(filename);
+  const path = storage.path.replace(/^\/|\/$/g, '');
+  const baseUrl = storage.baseUrl.replace(/\/+$/, '');
 
   return {
     title: Buffer.from(file.originalname, 'latin1').toString('utf8').replace(extname, ''),
     filename,
     extname,
     // TODO(feature): 暂时两者相同，后面 storage.path 模版化以后，这里只是 file 实际的 path
-    path: storage.path,
+    path,
     size: file.size,
     // 直接缓存起来
-    url: `${storage.baseUrl}${urlPath}/${filename}`,
+    url: `${baseUrl}/${path}/${filename}`,
     mimetype: file.mimetype,
     // @ts-ignore
     meta: ctx.request.body,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/ali-oss.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/ali-oss.ts
@@ -9,7 +9,7 @@
 
 import { AttachmentModel, StorageType } from '.';
 import { STORAGE_TYPE_ALI_OSS } from '../../constants';
-import { cloudFilenameGetter } from '../utils';
+import { cloudFilenameGetter, getFileKey } from '../utils';
 
 export default class extends StorageType {
   make(storage) {
@@ -35,10 +35,7 @@ export default class extends StorageType {
   }
   async delete(storage, records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {
     const { client } = this.make(storage);
-    const { deleted } = await client.deleteMulti(records.map((record) => `${record.path}/${record.filename}`));
-    return [
-      deleted.length,
-      records.filter((record) => !deleted.find((item) => item.Key === `${record.path}/${record.filename}`)),
-    ];
+    const { deleted } = await client.deleteMulti(records.map(getFileKey));
+    return [deleted.length, records.filter((record) => !deleted.find((item) => item.Key === getFileKey(record)))];
   }
 }

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/s3.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/s3.ts
@@ -9,7 +9,7 @@
 
 import { AttachmentModel, StorageType } from '.';
 import { STORAGE_TYPE_S3 } from '../../constants';
-import { cloudFilenameGetter } from '../utils';
+import { cloudFilenameGetter, getFileKey } from '../utils';
 
 export default class extends StorageType {
   filenameKey = 'key';
@@ -61,14 +61,11 @@ export default class extends StorageType {
       new DeleteObjectsCommand({
         Bucket: storage.options.bucket,
         Delete: {
-          Objects: records.map((record) => ({ Key: `${record.path}/${record.filename}` })),
+          Objects: records.map((record) => ({ Key: getFileKey(record) })),
         },
       }),
     );
 
-    return [
-      Deleted.length,
-      records.filter((record) => !Deleted.find((item) => item.Key === `${record.path}/${record.filename}`)),
-    ];
+    return [Deleted.length, records.filter((record) => !Deleted.find((item) => item.Key === getFileKey(record)))];
   }
 }

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
@@ -11,11 +11,7 @@ import { promisify } from 'util';
 
 import { AttachmentModel, StorageType } from '.';
 import { STORAGE_TYPE_TX_COS } from '../../constants';
-import { cloudFilenameGetter } from '../utils';
-
-function getFileKey(record) {
-  return `${record.path}/${record.filename}`.replace(new RegExp('^/|/$', 'g'), '');
-}
+import { cloudFilenameGetter, getFileKey } from '../utils';
 
 export default class extends StorageType {
   filenameKey = 'url';

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
@@ -38,7 +38,7 @@ export default class extends StorageType {
   }
   async delete(storage, records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {
     const { cos } = this.make(storage);
-    const { Deleted } = await promisify(cos.deleteMultipleObject)({
+    const { Deleted } = await promisify(cos.deleteMultipleObject).call(cos, {
       Region: storage.options.Region,
       Bucket: storage.options.Bucket,
       Objects: records.map((record) => ({ Key: `${record.path}/${record.filename}` })),

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
@@ -13,6 +13,10 @@ import { AttachmentModel, StorageType } from '.';
 import { STORAGE_TYPE_TX_COS } from '../../constants';
 import { cloudFilenameGetter } from '../utils';
 
+function getFileKey(record) {
+  return `${record.path}/${record.filename}`.replace(new RegExp('^/|/$', 'g'), '');
+}
+
 export default class extends StorageType {
   filenameKey = 'url';
   make(storage) {
@@ -41,11 +45,8 @@ export default class extends StorageType {
     const { Deleted } = await promisify(cos.deleteMultipleObject).call(cos, {
       Region: storage.options.Region,
       Bucket: storage.options.Bucket,
-      Objects: records.map((record) => ({ Key: `${record.path}/${record.filename}` })),
+      Objects: records.map((record) => ({ Key: getFileKey(record) })),
     });
-    return [
-      Deleted.length,
-      records.filter((record) => !Deleted.find((item) => item.Key === `${record.path}/${record.filename}`)),
-    ];
+    return [Deleted.length, records.filter((record) => !Deleted.find((item) => item.Key === getFileKey(record)))];
   }
 }

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
@@ -26,5 +26,5 @@ export const cloudFilenameGetter = (storage) => (req, file, cb) => {
 };
 
 export function getFileKey(record) {
-  return `${record.path.replace(/^\/|\/$/g, '')}/${record.filename}`;
+  return [record.path.replace(/^\/|\/$/g, ''), record.filename].filter(Boolean).join('/');
 }

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
@@ -24,3 +24,7 @@ export const cloudFilenameGetter = (storage) => (req, file, cb) => {
     cb(null, `${storage.path ? `${storage.path.replace(/\/+$/, '')}/` : ''}${filename}`);
   });
 };
+
+export function getFileKey(record) {
+  return `${record.path.replace(/^\/|\/$/g, '')}/${record.filename}`;
+}


### PR DESCRIPTION
## Description

Error thrown when deleting file of COS.

### Steps to reproduce

1. Create a COS storage.
2. Create a file collection which storage set to the COS.
3. Upload a file on the table.
4. Delete the file in the table row.

### Expected behavior

File deleted.

### Actual behavior

Error thrown:

```
{"log":"TypeError [ERR_INVALID_ARG_TYPE]: The \"cb\" argument must be of type function. Received undefined\n","stream":"stderr","time":"2024-05-30T05:02:30.36958009Z"}
{"log":"    at makeCallback (node:fs:185:3)\n","stream":"stderr","time":"2024-05-30T05:02:30.369618976Z"}
{"log":"    at Object.unlink (node:fs:1863:14)\n","stream":"stderr","time":"2024-05-30T05:02:30.369624558Z"}
{"log":"    at COSStorage._removeFile (/app/nocobase/node_modules/@nocobase/plugin-file-manager/dist/node_modules/multer-cos/index.js:36:5610)\n","stream":"stderr","time":"2024-05-30T05:02:30.36962885Z"}
{"log":"    at WriteStream.\u003canonymous\u003e (/app/nocobase/node_modules/@nocobase/plugin-file-manager/dist/node_modules/multer-cos/index.js:36:5413)\n","stream":"stderr","time":"2024-05-30T05:02:30.369633355Z"}
{"log":"    at WriteStream.emit (node:events:531:35)\n","stream":"stderr","time":"2024-05-30T05:02:30.369638356Z"}
{"log":"    at WriteStream.emit (node:domain:488:12)\n","stream":"stderr","time":"2024-05-30T05:02:30.369642392Z"}
{"log":"    at emitErrorNT (node:internal/streams/destroy:169:8)\n","stream":"stderr","time":"2024-05-30T05:02:30.369658865Z"}
{"log":"    at emitErrorCloseNT (node:internal/streams/destroy:128:3)\n","stream":"stderr","time":"2024-05-30T05:02:30.369663172Z"}
{"log":"    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {\n","stream":"stderr","time":"2024-05-30T05:02:30.369667386Z"}
{"log":"  code: 'ERR_INVALID_ARG_TYPE'\n","stream":"stderr","time":"2024-05-30T05:02:30.369671752Z"}
```

## Related issues

None.

## Reason

No `this` of promisified function.

## Solution

Fix `this`.
