### PR TITLE
fix(plugin-fm): fix cos path error

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/FileSizeField.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/FileSizeField.tsx
@@ -47,7 +47,7 @@ export function FileSizeField(props) {
   const dvOption = getUnitOption(defaultValue, defaultUnit);
   const dv = defaultValue / dvOption.value;
   const vOption = getUnitOption(value ?? defaultValue, defaultUnit);
-  const v = value == null ? dv : value / vOption.value;
+  const v = value == null ? value : value / vOption.value;
 
   const onNumberChange = useCallback(
     (val) => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -44,7 +44,7 @@ function getFileData(ctx: Context) {
   // make compatible filename across cloud service (with path)
   const filename = Path.basename(name);
   const extname = Path.extname(filename);
-  const path = storage.path.replace(/^\/|\/$/g, '');
+  const path = (storage.path || '').replace(/^\/|\/$/g, '');
   const baseUrl = storage.baseUrl.replace(/\/+$/, '');
   const pathname = [path, filename].filter(Boolean).join('/');
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
@@ -11,15 +11,18 @@ import { promisify } from 'util';
 
 import { AttachmentModel, StorageType } from '.';
 import { STORAGE_TYPE_TX_COS } from '../../constants';
-import { cloudFilenameGetter, getFileKey } from '../utils';
+import { getFilename, getFileKey } from '../utils';
 
 export default class extends StorageType {
   filenameKey = 'url';
   make(storage) {
     const createTxCosStorage = require('multer-cos');
     return new createTxCosStorage({
-      cos: storage.options,
-      filename: cloudFilenameGetter(storage),
+      cos: {
+        ...storage.options,
+        dir: (storage.path ?? '').replace(/\/+$/, ''),
+      },
+      filename: getFilename,
     });
   }
   defaults() {


### PR DESCRIPTION
## Description

When set path, upload cause error.

### Steps to reproduce

1. Create a COS storage with path like "abc".
2. Create a file collection use the COS storage.
3. Upload a file to the file collection.

### Expected behavior

File uploaded.

### Actual behavior

Error thrown.

```
app_1  | TypeError [ERR_INVALID_ARG_TYPE]: The "cb" argument must be of type function. Received undefined
app_1  |     at makeCallback (node:fs:185:3)
app_1  |     at Object.unlink (node:fs:1863:14)
app_1  |     at COSStorage._removeFile (/app/nocobase/node_modules/@nocobase/plugin-file-manager/dist/node_modules/multer-cos/index.js:36:5610)
app_1  |     at WriteStream.<anonymous> (/app/nocobase/node_modules/@nocobase/plugin-file-manager/dist/node_modules/multer-cos/index.js:36:5413)
app_1  |     at WriteStream.emit (node:events:531:35)
app_1  |     at WriteStream.emit (node:domain:488:12)
app_1  |     at emitErrorNT (node:internal/streams/destroy:169:8)
app_1  |     at emitErrorCloseNT (node:internal/streams/destroy:128:3)
app_1  |     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
app_1  |   code: 'ERR_INVALID_ARG_TYPE'
app_1  | }
```

## Related issues

lanbosm/multer-COS#1

## Reason

Destination configuration different with other vendors.

## Solution

Fix storage configuration.
