### PR TITLE
fix(plugin-workflow): fix workflow versions dropdown overflow

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -177,41 +177,40 @@ export function WorkflowCanvas() {
           />
         </header>
         <aside>
-          <div className="workflow-versions">
-            <Dropdown
-              trigger={['click']}
-              menu={{
-                onClick: onSwitchVersion,
-                defaultSelectedKeys: [`${workflow.id}`],
-                className: cx(styles.dropdownClass, styles.workflowVersionDropdownClass),
-                items: revisions
-                  .sort((a, b) => b.id - a.id)
-                  .map((item, index) => ({
-                    role: 'button',
-                    'aria-label': `version-${index}`,
-                    key: `${item.id}`,
-                    icon: item.current ? <RightOutlined /> : null,
-                    className: cx({
-                      executed: item.executed,
-                      unexecuted: !item.executed,
-                      enabled: item.enabled,
-                    }),
-                    label: (
-                      <>
-                        <strong>{`#${item.id}`}</strong>
-                        <time>{str2moment(item.createdAt).format('YYYY-MM-DD HH:mm:ss')}</time>
-                      </>
-                    ),
-                  })),
-              }}
-            >
-              <Button type="text" aria-label="version">
-                <label>{lang('Version')}</label>
-                <span>{workflow?.id ? `#${workflow.id}` : null}</span>
-                <DownOutlined />
-              </Button>
-            </Dropdown>
-          </div>
+          <Dropdown
+            className="workflow-versions"
+            trigger={['click']}
+            menu={{
+              onClick: onSwitchVersion,
+              defaultSelectedKeys: [`${workflow.id}`],
+              className: cx(styles.dropdownClass, styles.workflowVersionDropdownClass),
+              items: revisions
+                .sort((a, b) => b.id - a.id)
+                .map((item, index) => ({
+                  role: 'button',
+                  'aria-label': `version-${index}`,
+                  key: `${item.id}`,
+                  icon: item.current ? <RightOutlined /> : null,
+                  className: cx({
+                    executed: item.executed,
+                    unexecuted: !item.executed,
+                    enabled: item.enabled,
+                  }),
+                  label: (
+                    <>
+                      <strong>{`#${item.id}`}</strong>
+                      <time>{str2moment(item.createdAt).format('YYYY-MM-DD HH:mm:ss')}</time>
+                    </>
+                  ),
+                })),
+            }}
+          >
+            <Button type="text" aria-label="version">
+              <label>{lang('Version')}</label>
+              <span>{workflow?.id ? `#${workflow.id}` : null}</span>
+              <DownOutlined />
+            </Button>
+          </Dropdown>
           <Switch
             checked={workflow.enabled}
             onChange={onToggle}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
@@ -96,6 +96,9 @@ const useStyles = createStyles(({ css, token }) => {
     `,
 
     workflowVersionDropdownClass: css`
+      max-height: 80vh;
+      overflow-y: auto;
+
       .ant-dropdown-menu-item {
         .ant-dropdown-menu-title-content {
           strong {


### PR DESCRIPTION
## Description

Workflow versions dropdown overflow.

### Steps to reproduce

1. Add a lot of versions for a workflow more than one screen.
2. Open the versions dropdown.

### Expected behavior

Scroll bar in the dropdown.

### Actual behavior

No scroll bar in dropdown, and page overflowed.

## Related issues

None.

## Reason

No height limit for the versions dropdown.

## Solution

Add `max-height` for the dropdown.
