### PR TITLE
fix(client): fix attachment component

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -390,7 +390,8 @@ export function Uploader({ rules, ...props }: UploadProps) {
 
   const { mimetype: accept, size } = rules ?? {};
   const sizeHint = useSizeHint(size);
-  const selectable = !disabled && (multiple || !(value || pendingList.length));
+  const selectable =
+    !disabled && (multiple || ((!value || (Array.isArray(value) && !value.length)) && !pendingList.length));
 
   return (
     <>


### PR DESCRIPTION
## Description

Can not select file when attachment field set to not allowing multiple files.

### Steps to reproduce

1. Add an attachment field without allowing multiple files.
2. Add the field to a form.

### Expected behavior

Could use the uploader to upload file.

### Actual behavior

Uploader component disappears.

## Related issues

None.

## Reason

Selectable logic incorrect.

## Solution

Fix the selectable logic.
