### PR TITLE
fix(client): fix upload logo in system settings

### DIFF
--- a/packages/core/client/src/system-settings/SystemSettingsShortcut.tsx
+++ b/packages/core/client/src/system-settings/SystemSettingsShortcut.tsx
@@ -105,7 +105,7 @@ const schema: ISchema = {
             multiple: false,
             // accept: 'jpg,png'
           },
-          'x-use-component-props': 'useCollectionFieldStorageRules',
+          'x-use-component-props': 'useFileCollectionStorageRules',
         },
         enabledLanguages: {
           type: 'array',


### PR DESCRIPTION
## Description

Logo upload rule not correct in system settings.

### Steps to reproduce

1. Go to system settings.
2. Remove current logo.
3. Mouse hover on logo upload component.

### Expected behavior

Size rule shows correctly.

### Actual behavior

Warning in console tells hooks not exists.

## Related issues

None.

## Reason

Wrong hook name.

## Solution

Fix hook name.
