### PR TITLE
fix(client): fix action props

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -69,7 +69,7 @@ export const Action: ComposedAction = withDynamicSchemaProps(
       /** 如果为 true 则说明该按钮是树表格的 Add child 按钮 */
       addChild,
       onMouseEnter,
-      refreshDataBlockRequest,
+      refreshDataBlockRequest: propsRefreshDataBlockRequest,
       ...others
     } = useProps(props); // 新版 UISchema（1.0 之后）中已经废弃了 useProps，这里之所以继续保留是为了兼容旧版的 UISchema
     const aclCtx = useACLActionParamsContext();
@@ -89,6 +89,7 @@ export const Action: ComposedAction = withDynamicSchemaProps(
     const designerProps = fieldSchema['x-toolbar-props'] || fieldSchema['x-designer-props'];
     const openMode = fieldSchema?.['x-component-props']?.['openMode'];
     const openSize = fieldSchema?.['x-component-props']?.['openSize'];
+    const refreshDataBlockRequest = fieldSchema?.['x-component-props']?.['refreshDataBlockRequest'];
 
     const disabled = form.disabled || field.disabled || field.data?.disabled || propsDisabled || disableAction;
     const linkageRules = useMemo(() => fieldSchema?.['x-linkage-rules'] || [], [fieldSchema?.['x-linkage-rules']]);


### PR DESCRIPTION
## Description

Auto refresh after action not works.

### Steps to reproduce

1. Add an create form.
2. Submit form to create data.

### Expected behavior

Parent block refresh after submitted.

### Actual behavior

Not refresh.

## Related issues

#4562.

## Reason

`props` not equal to `field['x-component-props']`.

## Solution

Revert the property back.
