### PR TITLE
feat(client): allow JSON5 value in Form Input of type JSONTextArea

### DIFF
--- a/packages/core/client/package.json
+++ b/packages/core/client/package.json
@@ -61,7 +61,8 @@
     "react-router-dom": "^6.11.2",
     "react-to-print": "^2.14.7",
     "sanitize-html": "2.13.0",
-    "use-deep-compare-effect": "^1.8.1"
+    "use-deep-compare-effect": "^1.8.1",
+    "json5": "^2.2.3"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/core/client/src/schema-component/antd/input/Json.tsx
+++ b/packages/core/client/src/schema-component/antd/input/Json.tsx
@@ -13,8 +13,9 @@ import { Input } from 'antd';
 import { TextAreaProps } from 'antd/es/input';
 import React, { useState, useEffect, Ref } from 'react';
 import { cx, css } from '@emotion/css';
+import JSON5 from 'json5';
 
-export type JSONTextAreaProps = TextAreaProps & { value?: string; space?: number };
+export type JSONTextAreaProps = TextAreaProps & { value?: string; space?: number; json5?: boolean };
 
 const jsonCss = css`
   font-size: 80%;
@@ -22,13 +23,14 @@ const jsonCss = css`
 `;
 
 export const Json = React.forwardRef<typeof Input.TextArea, JSONTextAreaProps>(
-  ({ value, onChange, space = 2, ...props }: JSONTextAreaProps, ref: Ref<any>) => {
+  ({ value, onChange, space = 2, json5 = true, ...props }: JSONTextAreaProps, ref: Ref<any>) => {
+    const _JSON = json5 ? JSON5 : JSON;
     const field = useField<Field>();
     const [text, setText] = useState('');
     useEffect(() => {
       try {
         if (value != null) {
-          setText(JSON.stringify(value, null, space));
+          setText(_JSON.stringify(value, null, space));
         } else {
           setText(undefined);
         }
@@ -45,9 +47,9 @@ export const Json = React.forwardRef<typeof Input.TextArea, JSONTextAreaProps>(
         onChange={(ev) => {
           setText(ev.target.value);
           try {
-            const v = ev.target.value.trim() !== '' ? JSON.parse(ev.target.value) : null;
+            const v = ev.target.value.trim() !== '' ? _JSON.parse(ev.target.value) : null;
             if (ev.target.value.trim() !== '') {
-              JSON.parse(ev.target.value);
+              _JSON.parse(ev.target.value);
             }
             field.setFeedback({});
           } catch (err) {
@@ -60,7 +62,7 @@ export const Json = React.forwardRef<typeof Input.TextArea, JSONTextAreaProps>(
         }}
         onBlur={(ev) => {
           try {
-            const v = ev.target.value.trim() !== '' ? JSON.parse(ev.target.value) : null;
+            const v = ev.target.value.trim() !== '' ? _JSON.parse(ev.target.value) : null;
             field.setFeedback({});
             onChange?.(v);
           } catch (err) {

--- a/packages/core/client/src/schema-component/antd/input/Json.tsx
+++ b/packages/core/client/src/schema-component/antd/input/Json.tsx
@@ -23,7 +23,7 @@ const jsonCss = css`
 `;
 
 export const Json = React.forwardRef<typeof Input.TextArea, JSONTextAreaProps>(
-  ({ value, onChange, space = 2, json5 = true, ...props }: JSONTextAreaProps, ref: Ref<any>) => {
+  ({ value, onChange, space = 2, json5 = false, ...props }: JSONTextAreaProps, ref: Ref<any>) => {
     const _JSON = json5 ? JSON5 : JSON;
     const field = useField<Field>();
     const [text, setText] = useState('');

--- a/packages/core/client/src/schema-component/antd/input/__tests__/Input.test.tsx
+++ b/packages/core/client/src/schema-component/antd/input/__tests__/Input.test.tsx
@@ -10,10 +10,11 @@
 import { fireEvent, render, screen, userEvent, waitFor } from '@nocobase/test/client';
 import React from 'react';
 import App1 from '../demos/input';
-import App4 from '../demos/json';
 import App2 from '../demos/textarea';
 import App3 from '../demos/url';
 import JSON5 from 'json5';
+import JSONInput from '../demos/new-demos/json';
+import JSON5Input from '../demos/new-demos/json5';
 
 describe('Input', () => {
   it('should display the title', () => {
@@ -94,19 +95,17 @@ describe('Input.URL', () => {
 
 describe('Input.JSON', () => {
   it('should display the title', async () => {
-    render(<App4 />);
+    render(<JSONInput />);
 
     await waitFor(() => {
-      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
-      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
+      expect(screen.getByText('Test').innerHTML).toBe('Test');
     });
   });
 
   it('should display the value of user input', async () => {
-    const { container } = render(<App4 />);
+    const { container } = render(<JSONInput />);
     await waitFor(() => {
-      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
-      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
+      expect(screen.getByText('Test').innerHTML).toBe('Test');
     });
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
@@ -116,40 +115,25 @@ describe('Input.JSON', () => {
     await userEvent.type(textarea, '{{"name":"nocobase"}');
     // mock blur event
     await userEvent.click(document.body);
-    expect(JSON5.parse(textarea.value)).toEqual({ name: 'nocobase' });
+    expect(JSON.parse(textarea.value)).toEqual({ name: 'nocobase' });
     expect(pre).toMatchInlineSnapshot(`
-      <pre
-        class="ant-json css-4dta7v"
-      >
-        {
-        "name": "nocobase"
-      }
-      </pre>
+  <pre
+    data-testid="form-data"
+    style="margin-bottom: 20px;"
+  >
+    {
+    "test": {
+      "name": "nocobase"
+    }
+  }
+  </pre>
     `);
   });
 
   it('should display the error when the value is invalid', async () => {
-    const { container } = render(<App4 />);
+    const { container } = render(<JSONInput />);
     await waitFor(() => {
-      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
-      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
-    });
-
-    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
-    await userEvent.clear(textarea);
-    // To escape special characters, use double curly braces
-    await userEvent.type(textarea, '{{"name":nocobase}');
-    // mock blur event
-    await userEvent.click(document.body);
-    expect(screen.getByText(/invalid character 'o'/)).toBeInTheDocument();
-  });
-
-  it.only('should not display error when the value is valid JSON5', async () => {
-    const { container } = render(<App4 />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
-      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
+      expect(screen.getByText('Test').innerHTML).toBe('Test');
     });
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
@@ -158,17 +142,36 @@ describe('Input.JSON', () => {
     await userEvent.type(textarea, '{{name:"nocobase"}');
     // mock blur event
     await userEvent.click(document.body);
-    expect(screen.queryByText(/invalid /)).not.toBeInTheDocument();
+    expect(screen.getByText(/Unexpected token n/)).toBeInTheDocument();
+  });
+
+  it('should not display error when the value is valid JSON5', async () => {
+    const { container } = render(<JSON5Input />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test').innerHTML).toBe('Test');
+    });
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await userEvent.clear(textarea);
+    // To escape special characters, use double curly braces
+    await userEvent.type(textarea, '{{name:"nocobase"}');
+    // mock blur event
+    await userEvent.click(document.body);
+    expect(screen.queryByText(/Unexpected token /)).not.toBeInTheDocument();
     expect(JSON5.parse(textarea.value)).toEqual({ name: 'nocobase' });
     const pre = container.querySelector('pre') as HTMLPreElement;
     expect(pre).toMatchInlineSnapshot(`
-      <pre
-        class="ant-json css-4dta7v"
-      >
-        {
-        "name": "nocobase"
-      }
-      </pre>
+  <pre
+    data-testid="form-data"
+    style="margin-bottom: 20px;"
+  >
+    {
+    "test": {
+      "name": "nocobase"
+    }
+  }
+  </pre>
     `);
   });
 });

--- a/packages/core/client/src/schema-component/antd/input/__tests__/Input.test.tsx
+++ b/packages/core/client/src/schema-component/antd/input/__tests__/Input.test.tsx
@@ -129,7 +129,30 @@ describe('Input.JSON', () => {
       const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
       fireEvent.change(textarea, { target: { value: '{"name":nocobase}' } });
       fireEvent.blur(textarea, { target: { value: '{"name":nocobase}' } });
-      expect(screen.getByText(/Unexpected token/)).toBeInTheDocument();
+      expect(screen.getByText(/invalid character 'o'/)).toBeInTheDocument();
+    });
+  });
+
+  it('should not display error when the value is valid JSON5', async () => {
+    const { container } = render(<App4 />);
+
+    await waitFor(() => {
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: '{name:"nocobase"}' } });
+      fireEvent.blur(textarea, { target: { value: '{name:"nocobase"}' } });
+      expect(screen.getByText(/invalid /)).not.toBeInTheDocument();
+      expect(JSON.parse(textarea.value)).toEqual({ name: 'nocobase' });
+      const pre = container.querySelector('pre') as HTMLPreElement;
+
+      expect(pre).toMatchInlineSnapshot(`
+      <pre
+        class="ant-json css-4dta7v"
+      >
+        {
+        name: "nocobase"
+      }
+      </pre>
+    `);
     });
   });
 });

--- a/packages/core/client/src/schema-component/antd/input/__tests__/Input.test.tsx
+++ b/packages/core/client/src/schema-component/antd/input/__tests__/Input.test.tsx
@@ -13,6 +13,7 @@ import App1 from '../demos/input';
 import App4 from '../demos/json';
 import App2 from '../demos/textarea';
 import App3 from '../demos/url';
+import JSON5 from 'json5';
 
 describe('Input', () => {
   it('should display the title', () => {
@@ -103,14 +104,20 @@ describe('Input.JSON', () => {
 
   it('should display the value of user input', async () => {
     const { container } = render(<App4 />);
-
     await waitFor(() => {
-      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
-      const pre = container.querySelector('pre') as HTMLPreElement;
-      fireEvent.change(textarea, { target: { value: '{"name":"nocobase"}' } });
-      fireEvent.blur(textarea, { target: { value: '{"name":"nocobase"}' } });
-      expect(JSON.parse(textarea.value)).toEqual({ name: 'nocobase' });
-      expect(pre).toMatchInlineSnapshot(`
+      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
+      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
+    });
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    const pre = container.querySelector('pre') as HTMLPreElement;
+    await userEvent.clear(textarea);
+    // To escape special characters, use double curly braces
+    await userEvent.type(textarea, '{{"name":"nocobase"}');
+    // mock blur event
+    await userEvent.click(document.body);
+    expect(JSON5.parse(textarea.value)).toEqual({ name: 'nocobase' });
+    expect(pre).toMatchInlineSnapshot(`
       <pre
         class="ant-json css-4dta7v"
       >
@@ -119,40 +126,49 @@ describe('Input.JSON', () => {
       }
       </pre>
     `);
-    });
   });
 
   it('should display the error when the value is invalid', async () => {
     const { container } = render(<App4 />);
-
     await waitFor(() => {
-      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
-      fireEvent.change(textarea, { target: { value: '{"name":nocobase}' } });
-      fireEvent.blur(textarea, { target: { value: '{"name":nocobase}' } });
-      expect(screen.getByText(/invalid character 'o'/)).toBeInTheDocument();
+      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
+      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
     });
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await userEvent.clear(textarea);
+    // To escape special characters, use double curly braces
+    await userEvent.type(textarea, '{{"name":nocobase}');
+    // mock blur event
+    await userEvent.click(document.body);
+    expect(screen.getByText(/invalid character 'o'/)).toBeInTheDocument();
   });
 
-  it('should not display error when the value is valid JSON5', async () => {
+  it.only('should not display error when the value is valid JSON5', async () => {
     const { container } = render(<App4 />);
 
     await waitFor(() => {
-      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
-      fireEvent.change(textarea, { target: { value: '{name:"nocobase"}' } });
-      fireEvent.blur(textarea, { target: { value: '{name:"nocobase"}' } });
-      expect(screen.getByText(/invalid /)).not.toBeInTheDocument();
-      expect(JSON.parse(textarea.value)).toEqual({ name: 'nocobase' });
-      const pre = container.querySelector('pre') as HTMLPreElement;
+      expect(screen.getByText('Editable').innerHTML).toBe('Editable');
+      expect(screen.getByText('Read pretty').innerHTML).toBe('Read pretty');
+    });
 
-      expect(pre).toMatchInlineSnapshot(`
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await userEvent.clear(textarea);
+    // To escape special characters, use double curly braces
+    await userEvent.type(textarea, '{{name:"nocobase"}');
+    // mock blur event
+    await userEvent.click(document.body);
+    expect(screen.queryByText(/invalid /)).not.toBeInTheDocument();
+    expect(JSON5.parse(textarea.value)).toEqual({ name: 'nocobase' });
+    const pre = container.querySelector('pre') as HTMLPreElement;
+    expect(pre).toMatchInlineSnapshot(`
       <pre
         class="ant-json css-4dta7v"
       >
         {
-        name: "nocobase"
+        "name": "nocobase"
       }
       </pre>
     `);
-    });
   });
 });

--- a/packages/core/client/src/schema-component/antd/input/demos/new-demos/json.tsx
+++ b/packages/core/client/src/schema-component/antd/input/demos/new-demos/json.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { mockApp } from '@nocobase/client/demo-utils';
 import { SchemaComponent, Plugin, ISchema } from '@nocobase/client';
@@ -14,12 +13,12 @@ const schema: ISchema = {
       title: 'Test',
       'x-decorator': 'FormItem',
       'x-component': 'Input.JSON',
-      'x-value': {
+      default: {
         name: 'nocobase',
       },
     },
   },
-}
+};
 const Demo = () => {
   return <SchemaComponent schema={schema} />;
 };

--- a/packages/core/client/src/schema-component/antd/input/demos/new-demos/json.tsx
+++ b/packages/core/client/src/schema-component/antd/input/demos/new-demos/json.tsx
@@ -10,10 +10,13 @@ const schema: ISchema = {
   'x-component': 'ShowFormData',
   properties: {
     test: {
-      type: 'string',
+      type: 'json',
       title: 'Test',
       'x-decorator': 'FormItem',
       'x-component': 'Input.JSON',
+      'x-value': {
+        name: 'nocobase',
+      },
     },
   },
 }
@@ -23,7 +26,7 @@ const Demo = () => {
 
 class DemoPlugin extends Plugin {
   async load() {
-    this.app.router.add('root', { path: '/', Component: Demo })
+    this.app.router.add('root', { path: '/', Component: Demo });
   }
 }
 

--- a/packages/core/client/src/schema-component/antd/input/demos/new-demos/json5.tsx
+++ b/packages/core/client/src/schema-component/antd/input/demos/new-demos/json5.tsx
@@ -13,6 +13,12 @@ const schema: ISchema = {
       title: 'Test',
       'x-decorator': 'FormItem',
       'x-component': 'Input.JSON',
+      'x-component-props': {
+        json5: true,
+      },
+      default: {
+        name: 'nocobase',
+      },
     },
   },
 };

--- a/packages/core/client/src/schema-component/antd/input/index.en-US.md
+++ b/packages/core/client/src/schema-component/antd/input/index.en-US.md
@@ -92,7 +92,7 @@ interface URLReadPrettyProps {
 ### Basic Usage
 
 ```ts
-type JSONTextAreaProps = AntdTextAreaProps & { value?: string; space?: number }
+type JSONTextAreaProps = AntdTextAreaProps & { value?: string; space?: number; json5?: boolean; }
 ```
 
 <code src="./demos/new-demos/json.tsx"></code>

--- a/packages/core/client/src/schema-component/antd/input/index.en-US.md
+++ b/packages/core/client/src/schema-component/antd/input/index.en-US.md
@@ -97,6 +97,10 @@ type JSONTextAreaProps = AntdTextAreaProps & { value?: string; space?: number; j
 
 <code src="./demos/new-demos/json.tsx"></code>
 
+### JSON5
+
+<code src="./demos/new-demos/json5.tsx"></code>
+
 ### ReadPretty
 
 ```ts

--- a/packages/core/client/src/schema-component/antd/input/index.md
+++ b/packages/core/client/src/schema-component/antd/input/index.md
@@ -92,7 +92,7 @@ interface URLReadPrettyProps {
 ### Basic Usage
 
 ```ts
-type JSONTextAreaProps = AntdTextAreaProps & { value?: string; space?: number }
+type JSONTextAreaProps = AntdTextAreaProps & { value?: string; space?: number; json5?: boolean; }
 ```
 
 <code src="./demos/new-demos/json.tsx"></code>

--- a/packages/core/client/src/schema-component/antd/input/index.md
+++ b/packages/core/client/src/schema-component/antd/input/index.md
@@ -12,6 +12,10 @@ type InputProps = AntdInputProps;
 
 <code src="./demos/new-demos/input.tsx"></code>
 
+### JSON5
+
+<code src="./demos/new-demos/json5.tsx"></code>
+
 ### ReadPretty
 
 ```ts


### PR DESCRIPTION
# Description
Allow client values of JSON5 for FormInput JSONTextArea. Persisting is kept in valid JSON.

# Motivation
The old JSON Input Field did not allow JSON5 (Human friendly JSON) input. Advanced chart configuration for example was painfully when validated for raw JSON.

# Key changes
- Frontend
  - Component schema of JSONTextArea adjusted to validate by JSON 5 when input is changed. State value is parsed to JSON. 
  - Additional boolean prop `json5` introduced (default=true) to disable this behaviour
