### PR TITLE
fix(client): fix text wrap in variable input

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -313,6 +313,7 @@ export function Input(props: VariableInputProps) {
 
               .ant-input {
                 overflow: auto;
+                white-space: nowrap;
                 ${disabled ? '' : 'padding-right: 28px;'}
 
                 .ant-tag {

--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -313,7 +313,6 @@ export function Input(props: VariableInputProps) {
 
               .ant-input {
                 overflow: auto;
-                white-space: nowrap;
                 ${disabled ? '' : 'padding-right: 28px;'}
 
                 .ant-tag {
@@ -322,7 +321,6 @@ export function Input(props: VariableInputProps) {
                   margin: 0;
                   padding: 2px 7px;
                   border-radius: 10px;
-                  white-space: nowrap;
                 }
               }
             `,


### PR DESCRIPTION
## Description

Text overflow in `Variable.Input` component when name of variables is very long, and width of component is limited.

### Steps to reproduce

1. Layout 2 `Variable.Input` in a row, and limit column width.
2. Select a long variable.

### Expected behavior

Variable name should not overflow, but be wrapped.

### Actual behavior

Overflowing.

## Related issues

None.

## Reason

`white-space: nowrap`.

## Solution

Remove the style line.
