### PR TITLE
 feat(client): add searchbar and increase ux of select popover in icon-picker component

### DIFF
--- a/packages/core/client/src/locale/en_US.json
+++ b/packages/core/client/src/locale/en_US.json
@@ -829,5 +829,6 @@
   "This variable has been deprecated and can be replaced with \"Current form\"": "This variable has been deprecated and can be replaced with \"Current form\"",
   "The value of this variable is derived from the query string of the page URL. This variable can only be used normally when the page has a query string.": "The value of this variable is derived from the query string of the page URL. This variable can only be used normally when the page has a query string.",
   "URL search params": "URL search params",
-  "Expand All": "Expand All"
+  "Expand All": "Expand All",
+  "Search": "Search"
 }

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -955,8 +955,9 @@
   "Search parameters": "URL 查询参数",
   "Do not concatenate search params in the URL": "查询参数不要在 URL 里拼接",
   "The value of this variable is derived from the query string of the page URL. This variable can only be used normally when the page has a query string.": "该变量的值是根据页面 URL 的 query string 得来的，只有当页面存在 query string 的时候，该变量才能正常使用。",
-  "Edit link":"编辑链接",
-  "Add parameter":"添加参数",
+  "Edit link": "编辑链接",
+  "Add parameter": "添加参数",
   "URL search params": "URL 查询参数",
-  "Expand All": "展开全部"
+  "Expand All": "展开全部",
+  "Search": "搜索"
 }

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -35,35 +35,21 @@ interface IconPickerReadPrettyProps {
 }
 
 const useStyle = (isSearchable: IconPickerProps['searchable']) =>
-  createStyles(({ token, css }) => {
+  createStyles(({ css }) => {
     return {
       popoverContent: css`
         width: 26em;
         ${!isSearchable && 'max-'}height: 20em;
         overflow-y: auto;
       `,
-      searchbarDivider: css`
-        margin-top: ${token.marginXS}px;
-        margin-bottom: ${token.margin}px;
-
-        &::after {
-          position: relative;
-          top: 12px;
-          display: block;
-          width: calc(100% - 20px);
-          height: 1px;
-          background: ${token.colorSplit};
-          content: '';
-        }
-      `,
     };
   })();
 
 function IconField(props: IconPickerProps) {
-  const { fontSizeXL } = theme.useToken().token;
+  const { fontSizeHeading3 } = theme.useToken().token;
   const availableIcons = [...icons.keys()];
   const layout = useFormLayout();
-  const { value, onChange, disabled, iconSize = fontSizeXL, searchable = true } = props;
+  const { value, onChange, disabled, iconSize = fontSizeHeading3, searchable = true } = props;
   const [visible, setVisible] = useState(false);
   const [filteredIcons, setFilteredIcons] = useState(availableIcons);
   const { t } = useTranslation();
@@ -115,16 +101,15 @@ function IconField(props: IconPickerProps) {
             <div>
               <div>{t('Icon')}</div>
               {searchable && (
-                <div className={styles.searchbarDivider}>
-                  <Search
-                    role="search"
-                    name="icon-search"
-                    placeholder={t('Search') + '...'}
-                    allowClear
-                    onSearch={filterIcons}
-                    onChange={(event) => filterIcons(event.target?.value)}
-                  />
-                </div>
+                <Search
+                  style={{ marginTop: 8 }}
+                  role="search"
+                  name="icon-search"
+                  placeholder={t('Search')}
+                  allowClear
+                  onSearch={filterIcons}
+                  onChange={(event) => filterIcons(event.target?.value)}
+                />
               )}
             </div>
           }

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { Icon, hasIcon, icons } from '../../../icon';
 import { StablePopover } from '../popover';
 import { debounce } from 'lodash';
+import { createStyles } from 'antd-style';
 
 const { Search } = Input;
 
@@ -33,6 +34,31 @@ interface IconPickerReadPrettyProps {
   value?: string;
 }
 
+const useStyle = (isSearchable: IconPickerProps['searchable']) =>
+  createStyles(({ token, css }) => {
+    return {
+      popoverContent: css`
+        width: 26em;
+        ${!isSearchable && 'max-'}height: 20em;
+        overflow-y: auto;
+      `,
+      searchbarDivider: css`
+        margin-top: ${token.marginXS}px;
+        margin-bottom: ${token.margin}px;
+
+        &::after {
+          position: relative;
+          top: 12px;
+          display: block;
+          width: calc(100% - 20px);
+          height: 1px;
+          background: ${token.colorSplit};
+          content: '';
+        }
+      `,
+    };
+  })();
+
 function IconField(props: IconPickerProps) {
   const { fontSizeXL } = theme.useToken().token;
   const availableIcons = [...icons.keys()];
@@ -41,6 +67,7 @@ function IconField(props: IconPickerProps) {
   const [visible, setVisible] = useState(false);
   const [filteredIcons, setFilteredIcons] = useState(availableIcons);
   const { t } = useTranslation();
+  const { styles } = useStyle(searchable);
 
   const filterIcons = debounce((value) => {
     const searchValue = value?.trim() ?? '';
@@ -64,38 +91,43 @@ function IconField(props: IconPickerProps) {
             setVisible(val);
           }}
           content={
-            <div style={{ width: '26em', maxHeight: '20em', overflowY: 'auto' }}>
-              {searchable && (
-                <Search
-                  name="icon-search"
-                  placeholder={t('Search') + '...'}
-                  allowClear
-                  onSearch={filterIcons}
-                  onChange={(event) => filterIcons(event.target?.value)}
-                  style={{ width: 'calc(100% - 25px)' }}
-                />
-              )}
-
+            <div className={styles.popoverContent}>
               {filteredIcons.length === 0 ? (
                 <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
               ) : (
                 filteredIcons.map((key) => (
-                <span
-                  key={key}
-                  title={key.replace(/outlined|filled|twotone$/i, '')}
-                  style={{ fontSize: iconSize, marginRight: 10, cursor: 'pointer' }}
-                  onClick={() => {
-                    onChange(key);
-                    setVisible(false);
-                  }}
-                >
-                  <Icon type={key} />
-                </span>
+                  <span
+                    key={key}
+                    title={key.replace(/outlined|filled|twotone$/i, '')}
+                    style={{ fontSize: iconSize, marginRight: 10, cursor: 'pointer' }}
+                    onClick={() => {
+                      onChange(key);
+                      setVisible(false);
+                    }}
+                  >
+                    <Icon type={key} />
+                  </span>
                 ))
               )}
             </div>
           }
-          title={t('Icon')}
+          title={
+            <div>
+              <div>{t('Icon')}</div>
+              {searchable && (
+                <div className={styles.searchbarDivider}>
+                  <Search
+                    role="search"
+                    name="icon-search"
+                    placeholder={t('Search') + '...'}
+                    allowClear
+                    onSearch={filterIcons}
+                    onChange={(event) => filterIcons(event.target?.value)}
+                  />
+                </div>
+              )}
+            </div>
+          }
           trigger="click"
         >
           <Button size={layout.size as any} disabled={disabled}>

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -16,6 +16,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, hasIcon, icons } from '../../../icon';
 import { StablePopover } from '../popover';
+import { debounce } from 'lodash';
 
 export interface IconPickerProps {
   value?: string;
@@ -29,10 +30,22 @@ interface IconPickerReadPrettyProps {
 }
 
 function IconField(props: IconPickerProps) {
+  const availableIcons = [...icons.keys()];
   const layout = useFormLayout();
   const { value, onChange, disabled } = props;
   const [visible, setVisible] = useState(false);
+  const [filteredIcons, setFilteredIcons] = useState(availableIcons);
   const { t } = useTranslation();
+
+  const filterIcons = debounce((input?: string) => {
+    const searchValue = input?.trim() ?? '';
+    setFilteredIcons(
+      searchValue.length
+        ? availableIcons.filter((i) => i.split(' ').some((val) => val.includes(searchValue)))
+        : availableIcons,
+    );
+  }, 300);
+
   return (
     <div>
       <Space.Compact>
@@ -47,7 +60,16 @@ function IconField(props: IconPickerProps) {
           }}
           content={
             <div style={{ width: '26em', maxHeight: '20em', overflowY: 'auto' }}>
-              {[...icons.keys()].map((key) => (
+              <input
+                title={t('Search')}
+                type="search"
+                name="icon-search"
+                autoComplete="off"
+                style={{ width: 'calc(100% - 25px)' }}
+                placeholder={t('Search') + '...'}
+                onChange={(event) => filterIcons(event.target?.value)}
+              />
+              {filteredIcons.map((key) => (
                 <span
                   key={key}
                   style={{ fontSize: 18, marginRight: 10, cursor: 'pointer' }}

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -72,7 +72,8 @@ function IconField(props: IconPickerProps) {
               {filteredIcons.map((key) => (
                 <span
                   key={key}
-                  style={{ fontSize: 18, marginRight: 10, cursor: 'pointer' }}
+                  title={key.replace(/outlined|filled|twotone$/i, '')}
+                  style={{ fontSize: 24, marginRight: 10, cursor: 'pointer' }}
                   onClick={() => {
                     onChange(key);
                     setVisible(false);

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -11,18 +11,22 @@ import { CloseOutlined, LoadingOutlined } from '@ant-design/icons';
 import { useFormLayout } from '@formily/antd-v5';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { isValid } from '@formily/shared';
-import { Button, Space } from 'antd';
+import { Button, Space, Input, theme } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, hasIcon, icons } from '../../../icon';
 import { StablePopover } from '../popover';
 import { debounce } from 'lodash';
 
+const { Search } = Input;
+
 export interface IconPickerProps {
   value?: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
   suffix?: React.ReactNode;
+  iconSize?: number;
+  searchable?: boolean;
 }
 
 interface IconPickerReadPrettyProps {
@@ -30,21 +34,22 @@ interface IconPickerReadPrettyProps {
 }
 
 function IconField(props: IconPickerProps) {
+  const { fontSizeXL } = theme.useToken().token;
   const availableIcons = [...icons.keys()];
   const layout = useFormLayout();
-  const { value, onChange, disabled } = props;
+  const { value, onChange, disabled, iconSize = fontSizeXL, searchable = true } = props;
   const [visible, setVisible] = useState(false);
   const [filteredIcons, setFilteredIcons] = useState(availableIcons);
   const { t } = useTranslation();
 
-  const filterIcons = debounce((input?: string) => {
-    const searchValue = input?.trim() ?? '';
+  const filterIcons = debounce((value) => {
+    const searchValue = value?.trim() ?? '';
     setFilteredIcons(
       searchValue.length
         ? availableIcons.filter((i) => i.split(' ').some((val) => val.includes(searchValue)))
         : availableIcons,
     );
-  }, 300);
+  }, 250);
 
   return (
     <div>
@@ -60,20 +65,22 @@ function IconField(props: IconPickerProps) {
           }}
           content={
             <div style={{ width: '26em', maxHeight: '20em', overflowY: 'auto' }}>
-              <input
-                title={t('Search')}
-                type="search"
-                name="icon-search"
-                autoComplete="off"
-                style={{ width: 'calc(100% - 25px)' }}
-                placeholder={t('Search') + '...'}
-                onChange={(event) => filterIcons(event.target?.value)}
-              />
+              {searchable && (
+                <Search
+                  name="icon-search"
+                  placeholder={t('Search') + '...'}
+                  allowClear
+                  onSearch={filterIcons}
+                  onChange={(event) => filterIcons(event.target?.value)}
+                  style={{ width: 'calc(100% - 25px)' }}
+                />
+              )}
+
               {filteredIcons.map((key) => (
                 <span
                   key={key}
                   title={key.replace(/outlined|filled|twotone$/i, '')}
-                  style={{ fontSize: 24, marginRight: 10, cursor: 'pointer' }}
+                  style={{ fontSize: iconSize, marginRight: 10, cursor: 'pointer' }}
                   onClick={() => {
                     onChange(key);
                     setVisible(false);

--- a/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/IconPicker.tsx
@@ -11,7 +11,7 @@ import { CloseOutlined, LoadingOutlined } from '@ant-design/icons';
 import { useFormLayout } from '@formily/antd-v5';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { isValid } from '@formily/shared';
-import { Button, Space, Input, theme } from 'antd';
+import { Button, Empty, Space, Input, theme } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, hasIcon, icons } from '../../../icon';
@@ -76,7 +76,10 @@ function IconField(props: IconPickerProps) {
                 />
               )}
 
-              {filteredIcons.map((key) => (
+              {filteredIcons.length === 0 ? (
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+              ) : (
+                filteredIcons.map((key) => (
                 <span
                   key={key}
                   title={key.replace(/outlined|filled|twotone$/i, '')}
@@ -88,7 +91,8 @@ function IconField(props: IconPickerProps) {
                 >
                   <Icon type={key} />
                 </span>
-              ))}
+                ))
+              )}
             </div>
           }
           title={t('Icon')}

--- a/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { fireEvent, render, screen, userEvent } from '@nocobase/test/client';
+import { fireEvent, render, screen, userEvent, waitFor } from '@nocobase/test/client';
 import React from 'react';
 import App from '../demos/icon-picker';
 
@@ -18,14 +18,8 @@ describe('IconPicker', () => {
     const button = container.querySelector('button') as HTMLButtonElement;
     await userEvent.click(button);
 
-    expect(screen.getByText('Icon')).toMatchInlineSnapshot(`
-      <div
-        class="ant-popover-title"
-      >
-        Icon
-      </div>
-    `);
-    expect(screen.queryAllByRole('img').length).toBe(421);
+    expect(screen.getByText('Icon')).toHaveTextContent(`Icon`);
+    expect(screen.queryAllByRole('img').length).toBe(422);
   });
 
   it.skip('should display the selected icon', async () => {
@@ -48,14 +42,16 @@ describe('IconPicker', () => {
     expect(screen.queryAllByRole('img').length).toBe(0);
   }, 300000);
 
-  it('should filter the displayed icons when changing the value of search input', async () => {
+  it.only('should filter the displayed icons when changing the value of search input', async () => {
     const { container } = render(<App />);
 
-    const button = container.querySelector('button') as HTMLButtonElement;
-    await userEvent.click(button);
+    await waitFor(() => {
+      const button = container.querySelector('button') as HTMLButtonElement;
+      userEvent.click(button);
+    });
 
-    const searchInput = container.querySelector('input[name="icon-search"]') as HTMLInputElement;
-    fireEvent.change(searchInput, { target: { value: 'left' } });
-    expect(screen.queryAllByRole('img').length).toBeLessThan(421);
+    const searchInput = screen.queryByRole('search') as HTMLInputElement;
+    await userEvent.type(searchInput, 'left');
+    expect(screen.queryAllByRole('img').length).toBeLessThan(422);
   });
 });

--- a/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
@@ -42,7 +42,7 @@ describe('IconPicker', () => {
     expect(screen.queryAllByRole('img').length).toBe(0);
   }, 300000);
 
-  it.only('should filter the displayed icons when changing the value of search input', async () => {
+  it('should filter the displayed icons when changing the value of search input', async () => {
     const { container } = render(<App />);
 
     const button = container.querySelector('button') as HTMLButtonElement;

--- a/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
@@ -28,7 +28,8 @@ describe('IconPicker', () => {
     const button = container.querySelector('button') as HTMLButtonElement;
     await userEvent.click(button);
 
-    const icon = screen.queryAllByRole('img')[0];
+    // [0] is the icon of search input
+    const icon = screen.queryAllByRole('img')[1];
     await userEvent.click(icon);
 
     const icons = screen.queryAllByRole('img');

--- a/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
@@ -22,7 +22,7 @@ describe('IconPicker', () => {
     expect(screen.queryAllByRole('img').length).toBe(422);
   });
 
-  it.skip('should display the selected icon', async () => {
+  it('should display the selected icon', async () => {
     const { container } = render(<App />);
 
     const button = container.querySelector('button') as HTMLButtonElement;
@@ -45,13 +45,18 @@ describe('IconPicker', () => {
   it.only('should filter the displayed icons when changing the value of search input', async () => {
     const { container } = render(<App />);
 
-    await waitFor(() => {
-      const button = container.querySelector('button') as HTMLButtonElement;
-      userEvent.click(button);
-    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await userEvent.click(button);
 
     const searchInput = screen.queryByRole('search') as HTMLInputElement;
+    await waitFor(() => expect(searchInput).toBeInTheDocument());
+    expect(screen.queryAllByRole('img').length).toBe(422);
     await userEvent.type(searchInput, 'left');
-    expect(screen.queryAllByRole('img').length).toBeLessThan(422);
+    await waitFor(() => expect(screen.queryAllByRole('img').length).toBeLessThan(422));
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, 'abcd');
+    await waitFor(() => {
+      expect(screen.getByText('No data')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
+++ b/packages/core/client/src/schema-component/antd/icon-picker/__tests__/icon-picker.test.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { render, screen, userEvent } from '@nocobase/test/client';
+import { fireEvent, render, screen, userEvent } from '@nocobase/test/client';
 import React from 'react';
 import App from '../demos/icon-picker';
 
@@ -47,4 +47,15 @@ describe('IconPicker', () => {
     await userEvent.click(icons[1]);
     expect(screen.queryAllByRole('img').length).toBe(0);
   }, 300000);
+
+  it('should filter the displayed icons when changing the value of search input', async () => {
+    const { container } = render(<App />);
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await userEvent.click(button);
+
+    const searchInput = container.querySelector('input[name="icon-search"]') as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'left' } });
+    expect(screen.queryAllByRole('img').length).toBeLessThan(421);
+  });
 });

--- a/packages/core/client/src/schema-component/antd/icon-picker/index.en-US.md
+++ b/packages/core/client/src/schema-component/antd/icon-picker/index.en-US.md
@@ -9,6 +9,8 @@ interface IconPickerProps {
   value?: string;
   disabled?: boolean;
   suffix?: React.ReactNode;
+  iconSize?: number;
+  searchable?: boolean;
 }
 ```
 

--- a/packages/core/client/src/schema-component/antd/icon-picker/index.md
+++ b/packages/core/client/src/schema-component/antd/icon-picker/index.md
@@ -9,6 +9,8 @@ interface IconPickerProps {
   value?: string;
   disabled?: boolean;
   suffix?: React.ReactNode;
+  iconSize?: number;
+  searchable?: boolean;
 }
 ```
 


### PR DESCRIPTION
# Description
- Adds the ability for the user to search for icons
- Increase the UX by increasing the icon sizes and add a title tag to display the icon name on mousehover

# Motivation
- No way to search for a specific icon in icon-select popover
- To small icons make it hard to spot the correct item

# Key changes
- Frontend
  - Add input of type search to icon-select popover
  - Filter the available icons by comparing search input with icon name
  - Debounce the icon search filter to maintain performance on weak client devices
  - Add title tag to icon component wrapper element

# Showcase
<!-- Including any screenshots of the new feature or modification. -->

<img width="1440" alt="image" src="https://github.com/nocobase/nocobase/assets/3250534/f2973229-5722-407e-8e9b-c1fae57c5dee">

