### PR TITLE
fix(database): avoid deep clone caused error when using toJSON

### DIFF
--- a/packages/core/database/src/model.ts
+++ b/packages/core/database/src/model.ts
@@ -138,7 +138,7 @@ export class Model<TModelAttributes extends {} = any, TCreationAttributes extend
       return result as T;
     };
 
-    return traverseJSON(super.toJSON(), opts);
+    return traverseJSON(this.get({ plain: true }) as T, opts);
   }
 
   private hiddenObjKey(obj, options: JSONTransformerOptions) {


### PR DESCRIPTION
## Description

When using preload many-to-many association in approval event, error thrown.

### Steps to reproduce

1. Add a collection with an m2m field.
2. Add an approval event on the collection, and add the m2m field to preload configuration.
3. Trigger the event by submit a form with the m2m association data.

### Expected behavior

Approval event triggered correctly.

### Actual behavior

Error thrown:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at Object.length (/app/nocobase/node_modules/delegates/index.js:72:24)
    at isArrayLike (/app/nocobase/node_modules/lodash/lodash.js:11401:46)
    at keys (/app/nocobase/node_modules/lodash/lodash.js:13375:14)
    at baseGetAllKeys (/app/nocobase/node_modules/lodash/lodash.js:3094:20)
    at getAllKeys (/app/nocobase/node_modules/lodash/lodash.js:5916:14)
    at baseClone (/app/nocobase/node_modules/lodash/lodash.js:2726:39)
    at /app/nocobase/node_modules/lodash/lodash.js:2733:34
    at arrayEach (/app/nocobase/node_modules/lodash/lodash.js:530:11)
    at baseClone (/app/nocobase/node_modules/lodash/lodash.js:2727:7)
    at /app/nocobase/node_modules/lodash/lodash.js:2733:34
Waiting for the debugger to disconnect...
/app/nocobase/node_modules/delegates/index.js:72
    return this[target][name];
```

## Related issues

None.

## Reason

Deeply cloning object with deep reference.

## Solution

Use `this.get({ plain: true })` instead.
