### PR TITLE
fix(preset): fix plugin-workflow-mailer version

### DIFF
--- a/packages/presets/nocobase/src/server/index.ts
+++ b/packages/presets/nocobase/src/server/index.ts
@@ -68,7 +68,7 @@ export class PresetNocoBase extends Plugin {
     'api-doc>=0.13.0-alpha.1',
     'auth-sms>=0.10.0-alpha.2',
     'field-markdown-vditor>=0.21.0-alpha.16',
-    'workflow-mailer>=1.0.0-alpha.17',
+    'workflow-mailer',
   ];
 
   splitNames(name: string) {


### PR DESCRIPTION
## Description

Unpublished plugin is using wrong version.

### Steps to reproduce

1. Use main (x > v1.0.1-alpha.1) image.
2. Change to latest (v1.0.1-alpha.1) image.

### Expected behavior

App start normally.

### Actual behavior

Error thrown:

```
{"level":"error","message":"ENOENT: no such file or directory, realpath '/app/nocobase/node_modules/@nocobase/plugin-workflow-mailer/package.json'","stack":"Error: ENOENT: no such file or directory, realpath '/app/nocobase/node_modules/@nocobase/plugin-workflow-mailer/package.json'","meta":{},"module":"application","submodule":"","method":"","app":"app1","reqId":"0976f257-64e9-41ab-9b70-d14c17302aac","dataSourceKey":"main","timestamp":"2024-06-11 04:56:59"}
```

## Related issues

[#4618](https://github.com/nocobase/nocobase/discussions/4618)

## Reason

Wrong version number specified.

## Solution

Remove version number.
