### PR TITLE
fix(plugin-fm): add migration for fixing new added legacy attachment field

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/migrations/20240613110121-fix-schema-in-field.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/migrations/20240613110121-fix-schema-in-field.ts
@@ -1,0 +1,48 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Migration } from '@nocobase/server';
+
+export default class extends Migration {
+  on = 'afterLoad'; // 'beforeLoad' or 'afterLoad'
+
+  async up() {
+    const r = this.db.getRepository('fields');
+    await this.db.sequelize.transaction(async (transaction) => {
+      const items = await r.find({
+        filter: {
+          type: 'belongsToMany',
+          interface: 'attachment',
+        },
+        transaction,
+      });
+
+      let count = 0;
+      for (const item of items) {
+        if (
+          item.options.target === 'attachments' &&
+          item.options.uiSchema &&
+          item.options.uiSchema['x-component'] === 'Upload.Attachment' &&
+          !item.options.uiSchema['x-use-component-props']
+        ) {
+          count++;
+          const { uiSchema, ...options } = item.options;
+          uiSchema['x-use-component-props'] = 'useAttachmentFieldProps';
+          item.set('options', {
+            ...options,
+            uiSchema,
+          });
+          item.changed('options');
+          await item.save({ transaction });
+        }
+      }
+      console.log('item updated:', count);
+    });
+  }
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/migrations/20240613110121-fix-schema-in-field.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/migrations/20240613110121-fix-schema-in-field.ts
@@ -68,19 +68,15 @@ export default class extends Migration {
         }
 
         schemaCount++;
-        // console.log(item.schema['x-component-props']);
-        const {
-          schema: { action, ...schema },
-        } = item;
+
         item.set('schema', {
-          ...schema,
+          ...item.schema,
           'x-use-component-props': 'useAttachmentFieldProps',
         });
         item.changed('schema');
         await item.save({ transaction });
-
-        console.log('schema updated:', fieldCount);
       }
+      console.log('schema updated:', fieldCount);
     });
   }
 }


### PR DESCRIPTION
## Description

Upload file in a legacy attachment field meet error.

### Steps to reproduce

1. Use version older than v1.0.0-alpha.16.
2. Add an attachment field in a collection.
3. Add a form to add new record and add the attachment field.
4. Upgrade version to newer.
5. Try upload file in the form field.

### Expected behavior

File uploaded successfully.

### Actual behavior

Error thrown:

`404` on `/api`.

## Related issues

#4118.

Link T-4544.

## Reason

Default UI schema in field options not migrated.

## Solution

Add migration.
