### PR TITLE
fix(plugin-fm): set invalid when uploading is not completed to avoid submit

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -345,11 +345,10 @@ export function Uploader({ rules, ...props }: UploadProps) {
   const beforeUpload = useBeforeUpload(rules);
 
   useEffect(() => {
-    const error = pendingList.find((file) => file.status === 'error');
-    if (error) {
+    if (pendingList.length) {
       field.setFeedback({
         type: 'error',
-        code: 'UploadError',
+        code: 'ValidateError',
         messages: [t('Incomplete uploading files need to be resolved')],
       });
     } else {


### PR DESCRIPTION
## Description

Set upload field invalid when uploading is not completed to avoid submit.

### Steps to reproduce

1. Add an attachment field to a form block.
2. Upload a big file.
3. Click submit before uploading completed.

### Expected behavior

Form should not be submitted.

### Actual behavior

Form is submitted without attachment data.

## Related issues

Link T-4538.

## Reason

Miss field feedback when uploading.

## Solution

Add validation feedback.
