### PR TITLE
fix(plugin-workflow): fix incorrectly schema reaction

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/create.tsx
@@ -69,6 +69,9 @@ export default class extends Instruction {
         },
       ],
     },
+    usingAssignFormSchema: {
+      type: 'boolean',
+    },
     assignFormSchema: {
       type: 'object',
       title: '{{t("Fields values")}}',
@@ -76,10 +79,10 @@ export default class extends Instruction {
       'x-component': 'AssignedFieldsFormSchemaConfig',
       'x-reactions': [
         {
-          dependencies: ['collection'],
+          dependencies: ['collection', 'usingAssignFormSchema'],
           fulfill: {
             state: {
-              display: '{{($deps[0] && $self.value) ? "visible" : "hidden"}}',
+              display: '{{($deps[0] && $deps[1]) ? "visible" : "hidden"}}',
             },
           },
         },
@@ -92,7 +95,7 @@ export default class extends Instruction {
           ...values,
           'x-reactions': [
             {
-              dependencies: ['collection', 'assignFormSchema'],
+              dependencies: ['collection', 'usingAssignFormSchema'],
               fulfill: {
                 state: {
                   display: '{{($deps[0] && !$deps[1]) ? "visible" : "hidden"}}',
@@ -107,6 +110,7 @@ export default class extends Instruction {
   };
   createDefaultConfig() {
     return {
+      usingAssignFormSchema: true,
       assignFormSchema: {},
     };
   }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/update.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/update.tsx
@@ -95,7 +95,7 @@ export default class extends Instruction {
           ...values,
           'x-reactions': [
             {
-              dependencies: ['collection', 'assignFormSchema'],
+              dependencies: ['collection', 'usingAssignFormSchema'],
               fulfill: {
                 state: {
                   display: '{{($deps[0] && !$deps[1]) ? "visible" : "hidden"}}',
@@ -106,6 +106,9 @@ export default class extends Instruction {
         },
       },
     },
+    usingAssignFormSchema: {
+      type: 'boolean',
+    },
     assignFormSchema: {
       type: 'object',
       title: '{{t("Fields values")}}',
@@ -113,10 +116,10 @@ export default class extends Instruction {
       'x-component': 'AssignedFieldsFormSchemaConfig',
       'x-reactions': [
         {
-          dependencies: ['collection'],
+          dependencies: ['collection', 'usingAssignFormSchema'],
           fulfill: {
             state: {
-              display: '{{($deps[0] && $self.value) ? "visible" : "hidden"}}',
+              display: '{{($deps[0] && $deps[1]) ? "visible" : "hidden"}}',
             },
           },
         },
@@ -125,7 +128,8 @@ export default class extends Instruction {
   };
   createDefaultConfig() {
     return {
-      assignForm: uid(),
+      usingAssignFormSchema: true,
+      assignFormSchema: {},
     };
   }
   scope = {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -264,7 +264,6 @@ function getNormalizedFields(collectionName, { compile, getCollectionFields }) {
   const [dataSourceName, collection] = parseCollectionName(collectionName);
   // NOTE: `dataSourceName` will be ignored in new version
   const fields = getCollectionFields(collection, dataSourceName);
-  console.log('--------------', fields);
   const fkFields: any[] = [];
   const result: any[] = [];
   fields.forEach((field) => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20240613222612-fix-assign-field-config.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20240613222612-fix-assign-field-config.ts
@@ -1,0 +1,42 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Op } from '@nocobase/database';
+import { Migration } from '@nocobase/server';
+
+export default class extends Migration {
+  on = 'afterSync';
+  async up() {
+    const { db } = this.context;
+
+    const NodeRepo = db.getRepository('flow_nodes');
+    await db.sequelize.transaction(async (transaction) => {
+      const nodes = await NodeRepo.find({
+        filter: {
+          type: {
+            [Op.or]: ['create', 'update'],
+          },
+        },
+      });
+      for (const node of nodes) {
+        if (node.usingAssignFormSchema || !node.assignFormSchema) {
+          continue;
+        }
+        node.set({
+          config: { ...node.config, usingAssignFormSchema: true },
+        });
+        node.changed('config');
+        await node.save({
+          silent: true,
+          transaction,
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Description

### Steps to reproduce

1. Use version v1.0.1-alpha.1.
2. Add a create/update node.
3. Set a field for values.
4. Upgrade to v1.2.3-alpha
5. Reopen the node.

### Expected behavior

Assign field value configuration component still show in legacy node.

### Actual behavior

Changed to new schema component.

## Related issues

None.

## Reason

Incorrect reaction logic.

## Solution

Add a new flag to determine reaction logic.
