### PR TITLE
fix(data-vi): custom filter conditions are not applied

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/hooks/filter.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/hooks/filter.ts
@@ -417,7 +417,7 @@ export const useChartFilter = () => {
           if (!(typeof value === 'string' && value.startsWith('{{$') && value?.endsWith('}}'))) {
             return value;
           }
-          if (['$user', '$date', '$nDate', '$nRole'].some((n) => value.includes(n))) {
+          if (['$user', '$date', '$nDate', '$nRole', '$nFilter'].some((n) => value.includes(n))) {
             return value;
           }
           const result = variables?.parseVariable(value);

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/hooks/useVariableOptions.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/hooks/useVariableOptions.ts
@@ -36,7 +36,7 @@ export const useGeneralVariableOptions = (
     [datetimeSettings, currentUserSettings, currentRoleSettings, urlSearchParamsSettings],
   );
 
-  if (!operator || !schema) return [];
+  if (!schema) return [];
 
   return result;
 };


### PR DESCRIPTION
## Description

### Steps to reproduce

<!-- Clear steps to reproduce the bug. -->

1. Add a chart block
2. Add a custom filter field for charts
3. Set filter field value and filter

### Expected behavior

<!--- Describe what the expected behavior should be when the code is executed without the bug. -->

The filter condition is supposed to be appended to the query

### Actual behavior

<!-- Describe what actually happens when the code is executed with the bug. -->

The filter condition is not applied

## Related issues

<!-- Include any related issues or previous bug reports related to this bug. -->

## Reason

<!-- Explain what caused the bug to occur. -->

The custom filter field variables should not be parsed in the inner filter.

## Solution

<!-- Describe solution to the bug clearly and consciously. -->

Skip the custom filter field variables when parsing the inner filter conditions.
