### PR TITLE
refactor(plugin-workflow-dc): move collection template to plugin and remove sort field

### DIFF
--- a/packages/core/client/src/collection-manager/collectionPlugin.ts
+++ b/packages/core/client/src/collection-manager/collectionPlugin.ts
@@ -55,7 +55,6 @@ import {
 } from './interfaces';
 import {
   GeneralCollectionTemplate,
-  ExpressionCollectionTemplate,
   SqlCollectionTemplate,
   TreeCollectionTemplate,
   ViewCollectionTemplate,
@@ -180,7 +179,6 @@ export class CollectionPlugin extends Plugin {
   addCollectionTemplates() {
     this.dataSourceManager.addCollectionTemplates([
       GeneralCollectionTemplate,
-      ExpressionCollectionTemplate,
       SqlCollectionTemplate,
       TreeCollectionTemplate,
       ViewCollectionTemplate,

--- a/packages/core/client/src/collection-manager/templates/index.tsx
+++ b/packages/core/client/src/collection-manager/templates/index.tsx
@@ -9,6 +9,5 @@
 
 export * from './general';
 export * from './tree';
-export * from './expression';
 export * from './view';
 export * from './sql';

--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -486,6 +486,7 @@ async function preloadOptions(scope, value: string) {
 TextArea.ReadPretty = function ReadPretty(props): JSX.Element {
   const { value } = props;
   const scope = typeof props.scope === 'function' ? props.scope() : props.scope;
+  const { wrapSSR, hashId, componentCls } = useStyles();
 
   const [options, setOptions] = useState([]);
   const keyLabelMap = useMemo(() => createOptionsValueLabelMap(options), [options]);
@@ -499,21 +500,25 @@ TextArea.ReadPretty = function ReadPretty(props): JSX.Element {
   }, [scope, value]);
   const html = renderHTML(value ?? '', keyLabelMap);
 
-  const content = (
+  const content = wrapSSR(
     <span
       dangerouslySetInnerHTML={{ __html: html }}
-      className={css`
-        overflow: auto;
+      className={cx(
+        componentCls,
+        hashId,
+        css`
+          overflow: auto;
 
-        .ant-tag {
-          display: inline;
-          line-height: 19px;
-          margin: 0 0.25em;
-          padding: 2px 7px;
-          border-radius: 10px;
-        }
-      `}
-    />
+          .ant-tag {
+            display: inline;
+            line-height: 19px;
+            margin: 0 0.25em;
+            padding: 2px 7px;
+            border-radius: 10px;
+          }
+        `,
+      )}
+    />,
   );
 
   return (

--- a/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/ExpressionCollectionTemplate.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/ExpressionCollectionTemplate.ts
@@ -8,8 +8,7 @@
  */
 
 import { getOptions } from '@nocobase/evaluators/client';
-import { getConfigurableProperties } from './properties';
-import { CollectionTemplate } from '../../data-source/collection-template/CollectionTemplate';
+import { getConfigurableProperties, CollectionTemplate } from '@nocobase/client';
 
 export class ExpressionCollectionTemplate extends CollectionTemplate {
   name = 'expression';
@@ -21,7 +20,6 @@ export class ExpressionCollectionTemplate extends CollectionTemplate {
     updatedBy: true,
     createdAt: true,
     updatedAt: true,
-    sortable: true,
     fields: [
       {
         name: 'engine',

--- a/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/index.ts
@@ -13,6 +13,7 @@ import WorkflowPlugin from '@nocobase/plugin-workflow/client';
 import DynamicCalculation from './DynamicCalculation';
 import { DynamicExpression } from './DynamicExpression';
 import { ExpressionFieldInterface } from './expression';
+import { ExpressionCollectionTemplate } from './ExpressionCollectionTemplate';
 
 export default class extends Plugin {
   async afterAdd() {
@@ -27,6 +28,9 @@ export default class extends Plugin {
     this.app.addComponents({
       DynamicExpression,
     });
+
+    this.dataSourceManager.addCollectionTemplates([ExpressionCollectionTemplate]);
+
     const workflow = this.app.pm.get('workflow') as WorkflowPlugin;
     const dynamicCalculation = new DynamicCalculation();
     workflow.instructions.register(dynamicCalculation.type, dynamicCalculation);


### PR DESCRIPTION
# Description

Move collection template to plugin and remove sort field.

# Motivation

Collection template managed by plugin should not be placed in core package.

# Key changes

- Frontend
  - Expression collection template.
  - Remove default sort field of expression collection.
  - Fix Variable.TextArea.ReadPretty style.
- Backend

# Test plan

## Suggestions

None.

## Underlying risk

None.

# Showcase

None.
