### PR TITLE
fix(client): fix upload progress style

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -134,14 +134,14 @@ function AttachmentListItem(props) {
           {!readPretty && file.id && (
             <Button size={'small'} type={'text'} icon={<DownloadOutlined />} onClick={onDownload} />
           )}
-          {!readPretty && !disabled && (
+          {!readPretty && !disabled && file.status !== 'uploading' && (
             <Button size={'small'} type={'text'} icon={<DeleteOutlined />} onClick={onDelete} />
           )}
         </Space>
       </span>
       {file.status === 'uploading' && (
         <div className={`${prefixCls}-list-item-progress`}>
-          <Progress size={2} type={'line'} showInfo={false} percent={file.percent} />
+          <Progress strokeWidth={4} type={'line'} showInfo={false} percent={Number(file.percent)} />
         </div>
       )}
     </div>

--- a/packages/core/client/src/schema-component/antd/upload/style.ts
+++ b/packages/core/client/src/schema-component/antd/upload/style.ts
@@ -77,6 +77,7 @@ export const useStyles = genStyleHook('upload', (token) => {
         },
         [`${componentCls}-list-picture-card ${componentCls}-list-item-progress`]: {
           bottom: 'calc(50% - 11px)',
+          left: `${token.margin / 2}px`,
           pointerEvents: 'none',
         },
         [`${antCls}-btn`]: {


### PR DESCRIPTION
## Description

Fix upload progress style

### Steps to reproduce

1. Upload a big file.

### Expected behavior

Progress bar showing correctly when uploading.

### Actual behavior

Width is 2px.

## Related issues

#4118.

## Reason

`size={2}` cause this.

## Solution

Change back to `strokeWidth`.
