### PR TITLE
fix(plugin-fm): fix thumbnail rule

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -106,7 +106,13 @@ function AttachmentListItem(props) {
 
   const item = [
     <span key="thumbnail" className={`${prefixCls}-list-item-thumbnail`}>
-      {file.imageUrl && <img src={file.imageUrl} alt={file.title} className={`${prefixCls}-list-item-image`} />}
+      {file.imageUrl && (
+        <img
+          src={`${file.imageUrl}${file.thumbnailRule || ''}`}
+          alt={file.title}
+          className={`${prefixCls}-list-item-image`}
+        />
+      )}
     </span>,
     <span key="title" className={`${prefixCls}-list-item-name`} title={file.title}>
       {file.status === 'uploading' ? t('Uploading') : file.title}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/FileModel.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/FileModel.ts
@@ -15,6 +15,9 @@ export class FileModel extends Model {
     const fileStorages = this.constructor['database']?.['_fileStorages'];
     if (json.storageId && fileStorages && fileStorages.has(json.storageId)) {
       const storage = fileStorages.get(json.storageId);
+      if (storage?.options?.thumbnailRule) {
+        json['thumbnailRule'] = storage?.options?.thumbnailRule;
+      }
       if (storage?.type === 'local' && process.env.APP_PUBLIC_PATH) {
         json['url'] = process.env.APP_PUBLIC_PATH.replace(/\/$/g, '') + json.url;
       }


### PR DESCRIPTION
## Description

Fix ali-oss thumbnail URL on attachment.

### Steps to reproduce

1. Set thumbnail rule in storage of ali-oss type.
2. Add an attachment field with the ali-oss storage.
3. Upload a picture to the attachment field.

### Expected behavior

Image preview with the thumbnail URL.

### Actual behavior

Using original URL.

## Related issues

#4118.

## Reason

Rule ignored.

## Solution

Add rule back.
