### PR TITLE
fix(plugin-workflow): fix client warning

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/StatusButton.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/StatusButton.tsx
@@ -30,7 +30,8 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-export function StatusButton({ status, statusMap, ...props }) {
+export function StatusButton(props) {
+  const { status, statusMap, ...others } = props;
   const { styles } = useStyles();
   let tag = null;
   if (typeof status !== 'undefined' && statusMap?.[status]) {
@@ -40,7 +41,7 @@ export function StatusButton({ status, statusMap, ...props }) {
 
   return (
     <Button
-      {...props}
+      {...others}
       shape="circle"
       size="small"
       className={classnames(tag ? styles.statusButtonClass : styles.noStatusButtonClass, props.className)}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/StatusButton.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/StatusButton.tsx
@@ -30,11 +30,11 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-export function StatusButton(props) {
+export function StatusButton({ status, statusMap, ...props }) {
   const { styles } = useStyles();
   let tag = null;
-  if (typeof props.status !== 'undefined' && props.statusMap?.[props.status]) {
-    const { icon, color } = props.statusMap[props.status];
+  if (typeof status !== 'undefined' && statusMap?.[status]) {
+    const { icon, color } = statusMap[status];
     tag = <Tag color={color}>{icon}</Tag>;
   }
 


### PR DESCRIPTION
## Description

Fix client warning in execution canvas.

### Steps to reproduce

1. Go to any execution canvas with at least one executed node.

### Expected behavior

No waring in console.

### Actual behavior

Warning.

## Related issues

None.

## Reason

Non-DOM properties passed to DOM element.

## Solution

Do not pass.
