### PR TITLE
fix: checkbox style is not aligned when selecting the table

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -305,10 +305,13 @@ const cellClass = css`
   }
 `;
 
+const floatLeftClass = css`
+  float: left;
+`;
+
 const rowSelectCheckboxWrapperClass = css`
   position: relative;
   display: flex;
-  float: left;
   align-items: center;
   justify-content: space-evenly;
   padding-right: 8px;
@@ -594,7 +597,7 @@ export const Table: any = withDynamicSchemaProps(
                   <div
                     role="button"
                     aria-label={`table-index-${index}`}
-                    className={classNames(checked ? 'checked' : null, rowSelectCheckboxWrapperClass, {
+                    className={classNames(checked ? 'checked' : floatLeftClass, rowSelectCheckboxWrapperClass, {
                       [rowSelectCheckboxWrapperClassHover]: isRowSelect,
                     })}
                   >


### PR DESCRIPTION

## Description
表格checkbox会在数据大于10的时候无法对齐
![20240620165841_rec_](https://github.com/nocobase/nocobase/assets/23630052/322fbeb0-5e63-4f0a-846d-4998992f614e)

### Steps to reproduce

当表格数据多与10条时 点击rowSection全选表格数据

### Expected behavior

checkbox都在同一列对齐

### Actual behavior

9-10开始会错位

## Related issues

## Reason

表格显示rowSelection时因为tableIndex从9-10这种位数变化会引起宽度变化 float:left导致checkbox没有对齐

## Solution

只有在显示tableIndex时再添加float:left样式

