### PR TITLE
fix(client): fix undefined context

### DIFF
--- a/packages/core/client/src/schema-component/hooks/useBlockSize.ts
+++ b/packages/core/client/src/schema-component/hooks/useBlockSize.ts
@@ -91,7 +91,7 @@ const useTableHeight = () => {
   const schema = useFieldSchema();
   const heightProps = tableHeightProps || blockHeightProps;
   const pageFullScreenHeight = useFullScreenHeight(heightProps);
-  const { data } = useDataBlockRequest();
+  const { data } = useDataBlockRequest() ?? {};
   const { name } = useCollection();
   const { count, pageSize } = (data as any)?.meta || ({} as any);
   const hasPagination = count > pageSize;


### PR DESCRIPTION
## Description

While using sub-table component to represent one-to-many field in manual node block or assign field values in create/update node, error thrown.

### Steps to reproduce

1. Manual node:
    1. Add a data block with an one-to-many field in manual UI configuration.
    2. Switch the component of the field from title to sub-table.
2. Create/update node:
    1. Add a create/update node.
    2. Add an one-to-many field into assign value block.
    3. Switch the component of the field from select to sub-table.

### Expected behavior

Showing sub-table.

### Actual behavior

Error thrown:

```
TypeError: Cannot read properties of null (reading 'data')
useTableHeight
.nocobase/packages/core/client/src/schema-component/hooks/useBlockSize.ts:94:10

  91 | const schema = useFieldSchema();
  92 | const heightProps = tableHeightProps || blockHeightProps;
  93 | const pageFullScreenHeight = useFullScreenHeight(heightProps);
> 94 | const { data } = useDataBlockRequest();
     |        ^  95 | const { name } = useCollection();
  96 | const { count, pageSize } = (data as any)?.meta || ({} as any);
  97 | const hasPagination = count > pageSize;
```

## Related issues

None.

## Reason

No `DataBlockRequest` context in workflow nodes.

## Solution

Adapt undefined value.
