### PR TITLE
fix(plugin-workflow): fix duplicating sync workflow

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
@@ -84,7 +84,6 @@ export async function revision(context: Context, next) {
           title: origin.title,
           triggerTitle: origin.triggerTitle,
           allExecuted: origin.allExecuted,
-          sync: origin.sync,
         }
       : values;
 
@@ -93,6 +92,7 @@ export async function revision(context: Context, next) {
         title: `${origin.title} copy`,
         description: origin.description,
         ...revisionData,
+        sync: origin.sync,
         type: origin.type,
         config:
           typeof trigger.duplicateConfig === 'function'


### PR DESCRIPTION
## Description

Duplicated sync workflow becomes async.

### Steps to reproduce

1. Create a sync workflow.
2. Duplicate it to a new one in workflows list.

### Expected behavior

New workflow should be sync as the original one.

### Actual behavior

It becomes async.

## Related issues

None.

## Reason

Sync value missed in duplication action.

## Solution

Use sync field for both type or revision.
