### PR TITLE
fix(client): fix default size hint of upload component

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -22,7 +22,7 @@ import 'react-image-lightbox/style.css'; // This only needs to be imported once 
 import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
 import { useProps } from '../../hooks/useProps';
 import {
-  FILE_SIZE_LIMI_MAX,
+  FILE_SIZE_LIMIT_DEFAULT,
   isImage,
   isPdf,
   normalizeFile,
@@ -79,7 +79,7 @@ export const Upload: ComposedUpload = connect(
 Upload.ReadPretty = ReadPretty;
 
 function useSizeHint(size: number) {
-  const s = size ?? FILE_SIZE_LIMI_MAX;
+  const s = size ?? FILE_SIZE_LIMIT_DEFAULT;
   const { t, i18n } = useTranslation();
   const sizeString = filesize(s, { base: 2, standard: 'jedec', locale: i18n.language });
   return s !== 0 ? t('File size should not exceed {{size}}.', { size: sizeString }) : '';

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -16,7 +16,7 @@ import { useAPIClient } from '../../../api-client';
 import { UNKNOWN_FILE_ICON, UPLOAD_PLACEHOLDER } from './placeholder';
 import type { IUploadProps, UploadProps } from './type';
 
-export const FILE_SIZE_LIMI_MAX = 1024 * 1024 * 1024;
+export const FILE_SIZE_LIMIT_DEFAULT = 1024 * 1024 * 20;
 
 export const isImage = (file) => {
   return match(file.mimetype || file.type, 'image/*');
@@ -228,7 +228,7 @@ export const toValue = (fileList: any) => {
 
 const Rules: Record<string, RuleFunction> = {
   size(file, options: number): null | string {
-    const size = options ?? FILE_SIZE_LIMI_MAX;
+    const size = options ?? FILE_SIZE_LIMIT_DEFAULT;
     if (size === 0) {
       return null;
     }


### PR DESCRIPTION
## Description

Size hint of legacy attachment field shows 1GB, but can not upload greater than 20MB.

### Steps to reproduce

1. Use version before v1.0.0-alpha.17.
2. Add some attachment field based on default local storage.
3. Upgrade to latest version.
4. Hover to the upload component and check the hint.

### Expected behavior

20MB by default when no rules configured.

### Actual behavior

Showing 1GB but can not upload greater than 20MB.

## Related issues

#4118.

## Reason

Default size limit in client is not same as in server.

## Solution

Change client default size hint to be same as server (20MB).
