### PR TITLE
fix(plugin-workflow-mailer): fix payload in sync mode

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-mailer/src/server/MailerInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-mailer/src/server/MailerInstruction.ts
@@ -75,6 +75,8 @@ export default class extends Instruction {
         });
       })
       .catch((error) => {
+        processor.logger.warn(`smtp-mailer (#${node.id}) sent failed: ${error.message}`);
+
         job.set({
           status: JOB_STATUS.FAILED,
           result: error,

--- a/packages/plugins/@nocobase/plugin-workflow-mailer/src/server/MailerInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-mailer/src/server/MailerInstruction.ts
@@ -21,6 +21,7 @@ export default class extends Instruction {
       to = [],
       cc,
       bcc,
+      subject,
       html,
       text,
       ignoreFail,
@@ -36,6 +37,7 @@ export default class extends Instruction {
     const payload = {
       ...options,
       ...(contentType === 'html' ? { html } : { text }),
+      subject: subject?.trim(),
       to: to
         .flat()
         .map((item) => item?.trim())


### PR DESCRIPTION
## Description

Mail sending failed in sync mode.

### Steps to reproduce

1. Add a sync workflow (post-action).
2. Add a mailer node and configure it correctly.
3. Trigger the workflow.

### Expected behavior

Mail sent successfully.

### Actual behavior

Failed with error indicates configuration incorrectly.

## Related issues

None.

## Reason

Payload is not same in sync mode.

## Solution

Use same payload in each mode.