### PR TITLE
fix(client): fix output time in date-picker in date-only mode

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
+++ b/packages/core/client/src/schema-component/antd/date-picker/__tests__/util.test.ts
@@ -76,6 +76,12 @@ describe('moment2str', () => {
     expect(str).toBe(dayjs('2023-06-21 10:10:00').toISOString());
   });
 
+  test('gmt not configured', () => {
+    const d = dayjs('2024-06-30');
+    const str = moment2str(d);
+    expect(str).toBe(dayjs('2024-06-30 00:00:00').toISOString());
+  });
+
   test('with time', () => {
     const m = dayjs('2023-06-21 10:10:00');
     const str = moment2str(m, { showTime: true });

--- a/packages/core/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/core/client/src/schema-component/antd/date-picker/util.ts
@@ -71,7 +71,7 @@ export const moment2str = (value?: Dayjs | null, options: Moment2strOptions = {}
   if (typeof gmt === 'boolean') {
     return gmt ? toGmtByPicker(value, picker) : toLocalByPicker(value, picker);
   }
-  return toGmtByPicker(value, picker);
+  return toLocalByPicker(value, picker);
 };
 
 export const mapDatePicker = function () {


### PR DESCRIPTION
## Description

Fix output time in date-picker in date-only mode

### Steps to reproduce

1. Create a datetime field.
2. Pick a date.
3. Open show time option in component setting.

### Expected behavior

Time part should be '00:00:00'.

### Actual behavior

Time part is '08:00:00'.

## Related issues

None.

## Reason

Using GMT as default output.

## Solution

Use local timezone.
