### PR TITLE
fix(Safari): resolve issue with menu page not refreshing in Safari

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -35,9 +35,9 @@ import {
 } from '../../../';
 import { Plugin } from '../../../application/Plugin';
 import { useAppSpin } from '../../../application/hooks/useAppSpin';
+import { useMenuTranslation } from '../../../schema-component/antd/menu/locale';
 import { Help } from '../../../user/Help';
 import { VariablesProvider } from '../../../variables';
-import { useMenuTranslation } from '../../../schema-component/antd/menu/locale';
 
 const filterByACL = (schema, options) => {
   const { allowAll, allowMenuItemIds = [] } = options;
@@ -218,7 +218,6 @@ const MenuEditor = (props) => {
     <SchemaIdContext.Provider value={defaultSelectedUid}>
       <SchemaComponent
         distributed
-        memoized
         scope={{ useMenuProps, onSelect, sideMenuRef, defaultSelectedUid }}
         schema={schema}
       />

--- a/packages/core/client/src/schema-component/core/RemoteSchemaComponent.tsx
+++ b/packages/core/client/src/schema-component/core/RemoteSchemaComponent.tsx
@@ -62,10 +62,10 @@ const RequestSchemaComponent: React.FC<RemoteSchemaComponentProps> = (props) => 
     return <Spin />;
   }
   return noForm ? (
-    <SchemaComponent memoized components={components} scope={scope} schema={schemaTransform(data?.data || {})} />
+    <SchemaComponent components={components} scope={scope} schema={schemaTransform(data?.data || {})} />
   ) : (
     <FormProvider form={form}>
-      <SchemaComponent memoized components={components} scope={scope} schema={schemaTransform(data?.data || {})} />
+      <SchemaComponent components={components} scope={scope} schema={schemaTransform(data?.data || {})} />
     </FormProvider>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Bug fix
- [ ] Others

### Reproduction
1. Open a NocoBase page in Safari.
2. Select two slightly more complex pages and switch back and forth.
3. There is a certain chance that this issue will occur.

https://github.com/nocobase/nocobase/assets/38434641/98a062f4-0e4f-4c5f-ab62-023ba2c38501

### Related PR
merge https://github.com/nocobase/pro-plugins/pull/138
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue that the page does not refresh after switching menus in Safari.     |
| 🇨🇳 Chinese |     修复在 Safari 中，切换菜单后页面不刷新的问题。      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
