### PR TITLE
chore(router): disable using replace strategy when closing popups or …

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
+++ b/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
@@ -231,7 +231,7 @@ export const usePagePopup = () => {
       if (getStoredPopupContext(currentPopupUid)) {
         navigate(-1);
       } else {
-        navigate(withSearchParams(removeLastPopupPath(location.pathname)), { replace: true });
+        navigate(withSearchParams(removeLastPopupPath(location.pathname)));
       }
     },
     [navigate, location, isPopupVisibleControlledByURL],


### PR DESCRIPTION
…subpages

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
The user opens a subpage via a URL and then clicks back. If the user still wants to go back to the previous subpage, it is better to have the path of the previous subpage in the browser history so that the user can go back to it.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Just remove the "replace" parameter from navigate.
https://github.com/nocobase/nocobase/pull/4838/files#diff-a422a21d9cdf6ece2091e4c71819c9766506fc9f7d66ff0682564bf37f476eceL234
### Showcase
<!-- Including any screenshots of the changes. -->
None.
### Related issues
None.
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      The replace policy is not used when closing a popup or returning from a subpage.      |
| 🇨🇳 Chinese |     关闭弹窗或者从子页面返回时不使用 replace 策略。      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
