### PR TITLE
fix:  checkbox field as ineffective linkage rule conditions under many-to-one association field

### DIFF
--- a/packages/core/client/src/schema-component/common/utils/logic.js
+++ b/packages/core/client/src/schema-component/common/utils/logic.js
@@ -134,7 +134,7 @@ export function getJsonLogic() {
       return a.some((element) => b.includes(element));
     },
     $noneOf: function (a, b) {
-      if (a.length === 0) {
+      if (!a || a?.length === 0) {
         return true;
       }
       if (Array.isArray(a) && Array.isArray(b) && a.some((element) => Array.isArray(element))) {


### PR DESCRIPTION
…le under m2o association field

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Showcase
<!-- Including any screenshots of the changes. -->

### Related issues

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Ineffective condition checks when using checkbox fields under many-to-one association fields as linkage rule conditions.    |
| 🇨🇳 Chinese |     使用多对一关系字段下的复选框字段为联动规则条件时判断无效      |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
