### PR TITLE
fix(data-vi): fix the permission issue when using external data sources in data-vi plugin

### DIFF
--- a/packages/core/test/src/server/index.ts
+++ b/packages/core/test/src/server/index.ts
@@ -10,7 +10,7 @@
 import { describe } from 'vitest';
 import ws from 'ws';
 
-export { mockDatabase } from '@nocobase/database';
+export { mockDatabase, MockDatabase } from '@nocobase/database';
 export { default as supertest } from 'supertest';
 export * from './mockServer';
 

--- a/packages/plugins/@nocobase/plugin-data-visualization/package.json
+++ b/packages/plugins/@nocobase/plugin-data-visualization/package.json
@@ -31,7 +31,8 @@
     "@nocobase/database": "1.x",
     "@nocobase/server": "1.x",
     "@nocobase/test": "1.x",
-    "@nocobase/utils": "1.x"
+    "@nocobase/utils": "1.x",
+    "@nocobase/data-source-main": "1.x"
   },
   "gitHead": "d0b4efe4be55f8c79a98a331d99d9f8cf99021a1",
   "keywords": [

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/external-data-source.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/external-data-source.test.ts
@@ -1,0 +1,82 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { MockDatabase, MockServer, createMockServer } from '@nocobase/test';
+import { MockDataSource } from './mock-data-source';
+import { checkPermission } from '../actions/query';
+
+describe('external data source', () => {
+  let ctx: any;
+  let app: MockServer;
+  let db: MockDatabase;
+  let adminAgent: any;
+  beforeAll(async () => {
+    process.env.INIT_ROOT_USERNAME = 'test';
+    app = await createMockServer({
+      plugins: ['data-source-manager', 'users', 'acl'],
+    });
+    db = app.db;
+    ctx = {
+      app,
+      db,
+    };
+    app.dataSourceManager.factory.register('mock', MockDataSource);
+    await app.db.getRepository('dataSources').create({
+      values: {
+        key: 'mockInstance1',
+        type: 'mock',
+        displayName: 'Mock',
+        options: {},
+      },
+    });
+    const adminUser = await app.db.getRepository('users').findOne({
+      filter: {
+        username: process.env.INIT_ROOT_USERNAME,
+      },
+    });
+    adminAgent = app.agent().login(adminUser);
+  });
+
+  it('should check permission for external data source', async () => {
+    await app.db.getRepository('roles').create({
+      values: {
+        name: 'test',
+        title: 'test',
+      },
+    });
+    const context = {
+      ...ctx,
+      state: {
+        currentRole: 'test',
+      },
+      action: {
+        params: {
+          values: {
+            dataSource: 'mockInstance1',
+            collection: 'posts',
+          },
+        },
+      },
+      throw: vi.fn(),
+    };
+    await checkPermission(context, async () => {});
+    expect(context.throw).toBeCalledWith(403, 'No permissions');
+    vi.resetAllMocks();
+    await adminAgent.resource('dataSources.roles', 'mockInstance1').update({
+      filterByTk: 'test',
+      values: {
+        strategy: {
+          actions: ['view'],
+        },
+      },
+    });
+    await checkPermission(context, async () => {});
+    expect(context.throw).not.toBeCalled();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/mock-data-source.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/mock-data-source.ts
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { CollectionManager, DataSource, ICollectionManager, IModel, IRepository } from '@nocobase/data-source-manager';
+
+class MockRepository implements IRepository {
+  count(options?: any): Promise<Number> {
+    return Promise.resolve(0);
+  }
+
+  findAndCount(options?: any): Promise<[IModel[], Number]> {
+    return Promise.resolve([[], 0]);
+  }
+
+  async find() {
+    return [];
+  }
+
+  async findOne() {
+    return {} as any;
+  }
+
+  async create() {}
+
+  async update() {}
+
+  async destroy() {}
+}
+
+class MockCollectionManager extends CollectionManager {
+  getRepository(name: string, sourceId?: string | number): IRepository {
+    return new MockRepository();
+  }
+}
+
+export class MockDataSource extends DataSource {
+  async load(): Promise<void> {
+    this.collectionManager.defineCollection({
+      name: 'posts',
+      fields: [
+        {
+          type: 'string',
+          name: 'title',
+        },
+        {
+          type: 'hasMany',
+          name: 'comments',
+        },
+      ],
+    });
+
+    this.collectionManager.defineCollection({
+      name: 'comments',
+      fields: [
+        {
+          type: 'string',
+          name: 'content',
+        },
+      ],
+    });
+  }
+
+  createCollectionManager(options?: any): ICollectionManager {
+    return new MockCollectionManager();
+  }
+}

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts
@@ -63,6 +63,10 @@ describe('query', () => {
       };
     });
 
+    afterAll(async () => {
+      await app.destroy();
+    });
+
     it('should check permissions', async () => {
       const context = {
         ...ctx,

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
@@ -290,9 +290,10 @@ export const cacheMiddleware = async (ctx: Context, next: Next) => {
 };
 
 export const checkPermission = (ctx: Context, next: Next) => {
-  const { collection } = ctx.action.params.values as QueryParams;
+  const { collection, dataSource } = ctx.action.params.values as QueryParams;
   const roleName = ctx.state.currentRole || 'anonymous';
-  const can = ctx.app.acl.can({ role: roleName, resource: collection, action: 'list' });
+  const acl = ctx.app.dataSourceManager.get(dataSource)?.acl || ctx.app.acl;
+  const can = acl.can({ role: roleName, resource: collection, action: 'list' });
   if (!can && roleName !== 'root') {
     ctx.throw(403, 'No permissions');
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

In the data visualization plugin, when a non "root" role with "view" permissions querying data from an external data source, a "No permissions" error occurs.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

#### Reproduce steps

1. Connect to an external data source.
2. Switch to a non "root" role with "view" permissions for the data source.
3. Querying data from the data source in the data visualization plugin.

#### Reason

The data visualization plugin did not use the corresponding ACL instance of the data source when checking permissions.

### Related issues

fix T-4804

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the permission issue when using external data sources in data visualization plugin         |
| 🇨🇳 Chinese | 修复数据可视化插件连接外部数据源时的权限判断问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
