### PR TITLE
fix: initializer select close

### DIFF
--- a/packages/core/client/src/application/schema-initializer/components/SchemaInitializerSelect.tsx
+++ b/packages/core/client/src/application/schema-initializer/components/SchemaInitializerSelect.tsx
@@ -45,7 +45,7 @@ export const SchemaInitializerSelect: FC<SchemaInitializerSelectItemProps> = (pr
   );
 
   return (
-    <SchemaInitializerItem {...others}>
+    <SchemaInitializerItem closeInitializerMenuWhenClick={false} {...others}>
       <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
         {title}
         <Select

--- a/packages/core/client/src/schema-items/OpenModeSchemaItems.tsx
+++ b/packages/core/client/src/schema-items/OpenModeSchemaItems.tsx
@@ -31,6 +31,7 @@ export const SchemaInitializerOpenModeSchemaItems: React.FC<Options> = (options)
     <>
       {openMode ? (
         <SchemaInitializerSelect
+          closeInitializerMenuWhenClick={false}
           title={t('Open mode')}
           options={[
             { label: t('Drawer'), value: 'drawer' },
@@ -55,7 +56,7 @@ export const SchemaInitializerOpenModeSchemaItems: React.FC<Options> = (options)
         />
       ) : null}
       {openSize && ['modal', 'drawer'].includes(openModeValue) ? (
-        <SchemaInitializerItem>
+        <SchemaInitializerItem closeInitializerMenuWhenClick={false}>
           <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
             {t('Popup size')}
             <Select


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |The Kanban block initializer `openMode` and `Pop size` should not be closed after clicking on them |
| 🇨🇳 Chinese |看板区块 `打开方式` 和 `弹窗尺寸` 点击后不应该关闭 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
