### PR TITLE
fix: default values for fields should not be cleared after submission

### DIFF
--- a/packages/core/client/src/block-provider/FormBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/FormBlockProvider.tsx
@@ -151,7 +151,7 @@ export const useFormBlockContext = () => {
 /**
  * @internal
  */
-export const useFormBlockProps = () => {
+export const useFormBlockProps = (shouldClearInitialValues = false) => {
   const ctx = useFormBlockContext();
   const treeParentRecord = useTreeParentRecord();
   const { fieldSchema } = useActionContext();
@@ -171,7 +171,9 @@ export const useFormBlockProps = () => {
       if (form) {
         // form 字段中可能一开始就存在一些默认值（比如设置了字段默认值的模板区块）。在编辑表单中，
         // 这些默认值是不需要的，需要清除掉，不然会导致一些问题。比如：https://github.com/nocobase/nocobase/issues/4868
-        form.initialValues = {};
+        if (shouldClearInitialValues) {
+          form.initialValues = {};
+        }
         form.setInitialValues(ctx.service?.data?.data);
       }
     }

--- a/packages/core/client/src/modules/blocks/data-blocks/form/hooks/useEditFormBlockProps.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/hooks/useEditFormBlockProps.ts
@@ -10,5 +10,5 @@
 import { useFormBlockProps } from '../../../../../block-provider/FormBlockProvider';
 
 export function useEditFormBlockProps() {
-  return useFormBlockProps();
+  return useFormBlockProps(true);
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix bug caused by #4876.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Only the Edit Form block needs to be cleared out of the defaults at the beginning.
### Related issues
None.
### Showcase
<!-- Including any screenshots of the changes. -->
https://github.com/nocobase/nocobase/blob/819163689174b1a7b15a737863aeb28fa8826b9f/packages/core/client/src/modules/blocks/data-blocks/form/__e2e__/form-create/schemaInitializer.test.ts#L180-L209
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Field defaults should not be cleared after submitting data on a page form     |
| 🇨🇳 Chinese |     页面表单提交数据后，不应该清空字段默认值      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
