### PR TITLE
fix: image style issues in rich text field

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/unixTimestamp.tsx
+++ b/packages/core/client/src/collection-manager/interfaces/unixTimestamp.tsx
@@ -28,7 +28,7 @@ export class UnixTimestampFieldInterface extends CollectionFieldInterface {
       },
     },
   };
-  availableTypes = ['integet', 'bigInt'];
+  availableTypes = ['integer', 'bigInt'];
   hasDefaultValue = true;
   properties = {
     ...defaultProps,

--- a/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
+++ b/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
@@ -54,7 +54,7 @@ describe('CollectionSelect', () => {
             role="button"
           >
             <div
-              class="css-1nrq807 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-wwtqkl"
+              class="css-1yh5po ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-wwtqkl"
             >
               <div
                 class="ant-formily-item-label"
@@ -191,7 +191,7 @@ describe('CollectionSelect', () => {
             role="button"
           >
             <div
-              class="css-1nrq807 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-wwtqkl"
+              class="css-1yh5po ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-wwtqkl"
             >
               <div
                 class="ant-formily-item-label"

--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -34,6 +34,9 @@ const formItemWrapCss = css`
   & .ant-space {
     flex-wrap: wrap;
   }
+  .ant-description-textarea img {
+    max-width: 100%;
+  }
 `;
 
 const formItemLabelCss = css`


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       image style issues in rich text field    |
| 🇨🇳 Chinese |       富文本字段中的大图片导致样式撑开   |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
