### PR TITLE
fix: clear default value immediately after field deletion

### DIFF
--- a/packages/core/client/src/schema-initializer/items/InitializerWithSwitch.tsx
+++ b/packages/core/client/src/schema-initializer/items/InitializerWithSwitch.tsx
@@ -10,8 +10,8 @@
 import { merge } from '@formily/shared';
 import React from 'react';
 
-import { useCurrentSchema } from '../utils';
 import { SchemaInitializerSwitch, useSchemaInitializer } from '../../application';
+import { useCurrentSchema } from '../utils';
 
 export const InitializerWithSwitch = (props) => {
   const { type, schema, item, remove: passInRemove, disabled } = props;

--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -763,6 +763,7 @@ export const useCurrentSchema = (action: string, key: string, find = findSchema,
       form?.query(new RegExp(`${schema.parent.name}.${schema.name}$`)).forEach((field: Field) => {
         // 如果字段被删掉，那么在提交的时候不应该提交这个字段
         field.setValue?.(undefined);
+        field.setInitialValue?.(undefined);
       });
       schema && rm(schema, remove);
     },

--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -491,6 +491,7 @@ export const SchemaSettingsRemove: FC<SchemaSettingsRemoveProps> = (props) => {
             form?.query(new RegExp(`${fieldSchema.parent.name}.${fieldSchema.name}$`)).forEach((field: Field) => {
               // 如果字段被删掉，那么在提交的时候不应该提交这个字段
               field.setValue?.(undefined);
+              field.setInitialValue?.(undefined);
             });
             removeDataBlock(fieldSchema['x-uid']);
           },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix T-4585
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
See code, it's very simple.
### Related issues
close T-4585
### Showcase
<!-- Including any screenshots of the changes. -->
![20240721103812_rec_](https://github.com/user-attachments/assets/17a66763-0bc5-490c-82a1-a24a048aa5ad)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Form fields should be cleared of their default values immediately after they are deleted.     |
| 🇨🇳 Chinese |     表单字段被删除后，应该立即清空其默认值。      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
