### PR TITLE
refactor(test): change mock cluster constructor arguments

### DIFF
--- a/packages/core/test/src/server/mock-cluster.ts
+++ b/packages/core/test/src/server/mock-cluster.ts
@@ -15,19 +15,22 @@ import { uid } from '@nocobase/utils';
 import { createMockServer } from './mock-server';
 
 type ClusterOptions = {
+  script?: string;
   env?: Record<string, any>;
   plugins?: string[];
-  instances: number;
+  instances?: number;
 };
 
 export class MockCluster {
+  private script = `${process.env.APP_PACKAGE_ROOT}/src/index.ts`;
   private processes = [];
   private mockApp;
 
-  constructor(
-    private script: string,
-    private options: ClusterOptions = { instances: 2 },
-  ) {}
+  constructor(private options: ClusterOptions = {}) {
+    if (options.script) {
+      this.script = options.script;
+    }
+  }
 
   async start(): Promise<number[]> {
     // NOTE: use this for install app first

--- a/packages/core/test/src/server/mock-cluster.ts
+++ b/packages/core/test/src/server/mock-cluster.ts
@@ -14,22 +14,20 @@ import { getPortPromise } from 'portfinder';
 import { uid } from '@nocobase/utils';
 import { createMockServer } from './mock-server';
 
-type ProcessConfig = {
-  env: Record<string, any>;
-};
-
 type ClusterOptions = {
-  script: string;
-  config: ProcessConfig;
-  instances: number;
+  env?: Record<string, any>;
   plugins?: string[];
+  instances: number;
 };
 
 export class MockCluster {
   private processes = [];
   private mockApp;
 
-  constructor(private options: ClusterOptions) {}
+  constructor(
+    private script: string,
+    private options: ClusterOptions = { instances: 2 },
+  ) {}
 
   async start(): Promise<number[]> {
     // NOTE: use this for install app first
@@ -40,12 +38,12 @@ export class MockCluster {
     this.processes = [];
     const ports = [];
 
-    for (let i = 0; i < this.options.instances; i++) {
+    for (let i = 0; i < (this.options.instances ?? 2); i++) {
       const port = await getPortPromise();
-      const childProcess = spawn('node', ['./node_modules/tsx/dist/cli.mjs', this.options.script, 'start'], {
+      const childProcess = spawn('node', ['./node_modules/tsx/dist/cli.mjs', this.script, 'start'], {
         env: {
           ...process.env,
-          ...this.options.config.env,
+          ...this.options.env,
           APP_PORT: `${port}`,
           APPEND_PRESET_BUILT_IN_PLUGINS: (this.options.plugins ?? []).join(','),
           SOCKET_PATH: `storage/tests/gateway-cluster-${uid()}.sock`,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Simplify the API of `MockCluster`.

### Description 

Old:

```ts
new MockCluster({
  script: 'xxx.ts',
  config: {
    env: {}
  },
  instances: 2,
  plugins: [],
});
```

New

```ts
new MockCluster('xxx.ts', {
  env: {}
  instances: 2,
  plugins: [],
});
```

### Related issues

### Showcase

As above exmaple.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Change mock cluster constructor arguments |
| 🇨🇳 Chinese | 调整集群模拟类初始化参数 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
