### PR TITLE
fix: prevent URL change on clicking unconfigured association field

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/InternalViewer.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalViewer.tsx
@@ -97,10 +97,15 @@ const ButtonLinkList: FC<ButtonListProps> = (props) => {
                   if (designable) {
                     insertViewer(schema.Viewer);
                   }
-                  openPopup({
-                    recordData: record,
-                    parentRecordData: recordData,
-                  });
+
+                  // fix https://nocobase.height.app/T-4794/description
+                  if (fieldSchema.properties) {
+                    openPopup({
+                      recordData: record,
+                      parentRecordData: recordData,
+                    });
+                  }
+
                   ellipsisWithTooltipRef?.current?.setPopoverVisible(false);
                 }}
               >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Prevent issues with URL changes when clicking on a association field that is not configured for a popup window.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
- If the Schema of the current association field contains a properties attribute, it indicates that a popup has already been configured.
### Related issues
close T-4794
### Showcase
<!-- Including any screenshots of the changes. -->
![20240721163612_rec_](https://github.com/user-attachments/assets/d9093f51-0183-4fa1-869f-4f2eebb632be)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        When a  association field is not configured with a popup window, the URL should not change when clicked.   |
| 🇨🇳 Chinese |     关系字段未配置弹窗时，点击后 URL 不应该发生变化。      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
