### PR TITLE
fix: tree blocks with the same name can connect via associaiton field…

### DIFF
--- a/packages/core/client/src/filter-provider/utils.ts
+++ b/packages/core/client/src/filter-provider/utils.ts
@@ -61,6 +61,19 @@ export const getSupportFieldsByForeignKey = (
   });
 };
 
+export const canBeConnectedByForeignKey = (collection: Collection_deprecated, block: DataBlock) => {
+  return !!getSupportFieldsByForeignKey(collection, block)?.length;
+};
+
+export const canBeConnectedByAssociation = (
+  collection: Collection_deprecated,
+  block: DataBlock,
+  getAllCollectionsInheritChain: (collectionName: string, customDataSource?: string) => string[],
+) => {
+  return !!getSupportFieldsByAssociation(getAllCollectionsInheritChain(collection.name, collection.dataSource), block)
+    ?.length;
+};
+
 /**
  * 根据筛选区块类型筛选出支持的数据区块（同表或具有关系字段的表）
  * @param filterBlockType
@@ -88,9 +101,8 @@ export const useSupportedBlocks = (filterBlockType: FilterBlockType) => {
       return (
         fieldSchema['x-uid'] !== block.uid &&
         (isSameCollection(block.collection, collection) ||
-          getSupportFieldsByAssociation(getAllCollectionsInheritChain(collection.name, collection.dataSource), block)
-            ?.length ||
-          getSupportFieldsByForeignKey(collection, block)?.length)
+          canBeConnectedByAssociation(collection, block, getAllCollectionsInheritChain) ||
+          canBeConnectedByForeignKey(collection, block))
       );
     });
   }


### PR DESCRIPTION
…s and foreign keys

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
It should also be possible to create a connect between two blocks with the same collection based on a association field or foreign key.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
- Also returns all connection options that satisfy the condition.
- When a connection is established based on one item, disable the other options to prevent problems.
### Related issues
close T-4704
### Showcase
<!-- Including any screenshots of the changes. -->
![image](https://github.com/user-attachments/assets/97d8c527-a7db-40fb-9de6-1d83e2da499e)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Connects between tree tables with the same name can be created based on association fields and foreign keys.     |
| 🇨🇳 Chinese |     同名的树表之间可以根据关系字段和外键建立链接。      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
