### PR TITLE
fix: autoGenId default value  should be false when adding collection

### DIFF
--- a/packages/core/client/src/collection-manager/templates/components/PresetFields.tsx
+++ b/packages/core/client/src/collection-manager/templates/components/PresetFields.tsx
@@ -169,7 +169,7 @@ export const PresetFields = observer(
     ];
     useEffect(() => {
       const config = {
-        autoGenId: true,
+        autoGenId: false,
         createdAt: true,
         createdBy: true,
         updatedAt: true,
@@ -209,7 +209,7 @@ export const PresetFields = observer(
           onChange: (_, selectedRows) => {
             const fields = getDefaultCollectionFields(selectedRows, form.values);
             const config = {
-              autoGenId: !!fields.find((v) => v.name === 'id'),
+              autoGenId: false,
               createdAt: !!fields.find((v) => v.name === 'createdAt'),
               createdBy: !!fields.find((v) => v.name === 'createdBy'),
               updatedAt: !!fields.find((v) => v.name === 'updatedAt'),

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/client/__e2e__/collection-template/general2.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/client/__e2e__/collection-template/general2.test.ts
@@ -26,7 +26,7 @@ test.describe('create collection with preset fields', () => {
     const postData = request.postDataJSON();
     //默认提交的数据符合预期
     expect(postData).toMatchObject({
-      autoGenId: true,
+      autoGenId: false,
       createdAt: true,
       createdBy: true,
       updatedAt: true,
@@ -78,7 +78,7 @@ test.describe('create collection with preset fields', () => {
     const postData = request.postDataJSON();
     //提交的数据符合预期
     expect(postData).toMatchObject({
-      autoGenId: true,
+      autoGenId: false,
       createdAt: false,
       createdBy: false,
       updatedAt: false,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Set autoGenId default value to false when creating data tables        |
| 🇨🇳 Chinese |   创建数据表时autoGenId 默认值应该为 false     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
