### PR TITLE
refactor(client): allow select to show null option as tag in read pretty mode if configured

### DIFF
--- a/packages/core/client/src/schema-component/antd/select/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/select/ReadPretty.tsx
@@ -31,16 +31,16 @@ export const ReadPretty = observer(
   (props: SelectReadPrettyProps) => {
     const fieldNames = { ...defaultFieldNames, ...props.fieldNames };
     const field = useField<any>();
+    const collectionField = useCollectionField();
+    const dataSource = field.dataSource || props.options || collectionField?.uiSchema.enum || [];
+    const currentOptions = getCurrentOptions(field.value, dataSource, fieldNames);
 
-    if (!isValid(props.value)) {
+    if (!isValid(props.value) && !currentOptions.length) {
       return <div />;
     }
     if (isArrayField(field) && field?.value?.length === 0) {
       return <div />;
     }
-    const collectionField = useCollectionField();
-    const dataSource = field.dataSource || props.options || collectionField?.uiSchema.enum || [];
-    const currentOptions = getCurrentOptions(field.value, dataSource, fieldNames);
 
     return (
       <div>

--- a/packages/core/client/src/schema-component/antd/select/demos/new-demos/null-option.tsx
+++ b/packages/core/client/src/schema-component/antd/select/demos/new-demos/null-option.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { mockApp } from '@nocobase/client/demo-utils';
+import { SchemaComponent, Plugin, ISchema } from '@nocobase/client';
+
+const options = [
+  {
+    label: '福建',
+    value: 'FuJian',
+    children: [
+      { label: '{{t("福州")}}', value: 'FZ' },
+      { label: '莆田', value: 'PT' },
+    ],
+  },
+  { label: '江苏', value: 'XZ' },
+  { label: '浙江', value: 'ZX' },
+  { lable: '未选择', value: null },
+];
+
+const schema: ISchema = {
+  type: 'void',
+  name: 'root',
+  'x-decorator': 'FormV2',
+  'x-component': 'ShowFormData',
+  properties: {
+    test: {
+      type: 'string',
+      title: 'Test',
+      enum: options,
+      'x-decorator': 'FormItem',
+      'x-component': 'Select',
+    },
+  },
+};
+const Demo = () => {
+  return <SchemaComponent schema={schema} />;
+};
+
+class DemoPlugin extends Plugin {
+  async load() {
+    this.app.router.add('root', { path: '/', Component: Demo });
+  }
+}
+
+const app = mockApp({
+  plugins: [DemoPlugin],
+});
+
+export default app.getRootComponent();

--- a/packages/core/client/src/schema-component/antd/select/demos/new-demos/null-option.tsx
+++ b/packages/core/client/src/schema-component/antd/select/demos/new-demos/null-option.tsx
@@ -28,6 +28,7 @@ const schema: ISchema = {
       enum: options,
       'x-decorator': 'FormItem',
       'x-component': 'Select',
+      default: null,
     },
   },
 };

--- a/packages/core/client/src/schema-component/antd/select/utils.ts
+++ b/packages/core/client/src/schema-component/antd/select/utils.ts
@@ -45,9 +45,9 @@ function flatData(data: any[], fieldNames: FieldNames): any[] {
 
 export function getCurrentOptions(values: string | string[], dataSource: any[], fieldNames: FieldNames): Option[] {
   const result = flatData(dataSource, fieldNames);
-  const arrValues = castArray(values)
-    .filter((item) => item != null)
-    .map((val) => (isPlainObject(val) ? val[fieldNames.value] : val)) as string[];
+  const arrValues = castArray(values).map((val) =>
+    isPlainObject(val) && val !== null ? val[fieldNames.value] : val,
+  ) as string[];
 
   function findOptions(options: any[]): Option[] {
     if (!options) return [];

--- a/packages/core/client/src/schema-component/antd/select/utils.ts
+++ b/packages/core/client/src/schema-component/antd/select/utils.ts
@@ -43,11 +43,9 @@ function flatData(data: any[], fieldNames: FieldNames): any[] {
   return newArr;
 }
 
-export function getCurrentOptions(values: string | string[], dataSource: any[], fieldNames: FieldNames): Option[] {
+export function getCurrentOptions(values: any | any[], dataSource: any[], fieldNames: FieldNames): Option[] {
   const result = flatData(dataSource, fieldNames);
-  const arrValues = castArray(values).map((val) =>
-    isPlainObject(val) && val !== null ? val[fieldNames.value] : val,
-  ) as string[];
+  const arrValues = castArray(values).map((val) => (isPlainObject(val) ? val[fieldNames.value] : val)) as any[];
 
   function findOptions(options: any[]): Option[] {
     if (!options) return [];


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Option with `null` value could not be shown in read-pretty mode.

### Description 

In some data, the options will contain null value. But by default the option with null value could not be shown in read-pretty mode.

### Related issues

None.

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/8bc130b1-b465-4f41-b3b9-454922090a09">

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow select to show null option as tag in read pretty mode if configured |
| 🇨🇳 Chinese | Select 组件在阅读友好模式下可以显示 value 为 null 的选项标签。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
