### PR TITLE
fix(plugin-workflow): hide condition configuration in destroy collection event

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/collection.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/collection.tsx
@@ -160,10 +160,10 @@ export default class extends Trigger {
       'x-component-props': {},
       'x-reactions': [
         {
-          dependencies: ['collection'],
+          dependencies: ['collection', 'mode'],
           fulfill: {
             state: {
-              visible: '{{!!$deps[0]}}',
+              visible: `{{!!$deps[0] && !($deps[1] & ${COLLECTION_TRIGGER_MODE.DELETED})}}`,
             },
           },
         },

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -434,6 +434,29 @@ describe('workflow > triggers > collection', () => {
       expect(executions.length).toBe(1);
       expect(executions[0].context.data.title).toBe('t1');
     });
+
+    it('condition will not effect destroy', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 4,
+          collection: 'posts',
+          condition: {
+            title: 't1',
+          },
+        },
+      });
+
+      const post1 = await PostRepo.create({ values: { title: 't1' } });
+      await PostRepo.destroy({ filterByTk: post1.id });
+
+      await sleep(500);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(executions[0].context.data.title).toBe('t1');
+    });
   });
 
   describe('config.appends', () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -68,7 +68,7 @@ async function handler(this: CollectionTrigger, workflow: WorkflowModel, data: M
   }
 
   // NOTE: if no configured condition, or not match, do not trigger
-  if (isValidFilter(condition)) {
+  if (isValidFilter(condition) && !(mode & MODE_BITMAP.DESTROY)) {
     // TODO: change to map filter format to calculation format
     // const calculation = toCalculation(condition);
     const count = await repository.count({


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Condition configuration in destroy collection event not works and makes user confuse.

### Description 

Condition is implemented as a re-querying after event in before versions, which can not work with destroy event.

So we hide the condition configuration for now.

### Related issues

None.

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/bee2ce3c-41ed-48b7-bef3-8625549209d2" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide condition configuration in destroy collection event. |
| 🇨🇳 Chinese | 在数据表事件配置中，隐藏删除事件的条件配置项。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
