### PR TITLE
fix(plugin-workflow): fix schedule event on date field

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-date-field.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-date-field.test.ts
@@ -377,5 +377,30 @@ describe('workflow > triggers > schedule > date field mode', () => {
       const e2c = await workflow.countExecutions();
       expect(e2c).toBe(2);
     });
+
+    it('empty endsOn as no end', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'schedule',
+        config: {
+          mode: 1,
+          collection: 'posts',
+          startsOn: {
+            field: 'createdAt',
+          },
+          repeat: 1000,
+          endsOn: {},
+        },
+      });
+
+      await sleepToEvenSecond();
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(1700);
+
+      const e1c = await workflow.countExecutions();
+      expect(e1c).toBe(2);
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
@@ -54,7 +54,7 @@ function getDataOptionTime(record, on, dir = 1) {
     }
     case 'object': {
       const { field, offset = 0, unit = 1000 } = on;
-      if (!record.get(field)) {
+      if (!field || !record.get(field)) {
         return null;
       }
       const second = new Date(record.get(field).getTime());


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix error occurs in schedule event on date field.

### Description 

In configuration panel of schedule event on date field, with repeat option, and by default the "Ends on" option is set to empty object (`{}`). This cause error when related data record creating/updating.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix schedule event on date field. |
| 🇨🇳 Chinese | 修复基于时间字段定时任务在未设置结束时间时的错误。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
