### PR TITLE
fix(plugin-workflow): fix formula validation for expression

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
@@ -45,7 +45,7 @@ export default class extends Instruction {
       ['x-validator'](value, rules, { form }) {
         const { values } = form;
         const { evaluate } = evaluators.get(values.engine) as Evaluator;
-        const exp = value.trim().replace(/{{([^{}]+)}}/g, ' 1 ');
+        const exp = value.trim().replace(/{{([^{}]+)}}/g, ' "1" ');
         try {
           evaluate(exp);
           return '';

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
@@ -409,7 +409,7 @@ export default class extends Instruction {
       ['x-validator'](value, rules, { form }) {
         const { values } = form;
         const { evaluate } = evaluators.get(values.engine);
-        const exp = value.trim().replace(/{{([^{}]+)}}/g, ' 1 ');
+        const exp = value.trim().replace(/{{([^{}]+)}}/g, ' "1" ');
         try {
           evaluate(exp);
           return '';


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Validation on formula expression with variable, for example: `SUBSTITUTE({{$context.data.title}}, '1', '2')` will not pass, although it is correctly.

### Description 

The validation is based on replacement variables to number `1`. Number type in some function will cause error. So try to use string `"1"` as replacement to adapt more scenario.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix formula validation for expression. |
| 🇨🇳 Chinese | 修复计算表达式预验证错误。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
