### PR TITLE
fix(plugin-workflow): fix admin role with workflow plugin permission can not delete executions

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -223,6 +223,7 @@ export default class PluginWorkflowServer extends Plugin {
         'executions:list',
         'executions:get',
         'executions:cancel',
+        'executions:destroy',
         'flow_nodes:update',
         'flow_nodes:destroy',
       ],


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Admin role with workflow plugin permission can not delete executions, API report "No permissions".

### Description 

Permission of deleting executions is not included in snippets.

### Related issues

[Admin清空-工作流-执行历史提示失败无权限](https://forum.nocobase.com/t/admin/78)

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix admin role with workflow plugin permission can not delete executions. |
| 🇨🇳 Chinese | 修复 admin 角色拥有工作流插件权限的情况下无法删除执行记录的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
