### PR TITLE
fix(plugin-workflow): fix delete action button to bind pre-action workflow

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/client/ActionTrigger.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/client/ActionTrigger.tsx
@@ -86,7 +86,7 @@ function useVariables(config, options) {
 
 export default class extends Trigger {
   title = `{{t("Post-action event", { ns: "${NAMESPACE}" })}}`;
-  description = `{{t('Triggered after the completion of a request initiated through an action button or API, such as after adding, updating, or deleting data. Suitable for data processing, sending notifications, etc., after actions are completed.', { ns: "${NAMESPACE}" })}}`;
+  description = `{{t('Triggered after the completion of a request initiated through an action button or API, such as after adding or updating data. Suitable for data processing, sending notifications, etc., after actions are completed.', { ns: "${NAMESPACE}" })}}`;
   fieldset = {
     collection: {
       type: 'string',

--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/locale/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "Post-action event": "操作后事件",
-  "Triggered after the completion of a request initiated through an action button or API, such as after adding, updating, or deleting data. Suitable for data processing, sending notifications, etc., after actions are completed.":
-    "通过操作按钮或 API 发起请求时，在请求执行成功后触发该事件，比如新增、更新、删除操作之后。适用于在操作完成后进行数据处理、发送通知等。",
+  "Triggered after the completion of a request initiated through an action button or API, such as after adding or updating data. Suitable for data processing, sending notifications, etc., after actions are completed.":
+    "通过操作按钮或 API 发起请求时，在请求执行成功后触发该事件，比如新增、更新操作之后。适用于在操作完成后进行数据处理、发送通知等。",
   "Collection": "数据表",
   "The collection to which the triggered data belongs.": "触发数据所属的数据表。",
   "Trigger mode": "触发模式",

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
@@ -8,8 +8,10 @@
  */
 
 import React from 'react';
+import { useFieldSchema } from '@formily/react';
+import { isValid } from '@formily/shared';
 
-import { Plugin } from '@nocobase/client';
+import { Plugin, WorkflowConfig } from '@nocobase/client';
 import { Registry } from '@nocobase/utils/client';
 
 import { ExecutionPage } from './ExecutionPage';
@@ -90,6 +92,14 @@ export default class PluginWorkflowClient extends Plugin {
     });
 
     this.app.schemaSettingsManager.add(customizeSubmitToWorkflowActionSettings);
+
+    this.app.schemaSettingsManager.addItem('actionSettings:delete', 'workflowConfig', {
+      Component: WorkflowConfig,
+      useVisible() {
+        const fieldSchema = useFieldSchema();
+        return isValid(fieldSchema?.['x-action-settings']?.triggerWorkflows);
+      },
+    });
 
     this.registerTrigger('collection', CollectionTrigger);
     this.registerTrigger('schedule', ScheduleTrigger);


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The workflow binding settings missed when migrated to new button settings.

### Description 

Delete action button should be able to bind workflows.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix delete action button to bind pre-action workflow. |
| 🇨🇳 Chinese | 修复删除按钮无法绑定操作前事件的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
