### PR TITLE
fix: the date string in filter should not be UTC

### DIFF
--- a/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
@@ -19,6 +19,7 @@ import { FormProvider, SchemaComponent } from '../../core';
 import { useDesignable } from '../../hooks';
 import { useProps } from '../../hooks/useProps';
 import { Action, ActionProps } from '../action';
+import { DatePickerProvider } from '../date-picker/DatePicker';
 import { StablePopover } from '../popover';
 
 export const FilterActionContext = createContext<any>(null);
@@ -58,20 +59,22 @@ export const FilterAction = withDynamicSchemaProps(
           content={
             <form>
               <FormProvider form={form}>
-                <SchemaComponent
-                  schema={{
-                    type: 'object',
-                    properties: {
-                      filter: {
-                        type: 'string',
-                        enum: options || field.dataSource,
-                        default: fieldSchema.default,
-                        'x-component': 'Filter',
-                        'x-component-props': {},
+                <DatePickerProvider value={{ utc: false }}>
+                  <SchemaComponent
+                    schema={{
+                      type: 'object',
+                      properties: {
+                        filter: {
+                          type: 'string',
+                          enum: options || field.dataSource,
+                          default: fieldSchema.default,
+                          'x-component': 'Filter',
+                          'x-component-props': {},
+                        },
                       },
-                    },
-                  }}
-                />
+                    }}
+                  />
+                </DatePickerProvider>
                 <div
                   className={css`
                     display: flex;

--- a/packages/core/client/src/schema-component/antd/filter/__e2e__/FilterAction.test.ts
+++ b/packages/core/client/src/schema-component/antd/filter/__e2e__/FilterAction.test.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { test } from '@nocobase/test/e2e';
+import { theDateStringShouldNotBeUTC } from './templates';
+
+test.describe('FilterAction', () => {
+  test('the date string should not be UTC', async ({ page, mockPage }) => {
+    await mockPage(theDateStringShouldNotBeUTC).goto();
+
+    // 获取当前的日期，格式为：YYYY-MM-DD
+    const today = new Date().toISOString().split('T')[0];
+
+    // 断言：应该会触发一个请求，请求参数包含了 filter: {"$and":[{"createdAt":{"$dateOn":"2024-07-10"}}]}
+    const requestPromise = page.waitForRequest(
+      // /api/users:list?pageSize=20&page=1&filter={"$and":[{"createdAt":{"$dateOn":"2024-07-10"}}]}
+      `/api/users:list?pageSize=20&page=1&filter=%7B%22%24and%22%3A%5B%7B%22createdAt%22%3A%7B%22%24dateOn%22%3A%22${today}%22%7D%7D%5D%7D`,
+    );
+
+    await page.getByLabel('action-Filter.Action-Filter-').click();
+    await page.getByPlaceholder('Select date').click();
+    await page.getByTitle(today).click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await requestPromise;
+  });
+});

--- a/packages/core/client/src/schema-component/antd/filter/__e2e__/FilterAction.test.ts
+++ b/packages/core/client/src/schema-component/antd/filter/__e2e__/FilterAction.test.ts
@@ -14,10 +14,10 @@ test.describe('FilterAction', () => {
   test('the date string should not be UTC', async ({ page, mockPage }) => {
     await mockPage(theDateStringShouldNotBeUTC).goto();
 
-    // 获取当前的日期，格式为：YYYY-MM-DD
+    // get current date, format: YYYY-MM-DD
     const today = new Date().toISOString().split('T')[0];
 
-    // 断言：应该会触发一个请求，请求参数包含了 filter: {"$and":[{"createdAt":{"$dateOn":"2024-07-10"}}]}
+    // expect: should trigger a request, the request parameters contain filter: {"$and":[{"createdAt":{"$dateOn":"2024-07-10"}}]}
     const requestPromise = page.waitForRequest(
       // /api/users:list?pageSize=20&page=1&filter={"$and":[{"createdAt":{"$dateOn":"2024-07-10"}}]}
       `/api/users:list?pageSize=20&page=1&filter=%7B%22%24and%22%3A%5B%7B%22createdAt%22%3A%7B%22%24dateOn%22%3A%22${today}%22%7D%7D%5D%7D`,

--- a/packages/core/client/src/schema-component/antd/filter/__e2e__/templates.ts
+++ b/packages/core/client/src/schema-component/antd/filter/__e2e__/templates.ts
@@ -1,0 +1,190 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export const theDateStringShouldNotBeUTC = {
+  pageSchema: {
+    _isJSONSchemaObject: true,
+    version: '2.0',
+    type: 'void',
+    'x-component': 'Page',
+    'x-app-version': '1.2.26-alpha',
+    properties: {
+      es36mtcuj77: {
+        _isJSONSchemaObject: true,
+        version: '2.0',
+        type: 'void',
+        'x-component': 'Grid',
+        'x-initializer': 'page:addBlock',
+        'x-app-version': '1.2.26-alpha',
+        properties: {
+          rqpd9r2rueb: {
+            _isJSONSchemaObject: true,
+            version: '2.0',
+            type: 'void',
+            'x-component': 'Grid.Row',
+            'x-app-version': '1.2.26-alpha',
+            properties: {
+              '4n75f33bowk': {
+                _isJSONSchemaObject: true,
+                version: '2.0',
+                type: 'void',
+                'x-component': 'Grid.Col',
+                'x-app-version': '1.2.26-alpha',
+                properties: {
+                  ppcczd368ap: {
+                    _isJSONSchemaObject: true,
+                    version: '2.0',
+                    type: 'void',
+                    'x-decorator': 'TableBlockProvider',
+                    'x-acl-action': 'users:list',
+                    'x-use-decorator-props': 'useTableBlockDecoratorProps',
+                    'x-decorator-props': {
+                      collection: 'users',
+                      dataSource: 'main',
+                      action: 'list',
+                      params: {
+                        pageSize: 20,
+                      },
+                      rowKey: 'id',
+                      showIndex: true,
+                      dragSort: false,
+                    },
+                    'x-toolbar': 'BlockSchemaToolbar',
+                    'x-settings': 'blockSettings:table',
+                    'x-component': 'CardItem',
+                    'x-filter-targets': [],
+                    'x-app-version': '1.2.26-alpha',
+                    properties: {
+                      actions: {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'void',
+                        'x-initializer': 'table:configureActions',
+                        'x-component': 'ActionBar',
+                        'x-component-props': {
+                          style: {
+                            marginBottom: 'var(--nb-spacing)',
+                          },
+                        },
+                        'x-app-version': '1.2.26-alpha',
+                        properties: {
+                          '69dtb0exaep': {
+                            'x-uid': '7v2pn6flf92',
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            title: '{{ t("Filter") }}',
+                            'x-action': 'filter',
+                            'x-toolbar': 'ActionSchemaToolbar',
+                            'x-settings': 'actionSettings:filter',
+                            'x-component': 'Filter.Action',
+                            'x-use-component-props': 'useFilterActionProps',
+                            'x-component-props': {
+                              icon: 'FilterOutlined',
+                            },
+                            'x-align': 'left',
+                            'x-app-version': '1.2.26-alpha',
+                            default: {
+                              $and: [
+                                {
+                                  createdAt: {
+                                    $dateOn: null,
+                                  },
+                                },
+                              ],
+                            },
+                            'x-async': false,
+                            'x-index': 1,
+                          },
+                        },
+                        'x-uid': 'wq9tco5xrc5',
+                        'x-async': false,
+                        'x-index': 1,
+                      },
+                      mli07w96bpg: {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'array',
+                        'x-initializer': 'table:configureColumns',
+                        'x-component': 'TableV2',
+                        'x-use-component-props': 'useTableBlockProps',
+                        'x-component-props': {
+                          rowKey: 'id',
+                          rowSelection: {
+                            type: 'checkbox',
+                          },
+                        },
+                        'x-app-version': '1.2.26-alpha',
+                        properties: {
+                          actions: {
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            title: '{{ t("Actions") }}',
+                            'x-action-column': 'actions',
+                            'x-decorator': 'TableV2.Column.ActionBar',
+                            'x-component': 'TableV2.Column',
+                            'x-toolbar': 'TableColumnSchemaToolbar',
+                            'x-initializer': 'table:configureItemActions',
+                            'x-settings': 'fieldSettings:TableColumn',
+                            'x-toolbar-props': {
+                              initializer: 'table:configureItemActions',
+                            },
+                            'x-app-version': '1.2.26-alpha',
+                            properties: {
+                              gptrtf70ksb: {
+                                _isJSONSchemaObject: true,
+                                version: '2.0',
+                                type: 'void',
+                                'x-decorator': 'DndContext',
+                                'x-component': 'Space',
+                                'x-component-props': {
+                                  split: '|',
+                                },
+                                'x-app-version': '1.2.26-alpha',
+                                'x-uid': 'kf5es0sxa8d',
+                                'x-async': false,
+                                'x-index': 1,
+                              },
+                            },
+                            'x-uid': 'cz3uuywilz2',
+                            'x-async': false,
+                            'x-index': 1,
+                          },
+                        },
+                        'x-uid': '2qt9yfh8pnw',
+                        'x-async': false,
+                        'x-index': 2,
+                      },
+                    },
+                    'x-uid': '04je96az8ze',
+                    'x-async': false,
+                    'x-index': 1,
+                  },
+                },
+                'x-uid': 'gbljz8oqqrf',
+                'x-async': false,
+                'x-index': 1,
+              },
+            },
+            'x-uid': 'gwms2kvl983',
+            'x-async': false,
+            'x-index': 1,
+          },
+        },
+        'x-uid': 'm3gs8ov60rw',
+        'x-async': false,
+        'x-index': 1,
+      },
+    },
+    'x-uid': '1f2ikh8fvu9',
+    'x-async': true,
+    'x-index': 1,
+  },
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
This is a bug.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Use `DatePickerProvider` in FilterAction component to set utc to false.
### Related issues
close T-4935
### Showcase
<!-- Including any screenshots of the changes. -->
see: https://github.com/nocobase/nocobase/blob/7dcaa3f32af830eeca8531b60a951b36916ecbb7/packages/core/client/src/schema-component/antd/filter/__e2e__/FilterAction.test.ts#L14-L32
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       the date string in filter should not be UTC.    |
| 🇨🇳 Chinese |     筛选条件中的日期不应该带上时区。      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
