### PR TITLE
fix(plugin-workflow-manual): fix disabled status in clicked button of…

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowTodo.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowTodo.tsx
@@ -8,7 +8,7 @@
  */
 
 import { observer, useField, useFieldSchema, useForm } from '@formily/react';
-import { Space, Spin, Tag } from 'antd';
+import { Button, Space, Spin, Tag } from 'antd';
 import dayjs from 'dayjs';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
@@ -425,6 +425,7 @@ function ManualActionStatusProvider({ value, children }) {
   const { userJob, execution } = useFlowContext();
   const button = useField();
   const buttonSchema = useFieldSchema();
+  const compile = useCompile();
 
   useEffect(() => {
     if (execution.status || userJob.status) {
@@ -433,7 +434,17 @@ function ManualActionStatusProvider({ value, children }) {
     }
   }, [execution, userJob, value, button, buttonSchema.name]);
 
-  return <ManualActionStatusContext.Provider value={value}>{children}</ManualActionStatusContext.Provider>;
+  return (
+    <ManualActionStatusContext.Provider value={value}>
+      {execution.status || userJob.status ? (
+        <Button type="primary" disabled>
+          {compile(buttonSchema.title)}
+        </Button>
+      ) : (
+        children
+      )}
+    </ManualActionStatusContext.Provider>
+  );
 }
 
 function useSubmit() {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The button been used in manual todo should be disabled.

### Description 

Due to [alibaba/formily#4029](https://github.com/alibaba/formily/issues/4029), we can only use a button out of formily to render the disabled status.

### Related issues

[alibaba/formily#4029](https://github.com/alibaba/formily/issues/4029)

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/13b48fe0-4295-450f-82f3-ebb9e7d2d694" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix disabled status in clicked button of manual todo. |
| 🇨🇳 Chinese | 修复人工节点待办界面中已操作过的按钮的禁用状态。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
