### PR TITLE
fix(plugin-workflow-manual): fix assign field value for all action buttons of manual node

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowTodo.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowTodo.tsx
@@ -451,23 +451,30 @@ function useSubmit() {
   const api = useAPIClient();
   const { setVisible } = useActionContext();
   const { values, submit } = useForm();
+  const field = useField();
   const buttonSchema = useFieldSchema();
   const { service } = useTableBlockContext();
   const { userJob, execution } = useFlowContext();
   const { name: actionKey } = buttonSchema;
   const { name: formKey } = buttonSchema.parent.parent;
+  const { assignedValues = {} } = buttonSchema?.['x-action-settings'] ?? {};
   return {
     async run() {
       if (execution.status || userJob.status) {
         return;
       }
       await submit();
+      field.data = field.data || {};
+      field.data.loading = true;
+
       await api.resource('users_jobs').submit({
         filterByTk: userJob.id,
         values: {
-          result: { [formKey]: values, _: actionKey },
+          result: { [formKey]: { ...values, ...assignedValues.values }, _: actionKey },
         },
       });
+
+      field.data.loading = false;
       setVisible(false);
       service.refresh();
     },

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/SchemaConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/SchemaConfig.tsx
@@ -39,6 +39,7 @@ import {
   useSchemaInitializer,
   useSchemaInitializerItem,
   useSchemaOptionsContext,
+  useVariableScope,
 } from '@nocobase/client';
 import WorkflowPlugin, {
   DetailsBlockProvider,
@@ -358,7 +359,7 @@ function ActionInitializer() {
           ...actionProps,
           useAction: '{{ useSubmit }}',
         },
-        'x-designer': 'Action.Designer',
+        'x-designer': 'ManualActionDesigner',
         'x-action': `${action}`,
       }}
       type="x-action"

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/forms/update.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/forms/update.tsx
@@ -70,6 +70,7 @@ function UpdateFormDesigner() {
           });
           dn.refresh();
         }}
+        width="60%"
       />
       <SchemaSettingsLinkageRules collectionName={name} />
       <SchemaSettingsDivider />


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Assign field value not works in action buttons of manual node.

### Description 

1. Support assign field value for all action buttons.
2. Fix assign field value in submit function.

### Related issues

None.

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/761ed6e0-3712-45ad-8580-11a6d7a928eb" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix assign field value for all action buttons of manual node. |
| 🇨🇳 Chinese | 修复人工节点中所有操作按钮的字段赋值配置。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
