### PR TITLE
fix: issue where users with interface editing permissions cannot add tabs in the popup

### DIFF
--- a/packages/core/client/src/schema-initializer/buttons/TabPaneInitializers.tsx
+++ b/packages/core/client/src/schema-initializer/buttons/TabPaneInitializers.tsx
@@ -90,11 +90,13 @@ const TabPaneInitializers = (props?: any) => {
                   required: true,
                   'x-component': 'Input',
                   'x-decorator': 'FormItem',
+                  'x-acl-ignore': true,
                 },
                 icon: {
                   title: '{{t("Icon")}}',
                   'x-component': 'IconPicker',
                   'x-decorator': 'FormItem',
+                  'x-acl-ignore': true,
                 },
                 footer: {
                   'x-component': 'Action.Modal.Footer',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      issue where users with interface editing permissions cannot add tabs in the popup     |
| 🇨🇳 Chinese |    角色拥有界面编辑权限时，弹窗中无法新增 Tab 页的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
