### PR TITLE
fix(plugin-workflow): fix collection event triggers in async mode before transaction committed

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -161,7 +161,7 @@ export default class Processor {
       // for uncaught error, set to error
       this.logger.error(
         `execution (${this.execution.id}) run instruction [${node.type}] for node (${node.id}) failed: `,
-        { error: err },
+        err,
       );
       job = {
         result:

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -113,7 +113,13 @@ async function handler(this: CollectionTrigger, workflow: WorkflowModel, data: M
       },
     );
   } else {
-    this.workflow.trigger(workflow, { data: json, stack: context?.stack });
+    if (transaction) {
+      transaction.afterCommit(() => {
+        this.workflow.trigger(workflow, { data: json, stack: context?.stack });
+      });
+    } else {
+      this.workflow.trigger(workflow, { data: json, stack: context?.stack });
+    }
   }
 }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Collection events trigger in uncommitted transaction will cause data inconformity.

### Description 

1. Create a async collection event on new record created.
2. Create a destroy node to delete the newly created record.
3. Import some records to the collection to trigger the workflow.

The imported data remains not deleted by workflow.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix collection event triggers in async mode before transaction committed. |
| 🇨🇳 Chinese | 修复数据表事件在事务未提交之前就触发的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
