### PR TITLE
fix: remove leading and trailing spaces from the string during mandatory field validation

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/input.ts
+++ b/packages/core/client/src/collection-manager/interfaces/input.ts
@@ -8,14 +8,38 @@
  */
 
 import { ISchema } from '@formily/react';
-import { defaultProps, operators, unique, primaryKey } from './properties';
-import { i18n } from '../../i18n';
+import { isArr, isEmpty, isValid } from '@formily/shared';
 import { registerValidateRules } from '@formily/validator';
 import { CollectionFieldInterface } from '../../data-source/collection-field-interface/CollectionFieldInterface';
+import { i18n } from '../../i18n';
+import { defaultProps, operators, primaryKey, unique } from './properties';
+
+const isValidateEmpty = (value: any) => {
+  if (isArr(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (isValid(value[i])) return false;
+    }
+    return true;
+  } else {
+    //compat to draft-js
+    if (value?.getCurrentContent) {
+      /* istanbul ignore next */
+      return !value.getCurrentContent()?.hasText();
+    }
+    return isEmpty(value);
+  }
+};
 
 registerValidateRules({
   username(value) {
     return /^[^@.<>"'/]{1,50}$/.test(value) || i18n.t('Must be 1-50 characters in length (excluding @.<>"\'/)');
+  },
+  required(value, rule) {
+    if (rule.required === false) return '';
+    if (typeof value === 'string') {
+      value = value.trim();
+    }
+    return isValidateEmpty(value) ? rule.message : '';
   },
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove leading and trailing spaces from the string during mandatory field validation  |
| 🇨🇳 Chinese |  字段必填验证时过滤掉字符串的两端空格  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
