### PR TITLE
fix:  iframe HTML Template engine default value

### DIFF
--- a/packages/core/client/src/schema-component/common/utils/uitls.tsx
+++ b/packages/core/client/src/schema-component/common/utils/uitls.tsx
@@ -151,9 +151,9 @@ const getVariablesData = (localVariables) => {
 
 export async function getRenderContent(templateEngine, content, variables, localVariables, defaultParse) {
   if (content && templateEngine === 'handlebars') {
-    const renderedContent = Handlebars.compile(content);
-    // 处理渲染后的内容
     try {
+      const renderedContent = Handlebars.compile(content);
+      // 处理渲染后的内容
       const data = getVariablesData(localVariables);
       const html = renderedContent({ ...variables.ctxRef.current, ...data });
       return await defaultParse(html);

--- a/packages/plugins/@nocobase/plugin-block-iframe/src/client/schemaSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-block-iframe/src/client/schemaSettings.tsx
@@ -87,6 +87,17 @@ const commonOptions: any = {
             },
           });
         };
+        // 外部定义 description 的内容
+        const descriptionContent = (
+          <>
+            <span style={{ marginLeft: '.25em' }} className={'ant-formily-item-extra'}>
+              {t('Syntax references')}:
+            </span>
+            <a href="https://handlebarsjs.com/guide/" target="_blank" rel="noreferrer">
+              Handlebars.js
+            </a>
+          </>
+        );
 
         return {
           title: t('Edit iframe'),
@@ -129,6 +140,7 @@ const commonOptions: any = {
                 title: '{{t("Template engine")}}',
                 'x-component': 'Radio.Group',
                 'x-decorator': 'FormItem',
+                default: 'string',
                 enum: [
                   { value: 'string', label: t('String template') },
                   { value: 'handlebars', label: t('Handlebars') },
@@ -151,24 +163,25 @@ const commonOptions: any = {
                   rows: 10,
                 },
                 required: true,
-                description: (
-                  <>
-                    <span style={{ marginLeft: '.25em' }} className={'ant-formily-item-extra'}>
-                      {t('Syntax references')}:
-                    </span>
-                    <a href="https://handlebarsjs.com/guide/" target="_blank" rel="noreferrer">
-                      Handlebars.js
-                    </a>
-                  </>
-                ),
-                'x-reactions': {
-                  dependencies: ['mode'],
-                  fulfill: {
-                    state: {
-                      hidden: '{{$deps[0] === "url"}}',
+                description: descriptionContent,
+                'x-reactions': [
+                  {
+                    dependencies: ['mode'],
+                    fulfill: {
+                      state: {
+                        hidden: '{{$deps[0] === "url"}}',
+                      },
                     },
                   },
-                },
+                  (field) => {
+                    const { engine } = field.form.values;
+                    if (engine === 'handlebars') {
+                      field.description = descriptionContent;
+                    } else {
+                      field.description = null;
+                    }
+                  },
+                ],
               },
             },
           } as ISchema,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Iframe HTML Template engine is missing default value    |
| 🇨🇳 Chinese |   iframe HTML 模版引擎 缺失默认值        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
