### PR TITLE
fix(plugin-workflow): fix event key in date field schedule mode

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-date-field.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-date-field.test.ts
@@ -403,4 +403,42 @@ describe('workflow > triggers > schedule > date field mode', () => {
       expect(e1c).toBe(2);
     });
   });
+
+  describe('status', () => {
+    it('toggle off', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'schedule',
+        config: {
+          mode: 1,
+          collection: 'posts',
+          startsOn: {
+            field: 'createdAt',
+          },
+        },
+      });
+
+      const now = await sleepToEvenSecond();
+
+      const p1 = await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(1500);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(executions[0].context.data.id).toBe(p1.id);
+      const triggerTime = new Date(p1.createdAt);
+      triggerTime.setMilliseconds(0);
+      expect(executions[0].context.date).toBe(triggerTime.toISOString());
+
+      await workflow.update({ enabled: false });
+
+      const p2 = await PostRepo.create({ values: { title: 't2' } });
+
+      await sleep(1500);
+
+      const e2s = await workflow.getExecutions({ order: [['createdAt', 'ASC']] });
+      expect(e2s.length).toBe(1);
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
@@ -357,7 +357,6 @@ export default class ScheduleTrigger {
     const { collection } = workflow.config;
     const [dataSourceName, collectionName] = parseCollectionName(collection);
     const event = `${collectionName}.afterSaveWithAssociations`;
-    const eventKey = `${collection}.afterSaveWithAssociations`;
     const name = getHookId(workflow, event);
     if (this.events.has(name)) {
       return;
@@ -384,14 +383,13 @@ export default class ScheduleTrigger {
     const { collection } = workflow.config;
     const [dataSourceName, collectionName] = parseCollectionName(collection);
     const event = `${collectionName}.afterSaveWithAssociations`;
-    const eventKey = `${collection}.afterSaveWithAssociations`;
     const name = getHookId(workflow, event);
-    if (this.events.has(eventKey)) {
-      const listener = this.events.get(name);
+    const listener = this.events.get(name);
+    if (listener) {
       // @ts-ignore
       const { db } = this.workflow.app.dataSourceManager.dataSources.get(dataSourceName).collectionManager;
       db.off(event, listener);
-      this.events.delete(eventKey);
+      this.events.delete(name);
     }
   }
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where scheduled event based on date fields could still be triggered after being disabled.

### Description 

1. Create a schedule event on date field mode.
2. Set start from option to `createdAt` field of a collection.
3. Enable the workflow.
4. Trigger it by creating a record for 1st time.
5. Disable the workflow.
6. Trigger it by creating a record for 2nd time.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where scheduled tasks based on time fields could still be triggered after being disabled. |
| 🇨🇳 Chinese | 修复基于时间字段的定时任务禁用后仍能触发的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
