### PR TITLE
fix: allowMultiple should not appear on read-only association fields

### DIFF
--- a/packages/core/client/src/modules/fields/component/Select/selectComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/Select/selectComponentFieldSettings.tsx
@@ -362,9 +362,10 @@ export const selectComponentFieldSettings = new SchemaSettings({
     {
       ...allowMultiple,
       useVisible() {
+        const isFieldReadPretty = useIsFieldReadPretty();
         const isAssociationField = useIsAssociationField();
         const IsShowMultipleSwitch = useIsShowMultipleSwitch();
-        return isAssociationField && IsShowMultipleSwitch();
+        return !isFieldReadPretty && isAssociationField && IsShowMultipleSwitch();
       },
     },
     {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      allowMultiple should not appear on read-only association fields     |
| 🇨🇳 Chinese |     允许添加/关联多条 配置项不应出现在只读关系字段上      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
