### PR TITLE
fix: quote table name when get mysql table define

### DIFF
--- a/packages/core/database/src/query-interface/mysql-query-interface.ts
+++ b/packages/core/database/src/query-interface/mysql-query-interface.ts
@@ -91,7 +91,11 @@ export default class MysqlQueryInterface extends QueryInterface {
   async showTableDefinition(tableInfo: TableInfo): Promise<any> {
     const { tableName } = tableInfo;
 
-    const sql = `SHOW CREATE TABLE ${tableName}`;
+    //nint quote table name for it may be special word like group
+    let newTableName = tableName;
+    if (!tableName.startsWith('`')) newTableName = this.db.utils.quoteTable(tableName);
+    const sql = `SHOW CREATE TABLE ${newTableName}`;
+    //const sql = `SHOW CREATE TABLE ${tableName}`;
 
     const results = await this.db.sequelize.query(sql, { type: 'SELECT' });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [&check;] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
mysql数据库中特殊表名会报错（比如group）

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
1. 数据库相关增强、修复
1.1 修改查看mysql表结构时，特殊表名引起的sql错误；

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | quote table name when get mysql table define |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [&check;] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
