### PR TITLE
fix(client): show original field input component after cleared variable

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -385,7 +385,7 @@ export function Input(props: VariableInputProps) {
               // eslint-disable-next-line react/no-unknown-property
               unselectable="on"
               onClick={() => {
-                setIsFieldValue(false);
+                setIsFieldValue(Boolean(children));
                 onChange(null);
               }}
             >


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Before null option and field component (children) both supported, clear selected variable will show original field component.

But after null option added, it becomes null component, should do another select to constant component.

### Description 

1. Use assign field value and add some field.
2. Select some variable available.
3. Clear the variable to input constant.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show original field input component in variable component after cleared variable selected. |
| 🇨🇳 Chinese | 在变量组件中删除所选变量后，恢复默认的常量输入组件。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
