### PR TITLE
fix(plugin-workflow-aggregate): limit aggregate instruction to only work on db data source

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/AggregateInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/AggregateInstruction.tsx
@@ -238,6 +238,11 @@ export default class extends Instruction {
                   required: true,
                   'x-decorator': 'FormItem',
                   'x-component': 'DataSourceCollectionCascader',
+                  'x-component-props': {
+                    dataSourceFilter(datasource) {
+                      return datasource.key === 'main' || datasource.options.isDBInstance;
+                    },
+                  },
                   title: `{{t("Data of collection", { ns: "${NAMESPACE}" })}}`,
                   'x-reactions': [
                     {

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
@@ -25,6 +25,10 @@ export default class extends Instruction {
     const options = processor.getParsedValue(params, node.id);
     const [dataSourceName, collectionName] = parseCollectionName(collection);
     const { collectionManager } = this.workflow.app.dataSourceManager.dataSources.get(dataSourceName);
+    // @ts-ignore
+    if (!collectionManager.db) {
+      throw new Error('aggregate instruction can only work with data source of type database');
+    }
     const repo = associated
       ? collectionManager.getRepository(
           `${association?.associatedCollection}.${association.name}`,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Aggregate functions are only implemented on the data source of type database.

### Description 

Data sources should be filtered and only reserved of type database.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Limit aggregate instruction to only work on db data source. |
| 🇨🇳 Chinese | 限制聚合查询节点仅支持在数据库类型的数据源上使用。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
