### PR TITLE
refactor(plugin-workflow): add calculation nodes group

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/DynamicCalculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client/DynamicCalculation.tsx
@@ -43,9 +43,9 @@ function DynamicExpression({ value, onChange }) {
 }
 
 export default class extends Instruction {
-  title = `{{t("Dynamic Calculation", { ns: "${NAMESPACE}" })}}`;
+  title = `{{t("Dynamic expression calculation", { ns: "${NAMESPACE}" })}}`;
   type = 'dynamic-calculation';
-  group = 'extended';
+  group = 'calculation';
   description = `{{t("Calculate an expression based on a calculation engine and obtain a value as the result. Variables in the upstream nodes can be used in the expression. The expression is dynamic one from an expression collections.", { ns: "${NAMESPACE}" })}}`;
   fieldset = {
     expression: {

--- a/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/locale/zh-CN.json
@@ -1,6 +1,6 @@
 {
   "Expression": "表达式",
-  "Dynamic Calculation": "动态表达式计算",
+  "Dynamic expression calculation": "动态表达式计算",
   "Calculate an expression based on a calculation engine and obtain a value as the result. Variables in the upstream nodes can be used in the expression. The expression is dynamic one from an expression collections.": "基于计算引擎计算表达式并获取值作为结果。可以在表达式中使用上游节点的变量。表达式是从表达式表中动态获取的。",
   "Select dynamic expression": "选择动态表达式",
   "Select the dynamic expression queried from the upstream node. You need to query it from an expression collection.": "从上游节点中选择查询出来的动态表达式。你需要从动态表达式类型的数据表中查询。",

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/AddButton.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/AddButton.tsx
@@ -38,6 +38,7 @@ export function AddButton(props: AddButtonProps) {
   const groups = useMemo(() => {
     return [
       { key: 'control', label: `{{t("Control", { ns: "${NAMESPACE}" })}}` },
+      { key: 'calculation', label: `{{t("Calculation", { ns: "${NAMESPACE}" })}}` },
       { key: 'collection', label: `{{t("Collection operations", { ns: "${NAMESPACE}" })}}` },
       { key: 'manual', label: `{{t("Manual", { ns: "${NAMESPACE}" })}}` },
       { key: 'extended', label: `{{t("Extended types", { ns: "${NAMESPACE}" })}}` },

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
@@ -20,7 +20,7 @@ import { Instruction } from '.';
 export default class extends Instruction {
   title = `{{t("Calculation", { ns: "${NAMESPACE}" })}}`;
   type = 'calculation';
-  group = 'control';
+  group = 'calculation';
   description = `{{t("Calculate an expression based on a calculation engine and obtain a value as the result. Variables in the upstream nodes can be used in the expression.", { ns: "${NAMESPACE}" })}}`;
   fieldset = {
     engine: {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Calculation nodes grows and should not be put in "Control" group.

### Description 

Move "Calculation" and "Dynamic expression calculation" node into new group named "Calculation".

### Related issues

None.

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/35e9d44e-b846-41ca-9134-83b1c75b856f" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add "Calculation" nodes group. |
| 🇨🇳 Chinese | 增加“运算”节点组。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
