### PR TITLE
fix(linkageRules): fix an exception when the condition contains a ass…

### DIFF
--- a/packages/core/client/src/schema-component/common/utils/uitls.tsx
+++ b/packages/core/client/src/schema-component/common/utils/uitls.tsx
@@ -100,7 +100,9 @@ export const conditionAnalyses = async ({
     }
 
     const targetVariableName = targetFieldToVariableString(getTargetField(condition));
-    const targetValue = variables.parseVariable(targetVariableName, localVariables);
+    const targetValue = variables.parseVariable(targetVariableName, localVariables, {
+      doNotRequest: true,
+    });
 
     const parsingResult = isVariable(jsonlogic?.value)
       ? [variables.parseVariable(jsonlogic?.value, localVariables), targetValue]

--- a/packages/core/client/src/variables/VariablesProvider.tsx
+++ b/packages/core/client/src/variables/VariablesProvider.tsx
@@ -76,6 +76,8 @@ const VariablesProvider = ({ children }) => {
       options?: {
         /** 第一次请求时，需要包含的关系字段 */
         appends?: string[];
+        /** do not request when the association field is empty */
+        doNotRequest?: boolean;
       },
     ) => {
       const list = variablePath.split('.');
@@ -100,7 +102,7 @@ const VariablesProvider = ({ children }) => {
         const collectionPrimaryKey = getCollection(collectionName)?.getPrimaryKey();
         if (Array.isArray(current)) {
           const result = current.map((item) => {
-            if (shouldToRequest(item?.[key]) && item?.[collectionPrimaryKey] != null) {
+            if (!options?.doNotRequest && shouldToRequest(item?.[key]) && item?.[collectionPrimaryKey] != null) {
               if (associationField?.target) {
                 const url = `/${collectionName}/${
                   item[associationField.sourceKey || collectionPrimaryKey]
@@ -128,7 +130,12 @@ const VariablesProvider = ({ children }) => {
             return item?.[key];
           });
           current = removeThroughCollectionFields(_.flatten(await Promise.all(result)), associationField);
-        } else if (shouldToRequest(current[key]) && current[collectionPrimaryKey] != null && associationField?.target) {
+        } else if (
+          !options?.doNotRequest &&
+          shouldToRequest(current[key]) &&
+          current[collectionPrimaryKey] != null &&
+          associationField?.target
+        ) {
           const url = `/${collectionName}/${
             current[associationField.sourceKey || collectionPrimaryKey]
           }/${key}:${getAction(associationField.type)}`;
@@ -228,6 +235,8 @@ const VariablesProvider = ({ children }) => {
       options?: {
         /** 第一次请求时，需要包含的关系字段 */
         appends?: string[];
+        /** do not request when the association field is empty */
+        doNotRequest?: boolean;
       },
     ) => {
       if (!isVariable(str)) {

--- a/packages/core/client/src/variables/__tests__/useVariables.test.tsx
+++ b/packages/core/client/src/variables/__tests__/useVariables.test.tsx
@@ -303,6 +303,18 @@ describe('useVariables', () => {
     });
   });
 
+  it('set doNotRequest to true to ensure the result is empty', async () => {
+    const { result } = renderHook(() => useVariables(), {
+      wrapper: Providers,
+    });
+
+    await waitFor(async () => {
+      expect(await result.current.parseVariable('{{ $user.belongsToField }}', undefined, { doNotRequest: true })).toBe(
+        null,
+      );
+    });
+  });
+
   it('long variable path', async () => {
     const { result } = renderHook(() => useVariables(), {
       wrapper: Providers,

--- a/packages/core/client/src/variables/types.ts
+++ b/packages/core/client/src/variables/types.ts
@@ -44,6 +44,8 @@ export interface VariablesContextType {
     options?: {
       /** 第一次请求时，需要包含的关系字段 */
       appends?: string[];
+      /** do not request when the association field is empty */
+      doNotRequest?: boolean;
     },
   ) => Promise<any>;
   /**


### PR DESCRIPTION
…ociation field

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix BUG.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Add a `doNotRequest` option to avoid requesting association field data when the association field is empty.
### Related issues
close T-4990
### Showcase
<!-- Including any screenshots of the changes. -->
None.
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix an exception when the condition contains a relational field.    |
| 🇨🇳 Chinese |     修复条件中包含关系字段时异常的问题。     |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
