### PR TITLE
fix: disable edit and delete button for all records and own record in data scope configuration

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/PermissionManager/schemas/scopes.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/PermissionManager/schemas/scopes.tsx
@@ -15,6 +15,9 @@ import {
   useFilterFieldOptions,
   useFormBlockContext,
   withDynamicSchemaProps,
+  useCollectionRecord,
+  Action,
+  useDestroyActionProps,
 } from '@nocobase/client';
 import React, { useContext, useEffect } from 'react';
 import { RoleResourceCollectionContext } from '../RolesResourcesActions';
@@ -49,6 +52,20 @@ const useFormBlockProps = () => {
   return {
     form: ctx.form,
   };
+};
+
+const EditScopeActionComponent = (props) => {
+  const { data } = useCollectionRecord();
+  const { id } = data || ({} as any);
+  const actionProps = { ...props, disabled: [1, 2].includes(id) };
+  return <Action.Link {...actionProps} />;
+};
+
+const DestroyScopeActionComponent = (props) => {
+  const { data } = useCollectionRecord();
+  const { id } = data || ({} as any);
+  const actionProps = { ...props, ...useDestroyActionProps(), disabled: [1, 2].includes(id) };
+  return <Action.Link {...actionProps} />;
 };
 
 export const getScopesSchema = (dataSourceKey) => {
@@ -247,7 +264,7 @@ export const getScopesSchema = (dataSourceKey) => {
                                 title: '{{ t("Edit") }}',
                                 'x-action': 'update',
                                 'x-decorator': 'ACLActionProvider',
-                                'x-component': 'Action.Link',
+                                'x-component': EditScopeActionComponent,
                                 'x-component-props': {
                                   openMode: 'drawer',
                                   icon: 'EditOutlined',
@@ -341,8 +358,6 @@ export const getScopesSchema = (dataSourceKey) => {
                                 title: '{{ t("Delete") }}',
                                 'x-action': 'destroy',
                                 'x-decorator': 'ACLActionProvider',
-                                'x-component': 'Action.Link',
-                                'x-use-component-props': 'useDestroyActionProps',
                                 'x-component-props': {
                                   icon: 'DeleteOutlined',
                                   confirm: {
@@ -350,6 +365,7 @@ export const getScopesSchema = (dataSourceKey) => {
                                     content: "{{t('Are you sure you want to delete it?')}}",
                                   },
                                 },
+                                'x-component': DestroyScopeActionComponent,
                               },
                             },
                           },


### PR DESCRIPTION
… data scope configuration

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   disable edit and delete button for all records and own record in data scope configuration        |
| 🇨🇳 Chinese |   权限配置中的数据范围，所有记录和自己的记录禁用编辑和删除按钮        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
