### PR TITLE
feat(client): add parse options for variable input

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -24,7 +24,11 @@ import { useStyles } from './style';
 
 const JT_VALUE_RE = /^\s*{{\s*([^{}]+)\s*}}\s*$/;
 
-function parseValue(value: any): string | string[] {
+type ParseOptions = {
+  stringToDate?: boolean;
+};
+
+function parseValue(value: any, options: ParseOptions = {}): string | string[] {
   if (value == null) {
     return 'null';
   }
@@ -34,12 +38,11 @@ function parseValue(value: any): string | string[] {
     if (matched) {
       return matched[1].split('.');
     }
-    // const ts = Date.parse(value);
-    // if (value.match(/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d{0,3})Z$/) && !Number.isNaN(Date.parse(value))) {
-    //   return {
-    //     type: 'date',
-    //   };
-    // }
+    if (options.stringToDate) {
+      if (!Number.isNaN(Date.parse(value))) {
+        return 'date';
+      }
+    }
   }
   return type === 'object' && value instanceof Date ? 'date' : type;
 }
@@ -153,6 +156,7 @@ export type VariableInputProps = {
   disabled?: boolean;
   style?: React.CSSProperties;
   className?: string;
+  parseOptions?: ParseOptions;
 };
 
 export function Input(props: VariableInputProps) {
@@ -166,6 +170,7 @@ export function Input(props: VariableInputProps) {
     className,
     changeOnSelect,
     fieldNames,
+    parseOptions,
   } = props;
   const scope = typeof props.scope === 'function' ? props.scope() : props.scope;
   const { wrapSSR, hashId, componentCls, rootPrefixCls } = useStyles();
@@ -180,7 +185,7 @@ export function Input(props: VariableInputProps) {
   const [variableText, setVariableText] = React.useState([]);
   const [isFieldValue, setIsFieldValue] = React.useState(children && value != null ? true : false);
 
-  const parsed = useMemo(() => parseValue(value), [value]);
+  const parsed = useMemo(() => parseValue(value, parseOptions), [parseOptions, value]);
   const isConstant = typeof parsed === 'string';
   const type = isConstant ? parsed : '';
   const variable = isConstant ? null : parsed;

--- a/packages/core/client/src/schema-component/antd/variable/index.en-US.md
+++ b/packages/core/client/src/schema-component/antd/variable/index.en-US.md
@@ -18,7 +18,12 @@ import type { DefaultOptionType } from 'antd/lib/cascader';
   disabled?: boolean;
   style?: React.CSSProperties;
   className?: string;
+  parseOptions?: ParseOptions;
 }
+
+type ParseOptions = {
+  stringToDate?: boolean;
+};
 ```
 
 <code src="./demos/demo1.tsx"></code>

--- a/packages/core/client/src/schema-component/antd/variable/index.md
+++ b/packages/core/client/src/schema-component/antd/variable/index.md
@@ -18,7 +18,12 @@ import type { DefaultOptionType } from 'antd/lib/cascader';
   disabled?: boolean;
   style?: React.CSSProperties;
   className?: string;
+  parseOptions?: ParseOptions;
 }
+
+type ParseOptions = {
+  stringToDate?: boolean;
+};
 ```
 
 <code src="./demos/demo1.tsx"></code>


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

When using `Variable.Input`, whether to parse a date string is hard to decide. So we add an option for developers to determine it selves.

### Description 

Could use this:

```diff
<Variable.Input
+   parseOptions={{
+       stringToDate: true
+   }}
/>
```

### Related issues

None.

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1598a747-f1d0-4905-a647-629acf39a732" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add parse options for variable input. |
| 🇨🇳 Chinese | 对变量组件新增值解析选项。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | [Variable.Input](https://client.docs.nocobase.com/components/variable/#variableinput) |
| 🇨🇳 Chinese | [变量选择器](https://client.docs-cn.nocobase.com/components/variable#variableinput) |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
