### PR TITLE
fix(inherit): correct title for inherited sub-collection association …

### DIFF
--- a/packages/core/client/src/data-source/collection/Collection.ts
+++ b/packages/core/client/src/data-source/collection/Collection.ts
@@ -297,4 +297,12 @@ export class Collection {
   isTitleField(field: CollectionFieldOptions) {
     return this.app.dataSourceManager.collectionFieldInterfaceManager.getFieldInterface(field.interface)?.titleUsable;
   }
+
+  /**
+   * is inherited from other collection
+   * @returns boolean
+   */
+  isInherited() {
+    return this.inherits.length > 0;
+  }
 }

--- a/packages/core/client/src/modules/blocks/BlockSchemaToolbar.tsx
+++ b/packages/core/client/src/modules/blocks/BlockSchemaToolbar.tsx
@@ -20,7 +20,7 @@ export const BlockSchemaToolbar = (props) => {
   const cm = useCollectionManager();
   let { name: currentCollectionName, title: currentCollectionTitle } = useCollection() || {};
   const template = useSchemaTemplate();
-  const { association } = useDataBlockProps() || {};
+  const { association, collection } = useDataBlockProps() || {};
   const compile = useCompile();
 
   if (association) {
@@ -31,7 +31,10 @@ export const BlockSchemaToolbar = (props) => {
   }
 
   const associationField = cm.getCollectionField(association);
-  const associationCollection = cm.getCollection(associationField?.target);
+  // If both the collection and association parameters exist at the same time,
+  // it means that the collection of the current block is a child collection of inheritance,
+  // and the title of the child collection needs to be displayed at this time
+  const associationCollection = cm.getCollection(collection || associationField?.target);
   const templateName = ['FormItem', 'ReadPrettyFormItem'].includes(template?.componentName)
     ? `${template?.name} ${t('(Fields only)')}`
     : template?.name;

--- a/packages/core/client/src/modules/blocks/data-blocks/form/RecordFormBlockInitializer.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/RecordFormBlockInitializer.tsx
@@ -10,8 +10,8 @@
 import { FormOutlined } from '@ant-design/icons';
 import React, { useCallback } from 'react';
 import { SchemaInitializerItem, useSchemaInitializer, useSchemaInitializerItem } from '../../../../application';
-import { useAssociationName } from '../../../../data-source';
 import { useCollection_deprecated } from '../../../../collection-manager';
+import { useAssociationName, useCollectionManager } from '../../../../data-source';
 import { useRecordCollectionDataSourceItems } from '../../../../schema-initializer/utils';
 import { useSchemaTemplateManager } from '../../../../schema-templates';
 import { createEditFormBlockUISchema } from './createEditFormBlockUISchema';
@@ -49,40 +49,47 @@ export const RecordFormBlockInitializer = () => {
 export function useCreateEditFormBlock() {
   const { insert } = useSchemaInitializer();
   const association = useAssociationName();
+  const cm = useCollectionManager();
 
   const createEditFormBlock = useCallback(
     ({ item }) => {
+      const collectionName = item.collectionName || item.name;
+      const collection = cm.getCollection(collectionName);
       insert(
         createEditFormBlockUISchema(
           association
             ? {
                 association,
+                collectionName: collection.isInherited() ? collectionName : undefined,
                 dataSource: item.dataSource,
                 isCurrent: true,
               }
             : {
-                collectionName: item.collectionName || item.name,
+                collectionName,
                 dataSource: item.dataSource,
               },
         ),
       );
     },
-    [association, insert],
+    [association, cm, insert],
   );
 
   const templateWrap = useCallback(
     (templateSchema, { item }) => {
       if (item.template.componentName === 'FormItem') {
+        const collectionName = item.collectionName || item.name;
+        const collection = cm.getCollection(collectionName);
         const blockSchema = createEditFormBlockUISchema(
           association
             ? {
                 association,
+                collectionName: collection.isInherited() ? collectionName : undefined,
                 dataSource: item.dataSource,
                 templateSchema: templateSchema,
                 isCurrent: true,
               }
             : {
-                collectionName: item.collectionName || item.name,
+                collectionName,
                 dataSource: item.dataSource,
                 templateSchema: templateSchema,
               },
@@ -95,7 +102,7 @@ export function useCreateEditFormBlock() {
         return templateSchema;
       }
     },
-    [association],
+    [association, cm],
   );
 
   return { createEditFormBlock, templateWrap };

--- a/packages/core/client/src/schema-initializer/buttons/RecordBlockInitializers.tsx
+++ b/packages/core/client/src/schema-initializer/buttons/RecordBlockInitializers.tsx
@@ -12,7 +12,6 @@ import { useCallback, useMemo } from 'react';
 import {
   useCollection,
   useCollectionManager_deprecated,
-  useCollection_deprecated,
   useCreateAssociationDetailsBlock,
   useCreateAssociationDetailsWithoutPagination,
   useCreateAssociationFormBlock,
@@ -45,7 +44,7 @@ export const canMakeAssociationBlock = (field) => {
 };
 
 function useRecordBlocks() {
-  const collection = useCollection_deprecated();
+  const collection = useCollection();
   const { getChildrenCollections } = useCollectionManager_deprecated();
   const collectionsWithView = getChildrenCollections(collection.name, true, collection.dataSource).filter(
     (v) => v?.filterTargetKey,
@@ -59,7 +58,7 @@ function useRecordBlocks() {
       collectionName: collection.name,
       dataSource: collection.dataSource,
       useComponentProps() {
-        const currentCollection = useCollection_deprecated();
+        const currentCollection = useCollection();
         const { createSingleDetailsSchema, templateWrap } = useCreateSingleDetailsSchema();
         const { createAssociationDetailsBlock } = useCreateAssociationDetailsBlock();
         const {
@@ -125,7 +124,7 @@ function useRecordBlocks() {
       collectionName: collection.name,
       dataSource: collection.dataSource,
       useComponentProps() {
-        const currentCollection = useCollection_deprecated();
+        const currentCollection = useCollection();
         const { createEditFormBlock, templateWrap: templateWrapEdit } = useCreateEditFormBlock();
         const collectionsNeedToDisplay = [currentCollection, ...collectionsWithView];
 

--- a/packages/core/client/src/schema-initializer/items/RecordAssociationDetailsBlockInitializer.tsx
+++ b/packages/core/client/src/schema-initializer/items/RecordAssociationDetailsBlockInitializer.tsx
@@ -12,9 +12,9 @@ import React, { useCallback } from 'react';
 
 import { SchemaInitializerItem, useSchemaInitializer, useSchemaInitializerItem } from '../../application';
 import { useCollectionManager_deprecated } from '../../collection-manager';
+import { createDetailsWithPaginationUISchema } from '../../modules/blocks/data-blocks/details-multi/createDetailsWithPaginationUISchema';
 import { useSchemaTemplateManager } from '../../schema-templates';
 import { useRecordCollectionDataSourceItems } from '../utils';
-import { createDetailsWithPaginationUISchema } from '../../modules/blocks/data-blocks/details-multi/createDetailsWithPaginationUISchema';
 
 export const RecordAssociationDetailsBlockInitializer = () => {
   const itemConfig = useSchemaInitializerItem();


### PR DESCRIPTION
…block

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix BUG.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
If the collection of a association block is a child collection that inherits from another collection, the title in the upper left corner should show the title of the current child collection. To accomplish this, the block Schema should be created with `collection` in addition to `association`.
### Related issues
close T-4785
### Showcase
<!-- Including any screenshots of the changes. -->
None.
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix incorrect title in the upper left corner of the Association block of the Inheritance collection.     |
| 🇨🇳 Chinese |     修复继承表的关系区块左上角的标题不正确的问题。      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
