### PR TITLE
fix(inherit): fix 'Add new' button for inherited collectons

### DIFF
--- a/packages/core/client/src/data-source/collection/Collection.ts
+++ b/packages/core/client/src/data-source/collection/Collection.ts
@@ -297,4 +297,12 @@ export class Collection {
   isTitleField(field: CollectionFieldOptions) {
     return this.app.dataSourceManager.collectionFieldInterfaceManager.getFieldInterface(field.interface)?.titleUsable;
   }
+
+  /**
+   * is inherited from other collections
+   * @returns boolean
+   */
+  isInherited() {
+    return this.inherits.length > 0;
+  }
 }

--- a/packages/core/client/src/modules/actions/add-new/__e2e__/inherit.test.ts
+++ b/packages/core/client/src/modules/actions/add-new/__e2e__/inherit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { expect, test } from '@nocobase/test/e2e';
+import { T5084 } from './templates';
+
+test.describe('Add new: inherit', () => {
+  test('creating block by child collection should work correctly', async ({ page, mockPage }) => {
+    await mockPage(T5084).goto();
+
+    // 1. click the "Add new" button, and then create a block, the block's collection should be "parent"
+    await page.getByRole('button', { name: 'plus Add new' }).click();
+    await page.getByLabel('schema-initializer-Grid-popup').hover();
+    await page.getByRole('menuitem', { name: 'form Form right' }).hover();
+    await page.getByRole('menuitem', { name: 'Current collection' }).click();
+    await page.getByLabel('block-item-CardItem-parent-form').hover();
+    await expect(page.getByLabel('block-item-CardItem-parent-form').getByText('parent')).toBeVisible();
+    // close popup
+    await page.getByLabel('drawer-Action.Container-parent-Add record-mask').click();
+
+    // 2. click the "child1" option, and then create a block, the block's collection should be "child1"
+    await page.getByRole('button', { name: 'down' }).hover();
+    await page.getByRole('menuitem', { name: 'child1' }).click();
+    await page.getByLabel('schema-initializer-Grid-popup').hover();
+    await page.getByRole('menuitem', { name: 'form Form right' }).hover();
+    await page.getByRole('menuitem', { name: 'Current collection' }).click();
+    await page.getByLabel('block-item-CardItem-child1-').hover();
+    await expect(page.getByLabel('block-item-CardItem-child1-').getByText('child1')).toBeVisible();
+    // close popup
+    await page.getByLabel('drawer-Action.Container-child1-Add record-mask').click();
+
+    // 3. click the "child2" option, and then create a block, the block's collection should be "child2"
+    await page.getByRole('button', { name: 'down' }).hover();
+    await page.getByRole('menuitem', { name: 'child2' }).click();
+    await page.getByLabel('schema-initializer-Grid-popup').hover();
+    await page.getByRole('menuitem', { name: 'form Form right' }).hover();
+    await page.getByRole('menuitem', { name: 'Current collection' }).click();
+    await page.getByLabel('block-item-CardItem-child2-').hover();
+    await expect(page.getByLabel('block-item-CardItem-child2-').getByText('child2')).toBeVisible();
+  });
+});

--- a/packages/core/client/src/modules/actions/add-new/__e2e__/templates.ts
+++ b/packages/core/client/src/modules/actions/add-new/__e2e__/templates.ts
@@ -1,0 +1,273 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export const T5084 = {
+  collections: [
+    {
+      name: 'parent',
+    },
+    {
+      name: 'child1',
+      inherits: ['parent'],
+    },
+    {
+      name: 'child2',
+      inherits: ['parent'],
+    },
+  ],
+  pageSchema: {
+    _isJSONSchemaObject: true,
+    version: '2.0',
+    type: 'void',
+    'x-component': 'Page',
+    properties: {
+      '9z728grhuw5': {
+        _isJSONSchemaObject: true,
+        version: '2.0',
+        type: 'void',
+        'x-component': 'Grid',
+        'x-initializer': 'page:addBlock',
+        properties: {
+          qunhcwzgdrq: {
+            _isJSONSchemaObject: true,
+            version: '2.0',
+            type: 'void',
+            'x-component': 'Grid.Row',
+            'x-app-version': '1.3.0-alpha',
+            properties: {
+              '232zkncxw1p': {
+                _isJSONSchemaObject: true,
+                version: '2.0',
+                type: 'void',
+                'x-component': 'Grid.Col',
+                'x-app-version': '1.3.0-alpha',
+                properties: {
+                  hj5wtj01v9m: {
+                    _isJSONSchemaObject: true,
+                    version: '2.0',
+                    type: 'void',
+                    'x-decorator': 'TableBlockProvider',
+                    'x-acl-action': 'parent:list',
+                    'x-use-decorator-props': 'useTableBlockDecoratorProps',
+                    'x-decorator-props': {
+                      collection: 'parent',
+                      dataSource: 'main',
+                      action: 'list',
+                      params: {
+                        pageSize: 20,
+                      },
+                      rowKey: 'id',
+                      showIndex: true,
+                      dragSort: false,
+                    },
+                    'x-toolbar': 'BlockSchemaToolbar',
+                    'x-settings': 'blockSettings:table',
+                    'x-component': 'CardItem',
+                    'x-filter-targets': [],
+                    'x-app-version': '1.3.0-alpha',
+                    properties: {
+                      actions: {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'void',
+                        'x-initializer': 'table:configureActions',
+                        'x-component': 'ActionBar',
+                        'x-component-props': {
+                          style: {
+                            marginBottom: 'var(--nb-spacing)',
+                          },
+                        },
+                        'x-app-version': '1.3.0-alpha',
+                        properties: {
+                          uqw9g1a6bx2: {
+                            'x-uid': 'atwcb9plntt',
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            'x-action': 'create',
+                            'x-acl-action': 'create',
+                            title: "{{t('Add new')}}",
+                            'x-toolbar': 'ActionSchemaToolbar',
+                            'x-settings': 'actionSettings:addNew',
+                            'x-component': 'Action',
+                            'x-decorator': 'ACLActionProvider',
+                            'x-component-props': {
+                              openMode: 'drawer',
+                              type: 'primary',
+                              component: 'CreateRecordAction',
+                              icon: 'PlusOutlined',
+                            },
+                            'x-action-context': {
+                              dataSource: 'main',
+                              collection: 'parent',
+                            },
+                            'x-align': 'right',
+                            'x-acl-action-props': {
+                              skipScopeCheck: true,
+                            },
+                            'x-app-version': '1.3.0-alpha',
+                            'x-enable-children': [
+                              {
+                                collection: 'child1',
+                              },
+                              {
+                                collection: 'child2',
+                              },
+                            ],
+                            'x-allow-add-to-current': true,
+                            properties: {
+                              drawer: {
+                                _isJSONSchemaObject: true,
+                                version: '2.0',
+                                type: 'void',
+                                title: '{{ t("Add record") }}',
+                                'x-component': 'Action.Container',
+                                'x-component-props': {
+                                  className: 'nb-action-popup',
+                                },
+                                'x-app-version': '1.3.0-alpha',
+                                properties: {
+                                  tabs: {
+                                    _isJSONSchemaObject: true,
+                                    version: '2.0',
+                                    type: 'void',
+                                    'x-component': 'Tabs',
+                                    'x-component-props': {},
+                                    'x-initializer': 'popup:addTab',
+                                    'x-initializer-props': {
+                                      gridInitializer: 'popup:addNew:addBlock',
+                                    },
+                                    'x-app-version': '1.3.0-alpha',
+                                    properties: {
+                                      tab1: {
+                                        _isJSONSchemaObject: true,
+                                        version: '2.0',
+                                        type: 'void',
+                                        title: '{{t("Add new")}}',
+                                        'x-component': 'Tabs.TabPane',
+                                        'x-designer': 'Tabs.Designer',
+                                        'x-component-props': {},
+                                        'x-app-version': '1.3.0-alpha',
+                                        properties: {
+                                          grid: {
+                                            _isJSONSchemaObject: true,
+                                            version: '2.0',
+                                            type: 'void',
+                                            'x-component': 'Grid',
+                                            'x-initializer': 'popup:addNew:addBlock',
+                                            'x-app-version': '1.3.0-alpha',
+                                            'x-uid': '9b9jmnkn2f5',
+                                            'x-async': false,
+                                            'x-index': 1,
+                                          },
+                                        },
+                                        'x-uid': 'flmsg97ib9h',
+                                        'x-async': false,
+                                        'x-index': 1,
+                                      },
+                                    },
+                                    'x-uid': 'xd5niej584x',
+                                    'x-async': false,
+                                    'x-index': 1,
+                                  },
+                                },
+                                'x-uid': 'nlmwpvv9vd3',
+                                'x-async': false,
+                                'x-index': 1,
+                              },
+                            },
+                            'x-async': false,
+                            'x-index': 1,
+                          },
+                        },
+                        'x-uid': 'v0oc2ik3mqw',
+                        'x-async': false,
+                        'x-index': 1,
+                      },
+                      jecm8jee085: {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'array',
+                        'x-initializer': 'table:configureColumns',
+                        'x-component': 'TableV2',
+                        'x-use-component-props': 'useTableBlockProps',
+                        'x-component-props': {
+                          rowKey: 'id',
+                          rowSelection: {
+                            type: 'checkbox',
+                          },
+                        },
+                        'x-app-version': '1.3.0-alpha',
+                        properties: {
+                          actions: {
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            title: '{{ t("Actions") }}',
+                            'x-action-column': 'actions',
+                            'x-decorator': 'TableV2.Column.ActionBar',
+                            'x-component': 'TableV2.Column',
+                            'x-toolbar': 'TableColumnSchemaToolbar',
+                            'x-initializer': 'table:configureItemActions',
+                            'x-settings': 'fieldSettings:TableColumn',
+                            'x-toolbar-props': {
+                              initializer: 'table:configureItemActions',
+                            },
+                            'x-app-version': '1.3.0-alpha',
+                            properties: {
+                              '4f5sce3w9fx': {
+                                _isJSONSchemaObject: true,
+                                version: '2.0',
+                                type: 'void',
+                                'x-decorator': 'DndContext',
+                                'x-component': 'Space',
+                                'x-component-props': {
+                                  split: '|',
+                                },
+                                'x-app-version': '1.3.0-alpha',
+                                'x-uid': 'qtr5an6qbu6',
+                                'x-async': false,
+                                'x-index': 1,
+                              },
+                            },
+                            'x-uid': 'r8msyk257y9',
+                            'x-async': false,
+                            'x-index': 1,
+                          },
+                        },
+                        'x-uid': 'm2m7kgypy5z',
+                        'x-async': false,
+                        'x-index': 2,
+                      },
+                    },
+                    'x-uid': 'g0mdajxejhl',
+                    'x-async': false,
+                    'x-index': 1,
+                  },
+                },
+                'x-uid': 'r7uvf8c2gdq',
+                'x-async': false,
+                'x-index': 1,
+              },
+            },
+            'x-uid': 'fr8e99uwlgl',
+            'x-async': false,
+            'x-index': 1,
+          },
+        },
+        'x-uid': 'awqpmazhs8a',
+        'x-async': false,
+        'x-index': 1,
+      },
+    },
+    'x-uid': 'st43un0l7kl',
+    'x-async': true,
+    'x-index': 1,
+  },
+};

--- a/packages/core/client/src/schema-component/antd/page/PagePopups.tsx
+++ b/packages/core/client/src/schema-component/antd/page/PagePopups.tsx
@@ -155,7 +155,7 @@ const PagePopupsItemProvider: FC<{
       <PopupVisibleProvider visible={visible} setVisible={setVisible}>
         <DataBlockProvider
           dataSource={context.dataSource}
-          collection={context.collection}
+          collection={params.collection || context.collection}
           association={context.association}
           sourceId={params.sourceid}
           filterByTk={params.filterbytk}

--- a/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
+++ b/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
@@ -35,6 +35,8 @@ export interface PopupParams {
   sourceid?: string;
   /** tab uid */
   tab?: string;
+  /** collection name */
+  collection?: string;
 }
 
 export interface PopupContextStorage extends PopupContext {
@@ -101,9 +103,11 @@ export const getPopupParamsFromPath = _.memoize((path: string) => {
 });
 
 export const getPopupPathFromParams = (params: PopupParams) => {
-  const { popupuid: popupUid, tab, filterbytk, sourceid } = params;
+  const { popupuid: popupUid, tab, filterbytk, sourceid, collection } = params;
   const popupPath = [
     popupUid,
+    collection && 'collection',
+    collection,
     filterbytk && 'filterbytk',
     filterbytk,
     sourceid && 'sourceid',
@@ -148,15 +152,18 @@ export const usePagePopup = () => {
       popupUid,
       recordData,
       sourceId,
+      collection: _collection,
     }: {
       popupUid: string;
       recordData: Record<string, any>;
       sourceId: string;
       tabKey?: string;
+      collection?: string;
     }) => {
       const filterByTK = cm.getFilterByTK(association || collection, recordData);
       return getPopupPathFromParams({
         popupuid: popupUid,
+        collection: _collection,
         filterbytk: filterByTK,
         sourceid: sourceId,
         tab: tabKey,
@@ -179,9 +186,12 @@ export const usePagePopup = () => {
     ({
       recordData,
       parentRecordData,
+      collectionNameUsedInURL,
     }: {
       recordData?: Record<string, any>;
       parentRecordData?: Record<string, any>;
+      /** if this value exists, it will be saved in the URL */
+      collectionNameUsedInURL?: string;
     } = {}) => {
       if (!isPopupVisibleControlledByURL()) {
         return setVisibleFromAction?.(true);
@@ -190,7 +200,12 @@ export const usePagePopup = () => {
       const sourceId = getSourceId(parentRecordData);
 
       recordData = recordData || record?.data;
-      const pathname = getNewPathname({ popupUid: currentPopupUidWithoutOpened, recordData, sourceId });
+      const pathname = getNewPathname({
+        popupUid: currentPopupUidWithoutOpened,
+        recordData,
+        sourceId,
+        collection: collectionNameUsedInURL,
+      });
       let url = location.pathname;
       if (_.last(url) === '/') {
         url = url.slice(0, -1);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix BUG.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
#4706 assumed that all buttons would have only one collection associated with them. 

However, the "Add new" button may be associated with more than one collection at the same time (e.g., a block in an inheritance collection), and it is not possible to save the collection parameter to the button Schema's "x-action-context" of the button's schema. This is because "x-action-context" can only hold one colelction.

The solution is to save the collection in the URL.
### Related issues
https://github.com/nocobase/nocobase/pull/4706
close T-5084
### Showcase
<!-- Including any screenshots of the changes. -->
See E2E.
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix 'Add new' button for inherited blocks.     |
| 🇨🇳 Chinese |     修复继承区块的添加按钮。      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
