### PR TITLE
fix(database): check naming collision when creating m2m array fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/hooks/create-foreign-key.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/hooks/create-foreign-key.ts
@@ -12,9 +12,14 @@ import { elementTypeMap } from '../belongs-to-array-field';
 
 export const createForeignKey = (db: Database) => {
   return async (model: Model, { transaction }) => {
-    const { type, collectionName, target, targetKey, foreignKey } = model.get();
+    const { type, collectionName, target, targetKey, foreignKey, name } = model.get();
     if (type !== 'belongsToArray') {
       return;
+    }
+    if (name === foreignKey) {
+      throw new Error(
+        `Naming collision between attribute '${foreignKey}' and association '${name}' on model ${collectionName}. To remedy this, change either foreignKey or as in your association definition`,
+      );
     }
     const r = db.getRepository('fields');
     const instance = await r.findOne({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

When creating a m2m array field, the name of the foreign key must not be the same as the name of the field.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Add naming collision check.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add naming collision check between the foreign key and field name when creating m2m array fields |
| 🇨🇳 Chinese | 创建多对多（数组）字段时，增加字段和外键的命名冲突检查          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
