### PR TITLE
fix: increase the upload file size limit of field-markdown-vditor

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Edit.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Edit.tsx
@@ -75,6 +75,7 @@ export const Edit = withDynamicSchemaProps((props) => {
         headers: apiClient.getHeaders(),
         multiple: false,
         fieldName: 'file',
+        max: 1024 * 1024 * 1024, // 1G
         format(files, responseText) {
           const response = JSON.parse(responseText);
           const formatResponse = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

The default upload file size limit of Vditor is 10MB.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Set the maximum size of upload file in Markdown (Vditor) field to the same size limit as file storage.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Set the maximum size of upload file in Markdown (Vditor) field to the same size limit as file storage. |
| 🇨🇳 Chinese | 将 Markdown (Vditor) 字段的上传文件体积限制设置为文件存储器支持的文件体积上限。           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
