### PR TITLE
refactor: sorting of Table block data

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/table/hooks/useTableBlockProps.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/hooks/useTableBlockProps.tsx
@@ -78,13 +78,11 @@ export const useTableBlockProps = () => {
     ),
     onChange: useCallback(
       ({ current, pageSize }, filters, sorter) => {
-        const sort = !ctx.dragSort
-          ? sorter.order
-            ? sorter.order === `ascend`
-              ? [sorter.field]
-              : [`-${sorter.field}`]
-            : globalSort || ctx.dragSortBy
-          : ctx.dragSortBy;
+        const sort = sorter.order
+          ? sorter.order === `ascend`
+            ? [sorter.field]
+            : [`-${sorter.field}`]
+          : globalSort || ctx.dragSortBy;
         const currentPageSize = pageSize || fieldSchema.parent?.['x-decorator-props']?.['params']?.pageSize;
         const args = { ...params?.[0], page: current || 1, pageSize: currentPageSize };
         if (sort) {
@@ -92,7 +90,7 @@ export const useTableBlockProps = () => {
         }
         ctx.service.run(args);
       },
-      [globalSort, params],
+      [globalSort, params, ctx.dragSort],
     ),
     onClickRow: useCallback(
       (record, setSelectedRow, selectedRow) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
排序：

setting设置的排序是默认排序，表头那里是临时的，页面刷新之后就会回到默认值，点了表头就按表头的字段排序，不传seting的sort

表头 number 点第一下：number 字段正序*

点第二下：number 字段倒序** **

点第三下：按 settings 默认值来* ** ** 如果这时候同时翻页了，sort 信息要保留

只有刷新页面表头的sort才会去掉
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   sorting of Table block data        |
| 🇨🇳 Chinese |     表格区块的排序功能优化      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
