### PR TITLE
feat(data-vi): allow to set link for statistic chart

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/antd/components/Statistic.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/antd/components/Statistic.tsx
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { Statistic as AntdStatistic } from 'antd';
+
+export const Statistic: React.FC<any> = (props: any) => {
+  const { link, ...options } = props;
+  return (
+    <div
+      onClick={() => {
+        if (link) {
+          window.open(link, '__blank');
+        }
+      }}
+      style={{
+        cursor: link ? 'pointer' : 'auto',
+      }}
+    >
+      <AntdStatistic {...options} />
+    </div>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/antd/statistic.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/antd/statistic.ts
@@ -8,16 +8,16 @@
  */
 
 import { AntdChart } from './antd';
-import { Statistic as AntdStatistic } from 'antd';
 import { lang } from '../../locale';
 import { ChartType, RenderProps } from '../chart';
+import { Statistic as C } from './components/Statistic';
 
 export class Statistic extends AntdChart {
   constructor() {
     super({
       name: 'statistic',
       title: 'Statistic',
-      Component: AntdStatistic,
+      Component: C,
       config: [
         {
           property: 'field',
@@ -28,6 +28,14 @@ export class Statistic extends AntdChart {
         {
           title: {
             title: lang('Title'),
+            type: 'string',
+            'x-decorator': 'FormItem',
+            'x-component': 'Input',
+          },
+        },
+        {
+          link: {
+            title: lang('Link'),
             type: 'string',
             'x-decorator': 'FormItem',
             'x-component': 'Input',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Allow to set a fixed link for statistic charts.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

https://github.com/user-attachments/assets/fb7a43de-9e34-45b4-9db4-86babddfb8ff

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow to set a fixed link for statistic chart       |
| 🇨🇳 Chinese | 支持给统计数值图设置一个固定连接          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
