### PR TITLE
fix(filter): should not filter out zero

### DIFF
--- a/packages/core/client/src/filter-provider/__tests__/utiles.test.ts
+++ b/packages/core/client/src/filter-provider/__tests__/utiles.test.ts
@@ -196,6 +196,32 @@ describe('transformToFilter', () => {
     expect(filter).toEqual(expectedFilter);
   });
 
+  it('should keep 0 value', () => {
+    const valuesWithZero = {
+      field1: 0,
+      field2: 'value2',
+    };
+
+    const expectedFilter = {
+      $and: [
+        {
+          field1: {
+            $eq: 0,
+          },
+        },
+        {
+          field2: {
+            $ne: 'value2',
+          },
+        },
+      ],
+    };
+
+    const filter = transformToFilter(valuesWithZero, operators, getCollectionJoinField, collectionName);
+
+    expect(filter).toEqual(expectedFilter);
+  });
+
   it('should handle null values', () => {
     const valuesWithNull = {
       field1: null,

--- a/packages/core/client/src/filter-provider/utils.ts
+++ b/packages/core/client/src/filter-provider/utils.ts
@@ -144,7 +144,7 @@ export const transformToFilter = (
           key = `${key}.${collectionField.targetKey || 'id'}`;
         }
 
-        if (!value) {
+        if (_.isNil(value)) {
           return null;
         }
 

--- a/packages/core/client/src/filter-provider/utils.ts
+++ b/packages/core/client/src/filter-provider/utils.ts
@@ -144,7 +144,7 @@ export const transformToFilter = (
           key = `${key}.${collectionField.targetKey || 'id'}`;
         }
 
-        if (_.isNil(value)) {
+        if (!value && value !== 0 && value !== false) {
           return null;
         }
 
@@ -167,7 +167,7 @@ export const useAssociatedFields = () => {
 };
 
 export const isAssocField = (field?: FieldOptions) => {
-  return ['o2o', 'oho', 'obo', 'm2o', 'createdBy', 'updatedBy', 'o2m', 'm2m', 'linkTo', 'chinaRegion'].includes(
+  return ['o2o', 'oho', 'obo', 'm2o', 'createdBy', 'updatedBy', 'o2m', 'm2m', 'linkTo', 'chinaRegion', 'mbm'].includes(
     field?.interface,
   );
 };

--- a/packages/core/client/src/schema-component/antd/filter/__tests__/useFilterActionProps.test.ts
+++ b/packages/core/client/src/schema-component/antd/filter/__tests__/useFilterActionProps.test.ts
@@ -65,4 +65,17 @@ describe('removeNullCondition', () => {
     const result = removeNullCondition(filter);
     expect(result).toEqual(expected);
   });
+
+  it('should keep 0 value', () => {
+    const filter = {
+      field1: 0,
+      field2: 'value2',
+    };
+    const expected = {
+      field1: 0,
+      field2: 'value2',
+    };
+    const result = removeNullCondition(filter);
+    expect(result).toEqual(expected);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix BUG.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
You should to see the code, only one line changes.
### Related issues
https://tasks.aliyun.nocobase.com/admin/ugmnj2ycfgg/popups/1qlw5c38t3b/puid/dz42x7ffr7i/filterbytk/166
### Showcase
<!-- Including any screenshots of the changes. -->
None.
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix an issue where filter blocks could not filter 0 values.     |
| 🇨🇳 Chinese |     修复筛选区块无法筛选 0 值的问题。      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
