### PR TITLE
fix(data-vi): add size settings for pie, bar and dualAxes

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/bar.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/bar.ts
@@ -13,7 +13,12 @@ import { ChartType } from '../chart';
 
 export class Bar extends G2PlotChart {
   constructor() {
-    super({ name: 'bar', title: 'Bar Chart', Component: G2PlotBar, config: ['isGroup', 'isStack', 'isPercent'] });
+    super({
+      name: 'bar',
+      title: 'Bar Chart',
+      Component: G2PlotBar,
+      config: ['isGroup', 'isStack', 'isPercent', 'size'],
+    });
   }
 
   init: ChartType['init'] = (fields, { measures, dimensions }) => {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/dualAxes.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/dualAxes.ts
@@ -61,6 +61,7 @@ export class DualAxes extends G2PlotChart {
           },
         },
       },
+      'size',
     ];
   }
 

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/pie.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/pie.ts
@@ -27,6 +27,7 @@ export class Pie extends G2PlotChart {
         title: 'colorField',
         required: true,
       },
+      'size',
     ];
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

Forgot to add size settings for some chart types.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Add size settings for pie, bar and dualAxes.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add size settings for chart types: pie, bar and dualAxes          |
| 🇨🇳 Chinese | 给以下图表类型添加尺寸设置：饼图、条形图和双轴图           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
