### PR TITLE
fix(data-vi): allow to map integer enum value

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/utils.test.ts
@@ -1,0 +1,44 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { processData } from '../utils';
+
+describe('utils', () => {
+  it('processFields', () => {
+    expect(
+      processData(
+        [
+          {
+            name: 'tag',
+            type: 'bigInt',
+            interface: 'select',
+            uiSchema: {
+              type: 'string',
+              enum: [
+                {
+                  value: '1',
+                  label: 'Yes',
+                },
+                {
+                  value: '2',
+                  label: 'No',
+                },
+              ],
+            },
+            label: 'Tag',
+            value: 'tag',
+            key: 'tag',
+          },
+        ],
+        [{ tag: 1 }],
+        {},
+      ),
+    ).toEqual([{ tag: 'Yes' }]);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/utils.ts
@@ -93,7 +93,7 @@ export const processData = (selectedFields: FieldOption[], data: any[], scope: a
     if (Array.isArray(value)) {
       return value.map((v) => parseEnum(field, v));
     }
-    const option = options.find((option) => option.value === value.toString?.() || value);
+    const option = options.find((option) => option.value === (value?.toString?.() || value));
     return Schema.compile(option?.label || value, scope);
   };
   return data.map((record) => {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/utils.ts
@@ -93,7 +93,7 @@ export const processData = (selectedFields: FieldOption[], data: any[], scope: a
     if (Array.isArray(value)) {
       return value.map((v) => parseEnum(field, v));
     }
-    const option = options.find((option) => option.value === value);
+    const option = options.find((option) => option.value === value.toString?.() || value);
     return Schema.compile(option?.label || value, scope);
   };
   return data.map((record) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

The tooltips of charts can not map enum labels when the field values are integers.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

When mapping enum labels for chart tooltips, attempt to transform the values to string.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue of mapping labels when the enum field values are integers in charts.        |
| 🇨🇳 Chinese | 修复图表中枚举字段值为整数时无法映射成枚举标签的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
