### PR TITLE
feat(client): add constant props api for variable input

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -118,10 +118,19 @@ const ConstantTypes = {
   },
 };
 
-function getTypedConstantOption(type: string, types: true | string[], fieldNames) {
+type UseTypeConstantType = true | (string | [string, Record<string, any>])[];
+
+function getTypedConstantOption(type: string, types: UseTypeConstantType, fieldNames) {
   const allTypes = Object.values(ConstantTypes).filter((item) => item.value !== 'null');
   const children = (
-    types ? allTypes.filter((item) => (Array.isArray(types) && types.includes(item.value)) || types === true) : allTypes
+    types
+      ? allTypes.filter(
+          (item) =>
+            (Array.isArray(types) &&
+              types.filter((t) => (Array.isArray(t) ? t[0] === item.value : t === item.value)).length) ||
+            types === true,
+        )
+      : allTypes
   ).map((item) =>
     Object.keys(item).reduce(
       (result, key) =>
@@ -150,7 +159,7 @@ export type VariableInputProps = {
   onChange: (value: string, optionPath?: any[]) => void;
   children?: any;
   button?: React.ReactElement;
-  useTypedConstant?: true | string[];
+  useTypedConstant?: UseTypeConstantType;
   changeOnSelect?: CascaderProps['changeOnSelect'];
   fieldNames?: CascaderProps['fieldNames'];
   disabled?: boolean;
@@ -214,6 +223,9 @@ export function Input(props: VariableInputProps) {
   }, [type, useTypedConstant]);
 
   const ConstantComponent = constantOption && !children ? constantOption.component : NullComponent;
+  const constantComponentProps = Array.isArray(useTypedConstant)
+    ? (useTypedConstant.find((item) => Array.isArray(item) && item[0] === type)?.[1] as Record<string, any>) ?? {}
+    : {};
   let cValue;
   if (value == null) {
     if (children && isFieldValue) {
@@ -403,7 +415,13 @@ export function Input(props: VariableInputProps) {
           {children && isFieldValue ? (
             children
           ) : ConstantComponent ? (
-            <ConstantComponent role="button" aria-label="variable-constant" value={value} onChange={onChange} />
+            <ConstantComponent
+              role="button"
+              aria-label="variable-constant"
+              {...constantComponentProps}
+              value={value}
+              onChange={onChange}
+            />
           ) : null}
         </div>
       )}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow to configure properties for constant component in `Variable.Input`.

### Description 

```diff
{
  type: 'string',
  'x-component': 'Variable.Input',
  'x-compoennt-props': {
    useTypedConstant: [
      'string',
-     'number',
+     [
+       'number',
+       {
+         precision: 0,
+       }
+     ]
+   ]
  }
}
```

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add constant props api for variable input. |
| 🇨🇳 Chinese | 为变量组件添加使用基于类型常量时组件的 `props` API |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
