### PR TITLE
fix(plugin-workflow-parallel): fix missed transaction causing dead lock in mysql

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts
@@ -120,7 +120,7 @@ export default class extends Instruction {
     });
 
     if (job.status === JOB_STATUS.PENDING) {
-      await job.save();
+      await job.save({ transaction: processor.transaction });
       return processor.exit();
     }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix dead lock when using parallel node in mysql.

### Description 

```
2024-08-23 09:55:32 [info]  execution of workflow 6 created as 14        
2024-08-23 09:55:32 [info]  execution (14) starting...                   
2024-08-23 09:55:32 [info]  execution (14) run instruction [parallel] for node (21) 
2024-08-23 09:55:32 [debug] config of node                               data={"mode":"any"}
2024-08-23 09:55:32 [info]  execution (14) run instruction [condition] for node (22) 
2024-08-23 09:55:32 [debug] config of node                               data={"engine":"basic","calculation":{"group":{"type":"and","calculations":[{"operands":["{{$context.data.id}}","10000"],"calculator":"equal"}]}},"rejectOnFalse":true}
2024-08-23 09:55:32 [info]  execution (14) run instruction [condition] for node (22) finished as status: -1 
2024-08-23 09:55:32 [debug] result of node                               
2024-08-23 09:55:32 [debug] branch ended at node (22)                    
2024-08-23 09:55:32 [debug] not on main, recall to parent entry node (22)}) 
2024-08-23 09:55:32 [info]  execution (14) run instruction [parallel] for node (21) 
2024-08-23 09:55:32 [debug] config of node                               data={"mode":"any"}
2024-08-23 09:56:23 [error] execution (14) run instruction [parallel] for node (21) failed:  Lock wait timeout exceeded; try restarting transaction name=SequelizeDatabaseError parent={"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,null,null]","2024-08-23 01:55:32",65]} original={"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,null,null]","2024-08-23 01:55:32",65]} sql=UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ? parameters=["[-1,null,null]","2024-08-23 01:55:32",65] stack=Error
    at Query.run (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/dialects/mysql/query.js:46:25)
    at <anonymous> (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/sequelize.js:650:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at MySQLQueryInterface.update (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/dialects/abstract/query-interface.js:898:12)
    at model.save (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/model.js:4154:35)
    at ParallelInstruction_default.resume (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts:123:7)
    at Processor.exec (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts:157:13)
    at Processor.end (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts:223:7)
    at <anonymous> (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts:89:11)
    at ParallelInstruction_default.run (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts:83:5)
2024-08-23 09:56:23 [info]  execution (14) run instruction [parallel] for node (21) finished as status: -2 
2024-08-23 09:56:23 [debug] result of node                               data={"message":"Lock wait timeout exceeded; try restarting transaction","name":"SequelizeDatabaseError","parent":{"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,null,null]","2024-08-23 01:55:32",65]},"original":{"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,null,null]","2024-08-23 01:55:32",65]},"sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,null,null]","2024-08-23 01:55:32",65]}
2024-08-23 09:56:23 [debug] branch ended at node (21)                    
2024-08-23 09:56:23 [info]  execution (14) exiting with status -2        
2024-08-23 09:56:23 [info]  execution (14) run instruction [condition] for node (23) 
2024-08-23 09:56:23 [debug] config of node                               data={"engine":"basic","calculation":{"group":{"type":"and","calculations":[{"operands":["{{$context.data.id}}","1000"],"calculator":"equal"}]}},"rejectOnFalse":true}
2024-08-23 09:56:23 [info]  execution (14) run instruction [condition] for node (23) finished as status: -1 
2024-08-23 09:56:23 [debug] result of node                               
2024-08-23 09:56:23 [debug] branch ended at node (23)                    
2024-08-23 09:56:23 [debug] not on main, recall to parent entry node (23)}) 
2024-08-23 09:56:23 [info]  execution (14) run instruction [parallel] for node (21) 
2024-08-23 09:56:23 [debug] config of node                               data={"mode":"any"}
2024-08-23 09:57:13 [error] execution (14) run instruction [parallel] for node (21) failed:  Lock wait timeout exceeded; try restarting transaction name=SequelizeDatabaseError parent={"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,-1,null]","2024-08-23 01:56:23",65]} original={"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,-1,null]","2024-08-23 01:56:23",65]} sql=UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ? parameters=["[-1,-1,null]","2024-08-23 01:56:23",65] stack=Error
    at Query.run (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/dialects/mysql/query.js:46:25)
    at <anonymous> (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/sequelize.js:650:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at MySQLQueryInterface.update (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/dialects/abstract/query-interface.js:898:12)
    at model.save (/Users/chiming/Desktop/opensource/nocobase/node_modules/sequelize/src/model.js:4154:35)
    at ParallelInstruction_default.resume (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts:123:7)
    at Processor.exec (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts:157:13)
    at Processor.end (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts:223:7)
    at <anonymous> (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts:89:11)
    at ParallelInstruction_default.run (/Users/chiming/Desktop/opensource/nocobase/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts:83:5)
2024-08-23 09:57:13 [info]  execution (14) run instruction [parallel] for node (21) finished as status: -2 
2024-08-23 09:57:13 [debug] result of node                               data={"message":"Lock wait timeout exceeded; try restarting transaction","name":"SequelizeDatabaseError","parent":{"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,-1,null]","2024-08-23 01:56:23",65]},"original":{"code":"ER_LOCK_WAIT_TIMEOUT","errno":1205,"sqlState":"HY000","sqlMessage":"Lock wait timeout exceeded; try restarting transaction","sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,-1,null]","2024-08-23 01:56:23",65]},"sql":"UPDATE `jobs` SET `result`=?,`updatedAt`=? WHERE `id` = ?","parameters":["[-1,-1,null]","2024-08-23 01:56:23",65]}
2024-08-23 09:57:13 [debug] branch ended at node (21)                    
2024-08-23 09:57:13 [info]  execution (14) exiting with status -2        
2024-08-23 09:57:13 [info]  execution (14) run instruction [condition] for node (24) 
2024-08-23 09:57:13 [debug] config of node                               data={"engine":"basic","calculation":{"group":{"type":"and","calculations":[{"operands":["{{$context.data.id}}","1000"],"calculator":"lt"}]}},"rejectOnFalse":true}
2024-08-23 09:57:13 [info]  execution (14) run instruction [condition] for node (24) finished as status: 1 
2024-08-23 09:57:13 [debug] result of node                               data=true
2024-08-23 09:57:13 [debug] run next node (25)                           
2024-08-23 09:57:13 [info]  execution (14) run instruction [query] for node (25) 
2024-08-23 09:57:13 [debug] config of node                               data={"params":{"page":1,"sort":[],"filter":{"$and":[]},"appends":[],"pageSize":20},"multiple":false,"collection":"users"}
2024-08-23 09:57:13 [info]  execution (14) run instruction [query] for node (25) finished as status: 1 
2024-08-23 09:57:13 [debug] result of node                               data={"nickname":"Super Admin","phone":null,"createdAt":"2024-08-21T09:32:48.898Z","systemSettings":{},"appLang":null,"resetToken":null,"username":"nocobase","email":"admin@nocobase.com","password":"77f02abab8e021c16a1c016f8d8d6f2f9cc18451734c64ba39760f225ba6ad95","sort":1,"updatedAt":"2024-08-21T09:32:48.898Z","id":1,"updatedById":null,"createdById":null}
2024-08-23 09:57:13 [debug] branch ended at node (25)                    
2024-08-23 09:57:13 [debug] not on main, recall to parent entry node (25)}) 
2024-08-23 09:57:13 [info]  execution (14) run instruction [parallel] for node (21) 
2024-08-23 09:57:13 [debug] config of node                               data={"mode":"any"}
2024-08-23 09:57:13 [info]  execution (14) run instruction [parallel] for node (21) finished as status: 1 
2024-08-23 09:57:13 [debug] result of node                               data=[-1,-1,1]
2024-08-23 09:57:13 [debug] branch ended at node (21)                    
2024-08-23 09:57:13 [info]  execution (14) exiting with status 1         
2024-08-23 09:57:13 [info]  execution (14) finished with status: 1       execution={"id":14,"context":{"data":{"systemSettings":{},"id":15,"updatedAt":"2024-08-23T01:55:32.825Z","createdAt":"2024-08-23T01:55:32.825Z","sort":14,"updatedById":1,"createdById":1}},"key":"jawadc78ehc","eventKey":"203761d7-b344-435c-8804-18b6dee4e370","status":1,"workflowId":6,"updatedAt":"2024-08-23T01:57:13.260Z","createdAt":"2024-08-23T01:55:32.836Z"}
```

### Related issues

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missed transaction of parallel node causing dead lock in mysql. |
| 🇨🇳 Chinese | 修复并行分支节点由于缺失事务导致在 MySQL 下执行发生死锁问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
