### PR TITLE
refactor:  set remainsTheSame as the default value for field editing in bulk editing action

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/form/__e2e__/form-edit/bulkEditForm.test.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/__e2e__/form-edit/bulkEditForm.test.ts
@@ -26,7 +26,10 @@ test.describe('bulk edit form', () => {
     // 2. 打开弹窗，显示出批量编辑表单
     await page.getByLabel('action-Action-Bulk edit-').click();
 
-    // 默认为 "Changed to" 模式，此时应该显示字段是必填的
+    await page.getByLabel('block-item-BulkEditField-').click();
+    await page.getByRole('option', { name: 'Changed to' }).click();
+
+    //  "Changed to" 模式，此时应该显示字段是必填的
     await expect(page.getByLabel('block-item-BulkEditField-').getByText('*')).toBeVisible();
 
     // 3. 输入值，点击提交
@@ -45,7 +48,10 @@ test.describe('bulk edit form', () => {
     // 1. 打开弹窗，显示出批量编辑表单
     await page.getByLabel('action-Action-Bulk edit-').click();
 
-    // 默认为 "Changed to" 模式，此时应该显示字段是必填的
+    await page.getByLabel('block-item-BulkEditField-').click();
+    await page.getByRole('option', { name: 'Changed to' }).click();
+
+    //  "Changed to" 模式，此时应该显示字段是必填的
     await expect(page.getByLabel('block-item-BulkEditField-').getByText('*')).toBeVisible();
 
     // 2. 切换为其它模式，此时应该不显示字段是必填的

--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/component/BulkEditField.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/component/BulkEditField.tsx
@@ -95,7 +95,7 @@ export const BulkEditField = (props: any) => {
   const { t } = useTranslation();
   const fieldSchema = useFieldSchema();
   const field = useField<Field>();
-  const [type, setType] = useState<number>(BulkEditFormItemValueType.ChangedTo);
+  const [type, setType] = useState<number>(BulkEditFormItemValueType.RemainsTheSame);
   const [value, setValue] = useState(null);
   const { getField } = useCollection_deprecated();
   const collectionField = getField(fieldSchema.name) || {};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    bulk edit set remainsTheSame as default value       |
| 🇨🇳 Chinese |      批量更新，默认值应该是“保持不变”     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
