### PR TITLE
fix(client): fix field names of variable input

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -132,14 +132,14 @@ function getTypedConstantOption(type: string, types: UseTypeConstantType, fieldN
         )
       : allTypes
   ).map((item) =>
-    Object.keys(item).reduce(
+    Object.keys(fieldNames).reduce(
       (result, key) =>
-        fieldNames[key] in item
+        key in item
           ? Object.assign(result, {
               [fieldNames[key]]: item[key],
             })
           : result,
-      item,
+      { ...item },
     ),
   );
   return {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Show constant options correctly when field names configured.

### Description 

1. Add custom request action for a record.
2. Open configuration of the custom request action button.
3. Add a variable in params.
4. Try to select typed constant to input.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix field names of variable input. |
| 🇨🇳 Chinese | 修复变量组件的字段名称问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
