### PR TITLE
fix: association select data scope linkage should be  supported in  sub-form

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -79,9 +79,6 @@ const InternalAssociationSelect = observer(
         //支持深层次子表单
         onFieldInputValueChange('*', (fieldPath: any) => {
           const linkageFields = filterAnalyses(field.componentProps?.service?.params?.filter) || [];
-          console.log(linkageFields);
-          console.log(field.componentProps?.service?.params?.filter);
-          console.log(linkageFields.includes(fieldPath?.props?.name), field.value);
           if (linkageFields.includes(fieldPath?.props?.name) && field.value) {
             field.setValue(field.initialValue);
             setInnerValue(field.initialValue);

--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -41,7 +41,7 @@ export const filterAnalyses = (filters): any[] => {
     if (!operator) {
       return true;
     }
-    const regex = /\{\{\$(?:[a-zA-Z_]\w*)\.([a-zA-Z_]\w*)(?:\.id)?\}\}/;
+    const regex = /\{\{\$[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*\.(\w+)\.id\}\}/;
     const fieldName = jsonlogic?.value?.match?.(regex)?.[1];
     if (fieldName) {
       results.push(fieldName);
@@ -79,6 +79,9 @@ const InternalAssociationSelect = observer(
         //支持深层次子表单
         onFieldInputValueChange('*', (fieldPath: any) => {
           const linkageFields = filterAnalyses(field.componentProps?.service?.params?.filter) || [];
+          console.log(linkageFields);
+          console.log(field.componentProps?.service?.params?.filter);
+          console.log(linkageFields.includes(fieldPath?.props?.name), field.value);
           if (linkageFields.includes(fieldPath?.props?.name) && field.value) {
             field.setValue(field.initialValue);
             setInnerValue(field.initialValue);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
以下为修改后的效果
![20240828144956](https://github.com/user-attachments/assets/295aaa5d-f10a-4170-9859-895ba73d65c9)

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    The data scope of association field in sub form should be linked. when switching option, the linked association field should be cleared      |
| 🇨🇳 Chinese |      子表单中关系字段数据范围联动，切换选项时，联动的关系字段清空选项     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
