### PR TITLE
fix(data-vi): cast the values of decimal fields from type string to number

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
@@ -79,6 +79,7 @@ export const postProcess = async (ctx: Context, next: Next) => {
         case 'integer':
         case 'float':
         case 'double':
+        case 'decimal':
           record[key] = Number(value);
           break;
       }


### PR DESCRIPTION
… to number

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

The values of decimal fields in chart query are not casted into number type.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Add `decimal` type to the auto cast type list.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where `decimal` field values in chart query results are not cast into number type automatically          |
| 🇨🇳 Chinese | 修复图表查询结果中 `decimal` 字段值没有自动转换成数字类型的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
