### PR TITLE
fix: issue in  data selector other block  should display  Markdown, not 'Add Text'

### DIFF
--- a/packages/core/client/src/modules/fields/component/Picker/TableSelectorInitializers.tsx
+++ b/packages/core/client/src/modules/fields/component/Picker/TableSelectorInitializers.tsx
@@ -70,21 +70,9 @@ const commonOptions = {
       name: 'otherBlocks',
       children: [
         {
-          title: '{{t("Add text")}}',
-          Component: 'BlockItemInitializer',
-          name: 'addText',
-          schema: {
-            type: 'void',
-            'x-editable': false,
-            'x-decorator': 'BlockItem',
-            // 'x-designer': 'Markdown.Void.Designer',
-            'x-toolbar': 'BlockSchemaToolbar',
-            'x-settings': 'blockSettings:markdown',
-            'x-component': 'Markdown.Void',
-            'x-component-props': {
-              content: '{{t("This is a demo text, **supports Markdown syntax**.")}}',
-            },
-          },
+          name: 'markdown',
+          title: '{{t("Markdown")}}',
+          Component: 'MarkdownBlockInitializer',
         },
       ],
     },


### PR DESCRIPTION
…ot 'Add Text'

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     issue in  data selector other block  should display  Markdown, not 'Add Text'        |
| 🇨🇳 Chinese | 关系的数据选择器弹窗中其他区块应显示 Markdown，不是 Add Text      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
