### PR TITLE
fix: formula field as datetime cause ui loop

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-formula/src/client/components/Formula/Result.tsx
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client/components/Formula/Result.tsx
@@ -99,6 +99,7 @@ export function Result(props) {
         setEditingValue(v);
       }
       setEditingValue(v);
+      v = v instanceof Date ? v.toISOString() : v; //treat Date as string for value compare
       if (v !== field.value) {
         field.value = v;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [&check;] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
在 添加/编辑 UI中 展示日期类型的公式字段时，页面会无限循环报错
（JS中，日期对象不能做==，!=比较）

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
修改公式计算结果，如果是日期类型，当做字符串处理。


### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->
重现方法：
1. 数据库 test 字段
start_date: Datetime
end_date: Datetime
max_date: IF(start_date>end_date, start_date, end_date)
2. test 添加UI
放入上述3个字段到表单中
3. 设置start/end max会循环赋值导致页面崩溃

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | fix: 修正 在添加/编辑UI中展示日期类型的公式字段时，页面会无限循环报错的问题  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [&check;] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
