### PR TITLE
feat(client): display system title when logo is missing

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -441,7 +441,7 @@ export const InternalAdminLayout = () => {
                 />
               ) : (
                 <span
-                  style={{ fontSize: token.fontSizeHeading1 }}
+                  style={{ fontSize: token.fontSizeHeading3 }}
                   className={css`
                     padding: 0 16px;
                     width: 100%;

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -447,6 +447,10 @@ export const InternalAdminLayout = () => {
                     width: 100%;
                     height: 100%;
                     font-weight: 500;
+                    text-align: center;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                   `}
                 >
                   {result?.data?.data?.title}

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -429,15 +429,29 @@ export const InternalAdminLayout = () => {
                 align-items: center;
               `}
             >
-              <img
-                className={css`
-                  padding: 0 16px;
-                  object-fit: contain;
-                  width: 100%;
-                  height: 100%;
-                `}
-                src={result?.data?.data?.logo?.url}
-              />
+              {result?.data?.data?.logo?.url ? (
+                <img
+                  className={css`
+                    padding: 0 16px;
+                    object-fit: contain;
+                    width: 100%;
+                    height: 100%;
+                  `}
+                  src={result?.data?.data?.logo?.url}
+                />
+              ) : (
+                <span
+                  className={css`
+                    padding: 0 16px;
+                    width: 100%;
+                    height: 100%;
+                    font-weight: 500;
+                    font-size: 2em;
+                  `}
+                >
+                  {result?.data?.data?.title}
+                </span>
+              )}
             </div>
             <div
               className={css`

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -441,12 +441,12 @@ export const InternalAdminLayout = () => {
                 />
               ) : (
                 <span
+                  style={{ fontSize: token.fontSizeHeading1 }}
                   className={css`
                     padding: 0 16px;
                     width: 100%;
                     height: 100%;
                     font-weight: 500;
-                    font-size: 2em;
                   `}
                 >
                   {result?.data?.data?.title}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

![Xnip2024-09-03_10-46-55](https://github.com/user-attachments/assets/0ee45fa7-80e2-497e-a05e-543da3e36bba)

![Xnip2024-09-03_10-48-42](https://github.com/user-attachments/assets/a357c08a-2bbc-4fe4-bd50-ad9103895d46)



### Description 
If no logo is uploaded, the system title will be displayed.


### Showcase
![Xnip2024-09-03_10-47-03](https://github.com/user-attachments/assets/bb8814f4-fd89-40b1-8283-f2a626f8b7b9)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Display system title when logo is missing.       |
| 🇨🇳 Chinese |    当缺少 logo 时，显示系统标题。       |
