### PR TITLE
refactor: secondary confirmation information supports customization

### DIFF
--- a/packages/core/client/src/locale/en_US.json
+++ b/packages/core/client/src/locale/en_US.json
@@ -838,5 +838,7 @@
   "Open in new window": "Open in new window",
   "Sorry, the page you visited does not exist.": "Sorry, the page you visited does not exist.",
   "is none of": "is none of",
-  "is any of": "is any of"
+  "is any of": "is any of",
+  "Skip getting the total number of table records during paging to speed up loading. It is recommended to enable this option for data tables with a large amount of data": "Skip getting the total number of table records during paging to speed up loading. It is recommended to enable this option for data tables with a large amount of data",
+  "Enable secondary confirmation": "Enable secondary confirmation"
 }

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -971,5 +971,7 @@
   "Use simple pagination mode": "使用简单分页模式",
   "Sorry, the page you visited does not exist.": "抱歉，你访问的页面不存在。",
   "Set Template Engine": "设置模板引擎",
-  "Skip getting the total number of table records during paging to speed up loading. It is recommended to enable this option for data tables with a large amount of data": "在分页时跳过获取表记录总数，以加快加载速度，建议对有大量数据的数据表开启此选项"
+  "Skip getting the total number of table records during paging to speed up loading. It is recommended to enable this option for data tables with a large amount of data": "在分页时跳过获取表记录总数，以加快加载速度，建议对有大量数据的数据表开启此选项",
+  "Enable secondary confirmation": "启用二次确认",
+  "Content": "内容"
 }

--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -823,6 +823,10 @@ export function SecondConFirm() {
   return (
     <SchemaSettingsModalItem
       title={t('Secondary confirmation')}
+      initialValues={{
+        title: fieldSchema?.['x-component-props']?.confirm?.title || fieldSchema.title,
+        content: fieldSchema?.['x-component-props']?.confirm?.content,
+      }}
       schema={
         {
           type: 'object',
@@ -831,7 +835,7 @@ export function SecondConFirm() {
             enable: {
               'x-decorator': 'FormItem',
               'x-component': 'Checkbox',
-              'x-content': t('Enable'),
+              title: t('Enable secondary confirmation'),
               default:
                 fieldSchema?.['x-component-props']?.confirm?.enable !== false &&
                 !!fieldSchema?.['x-component-props']?.confirm?.content,
@@ -840,8 +844,7 @@ export function SecondConFirm() {
             title: {
               'x-decorator': 'FormItem',
               'x-component': 'Input.TextArea',
-              title: t('Confirm title'),
-              default: fieldSchema?.['x-component-props']?.confirm?.title || fieldSchema.title,
+              title: t('Title'),
               'x-reactions': {
                 dependencies: ['enable'],
                 fulfill: {
@@ -854,8 +857,7 @@ export function SecondConFirm() {
             content: {
               'x-decorator': 'FormItem',
               'x-component': 'Input.TextArea',
-              title: t('Confirm content'),
-              default: fieldSchema?.['x-component-props']?.confirm?.content,
+              title: t('Content'),
               'x-reactions': {
                 dependencies: ['enable'],
                 fulfill: {

--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -835,7 +835,7 @@ export function SecondConFirm() {
             enable: {
               'x-decorator': 'FormItem',
               'x-component': 'Checkbox',
-              title: t('Enable secondary confirmation'),
+              'x-content': t('Enable secondary confirmation'),
               default:
                 fieldSchema?.['x-component-props']?.confirm?.enable !== false &&
                 !!fieldSchema?.['x-component-props']?.confirm?.content,

--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -837,10 +837,24 @@ export function SecondConFirm() {
                 !!fieldSchema?.['x-component-props']?.confirm?.content,
               'x-component-props': {},
             },
+            title: {
+              'x-decorator': 'FormItem',
+              'x-component': 'Input.TextArea',
+              title: t('Confirm title'),
+              default: fieldSchema?.['x-component-props']?.confirm?.title || fieldSchema.title,
+              'x-reactions': {
+                dependencies: ['enable'],
+                fulfill: {
+                  state: {
+                    required: '{{$deps[0]}}',
+                  },
+                },
+              },
+            },
             content: {
               'x-decorator': 'FormItem',
               'x-component': 'Input.TextArea',
-              title: t('Confirm message'),
+              title: t('Confirm content'),
               default: fieldSchema?.['x-component-props']?.confirm?.content,
               'x-reactions': {
                 dependencies: ['enable'],
@@ -854,10 +868,11 @@ export function SecondConFirm() {
           },
         } as ISchema
       }
-      onSubmit={({ enable, content }) => {
+      onSubmit={({ enable, title, content }) => {
         fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
         fieldSchema['x-component-props'].confirm = {};
         fieldSchema['x-component-props'].confirm.enable = enable;
+        fieldSchema['x-component-props'].confirm.title = title;
         fieldSchema['x-component-props'].confirm.content = content;
         field.componentProps.confirm = { ...fieldSchema['x-component-props']?.confirm };
         dn.emit('patch', {

--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -819,34 +819,56 @@ export function SecondConFirm() {
   const { dn } = useDesignable();
   const fieldSchema = useFieldSchema();
   const { t } = useTranslation();
-  const field = useField<Field>();
-
+  const field = useField();
   return (
-    <SchemaSettingsSwitchItem
+    <SchemaSettingsModalItem
       title={t('Secondary confirmation')}
-      checked={!!fieldSchema?.['x-component-props']?.confirm?.content}
-      onChange={(value) => {
-        if (!fieldSchema['x-component-props']) {
-          fieldSchema['x-component-props'] = {};
-        }
-        if (value) {
-          fieldSchema['x-component-props'].confirm = value
-            ? {
-                title: 'Perform the {{title}}',
-                content: 'Are you sure you want to perform the {{title}} action?',
-              }
-            : {};
-        } else {
-          fieldSchema['x-component-props'].confirm = {};
-        }
+      schema={
+        {
+          type: 'object',
+          title: t('Secondary confirmation'),
+          properties: {
+            enable: {
+              'x-decorator': 'FormItem',
+              'x-component': 'Checkbox',
+              'x-content': t('Enable'),
+              default:
+                fieldSchema?.['x-component-props']?.confirm?.enable !== false &&
+                !!fieldSchema?.['x-component-props']?.confirm?.content,
+              'x-component-props': {},
+            },
+            content: {
+              'x-decorator': 'FormItem',
+              'x-component': 'Input.TextArea',
+              title: t('Confirm message'),
+              default: fieldSchema?.['x-component-props']?.confirm?.content,
+              'x-reactions': {
+                dependencies: ['enable'],
+                fulfill: {
+                  state: {
+                    required: '{{$deps[0]}}',
+                  },
+                },
+              },
+            },
+          },
+        } as ISchema
+      }
+      onSubmit={({ enable, content }) => {
+        fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
+        fieldSchema['x-component-props'].confirm = {};
+        fieldSchema['x-component-props'].confirm.enable = enable;
+        fieldSchema['x-component-props'].confirm.content = content;
         field.componentProps.confirm = { ...fieldSchema['x-component-props']?.confirm };
-
         dn.emit('patch', {
           schema: {
             ['x-uid']: fieldSchema['x-uid'],
-            'x-component-props': { ...fieldSchema['x-component-props'] },
+            'x-component-props': {
+              ...fieldSchema['x-component-props'],
+            },
           },
         });
+        dn.refresh();
       }}
     />
   );

--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -344,7 +344,7 @@ function RenderButton({
             }
           }
         };
-        if (confirm?.content) {
+        if (confirm?.enable !== false && confirm?.content) {
           modal.confirm({
             title: t(confirm.title, { title: actionTitle }),
             content: t(confirm.content, { title: actionTitle }),

--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -310,6 +310,7 @@ function RenderButton({
   const { t } = useTranslation();
   const { isPopupVisibleControlledByURL } = usePopupSettings();
   const { openPopup } = usePopupUtils();
+  const compile = useCompile();
 
   const handleButtonClick = useCallback(
     (e: React.MouseEvent, checkPortal = true) => {
@@ -346,8 +347,8 @@ function RenderButton({
         };
         if (confirm?.enable !== false && confirm?.content) {
           modal.confirm({
-            title: t(confirm.title, { title: actionTitle }),
-            content: t(confirm.content, { title: actionTitle }),
+            title: compile(confirm.title, { title: actionTitle }),
+            content: compile(confirm.content, { title: actionTitle }),
             onOk,
           });
         } else {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
统一修改了所有二次确认配置
- 部分按钮有默认的二次确认信息（如删除按钮）
- 支持多语言写法 {{t('xxx')}}
![20240904212204](https://github.com/user-attachments/assets/ee5284cf-fb2a-4b5d-ad65-6a890315df05)

<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    The secondary confirmation information of button supports customization     |
| 🇨🇳 Chinese |    操作按钮的二次确认信息支持自定义      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
