### PR TITLE
fix: hide pager when no data, not when only one page

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -326,7 +326,7 @@ const usePaginationProps = (pagination1, pagination2) => {
     return false;
   }
 
-  return result.total <= result.pageSize ? false : result;
+  return totalCount ? result : false;
 };
 
 const headerClass = css`


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [&check;] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
分页选择器应该是在没有数据时隐藏，而不是只有1页数据时隐藏。
因为如果修改了每页记录条数，总页数有可能也会变。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
根据totalCount来判断是否隐藏分页

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | always show pageSize changer and totalCount when data exist |
| 🇨🇳 Chinese | 当有数据时，一直显示分页器 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [&check;] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
