### PR TITLE
fix(data-vi): issue of getting wrong value when aggregating select fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/utils.test.ts
@@ -10,35 +10,72 @@
 import { processData } from '../utils';
 
 describe('utils', () => {
-  it('processFields', () => {
-    expect(
-      processData(
-        [
-          {
-            name: 'tag',
-            type: 'bigInt',
-            interface: 'select',
-            uiSchema: {
-              type: 'string',
-              enum: [
-                {
-                  value: '1',
-                  label: 'Yes',
-                },
-                {
-                  value: '2',
-                  label: 'No',
-                },
-              ],
+  describe('process data', () => {
+    it('should process select field', () => {
+      expect(
+        processData(
+          [
+            {
+              name: 'tag',
+              type: 'bigInt',
+              interface: 'select',
+              uiSchema: {
+                type: 'string',
+                enum: [
+                  {
+                    value: '1',
+                    label: 'Yes',
+                  },
+                  {
+                    value: '2',
+                    label: 'No',
+                  },
+                ],
+              },
+              label: 'Tag',
+              value: 'tag',
+              key: 'tag',
             },
-            label: 'Tag',
-            value: 'tag',
-            key: 'tag',
-          },
-        ],
-        [{ tag: 1 }],
-        {},
-      ),
-    ).toEqual([{ tag: 'Yes' }]);
+          ],
+          [{ tag: 1 }],
+          {},
+        ),
+      ).toEqual([{ tag: 'Yes' }]);
+    });
+    it('should not process when aggregating', () => {
+      expect(
+        processData(
+          [
+            {
+              name: 'tag',
+              type: 'bigInt',
+              interface: 'select',
+              uiSchema: {
+                type: 'string',
+                enum: [
+                  {
+                    value: '1',
+                    label: 'Yes',
+                  },
+                  {
+                    value: '2',
+                    label: 'No',
+                  },
+                ],
+              },
+              label: 'Tag',
+              value: 'tag',
+              key: 'tag',
+              query: {
+                field: 'tag',
+                aggregation: 'count',
+              },
+            },
+          ],
+          [{ tag: 1 }],
+          {},
+        ),
+      ).toEqual([{ tag: 1 }]);
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/utils.ts
@@ -73,6 +73,7 @@ export const getSelectedFields = (fields: FieldOption[], query: QueryProps) => {
         key: selectedField.alias || fieldProps?.key,
         label: selectedField.alias || fieldProps?.label,
         value: selectedField.alias || fieldProps?.value,
+        query: selectedField,
       };
     });
   };
@@ -84,7 +85,7 @@ export const getSelectedFields = (fields: FieldOption[], query: QueryProps) => {
   return selectedFields;
 };
 
-export const processData = (selectedFields: FieldOption[], data: any[], scope: any) => {
+export const processData = (selectedFields: (FieldOption & { query?: any })[], data: any[], scope: any) => {
   const parseEnum = (field: FieldOption, value: any) => {
     const options = field.uiSchema?.enum as { value: string; label: string }[];
     if (!options || !Array.isArray(options)) {
@@ -99,7 +100,7 @@ export const processData = (selectedFields: FieldOption[], data: any[], scope: a
   return data.map((record) => {
     const processed = {};
     Object.entries(record).forEach(([key, value]) => {
-      const field = selectedFields.find((field) => field.value === key);
+      const field = selectedFields.find((field) => field.value === key && !field?.query?.aggregation);
       if (!field) {
         processed[key] = value;
         return;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

When aggregating select fields, it got a option label instead of a numeric value.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

When aggregating select fields, if the result matches one of the option values coincidentally, it returns the option label instead of the correct result value.

### Related issues

https://forum.nocobase.com/t/topic/693
https://forum.nocobase.com/t/topic/593

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue of getting wrong value when aggregating select fields            |
| 🇨🇳 Chinese | 修复聚合选项字段时，获取结果不正确的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
