### PR TITLE
fix: incorrect rowkey in datasource permission table

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/PermissionManager/schemas/dataSourceTable.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/PermissionManager/schemas/dataSourceTable.ts
@@ -79,7 +79,7 @@ export const dataSourceSchema: ISchema = {
           'x-uid': 'input',
           'x-component': 'Table.Void',
           'x-component-props': {
-            rowKey: 'name',
+            rowKey: 'key',
             rowSelection: {
               type: 'checkbox',
             },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Will improve performance when there are many datasource tables in roles/permission page

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Before the fix, this warning will be shown in the browser's console, this kind of warning indicate pential performance issue.
![image](https://github.com/user-attachments/assets/92510858-c856-44bc-8c8d-320be459d952)

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect `rowKey` of the datasource table in `Users & Permissions` page          |
| 🇨🇳 Chinese |修复`用户和权限`设置页面中数据源表格`rowKey`不正确问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
