### PR TITLE
fix(popup): fix URL anomalies caused by using popups together with Link buttons

### DIFF
--- a/packages/core/client/src/modules/popup/__e2e__/subPage.test.ts
+++ b/packages/core/client/src/modules/popup/__e2e__/subPage.test.ts
@@ -40,7 +40,7 @@ test.describe('sub page', () => {
       page.getByLabel('block-item-Markdown.Void-').getByText('Markdown：从弹窗中打开的子页面，tab2。'),
     ).toBeVisible();
     await page.getByLabel('back-button').click();
-    await page.goBack();
+    await page.getByLabel('drawer-Action.Container-users-View record-mask').click();
 
     // 从嵌套弹窗中打开子页面 --------------------------------------------------------------------
     await page.getByLabel('action-Action.Link-View-view-').nth(2).click();

--- a/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
+++ b/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
@@ -48,10 +48,6 @@ export interface PopupContextStorage extends PopupContext {
   /** used to refresh data for block */
   service?: any;
   sourceId?: string;
-  /**
-   * if true, will not back to the previous path when closing the popup
-   */
-  notBackToPreviousPath?: boolean;
 }
 
 const popupsContextStorage: Record<string, PopupContextStorage> = {};
@@ -279,14 +275,7 @@ export const usePopupUtils = (
         return setVisibleFromAction?.(false);
       }
 
-      // 1. If there is a value in the cache, it means that the current popup was opened by manual click, so we can simply return to the previous record;
-      // 2. If there is no value in the cache, it means that the current popup was opened by clicking the URL elsewhere, and since there is no history,
-      //    we need to construct the URL of the previous record to return to;
-      if (getStoredPopupContext(currentPopupUid) && !getStoredPopupContext(currentPopupUid).notBackToPreviousPath) {
-        navigate(-1);
-      } else {
-        navigate(withSearchParams(removeLastPopupPath(location.pathname)));
-      }
+      navigate(withSearchParams(removeLastPopupPath(location.pathname)), { replace: true });
     },
     [isPopupVisibleControlledByURL, setVisibleFromAction, navigate, location?.pathname],
   );

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowManualProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowManualProvider.tsx
@@ -33,7 +33,6 @@ function cacheSchema(collectionNameList: string[]) {
     storePopupContext(workflowTodoViewActionSchema['x-uid'], {
       schema: workflowTodoViewActionSchema,
       ...workflowTodoViewActionSchema['x-action-context'],
-      notBackToPreviousPath: true,
     });
   });
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix bug.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Previously, `navigate(-1)` was used to close the popup. If the previous history record still displayed the current popup, calling `closePopup` would not correctly close the popup. Although the popup was indeed closed, it would be found that it couldn't be opened the next time you tried to open the popup.

![image](https://github.com/user-attachments/assets/27efc81f-78ad-4637-8c3a-f64d6a7cbc73)

https://github.com/user-attachments/assets/98cbc279-c22a-4d2b-8be3-de055b3661db

Now, the `navigate(-1)` approach has been removed to prevent this situation from occurring:

![image](https://github.com/user-attachments/assets/86011f3b-4f2a-44ea-9725-77016bb47763)


### Showcase
<!-- Including any screenshots of the changes. -->

https://github.com/user-attachments/assets/71228283-4247-4d89-814f-69fc299b77bd


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix URL anomalies caused by using popups together with Link buttons    |
| 🇨🇳 Chinese |      修复因弹窗与 Link 按钮一起使用，所导致的 URL 异常的问题     |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
