### PR TITLE
fix(users): remove phone validation when editing user phones in user management

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client/schemas/users.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/client/schemas/users.ts
@@ -376,7 +376,6 @@ export const usersSchema: ISchema = {
                             phone: {
                               title: '{{t("Phone")}}',
                               'x-component': 'Input',
-                              'x-validator': 'phone',
                               'x-decorator': 'FormItem',
                               required: false,
                             },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

The default phone validation is only applicable for China mainland.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Remove phone validation when editing user phones in user management.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove phone format validation when editing user phones in user management            |
| 🇨🇳 Chinese | 移除在用户管理中编辑用户资料时的手机号格式验证          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
