### PR TITLE
fix(plugin-workflow): fix trigger type column showing wrong text after new workflow created

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -359,15 +359,15 @@ function WorkflowSelect({ formAction, buttonAction, actionType, ...props }) {
   const compile = useCompile();
 
   const workflowPlugin = usePlugin('workflow') as any;
+  const triggerOptions = workflowPlugin.useTriggersOptions();
   const workflowTypes = useMemo(
     () =>
-      workflowPlugin
-        .getTriggersOptions()
+      triggerOptions
         .filter((item) => {
           return typeof item.options.isActionTriggerable === 'function' || item.options.isActionTriggerable === true;
         })
         .map((item) => item.value),
-    [workflowPlugin],
+    [triggerOptions],
   );
 
   useFormEffects(() => {

--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -435,7 +435,7 @@ function WorkflowSelect({ formAction, buttonAction, actionType, ...props }) {
         }}
         optionFilter={optionFilter}
         optionRender={({ label, data }) => {
-          const typeOption = workflowPlugin.getTriggersOptions().find((item) => item.value === data.type);
+          const typeOption = triggerOptions.find((item) => item.value === data.type);
           return typeOption ? (
             <Flex justify="space-between">
               <span>{label}</span>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowPane.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowPane.tsx
@@ -66,7 +66,7 @@ function useWorkflowSyncAction(field) {
 
 export function WorkflowPane() {
   const ctx = useContext(SchemaComponentContext);
-  const { getTriggersOptions } = usePlugin(WorkflowPlugin);
+  const { useTriggersOptions } = usePlugin(WorkflowPlugin);
   return (
     <Card bordered={false}>
       <SchemaComponentContext.Provider value={{ ...ctx, designable: false }}>
@@ -83,7 +83,7 @@ export function WorkflowPane() {
             Tooltip,
           }}
           scope={{
-            getTriggersOptions,
+            useTriggersOptions,
             useWorkflowSyncAction,
             useRefreshActionProps,
           }}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { useFieldSchema } from '@formily/react';
 import { isValid } from '@formily/shared';
 
-import { Plugin, WorkflowConfig } from '@nocobase/client';
+import { Plugin, useCompile, WorkflowConfig } from '@nocobase/client';
 import { Registry } from '@nocobase/utils/client';
 
 import { ExecutionPage } from './ExecutionPage';
@@ -35,10 +35,11 @@ import { customizeSubmitToWorkflowActionSettings } from './settings/customizeSub
 export default class PluginWorkflowClient extends Plugin {
   triggers = new Registry<Trigger>();
   instructions = new Registry<Instruction>();
-  getTriggersOptions = () => {
+  useTriggersOptions = () => {
+    const compile = useCompile();
     return Array.from(this.triggers.getEntities()).map(([value, { title, ...options }]) => ({
       value,
-      label: title,
+      label: compile(title),
       color: 'gold',
       options,
     }));

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/index.tsx
@@ -261,37 +261,41 @@ export function JobButton() {
     setViewJob(job);
   }
 
-  return jobs.length > 1 ? (
-    <Dropdown
-      menu={{
-        items: jobs.map((job) => {
-          return {
-            key: job.id,
-            label: (
-              <>
-                <StatusButton statusMap={JobStatusOptionsMap} status={job.status} />
-                <time>{str2moment(job.updatedAt).format('YYYY-MM-DD HH:mm:ss')}</time>
-              </>
-            ),
-          };
-        }),
-        onClick: onOpenJob,
-        className: styles.dropdownClass,
-      }}
-    >
-      <StatusButton
-        statusMap={JobStatusOptionsMap}
-        status={jobs[jobs.length - 1].status}
-        className={styles.nodeJobButtonClass}
-      />
-    </Dropdown>
-  ) : (
-    <StatusButton
-      statusMap={JobStatusOptionsMap}
-      status={jobs[0].status}
-      onClick={() => setViewJob(jobs[0])}
-      className={styles.nodeJobButtonClass}
-    />
+  return (
+    <Tooltip title={lang('View result')}>
+      {jobs.length > 1 ? (
+        <Dropdown
+          menu={{
+            items: jobs.map((job) => {
+              return {
+                key: job.id,
+                label: (
+                  <>
+                    <StatusButton statusMap={JobStatusOptionsMap} status={job.status} />
+                    <time>{str2moment(job.updatedAt).format('YYYY-MM-DD HH:mm:ss')}</time>
+                  </>
+                ),
+              };
+            }),
+            onClick: onOpenJob,
+            className: styles.dropdownClass,
+          }}
+        >
+          <StatusButton
+            statusMap={JobStatusOptionsMap}
+            status={jobs[jobs.length - 1].status}
+            className={styles.nodeJobButtonClass}
+          />
+        </Dropdown>
+      ) : (
+        <StatusButton
+          statusMap={JobStatusOptionsMap}
+          status={jobs[0].status}
+          onClick={() => setViewJob(jobs[0])}
+          className={styles.nodeJobButtonClass}
+        />
+      )}
+    </Tooltip>
   );
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/schemas/workflows.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/schemas/workflows.ts
@@ -40,8 +40,8 @@ const collection = {
         type: 'string',
         'x-decorator': 'FormItem',
         'x-component': 'Select',
+        enum: '{{useTriggersOptions()}}',
         'x-component-props': {
-          options: `{{getTriggersOptions()}}`,
           optionRender: TriggerOptionRender,
           popupMatchSelectWidth: true,
           listHeight: 300,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
@@ -353,7 +353,7 @@ const useStyles = createStyles(({ css, token }) => {
 
     nodeJobResultClass: css`
       padding: 1em;
-      background-color: ${token.colorBgContainer};
+      background-color: #f3f3f3;
     `,
 
     addButtonClass: css`

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/triggers/index.tsx
@@ -88,9 +88,16 @@ function TriggerExecution() {
 
   return (
     <SchemaComponent
+      components={{
+        Tooltip,
+      }}
       schema={{
         type: 'void',
         name: 'execution',
+        'x-decorator': 'Tooltip',
+        'x-decorator-props': {
+          title: lang('View result'),
+        },
         'x-component': 'Action',
         'x-component-props': {
           title: <InfoOutlined />,
@@ -133,7 +140,7 @@ function TriggerExecution() {
                 'x-component-props': {
                   className: css`
                     padding: 1em;
-                    background-color: #eee;
+                    background-color: #f3f3f3;
                   `,
                 },
                 'x-read-pretty': true,

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
@@ -117,6 +117,7 @@
   "Canceled": "已取消",
   "Rejected": "已拒绝",
   "Retry needed": "需重试",
+  "View result": "查看结果",
 
   "Triggered but still waiting in queue to execute.": "已触发但仍在队列中等待执行。",
   "Started and executing, maybe waiting for an async callback (manual, delay etc.).":


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Trigger type column showing wrong text after new workflow created.

### Description

Also add hint on job button in execution history.

### Related issues

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix trigger type column showing wrong text after new workflow created |
| 🇨🇳 Chinese | 修复创建工作流后类型列展示错误文字的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
