### PR TITLE
refactor(client): add nullable option for variable input component

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -232,7 +232,7 @@ export function Input(props: VariableInputProps) {
     return null;
   }, [type, useTypedConstant]);
 
-  const ConstantComponent = constantOption.component ?? NullComponent;
+  const ConstantComponent = constantOption?.component ?? NullComponent;
   const constantComponentProps = Array.isArray(useTypedConstant)
     ? (useTypedConstant.find((item) => Array.isArray(item) && item[0] === type)?.[1] as Record<string, any>) ?? {}
     : {};

--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -59,7 +59,9 @@ const ConstantTypes = {
     component: function StringComponent({ onChange, value, ...otherProps }) {
       return <AntInput value={value} onChange={(ev) => onChange(ev.target.value)} {...otherProps} />;
     },
-    default: '',
+    default() {
+      return '';
+    },
   },
   number: {
     label: '{{t("Number")}}',
@@ -67,7 +69,9 @@ const ConstantTypes = {
     component: function NumberComponent({ onChange, value, ...otherProps }) {
       return <InputNumber value={value} onChange={onChange} {...otherProps} />;
     },
-    default: 0,
+    default() {
+      return 0;
+    },
   },
   boolean: {
     label: `{{t("Boolean")}}`,
@@ -104,17 +108,19 @@ const ConstantTypes = {
         />
       );
     },
-    default: (() => {
+    default() {
       const now = new Date();
       return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
-    })(),
+    },
   },
   // NOTE: keep null option here for compatibility
   null: {
     label: '{{t("Null")}}',
     value: 'null',
     component: NullComponent,
-    default: null,
+    default() {
+      return null;
+    },
   },
 };
 
@@ -160,6 +166,7 @@ export type VariableInputProps = {
   children?: any;
   button?: React.ReactElement;
   useTypedConstant?: UseTypeConstantType;
+  nullable?: boolean;
   changeOnSelect?: CascaderProps['changeOnSelect'];
   fieldNames?: CascaderProps['fieldNames'];
   disabled?: boolean;
@@ -175,6 +182,7 @@ export function Input(props: VariableInputProps) {
     children,
     button,
     useTypedConstant,
+    nullable = true,
     style,
     className,
     changeOnSelect,
@@ -198,6 +206,7 @@ export function Input(props: VariableInputProps) {
   const isConstant = typeof parsed === 'string';
   const type = isConstant ? parsed : '';
   const variable = isConstant ? null : parsed;
+  // const [prevType, setPrevType] = React.useState<string>(type);
   const names = Object.assign(
     {
       label: 'label',
@@ -216,22 +225,31 @@ export function Input(props: VariableInputProps) {
         [names.label]: t('Constant'),
       };
     }
+
     if (useTypedConstant) {
       return getTypedConstantOption(type, useTypedConstant, names);
     }
     return null;
   }, [type, useTypedConstant]);
 
-  const ConstantComponent = constantOption && !children ? constantOption.component : NullComponent;
+  const ConstantComponent = constantOption.component ?? NullComponent;
   const constantComponentProps = Array.isArray(useTypedConstant)
     ? (useTypedConstant.find((item) => Array.isArray(item) && item[0] === type)?.[1] as Record<string, any>) ?? {}
     : {};
   let cValue;
   if (value == null) {
-    if (children && isFieldValue) {
-      cValue = ['$'];
+    if (nullable) {
+      if (children && isFieldValue) {
+        cValue = ['$'];
+      } else {
+        cValue = [''];
+      }
     } else {
-      cValue = [''];
+      if (children) {
+        cValue = ['$'];
+      } else {
+        cValue = [' ', type];
+      }
     }
   } else {
     cValue = children ? ['$'] : [' ', type];
@@ -240,12 +258,16 @@ export function Input(props: VariableInputProps) {
   useEffect(() => {
     const { component, ...cOption } = constantOption ?? {};
     const options = [
-      {
-        value: '',
-        label: t('Null'),
-        [names.value]: '',
-        [names.label]: t('Null'),
-      },
+      ...(nullable
+        ? [
+            {
+              value: '',
+              label: t('Null'),
+              [names.value]: '',
+              [names.label]: t('Null'),
+            },
+          ]
+        : []),
       ...(constantOption ? [compile(cOption)] : []),
       ...(scope ? [...scope] : []),
     ].filter((item) => {
@@ -253,7 +275,7 @@ export function Input(props: VariableInputProps) {
     });
 
     setOptions(options);
-  }, [scope, variable, constantOption]);
+  }, [scope, variable, constantOption, nullable]);
 
   const loadData = async (selectedOptions: DefaultOptionType[]) => {
     const option = selectedOptions[selectedOptions.length - 1];
@@ -290,7 +312,8 @@ export function Input(props: VariableInputProps) {
       if (next[0] === ' ') {
         if (next[1]) {
           if (next[1] !== type) {
-            onChange(ConstantTypes[next[1]]?.default ?? null, optionPath);
+            // setPrevType(next[1]);
+            onChange(ConstantTypes[next[1]]?.default?.() ?? null, optionPath);
           }
         } else {
           if (variable) {
@@ -303,6 +326,15 @@ export function Input(props: VariableInputProps) {
     },
     [type, variable, onChange],
   );
+
+  const onClearVariable = useCallback(() => {
+    setIsFieldValue(Boolean(children));
+    if (constantOption?.children?.length) {
+      const v = constantOption.children[0].default();
+      return onChange(v);
+    }
+    onChange(null);
+  }, [constantOption]);
 
   useEffect(() => {
     const run = async () => {
@@ -401,10 +433,7 @@ export function Input(props: VariableInputProps) {
               className={cx('clear-button')}
               // eslint-disable-next-line react/no-unknown-property
               unselectable="on"
-              onClick={() => {
-                setIsFieldValue(Boolean(children));
-                onChange(null);
-              }}
+              onClick={onClearVariable}
             >
               <CloseCircleFilled />
             </span>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/condition.tsx
@@ -239,30 +239,36 @@ function CalculationGroup({ value, onChange }) {
   const { t } = useTranslation();
   const { type = 'and', calculations = [] } = value;
 
-  function onAddSingle() {
+  const onAddSingle = useCallback(() => {
     onChange({
       ...value,
       calculations: [...calculations, { not: false, calculator: 'equal' }],
     });
-  }
+  }, [value, calculations, onChange]);
 
-  function onAddGroup() {
+  const onAddGroup = useCallback(() => {
     onChange({
       ...value,
       calculations: [...calculations, { not: false, group: { type: 'and', calculations: [] } }],
     });
-  }
+  }, [value, calculations, onChange]);
 
-  function onRemove(i: number) {
-    calculations.splice(i, 1);
-    onChange({ ...value, calculations: [...calculations] });
-  }
+  const onRemove = useCallback(
+    (i: number) => {
+      calculations.splice(i, 1);
+      onChange({ ...value, calculations: [...calculations] });
+    },
+    [value, calculations, onChange],
+  );
 
-  function onItemChange(i: number, v) {
-    calculations.splice(i, 1, v);
+  const onItemChange = useCallback(
+    (i: number, v) => {
+      calculations.splice(i, 1, v);
 
-    onChange({ ...value, calculations: [...calculations] });
-  }
+      onChange({ ...value, calculations: [...calculations] });
+    },
+    [value, calculations, onChange],
+  );
 
   return (
     <div


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow not to use null option in `Variable.Input`.

### Description 

Add a `nullable` option for the component.

Example:

```diff
  <Variable.Input
    scope={yourScope}
+   nullable={false}
  />
```

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `nullable` option for `Variable.Input` component |
| 🇨🇳 Chinese | 为 `Variable.Input` 组件增加 `nullable` 的选项参数 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
