### PR TITLE
fix(defails): avoid infinite loop

### DIFF
--- a/packages/core/client/src/block-provider/DetailsBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/DetailsBlockProvider.tsx
@@ -142,7 +142,7 @@ export const useDetailsBlockProps = () => {
         .reset()
         .then(() => {
           ctx.form.setInitialValues(data || {});
-          ctx.form.setValues(data || {});
+          // Using `ctx.form.setValues(data || {});` here may cause an internal infinite loop in Formily
         })
         .catch(console.error);
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix bug.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
The issue occurs in the following two lines of code:
```ts
ctx.form.setInitialValues(data || {});
ctx.form.setValues(data || {});
```
Calling these two lines simultaneously may cause an internal infinite loop problem in Formily. The solution is to remove the second line: `ctx.form.setValues(data || {});`.

The reason for keeping `ctx.form.setInitialValues(data || {});` is that this part is mainly responsible for initializing the form values of the details block, so it's more appropriate to only set its initial values.
### Related issues
![image](https://github.com/user-attachments/assets/20b9c815-939d-4949-b8f2-d88c9d1bd3c0)

### Showcase
<!-- Including any screenshots of the changes. -->
None.
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the "Maximum call stack size exceeded" error that occurs in the details block    |
| 🇨🇳 Chinese |      修复在详情区块中出现的 “Maximum call stack size exceeded” 错误     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
