### PR TITLE
fix(mbm): issue of setting uid target key for m2m array field

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/belongs-to-array-field.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/belongs-to-array-field.ts
@@ -12,6 +12,7 @@ import { BaseColumnFieldOptions, BelongsToArrayAssociation, Model, RelationField
 export const elementTypeMap = {
   nanoid: 'string',
   sequence: 'string',
+  uid: 'string',
 };
 
 export class BelongsToArrayField extends RelationField {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

It occurred error "ARRAY is missing type definition for its values." when setting uid field as target key for a many to many (array) field.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

It should map `uid` field type to `string`.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error where setting a field of `uid` type as target key for a many to many (array) field |
| 🇨🇳 Chinese | 修复将 `uid` 类型的字段设置为多对多（数组）字段的目标键时出现的报错          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
