### PR TITLE
fix(mbm): fix the error when deleting a collection contains m2m array fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/hooks/before-destroy-foreign-key.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/hooks/before-destroy-foreign-key.ts
@@ -19,6 +19,9 @@ export function beforeDestroyForeignKey(db: Database) {
 
     const fieldKeys = [];
     const collection = db.getCollection(collectionName);
+    if (!collection) {
+      return;
+    }
 
     for (const [, field] of collection.fields) {
       const fieldKey = field.options?.key;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

It occurred error when deleting a collection contains many to many (array) fields.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

It should check if the collection exists when triggering `beforeDestoryForeignKey` hook of many to many (array) fields.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the error when deleting a collection contains m2m array fields          |
| 🇨🇳 Chinese | 修复删除包含多对多（数组）字段的数据表时出现的错误          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
