### PR TITLE
feat(plugin-workflow-request): add xml and text to content type select

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-request/src/client/RequestInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/client/RequestInstruction.tsx
@@ -15,6 +15,7 @@ import { ArrayItems } from '@formily/antd-v5';
 import {
   Instruction,
   WorkflowVariableJSON,
+  WorkflowVariableRawTextArea,
   WorkflowVariableTextArea,
   defaultFieldNames,
 } from '@nocobase/plugin-workflow/client';
@@ -91,6 +92,45 @@ const BodySchema = {
       },
     },
   },
+  'application/xml': {
+    type: 'void',
+    properties: {
+      data: {
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'WorkflowVariableRawTextArea',
+        'x-component-props': {
+          placeholder: '<?xml version="1.0" encoding="UTF-8"?>',
+          autoSize: {
+            minRows: 10,
+          },
+          className: css`
+            font-size: 80%;
+            font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+          `,
+        },
+      },
+    },
+  },
+  'text/plain': {
+    type: 'void',
+    properties: {
+      data: {
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'WorkflowVariableRawTextArea',
+        'x-component-props': {
+          autoSize: {
+            minRows: 10,
+          },
+          className: css`
+            font-size: 80%;
+            font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+          `,
+        },
+      },
+    },
+  },
 };
 
 function BodyComponent(props) {
@@ -158,6 +198,8 @@ export default class extends Instruction {
       enum: [
         { label: 'application/json', value: 'application/json' },
         { label: 'application/x-www-form-urlencoded', value: 'application/x-www-form-urlencoded' },
+        { label: 'application/xml', value: 'application/xml' },
+        { label: 'text/plain', value: 'text/plain' },
       ],
       default: 'application/json',
     },
@@ -316,8 +358,9 @@ export default class extends Instruction {
   components = {
     ArrayItems,
     BodyComponent,
-    WorkflowVariableTextArea,
     WorkflowVariableJSON,
+    WorkflowVariableTextArea,
+    WorkflowVariableRawTextArea,
   };
   useVariables({ key, title, config }, { types }) {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -52,6 +52,7 @@ async function request(config) {
 
   // TODO(feat): only support JSON type for now, should support others in future
   headers['Content-Type'] = contentType;
+  const transformer = ContentTypeTransformers[contentType];
 
   return axios.request({
     url: trim(url),
@@ -61,7 +62,7 @@ async function request(config) {
     timeout,
     ...(method.toLowerCase() !== 'get' && data != null
       ? {
-          data: ContentTypeTransformers[contentType](data),
+          data: transformer ? transformer(data) : data.toString(),
         }
       : {}),
   });


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

To support XML and plain text in request content-type.

### Description 

None.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add XML and text to `Content-Type` support list of request node. |
| 🇨🇳 Chinese | 对请求节点的 `Content-Type` 配置增加 XML 和简单文本类型支持。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
