### PR TITLE
fix: column width issue with scroll.y when table has no data

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -714,9 +714,9 @@ export const Table: any = withDynamicSchemaProps(
     const scroll = useMemo(() => {
       return {
         x: 'max-content',
-        y: tableHeight,
+        y: dataSource.length > 0 ? tableHeight : undefined,
       };
-    }, [tableHeight, maxContent]);
+    }, [tableHeight, maxContent, dataSource]);
 
     const rowClassName = useCallback(
       (record) => (selectedRow.includes(record[rowKey]) ? highlightRow : ''),
@@ -754,6 +754,9 @@ export const Table: any = withDynamicSchemaProps(
                   height: 100%;
                   display: flex;
                   flex-direction: column;
+                  .ant-table-expanded-row-fixed {
+                    min-height: ${tableHeight}px;
+                  }
                   .ant-table-body {
                     min-height: ${tableHeight}px;
                   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
before
![20240911172114](https://github.com/user-attachments/assets/c1b8454c-d938-4a3c-997a-2bb5911779a6)
after
![20240911172231](https://github.com/user-attachments/assets/62ce80b1-bc72-443e-be61-384b80bdcc3c)

<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      column width issue with scroll.y when table has no data     |
| 🇨🇳 Chinese |     表格没有数据时且设置了区块高度时无法设置列宽      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
