### PR TITLE
feat(client): numbers in tables are left-aligned

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -345,7 +345,7 @@ const cellClass = css`
   max-width: 300px;
   white-space: nowrap;
   .nb-read-pretty-input-number {
-    text-align: right;
+    text-align: left;
   }
   .ant-color-picker-trigger {
     position: absolute;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
![Xnip2024-09-13_10-47-53](https://github.com/user-attachments/assets/7ea96700-47b4-4f7f-b466-6215ca30eb3d)



### Description 
Now if there are numbers in the table, they will be displayed on the right. This display method is not in line with convention. I wonder if it is a special requirement? I changed it to left alignment. Maybe this setting can be exposed to users? If you have other plans, please close my PR.

### Related issues

### Showcase
![Xnip2024-09-13_10-48-23](https://github.com/user-attachments/assets/bdd0e055-f685-40b9-99cc-3a4fad57815e)



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Numbers in tables are left-aligned       |
| 🇨🇳 Chinese |     让表格中的数字左对齐      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
