### PR TITLE
fix: radio choose, close popup, refresh calendar

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/index.ts
+++ b/packages/core/client/src/schema-component/antd/page/index.ts
@@ -13,6 +13,6 @@ export * from './FixedBlockDesignerItem';
 export * from './Page';
 export * from './Page.Settings';
 export { PagePopups } from './PagePopups';
-export { storePopupContext } from './pagePopupUtils';
+export { storePopupContext, getStoredPopupContext } from './pagePopupUtils';
 export * from './PageTab.Settings';
 export { PopupSettingsProvider } from './PopupSettingsProvider';

--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calendar.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calendar.tsx
@@ -86,14 +86,15 @@ const useEvents = (dataSource: any, fieldNames: any, date: Date, view: (typeof W
        * 假设 10.1 号是星期六，我们需要将日程的开始时间调整为这一周的星期一，也就是 9.25 号
        * 而结束时间需要调整为 10.31 号这一周的星期日，也就是 10.5 号
        */
-      if (view === 'month') {
+      // week have same problem as month
+      if (view === 'month' || view === 'week') {
         startDate = startDate.startOf('week');
         endDate = endDate.endOf('week');
       }
 
       const push = (eventStart: Dayjs = start.clone()) => {
         // 必须在这个月的开始时间和结束时间，且在日程的开始时间之后
-        if (eventStart.isBefore(start)) {
+        if (eventStart.isBefore(start) || !eventStart.isBetween(startDate, endDate)) {
           return;
         }
 
@@ -107,7 +108,7 @@ const useEvents = (dataSource: any, fieldNames: any, date: Date, view: (typeof W
             return eventStart.isSame(d);
           }
         });
-        console.log(99);
+
         if (res) return out;
         const title = getLabelFormatValue(labelUiSchema, get(item, fieldNames.title), true);
         const event = {
@@ -216,7 +217,6 @@ export const Calendar: any = withDynamicSchemaProps(
         noEventsInRange: i18nt('None'),
         showMore: (count) => i18nt('{{count}} more items', { count }),
       };
-      console.log(events, dataSource, fieldNames, date, view);
       return wrapSSR(
         <div className={`${hashId} ${containerClassName}`} style={{ height: height || 700 }}>
           <PopupContextProvider visible={visible} setVisible={setVisible}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [&check;] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
日历中删除日程不正常

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
修复日程删除问题：
1. 删除确认中，【此日程】和【此日程及后续日程】2个选项无法点选；
（点选后，看起来没有选中，实际是有效的，提交的数据也永远是当前时间）
2. 删除日程后，popup不会自动关闭
3. 删除日程后，日历上的日程不更新

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 修复日历中删除日程时，日程选项无法点选，删除后日历不更新的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [&check;] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
