### PR TITLE
fix(evaluators): fix mathjs matrix output type

### DIFF
--- a/packages/core/evaluators/src/utils/__tests__/mathjs.test.ts
+++ b/packages/core/evaluators/src/utils/__tests__/mathjs.test.ts
@@ -1,0 +1,16 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import mathjs from '../mathjs';
+
+describe('evaluators > mathjs', () => {
+  it('matrix type should be to array', () => {
+    expect(mathjs('range(1, 3, 1)')).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/evaluators/src/utils/mathjs.ts
+++ b/packages/core/evaluators/src/utils/mathjs.ts
@@ -20,6 +20,9 @@ export default evaluate.bind(
       }
       return math.round(result, 9);
     }
+    if (result instanceof math.Matrix) {
+      return result.toArray();
+    }
     return result;
   },
   { replaceKey: true },


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix error caused by `Matrix` type from mathjs.

### Description

Transform any `Matrix` output to common `Array`.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix error caused by `Matrix` type from mathjs |
| 🇨🇳 Chinese | 修复 Math.js 计算输出矩阵类型导致的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
