### PR TITLE
fix:  issue with recordPicker rowSelection 

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/uuid.ts
+++ b/packages/core/client/src/collection-manager/interfaces/uuid.ts
@@ -26,7 +26,7 @@ export class UUIDFieldInterface extends CollectionFieldInterface {
       'x-validator': 'uuid',
     },
   };
-  availableTypes = ['string', 'uid', 'uuid'];
+  availableTypes = ['string', 'uuid'];
   properties = {
     'uiSchema.title': {
       type: 'string',

--- a/packages/core/client/src/schema-component/antd/association-field/InternalPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalPicker.tsx
@@ -51,9 +51,6 @@ export const useTableSelectorProps = () => {
     rowKey,
     rowSelection: {
       type: multiple ? 'checkbox' : 'radio',
-      selectedRowKeys: rcSelectRows
-        ?.filter((item) => options.every((row) => row[rowKey] !== item[rowKey]))
-        .map((item) => item[rowKey]?.toString()),
     },
     onRowSelectionChange(selectedRowKeys, selectedRows) {
       if (multiple) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Selecting options with the data record selector has no effect on multi association fields     |
| 🇨🇳 Chinese |     对多关系字段使用数据选择器勾选无效果      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
