### PR TITLE
fix(Table): prevent empty lines at the beginning

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -145,8 +145,8 @@ const useTableColumns = (props: { showDel?: boolean; isSubTable?: boolean }) => 
               </SubFormProvider>
             );
           },
-          onCell: (record, index) => {
-            return { record, schema: s, index };
+          onCell: (record, rowIndex) => {
+            return { record, schema: s, rowIndex };
           },
         } as TableColumnProps<any>;
       }),
@@ -578,7 +578,7 @@ export const Table: any = withDynamicSchemaProps(
     const BodyCellComponent = useCallback(
       (props) => {
         const isIndex = props.className?.includes('selection-column');
-        const { record, schema, index } = props;
+        const { record, schema, rowIndex } = props;
         const { ref, inView } = useInView({
           threshold: 0,
           triggerOnce: true,
@@ -588,7 +588,8 @@ export const Table: any = withDynamicSchemaProps(
         const { valueMap } = useSatisfiedActionValues({ formValues: record, category: 'style', schema });
         const style = useMemo(() => Object.assign({ ...props.style }, valueMap), [props.style, valueMap]);
 
-        if (index < 20) {
+        // fix the problem of blank rows at the beginning of a table block
+        if (rowIndex < 20) {
           return (
             <td {...props} className={classNames(props.className, cellClass)} style={style}>
               {props.children}

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -145,8 +145,8 @@ const useTableColumns = (props: { showDel?: boolean; isSubTable?: boolean }) => 
               </SubFormProvider>
             );
           },
-          onCell: (record) => {
-            return { record, schema: s };
+          onCell: (record, index) => {
+            return { record, schema: s, index };
           },
         } as TableColumnProps<any>;
       }),
@@ -578,15 +578,23 @@ export const Table: any = withDynamicSchemaProps(
     const BodyCellComponent = useCallback(
       (props) => {
         const isIndex = props.className?.includes('selection-column');
-        const { record, schema } = props;
+        const { record, schema, index } = props;
         const { ref, inView } = useInView({
           threshold: 0,
           triggerOnce: true,
-          initialInView: isIndex || !!process.env.__E2E__ || dataSource.length <= 10,
+          initialInView: isIndex || !!process.env.__E2E__,
           skip: isIndex || !!process.env.__E2E__,
         });
         const { valueMap } = useSatisfiedActionValues({ formValues: record, category: 'style', schema });
         const style = useMemo(() => Object.assign({ ...props.style }, valueMap), [props.style, valueMap]);
+
+        if (index < 20) {
+          return (
+            <td {...props} className={classNames(props.className, cellClass)} style={style}>
+              {props.children}
+            </td>
+          );
+        }
 
         return (
           <td {...props} ref={ref} className={classNames(props.className, cellClass)} style={style}>
@@ -595,7 +603,7 @@ export const Table: any = withDynamicSchemaProps(
           </td>
         );
       },
-      [dataSource.length, others.isSubTable],
+      [others.isSubTable],
     );
 
     const components = useMemo(() => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
This problem is caused by the table cell using lazy rendering. The solution is to not use lazy rendering for the first 20 rows of the table. Beginning with row 21, use lazy rendering.
### Related issues
For each line, a blank space will be displayed first, followed by the content:

![20240918130122_rec_](https://github.com/user-attachments/assets/b2dac38b-ec5c-4415-9c57-d8f40d5aadfb)

### Showcase
<!-- Including any screenshots of the changes. -->
After the fix:

![20240918131158_rec_](https://github.com/user-attachments/assets/9e6f649c-3ead-4b79-9d6c-e01a7bab9dc0)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the problem of blank rows at the beginning of a table block     |
| 🇨🇳 Chinese |     修复表格区块在一开始出现空白行的问题      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
