### PR TITLE
fix: missing rowkey in actions permissions table

### DIFF
--- a/packages/core/client/src/acl/Configuration/StrategyActions.tsx
+++ b/packages/core/client/src/acl/Configuration/StrategyActions.tsx
@@ -54,6 +54,7 @@ export const StrategyActions = connect((props) => {
       <Table
         size={'small'}
         pagination={false}
+        rowKey={'name'}
         columns={[
           {
             dataIndex: 'displayName',

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/PermissionManager/StrategyActions.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/PermissionManager/StrategyActions.tsx
@@ -54,6 +54,7 @@ export const StrategyActions = connect((props) => {
       <Table
         size={'small'}
         pagination={false}
+        rowKey={'name'}
         columns={[
           {
             dataIndex: 'displayName',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Before the fix:
![image](https://github.com/user-attachments/assets/09ce3edc-6542-4ca4-b3c1-b8658bdad324)


### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix incorrect `rowKey` of the `General action permissions table` in Users & Permissions page|
| 🇨🇳 Chinese |修复用户和权限设置页面中`通用操作权限表格`的`rowKey`不正确问题|

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
