### PR TITLE
feat(next-plugin-calendar): support for configuring the background co…

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/__e2e__/eventsBackgroundColor.test.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/__e2e__/eventsBackgroundColor.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { expect, test } from '@nocobase/test/e2e';
+import { backgroundColorFieldBasic } from './templates';
+
+test.describe('Background color field', () => {
+  test('basic', async ({ mockPage, mockRecords, page }) => {
+    const nocoPage = await mockPage(backgroundColorFieldBasic).waitForInit();
+    await mockRecords('calendar', 3);
+    await nocoPage.goto();
+
+    // 1. The default option is Not selected
+    await page.getByLabel('block-item-CardItem-calendar-').hover();
+    await page.getByLabel('designer-schema-settings-CardItem-blockSettings:calendar-calendar').hover();
+    await page.getByRole('menuitem', { name: 'Background color field Not selected' }).click();
+
+    // 2. Switch to the single select option
+    await page.getByRole('option', { name: 'Single select' }).click();
+    await expect(page.getByRole('menuitem', { name: 'Background color field Single select' })).toBeVisible();
+    await page.mouse.move(-300, 0);
+
+    // 3. Switch to the radio group option
+    await page.getByLabel('block-item-CardItem-calendar-').hover();
+    await page.getByLabel('designer-schema-settings-CardItem-blockSettings:calendar-calendar').hover();
+    await page.getByRole('menuitem', { name: 'Background color field Single select' }).click();
+    await page.getByRole('option', { name: 'Radio group' }).click();
+    await expect(page.getByRole('menuitem', { name: 'Background color field Radio group' })).toBeVisible();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-calendar/src/client/__e2e__/templates.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/__e2e__/templates.ts
@@ -245,3 +245,247 @@ export const oneTableWithCalendarCollection: PageConfig = {
     'x-index': 1,
   },
 };
+export const backgroundColorFieldBasic = {
+  collections: [
+    {
+      name: 'calendar',
+      fields: [
+        {
+          name: 'singleText',
+          interface: 'input',
+        },
+        {
+          interface: 'select',
+          uiSchema: {
+            title: 'Single select',
+            type: 'string',
+            'x-component': 'Select',
+            enum: [
+              {
+                value: 'b1s9wbnb1of',
+                label: 'red',
+                color: 'red',
+              },
+              {
+                value: 'zkkpor6acnk',
+                label: 'green',
+                color: 'green',
+              },
+              {
+                value: '5nj53k4nxjg',
+                label: 'blue',
+                color: 'blue',
+              },
+            ],
+          },
+        },
+        {
+          interface: 'radioGroup',
+          uiSchema: {
+            enum: [
+              {
+                value: 'l28f7llee0h',
+                label: 'gold',
+                color: 'gold',
+              },
+              {
+                value: 'w80pdvckqga',
+                label: 'lime',
+                color: 'lime',
+              },
+              {
+                value: 'bq4i930gql2',
+                label: 'cyan',
+                color: 'cyan',
+              },
+            ],
+            type: 'string',
+            'x-component': 'Radio.Group',
+            title: 'Radio group',
+          },
+        },
+      ],
+    },
+  ],
+  pageSchema: {
+    _isJSONSchemaObject: true,
+    version: '2.0',
+    type: 'void',
+    'x-component': 'Page',
+    properties: {
+      hsu2v4rjr50: {
+        _isJSONSchemaObject: true,
+        version: '2.0',
+        type: 'void',
+        'x-component': 'Grid',
+        'x-initializer': 'page:addBlock',
+        properties: {
+          '7394n0636cb': {
+            _isJSONSchemaObject: true,
+            version: '2.0',
+            type: 'void',
+            'x-component': 'Grid.Row',
+            'x-app-version': '1.3.22-beta',
+            properties: {
+              oz0q63vbxy2: {
+                _isJSONSchemaObject: true,
+                version: '2.0',
+                type: 'void',
+                'x-component': 'Grid.Col',
+                'x-app-version': '1.3.22-beta',
+                properties: {
+                  pktfhea4eub: {
+                    _isJSONSchemaObject: true,
+                    version: '2.0',
+                    type: 'void',
+                    'x-acl-action': 'calendar:list',
+                    'x-decorator': 'CalendarBlockProvider',
+                    'x-use-decorator-props': 'useCalendarBlockDecoratorProps',
+                    'x-decorator-props': {
+                      collection: 'calendar',
+                      dataSource: 'main',
+                      action: 'list',
+                      fieldNames: {
+                        id: 'id',
+                        start: 'createdAt',
+                        title: 'singleText',
+                        end: ['updatedAt'],
+                      },
+                      params: {
+                        paginate: false,
+                      },
+                    },
+                    'x-toolbar': 'BlockSchemaToolbar',
+                    'x-settings': 'blockSettings:calendar',
+                    'x-component': 'CardItem',
+                    'x-app-version': '1.3.22-beta',
+                    properties: {
+                      '3byzt7u4wnz': {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'void',
+                        'x-component': 'CalendarV2',
+                        'x-use-component-props': 'useCalendarBlockProps',
+                        'x-app-version': '1.3.22-beta',
+                        properties: {
+                          toolBar: {
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            'x-component': 'CalendarV2.ActionBar',
+                            'x-component-props': {
+                              style: {
+                                marginBottom: 24,
+                              },
+                            },
+                            'x-initializer': 'calendar:configureActions',
+                            'x-app-version': '1.3.22-beta',
+                            'x-uid': 'v8411egfjtm',
+                            'x-async': false,
+                            'x-index': 1,
+                          },
+                          event: {
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            'x-component': 'CalendarV2.Event',
+                            'x-app-version': '1.3.22-beta',
+                            properties: {
+                              drawer: {
+                                _isJSONSchemaObject: true,
+                                version: '2.0',
+                                type: 'void',
+                                'x-component': 'Action.Container',
+                                'x-component-props': {
+                                  className: 'nb-action-popup',
+                                },
+                                title: "{{t('View record', { ns: 'calendar' })}}",
+                                'x-app-version': '1.3.22-beta',
+                                properties: {
+                                  tabs: {
+                                    _isJSONSchemaObject: true,
+                                    version: '2.0',
+                                    type: 'void',
+                                    'x-component': 'Tabs',
+                                    'x-component-props': {},
+                                    'x-initializer': 'popup:addTab',
+                                    'x-initializer-props': {
+                                      gridInitializer: 'popup:common:addBlock',
+                                    },
+                                    'x-app-version': '1.3.22-beta',
+                                    properties: {
+                                      tab1: {
+                                        _isJSONSchemaObject: true,
+                                        version: '2.0',
+                                        type: 'void',
+                                        title: "{{t('Details', { ns: 'calendar' })}}",
+                                        'x-component': 'Tabs.TabPane',
+                                        'x-designer': 'Tabs.Designer',
+                                        'x-component-props': {},
+                                        'x-app-version': '1.3.22-beta',
+                                        properties: {
+                                          grid: {
+                                            _isJSONSchemaObject: true,
+                                            version: '2.0',
+                                            type: 'void',
+                                            'x-component': 'Grid',
+                                            'x-initializer-props': {
+                                              actionInitializers: 'details:configureActions',
+                                            },
+                                            'x-initializer': 'popup:common:addBlock',
+                                            'x-app-version': '1.3.22-beta',
+                                            'x-uid': 'f58sh31pm0e',
+                                            'x-async': false,
+                                            'x-index': 1,
+                                          },
+                                        },
+                                        'x-uid': 'akuiknd4af2',
+                                        'x-async': false,
+                                        'x-index': 1,
+                                      },
+                                    },
+                                    'x-uid': 'k7r14sqqjfx',
+                                    'x-async': false,
+                                    'x-index': 1,
+                                  },
+                                },
+                                'x-uid': 'rhqf8zhc1vc',
+                                'x-async': false,
+                                'x-index': 1,
+                              },
+                            },
+                            'x-uid': 'nvx5lwhpcl6',
+                            'x-async': false,
+                            'x-index': 2,
+                          },
+                        },
+                        'x-uid': '7km5lr1a7uc',
+                        'x-async': false,
+                        'x-index': 1,
+                      },
+                    },
+                    'x-uid': '5grvnpumvhd',
+                    'x-async': false,
+                    'x-index': 1,
+                  },
+                },
+                'x-uid': '723oca1vx1l',
+                'x-async': false,
+                'x-index': 1,
+              },
+            },
+            'x-uid': 'mogc1df80uh',
+            'x-async': false,
+            'x-index': 1,
+          },
+        },
+        'x-uid': 'lzuv4wavilz',
+        'x-async': false,
+        'x-index': 1,
+      },
+    },
+    'x-uid': 'wg0v4pihpus',
+    'x-async': true,
+    'x-index': 1,
+  },
+};

--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calender.Settings.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calender.Settings.tsx
@@ -100,6 +100,45 @@ export const calendarBlockSettings = new SchemaSettings({
       },
     },
     {
+      name: 'colorField',
+      Component: SchemaSettingsSelectItem,
+      useComponentProps() {
+        const { t } = useTranslation();
+        const fieldSchema = useFieldSchema();
+        const fieldNames = fieldSchema?.['x-decorator-props']?.['fieldNames'] || {};
+        const { service } = useCalendarBlockContext();
+        const { getCollectionFieldsOptions } = useCollectionManager_deprecated();
+        const { name } = useCollection();
+        const field = useField();
+        const { dn } = useDesignable();
+        const fliedList = getCollectionFieldsOptions(name, 'string');
+        const filteredItems = [
+          { label: t('Not selected'), value: '' },
+          ...fliedList.filter((item) => item.interface === 'radioGroup' || item.interface === 'select'),
+        ];
+
+        return {
+          title: t('Background color field'),
+          value: fieldNames.colorFieldName || '',
+          options: filteredItems,
+          onChange: (colorFieldName: string) => {
+            const fieldNames = fieldSchema['x-decorator-props']?.fieldNames || {};
+            fieldNames.colorFieldName = colorFieldName;
+            field.decoratorProps.fieldNames = fieldNames;
+            fieldSchema['x-decorator-props'].fieldNames = fieldNames;
+            service.refresh();
+            dn.emit('patch', {
+              schema: {
+                ['x-uid']: fieldSchema['x-uid'],
+                'x-decorator-props': fieldSchema['x-decorator-props'],
+              },
+            });
+            dn.refresh();
+          },
+        };
+      },
+    },
+    {
       name: 'showLunar',
       Component: ShowLunarDesignerItem,
     },
@@ -153,7 +192,7 @@ export const calendarBlockSettings = new SchemaSettings({
         return {
           title: t('End date field'),
           value: fieldNames.end,
-          options: getCollectionFieldsOptions(name, ['date', 'datetime', 'dateOnly', 'datetimeNoTz'], {
+          options: getCollectionFieldsOptions(name, 'date', {
             association: ['o2o', 'obo', 'oho', 'm2o'],
           }),
           onChange: (end) => {

--- a/packages/plugins/@nocobase/plugin-calendar/src/client/schema-initializer/items/CalendarBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/schema-initializer/items/CalendarBlockInitializer.tsx
@@ -70,7 +70,7 @@ export const useCreateCalendarBlock = () => {
 
   const createCalendarBlock = async ({ item }) => {
     const stringFieldsOptions = getCollectionFieldsOptions(item.name, 'string', { dataSource: item.dataSource });
-    const dateFieldsOptions = getCollectionFieldsOptions(item.name, ['date', 'datetime', 'dateOnly', 'datetimeNoTz'], {
+    const dateFieldsOptions = getCollectionFieldsOptions(item.name, 'date', {
       association: ['o2o', 'obo', 'oho', 'm2o'],
       dataSource: item.dataSource,
     });

--- a/packages/plugins/@nocobase/plugin-calendar/src/locale/en_US.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/locale/en_US.ts
@@ -7,6 +7,15 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 export default {
   "Configure calendar": "Configure calendar",
   "Title field": "Title field",
@@ -50,5 +59,7 @@ export default {
   "Weekly": "Weekly",
   "Monthly": "Monthly",
   "Yearly": "Yearly",
-  "Repeats": "Repeats"
+  "Repeats": "Repeats",
+  "Background color field": "Background color field",
+  "Not selected": "Not selected",
 };

--- a/packages/plugins/@nocobase/plugin-calendar/src/locale/es_ES.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/locale/es_ES.ts
@@ -7,6 +7,15 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 export default {
   "Configure calendar": "Configurar calendario",
   "Title field": "Campo de título",
@@ -50,5 +59,7 @@ export default {
   "Weekly": "Semanal",
   "Monthly": "Mensual",
   "Yearly": "Anual",
-  "Repeats": "se repite"
+  "Repeats": "se repite",
+  "Background color field": "Campo de color de fondo",
+  "Not selected": "No seleccionado",
 };

--- a/packages/plugins/@nocobase/plugin-calendar/src/locale/zh-CN.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/locale/zh-CN.ts
@@ -7,6 +7,15 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 export default {
   'Configure calendar': '配置日历',
   'Title field': '标题字段',
@@ -52,4 +61,6 @@ export default {
   Monthly: '每月',
   Yearly: '每年',
   Repeats: '重复',
+  'Background color field': '背景颜色字段',
+  'Not selected': '未选择',
 };


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Showcase
<!-- Including any screenshots of the changes. -->
![20240914192017_rec_](https://nocobase-docs.oss-cn-beijing.aliyuncs.com/20240914192017_rec_.gif)
### Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support for configuring the background color of calendar events |
| 🇨🇳 Chinese | 支持配置日历事件的背景颜色 |
### Docs
| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  [Title](https://github.com/nocobase/docs/pull/161)    |
| 🇨🇳 Chinese |  [合并之后更改](https://github.com/nocobase/docs/pull/161)  |
### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary