### PR TITLE
fix: during export action, fields from referenced tables are not rendered by field interface

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-export/src/server/xlsx-exporter.ts
+++ b/packages/plugins/@nocobase/plugin-action-export/src/server/xlsx-exporter.ts
@@ -152,7 +152,7 @@ class XlsxExporter {
     if (dataIndex.length > 1) {
       let targetCollection: ICollection;
 
-      for (let i = 0; i < dataIndex.length - 1; i++) {
+      for (let i = 0; i < dataIndex.length; i++) {
         const isLast = i === dataIndex.length - 1;
 
         if (isLast) {
@@ -185,42 +185,32 @@ class XlsxExporter {
     return value;
   }
 
+  private getFieldRenderer(field?: IField, ctx?): (value) => any {
+    const InterfaceClass = this.options.collectionManager.getFieldInterface(field?.options?.interface);
+    if (!InterfaceClass) {
+      return this.renderRawValue;
+    }
+    const fieldInternface = new InterfaceClass(field?.options);
+    return (value) => fieldInternface.toString(value, ctx);
+  }
+
   private renderCellValue(rowData: IModel, column: ExportColumn, ctx?) {
     const { dataIndex } = column;
     rowData = rowData.toJSON();
     const value = rowData[dataIndex[0]];
+    const field = this.findFieldByDataIndex(dataIndex);
+    const render = this.getFieldRenderer(field, ctx);
 
     if (dataIndex.length > 1) {
       const deepValue = deepGet(rowData, dataIndex);
 
       if (Array.isArray(deepValue)) {
-        return deepValue.join(',');
+        return deepValue.map(render).join(',');
       }
 
-      return deepValue;
+      return render(deepValue);
     }
-
-    const field = this.findFieldByDataIndex(dataIndex);
-
-    if (!field) {
-      return this.renderRawValue(value);
-    }
-
-    const fieldOptions = field.options;
-    const interfaceName = fieldOptions['interface'];
-
-    if (!interfaceName) {
-      return this.renderRawValue(value);
-    }
-
-    const InterfaceClass = this.options.collectionManager.getFieldInterface(interfaceName);
-
-    if (!InterfaceClass) {
-      return this.renderRawValue(value);
-    }
-
-    const interfaceInstance = new InterfaceClass(fieldOptions);
-    return interfaceInstance.toString(value, ctx);
+    return render(value);
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
I would like to add some extral logic when rendering cell in export action. But this can't be done for the fields in the referenced table due to this bug.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix fields from assicated tables are not processed by the field interface|
| 🇨🇳 Chinese |修复导出操作时，关联表中的字段未执行interface渲染逻辑|

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
