### PR TITLE
fix(plugin-workflow): fix non-existed field in collection trigger causes error

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -59,9 +59,10 @@ async function handler(this: CollectionTrigger, workflow: WorkflowModel, data: M
     changed &&
     changed.length &&
     changed
-      .filter(
-        (name) => !['linkTo', 'hasOne', 'hasMany', 'belongsToMany'].includes(collection.getField(name).options.type),
-      )
+      .filter((name) => {
+        const field = collection.getField(name);
+        return field && !['linkTo', 'hasOne', 'hasMany', 'belongsToMany'].includes(field.options.type);
+      })
       .every((name) => !data.changedWithAssociations(getFieldRawName(collection, name)))
   ) {
     return;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Some field deleted but configured in workflow changed fields before, will cause error when triggering.

### Description 

1. Add collection workflow which triggers on record update.
2. Add a field to changed fields.
3. Remove the field from collection configuration.
4. Trigger the workflow.

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix non-existed field in collection trigger causes error |
| 🇨🇳 Chinese | 修复数据表事件中发生改变的字段被删除后报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
