### PR TITLE
fix(plugin-workflow): track error when instruction not exist

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -206,6 +206,9 @@ export default class Processor {
   public async run(node, input?) {
     const { instructions } = this.options.plugin;
     const instruction = instructions.get(node.type);
+    if (!instruction) {
+      return Promise.reject(new Error(`instruction [${node.type}] not found for node (#${node.id})`));
+    }
     if (typeof instruction.run !== 'function') {
       return Promise.reject(new Error('`run` should be implemented for customized execution of the node'));
     }
@@ -232,6 +235,9 @@ export default class Processor {
   private async recall(node, job) {
     const { instructions } = this.options.plugin;
     const instruction = instructions.get(node.type);
+    if (!instruction) {
+      return Promise.reject(new Error(`instruction [${node.type}] not found for node (#${node.id})`));
+    }
     if (typeof instruction.resume !== 'function') {
       return Promise.reject(
         new Error(`"resume" method should be implemented for [${node.type}] instruction of node (#${node.id})`),


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

When processing node type not registered to workflow, there will be error. Need to track this error.

### Description 

```
{"level":"error","message":"execution (945) error: Cannot read properties of undefined (reading 'run') Cannot read properties of undefined (reading 'run')","stack":"TypeError: Cannot read properties of undefined (reading 'run')
    at Processor.run (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Processor.js:195:28)
    at Processor.exec (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Processor.js:188:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Processor.start (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Processor.js:136:7)
    at async PluginWorkflowServer.process (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Plugin.js:508:7)
    at async /app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Plugin.js:489:11","timestamp":"2024-09-25 08:30:00"}
```

### Related issues

None.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add error handling for unregistered node type |
| 🇨🇳 Chinese | 增加对未注册的节点类型导致错误的跟踪报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
