### PR TITLE
fix:  missing afterSuccess configuration for the submit action

### DIFF
--- a/packages/core/client/src/modules/actions/save-record/customizeSaveRecordActionSettings.tsx
+++ b/packages/core/client/src/modules/actions/save-record/customizeSaveRecordActionSettings.tsx
@@ -52,10 +52,6 @@ export const customizeSaveRecordActionSettings = new SchemaSettings({
     {
       name: 'afterSuccessfulSubmission',
       Component: AfterSuccess,
-      useVisible() {
-        const fieldSchema = useFieldSchema();
-        return isValid(fieldSchema?.['x-action-settings']?.onSuccess);
-      },
     },
     {
       name: 'bindWorkflow',

--- a/packages/core/client/src/modules/actions/submit/createSubmitActionSettings.tsx
+++ b/packages/core/client/src/modules/actions/submit/createSubmitActionSettings.tsx
@@ -175,10 +175,6 @@ export const createSubmitActionSettings = new SchemaSettings({
     {
       name: 'afterSuccessfulSubmission',
       Component: AfterSuccess,
-      useVisible() {
-        const fieldSchema = useFieldSchema();
-        return isValid(fieldSchema?.['x-action-settings']?.onSuccess);
-      },
     },
     {
       name: 'refreshDataBlockRequest',

--- a/packages/core/client/src/modules/actions/submit/updateSubmitActionSettings.tsx
+++ b/packages/core/client/src/modules/actions/submit/updateSubmitActionSettings.tsx
@@ -71,10 +71,6 @@ export const updateSubmitActionSettings = new SchemaSettings({
     {
       name: 'afterSuccessfulSubmission',
       Component: AfterSuccess,
-      useVisible() {
-        const fieldSchema = useFieldSchema();
-        return isValid(fieldSchema?.['x-action-settings']?.onSuccess);
-      },
     },
     {
       name: 'refreshDataBlockRequest',

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/BulkUpdateAction.Settings.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/BulkUpdateAction.Settings.tsx
@@ -144,10 +144,6 @@ const schemaSettingsItems: SchemaSettingsItemType[] = [
   {
     name: 'afterSuccess',
     Component: AfterSuccess,
-    useVisible() {
-      const fieldSchema = useFieldSchema();
-      return isValid(fieldSchema?.['x-action-settings']?.onSuccess);
-    },
   },
   {
     name: 'refreshDataBlockRequest',

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/settings/customizeSubmitToWorkflowActionSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/settings/customizeSubmitToWorkflowActionSettings.tsx
@@ -47,10 +47,6 @@ export const customizeSubmitToWorkflowActionSettings = new SchemaSettings({
     {
       name: 'afterSuccessfulSubmission',
       Component: AfterSuccess,
-      useVisible() {
-        const fieldSchema = useFieldSchema();
-        return isValid(fieldSchema?.['x-action-settings']?.onSuccess);
-      },
     },
     {
       name: 'bindWorkflow',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix missing afterSuccess configuration for the submit action     |
| 🇨🇳 Chinese |    提交按钮缺少“提交成功后”的配置项       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
