### PR TITLE
fix(mobile): correct z-index

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/mobile/Mobile.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/mobile/Mobile.tsx
@@ -102,7 +102,7 @@ export const Mobile = () => {
                   <ResetSchemaOptionsProvider>
                     <AssociationFieldModeProvider modeToComponent={modeToComponent}>
                       {/* the z-index of all popups and subpages will be based on this value */}
-                      <BasicZIndexProvider basicZIndex={1000}>
+                      <BasicZIndexProvider basicZIndex={800}>
                         <MobileRouter />
                       </BasicZIndexProvider>
                     </AssociationFieldModeProvider>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the problem that the Add Block menu cannot be displayed after opening a subpage with more than 3 levels on the mobile     |
| 🇨🇳 Chinese |     修复在移动端中，打开 3 层以上子页面后，无法显示添加区块菜单的问题      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
