### PR TITLE
fix(variable): fix the issue of inherited table fields not being able…

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-item/hooks/useParseDefaultValue.ts
+++ b/packages/core/client/src/schema-component/antd/form-item/hooks/useParseDefaultValue.ts
@@ -16,8 +16,10 @@ import { useCallback, useEffect } from 'react';
 import { useRecordIndex } from '../../../../../src/record-provider';
 import { useOperators } from '../../../../block-provider/CollectOperators';
 import { useFormBlockContext } from '../../../../block-provider/FormBlockProvider';
-import { useCollection_deprecated } from '../../../../collection-manager';
+import { InheritanceCollectionMixin, useCollection_deprecated } from '../../../../collection-manager';
 import { useCollectionRecord } from '../../../../data-source/collection-record/CollectionRecordProvider';
+import { DataSourceManager } from '../../../../data-source/data-source/DataSourceManager';
+import { useDataSourceManager } from '../../../../data-source/data-source/DataSourceManagerProvider';
 import { useFlag } from '../../../../flag-provider';
 import { DEBOUNCE_WAIT, useLocalVariables, useVariables } from '../../../../variables';
 import { getPath } from '../../../../variables/utils/getPath';
@@ -43,6 +45,7 @@ const useParseDefaultValue = () => {
   const index = useRecordIndex();
   const { type, form } = useFormBlockContext();
   const { getOperator } = useOperators();
+  const dm = useDataSourceManager();
 
   /**
    * name: 如 $user
@@ -97,16 +100,25 @@ const useParseDefaultValue = () => {
           }
         }
 
-        const { value: parsedValue, collectionName: collectionNameOfVariable } = await variables.parseVariable(
-          fieldSchema.default,
-          localVariables,
-          {
-            fieldOperator: getOperator(fieldSchema.name),
-          },
-        );
+        const {
+          value: parsedValue,
+          collectionName: collectionNameOfVariable,
+          dataSource = 'main',
+        } = await variables.parseVariable(fieldSchema.default, localVariables, {
+          fieldOperator: getOperator(fieldSchema.name),
+        });
 
         // fix https://tasks.aliyun.nocobase.com/admin/ugmnj2ycfgg/popups/1qlw5c38t3b/puid/dz42x7ffr7i/filterbytk/199
-        if (collectionField.target && collectionField.target !== collectionNameOfVariable) {
+        if (
+          collectionField.target &&
+          collectionField.target !== collectionNameOfVariable &&
+          !isInherit({
+            collectionName: collectionField.target,
+            targetCollectionName: collectionNameOfVariable,
+            dm,
+            dataSource,
+          })
+        ) {
           field.loading = false;
           return;
         }
@@ -179,7 +191,30 @@ const useParseDefaultValue = () => {
       // 解决子表格（或子表单）中新增一行数据时，默认值不生效的问题
       field.setValue(fieldSchema.default);
     }
-  }, [fieldSchema.default, localVariables, type, getOperator]);
+  }, [fieldSchema.default, localVariables, type, getOperator, dm]);
 };
 
 export default useParseDefaultValue;
+
+/**
+ * Determine if there is an inheritance relationship between two data tables
+ * @param param0
+ * @returns
+ */
+const isInherit = ({
+  collectionName,
+  targetCollectionName,
+  dm,
+  dataSource,
+}: {
+  collectionName: string;
+  targetCollectionName: string;
+  dm: DataSourceManager;
+  dataSource: string;
+}) => {
+  const cm = dm?.getDataSource(dataSource)?.collectionManager;
+  return cm
+    ?.getCollection<InheritanceCollectionMixin>(collectionName)
+    ?.getAllCollectionsInheritChain()
+    ?.includes(targetCollectionName);
+};


### PR DESCRIPTION
… to use variables normally

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue where inherited collection association fields cannot properly use variables     |
| 🇨🇳 Chinese |     修复继承表关系字段无法正常使用变量的问题      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
