### PR TITLE
refactor(client): add attachment file type registry

### DIFF
--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -800,6 +800,7 @@
   "Try again": "重试一下",
   "Download logs": "下载日志",
   "Download": "下载",
+  "File type is not supported for previewing, please download it to preview.": "不支持预览该文件类型，请下载后查看。",
   "Click or drag file to this area to upload": "点击或拖拽文件到此区域上传",
   "Support for a single or bulk upload.": "支持单个或批量上传",
   "File size should not exceed {{size}}.": "文件大小不能超过 {{size}}",

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -313,7 +313,7 @@ export function AttachmentList(props) {
         setPreview(index);
       } else {
         if (file.id) {
-          saveAs(file.url, `${file.title}${file.extname}`);
+          window.open(file.url);
         }
       }
     },

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -200,7 +200,7 @@ function useSizeHint(size: number) {
 
 function DefaultThumbnailPreviewer({ file }) {
   const { componentCls: prefixCls } = useStyles();
-  const { getThumbnailURL = getThumbnailPlaceholderURL } = attachmentFileTypes.getTypeByFile(file);
+  const { getThumbnailURL = getThumbnailPlaceholderURL } = attachmentFileTypes.getTypeByFile(file) ?? {};
   const imageUrl = getThumbnailURL(file);
   return <img src={imageUrl} alt={file.title} className={`${prefixCls}-list-item-image`} />;
 }
@@ -224,7 +224,7 @@ function AttachmentListItem(props) {
     saveAs(file.url, `${file.title}${file.extname}`);
   }, [file]);
 
-  const { ThumbnailPreviewer = DefaultThumbnailPreviewer } = attachmentFileTypes.getTypeByFile(file);
+  const { ThumbnailPreviewer = DefaultThumbnailPreviewer } = attachmentFileTypes.getTypeByFile(file) ?? {};
 
   const item = [
     <span key="thumbnail" className={`${prefixCls}-list-item-thumbnail`}>
@@ -287,7 +287,7 @@ function Previewer({ index, onSwitchIndex, list }) {
     return null;
   }
   const file = list[index];
-  const { Previewer: Component } = attachmentFileTypes.getTypeByFile(file);
+  const { Previewer: Component } = attachmentFileTypes.getTypeByFile(file) ?? {};
   if (!Component) {
     return null;
   }

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -18,13 +18,14 @@ import filesize from 'filesize';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import LightBox from 'react-image-lightbox';
+import match from 'mime-match';
 import 'react-image-lightbox/style.css'; // This only needs to be imported once in your app
 import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
 import { useProps } from '../../hooks/useProps';
 import {
   FILE_SIZE_LIMIT_DEFAULT,
-  isImage,
-  isPdf,
+  attachmentFileTypes,
+  getThumbnailPlaceholderURL,
   normalizeFile,
   toFileList,
   toValueItem,
@@ -33,6 +34,118 @@ import {
 } from './shared';
 import { useStyles } from './style';
 import type { ComposedUpload, DraggerProps, DraggerV2Props, UploadProps } from './type';
+
+attachmentFileTypes.add({
+  matcher(file) {
+    return match(file.mimetype || file.type, 'image/*');
+  },
+  getThumbnailURL(file) {
+    return file.url ? `${file.url}${file.thumbnailRule || ''}` : URL.createObjectURL(file.originFileObj);
+  },
+  Previewer({ index, list, onSwitchIndex }) {
+    const onDownload = useCallback(
+      (e) => {
+        e.preventDefault();
+        const file = list[index];
+        saveAs(file.url, `${file.title}${file.extname}`);
+      },
+      [index, list],
+    );
+    return (
+      <LightBox
+        // discourageDownloads={true}
+        mainSrc={list[index]?.url}
+        nextSrc={list[(index + 1) % list.length]?.url}
+        prevSrc={list[(index + list.length - 1) % list.length]?.url}
+        onCloseRequest={() => onSwitchIndex(null)}
+        onMovePrevRequest={() => onSwitchIndex((index + list.length - 1) % list.length)}
+        onMoveNextRequest={() => onSwitchIndex((index + 1) % list.length)}
+        imageTitle={list[index]?.title}
+        toolbarButtons={[
+          <button
+            key={'preview-img'}
+            style={{ fontSize: 22, background: 'none', lineHeight: 1 }}
+            type="button"
+            aria-label="Download"
+            title="Download"
+            className="ril-zoom-in ril__toolbarItemChild ril__builtinButton"
+            onClick={onDownload}
+          >
+            <DownloadOutlined />
+          </button>,
+        ]}
+      />
+    );
+  },
+});
+
+attachmentFileTypes.add({
+  matcher(file) {
+    return match(file.mimetype || file.type, 'application/pdf');
+  },
+  Previewer({ index, list, onSwitchIndex }) {
+    const { t } = useTranslation();
+    const onDownload = useCallback(
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const file = list[index];
+        saveAs(file.url, `${file.title}${file.extname}`);
+      },
+      [index, list],
+    );
+    const onClose = useCallback(() => {
+      onSwitchIndex(null);
+    }, [onSwitchIndex]);
+    return (
+      <Modal
+        open={index != null}
+        title={'PDF - ' + list[index].title}
+        onCancel={onClose}
+        footer={[
+          <Button
+            key="download"
+            style={{
+              textTransform: 'capitalize',
+            }}
+            onClick={onDownload}
+          >
+            {t('Download')}
+          </Button>,
+          <Button key="close" onClick={onClose} style={{ textTransform: 'capitalize' }}>
+            {t('Close')}
+          </Button>,
+        ]}
+        width={'85vw'}
+        centered={true}
+      >
+        <div
+          style={{
+            padding: '8px',
+            maxWidth: '100%',
+            maxHeight: 'calc(100vh - 256px)',
+            height: '90vh',
+            width: '100%',
+            background: 'white',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            overflowY: 'auto',
+          }}
+        >
+          <iframe
+            src={list[index].url}
+            style={{
+              width: '100%',
+              maxHeight: '90vh',
+              flex: '1 1 auto',
+            }}
+          />
+        </div>
+      </Modal>
+    );
+  },
+});
 
 function InternalUpload(props: UploadProps) {
   const { onChange, ...rest } = props;
@@ -85,6 +198,13 @@ function useSizeHint(size: number) {
   return s !== 0 ? t('File size should not exceed {{size}}.', { size: sizeString }) : '';
 }
 
+function DefaultThumbnailPreviewer({ file }) {
+  const { componentCls: prefixCls } = useStyles();
+  const { getThumbnailURL = getThumbnailPlaceholderURL } = attachmentFileTypes.getTypeByFile(file);
+  const imageUrl = getThumbnailURL(file);
+  return <img src={imageUrl} alt={file.title} className={`${prefixCls}-list-item-image`} />;
+}
+
 function AttachmentListItem(props) {
   const { file, disabled, onPreview, onDelete: propsOnDelete, readPretty } = props;
   const { componentCls: prefixCls } = useStyles();
@@ -104,15 +224,11 @@ function AttachmentListItem(props) {
     saveAs(file.url, `${file.title}${file.extname}`);
   }, [file]);
 
+  const { ThumbnailPreviewer = DefaultThumbnailPreviewer } = attachmentFileTypes.getTypeByFile(file);
+
   const item = [
     <span key="thumbnail" className={`${prefixCls}-list-item-thumbnail`}>
-      {file.imageUrl && (
-        <img
-          src={`${file.imageUrl}${file.thumbnailRule || ''}`}
-          alt={file.title}
-          className={`${prefixCls}-list-item-image`}
-        />
-      )}
+      <ThumbnailPreviewer file={file} />
     </span>,
     <span key="title" className={`${prefixCls}-list-item-name`} title={file.title}>
       {file.status === 'uploading' ? t('Uploading') : file.title}
@@ -166,118 +282,12 @@ function AttachmentListItem(props) {
   );
 }
 
-const PreviewerTypes = [
-  {
-    matcher: isImage,
-    Component({ index, list, onSwitchIndex }) {
-      const onDownload = useCallback(
-        (e) => {
-          e.preventDefault();
-          const file = list[index];
-          saveAs(file.url, `${file.title}${file.extname}`);
-        },
-        [index, list],
-      );
-      return (
-        <LightBox
-          // discourageDownloads={true}
-          mainSrc={list[index]?.imageUrl}
-          nextSrc={list[(index + 1) % list.length]?.imageUrl}
-          prevSrc={list[(index + list.length - 1) % list.length]?.imageUrl}
-          onCloseRequest={() => onSwitchIndex(null)}
-          onMovePrevRequest={() => onSwitchIndex((index + list.length - 1) % list.length)}
-          onMoveNextRequest={() => onSwitchIndex((index + 1) % list.length)}
-          imageTitle={list[index]?.title}
-          toolbarButtons={[
-            <button
-              key={'preview-img'}
-              style={{ fontSize: 22, background: 'none', lineHeight: 1 }}
-              type="button"
-              aria-label="Download"
-              title="Download"
-              className="ril-zoom-in ril__toolbarItemChild ril__builtinButton"
-              onClick={onDownload}
-            >
-              <DownloadOutlined />
-            </button>,
-          ]}
-        />
-      );
-    },
-  },
-  {
-    matcher: isPdf,
-    Component({ index, list, onSwitchIndex }) {
-      const { t } = useTranslation();
-      const onDownload = useCallback(
-        (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const file = list[index];
-          saveAs(file.url, `${file.title}${file.extname}`);
-        },
-        [index, list],
-      );
-      const onClose = useCallback(() => {
-        onSwitchIndex(null);
-      }, [onSwitchIndex]);
-      return (
-        <Modal
-          open={index != null}
-          title={'PDF - ' + list[index].title}
-          onCancel={onClose}
-          footer={[
-            <Button
-              key="download"
-              style={{
-                textTransform: 'capitalize',
-              }}
-              onClick={onDownload}
-            >
-              {t('Download')}
-            </Button>,
-            <Button key="close" onClick={onClose} style={{ textTransform: 'capitalize' }}>
-              {t('Close')}
-            </Button>,
-          ]}
-          width={'85vw'}
-          centered={true}
-        >
-          <div
-            style={{
-              padding: '8px',
-              maxWidth: '100%',
-              maxHeight: 'calc(100vh - 256px)',
-              height: '90vh',
-              width: '100%',
-              background: 'white',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              overflowY: 'auto',
-            }}
-          >
-            <iframe
-              src={list[index].url}
-              style={{
-                width: '100%',
-                maxHeight: '90vh',
-                flex: '1 1 auto',
-              }}
-            />
-          </div>
-        </Modal>
-      );
-    },
-  },
-];
-
 function Previewer({ index, onSwitchIndex, list }) {
   if (index == null) {
     return null;
   }
   const file = list[index];
-  const { Component } = PreviewerTypes.find((type) => type.matcher(file)) ?? {};
+  const { Previewer: Component } = attachmentFileTypes.getTypeByFile(file);
   if (!Component) {
     return null;
   }
@@ -298,7 +308,7 @@ export function AttachmentList(props) {
   const onPreview = useCallback(
     (file) => {
       const index = fileList.findIndex((item) => item.id === file.id);
-      const previewType = PreviewerTypes.find((type) => type.matcher(file));
+      const previewType = attachmentFileTypes.getTypeByFile(file);
       if (previewType) {
         setPreview(index);
       } else {

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -36,7 +36,7 @@ import { useStyles } from './style';
 import type { ComposedUpload, DraggerProps, DraggerV2Props, UploadProps } from './type';
 
 attachmentFileTypes.add({
-  matcher(file) {
+  match(file) {
     return match(file.mimetype || file.type, 'image/*');
   },
   getThumbnailURL(file) {
@@ -80,7 +80,7 @@ attachmentFileTypes.add({
 });
 
 attachmentFileTypes.add({
-  matcher(file) {
+  match(file) {
     return match(file.mimetype || file.type, 'application/pdf');
   },
   Previewer({ index, list, onSwitchIndex }) {

--- a/packages/core/client/src/schema-component/antd/upload/index.ts
+++ b/packages/core/client/src/schema-component/antd/upload/index.ts
@@ -8,3 +8,4 @@
  */
 
 export * from './Upload';
+export { attachmentFileTypes } from './shared';

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -35,6 +35,9 @@ export class AttachmentFileTypes {
   }
 }
 
+/**
+ * @experimental
+ */
 export const attachmentFileTypes = new AttachmentFileTypes();
 
 const toArr = (value) => {
@@ -47,7 +50,7 @@ const toArr = (value) => {
   return toArray(value);
 };
 
-export const testOpts = (ext: RegExp, options: { exclude?: string[]; include?: string[] }) => {
+const testOpts = (ext: RegExp, options: { exclude?: string[]; include?: string[] }) => {
   if (options && isArr(options.include)) {
     return options.include.some((url) => ext.test(url));
   }
@@ -62,7 +65,7 @@ export const testOpts = (ext: RegExp, options: { exclude?: string[]; include?: s
 export function getThumbnailPlaceholderURL(file, options: any = {}) {
   for (let i = 0; i < UPLOAD_PLACEHOLDER.length; i++) {
     // console.log(UPLOAD_PLACEHOLDER[i].ext, testOpts(UPLOAD_PLACEHOLDER[i].ext, options));
-    if (UPLOAD_PLACEHOLDER[i].ext.test(file.name)) {
+    if (UPLOAD_PLACEHOLDER[i].ext.test(file.extname || file.filename || file.url || file.name)) {
       if (testOpts(UPLOAD_PLACEHOLDER[i].ext, options)) {
         return UPLOAD_PLACEHOLDER[i].icon || UNKNOWN_FILE_ICON;
       } else {
@@ -72,10 +75,6 @@ export function getThumbnailPlaceholderURL(file, options: any = {}) {
   }
   return UNKNOWN_FILE_ICON;
 }
-
-export const getURL = (target: any) => {
-  return target?.['url'] || target?.['downloadURL'] || target?.['imgURL'] || target?.['name'];
-};
 
 export function getResponseMessage({ error, response }: UploadFile<any>) {
   if (error instanceof Error && 'isAxiosError' in error) {
@@ -169,12 +168,6 @@ export const toItem = (file) => {
 
 export const toFileList = (fileList: any) => {
   return toArr(fileList).filter(Boolean).map(toItem);
-};
-
-export const toValue = (fileList: any) => {
-  return toArr(fileList)
-    .filter((file) => !file.response || file.status === 'done')
-    .map((file) => file?.response?.data || file);
 };
 
 const Rules: Record<string, RuleFunction> = {

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -31,7 +31,7 @@ export class AttachmentFileTypes {
     this.types.push(type);
   }
   getTypeByFile(file): Omit<AttachmentFileType, 'match'> {
-    return this.types.find((type) => type.match(file)) ?? {};
+    return this.types.find((type) => type.match(file));
   }
 }
 

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -19,7 +19,7 @@ import type { IUploadProps, UploadProps } from './type';
 export const FILE_SIZE_LIMIT_DEFAULT = 1024 * 1024 * 20;
 
 export interface AttachmentFileType {
-  matcher(file: any): boolean;
+  match(file: any): boolean;
   getThumbnailURL?(file: any): string;
   ThumbnailPreviewer?: React.ComponentType<any>;
   Previewer?: React.ComponentType<any>;
@@ -30,8 +30,8 @@ export class AttachmentFileTypes {
   add(type: AttachmentFileType) {
     this.types.push(type);
   }
-  getTypeByFile(file): Omit<AttachmentFileType, 'matcher'> {
-    return this.types.find((type) => type.matcher(file)) ?? {};
+  getTypeByFile(file): Omit<AttachmentFileType, 'match'> {
+    return this.types.find((type) => type.match(file)) ?? {};
   }
 }
 

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -28,7 +28,8 @@ export interface AttachmentFileType {
 export class AttachmentFileTypes {
   types: AttachmentFileType[] = [];
   add(type: AttachmentFileType) {
-    this.types.push(type);
+    // NOTE: use unshift to make sure the custom type has higher priority
+    this.types.unshift(type);
   }
   getTypeByFile(file): Omit<AttachmentFileType, 'match'> {
     return this.types.find((type) => type.match(file));

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -18,11 +18,28 @@ import type { IUploadProps, UploadProps } from './type';
 
 export const FILE_SIZE_LIMIT_DEFAULT = 1024 * 1024 * 20;
 
+export interface FileModel {
+  id: number;
+  filename: string;
+  path: string;
+  title: string;
+  url: string;
+  extname: string;
+  size: number;
+  mimetype: string;
+}
+
+export interface PreviewerProps {
+  index: number;
+  list: FileModel[];
+  onSwitchIndex(index): void;
+}
+
 export interface AttachmentFileType {
   match(file: any): boolean;
   getThumbnailURL?(file: any): string;
-  ThumbnailPreviewer?: React.ComponentType<any>;
-  Previewer?: React.ComponentType<any>;
+  ThumbnailPreviewer?: React.ComponentType<{ file: FileModel }>;
+  Previewer?: React.ComponentType<PreviewerProps>;
 }
 
 export class AttachmentFileTypes {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

To make file previewer to be extensible.

### Description 

Example for video file:

```tsx
import { Plugin, attachmentFileTypes } from '@nocobase/client';

class MyPlugin extends Plugin {
  load() {
    attachmentFileTypes.add({
      match(file) {
        return file.name.endsWith('.mp4');
      },
      Previewer({ index, list, onSwitchIndex }) {
        const { t } = useTranslation();
        const onClose = useCallback(() => {
          onSwitchIndex(null);
        }, [onSwitchIndex]);
        return (
          <Modal
            open={index != null}
            title={list[index].title}
            onCancel={onClose}
            footer={[
              <Button key="close" onClick={onClose} style={{ textTransform: 'capitalize' }}>
                {t('Close')}
              </Button>,
            ]}
            width={'85vw'}
            centered={true}
          >
            <video
              src={list[index].url}
              controls
              style={{
                width: '100%',
                height: '100%',
              }}
            />
          </Modal>
        );
      },
    });
  }
}

export default MyPlugin;
```

### Related issues

#5230.

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/74280d7c-deb4-46cd-860f-48c3d3c30fc4" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add open api for customize file previewer based on file types |
| 🇨🇳 Chinese | 增加附件字段上传组件可以基于类型自定义预览组件的开放接口 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese | [文件管理器：扩展开发](https://docs-cn.nocobase.com/handbook/file-manager/development) |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
