### PR TITLE
fix(client): boolean type crash in variable input

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -92,7 +92,9 @@ const ConstantTypes = {
         />
       );
     },
-    default: false,
+    default() {
+      return false;
+    },
   },
   date: {
     label: '{{t("Date")}}',


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix page crash when input boolean constant in `Variable.Input` component.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix page crash when input boolean constant in `Variable.Input` component |
| 🇨🇳 Chinese | 修复变量组件中选择输入布尔值常量导致页面崩溃的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
