### PR TITLE
fix(plugin-workflow): fix field crash in block

### DIFF
--- a/packages/core/client/src/data-source/data-block/DataBlockProvider.tsx
+++ b/packages/core/client/src/data-source/data-block/DataBlockProvider.tsx
@@ -122,7 +122,7 @@ export const DataBlockContext = createContext<DataBlockContextValue<any>>({} as 
 DataBlockContext.displayName = 'DataBlockContext';
 
 const DataBlockResourceContext = createContext<{ rerenderDataBlock: () => void }>(null);
-const RerenderDataBlockProvider: FC = ({ children }) => {
+export const RerenderDataBlockProvider: FC = ({ children }) => {
   const [hidden, setHidden] = React.useState(false);
   const value = useMemo(() => {
     return {

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/FormBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/FormBlockProvider.tsx
@@ -18,6 +18,7 @@ import {
   FormBlockContext,
   FormV2,
   RecordProvider,
+  RerenderDataBlockProvider,
   useAPIClient,
   useAssociationNames,
   useBlockRequestContext,
@@ -82,16 +83,18 @@ export function FormBlockProvider(props) {
     <CollectionManagerProvider dataSource={dataSource}>
       <CollectionProvider_deprecated collection={props.collection}>
         <RecordProvider record={values} parent={null}>
-          <FormActiveFieldsProvider name="form">
-            <BlockRequestContext_deprecated.Provider
-              value={{ block: 'form', props, field, service, resource, __parent }}
-            >
-              <FormBlockContext.Provider value={formBlockValue}>
-                <FormV2.Templates style={{ marginBottom: token.margin }} form={form} />
-                <div ref={formBlockRef}>{props.children}</div>
-              </FormBlockContext.Provider>
-            </BlockRequestContext_deprecated.Provider>
-          </FormActiveFieldsProvider>
+          <RerenderDataBlockProvider>
+            <FormActiveFieldsProvider name="form">
+              <BlockRequestContext_deprecated.Provider
+                value={{ block: 'form', props, field, service, resource, __parent }}
+              >
+                <FormBlockContext.Provider value={formBlockValue}>
+                  <FormV2.Templates style={{ marginBottom: token.margin }} form={form} />
+                  <div ref={formBlockRef}>{props.children}</div>
+                </FormBlockContext.Provider>
+              </BlockRequestContext_deprecated.Provider>
+            </FormActiveFieldsProvider>
+          </RerenderDataBlockProvider>
         </RecordProvider>
       </CollectionProvider_deprecated>
     </CollectionManagerProvider>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/AssignedFieldsFormSchemaConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/AssignedFieldsFormSchemaConfig.tsx
@@ -19,6 +19,7 @@ import {
   CollectionManagerProvider,
   CollectionProvider,
   FormProvider,
+  RerenderDataBlockProvider,
   SchemaComponent,
   SchemaComponentOptions,
   SchemaComponentProvider,
@@ -57,8 +58,7 @@ export function AssignedFieldsFormSchemaConfig(props) {
   const { setFormValueChanged } = useActionContext();
   const api = useAPIClient();
   const scope = useWorkflowVariableOptions();
-  const nodeForm = useForm();
-  const { values, setValuesIn } = nodeForm;
+  const { values, setValuesIn, disabled } = useForm();
   const params = toJS(values.params);
   const [dataSourceName, collectionName] = parseCollectionName(values.collection);
 
@@ -121,17 +121,19 @@ export function AssignedFieldsFormSchemaConfig(props) {
     <Card>
       <CollectionManagerProvider dataSource={dataSourceName}>
         <CollectionProvider name={collectionName}>
-          <FormProvider form={form}>
-            <FormLayout layout={'vertical'}>
-              <VariableScopeProvider scope={scope}>
-                <SchemaComponentProvider form={form} designable={!nodeForm.disabled}>
-                  <SchemaComponentOptions {...schemaOptions}>
-                    <SchemaComponent schema={schema} onChange={onChange} />
-                  </SchemaComponentOptions>
-                </SchemaComponentProvider>
-              </VariableScopeProvider>
-            </FormLayout>
-          </FormProvider>
+          <RerenderDataBlockProvider>
+            <FormProvider form={form}>
+              <FormLayout layout={'vertical'}>
+                <VariableScopeProvider scope={scope}>
+                  <SchemaComponentProvider form={form} designable={!disabled}>
+                    <SchemaComponentOptions {...schemaOptions}>
+                      <SchemaComponent schema={schema} onChange={onChange} />
+                    </SchemaComponentOptions>
+                  </SchemaComponentProvider>
+                </VariableScopeProvider>
+              </FormLayout>
+            </FormProvider>
+          </RerenderDataBlockProvider>
         </CollectionProvider>
       </CollectionManagerProvider>
     </Card>


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix block crash in field configuration of create/update node.

### Description 

1. Add a create/update node to a workflow.
2. Select a collection with association field.
3. Add an association field.
4. Try to switch its component to sub-form or others.

### Related issues

Involved by #5159.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix switching component of association field in assigned fields caused page crash in create/update node |
| 🇨🇳 Chinese | 修复新增、更新节点中配置关系字段赋值时切换组件导致的页面崩溃 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
