### PR TITLE
fix(plugin-file-manager): fix storage configuration error

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/FileStorage.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/FileStorage.tsx
@@ -38,7 +38,7 @@ export const CreateStorage = () => {
                   [uid()]: {
                     type: 'void',
                     'x-component': 'Action.Drawer',
-                    'x-decorator': 'FormV2',
+                    'x-decorator': 'Form',
                     'x-decorator-props': {
                       initialValue: {
                         type: storageType.name,
@@ -105,8 +105,8 @@ export const EditStorage = () => {
           onClick={() => {
             setVisible(true);
             const storageType = plugin.storageTypes.get(record.type);
-            if (storageType.properties['default']) {
-              storageType.properties['default']['x-reactions'] = (field) => {
+            if (storageType.fieldset['default']) {
+              storageType.fieldset['default']['x-reactions'] = (field) => {
                 if (field.initialValue) {
                   field.disabled = true;
                 } else {
@@ -120,7 +120,7 @@ export const EditStorage = () => {
                 [uid()]: {
                   type: 'void',
                   'x-component': 'Action.Drawer',
-                  'x-decorator': 'FormV2',
+                  'x-decorator': 'Form',
                   'x-decorator-props': {
                     initialValue: {
                       ...record,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix page crash when edit storage.

### Description 

Storage configuration fields key changed, but not changed completed in code.

### Related issues

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix page crash when edit storage in file manager |
| 🇨🇳 Chinese | 修复文件管理器编辑存储引擎时的页面错误 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
