### PR TITLE
fix: component CustomRequestAction support x-use-component-props

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client/components/CustomRequestAction.tsx
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client/components/CustomRequestAction.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Action, useAPIClient, useRequest } from '@nocobase/client';
+import { Action, useAPIClient, useRequest, withDynamicSchemaProps } from '@nocobase/client';
 import React from 'react';
 import { useFieldSchema } from '@formily/react';
 import { listByCurrentRoleUrl } from '../constants';
@@ -39,12 +39,14 @@ const components = {
   'customize:table:request': Action.Link,
 };
 
-export const CustomRequestAction = (props) => {
+export const CustomRequestAction: React.FC<any> & {
+  [key: string]: any;
+} = withDynamicSchemaProps((props) => {
   const fieldSchema = useFieldSchema();
   const xAction = fieldSchema['x-action'];
   const Component = components[xAction] || Action;
   return <Component {...props} useProps={useCustomizeRequestActionProps}></Component>;
-};
+});
 
 CustomRequestAction.Designer = CustomRequestActionDesigner;
 CustomRequestAction.Decorator = CustomRequestActionACLDecorator;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow `CustomRequestAction` in `@nocobase/plugin-action-custom-request` to support `x-use-component-props` property.

### Description

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | allow `CustomRequestAction` to support `x-use-component-props` |
| 🇨🇳 Chinese | `CustomRequestAction` 组件支持 `x-use-component-props` 配置解析 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
