### PR TITLE
feat: support field's dynamic filter operators in filter form block

### DIFF
--- a/packages/core/client/src/schema-component/antd/filter/__tests__/useOperators.test.ts
+++ b/packages/core/client/src/schema-component/antd/filter/__tests__/useOperators.test.ts
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFieldSchema } from '@formily/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCollection_deprecated, useCollectionManager_deprecated } from '../../../../collection-manager';
+import { useOperatorList } from '../useOperators';
+
+// Mock dependencies
+vi.mock('@formily/react', () => ({
+  useFieldSchema: vi.fn(),
+}));
+
+vi.mock('../../../../collection-manager', () => ({
+  useCollection_deprecated: vi.fn(),
+  useCollectionManager_deprecated: vi.fn(),
+}));
+
+describe('useOperatorList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return operators list based on x-designer-props', () => {
+    const mockSchema = {
+      'x-designer-props': {
+        interface: 'input',
+      },
+    };
+    const mockOperators = ['eq', 'ne'];
+
+    vi.mocked(useFieldSchema).mockReturnValue(mockSchema as any);
+    vi.mocked(useCollection_deprecated).mockReturnValue({ name: 'test' } as any);
+    vi.mocked(useCollectionManager_deprecated).mockReturnValue({
+      getCollectionFields: vi.fn(),
+      getInterface: vi.fn().mockReturnValue({
+        filterable: {
+          operators: mockOperators,
+        },
+      }),
+    } as any);
+
+    const { result } = renderHook(() => useOperatorList());
+    expect(result.current).toEqual(mockOperators);
+  });
+
+  it('should return operators list based on field interface', () => {
+    const mockSchema = { name: 'testField' };
+    const mockOperators = ['contains', 'notContains'];
+    const mockField = { name: 'testField', interface: 'input' };
+
+    vi.mocked(useFieldSchema).mockReturnValue(mockSchema as any);
+    vi.mocked(useCollection_deprecated).mockReturnValue({ name: 'test' } as any);
+    vi.mocked(useCollectionManager_deprecated).mockReturnValue({
+      getCollectionFields: vi.fn().mockReturnValue([mockField]),
+      getInterface: vi.fn().mockReturnValue({
+        filterable: {
+          operators: mockOperators,
+        },
+      }),
+    } as any);
+
+    const { result } = renderHook(() => useOperatorList());
+    expect(result.current).toEqual(mockOperators);
+  });
+
+  it('should filter out invisible operators', () => {
+    const mockSchema = { name: 'testField' };
+    const mockOperators = [{ name: 'eq', visible: () => true }, { name: 'ne', visible: () => false }, { name: 'gt' }];
+    const mockField = { name: 'testField', interface: 'input' };
+
+    vi.mocked(useFieldSchema).mockReturnValue(mockSchema as any);
+    vi.mocked(useCollection_deprecated).mockReturnValue({ name: 'test' } as any);
+    vi.mocked(useCollectionManager_deprecated).mockReturnValue({
+      getCollectionFields: vi.fn().mockReturnValue([mockField]),
+      getInterface: vi.fn().mockReturnValue({
+        filterable: {
+          operators: mockOperators,
+        },
+      }),
+    } as any);
+
+    const { result } = renderHook(() => useOperatorList());
+    expect(result.current).toEqual([{ name: 'eq', visible: expect.any(Function) }, { name: 'gt' }]);
+  });
+});

--- a/packages/core/client/src/schema-component/antd/filter/useOperators.ts
+++ b/packages/core/client/src/schema-component/antd/filter/useOperators.ts
@@ -27,7 +27,8 @@ export const useOperatorList = (): any[] => {
       return getInterface(fieldInterface)?.filterable?.operators || [];
     }
     const field = collectionFields.find((item) => item.name === schema.name);
-    return getInterface(field?.interface)?.filterable?.operators || [];
+    const ops = getInterface(field?.interface)?.filterable?.operators || [];
+    return ops.filter((o) => typeof o.visible !== 'function' || o.visible(field));
   }, [schema.name]);
   return res;
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
在表格区块中，operator's visible函数会生效，会过滤掉visible() 为false的operators.
然而在筛选区块中，却不支持，我们应当使其表现一致。

In the table block's filter, we are respecting the filter operator's visible function.
But in the filter block, operator's  visible will not take effect. 
I think we should make it consitent.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support showing dynamic filter operators based on field's properties in filter form block |
| 🇨🇳 Chinese | 支持在筛选区块根据字段属性动态显示过滤运算符 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
