### PR TITLE
fix(client): fix wrongly thumbnail previewing when file type is not supported by default

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -93,11 +93,7 @@ const testOpts = (ext: RegExp, options: { exclude?: string[]; include?: string[]
 };
 
 export function getThumbnailPlaceholderURL(file, options: any = {}) {
-  if (file.url) {
-    return file.url;
-  }
   for (let i = 0; i < UPLOAD_PLACEHOLDER.length; i++) {
-    // console.log(UPLOAD_PLACEHOLDER[i].ext, testOpts(UPLOAD_PLACEHOLDER[i].ext, options));
     if (UPLOAD_PLACEHOLDER[i].ext.test(file.extname || file.filename || file.url || file.name)) {
       if (testOpts(UPLOAD_PLACEHOLDER[i].ext, options)) {
         return UPLOAD_PLACEHOLDER[i].icon || UNKNOWN_FILE_ICON;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Thumbnail of PDF file is not showing as placeholder by default.

### Description 

1. Upload a PDF file to attachment field.
2. View the thumbnail in field items.

### Related issues

Involved by #5313.

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix wrongly thumbnail previewing when file type is not supported by default |
| 🇨🇳 Chinese | 修复上传文件中非默认支持的文件类型缩略图显示异常的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
