### PR TITLE
fix(subTable): fix 'association product in order not found…

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -1509,7 +1509,8 @@ export const useAssociationNames = (dataSource?: string) => {
         ['hasOne', 'hasMany', 'belongsTo', 'belongsToMany', 'belongsToArray'].includes(collectionField.type);
 
       // 根据联动规则中条件的字段获取一些 appends
-      if (s['x-linkage-rules']) {
+      // 需要排除掉子表格和子表单中的联动规则
+      if (s['x-linkage-rules'] && !isSubMode(s)) {
         const collectAppends = (obj) => {
           const type = Object.keys(obj)[0] || '$and';
           const list = obj[type];


### PR DESCRIPTION
…' error

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Related issues
![image](https://github.com/user-attachments/assets/6444b2a4-df29-4c1c-b974-6ebcf68b8b3a)


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the error of not finding the association field when linkage rules are set for the subtable     |
| 🇨🇳 Chinese |     修复当子表格设置了联动规则后，报找不到关系字段的错误      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
