### PR TITLE
style: center icon when action buttons use icon-only

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.style.ts
+++ b/packages/core/client/src/schema-component/antd/action/Action.style.ts
@@ -47,6 +47,13 @@ const useStyles = genStyleHook('nb-action', (token) => {
           },
         },
       },
+
+      '.ant-btn-icon': {
+        marginInlineEnd: '0px !important',
+      },
+      '.nb-action-title': {
+        marginInlineStart: '8px',
+      },
     },
   };
 });

--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -377,7 +377,6 @@ function RenderButton({
   if (!designable && (field?.data?.hidden || !aclCtx)) {
     return null;
   }
-
   return (
     <SortableItem
       role="button"
@@ -393,7 +392,7 @@ function RenderButton({
       className={classnames(componentCls, hashId, className, 'nb-action')}
       type={type === 'danger' ? undefined : type}
     >
-      {actionTitle}
+      {actionTitle && <span className={icon ? 'nb-action-title' : null}>{actionTitle}</span>}
       <Designer {...designerProps} />
     </SortableItem>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   style optimization for  centering icon when action buttons use icon-only     |
| 🇨🇳 Chinese |  操作按钮单独使用图标时，图标居中         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
