### PR TITLE
fix(workflow): workflow node variables do not display inherited collection fields 

### DIFF
--- a/packages/core/client/src/data-source/collection/Collection.ts
+++ b/packages/core/client/src/data-source/collection/Collection.ts
@@ -250,6 +250,10 @@ export class Collection {
     return predicate ? filter(this.fields, predicate) : this.fields;
   }
 
+  getAllFields(predicate?: GetCollectionFieldPredicate) {
+    return this.getFields(predicate);
+  }
+
   protected getFieldsMap() {
     if (!this.fieldsMap) {
       this.fieldsMap = this.getFields().reduce((memo, field) => {

--- a/packages/core/client/src/data-source/collection/CollectionManager.ts
+++ b/packages/core/client/src/data-source/collection/CollectionManager.ts
@@ -140,6 +140,10 @@ export class CollectionManager {
     return this.getCollection(collectionName)?.getFields(predicate) || [];
   }
 
+  getCollectionAllFields(collectionName: string, predicate?: GetCollectionFieldPredicate) {
+    return this.getCollection(collectionName)?.getAllFields(predicate) || [];
+  }
+
   /**
    * @example
    * getFilterByTK('users', { id: 1 }); // 1

--- a/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
@@ -12,13 +12,7 @@ import { Tag, TreeSelect } from 'antd';
 import type { DefaultOptionType, TreeSelectProps } from 'rc-tree-select/es/TreeSelect';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  CollectionFieldOptions_deprecated,
-  parseCollectionName,
-  useApp,
-  useCollectionManager_deprecated,
-  useCompile,
-} from '../../..';
+import { CollectionFieldOptions_deprecated, parseCollectionName, useApp, useCompile } from '../../..';
 
 export type AppendsTreeSelectProps = {
   value: string[] | string;
@@ -106,7 +100,10 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
   const [dataSourceName, collectionName] = parseCollectionName(collectionString);
   const app = useApp();
   const { collectionManager } = app.dataSourceManager.getDataSource(dataSourceName);
-  const getCollectionFields = collectionManager.getCollectionFields.bind(collectionManager);
+  const getCollectionFields = (name, predicate) => {
+    const instance = collectionManager.getCollection(name);
+    return instance.getAllFields(predicate);
+  };
   const treeData = Object.values(optionsMap);
   const value: string | DefaultOptionType[] = useMemo(() => {
     if (props.multiple) {

--- a/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
@@ -102,7 +102,8 @@ export const AppendsTreeSelect: React.FC<TreeSelectProps & AppendsTreeSelectProp
   const { collectionManager } = app.dataSourceManager.getDataSource(dataSourceName);
   const getCollectionFields = (name, predicate) => {
     const instance = collectionManager.getCollection(name);
-    return instance.getAllFields(predicate);
+    // NOTE: condition for compatibility with hidden collections like "attachments"
+    return instance ? instance.getAllFields(predicate) : [];
   };
   const treeData = Object.values(optionsMap);
   const value: string | DefaultOptionType[] = useMemo(() => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -503,7 +503,7 @@ export function useGetCollectionFields(dataSourceName?) {
   const app = useApp();
   const { collectionManager } = app.dataSourceManager.getDataSource(dataSourceName);
 
-  return useCallback((collectionName) => collectionManager.getCollectionFields(collectionName), [collectionManager]);
+  return useCallback((collectionName) => collectionManager.getCollectionAllFields(collectionName), [collectionManager]);
 }
 
 export function WorkflowVariableInput({ variableOptions, ...props }): JSX.Element {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Workflow node variables do not display inherited collection fields  |
| 🇨🇳 Chinese |  工作流节点变量不显示继承表字段         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
