### PR TITLE
fix(plugin-workflow): fix hint of update node

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/update.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/update.tsx
@@ -73,7 +73,7 @@ export default class extends Instruction {
               {
                 label: `{{t("Update in a batch", { ns: "${NAMESPACE}" })}}`,
                 value: false,
-                tooltip: `{{t("Update all eligible data at one time, which has better performance when the amount of data is large. But the updated data will not trigger other workflows, and will not record audit logs.", { ns: "${NAMESPACE}" })}}`,
+                tooltip: `{{t("Update all eligible data at one time, which has better performance when the amount of data is large. But association fields are not supported (unless foreign key in current collection), and the updated data will not trigger other workflows.", { ns: "${NAMESPACE}" })}}`,
               },
               {
                 label: `{{t("Update one by one", { ns: "${NAMESPACE}" })}}`,

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
@@ -169,8 +169,8 @@
   "Update mode": "更新模式",
   "Update in a batch": "批量更新",
   "Update one by one": "逐条更新",
-  "Update all eligible data at one time, which has better performance when the amount of data is large. But the updated data will not trigger other workflows, and will not record audit logs.":
-    "一次性更新所有符合条件的数据，在数据量较大时有比较好的性能；但被更新的数据不会触发其他工作流，也不会记录更新日志。",
+  "Update all eligible data at one time, which has better performance when the amount of data is large. But association fields are not supported (unless foreign key in current collection), and the updated data will not trigger other workflows.":
+    "一次性更新所有符合条件的数据，在数据量较大时有比较好的性能；但不支持关系字段的更新（除非是在当前表中的外键），被更新的数据也不会触发其他工作流。",
   "The updated data can trigger other workflows, and the audit log will also be recorded. But it is usually only applicable to several or dozens of pieces of data, otherwise there will be performance problems.":
     "被更新的数据可以再次触发其他工作流，也会记录更新日志；但通常只适用于数条或数十条数据，否则会有性能问题。",
   "Query record": "查询数据",


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Need to explain why association fields are not updated in batch mode.

### Description 

In batch mode of update node, only update the fields in self collection.

### Related issues

#5406.

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add association field related hint to the batch mode of update node |
| 🇨🇳 Chinese | 对更新数据节点的批量模式增加关于关系字段的提示 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
