### PR TITLE
fix: adjust supported availableTypes for uuid, nano, and id to exclude string

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/id.ts
+++ b/packages/core/client/src/collection-manager/interfaces/id.ts
@@ -31,7 +31,7 @@ export class IdFieldInterface extends CollectionFieldInterface {
       'x-read-pretty': true,
     },
   };
-  availableTypes = ['bigInt', 'integer', 'string'];
+  availableTypes = ['bigInt', 'integer'];
   properties = {
     'uiSchema.title': {
       type: 'string',

--- a/packages/core/client/src/collection-manager/interfaces/nanoid.ts
+++ b/packages/core/client/src/collection-manager/interfaces/nanoid.ts
@@ -24,7 +24,7 @@ export class NanoidFieldInterface extends CollectionFieldInterface {
       'x-component': 'NanoIDInput',
     },
   };
-  availableTypes = ['string', 'nanoid'];
+  availableTypes = ['nanoid'];
   properties = {
     'uiSchema.title': {
       type: 'string',

--- a/packages/core/client/src/collection-manager/interfaces/uuid.ts
+++ b/packages/core/client/src/collection-manager/interfaces/uuid.ts
@@ -26,7 +26,7 @@ export class UUIDFieldInterface extends CollectionFieldInterface {
       'x-validator': 'uuid',
     },
   };
-  availableTypes = ['string', 'uid', 'uuid'];
+  availableTypes = ['uid', 'uuid'];
   properties = {
     'uiSchema.title': {
       type: 'string',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      adjust supported availableTypes for uuid, nano, and id to exclude string     |
| 🇨🇳 Chinese |     调整 interface uuid、 nano、 id支持的数据类型 ，不应支持string     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
