### PR TITLE
fix(plugin-file-manager): fix storage field in template to load more storages

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/templates/file.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/templates/file.ts
@@ -157,12 +157,24 @@ export class FileCollectionTemplate extends CollectionTemplate {
     },
     ...getConfigurableProperties('category', 'description'),
     storage: {
-      title: `{{t("File storage", { ns: "${NAMESPACE}" })}}`,
-      type: 'hasOne',
+      type: 'string',
       name: 'storage',
+      title: `{{t("File storage", { ns: "${NAMESPACE}" })}}`,
       'x-decorator': 'FormItem',
-      'x-component': 'Select',
-      'x-reactions': ['{{useAsyncDataSource(loadStorages)}}'],
+      'x-component': 'RemoteSelect',
+      'x-component-props': {
+        service: {
+          resource: 'storages',
+          params: {
+            // pageSize: -1
+          },
+        },
+        manual: false,
+        fieldNames: {
+          label: 'title',
+          value: 'name',
+        },
+      },
     },
     ...getConfigurableProperties('presetFields'),
   };


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

To load more storages in file collection template configuration.

### Description 

Currently, only load 20 items.

### Related issues

#5428.

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | remove the 20 items limit of loading storages in file template collection configuration |
| 🇨🇳 Chinese | 移除文件表选择存储空间时仅加载 20 个的限制 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
