### PR TITLE
fix: allow table column title to be reset to default

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
@@ -66,16 +66,15 @@ export const tableColumnSettings = new SchemaSettings({
                 },
               } as ISchema,
               onSubmit: ({ title }) => {
-                if (title) {
-                  field.title = title;
-                  columnSchema.title = title;
-                  dn.emit('patch', {
-                    schema: {
-                      'x-uid': columnSchema['x-uid'],
-                      title: columnSchema.title,
-                    },
-                  });
-                }
+                field.title = title;
+                columnSchema.title = title;
+                dn.emit('patch', {
+                  schema: {
+                    'x-uid': columnSchema['x-uid'],
+                    title: columnSchema.title,
+                  },
+                });
+
                 dn.refresh();
               },
             };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       allow table column title to be reset to default    |
| 🇨🇳 Chinese |    表格列标题一旦自定义之后，清空后恢复默认值       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
