### PR TITLE
fix: data clearing bug when selecting association data with data scope in nested sub-tables

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -13,6 +13,7 @@ import { RecursionField, connect, mapProps, observer, useField, useFieldSchema, 
 import { uid } from '@formily/shared';
 import { Space, message } from 'antd';
 import { isFunction } from 'mathjs';
+import { last } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClearCollectionFieldContext, RecordProvider, useAPIClient, useCollectionRecordData } from '../../../';
@@ -82,7 +83,7 @@ const InternalAssociationSelect = observer(
           if (
             linkageFields.includes(fieldPath?.props?.name) &&
             field.value &&
-            fieldPath?.indexes?.[0] === field?.indexes?.[0] &&
+            last(fieldPath?.indexes) === last(field?.indexes) &&
             fieldPath?.props?.name !== field.props.name
           ) {
             field.setValue(undefined);


### PR DESCRIPTION
…e in nested sub-table

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix data clearing bug when selecting association data with data scope in nested sub-tables        |
| 🇨🇳 Chinese |   多层关系下的子表格中关系字段设置数据范围后，选择关系数据后其他行记录被清空        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
