### PR TITLE
fix(client): fix selected background color of table row

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -476,18 +476,15 @@ export const Table: any = withDynamicSchemaProps(
     const highlightRowCss = useMemo(() => {
       return css`
         & > td {
-          background-color: ${token.controlItemBgActiveHover} !important;
+          background-color: ${token.controlItemBgActive} !important;
         }
         &:hover > td {
           background-color: ${token.controlItemBgActiveHover} !important;
         }
       `;
-    }, [token.controlItemBgActiveHover]);
+    }, [token.controlItemBgActive, token.controlItemBgActiveHover]);
 
-    const highlightRow = useMemo(
-      () => (onClickRow ? highlightRowCss : ''),
-      [onClickRow, token.controlItemBgActiveHover],
-    );
+    const highlightRow = useMemo(() => (onClickRow ? highlightRowCss : ''), [highlightRowCss, onClickRow]);
 
     const onRow = useMemo(() => {
       if (onClickRow) {
@@ -581,7 +578,7 @@ export const Table: any = withDynamicSchemaProps(
     const BodyCellComponent = useCallback(
       (props) => {
         const isIndex = props.className?.includes('selection-column');
-        const { record, schema, rowIndex } = props;
+        const { record, schema, rowIndex, ...others } = props;
         const { ref, inView } = useInView({
           threshold: 0,
           triggerOnce: true,
@@ -594,7 +591,7 @@ export const Table: any = withDynamicSchemaProps(
         // fix the problem of blank rows at the beginning of a table block
         if (rowIndex < 20) {
           return (
-            <td {...props} className={classNames(props.className, cellClass)} style={style}>
+            <td {...others} className={classNames(props.className, cellClass)} style={style}>
               {props.children}
             </td>
           );


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The background color of table selected row is not same as Ant design component as default.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix selected background color of table row |
| 🇨🇳 Chinese | 修复表格行选中时的背景颜色 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
