### PR TITLE
fix(plugin-file-manager): fix calling storage rule hook on read-pretty fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageRules.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageRules.ts
@@ -7,16 +7,25 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { useCollectionField, useCollectionManager, useRequest } from '@nocobase/client';
+import { useField } from '@formily/react';
+import { useAPIClient, useCollectionField, useCollectionManager, useRequest } from '@nocobase/client';
 
 export function useStorageRules(storage) {
   const name = storage ?? '';
+  const apiClient = useAPIClient();
+  const field = useField<any>();
   const { loading, data } = useRequest<any>(
-    {
-      url: `storages:getRules/${name}`,
+    async () => {
+      if (field.pattern !== 'editable') {
+        return null;
+      }
+      return apiClient.request({
+        url: `storages:getRules/${name}`,
+      });
     },
     {
       refreshDeps: [name],
+      cacheKey: name,
     },
   );
   return (!loading && data?.data) || null;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Reduce useless hooks calling backend API causing performance issue.

### Description 

Attachment field needs rules from storage when editable. But it is not needed in read-pretty mode.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix calling storage rule hook on read-pretty fields |
| 🇨🇳 Chinese | 屏蔽阅读模式下附件字段对存储规则不必要的查询 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
