### PR TITLE
feat(client): support json input in variable input

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { useCompile } from '../../hooks';
 import { XButton } from './XButton';
 import { useStyles } from './style';
+import { Json } from '../input';
 
 const JT_VALUE_RE = /^\s*{{\s*([^{}]+)\s*}}\s*$/;
 
@@ -122,6 +123,14 @@ const ConstantTypes = {
     component: NullComponent,
     default() {
       return null;
+    },
+  },
+  object: {
+    label: '{{t("JSON")}}',
+    value: 'object',
+    component: Json,
+    default() {
+      return {};
     },
   },
 };


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow to input JSON as constant of `Variable.Input`.

### Description 

`Variable.Input` only allow to input primitive types, JSON will be a lot helpful.

### Related issues

### Showcase

None.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support json input in variable input |
| 🇨🇳 Chinese | 变量组件支持输入 JSON 常量 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
