### PR TITLE
fix: incorrect time display for noTimeZone datetime field with showTi…

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/__tests__/mapDatePicker.test.ts
+++ b/packages/core/client/src/schema-component/antd/date-picker/__tests__/mapDatePicker.test.ts
@@ -62,7 +62,7 @@ describe('mapDatePicker', () => {
     };
     const result = mapDatePicker()(props);
     result.onChange(dayjs.utc('2022-02-22 22:22:22'));
-    expect(props.onChange).toHaveBeenCalledWith('2022-02-22 00:00:00');
+    expect(props.onChange).toHaveBeenCalledWith('2022-02-22 22:22:22');
   });
 
   it('should call onChange with correct value when showTime is true and gmt is false', () => {
@@ -74,7 +74,7 @@ describe('mapDatePicker', () => {
     const result = mapDatePicker()(props);
     const m = dayjs('2022-02-22 22:22:22');
     result.onChange(m);
-    expect(props.onChange).toHaveBeenCalledWith('2022-02-22 00:00:00');
+    expect(props.onChange).toHaveBeenCalledWith('2022-02-22 22:22:22');
   });
 
   it('should call onChange with correct value when showTime is false and gmt is true', () => {
@@ -202,7 +202,7 @@ describe('mapDatePicker', () => {
     };
     const result = mapDatePicker()(props);
     result.onChange(dayjs('2022-02-22 22:22:22'));
-    expect(props.onChange).toHaveBeenCalledWith('2022-02-22 00:00:00');
+    expect(props.onChange).toHaveBeenCalledWith('2022-02-22 22:22:22');
   });
 
   it('should call onChange with correct value when picker is year and utc is false', () => {

--- a/packages/core/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/core/client/src/schema-component/antd/date-picker/util.ts
@@ -100,6 +100,9 @@ const handleChangeOnForm = (value, dateOnly, utc, picker, showTime, gmt) => {
     const formattedDate = dayjs(value).format(format);
     return dayjs(formattedDate).toISOString();
   }
+  if (showTime) {
+    return dayjs(value).format(format);
+  }
   return dayjs(value).startOf(picker).format(format);
 };
 


### PR DESCRIPTION
…me enabled

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix incorrect time display for noTimeZone datetime field with showTime enabled      |
| 🇨🇳 Chinese |     无时区时间字段设置showtime 为true后选择时分秒显示错误      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
