### PR TITLE
fix(formula): scope calc bug if field name like task.todos.0.sub_todos.0.desc

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-formula/src/client/components/Formula/Result.tsx
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client/components/Formula/Result.tsx
@@ -61,6 +61,21 @@ function getValuesByPath(values, key, index?) {
   }
 }
 
+function getValuesByFullPath(values, fieldPath) {
+  const fieldPaths = fieldPath.split('.');
+  let currentKeyIndex = 0;
+  let value = values;
+  //loop to get the last field
+  while (currentKeyIndex < fieldPaths.length) {
+    const fieldName = fieldPaths[currentKeyIndex];
+    const index = parseInt(fieldPaths?.[currentKeyIndex + 1]);
+    value = getValuesByPath(value, fieldName, index);
+    //have index means an array, then jump 2; else 1
+    currentKeyIndex = currentKeyIndex + (index >= 0 ? 2 : 1);
+  }
+  return value;
+}
+
 function areValuesEqual(value1, value2) {
   if (_.isString(value1) && !isNaN(Date.parse(value1))) {
     value1 = new Date(value1);
@@ -87,8 +102,7 @@ export function Result(props) {
   const field: any = useField();
   const path: any = field.path.entire;
   const fieldPath = path?.replace(`.${fieldSchema.name}`, '');
-  const fieldName = fieldPath.split('.')[0];
-  const index = parseInt(fieldPath.split('.')?.[1]);
+
   useEffect(() => {
     setEditingValue(value);
   }, [value]);
@@ -103,7 +117,9 @@ export function Result(props) {
       ) {
         return;
       }
-      const scope = toJS(getValuesByPath(form.values, fieldName, index));
+      //field name may be like todos.0.sub_todos.0.title
+      //scope should be the deepest one
+      const scope = toJS(getValuesByFullPath(form.values, fieldPath));
       let v;
       try {
         v = evaluate(expression, scope);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
多层表格嵌套时，公式计算结果错误。
如图的表单，使用了多层表单/表格嵌套
3级子表格，公式配置为=3级表格的desc字段
前端实际计算时使用了2级表格的desc字段，
如果2级没有desc字段，则3级的这个公式结果会为空。
（服务端保存时使用了当前记录做计算无此问题）
![image](https://github.com/user-attachments/assets/f4934f9d-3420-40ba-8c75-3f31ac155b7b)

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
涉及多层嵌套，公式字段的路径变成了类似todos.0.sub_todos.0.desc
故修改公式计算时获取scope的方法，使用全路径查找，返回最底层的sub_todos,而不是顶层的todos
![image](https://github.com/user-attachments/assets/211d6b68-7771-4090-94ac-d040983f4f3e)

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese | 修复 多层表格嵌套时，公式计算结果的错误 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
