### PR TITLE
fix: variable value is lost after refreshing markdown block popup

### DIFF
--- a/packages/core/client/src/schema-component/antd/markdown/Markdown.Void.tsx
+++ b/packages/core/client/src/schema-component/antd/markdown/Markdown.Void.tsx
@@ -145,15 +145,16 @@ export const MarkdownVoid: any = withDynamicSchemaProps(
     useEffect(() => {
       setLoading(true);
       const cvtContentToHTML = async () => {
-        const replacedContent = await getRenderContent(
-          engine,
-          content,
-          compile(variables),
-          compile(localVariables),
-          parseMarkdown,
-        );
-
-        setHtml(replacedContent);
+        setTimeout(async () => {
+          const replacedContent = await getRenderContent(
+            engine,
+            content,
+            compile(variables),
+            compile(localVariables),
+            parseMarkdown,
+          );
+          setHtml(replacedContent);
+        });
         setLoading(false);
       };
       cvtContentToHTML();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     variable value is lost after refreshing markdown block popup      |
| 🇨🇳 Chinese |    markdown 区块弹窗刷新后变量值丢失的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
