### PR TITLE
fix(plugin-workflow): fix locale of binding workflow on button

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -466,20 +466,17 @@ export function WorkflowConfig() {
   const buttonAction = fieldSchema['x-action'];
 
   const description = {
-    submit: t(
-      'Workflow will be triggered before or after submitting succeeded based on workflow type (supports pre/post action event in local mode, and approval event).',
-      {
-        ns: 'workflow',
-      },
-    ),
+    submit: t('Support pre-action event (local mode), post-action event (local mode), and approval event here.', {
+      ns: 'workflow',
+    }),
     'customize:save': t(
-      'Workflow will be triggered before or after submitting succeeded based on workflow type (supports pre/post action event in local mode, and approval event).',
+      'Support pre-action event (local mode), post-action event (local mode), and approval event here.',
       {
         ns: 'workflow',
       },
     ),
     'customize:update': t(
-      'Workflow will be triggered before or after submitting succeeded based on workflow type (supports pre/post action event in local mode, and approval event).',
+      'Support pre-action event (local mode), post-action event (local mode), and approval event here.',
       { ns: 'workflow' },
     ),
     'customize:triggerWorkflows': t(

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
@@ -39,7 +39,7 @@
     "适用于需要即时反馈的用户操作。不能在此模式下使用异步节点，并且不建议在同步模式下执行耗时的操作。",
   "Go back": "返回",
   "Bind workflows": "绑定工作流",
-  "Workflow will be triggered before or after submitting succeeded based on workflow type (supports pre/post action event in local mode, and approval event).": "工作流会基于其类型在提交成功之前或之后触发（支持局部模式的操作前、操作后事件，和审批事件）。",
+  "Support pre-action event (local mode), post-action event (local mode), and approval event here.": "此处支持“操作前事件（局部模式）”、“操作后事件（局部模式）”、“审批事件”。",
   "Workflow will be triggered directly once the button clicked, without data saving. Only supports to be bound with \"Custom action event\".": "按钮点击后直接触发工作流，但不会保存数据。仅支持绑定“自定义操作事件”。",
   "\"Submit to workflow\" to \"Post-action event\" is deprecated, please use \"Custom action event\" instead.": "“提交至工作流”到“操作后事件”的方式已被弃用，请使用“自定义操作事件”代替。",
   "Workflow will be triggered before deleting succeeded (only supports pre-action event in local mode).": "删除成功之前触发工作流（支持操作前事件）。",


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Simplify the hint of which workflows could be selected when binding to a button.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjust hint in configuration panel of binding workflow to a button |
| 🇨🇳 Chinese | 调整绑定工作流配置面板中的提示文案 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
