### PR TITLE
fix(client): fix special white space appears when paste content

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -210,7 +210,7 @@ function getCurrentRange(element: HTMLElement): RangeIndexes {
 
 export function TextArea(props) {
   const { wrapSSR, hashId, componentCls } = useStyles();
-  const { value = '', scope, onChange, multiline = true, changeOnSelect, style } = props;
+  const { value = '', scope, onChange, changeOnSelect, style } = props;
   const inputRef = useRef<HTMLDivElement>(null);
   const [options, setOptions] = useState([]);
   const form = useForm();
@@ -420,9 +420,10 @@ export function TextArea(props) {
           hashId,
           'ant-input',
           { 'ant-input-disabled': disabled },
+          // NOTE: `pre-wrap` here for avoid the `&nbsp;` (\x160) issue when paste content, we need normal space (\x32).
           css`
             overflow: auto;
-            white-space: ${multiline ? 'normal' : 'nowrap'};
+            white-space: pre-wrap;
 
             &[placeholder]:empty::before {
               content: attr(placeholder);

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -25,8 +25,8 @@ export type RequestConfig = Pick<AxiosRequestConfig, 'url' | 'method' | 'params'
 };
 
 const ContentTypeTransformers = {
-  'application/json'(data) {
-    return data;
+  'text/plain'(data) {
+    return data.toString();
   },
   'application/x-www-form-urlencoded'(data: { name: string; value: string }[]) {
     return new URLSearchParams(
@@ -52,6 +52,7 @@ async function request(config) {
 
   // TODO(feat): only support JSON type for now, should support others in future
   headers['Content-Type'] = contentType;
+  const transformer = ContentTypeTransformers[contentType];
 
   return axios.request({
     url: trim(url),
@@ -61,7 +62,7 @@ async function request(config) {
     timeout,
     ...(method.toLowerCase() !== 'get' && data != null
       ? {
-          data: ContentTypeTransformers[contentType](data),
+          data: transformer ? transformer(data) : data,
         }
       : {}),
   });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When paste content into Variable.TextArea, special white space character `\x160` appears, and makes server logic failed.

### Description 

1. Create a HTTP request node in workflow.
2. Add a header item with name as "Authorization".
3. Input "Bearer " (with the normal space), then paste the correct token text content into the input box.
4. Test the request node with test button.
5. API will return a failure status due to the token not match.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix special white space appears when paste content into variable textarea caused issue |
| 🇨🇳 Chinese | 修复变量文本输入框中在粘贴时可能产生非标准空格导致服务端逻辑错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
