### PR TITLE
fix: limit editing to current collection form block  in non-config mode

### DIFF
--- a/packages/core/client/src/block-provider/FormBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/FormBlockProvider.tsx
@@ -24,6 +24,8 @@ import { useActionContext } from '../schema-component';
 import { BlockProvider, useBlockRequestContext } from './BlockProvider';
 import { TemplateBlockProvider } from './TemplateBlockProvider';
 import { FormActiveFieldsProvider } from './hooks/useFormActiveFields';
+import { useDesignable } from '../schema-component';
+import { useCollectionRecordData } from '../data-source';
 
 export const FormBlockContext = createContext<{
   form?: any;
@@ -123,6 +125,18 @@ export const useIsDetailBlock = () => {
 export const FormBlockProvider = withDynamicSchemaProps((props) => {
   const parentRecordData = useCollectionParentRecordData();
   const { parentRecord } = props;
+  const record = useCollectionRecordData();
+  const { association } = props;
+  const cm = useCollectionManager();
+  const { __collection } = record || {};
+  const { designable } = useDesignable();
+  const collection = props.collection || cm.getCollection(association).name;
+
+  if (!designable && __collection) {
+    if (__collection !== collection) {
+      return null;
+    }
+  }
 
   return (
     <TemplateBlockProvider>


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      In non-config mode, display only the current collection  in the edit form.     |
| 🇨🇳 Chinese |      在非配置状态下，编辑表单应只显示本表区块     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
