### PR TITLE
fix(FilterBlocks): allow adding filter blocks in popup even without a…

### DIFF
--- a/packages/core/client/src/modules/fields/__e2e__/component/Input.Preview/basic.test.ts
+++ b/packages/core/client/src/modules/fields/__e2e__/component/Input.Preview/basic.test.ts
@@ -32,7 +32,12 @@ test.describe('Input.Preview', () => {
     // 4. 切换图片大小到 Large，大小切换正常
     await page.getByLabel('block-item-CollectionField-').hover();
     await page.getByLabel('designer-schema-settings-CollectionField-fieldSettings:FormItem-general-general').hover();
-    await page.getByRole('menuitem', { name: 'Size Small' }).click();
+    await page.getByRole('menuitem', { name: 'Size Small' }).click({
+      position: {
+        x: 160,
+        y: 10,
+      },
+    });
     await page.getByRole('option', { name: 'Large' }).click();
     await expect(page.getByLabel('block-item-CollectionField-').getByRole('img').first()).toHaveJSProperty('width', 72);
 

--- a/packages/core/client/src/schema-initializer/buttons/RecordBlockInitializers.tsx
+++ b/packages/core/client/src/schema-initializer/buttons/RecordBlockInitializers.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Schema } from '@formily/react';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import {
   useActionAvailable,
   useCollection,
@@ -283,16 +283,6 @@ const commonOptions = {
       name: 'filterBlocks',
       title: '{{t("Filter blocks")}}',
       type: 'itemGroup',
-      useVisible() {
-        const collection = useCollection();
-        return useMemo(
-          () =>
-            collection.fields.some(
-              (field) => canMakeAssociationBlock(field) && ['hasMany', 'belongsToMany'].includes(field.type),
-            ),
-          [collection.fields],
-        );
-      },
       children: [
         {
           name: 'filterForm',


### PR DESCRIPTION
…ssociation fields

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Previously, in pop-ups, Filter blocks could only be added to "Association blocks". Later, with the introduction of the "Other blocks" option, this restriction became unnecessary.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue where filter blocks cannot be added in the popup     |
| 🇨🇳 Chinese |     修复弹窗中无法添加筛选区块的问题      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
