### PR TITLE
fix: app's afterLoad event wasn't triggered after installation

### DIFF
--- a/packages/core/server/src/application.ts
+++ b/packages/core/server/src/application.ts
@@ -914,7 +914,7 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     }
     await this.reInit();
     await this.db.sync();
-    await this.load({ hooks: false });
+    await this.load();
 
     this.log.debug('emit beforeInstall', { method: 'install' });
     this.setMaintainingMessage('call beforeInstall hook...');

--- a/packages/core/server/src/application.ts
+++ b/packages/core/server/src/application.ts
@@ -566,6 +566,10 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
       }
     }
 
+    if (this.cacheManager) {
+      await this.cacheManager.close();
+    }
+
     this._cacheManager = await createCacheManager(this, this.options.cacheManager);
 
     this.log.debug('init plugins');
@@ -582,10 +586,12 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
 
     // Telemetry is initialized after beforeLoad hook
     // since some configuration may be registered in beforeLoad hook
-    this.telemetry.init();
-    if (this.options.telemetry?.enabled) {
-      // Start collecting telemetry data if enabled
-      this.telemetry.start();
+    if (!this.telemetry.started) {
+      this.telemetry.init();
+      if (this.options.telemetry?.enabled) {
+        // Start collecting telemetry data if enabled
+        this.telemetry.start();
+      }
     }
 
     await this.pm.load(options);
@@ -914,8 +920,8 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
     }
     await this.reInit();
     await this.db.sync();
-    await this.load();
-
+    await this.load({ hooks: false });
+    this._loaded = false;
     this.log.debug('emit beforeInstall', { method: 'install' });
     this.setMaintainingMessage('call beforeInstall hook...');
     await this.emitAsync('beforeInstall', this, options);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   App's afterLoad event wasn't triggered after installation   |
| 🇨🇳 Chinese |   应用安装后未触发 app 的 afterLoad 事件  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
