### PR TITLE
fix(client): string operators "contains/does not contains" should handle `null` value

### DIFF
--- a/packages/core/client/src/variables/utils/getAction.tsx
+++ b/packages/core/client/src/variables/utils/getAction.tsx
@@ -12,6 +12,7 @@ const TYPE_TO_ACTION = {
   belongsTo: 'get',
   hasOne: 'get',
   belongsToMany: 'list?pageSize=9999',
+  belongsToArray: 'get',
 };
 export const getAction = (type: string) => {
   if (process.env.NODE_ENV !== 'production' && !(type in TYPE_TO_ACTION)) {

--- a/packages/core/database/src/operators/string.ts
+++ b/packages/core/database/src/operators/string.ts
@@ -16,6 +16,11 @@ function escapeLike(value: string) {
 
 export default {
   $includes(value, ctx) {
+    if (value === null) {
+      return {
+        [Op.is]: null,
+      };
+    }
     if (Array.isArray(value)) {
       const conditions = value.map((item) => ({
         [isPg(ctx) ? Op.iLike : Op.like]: `%${escapeLike(item)}%`,
@@ -32,6 +37,11 @@ export default {
   },
 
   $notIncludes(value, ctx) {
+    if (value === null) {
+      return {
+        [Op.not]: null,
+      };
+    }
     if (Array.isArray(value)) {
       const conditions = value.map((item) => ({
         [isPg(ctx) ? Op.notILike : Op.notLike]: `%${escapeLike(item)}%`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where string operators "contains" and "does not contain do not properly handle `null` values |
| 🇨🇳 Chinese | 修复字符串操作符”包含“和”不包含“没有正确处理 `null` 值的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
