### PR TITLE
fix(plugin-notification-email): fix form reaction based on local path

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-email/src/client/ContentConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/client/ContentConfigForm.tsx
@@ -55,7 +55,7 @@ export const ContentConfigForm = ({ variableOptions }) => {
             },
             'x-reactions': [
               {
-                dependencies: ['contentType'],
+                dependencies: ['.contentType'],
                 fulfill: {
                   state: {
                     visible: '{{$deps[0] === "html"}}',
@@ -79,7 +79,7 @@ export const ContentConfigForm = ({ variableOptions }) => {
             },
             'x-reactions': [
               {
-                dependencies: ['contentType'],
+                dependencies: ['.contentType'],
                 fulfill: {
                   state: {
                     visible: '{{$deps[0] === "text"}}',


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix `ContentConfigForm` using local path in dynamic form.

### Description 

`dependencies: ['contnetType']` => `dependencies: ['.contnetType']`.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix reaction field path in dynamic form of email notification |
| 🇨🇳 Chinese | 修复 Email 通知渠道动态表单联动规则路径问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
