### PR TITLE
refactor(plugin-notification-mananger): add types data hook api

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-manager/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/client/index.tsx
@@ -11,12 +11,15 @@ import { Plugin } from '@nocobase/client';
 import { lang as t } from './locale';
 import { ChannelManager } from './manager/channel/components';
 import { RegisterChannelOptions } from './manager/channel/types';
+import { useNotificationTypes } from './manager/channel/hooks';
 import { LogManager } from './manager/log/components/Manager';
 import NotificationManager from './notification-manager';
 
 const NAMESPACE = 'notification-manager';
 export class PluginNotificationManagerClient extends Plugin {
   private manager: NotificationManager;
+
+  useNotificationTypes = useNotificationTypes;
 
   get channelTypes() {
     return this.manager.channelTypes;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Expose a hook for get all registered notification types.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add API of notification manager plugin for getting all registered types |
| 🇨🇳 Chinese | 增加通知插件获取所有已注册通知类型的接口 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
