### PR TITLE
refactor(plugin-notification-manager): expose notification types api

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/manager.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/manager.ts
@@ -20,7 +20,7 @@ import type {
 
 export class NotificationManager implements NotificationManager {
   private plugin: PluginNotificationManagerServer;
-  private notificationTypes = new Registry<{ Channel: NotificationChannelConstructor }>();
+  public notificationTypes = new Registry<{ Channel: NotificationChannelConstructor }>();
 
   constructor({ plugin }: { plugin: PluginNotificationManagerServer }) {
     this.plugin = plugin;

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/plugin.ts
@@ -15,6 +15,10 @@ export class PluginNotificationManagerServer extends Plugin {
   private manager: NotificationManager;
   logger: Logger;
 
+  get notificationTypes() {
+    return this.manager.notificationTypes;
+  }
+
   registerChannelType(params: RegisterServerTypeFnParams) {
     this.manager.registerType(params);
   }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Expose notification types API.

### Description 

```
plugin.notificationTypes
```

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add API for getting channel types registry of notification plugin |
| 🇨🇳 Chinese | 增加通知插件的渠道类型注册中心接口 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
