### PR TITLE
refactor(plugin-notification-manager): adjust api

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/manager.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/manager.ts
@@ -20,14 +20,14 @@ import type {
 
 export class NotificationManager implements NotificationManager {
   private plugin: PluginNotificationManagerServer;
-  public notificationTypes = new Registry<{ Channel: NotificationChannelConstructor }>();
+  public channelTypes = new Registry<{ Channel: NotificationChannelConstructor }>();
 
   constructor({ plugin }: { plugin: PluginNotificationManagerServer }) {
     this.plugin = plugin;
   }
 
   registerType({ type, Channel }: RegisterServerTypeFnParams) {
-    this.notificationTypes.register(type, { Channel });
+    this.channelTypes.register(type, { Channel });
   }
 
   createSendingRecord = async (options: WriteLogOptions) => {
@@ -46,7 +46,7 @@ export class NotificationManager implements NotificationManager {
     try {
       const channel = await channelsRepo.findOne({ filterByTk: params.channelName });
       if (channel) {
-        const Channel = this.notificationTypes.get(channel.notificationType).Channel;
+        const Channel = this.channelTypes.get(channel.notificationType).Channel;
         const instance = new Channel(this.plugin.app);
         logData.channelTitle = channel.title;
         logData.notificationType = channel.notificationType;

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/plugin.ts
@@ -15,8 +15,8 @@ export class PluginNotificationManagerServer extends Plugin {
   private manager: NotificationManager;
   logger: Logger;
 
-  get notificationTypes() {
-    return this.manager.notificationTypes;
+  get channelTypes() {
+    return this.manager.channelTypes;
   }
 
   registerChannelType(params: RegisterServerTypeFnParams) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Adjust notification channel types API.

### Description 

```diff
- notificationTypes
+ channelTypes
```

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | adjust channel types registry name of notification plugin |
| 🇨🇳 Chinese | 调整通知插件渠道类型注册中心的接口名称 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
