### PR TITLE
fix(plugin-notification-manager-email): fix user query by ids

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-email/src/server/mail-server.ts
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/server/mail-server.ts
@@ -47,7 +47,7 @@ export class MailNotificationChannel extends BaseNotificationChannel {
       if (receivers?.type === 'userId') {
         const users = await userRepo.find({
           filter: {
-            $in: receivers.value,
+            id: receivers.value,
           },
         });
         const usersEmail = users.map((user) => user.email).filter(Boolean);


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

To query users by ids correctly.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the query for users by ids in email notification |
| 🇨🇳 Chinese | 修复基于用户 ID 发送 email 通知的查询 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
