### PR TITLE
fix(m2m-array): issue where select component for a m2m array field has only one option

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/index.ts
+++ b/packages/core/client/src/collection-manager/interfaces/index.ts
@@ -48,3 +48,5 @@ export * from './nanoid';
 export * from './unixTimestamp';
 export * from './dateOnly';
 export * from './datetimeNoTz';
+
+export { getUniqueKeyFromCollection } from './utils';

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/client/mbm.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/client/mbm.ts
@@ -8,13 +8,9 @@
  */
 
 import { ISchema } from '@formily/react';
-import { Collection, CollectionFieldInterface } from '@nocobase/client';
+import { CollectionFieldInterface, getUniqueKeyFromCollection } from '@nocobase/client';
 import { tval } from '@nocobase/utils/client';
 import { NAMESPACE } from './locale';
-
-function getUniqueKeyFromCollection(collection: Collection) {
-  return collection?.filterTargetKey?.[0] || collection?.filterTargetKey || collection?.getPrimaryKey() || 'id';
-}
 
 export class MBMFieldInterface extends CollectionFieldInterface {
   name = 'mbm';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the issue where select component for a many to many (array) field has only one option         |
| 🇨🇳 Chinese | 修复多对多（数组）字段的选择组件只有一个选项的问题           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
