### PR TITLE
fix: sequelize primary key field with multi filter target keys

### DIFF
--- a/packages/core/database/src/collection.ts
+++ b/packages/core/database/src/collection.ts
@@ -189,10 +189,6 @@ export class Collection<
     return this.model.primaryKeyAttribute;
   }
 
-  isMultiFilterTargetKey() {
-    return Array.isArray(this.filterTargetKey) && this.filterTargetKey.length > 1;
-  }
-
   get name() {
     return this.options.name;
   }
@@ -223,6 +219,10 @@ export class Collection<
         return field;
       }
     }
+  }
+
+  isMultiFilterTargetKey() {
+    return Array.isArray(this.filterTargetKey) && this.filterTargetKey.length > 1;
   }
 
   tableName() {
@@ -310,6 +310,20 @@ export class Collection<
 
       set(value) {
         this._primaryKeyAttributes = value;
+      },
+    });
+
+    Object.defineProperty(this.model, 'primaryKeyField', {
+      get: function () {
+        if (this.primaryKeyAttribute) {
+          return this.rawAttributes[this.primaryKeyAttribute].field || this.primaryKeyAttribute;
+        }
+
+        return null;
+      }.bind(this.model),
+
+      set(val) {
+        this._primaryKeyField = val;
       },
     });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix wrong primaryKeyField value in sequelize when works with multi filter target keys     |
| 🇨🇳 Chinese |    修复联合主键中 sequelize primaryKeyField 属性读取错误的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
