### PR TITLE
fix: validate association field permissions when checking association collection field

### DIFF
--- a/packages/core/client/src/acl/ACLProvider.tsx
+++ b/packages/core/client/src/acl/ACLProvider.tsx
@@ -297,7 +297,7 @@ export const useACLFieldWhitelist = () => {
   return {
     whitelist,
     schemaInWhitelist: useCallback(
-      (fieldSchema: Schema, isSkip?) => {
+      (fieldSchema: Schema | any, isSkip?) => {
         if (isSkip) {
           return true;
         }
@@ -311,7 +311,8 @@ export const useACLFieldWhitelist = () => {
           return true;
         }
         const [key1, key2] = fieldSchema['x-collection-field'].split('.');
-        return whitelist?.includes(key2 || key1);
+        const [associationField] = fieldSchema['name'].split('.');
+        return whitelist?.includes(associationField || key2 || key1);
       },
       [whitelist],
     ),


### PR DESCRIPTION
… collection field permissions

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     permission for the association table field in the table is based on the permission of the corresponding association field     |
| 🇨🇳 Chinese |      表格中关系表字段权限为该关系字段的权限     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
