### PR TITLE
feat: table block support popup action

### DIFF
--- a/packages/core/client/src/modules/actions/view-edit-popup/PopupActionInitializer.tsx
+++ b/packages/core/client/src/modules/actions/view-edit-popup/PopupActionInitializer.tsx
@@ -53,7 +53,7 @@ export const PopupActionInitializer = (props) => {
                   grid: {
                     type: 'void',
                     'x-component': 'Grid',
-                    'x-initializer': 'popup:common:addBlock',
+                    'x-initializer': props?.['x-initializer'] || 'popup:common:addBlock',
                     properties: {},
                   },
                 },

--- a/packages/core/client/src/modules/blocks/data-blocks/table/TableActionInitializers.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/TableActionInitializers.tsx
@@ -44,6 +44,19 @@ const commonOptions = {
     },
     {
       type: 'item',
+      title: "{{t('Popup')}}",
+      name: 'popup',
+      Component: 'PopupActionInitializer',
+      componentProps: {
+        'x-component': 'Action',
+        'x-initializer': 'page:addBlock',
+      },
+      schema: {
+        'x-align': 'right',
+      },
+    },
+    {
+      type: 'item',
       title: "{{t('Delete')}}",
       name: 'delete',
       Component: 'BulkDestroyActionInitializer',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The configuration actions of the table component cannot meet the requirements, and new actions need to be added

### Description 
The data source in the table is other collections. After adding a pop-up window, you can select other collections and execute business logic through custom requests or workflows

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  [table] Add 'popup' action to configure actions         |
| 🇨🇳 Chinese | [表格] 配置操作中增加‘打开弹窗’按钮           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
