### PR TITLE
refactor(client): move getFilterTargetKey api to collection

### DIFF
--- a/packages/core/client/src/data-source/__tests__/collection/Collection.test.tsx
+++ b/packages/core/client/src/data-source/__tests__/collection/Collection.test.tsx
@@ -181,6 +181,23 @@ describe('Collection', () => {
     });
   });
 
+  describe('getFilterTargetKey()', () => {
+    test('not set as id', () => {
+      const collection = getCollection({ name: 'test' });
+      expect(collection.getFilterTargetKey()).toBe('id');
+    });
+
+    test('single ftk', () => {
+      const collection = getCollection({ name: 'test', filterTargetKey: 'a' });
+      expect(collection.getFilterTargetKey()).toBe('a');
+    });
+
+    test('multiple ftk', () => {
+      const collection = getCollection({ name: 'test', filterTargetKey: ['a', 'b'] });
+      expect(collection.getFilterTargetKey()).toMatchObject(['a', 'b']);
+    });
+  });
+
   test('properties', () => {
     const app = new Application({
       dataSourceManager: {

--- a/packages/core/client/src/data-source/collection/Collection.ts
+++ b/packages/core/client/src/data-source/collection/Collection.ts
@@ -52,7 +52,7 @@ export interface CollectionOptions {
   viewName?: string;
   writableView?: boolean;
 
-  filterTargetKey?: string | string[];
+  filterTargetKey?: string;
   fields?: CollectionFieldOptions[];
   model?: any;
   repository?: any;

--- a/packages/core/client/src/data-source/collection/Collection.ts
+++ b/packages/core/client/src/data-source/collection/Collection.ts
@@ -52,7 +52,7 @@ export interface CollectionOptions {
   viewName?: string;
   writableView?: boolean;
 
-  filterTargetKey?: string;
+  filterTargetKey?: string | string[];
   fields?: CollectionFieldOptions[];
   model?: any;
   repository?: any;
@@ -163,6 +163,9 @@ export class Collection {
     this.primaryKey = field?.name;
 
     return this.primaryKey;
+  }
+  getFilterTargetKey() {
+    return this.filterTargetKey || this.getPrimaryKey() || 'id';
   }
 
   get inherits() {

--- a/packages/core/client/src/data-source/collection/CollectionManager.ts
+++ b/packages/core/client/src/data-source/collection/CollectionManager.ts
@@ -164,7 +164,6 @@ export class CollectionManager {
       );
       return;
     }
-    const getTargetKey = (collection: Collection) => collection.filterTargetKey || collection.getPrimaryKey() || 'id';
 
     const buildFilterByTk = (targetKey: string | string[], record: Record<string, any>) => {
       if (Array.isArray(targetKey)) {
@@ -179,7 +178,7 @@ export class CollectionManager {
     };
 
     if (collectionOrAssociation instanceof Collection) {
-      const targetKey = getTargetKey(collectionOrAssociation);
+      const targetKey = collectionOrAssociation.getFilterTargetKey();
       return buildFilterByTk(targetKey, collectionRecordOrAssociationRecord);
     }
 
@@ -204,7 +203,7 @@ export class CollectionManager {
       );
       return;
     }
-    const targetKey = getTargetKey(targetCollection);
+    const targetKey = targetCollection.getFilterTargetKey();
     return buildFilterByTk(targetKey, collectionRecordOrAssociationRecord);
   }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support `getFilterTargetKey()` from `Collection` class.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support `getFilterTargetKey()` from `Collection` class |
| 🇨🇳 Chinese | 在 `Collection` 类中支持 `getFilterTargetKey()` 方法 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
