### PR TITLE
feat(client): add delimiters props to variable text

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/ContentConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/ContentConfigForm.tsx
@@ -57,6 +57,7 @@ export const ContentConfigForm = ({ variableOptions }) => {
                 'x-component-props': {
                   scope: variableOptions,
                   useTypedConstant: ['string'],
+                  delimiters: ['{{{', '}}}'],
                 },
                 description: tval(
                   'Support two types of links: internal links and external links. If using an internal link, the link starts with"/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
@@ -71,6 +72,7 @@ export const ContentConfigForm = ({ variableOptions }) => {
                 'x-component-props': {
                   scope: variableOptions,
                   useTypedConstant: ['string'],
+                  delimiters: ['{{{', '}}}'],
                 },
                 description: tval(
                   "Support two types of links: internal links and external links. If using an internal link, the link starts with '/', for example, '/m'. If using an external link, the link starts with 'http', for example, 'https://example.com'.",


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to define different delimiters of variable expression other than `{{` and `}}`.

### Description 

```diff
  <Variable.TextArea
+   delimiters={['{{{', '}}}']}
  />
```

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support delimiters properties for variable expression component |
| 🇨🇳 Chinese | 为变量表达式输入组件增加定界符配置项 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
