### PR TITLE
refactor: adjust default column width to 100 in table

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/table-selector/__e2e__/schemaInitializer.test.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/table-selector/__e2e__/schemaInitializer.test.ts
@@ -87,8 +87,8 @@ test.describe('configure actions column', () => {
       expect(Math.floor(box.width)).toBe(width);
     };
 
-    // 列宽度默认为 200
-    await expectActionsColumnWidth(200);
+    // 列宽度默认为 100
+    await expectActionsColumnWidth(100);
 
     await page.getByText('Actions', { exact: true }).hover();
     await page.getByLabel('designer-schema-settings-TableV2.Column-fieldSettings:TableColumn-users').hover();

--- a/packages/core/client/src/modules/blocks/data-blocks/table/TableActionColumnInitializers.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/TableActionColumnInitializers.tsx
@@ -51,7 +51,7 @@ export const Resizable = () => {
               'x-decorator': 'FormItem',
               'x-component': 'InputNumber',
               'x-component-props': {},
-              default: fieldSchema?.['x-component-props']?.width || 200,
+              default: fieldSchema?.['x-component-props']?.width || 100,
             },
           },
         } as ISchema

--- a/packages/core/client/src/modules/blocks/data-blocks/table/__e2e__/schemaInitializer.test.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/__e2e__/schemaInitializer.test.ts
@@ -321,8 +321,8 @@ test.describe('configure actions column', () => {
   test('column width', async ({ page, mockPage }) => {
     await mockPage(oneEmptyTable).goto();
 
-    // 列宽度默认为 200
-    await expect(page.getByRole('columnheader', { name: 'Actions', exact: true })).toHaveJSProperty('offsetWidth', 200);
+    // 列宽度默认为 100
+    await expect(page.getByRole('columnheader', { name: 'Actions', exact: true })).toHaveJSProperty('offsetWidth', 100);
 
     await page.getByText('Actions', { exact: true }).hover();
     await page.getByLabel('designer-schema-settings-TableV2.Column-TableV2.ActionColumnDesigner-').hover();

--- a/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
@@ -122,7 +122,7 @@ export const tableColumnSettings = new SchemaSettings({
                 title: t('Column width'),
                 properties: {
                   width: {
-                    default: columnSchema?.['x-component-props']?.['width'] || 200,
+                    default: columnSchema?.['x-component-props']?.['width'] || 100,
                     'x-decorator': 'FormItem',
                     'x-component': 'InputNumber',
                     'x-component-props': {},

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Designer.tsx
@@ -172,7 +172,7 @@ export const TableColumnDesigner = (props) => {
             title: t('Column width'),
             properties: {
               width: {
-                default: columnSchema?.['x-component-props']?.['width'] || 200,
+                default: columnSchema?.['x-component-props']?.['width'] || 100,
                 'x-decorator': 'FormItem',
                 'x-component': 'InputNumber',
                 'x-component-props': {},

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -129,7 +129,7 @@ const useTableColumns = (props: { showDel?: any; isSubTable?: boolean }, paginat
           sorter: s['x-component-props']?.['sorter'],
           columnHidden,
           ...s['x-component-props'],
-          width: columnHidden && !designable ? 0 : s['x-component-props']?.width || 200,
+          width: columnHidden && !designable ? 0 : s['x-component-props']?.width || 100,
           render: (v, record) => {
             // 这行代码会导致这里的测试不通过：packages/core/client/src/modules/blocks/data-blocks/table/__e2e__/schemaInitializer.test.ts:189
             // if (collectionFields?.length === 1 && collectionFields[0]['x-read-pretty'] && v == undefined) return null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   adjust default column width to 100 in table   block     |
| 🇨🇳 Chinese |    表格column 默认宽度调整为100       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
