### PR TITLE
fix(evaluators): change formula.js to default calculation engine

### DIFF
--- a/packages/core/evaluators/src/client/index.tsx
+++ b/packages/core/evaluators/src/client/index.tsx
@@ -22,8 +22,8 @@ export interface Evaluator {
 
 export const evaluators = new Registry<Evaluator>();
 
-evaluators.register('math.js', mathjs);
 evaluators.register('formula.js', formulajs);
+evaluators.register('math.js', mathjs);
 evaluators.register('string', string);
 
 export function getOptions() {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/calculation.tsx
@@ -32,7 +32,7 @@ export default class extends Instruction {
         options: getOptions(),
       },
       required: true,
-      default: 'math.js',
+      default: 'formula.js',
     },
     expression: {
       type: 'string',


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Use Formula.js as default evaluator.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | use Formula.js as default evaluator in calculation node |
| 🇨🇳 Chinese | 将运算节点的默认计算引擎更换为 Formula.js |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
