### PR TITLE
fix: reset issue that reverts filter button title to default

### DIFF
--- a/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
@@ -21,6 +21,7 @@ import { useProps } from '../../hooks/useProps';
 import { Action, ActionProps } from '../action';
 import { DatePickerProvider } from '../date-picker/DatePicker';
 import { StablePopover } from '../popover';
+import { useCompile } from '../../';
 
 export const FilterActionContext = createContext<any>(null);
 FilterActionContext.displayName = 'FilterActionContext';
@@ -50,6 +51,8 @@ export const FilterAction = withDynamicSchemaProps(
     const [visible, setVisible] = useState(false);
     const { designable, dn } = useDesignable();
     const fieldSchema = useFieldSchema();
+    const compile = useCompile();
+
     const form = useMemo<Form>(() => props.form || createForm(), []);
 
     // 新版 UISchema（1.0 之后）中已经废弃了 useProps，这里之所以继续保留是为了兼容旧版的 UISchema
@@ -98,6 +101,7 @@ export const FilterAction = withDynamicSchemaProps(
                       onClick={async () => {
                         await form.reset();
                         onReset?.(form.values);
+                        field.title = compile(fieldSchema.title) || t('Filter');
                         setVisible(false);
                       }}
                     >

--- a/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/FilterAction.tsx
@@ -58,7 +58,6 @@ export const FilterAction = withDynamicSchemaProps(
     const onOpenChange = useCallback((visible: boolean): void => {
       setVisible(visible);
     }, []);
-
     return (
       <FilterActionContext.Provider value={{ field, fieldSchema, designable, dn }}>
         <Container
@@ -99,7 +98,6 @@ export const FilterAction = withDynamicSchemaProps(
                       onClick={async () => {
                         await form.reset();
                         onReset?.(form.values);
-                        field.title = t('Filter');
                         setVisible(false);
                       }}
                     >

--- a/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -16,7 +16,7 @@ import { useBlockRequestContext } from '../../../block-provider';
 import { useCollectionManager_deprecated, useCollection_deprecated } from '../../../collection-manager';
 import { mergeFilter } from '../../../filter-provider/utils';
 import { useDataLoadingMode } from '../../../modules/blocks/data-blocks/details-multi/setDataLoadingModeSettingsItem';
-
+import { useCompile } from '../../';
 export const useGetFilterOptions = () => {
   const { getCollectionFields } = useCollectionManager_deprecated();
   const getFilterFieldOptions = useGetFilterFieldOptions();
@@ -183,6 +183,7 @@ export const useFilterFieldProps = ({ options, service, params }) => {
   const field = useField<Field>();
   const dataLoadingMode = useDataLoadingMode();
   const fieldSchema = useFieldSchema();
+  const compile = useCompile();
 
   return {
     options,
@@ -206,7 +207,7 @@ export const useFilterFieldProps = ({ options, service, params }) => {
       if (items?.length) {
         field.title = t('{{count}} filter items', { count: items?.length || 0 });
       } else {
-        field.title = fieldSchema.title || t('Filter');
+        field.title = compile(fieldSchema.title) || t('Filter');
       }
     },
     onReset() {

--- a/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -182,6 +182,7 @@ export const useFilterFieldProps = ({ options, service, params }) => {
   const { t } = useTranslation();
   const field = useField<Field>();
   const dataLoadingMode = useDataLoadingMode();
+  const fieldSchema = useFieldSchema();
 
   return {
     options,
@@ -205,7 +206,7 @@ export const useFilterFieldProps = ({ options, service, params }) => {
       if (items?.length) {
         field.title = t('{{count}} filter items', { count: items?.length || 0 });
       } else {
-        field.title = t('Filter');
+        field.title = fieldSchema.title || t('Filter');
       }
     },
     onReset() {
@@ -221,8 +222,6 @@ export const useFilterFieldProps = ({ options, service, params }) => {
         },
         { filters },
       ];
-
-      field.title = t('Filter');
 
       if (dataLoadingMode === 'manual') {
         service.params = newParams;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix  reset issue that reverts filter button title to default     |
| 🇨🇳 Chinese |      修复筛选按钮重置后标题恢复为默认名称的问题     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
