### PR TITLE
fix(data-vi): issue where data transformations do not work on tooltip in dual-axes charts

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/dualAxes.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/chart/g2plot/dualAxes.ts
@@ -84,6 +84,20 @@ export class DualAxes extends G2PlotChart {
           return {
             type: 'line',
             yField,
+            tooltip: {
+              items: [
+                (data: any) => {
+                  const { [yField]: y } = data;
+                  const yFieldProps = fieldProps[yField];
+                  const name = yFieldProps?.label || yField;
+                  const value = yFieldProps?.transformer ? yFieldProps.transformer(y) : y;
+                  return {
+                    name,
+                    value,
+                  };
+                },
+              ],
+            },
             colorField: () => {
               const props = fieldProps[yField];
               return props?.label || yField;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where data transformations do not work on tooltip in dual-axes charts          |
| 🇨🇳 Chinese | 修复双轴图中数据转换没有对 tooltip 生效的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
