### PR TITLE
fix(client): fix components

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -65,7 +65,6 @@ export const Action: ComposedAction = withDynamicSchemaProps(
       onClick,
       style,
       loading,
-      openSize: os,
       disabled: propsDisabled,
       actionCallback,
       confirm: propsConfirm,
@@ -199,6 +198,8 @@ interface InternalActionProps {
   setSubmitted: (v: boolean) => void;
   getAriaLabel: (postfix?: string) => string;
   parentRecordData: any;
+  openMode?: ActionContextProps['openMode'];
+  openSize?: ActionContextProps['openSize'];
 }
 
 const InternalAction: React.FC<InternalActionProps> = observer(function Com(props) {
@@ -231,14 +232,16 @@ const InternalAction: React.FC<InternalActionProps> = observer(function Com(prop
     setSubmitted,
     getAriaLabel,
     parentRecordData,
+    openMode: om,
+    openSize: os,
     ...others
   } = props;
   const [visible, setVisible] = useState(false);
   const { wrapSSR, componentCls, hashId } = useStyles();
   const [formValueChanged, setFormValueChanged] = useState(false);
   const designerProps = fieldSchema['x-toolbar-props'] || fieldSchema['x-designer-props'];
-  const openMode = fieldSchema?.['x-component-props']?.['openMode'];
-  const openSize = fieldSchema?.['x-component-props']?.['openSize'];
+  const openMode = om ?? fieldSchema?.['x-component-props']?.['openMode'];
+  const openSize = os ?? fieldSchema?.['x-component-props']?.['openSize'];
   const refreshDataBlockRequest = fieldSchema?.['x-component-props']?.['refreshDataBlockRequest'];
   const { modal } = App.useApp();
   const form = useForm();

--- a/packages/core/client/src/schema-component/antd/page/index.ts
+++ b/packages/core/client/src/schema-component/antd/page/index.ts
@@ -12,7 +12,7 @@ export * from './FixedBlock';
 export * from './FixedBlockDesignerItem';
 export * from './Page';
 export * from './Page.Settings';
-export { PagePopups } from './PagePopups';
+export { PagePopups, useCurrentPopupContext } from './PagePopups';
 export { getPopupPathFromParams, getStoredPopupContext, storePopupContext, withSearchParams } from './pagePopupUtils';
 export * from './PageTab.Settings';
 export { PopupSettingsProvider, usePopupSettings } from './PopupSettingsProvider';

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -474,10 +474,10 @@ const columnOpacityStyle = {
   opacity: 0.3,
 };
 
-const HeaderCellComponent = (props) => {
+const HeaderCellComponent = ({ columnHidden, ...props }) => {
   const { designable } = useDesignable();
 
-  if (props.columnHidden) {
+  if (columnHidden) {
     return <th style={designable ? columnOpacityStyle : columnHiddenStyle}>{designable ? props.children : null}</th>;
   }
 
@@ -515,10 +515,10 @@ const InternalBodyCellComponent = (props) => {
 };
 
 const displayNone = { display: 'none' };
-const BodyCellComponent = (props) => {
+const BodyCellComponent = ({ columnHidden, ...props }) => {
   const { designable } = useDesignable();
 
-  if (props.columnHidden) {
+  if (columnHidden) {
     return (
       <td style={designable ? columnOpacityStyle : columnHiddenStyle}>
         {designable ? props.children : <span style={displayNone}>{props.children}</span>}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

* Allow to pass `openSize` in to internal button in `Action`.
* Export `useCurrentPopupContext()` hook for getting popup params.
* Fix `columnHidden` props caused warning.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | adjust some api of client core, and fix warning |
| 🇨🇳 Chinese | 调整部分前端内核的接口，并修复警告 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
