### PR TITLE
fix: style issue when using long text as the title field in association field

### DIFF
--- a/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
@@ -65,6 +65,7 @@ const InternalRemoteSelect = withDynamicSchemaProps(
         optionFilter,
         dataSource: propsDataSource,
         toOptionsItem = (value) => value,
+        popupMatchSelectWidth = false,
         ...others
       } = props;
       const dataSource = useDataSourceKey();
@@ -245,7 +246,7 @@ const InternalRemoteSelect = withDynamicSchemaProps(
       return (
         <Select
           open={open}
-          popupMatchSelectWidth={false}
+          popupMatchSelectWidth={popupMatchSelectWidth}
           autoClearSearchValue
           filterOption={false}
           filterSort={null}

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
@@ -7,10 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { RemoteSchemaComponent, AssociatedFields } from '@nocobase/client';
+import { RemoteSchemaComponent, AssociationField } from '@nocobase/client';
 import React, { useCallback } from 'react';
 import { Outlet, useParams } from 'react-router-dom';
-import { Button as MobileButton, Form as MobileForm, List as MobileList, Dialog as MobileDialog } from 'antd-mobile';
+import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
 import { MobilePicker } from './components/MobilePicker';
 import { MobileDateTimePicker } from './components/MobileDatePicker';
 
@@ -20,11 +20,9 @@ const mobileComponents = {
   DatePicker: MobileDateTimePicker,
   UnixTimestamp: MobileDateTimePicker,
   Modal: MobileDialog,
-  AssociatedFields: (
-    <div contentEditable="false">
-      <AssociatedFields />
-    </div>
-  ),
+  AssociationField: (props) => {
+    return <AssociationField {...props} popupMatchSelectWidth={true} />;
+  },
 };
 
 export const MobilePage = () => {


### PR DESCRIPTION
…on  fields

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      style issue when using long text as the title field in association field      |
| 🇨🇳 Chinese |      修复关系字段使用超长文本作为标题时的样式问题     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
