### PR TITLE
fix(client): revert opensize back

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -65,6 +65,7 @@ export const Action: ComposedAction = withDynamicSchemaProps(
       onClick,
       style,
       loading,
+      openSize: os,
       disabled: propsDisabled,
       actionCallback,
       confirm: propsConfirm,
@@ -198,8 +199,6 @@ interface InternalActionProps {
   setSubmitted: (v: boolean) => void;
   getAriaLabel: (postfix?: string) => string;
   parentRecordData: any;
-  openMode?: ActionContextProps['openMode'];
-  openSize?: ActionContextProps['openSize'];
 }
 
 const InternalAction: React.FC<InternalActionProps> = observer(function Com(props) {
@@ -232,16 +231,14 @@ const InternalAction: React.FC<InternalActionProps> = observer(function Com(prop
     setSubmitted,
     getAriaLabel,
     parentRecordData,
-    openMode: om,
-    openSize: os,
     ...others
   } = props;
   const [visible, setVisible] = useState(false);
   const { wrapSSR, componentCls, hashId } = useStyles();
   const [formValueChanged, setFormValueChanged] = useState(false);
   const designerProps = fieldSchema['x-toolbar-props'] || fieldSchema['x-designer-props'];
-  const openMode = om ?? fieldSchema?.['x-component-props']?.['openMode'];
-  const openSize = os ?? fieldSchema?.['x-component-props']?.['openSize'];
+  const openMode = fieldSchema?.['x-component-props']?.['openMode'];
+  const openSize = fieldSchema?.['x-component-props']?.['openSize'];
   const refreshDataBlockRequest = fieldSchema?.['x-component-props']?.['refreshDataBlockRequest'];
   const { modal } = App.useApp();
   const form = useForm();


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The size configuration of opened drawer perform not correctly.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | revert modification of `openSize` props in action button |
| 🇨🇳 Chinese | 撤回对按钮打开尺寸传参的修改 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
