### PR TITLE
fix(client): fix file type matching when file or property is null

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -60,11 +60,14 @@ export class AttachmentFileTypes {
 export const attachmentFileTypes = new AttachmentFileTypes();
 
 export function matchMimetype(file: FileModel | UploadFile<any>, type: string) {
-  if ('originFileObj' in file) {
-    return match(file.type, type);
+  if (!file) {
+    return false;
   }
-  if ('mimetype' in file) {
-    return match(file.mimetype, type);
+  if ((<UploadFile>file).originFileObj) {
+    return match((<UploadFile>file).type, type);
+  }
+  if ((<FileModel>file).mimetype) {
+    return match((<FileModel>file).mimetype, type);
   }
   if (file.url) {
     const [fileUrl] = file.url.split('?');


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix file type matching when file or property is null

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix file type matching when file or property is null |
| 🇨🇳 Chinese | 修复当文件或特定属性为空时文件类型匹配的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |


### Checklists

- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
