### PR TITLE
fix(m2m-array): error when retriving association records with m2m array field

### DIFF
--- a/packages/core/database/src/relation-repository/multiple-relation-repository.ts
+++ b/packages/core/database/src/relation-repository/multiple-relation-repository.ts
@@ -82,10 +82,14 @@ export abstract class MultipleRelationRepository extends RelationRepository {
     if (!sourceModel) return 0;
 
     const queryOptions = this.buildQueryOptions(options);
+    const include = queryOptions.include?.filter((item: { association: string }) => {
+      const association = this.targetModel.associations?.[item.association];
+      return association?.associationType !== 'BelongsToArray';
+    });
 
     const count = await sourceModel[this.accessors().get]({
       where: queryOptions.where,
-      include: queryOptions.include,
+      include,
       includeIgnoreAttributes: false,
       attributes: [
         [

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/issues.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/issues.test.ts
@@ -1,0 +1,115 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { MockDatabase, MockServer, createMockServer } from '@nocobase/test';
+
+describe('m2m array api, bigInt targetKey', () => {
+  let app: MockServer;
+  let db: MockDatabase;
+  let agent;
+
+  beforeEach(async () => {
+    app = await createMockServer({
+      plugins: ['field-m2m-array', 'data-source-manager', 'data-source-main', 'error-handler'],
+    });
+    db = app.db;
+    agent = app.agent();
+  });
+
+  afterEach(async () => {
+    await db.clean({ drop: true });
+    await app.destroy();
+  });
+
+  test('get relation collection with m2m array field', async () => {
+    await db.getRepository('collections').create({
+      values: {
+        name: 'tags',
+        fields: [
+          {
+            name: 'id',
+            type: 'bigInt',
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          {
+            name: 'title',
+            type: 'string',
+          },
+        ],
+      },
+    });
+    await db.getRepository('collections').create({
+      values: {
+        name: 'users',
+        fields: [
+          {
+            name: 'id',
+            type: 'bigInt',
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          {
+            name: 'username',
+            type: 'string',
+          },
+          {
+            name: 'tags',
+            type: 'belongsToArray',
+            foreignKey: 'tag_ids',
+            target: 'tags',
+            targetKey: 'id',
+          },
+        ],
+      },
+    });
+    await db.getRepository('collections').create({
+      values: {
+        name: 'projects',
+        fields: [
+          {
+            name: 'id',
+            type: 'bigInt',
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          {
+            name: 'title',
+            type: 'string',
+          },
+          {
+            name: 'users',
+            type: 'hasMany',
+            foreignKey: 'project_id',
+            target: 'users',
+          },
+        ],
+      },
+    });
+    // @ts-ignore
+    await db.getRepository('collections').load();
+    await db.sync();
+    await db.getRepository('tags').create({
+      values: [{ title: 'a' }, { title: 'b' }, { title: 'c' }],
+    });
+    await db.getRepository('users').create({
+      values: { id: 1, username: 'a', tag_ids: [1, 2] },
+    });
+    await db.getRepository('projects').create({
+      values: { id: 1, title: 'p1', users: [1] },
+    });
+    const res = await agent.resource('projects.users', 1).list({
+      appends: ['tags'],
+    });
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where retrieving records in an association collection with many to many (array) fields causes an error          |
| 🇨🇳 Chinese | 修复在获取含有多对多（数组）字段的关联表记录时报错的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
