### PR TITLE
fix: use desktop components for select in mobile configuration mode & fix error when using variables as default values in datePicker

### DIFF
--- a/packages/core/utils/src/date.ts
+++ b/packages/core/utils/src/date.ts
@@ -69,9 +69,12 @@ export const toLocal = (value: dayjs.Dayjs) => {
 };
 
 const convertQuarterToFirstDay = (quarterStr) => {
-  const year = parseInt(quarterStr.slice(0, 4)); // 提取年份
-  const quarter = parseInt(quarterStr.slice(-1)); // 提取季度数字
-  return dayjs().quarter(quarter).year(year);
+  if (dayjs(quarterStr).isValid()) {
+    const year = parseInt(quarterStr.slice(0, 4)); // 提取年份
+    const quarter = parseInt(quarterStr.slice(-1)); // 提取季度数字
+    return dayjs().quarter(quarter).year(year);
+  }
+  return null;
 };
 
 const toMoment = (val: any, options?: Str2momentOptions) => {

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { RemoteSchemaComponent, AssociationField } from '@nocobase/client';
+import { RemoteSchemaComponent, AssociationField, useDesignable, Select } from '@nocobase/client';
 import React, { useCallback } from 'react';
 import { Outlet, useParams } from 'react-router-dom';
 import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
@@ -16,7 +16,14 @@ import { MobileDateTimePicker } from './components/MobileDatePicker';
 
 const mobileComponents = {
   Button: MobileButton,
-  Select: MobilePicker,
+  Select: (props) => {
+    const { designable } = useDesignable();
+    if (designable !== false) {
+      return <Select {...props} />;
+    } else {
+      return <MobilePicker {...props} />;
+    }
+  },
   DatePicker: MobileDateTimePicker,
   UnixTimestamp: MobileDateTimePicker,
   Modal: MobileDialog,

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { RemoteSchemaComponent, AssociationField, useDesignable, Select } from '@nocobase/client';
+import { RemoteSchemaComponent, AssociationField, useDesignable, Select, DatePicker } from '@nocobase/client';
 import React, { useCallback } from 'react';
 import { Outlet, useParams } from 'react-router-dom';
 import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
@@ -24,7 +24,14 @@ const mobileComponents = {
       return <MobilePicker {...props} />;
     }
   },
-  DatePicker: MobileDateTimePicker,
+  DatePicker: (props) => {
+    const { designable } = useDesignable();
+    if (designable !== false) {
+      return <DatePicker {...props} />;
+    } else {
+      return <MobileDateTimePicker {...props} />;
+    }
+  },
   UnixTimestamp: MobileDateTimePicker,
   Modal: MobileDialog,
   AssociationField: (props) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: use desktop components for select in mobile configuration mode & fix error when using variables as default values in datePicker       |
| 🇨🇳 Chinese |      移动端配置态的时候 select 还是使用桌面组件& 修复日期组件使用变量作为默认值时报错     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
