### PR TITLE
fix: style issue on mobile when subtable is configured to allow select data only

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { RemoteSchemaComponent, AssociationField, useDesignable, Select, DatePicker } from '@nocobase/client';
+import { RemoteSchemaComponent, AssociationField, useDesignable, Select, DatePicker, Action } from '@nocobase/client';
 import React, { useCallback } from 'react';
 import { Outlet, useParams } from 'react-router-dom';
 import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
@@ -20,9 +20,9 @@ const AssociationFieldMobile = (props) => {
 
 AssociationFieldMobile.SubTable = AssociationField.SubTable;
 AssociationFieldMobile.Nester = AssociationField.Nester;
-AssociationFieldMobile.AddNewer = AssociationField.Container;
-AssociationFieldMobile.Selector = AssociationField.Container;
-AssociationFieldMobile.Viewer = AssociationField.Container;
+AssociationFieldMobile.AddNewer = Action.Container;
+AssociationFieldMobile.Selector = Action.Container;
+AssociationFieldMobile.Viewer = Action.Container;
 AssociationFieldMobile.InternalSelect = AssociationField.InternalSelect;
 AssociationFieldMobile.ReadPretty = AssociationField.ReadPretty;
 AssociationFieldMobile.FileSelector = AssociationField.FileSelector;


### PR DESCRIPTION
…ting existing data only

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        fix: style issue on mobile when subtable is configured to allow select data only   |
| 🇨🇳 Chinese |    修复：移动端配置子表格仅允许选择已有数据时样式异常       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
