### PR TITLE
fix：missing date field options with and without timezone in calendar block

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calender.Settings.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calender.Settings.tsx
@@ -186,7 +186,7 @@ export const calendarBlockSettings = new SchemaSettings({
         return {
           title: t('Start date field'),
           value: fieldNames.start,
-          options: getCollectionFieldsOptions(name, 'date', {
+          options: getCollectionFieldsOptions(name, ['date', 'datetime', 'dateOnly', 'datetimeNoTz', 'unixTimestamp'], {
             association: ['o2o', 'obo', 'oho', 'm2o'],
           }),
           onChange: (start) => {
@@ -221,7 +221,7 @@ export const calendarBlockSettings = new SchemaSettings({
         return {
           title: t('End date field'),
           value: fieldNames.end,
-          options: getCollectionFieldsOptions(name, ['date', 'datetime', 'dateOnly', 'datetimeNoTz'], {
+          options: getCollectionFieldsOptions(name, ['date', 'datetime', 'dateOnly', 'datetimeNoTz', 'unixTimestamp'], {
             association: ['o2o', 'obo', 'oho', 'm2o'],
           }),
           onChange: (end) => {

--- a/packages/plugins/@nocobase/plugin-calendar/src/client/schema-initializer/items/CalendarBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/schema-initializer/items/CalendarBlockInitializer.tsx
@@ -70,10 +70,14 @@ export const useCreateCalendarBlock = () => {
 
   const createCalendarBlock = async ({ item }) => {
     const stringFieldsOptions = getCollectionFieldsOptions(item.name, 'string', { dataSource: item.dataSource });
-    const dateFieldsOptions = getCollectionFieldsOptions(item.name, ['date', 'datetime', 'dateOnly', 'datetimeNoTz'], {
-      association: ['o2o', 'obo', 'oho', 'm2o'],
-      dataSource: item.dataSource,
-    });
+    const dateFieldsOptions = getCollectionFieldsOptions(
+      item.name,
+      ['date', 'datetime', 'dateOnly', 'datetimeNoTz', 'unixTimestamp'],
+      {
+        association: ['o2o', 'obo', 'oho', 'm2o'],
+        dataSource: item.dataSource,
+      },
+    );
 
     const values = await FormDialog(
       t('Create calendar block'),


### PR DESCRIPTION
… block

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix missing date field options with and without timezone in calendar block     |
| 🇨🇳 Chinese |     修复日历区块中日期字段选项缺失无时区和含时区字段      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
