### PR TITLE
refactor(plugin-workflow): support to register system variables in client

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
@@ -29,12 +29,15 @@ import CreateInstruction from './nodes/create';
 import UpdateInstruction from './nodes/update';
 import DestroyInstruction from './nodes/destroy';
 import { getWorkflowDetailPath, getWorkflowExecutionsPath } from './utils';
-import { NAMESPACE } from './locale';
+import { lang, NAMESPACE } from './locale';
 import { customizeSubmitToWorkflowActionSettings } from './settings/customizeSubmitToWorkflowActionSettings';
+import { VariableOption } from './variable';
 
 export default class PluginWorkflowClient extends Plugin {
   triggers = new Registry<Trigger>();
   instructions = new Registry<Instruction>();
+  systemVariables = new Registry<VariableOption>();
+
   useTriggersOptions = () => {
     const compile = useCompile();
     return Array.from(this.triggers.getEntities()).map(([value, { title, ...options }]) => ({
@@ -67,6 +70,10 @@ export default class PluginWorkflowClient extends Plugin {
     } else {
       throw new TypeError('invalid instruction type to register');
     }
+  }
+
+  registerSystemVariable(option: VariableOption) {
+    this.systemVariables.register(option.key, option);
   }
 
   async load() {
@@ -113,6 +120,124 @@ export default class PluginWorkflowClient extends Plugin {
     this.registerInstruction('create', CreateInstruction);
     this.registerInstruction('update', UpdateInstruction);
     this.registerInstruction('destroy', DestroyInstruction);
+
+    this.registerSystemVariable({
+      key: 'now',
+      label: `{{t("System time", { ns: "${NAMESPACE}" })}}`,
+      value: 'now',
+    });
+    this.registerSystemVariable({
+      key: 'dateRange',
+      label: `{{t("Date range", { ns: "${NAMESPACE}" })}}`,
+      value: 'dateRange',
+      children: [
+        {
+          key: 'yesterday',
+          value: 'yesterday',
+          label: `{{t("Yesterday", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'today',
+          value: 'today',
+          label: `{{t("Today", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'tomorrow',
+          value: 'tomorrow',
+          label: `{{t("Tomorrow", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'lastWeek',
+          value: 'lastWeek',
+          label: `{{t("Last week", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'thisWeek',
+          value: 'thisWeek',
+          label: `{{t("This week", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'nextWeek',
+          value: 'nextWeek',
+          label: `{{t("Next week", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'lastMonth',
+          value: 'lastMonth',
+          label: `{{t("Last month", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'thisMonth',
+          value: 'thisMonth',
+          label: `{{t("This month", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'nextMonth',
+          value: 'nextMonth',
+          label: `{{t("Next month", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'lastQuarter',
+          value: 'lastQuarter',
+          label: `{{t("Last quarter", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'thisQuarter',
+          value: 'thisQuarter',
+          label: `{{t("This quarter", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'nextQuarter',
+          value: 'nextQuarter',
+          label: `{{t("Next quarter", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'lastYear',
+          value: 'lastYear',
+          label: `{{t("Last year", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'thisYear',
+          value: 'thisYear',
+          label: `{{t("This year", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'nextYear',
+          value: 'nextYear',
+          label: `{{t("Next year", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'last7Days',
+          value: 'last7Days',
+          label: `{{t("Last 7 days", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'next7Days',
+          value: 'next7Days',
+          label: `{{t("Next 7 days", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'last30Days',
+          value: 'last30Days',
+          label: `{{t("Last 30 days", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'next30Days',
+          value: 'next30Days',
+          label: `{{t("Next 30 days", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'last90Days',
+          value: 'last90Days',
+          label: `{{t("Last 90 days", { ns: "${NAMESPACE}" })}}`,
+        },
+        {
+          key: 'next90Days',
+          value: 'next90Days',
+          label: `{{t("Next 90 days", { ns: "${NAMESPACE}" })}}`,
+        },
+      ],
+    });
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -54,114 +54,6 @@ export type UseVariableOptions = {
 
 export const defaultFieldNames = { label: 'label', value: 'value', children: 'children' } as const;
 
-const getDateOptions = (t) => [
-  {
-    key: 'yesterday',
-    value: 'yesterday',
-    label: t('Yesterday'),
-  },
-  {
-    key: 'today',
-    value: 'today',
-    label: t('Today'),
-  },
-  {
-    key: 'tomorrow',
-    value: 'tomorrow',
-    label: t('Tomorrow'),
-  },
-  {
-    key: 'lastWeek',
-    value: 'lastWeek',
-    label: t('Last week'),
-  },
-  {
-    key: 'thisWeek',
-    value: 'thisWeek',
-    label: t('This week'),
-  },
-  {
-    key: 'nextWeek',
-    value: 'nextWeek',
-    label: t('Next week'),
-  },
-  {
-    key: 'lastMonth',
-    value: 'lastMonth',
-    label: t('Last month'),
-  },
-  {
-    key: 'thisMonth',
-    value: 'thisMonth',
-    label: t('This month'),
-  },
-  {
-    key: 'nextMonth',
-    value: 'nextMonth',
-    label: t('Next month'),
-  },
-  {
-    key: 'lastQuarter',
-    value: 'lastQuarter',
-    label: t('Last quarter'),
-  },
-  {
-    key: 'thisQuarter',
-    value: 'thisQuarter',
-    label: t('This quarter'),
-  },
-  {
-    key: 'nextQuarter',
-    value: 'nextQuarter',
-    label: t('Next quarter'),
-  },
-  {
-    key: 'lastYear',
-    value: 'lastYear',
-    label: t('Last year'),
-  },
-  {
-    key: 'thisYear',
-    value: 'thisYear',
-    label: t('This year'),
-  },
-  {
-    key: 'nextYear',
-    value: 'nextYear',
-    label: t('Next year'),
-  },
-  {
-    key: 'last7Days',
-    value: 'last7Days',
-    label: t('Last 7 days'),
-  },
-  {
-    key: 'next7Days',
-    value: 'next7Days',
-    label: t('Next 7 days'),
-  },
-  {
-    key: 'last30Days',
-    value: 'last30Days',
-    label: t('Last 30 days'),
-  },
-  {
-    key: 'next30Days',
-    value: 'next30Days',
-    label: t('Next 30 days'),
-  },
-  {
-    key: 'last90Days',
-    value: 'last90Days',
-    label: t('Last 90 days'),
-  },
-  {
-    key: 'next90Days',
-    value: 'next90Days',
-    label: t('Next 90 days'),
-  },
-];
-
 export const nodesOptions = {
   label: `{{t("Node result", { ns: "${NAMESPACE}" })}}`,
   value: '$jobsMapByNodeKey',
@@ -221,25 +113,10 @@ export const scopeOptions = {
 export const systemOptions = {
   label: `{{t("System variables", { ns: "${NAMESPACE}" })}}`,
   value: '$system',
-  useOptions({ types, fieldNames = defaultFieldNames }: UseVariableOptions) {
-    const { t } = useTranslation();
-    return [
-      ...(!types || types.includes('date')
-        ? [
-            {
-              key: 'now',
-              [fieldNames.label]: lang('System time'),
-              [fieldNames.value]: 'now',
-            },
-            {
-              key: 'dateRange',
-              [fieldNames.label]: lang('Date range'),
-              [fieldNames.value]: 'dateRange',
-              children: getDateOptions(t),
-            },
-          ]
-        : []),
-    ];
+  useOptions(options: UseVariableOptions) {
+    const { systemVariables } = usePlugin(WorkflowPlugin);
+    const compile = useCompile();
+    return compile(Array.from(systemVariables.getValues()));
   },
 };
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

System function as variable in workflow could be extended on server side, but not client side.

### Description 

```ts
// Single
pluginWorkflowClient.registerSystemVariable({
  key: 'someVariable',
  label: `{{t("Some variable", { ns: "YourNamespace" })}}`,
  value: 'someVariable',
});

// Group
pluginWorkflowClient.registerSystemVariable({
  key: 'someGroup',
  label: `{{t("Some group", { ns: "YourNamespace" })}}`,
  value: 'someGroup',
  children: [
    { key: 'a', label: 'A', value: 'a' },
    { key: 'b', label: 'B', value: 'b' },
  ]
});
```

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support to register system variables in client |
| 🇨🇳 Chinese | 支持在前端扩展工作流的系统变量 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
