### PR TITLE
chore(client): support hidden property for component `Tabs.TabPane`

### DIFF
--- a/packages/core/client/src/schema-component/antd/tabs/Tabs.tsx
+++ b/packages/core/client/src/schema-component/antd/tabs/Tabs.tsx
@@ -13,6 +13,7 @@ import { Tabs as AntdTabs, TabPaneProps, TabsProps } from 'antd';
 import classNames from 'classnames';
 import React, { useMemo } from 'react';
 import { useSchemaInitializerRender } from '../../../application';
+import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
 import { Icon } from '../../../icon';
 import { DndContext, SortableItem } from '../../common';
 import { SchemaComponent } from '../../core';
@@ -109,18 +110,27 @@ const designerCss = css`
   }
 `;
 
-Tabs.TabPane = observer(
-  (props: TabPaneProps & { icon?: any }) => {
-    const Designer = useDesigner();
-    const field = useField();
-    return (
-      <SortableItem className={classNames('nb-action-link', designerCss, props.className)}>
-        {props.icon && <Icon style={{ marginRight: 2 }} type={props.icon} />} {props.tab || field.title}
-        <Designer />
-      </SortableItem>
-    );
-  },
-  { displayName: 'Tabs.TabPane' },
+Tabs.TabPane = withDynamicSchemaProps(
+  observer(
+    (props: TabPaneProps & { icon?: any; hidden?: boolean }) => {
+      const Designer = useDesigner();
+      const field = useField();
+
+      if (props.hidden) {
+        return null;
+      }
+
+      return (
+        <SortableItem className={classNames('nb-action-link', designerCss, props.className)}>
+          {props.icon && <Icon style={{ marginRight: 2 }} type={props.icon} />} {props.tab || field.title}
+          <Designer />
+        </SortableItem>
+      );
+    },
+    { displayName: 'Tabs.TabPane' },
+  ),
 );
+
+Tabs.TabPane.displayName = 'Tabs.TabPane';
 
 Tabs.Designer = TabsDesigner;

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/mobile-action-page/MobileTabsForMobileActionPage.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/mobile-action-page/MobileTabsForMobileActionPage.tsx
@@ -16,14 +16,16 @@ import {
   SortableItem,
   Tabs as TabsOfPC,
   useBackButton,
+  useCompile,
   useDesigner,
   useSchemaInitializerRender,
   useTabsContext,
+  withDynamicSchemaProps,
 } from '@nocobase/client';
 import { Tabs } from 'antd-mobile';
 import { LeftOutline } from 'antd-mobile-icons';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { MobilePageHeader } from '../../pages/dynamic-page';
 import { MobilePageContentContainer } from '../../pages/dynamic-page/content/MobilePageContentContainer';
 import { useStyles } from '../../pages/dynamic-page/header/tabs';
@@ -39,7 +41,6 @@ export const MobileTabsForMobileActionPage: any = observer(
     const { styles } = useStyles();
     const { styles: mobileTabsForMobileActionPageStyle } = useMobileTabsForMobileActionPageStyle();
     const { goBack } = useBackButton();
-    const keyToTabRef = useRef({});
 
     const onChange = useCallback(
       (key) => {
@@ -55,7 +56,6 @@ export const MobileTabsForMobileActionPage: any = observer(
 
     const items = useMemo(() => {
       const result = fieldSchema.mapProperties((schema, key) => {
-        keyToTabRef.current[key] = <SchemaComponent name={key} schema={schema} onlyRenderProperties distributed />;
         return <Tabs.Tab title={<RecursionField name={key} schema={schema} onlyRenderSelf />} key={key}></Tabs.Tab>;
       });
 
@@ -148,18 +148,28 @@ const designerCss = css`
   }
 `;
 
-MobileTabsForMobileActionPage.TabPane = observer(
-  (props: any) => {
-    const Designer = useDesigner();
-    const field = useField();
-    return (
-      <SortableItem className={classNames('nb-action-link', designerCss, props.className)}>
-        {props.icon && <Icon style={{ marginRight: 2 }} type={props.icon} />} {props.tab || field.title}
-        <Designer />
-      </SortableItem>
-    );
-  },
-  { displayName: 'MobileTabsForMobileActionPage.TabPane' },
+MobileTabsForMobileActionPage.TabPane = withDynamicSchemaProps(
+  observer(
+    (props: any) => {
+      const Designer = useDesigner();
+      const field = useField();
+      const compile = useCompile();
+
+      if (props.hidden) {
+        return null;
+      }
+
+      return (
+        <SortableItem className={classNames('nb-action-link', designerCss, props.className)}>
+          {props.icon && <Icon style={{ marginRight: 2 }} type={props.icon} />} {props.tab || compile(field.title)}
+          <Designer />
+        </SortableItem>
+      );
+    },
+    { displayName: 'MobileTabsForMobileActionPage.TabPane' },
+  ),
 );
+
+MobileTabsForMobileActionPage.displayName = 'MobileTabsForMobileActionPage';
 
 MobileTabsForMobileActionPage.Designer = TabsOfPC.Designer;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to hide `TabPane` with dynamic property `hidden`.

### Description

Tab is not needed to be render based on some conditions.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support dynamic property `hidden` for component `Tabs.TabPan` to control rendering |
| 🇨🇳 Chinese | `Tabs.TabPane` 组件支持用于控制是否渲染的动态属性 `hidden` |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
