### PR TITLE
fix(zIndex): fix the issue of modal being obscured

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -43,7 +43,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { SchemaSettingsItemType, VariablesContext } from '../';
+import { SchemaSettingsItemType, VariablesContext, useZIndexContext, zIndexContext } from '../';
 import { APIClientProvider } from '../api-client/APIClientProvider';
 import { useAPIClient } from '../api-client/hooks/useAPIClient';
 import { ApplicationContext, LocationSearchContext, useApp, useLocationSearch } from '../application';
@@ -629,6 +629,9 @@ export const SchemaSettingsActionModalItem: FC<SchemaSettingsActionModalItemProp
   const compile = useCompile();
   const api = useAPIClient();
   const upLevelActiveFields = useFormActiveFields();
+  const parentZIndex = useZIndexContext();
+
+  const zIndex = parentZIndex + 10;
 
   const form = useMemo(
     () =>
@@ -682,7 +685,7 @@ export const SchemaSettingsActionModalItem: FC<SchemaSettingsActionModalItemProp
 
   const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLLIElement>): void => e.stopPropagation(), []);
   return (
-    <>
+    <zIndexContext.Provider value={zIndex}>
       <SchemaSettingsItem
         title={compile(title)}
         {...others}
@@ -699,6 +702,7 @@ export const SchemaSettingsActionModalItem: FC<SchemaSettingsActionModalItemProp
           destroyOnClose
           open={visible}
           onCancel={cancelHandler}
+          zIndex={zIndex}
           footer={
             <Space>
               <Button onClick={cancelHandler}>{t('Cancel')}</Button>
@@ -723,7 +727,7 @@ export const SchemaSettingsActionModalItem: FC<SchemaSettingsActionModalItemProp
         </Modal>,
         document.body,
       )}
-    </>
+    </zIndexContext.Provider>
   );
 });
 SchemaSettingsActionModalItem.displayName = 'SchemaSettingsActionModalItem';

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/__e2e__/templates.ts
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/__e2e__/templates.ts
@@ -1063,3 +1063,613 @@ export const shouldDisplayImageNormally = {
     'x-index': 1,
   },
 };
+export const modalOfAssignFieldValuesAndModalOfBindWorkflows = {
+  pageSchema: {
+    type: 'void',
+    'x-component': 'Grid',
+    'x-component-props': {
+      showDivider: false,
+    },
+    'x-initializer': 'mobile:addBlock',
+    properties: {
+      j4757e2c0im: {
+        _isJSONSchemaObject: true,
+        version: '2.0',
+        type: 'void',
+        'x-component': 'Grid.Row',
+        'x-app-version': '1.4.0-beta.1',
+        properties: {
+          zdmjnkcywfz: {
+            _isJSONSchemaObject: true,
+            version: '2.0',
+            type: 'void',
+            'x-component': 'Grid.Col',
+            'x-app-version': '1.4.0-beta.1',
+            properties: {
+              o1ibqsbm02h: {
+                _isJSONSchemaObject: true,
+                version: '2.0',
+                type: 'void',
+                'x-acl-action-props': {
+                  skipScopeCheck: true,
+                },
+                'x-acl-action': 'users:create',
+                'x-decorator': 'FormBlockProvider',
+                'x-use-decorator-props': 'useCreateFormBlockDecoratorProps',
+                'x-decorator-props': {
+                  dataSource: 'main',
+                  collection: 'users',
+                },
+                'x-toolbar': 'BlockSchemaToolbar',
+                'x-settings': 'blockSettings:createForm',
+                'x-component': 'CardItem',
+                'x-app-version': '1.4.0-beta.1',
+                properties: {
+                  n0nnwyjlz1g: {
+                    _isJSONSchemaObject: true,
+                    version: '2.0',
+                    type: 'void',
+                    'x-component': 'FormV2',
+                    'x-use-component-props': 'useCreateFormBlockProps',
+                    'x-app-version': '1.4.0-beta.1',
+                    properties: {
+                      grid: {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'void',
+                        'x-component': 'Grid',
+                        'x-initializer': 'form:configureFields',
+                        'x-app-version': '1.4.0-beta.1',
+                        properties: {
+                          h7ugm9fh3f2: {
+                            _isJSONSchemaObject: true,
+                            version: '2.0',
+                            type: 'void',
+                            'x-component': 'Grid.Row',
+                            'x-app-version': '1.4.0-beta.1',
+                            properties: {
+                              '0u4sc3bgsk9': {
+                                _isJSONSchemaObject: true,
+                                version: '2.0',
+                                type: 'void',
+                                'x-component': 'Grid.Col',
+                                'x-app-version': '1.4.0-beta.1',
+                                properties: {
+                                  roles: {
+                                    'x-uid': 'k9tszeor48y',
+                                    _isJSONSchemaObject: true,
+                                    version: '2.0',
+                                    type: 'string',
+                                    'x-toolbar': 'FormItemSchemaToolbar',
+                                    'x-settings': 'fieldSettings:FormItem',
+                                    'x-component': 'CollectionField',
+                                    'x-decorator': 'FormItem',
+                                    'x-collection-field': 'users.roles',
+                                    'x-component-props': {
+                                      fieldNames: {
+                                        label: 'name',
+                                        value: 'name',
+                                      },
+                                      mode: 'Picker',
+                                    },
+                                    'x-app-version': '1.4.0-beta.1',
+                                    properties: {
+                                      '7bcobi612z4': {
+                                        _isJSONSchemaObject: true,
+                                        version: '2.0',
+                                        type: 'void',
+                                        'x-component': 'AssociationField.Selector',
+                                        title: '{{ t("Select record") }}',
+                                        'x-component-props': {
+                                          className: 'nb-record-picker-selector',
+                                        },
+                                        'x-index': 1,
+                                        'x-app-version': '1.4.0-beta.1',
+                                        properties: {
+                                          grid: {
+                                            _isJSONSchemaObject: true,
+                                            version: '2.0',
+                                            type: 'void',
+                                            'x-component': 'Grid',
+                                            'x-initializer': 'popup:tableSelector:addBlock',
+                                            'x-app-version': '1.4.0-beta.1',
+                                            properties: {
+                                              '0h1l5qekjbj': {
+                                                _isJSONSchemaObject: true,
+                                                version: '2.0',
+                                                type: 'void',
+                                                'x-component': 'Grid.Row',
+                                                'x-app-version': '1.4.0-beta.1',
+                                                properties: {
+                                                  '0huvxhjfr3f': {
+                                                    _isJSONSchemaObject: true,
+                                                    version: '2.0',
+                                                    type: 'void',
+                                                    'x-component': 'Grid.Col',
+                                                    'x-app-version': '1.4.0-beta.1',
+                                                    properties: {
+                                                      '5ao6es650n4': {
+                                                        _isJSONSchemaObject: true,
+                                                        version: '2.0',
+                                                        type: 'void',
+                                                        'x-acl-action': 'roles:list',
+                                                        'x-decorator': 'TableSelectorProvider',
+                                                        'x-use-decorator-props': 'useTableSelectorDecoratorProps',
+                                                        'x-decorator-props': {
+                                                          collection: 'roles',
+                                                          dataSource: 'main',
+                                                          action: 'list',
+                                                          params: {
+                                                            pageSize: 20,
+                                                          },
+                                                          rowKey: 'name',
+                                                        },
+                                                        'x-toolbar': 'BlockSchemaToolbar',
+                                                        'x-settings': 'blockSettings:tableSelector',
+                                                        'x-component': 'CardItem',
+                                                        'x-app-version': '1.4.0-beta.1',
+                                                        properties: {
+                                                          '1xwk3sx6uzm': {
+                                                            _isJSONSchemaObject: true,
+                                                            version: '2.0',
+                                                            type: 'void',
+                                                            'x-initializer': 'table:configureActions',
+                                                            'x-component': 'ActionBar',
+                                                            'x-component-props': {
+                                                              style: {
+                                                                marginBottom: 'var(--nb-spacing)',
+                                                              },
+                                                            },
+                                                            'x-app-version': '1.4.0-beta.1',
+                                                            properties: {
+                                                              '1fimr016ici': {
+                                                                _isJSONSchemaObject: true,
+                                                                version: '2.0',
+                                                                type: 'void',
+                                                                'x-action': 'create',
+                                                                'x-acl-action': 'create',
+                                                                title: "{{t('Add new')}}",
+                                                                'x-toolbar': 'ActionSchemaToolbar',
+                                                                'x-settings': 'actionSettings:addNew',
+                                                                'x-component': 'Action',
+                                                                'x-decorator': 'ACLActionProvider',
+                                                                'x-component-props': {
+                                                                  openMode: 'page',
+                                                                  type: 'primary',
+                                                                  component: 'CreateRecordAction',
+                                                                  icon: 'PlusOutlined',
+                                                                },
+                                                                'x-action-context': {
+                                                                  dataSource: 'main',
+                                                                  collection: 'roles',
+                                                                },
+                                                                'x-align': 'right',
+                                                                'x-acl-action-props': {
+                                                                  skipScopeCheck: true,
+                                                                },
+                                                                'x-app-version': '1.4.0-beta.1',
+                                                                properties: {
+                                                                  psx65sfu4kg: {
+                                                                    _isJSONSchemaObject: true,
+                                                                    version: '2.0',
+                                                                    type: 'void',
+                                                                    'x-component': 'AssociationField.AddNewer',
+                                                                    'x-action': 'create',
+                                                                    title: '{{ t("Add record") }}',
+                                                                    'x-component-props': {
+                                                                      className: 'nb-action-popup',
+                                                                    },
+                                                                    'x-index': 1,
+                                                                    'x-app-version': '1.4.0-beta.1',
+                                                                    properties: {
+                                                                      tabs: {
+                                                                        _isJSONSchemaObject: true,
+                                                                        version: '2.0',
+                                                                        type: 'void',
+                                                                        'x-component': 'Tabs',
+                                                                        'x-component-props': {},
+                                                                        'x-initializer': 'popup:addTab',
+                                                                        'x-initializer-props': {
+                                                                          gridInitializer: 'popup:addNew:addBlock',
+                                                                        },
+                                                                        'x-app-version': '1.4.0-beta.1',
+                                                                        properties: {
+                                                                          tab1: {
+                                                                            _isJSONSchemaObject: true,
+                                                                            version: '2.0',
+                                                                            type: 'void',
+                                                                            title: '{{t("Add new")}}',
+                                                                            'x-component': 'Tabs.TabPane',
+                                                                            'x-designer': 'Tabs.Designer',
+                                                                            'x-component-props': {},
+                                                                            'x-app-version': '1.4.0-beta.1',
+                                                                            properties: {
+                                                                              grid: {
+                                                                                _isJSONSchemaObject: true,
+                                                                                version: '2.0',
+                                                                                type: 'void',
+                                                                                'x-component': 'Grid',
+                                                                                'x-initializer':
+                                                                                  'popup:addNew:addBlock',
+                                                                                'x-app-version': '1.4.0-beta.1',
+                                                                                properties: {
+                                                                                  t5y2rkf784r: {
+                                                                                    _isJSONSchemaObject: true,
+                                                                                    version: '2.0',
+                                                                                    type: 'void',
+                                                                                    'x-component': 'Grid.Row',
+                                                                                    'x-app-version': '1.4.0-beta.1',
+                                                                                    properties: {
+                                                                                      '6gyt9b3kgpb': {
+                                                                                        _isJSONSchemaObject: true,
+                                                                                        version: '2.0',
+                                                                                        type: 'void',
+                                                                                        'x-component': 'Grid.Col',
+                                                                                        'x-app-version': '1.4.0-beta.1',
+                                                                                        properties: {
+                                                                                          gx1pmdv9shu: {
+                                                                                            _isJSONSchemaObject: true,
+                                                                                            version: '2.0',
+                                                                                            type: 'void',
+                                                                                            'x-acl-action-props': {
+                                                                                              skipScopeCheck: true,
+                                                                                            },
+                                                                                            'x-acl-action':
+                                                                                              'roles:create',
+                                                                                            'x-decorator':
+                                                                                              'FormBlockProvider',
+                                                                                            'x-use-decorator-props':
+                                                                                              'useCreateFormBlockDecoratorProps',
+                                                                                            'x-decorator-props': {
+                                                                                              dataSource: 'main',
+                                                                                              collection: 'roles',
+                                                                                            },
+                                                                                            'x-toolbar':
+                                                                                              'BlockSchemaToolbar',
+                                                                                            'x-settings':
+                                                                                              'blockSettings:createForm',
+                                                                                            'x-component': 'CardItem',
+                                                                                            'x-app-version':
+                                                                                              '1.4.0-beta.1',
+                                                                                            properties: {
+                                                                                              '9gwa4odr0ld': {
+                                                                                                _isJSONSchemaObject:
+                                                                                                  true,
+                                                                                                version: '2.0',
+                                                                                                type: 'void',
+                                                                                                'x-component': 'FormV2',
+                                                                                                'x-use-component-props':
+                                                                                                  'useCreateFormBlockProps',
+                                                                                                'x-app-version':
+                                                                                                  '1.4.0-beta.1',
+                                                                                                properties: {
+                                                                                                  grid: {
+                                                                                                    _isJSONSchemaObject:
+                                                                                                      true,
+                                                                                                    version: '2.0',
+                                                                                                    type: 'void',
+                                                                                                    'x-component':
+                                                                                                      'Grid',
+                                                                                                    'x-initializer':
+                                                                                                      'form:configureFields',
+                                                                                                    'x-app-version':
+                                                                                                      '1.4.0-beta.1',
+                                                                                                    'x-uid':
+                                                                                                      'nk9bd6diklg',
+                                                                                                    'x-async': false,
+                                                                                                    'x-index': 1,
+                                                                                                  },
+                                                                                                  i0qyrh2a0i0: {
+                                                                                                    _isJSONSchemaObject:
+                                                                                                      true,
+                                                                                                    version: '2.0',
+                                                                                                    type: 'void',
+                                                                                                    'x-initializer':
+                                                                                                      'createForm:configureActions',
+                                                                                                    'x-component':
+                                                                                                      'ActionBar',
+                                                                                                    'x-component-props':
+                                                                                                      {
+                                                                                                        layout:
+                                                                                                          'one-column',
+                                                                                                      },
+                                                                                                    'x-app-version':
+                                                                                                      '1.4.0-beta.1',
+                                                                                                    properties: {
+                                                                                                      y28j0b1us5r: {
+                                                                                                        'x-uid':
+                                                                                                          '5aeqt19kheh',
+                                                                                                        _isJSONSchemaObject:
+                                                                                                          true,
+                                                                                                        version: '2.0',
+                                                                                                        title:
+                                                                                                          '{{ t("Submit") }}',
+                                                                                                        'x-action':
+                                                                                                          'submit',
+                                                                                                        'x-component':
+                                                                                                          'Action',
+                                                                                                        'x-use-component-props':
+                                                                                                          'useCreateActionProps',
+                                                                                                        'x-toolbar':
+                                                                                                          'ActionSchemaToolbar',
+                                                                                                        'x-settings':
+                                                                                                          'actionSettings:createSubmit',
+                                                                                                        'x-component-props':
+                                                                                                          {
+                                                                                                            type: 'primary',
+                                                                                                            htmlType:
+                                                                                                              'submit',
+                                                                                                          },
+                                                                                                        'x-action-settings':
+                                                                                                          {
+                                                                                                            triggerWorkflows:
+                                                                                                              [],
+                                                                                                            schemaUid:
+                                                                                                              'dk7pd4eex61',
+                                                                                                          },
+                                                                                                        type: 'void',
+                                                                                                        'x-app-version':
+                                                                                                          '1.4.0-beta.1',
+                                                                                                        'x-async':
+                                                                                                          false,
+                                                                                                        'x-index': 1,
+                                                                                                      },
+                                                                                                    },
+                                                                                                    'x-uid':
+                                                                                                      'vpboq88gsyr',
+                                                                                                    'x-async': false,
+                                                                                                    'x-index': 2,
+                                                                                                  },
+                                                                                                },
+                                                                                                'x-uid': 'orusumwzgen',
+                                                                                                'x-async': false,
+                                                                                                'x-index': 1,
+                                                                                              },
+                                                                                            },
+                                                                                            'x-uid': 'upds36o99q2',
+                                                                                            'x-async': false,
+                                                                                            'x-index': 1,
+                                                                                          },
+                                                                                        },
+                                                                                        'x-uid': '14cy9ehr7s4',
+                                                                                        'x-async': false,
+                                                                                        'x-index': 1,
+                                                                                      },
+                                                                                    },
+                                                                                    'x-uid': '1o97lp1pnvn',
+                                                                                    'x-async': false,
+                                                                                    'x-index': 1,
+                                                                                  },
+                                                                                },
+                                                                                'x-uid': 'w6goapz7pow',
+                                                                                'x-async': false,
+                                                                                'x-index': 1,
+                                                                              },
+                                                                            },
+                                                                            'x-uid': 'gjc3bcihkey',
+                                                                            'x-async': false,
+                                                                            'x-index': 1,
+                                                                          },
+                                                                        },
+                                                                        'x-uid': '5w47tfwh54o',
+                                                                        'x-async': false,
+                                                                        'x-index': 1,
+                                                                      },
+                                                                    },
+                                                                    'x-uid': 'znu9u5nmb90',
+                                                                    'x-async': false,
+                                                                  },
+                                                                  drawer: {
+                                                                    _isJSONSchemaObject: true,
+                                                                    version: '2.0',
+                                                                    type: 'void',
+                                                                    title: '{{ t("Add record") }}',
+                                                                    'x-component': 'Action.Container',
+                                                                    'x-component-props': {
+                                                                      className: 'nb-action-popup',
+                                                                    },
+                                                                    'x-app-version': '1.4.0-beta.1',
+                                                                    properties: {
+                                                                      tabs: {
+                                                                        _isJSONSchemaObject: true,
+                                                                        version: '2.0',
+                                                                        type: 'void',
+                                                                        'x-component': 'Tabs',
+                                                                        'x-component-props': {},
+                                                                        'x-initializer': 'popup:addTab',
+                                                                        'x-initializer-props': {
+                                                                          gridInitializer: 'popup:addNew:addBlock',
+                                                                        },
+                                                                        'x-app-version': '1.4.0-beta.1',
+                                                                        properties: {
+                                                                          tab1: {
+                                                                            _isJSONSchemaObject: true,
+                                                                            version: '2.0',
+                                                                            type: 'void',
+                                                                            title: '{{t("Add new")}}',
+                                                                            'x-component': 'Tabs.TabPane',
+                                                                            'x-designer': 'Tabs.Designer',
+                                                                            'x-component-props': {},
+                                                                            'x-app-version': '1.4.0-beta.1',
+                                                                            properties: {
+                                                                              grid: {
+                                                                                _isJSONSchemaObject: true,
+                                                                                version: '2.0',
+                                                                                type: 'void',
+                                                                                'x-component': 'Grid',
+                                                                                'x-initializer':
+                                                                                  'popup:addNew:addBlock',
+                                                                                'x-app-version': '1.4.0-beta.1',
+                                                                                'x-uid': 'xyclo4rucxu',
+                                                                                'x-async': false,
+                                                                                'x-index': 1,
+                                                                              },
+                                                                            },
+                                                                            'x-uid': 'akxl3h7ky4c',
+                                                                            'x-async': false,
+                                                                            'x-index': 1,
+                                                                          },
+                                                                        },
+                                                                        'x-uid': '61lvw8ku1oz',
+                                                                        'x-async': false,
+                                                                        'x-index': 1,
+                                                                      },
+                                                                    },
+                                                                    'x-uid': 'f1mt0hlih3r',
+                                                                    'x-async': false,
+                                                                    'x-index': 2,
+                                                                  },
+                                                                },
+                                                                'x-uid': 'm04q1mm38np',
+                                                                'x-async': false,
+                                                                'x-index': 1,
+                                                              },
+                                                            },
+                                                            'x-uid': 'uyfsee3r0r5',
+                                                            'x-async': false,
+                                                            'x-index': 1,
+                                                          },
+                                                          value: {
+                                                            _isJSONSchemaObject: true,
+                                                            version: '2.0',
+                                                            type: 'array',
+                                                            'x-initializer': 'table:configureColumns',
+                                                            'x-component': 'TableV2.Selector',
+                                                            'x-use-component-props': 'useTableSelectorProps',
+                                                            'x-component-props': {
+                                                              rowSelection: {
+                                                                type: 'checkbox',
+                                                              },
+                                                            },
+                                                            'x-app-version': '1.4.0-beta.1',
+                                                            'x-uid': 'ohaoun0dzca',
+                                                            'x-async': false,
+                                                            'x-index': 2,
+                                                          },
+                                                        },
+                                                        'x-uid': 'f01juz03umn',
+                                                        'x-async': false,
+                                                        'x-index': 1,
+                                                      },
+                                                    },
+                                                    'x-uid': '0fgc997nb98',
+                                                    'x-async': false,
+                                                    'x-index': 1,
+                                                  },
+                                                },
+                                                'x-uid': 'st7frs3m2ig',
+                                                'x-async': false,
+                                                'x-index': 1,
+                                              },
+                                            },
+                                            'x-uid': 'bzeuuioy9z5',
+                                            'x-async': false,
+                                            'x-index': 1,
+                                          },
+                                          footer: {
+                                            _isJSONSchemaObject: true,
+                                            version: '2.0',
+                                            'x-component': 'Action.Container.Footer',
+                                            'x-component-props': {},
+                                            'x-app-version': '1.4.0-beta.1',
+                                            properties: {
+                                              actions: {
+                                                _isJSONSchemaObject: true,
+                                                version: '2.0',
+                                                type: 'void',
+                                                'x-component': 'ActionBar',
+                                                'x-component-props': {},
+                                                'x-app-version': '1.4.0-beta.1',
+                                                properties: {
+                                                  submit: {
+                                                    _isJSONSchemaObject: true,
+                                                    version: '2.0',
+                                                    title: '{{ t("Submit") }}',
+                                                    'x-action': 'submit',
+                                                    'x-component': 'Action',
+                                                    'x-use-component-props': 'usePickActionProps',
+                                                    'x-toolbar': 'ActionSchemaToolbar',
+                                                    'x-settings': 'actionSettings:submit',
+                                                    'x-component-props': {
+                                                      type: 'primary',
+                                                      htmlType: 'submit',
+                                                    },
+                                                    'x-app-version': '1.4.0-beta.1',
+                                                    'x-uid': '9h1w507rzlf',
+                                                    'x-async': false,
+                                                    'x-index': 1,
+                                                  },
+                                                },
+                                                'x-uid': 'x4b306quc60',
+                                                'x-async': false,
+                                                'x-index': 1,
+                                              },
+                                            },
+                                            'x-uid': 'haomuho6sx4',
+                                            'x-async': false,
+                                            'x-index': 2,
+                                          },
+                                        },
+                                        'x-uid': 't07l8fdpvj5',
+                                        'x-async': false,
+                                      },
+                                    },
+                                    'x-async': false,
+                                    'x-index': 1,
+                                  },
+                                },
+                                'x-uid': '9kei238jan5',
+                                'x-async': false,
+                                'x-index': 1,
+                              },
+                            },
+                            'x-uid': '4hzbxhqhx08',
+                            'x-async': false,
+                            'x-index': 1,
+                          },
+                        },
+                        'x-uid': 'p8xjicpyxcj',
+                        'x-async': false,
+                        'x-index': 1,
+                      },
+                      '3w5xq5lh28z': {
+                        _isJSONSchemaObject: true,
+                        version: '2.0',
+                        type: 'void',
+                        'x-initializer': 'createForm:configureActions',
+                        'x-component': 'ActionBar',
+                        'x-component-props': {
+                          layout: 'one-column',
+                        },
+                        'x-app-version': '1.4.0-beta.1',
+                        'x-uid': 'cnuwpgur1i7',
+                        'x-async': false,
+                        'x-index': 2,
+                      },
+                    },
+                    'x-uid': '0w4uveuxenb',
+                    'x-async': false,
+                    'x-index': 1,
+                  },
+                },
+                'x-uid': 'd6gzz1xh5oz',
+                'x-async': false,
+                'x-index': 1,
+              },
+            },
+            'x-uid': 'asbtnw88jlm',
+            'x-async': false,
+            'x-index': 1,
+          },
+        },
+        'x-uid': 'sncilt9p3l9',
+        'x-async': false,
+        'x-index': 1,
+      },
+    },
+    name: 'svr60fv9z8l',
+    'x-uid': 'svr60fv9z8l',
+    'x-async': true,
+    'x-index': 1,
+  },
+};

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/__e2e__/zIndex.test.ts
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/__e2e__/zIndex.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { expect, test } from '@nocobase/test/e2e';
-import { shouldDisplayImageNormally } from './templates';
+import { modalOfAssignFieldValuesAndModalOfBindWorkflows, shouldDisplayImageNormally } from './templates';
 
 test.describe('zIndex', () => {
   test('should display image normally', async ({ page, mockMobilePage, mockRecord }) => {
@@ -68,5 +68,37 @@ test.describe('zIndex', () => {
     await page.waitForTimeout(300);
     await check(3);
     await page.getByLabel('Close lightbox').click();
+  });
+
+  test('modal of Assign field values and modal of Bind workflows', async ({ page, mockMobilePage, mockRecord }) => {
+    await mockMobilePage(modalOfAssignFieldValuesAndModalOfBindWorkflows).goto();
+
+    // 1. 打开 Assign field values 的弹窗
+    await page.getByTestId('select-data-picker').click();
+    await page.getByLabel('action-Action-Add new-create-').click();
+    await page.getByLabel('block-item-CardItem-roles-form').getByLabel('action-Action-Submit-submit-').hover();
+    await page.getByLabel('designer-schema-settings-Action-actionSettings:createSubmit-roles').hover();
+    await page.getByRole('menuitem', { name: 'Assign field values' }).click();
+
+    // 2. 检测弹窗是否被覆盖
+    await page.getByRole('button', { name: 'Cancel' }).hover({ timeout: 300, position: { x: 5, y: 5 } });
+    // 3. 关闭弹窗
+    await page.getByLabel('Close', { exact: true }).click();
+
+    // -----------------------------------------------------------------------------------------------------
+
+    // 1. 打开 Bind workflows 弹窗
+    await page.getByLabel('block-item-CardItem-roles-form').getByLabel('action-Action-Submit-submit-').hover();
+    await page.getByLabel('designer-schema-settings-Action-actionSettings:createSubmit-roles').hover();
+    await page.getByRole('menuitem', { name: 'Bind workflows' }).click();
+
+    // 2. 检测弹窗是否被覆盖
+    await page
+      .getByLabel('Bind workflows')
+      .getByRole('button', { name: 'Cancel' })
+      .hover({ timeout: 300, position: { x: 5, y: 5 } });
+
+    // 3. 关闭弹窗
+    await page.getByLabel('Bind workflows').getByLabel('Close', { exact: true }).click();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Related issues
![image](https://github.com/user-attachments/assets/209e3b57-f4b8-43ba-80fb-c492535b3595)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where the 'Assign field values' modal is obscured on the mobile configuration page    |
| 🇨🇳 Chinese |     修复在移动端配置页，字段赋值的弹窗被遮挡的问题      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
