### PR TITLE
fix:  unable to set minimum width for subtable labels in horizontal mode

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-v2/Form.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Form.tsx
@@ -65,6 +65,11 @@ const FormComponent: React.FC<FormProps> = (props) => {
                 margin-right: -${token.marginLG}px;
                 padding-left: ${token.marginLG}px;
                 padding-right: ${token.marginLG}px;
+                .ant-formily-item-layout-horizontal {
+                  .ant-formily-item-control {
+                    max-width: calc(100% - ${labelWidth}px);
+                  }
+                }
               }
             `}
           >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix subtable label minimum width issue in horizontal mode     |
| 🇨🇳 Chinese |      修复表单横排模式下子表格的 label 宽度的问题     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
