### PR TITLE
fix(plugin-notification-in-app-message): remove in-app message title string slicing logic

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/MessageList.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/MessageList.tsx
@@ -104,7 +104,9 @@ const MessageList = observer(() => {
                     style={{
                       fontWeight: message.status === 'unread' ? 'bold' : 'normal',
                       cursor: 'pointer',
-                      width: '100%',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
                     }}
                   >
                     {message.title}

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/InAppNotificationChannel.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/InAppNotificationChannel.ts
@@ -65,8 +65,8 @@ export default class InAppNotificationChannel extends BaseNotificationChannel {
             type: message.type,
             data: {
               ...message.data,
-              title: message.data.title?.slice(0, 30) || '',
-              content: message.data.content?.slice(0, 105) || '',
+              title: message.data.title || '',
+              content: message.data.content || '',
             },
           })}\n\n`,
         );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Remove in-app message title string slicing logic.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Remove in-app message title string slicing logic.      |
| 🇨🇳 Chinese |   移除站内信消息标题字符串截取逻辑。         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
