### PR TITLE
fix(client): use children component when nullable is false

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -460,7 +460,7 @@ export function Input(props: VariableInputProps) {
         </div>
       ) : (
         <div style={{ flex: 1 }}>
-          {children && isFieldValue ? (
+          {children && (isFieldValue || !nullable) ? (
             children
           ) : ConstantComponent ? (
             <ConstantComponent


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Not to use `Null` component when set `nullable: false` and show origin component.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | support variable input component to use custom component when `nullable` is set to `false` |
| 🇨🇳 Chinese | 支持变量组件在设置 `nullable` 为 `false` 时使用既有的自定义组件 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
