### PR TITLE
fix(cli): daemon mode does not delete sock files

### DIFF
--- a/packages/core/cli/src/commands/start.js
+++ b/packages/core/cli/src/commands/start.js
@@ -61,7 +61,9 @@ module.exports = (cli) => {
         return;
       }
       await postCheck(opts);
-      deleteSockFiles();
+      if (!opts.daemon) {
+        deleteSockFiles();
+      }
       const instances = opts.instances || process.env.CLUSTER_MODE;
       const instancesArgs = instances ? ['-i', instances] : [];
       if (opts.daemon) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Daemon mode does not delete sock files   |
| 🇨🇳 Chinese |  Daemon 模式不删除 sock 文件  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
