### PR TITLE
fix(data-vi): issue where filter field components of chart blocks not rendering

### DIFF
--- a/packages/core/client/src/formily/NocoBaseRecursionField.tsx
+++ b/packages/core/client/src/formily/NocoBaseRecursionField.tsx
@@ -86,7 +86,7 @@ export const useCollectionFieldUISchema = () => {
   return React.useContext(CollectionFieldUISchemaContext) || {};
 };
 
-const CollectionFieldUISchemaProvider: FC<{
+export const CollectionFieldUISchemaProvider: FC<{
   fieldSchema: Schema;
 }> = (props) => {
   const { children, fieldSchema } = props;

--- a/packages/core/client/src/formily/NocoBaseRecursionField.tsx
+++ b/packages/core/client/src/formily/NocoBaseRecursionField.tsx
@@ -229,7 +229,7 @@ const propertiesToReactElement = ({
   );
 };
 
-const IsInNocoBaseRecursionFieldContext = React.createContext(false);
+export const IsInNocoBaseRecursionFieldContext = React.createContext(false);
 
 /**
  * @internal

--- a/packages/core/client/src/index.ts
+++ b/packages/core/client/src/index.ts
@@ -82,4 +82,8 @@ export { useCurrentPopupRecord } from './modules/variable/variablesProvider/Vari
 export { languageCodes } from './locale';
 
 // Override Formily API
-export { NocoBaseRecursionField, CollectionFieldUISchemaProvider } from './formily/NocoBaseRecursionField';
+export {
+  NocoBaseRecursionField,
+  CollectionFieldUISchemaProvider,
+  IsInNocoBaseRecursionFieldContext,
+} from './formily/NocoBaseRecursionField';

--- a/packages/core/client/src/index.ts
+++ b/packages/core/client/src/index.ts
@@ -82,4 +82,4 @@ export { useCurrentPopupRecord } from './modules/variable/variablesProvider/Vari
 export { languageCodes } from './locale';
 
 // Override Formily API
-export { NocoBaseRecursionField } from './formily/NocoBaseRecursionField';
+export { NocoBaseRecursionField, CollectionFieldUISchemaProvider } from './formily/NocoBaseRecursionField';

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterItemInitializers.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterItemInitializers.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_DATA_SOURCE_KEY,
   FormDialog,
   HTMLEncode,
+  IsInNocoBaseRecursionFieldContext,
   SchemaComponent,
   SchemaComponentOptions,
   SchemaInitializerItem,
@@ -30,7 +31,6 @@ import {
   useDesignable,
   useGlobalTheme,
   useSchemaInitializerItem,
-  CollectionFieldUISchemaProvider,
 } from '@nocobase/client';
 import { useMemoizedFn } from 'ahooks';
 import { Alert, ConfigProvider, Typography } from 'antd';
@@ -100,13 +100,15 @@ export const ChartFilterFormItem = observer(
       <BlockItem className={'nb-form-item'}>
         <CollectionManagerProvider dataSource={dataSource}>
           <CollectionProvider name={collection} allowNull={!collection}>
-            <CollectionFieldUISchemaProvider fieldSchema={schema}>
+            <CollectionFieldProvider name={schema.name} allowNull={!schema['x-collection-field']}>
               <ACLCollectionFieldProvider>
                 <ErrorBoundary onError={console.log} FallbackComponent={ErrorFallback}>
-                  <FormItem className={className} {...props} extra={extra} />
+                  <IsInNocoBaseRecursionFieldContext.Provider value={false}>
+                    <FormItem className={className} {...props} extra={extra} />
+                  </IsInNocoBaseRecursionFieldContext.Provider>
                 </ErrorBoundary>
               </ACLCollectionFieldProvider>
-            </CollectionFieldUISchemaProvider>
+            </CollectionFieldProvider>
           </CollectionProvider>
         </CollectionManagerProvider>
       </BlockItem>

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterItemInitializers.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterItemInitializers.tsx
@@ -30,6 +30,7 @@ import {
   useDesignable,
   useGlobalTheme,
   useSchemaInitializerItem,
+  CollectionFieldUISchemaProvider,
 } from '@nocobase/client';
 import { useMemoizedFn } from 'ahooks';
 import { Alert, ConfigProvider, Typography } from 'antd';
@@ -95,25 +96,17 @@ export const ChartFilterFormItem = observer(
     const dataSource = schema?.['x-data-source'] || DEFAULT_DATA_SOURCE_KEY;
     const collectionField = schema?.['x-collection-field'] || '';
     const [collection] = collectionField.split('.');
-    // const { getIsChartCollectionExists } = useChartData();
-    // const exists = (schema.name as string).startsWith('custom.') || getIsChartCollectionExists(dataSource, collection);
     return (
       <BlockItem className={'nb-form-item'}>
         <CollectionManagerProvider dataSource={dataSource}>
           <CollectionProvider name={collection} allowNull={!collection}>
-            <CollectionFieldProvider name={schema.name} allowNull={!schema['x-collection-field']}>
+            <CollectionFieldUISchemaProvider fieldSchema={schema}>
               <ACLCollectionFieldProvider>
-                {/* {exists ? ( */}
                 <ErrorBoundary onError={console.log} FallbackComponent={ErrorFallback}>
                   <FormItem className={className} {...props} extra={extra} />
                 </ErrorBoundary>
-                {/* ) : ( */}
-                {/*   <div style={{ color: '#ccc', marginBottom: '10px' }}> */}
-                {/*     {t('The chart using the collection of this field have been deleted. Please  remove this field.')} */}
-                {/*   </div> */}
-                {/* )} */}
               </ACLCollectionFieldProvider>
-            </CollectionFieldProvider>
+            </CollectionFieldUISchemaProvider>
           </CollectionProvider>
         </CollectionManagerProvider>
       </BlockItem>

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterVariableInput.tsx
@@ -13,6 +13,7 @@ import {
   VariableScopeProvider,
   getShouldChange,
   CollectionProvider,
+  CollectionFieldUISchemaProvider,
 } from '@nocobase/client';
 import { useMemoizedFn } from 'ahooks';
 import React, { useEffect } from 'react';
@@ -26,14 +27,10 @@ export const ChartFilterVariableInput: React.FC<any> = (props) => {
   const schema = {
     ...fieldSchema,
     'x-component': fieldSchema['x-component'] || 'Input',
-    'x-decorator': 'CollectionProvider',
-    'x-decorator-props': {
-      name: collection,
-      allowNull: !collection,
-    },
     title: '',
     name: 'value',
     default: '',
+    'x-read-pretty': false,
   };
   const componentProps = fieldSchema['x-component-props'] || {};
   const handleChange = useMemoizedFn(onChange);
@@ -47,7 +44,13 @@ export const ChartFilterVariableInput: React.FC<any> = (props) => {
     <VariableScopeProvider scope={options}>
       <VariableInput
         {...componentProps}
-        renderSchemaComponent={() => <SchemaComponent schema={schema} components={{ CollectionProvider }} />}
+        renderSchemaComponent={() => (
+          <CollectionProvider name={collection} allowNull={!collection}>
+            <CollectionFieldUISchemaProvider fieldSchema={fieldSchema}>
+              <SchemaComponent schema={schema} />
+            </CollectionFieldUISchemaProvider>
+          </CollectionProvider>
+        )}
         fieldNames={{}}
         value={value?.value}
         scope={options}

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterVariableInput.tsx
@@ -13,7 +13,7 @@ import {
   VariableScopeProvider,
   getShouldChange,
   CollectionProvider,
-  CollectionFieldUISchemaProvider,
+  IsInNocoBaseRecursionFieldContext,
 } from '@nocobase/client';
 import { useMemoizedFn } from 'ahooks';
 import React, { useEffect } from 'react';
@@ -46,9 +46,9 @@ export const ChartFilterVariableInput: React.FC<any> = (props) => {
         {...componentProps}
         renderSchemaComponent={() => (
           <CollectionProvider name={collection} allowNull={!collection}>
-            <CollectionFieldUISchemaProvider fieldSchema={fieldSchema}>
+            <IsInNocoBaseRecursionFieldContext.Provider value={false}>
               <SchemaComponent schema={schema} />
-            </CollectionFieldUISchemaProvider>
+            </IsInNocoBaseRecursionFieldContext.Provider>
           </CollectionProvider>
         )}
         fieldNames={{}}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where filter field components of chart blocks not rendering          |
| 🇨🇳 Chinese | 修复图表区块的筛选字段组件没有渲染的问题           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
