### PR TITLE
Fix/use dynamic props not working with lazy component

### DIFF
--- a/packages/core/client/src/lazy-helper/index.tsx
+++ b/packages/core/client/src/lazy-helper/index.tsx
@@ -12,7 +12,7 @@ import { Spin } from 'antd';
 import { get } from 'lodash';
 import { useImported, loadableResource } from 'react-imported-component';
 
-export const COMPONENT_LAZY_LOADED = Symbol('$$component_lazy_loaded');
+export const LAZY_COMPONENT_KEY = Symbol('LAZY_COMPONENT_KEY');
 
 /**
  * Lazily loads a React component or multiple components.
@@ -48,7 +48,7 @@ export function lazy<M extends Record<string, any>, K extends keyof M & string>(
     const LazyComponent = ReactLazy(() =>
       factory().then((module) => {
         const ret = module.default;
-        Component[COMPONENT_LAZY_LOADED] = ret;
+        Component[LAZY_COMPONENT_KEY] = ret;
         return {
           default: ret,
         };
@@ -67,7 +67,7 @@ export function lazy<M extends Record<string, any>, K extends keyof M & string>(
       const LazyComponent = ReactLazy(() =>
         factory().then((module) => {
           const component = get(module, name);
-          acc[name][COMPONENT_LAZY_LOADED] = component;
+          acc[name][LAZY_COMPONENT_KEY] = component;
           return {
             default: component,
           };

--- a/packages/core/client/src/schema-component/hooks/useDesignable.tsx
+++ b/packages/core/client/src/schema-component/hooks/useDesignable.tsx
@@ -17,6 +17,7 @@ import set from 'lodash/set';
 import React, { ComponentType, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { APIClient, useAPIClient } from '../../api-client';
+import { COMPONENT_LAZY_LOADED } from '../../lazy-helper';
 import { SchemaComponentContext } from '../context';
 import { addAppVersion } from './addAppVersion';
 
@@ -778,7 +779,8 @@ export function useDesignable() {
         if (typeof component !== 'string') {
           return component;
         }
-        return get(components, component);
+        const c = get(components, component);
+        return c[COMPONENT_LAZY_LOADED] ?? c;
       },
       [get],
     ),

--- a/packages/core/client/src/schema-component/hooks/useDesignable.tsx
+++ b/packages/core/client/src/schema-component/hooks/useDesignable.tsx
@@ -17,7 +17,7 @@ import set from 'lodash/set';
 import React, { ComponentType, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { APIClient, useAPIClient } from '../../api-client';
-import { COMPONENT_LAZY_LOADED } from '../../lazy-helper';
+import { LAZY_COMPONENT_KEY } from '../../lazy-helper';
 import { SchemaComponentContext } from '../context';
 import { addAppVersion } from './addAppVersion';
 
@@ -780,7 +780,7 @@ export function useDesignable() {
           return component;
         }
         const c = get(components, component);
-        return c[COMPONENT_LAZY_LOADED] ?? c;
+        return c[LAZY_COMPONENT_KEY] ?? c;
       },
       [get],
     ),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where component's dynamic props do not work with lazy loading |
| 🇨🇳 Chinese | 修复懒加载组件时组件的动态属性不起作用的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
