### PR TITLE
fix: fix the issue where association field values are empty in block templates

### DIFF
--- a/packages/core/client/src/block-provider/DetailsBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/DetailsBlockProvider.tsx
@@ -9,6 +9,7 @@
 
 import { createForm } from '@formily/core';
 import { useField, useFieldSchema } from '@formily/react';
+import { useUpdate } from 'ahooks';
 import { Spin } from 'antd';
 import React, { createContext, useContext, useEffect, useMemo, useRef } from 'react';
 import { useCollectionManager_deprecated } from '../collection-manager';
@@ -108,12 +109,14 @@ export const DetailsBlockProvider = withDynamicSchemaProps((props) => {
     detailFlag = __collection === collection;
   }
 
+  const refresh = useUpdate();
+
   if (!detailFlag || parseVariableLoading) {
     return null;
   }
 
   return (
-    <TemplateBlockProvider>
+    <TemplateBlockProvider onTemplateLoaded={refresh}>
       <BlockProvider name="details" {...props} params={params}>
         <InternalDetailsBlockProvider {...props} />
       </BlockProvider>

--- a/packages/core/client/src/block-provider/FormBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/FormBlockProvider.tsx
@@ -9,6 +9,7 @@
 
 import { createForm, Form } from '@formily/core';
 import { Schema, useField } from '@formily/react';
+import { useUpdate } from 'ahooks';
 import React, { createContext, useContext, useEffect, useMemo, useRef } from 'react';
 import {
   CollectionRecord,
@@ -126,6 +127,8 @@ export const FormBlockProvider = withDynamicSchemaProps((props) => {
   const { designable } = useDesignable();
   const collection = props.collection || cm.getCollection(association).name;
 
+  const refresh = useUpdate();
+
   if (!designable && __collection) {
     if (__collection !== collection) {
       return null;
@@ -133,7 +136,7 @@ export const FormBlockProvider = withDynamicSchemaProps((props) => {
   }
 
   return (
-    <TemplateBlockProvider>
+    <TemplateBlockProvider onTemplateLoaded={refresh}>
       <BlockProvider
         name={props.name || 'form'}
         {...props}

--- a/packages/core/client/src/block-provider/TableBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/TableBlockProvider.tsx
@@ -187,7 +187,7 @@ export const TableBlockProvider = withDynamicSchemaProps((props) => {
   const fieldSchema = useFieldSchema();
   const { getCollection, getCollectionField } = useCollectionManager_deprecated(props.dataSource);
   const collection = getCollection(props.collection, props.dataSource);
-  const { treeTable, pagingMode } = fieldSchema?.['x-decorator-props'] || {};
+  const { treeTable } = fieldSchema?.['x-decorator-props'] || {};
   const { params, parseVariableLoading } = useTableBlockParamsCompat(props);
   let childrenColumnName = 'children';
 

--- a/packages/core/client/src/block-provider/TemplateBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/TemplateBlockProvider.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, FC, useCallback, useContext, useMemo, useState } from 'react';
 
 const TemplateBlockContext = createContext<{
   // 模板是否已经请求结束
@@ -23,11 +23,14 @@ export const useTemplateBlockContext = () => {
   return useContext(TemplateBlockContext);
 };
 
-const TemplateBlockProvider = (props) => {
+const TemplateBlockProvider: FC<{ onTemplateLoaded?: () => void }> = ({ onTemplateLoaded, children }) => {
   const [templateFinished, setTemplateFinished] = useState(false);
-  const onTemplateSuccess = useCallback(() => setTemplateFinished(true), []);
+  const onTemplateSuccess = useCallback(() => {
+    setTemplateFinished(true);
+    onTemplateLoaded?.();
+  }, [onTemplateLoaded]);
   const value = useMemo(() => ({ templateFinished, onTemplateSuccess }), [onTemplateSuccess, templateFinished]);
-  return <TemplateBlockContext.Provider value={value}>{props.children}</TemplateBlockContext.Provider>;
+  return <TemplateBlockContext.Provider value={value}>{children}</TemplateBlockContext.Provider>;
 };
 
 export { TemplateBlockProvider };

--- a/packages/core/client/src/variables/VariablesProvider.tsx
+++ b/packages/core/client/src/variables/VariablesProvider.tsx
@@ -117,7 +117,7 @@ const VariablesProvider = ({ children, filterVariables }: any) => {
         const key = list[index];
         const { fieldPath } = getFieldPath(list.slice(0, index + 1).join('.'), _variableToCollectionName);
         const associationField: CollectionFieldOptions_deprecated = getCollectionJoinField(fieldPath, dataSource);
-        const collectionPrimaryKey = getCollection(collectionName)?.getPrimaryKey();
+        const collectionPrimaryKey = getCollection(collectionName, dataSource)?.getPrimaryKey();
         if (Array.isArray(current)) {
           const result = current.map((item) => {
             if (!options?.doNotRequest && shouldToRequest(item?.[key]) && item?.[collectionPrimaryKey] != null) {

--- a/packages/core/test/src/e2e/e2eUtils.ts
+++ b/packages/core/test/src/e2e/e2eUtils.ts
@@ -1325,6 +1325,7 @@ export async function expectSettingsMenu({
   page,
   unsupportedOptions,
 }: ExpectSettingsMenuParams) {
+  await page.waitForTimeout(100);
   await showMenu();
   for (const option of supportedOptions) {
     await expect(page.getByRole('menuitem', { name: option })).toBeVisible();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where association field values are empty in block templates. Fix the problem where block data scope using variables don't work properly in third-party data sources    |
| 🇨🇳 Chinese |     修复区块模板中，关系字段值为空的问题。修复第三方数据源的区块数据范围，使用变量时，不能正常工作的问题      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
