### PR TITLE
fix: async chunk has been cached incorrectly

### DIFF
--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -23,7 +23,7 @@ import {
   getExcludePackages,
   getIncludePackages,
   getPackagesFromFiles,
-  getSourcePackages
+  getSourcePackages,
 } from './utils/buildPluginUtils';
 import { getDepPkgPath, getDepsConfig } from './utils/getDepsConfig';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
@@ -338,6 +338,7 @@ export async function buildPluginClient(cwd: string, userConfig: UserConfig, sou
     output: {
       path: outDir,
       filename: outputFileName,
+      chunkFilename: '[chunkhash].js',
       publicPath: `/static/plugins/${packageJson.name}/dist/client/`,
       clean: true,
       library: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect caching of frontend js files after plugin build |
| 🇨🇳 Chinese | 修复插件构建后前端 js 文件错误缓存的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
