### PR TITLE
fix(plugin-notification-manager):  notification channel name can not be edit when creating on demo site

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-manager/src/collections/channel.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/collections/channel.ts
@@ -28,10 +28,9 @@ export default {
         type: 'string',
         title: '{{t("Channel name")}}',
         'x-component': 'Input',
-        'x-read-pretty': true,
         required: true,
         description:
-          "{{t('Randomly generated and can be modified. Support letters, numbers and underscores, must start with an letter.')}}",
+          "{{t('Randomly generated and can not be modified. Support letters, numbers and underscores, must start with an letter.')}}",
       },
     },
     {

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/locale/en-US.json
@@ -35,5 +35,6 @@
   "Failed reason": "Failed reason",
   "Log detail": "Log detail",
   "Message": "Message",
-  "Notification manager": "Notification manager"
+  "Notification manager": "Notification manager",
+  "Randomly generated and can not be modified. Support letters, numbers and underscores, must start with an letter.": "Randomly generated and can not be modified. Support letters, numbers and underscores, must start with an letter."
 }

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/locale/zh-CN.json
@@ -37,5 +37,6 @@
   "Failed reason": "失败原因",
   "Log detail": "日志详情",
   "Message": "消息内容",
-  "Notification manager": "通知管理"
+  "Notification manager": "通知管理",
+  "Randomly generated and can not be modified. Support letters, numbers and underscores, must start with an letter.": "随机生成，不可修改。支持英文、数字和下划线，必须以英文字母开头。。"
 }

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/locale/zh-CN.json
@@ -38,5 +38,5 @@
   "Log detail": "日志详情",
   "Message": "消息内容",
   "Notification manager": "通知管理",
-  "Randomly generated and can not be modified. Support letters, numbers and underscores, must start with an letter.": "随机生成，不可修改。支持英文、数字和下划线，必须以英文字母开头。。"
+  "Randomly generated and can not be modified. Support letters, numbers and underscores, must start with an letter.": "随机生成，不可修改。支持英文、数字和下划线，必须以英文字母开头。"
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix notification channel name can not be edit when creating on demo site.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix notification channel name can not be edit when creating on demo site.       |
| 🇨🇳 Chinese |      修复了在新增通知渠道时不能编辑渠道名的问题。     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
