### PR TITLE
fix(m2m-array): issue where updating m2m array fields in single relation collection

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/FileManager.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/FileManager.tsx
@@ -195,7 +195,7 @@ const InternalFileManager = (props) => {
   const pickerProps = {
     size: 'small',
     fieldNames,
-    multiple: ['o2m', 'm2m'].includes(collectionField?.interface) && multiple,
+    multiple: ['o2m', 'm2m', 'mbm'].includes(collectionField?.interface) && multiple,
     association: {
       target: collectionField?.target,
     },

--- a/packages/core/database/src/relation-repository/single-relation-repository.ts
+++ b/packages/core/database/src/relation-repository/single-relation-repository.ts
@@ -108,7 +108,7 @@ export abstract class SingleRelationRepository extends RelationRepository {
     }
 
     await updateModelByValues(target, options?.values, {
-      ...lodash.omit(options, 'values'),
+      ...options,
       transaction,
     });
 

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/issues.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/issues.test.ts
@@ -112,4 +112,108 @@ describe('m2m array api, bigInt targetKey', () => {
     });
     expect(res.status).toBe(200);
   });
+
+  test('update m2m array field in single realtion collection', async () => {
+    await db.getRepository('collections').create({
+      values: {
+        name: 'tags',
+        fields: [
+          {
+            name: 'id',
+            type: 'bigInt',
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          {
+            name: 'title',
+            type: 'string',
+          },
+        ],
+      },
+    });
+    await db.getRepository('collections').create({
+      values: {
+        name: 'users',
+        fields: [
+          {
+            name: 'id',
+            type: 'bigInt',
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          {
+            name: 'username',
+            type: 'string',
+          },
+          {
+            name: 'tags',
+            type: 'belongsToArray',
+            foreignKey: 'tag_ids',
+            target: 'tags',
+            targetKey: 'id',
+          },
+        ],
+      },
+    });
+    await db.getRepository('collections').create({
+      values: {
+        name: 'projects',
+        fields: [
+          {
+            name: 'id',
+            type: 'bigInt',
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          {
+            name: 'title',
+            type: 'string',
+          },
+          {
+            name: 'users',
+            type: 'belongsTo',
+            foreignKey: 'user_id',
+            target: 'users',
+          },
+        ],
+      },
+    });
+    // @ts-ignore
+    await db.getRepository('collections').load();
+    await db.sync();
+    await db.getRepository('tags').create({
+      values: [{ title: 'a' }, { title: 'b' }, { title: 'c' }],
+    });
+    await db.getRepository('users').create({
+      values: { id: 1, username: 'a' },
+    });
+    let user = await db.getRepository('users').findOne({
+      filterByTk: 1,
+    });
+    expect(user.tag_ids).toEqual(null);
+    await db.getRepository('projects').create({
+      values: { id: 1, title: 'p1', user_id: 1 },
+    });
+    const res = await agent.resource('projects.users', 1).update({
+      filterByTk: 1,
+      values: {
+        tags: [
+          { id: 1, title: 'a' },
+          { id: 2, title: 'b' },
+        ],
+      },
+    });
+    user = await db.getRepository('users').findOne({
+      filterByTk: 1,
+    });
+    if (db.sequelize.getDialect() === 'postgres') {
+      expect(user.tag_ids).toMatchObject(['1', '2']);
+    } else {
+      expect(user.tag_ids).toMatchObject([1, 2]);
+    }
+    expect(res.status).toBe(200);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/m2m-array-bigint-api.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/m2m-array-bigint-api.test.ts
@@ -256,6 +256,18 @@ describe('m2m array api, bigInt targetKey', () => {
       } else {
         expect(user2.tag_ids).toMatchObject([1, 3]);
       }
+      const user3 = await db.getRepository('users').create({
+        values: {
+          id: 5,
+          username: 'e',
+          tags: { id: 1 },
+        },
+      });
+      if (db.sequelize.getDialect() === 'postgres') {
+        expect(user3.tag_ids).toMatchObject(['1']);
+      } else {
+        expect(user3.tag_ids).toMatchObject([1]);
+      }
     });
 
     it('should create target when creating belongsToArray', async () => {

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/m2m-array-string-api.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/__tests__/m2m-array-string-api.test.ts
@@ -227,6 +227,14 @@ describe('m2m array api, string targetKey', () => {
         },
       });
       expect(user2.tag_ids).toMatchObject(['a', 'c']);
+      const user3 = await db.getRepository('users').create({
+        values: {
+          id: 5,
+          username: 'e',
+          tags: { stringCode: 'a' },
+        },
+      });
+      expect(user3.tag_ids).toMatchObject(['a']);
     });
 
     it('should create target when creating belongsToArray', async () => {

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/belongs-to-array-field.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/belongs-to-array-field.ts
@@ -25,7 +25,10 @@ export class BelongsToArrayField extends RelationField {
     if (!values || values[name] === undefined) {
       return;
     }
-    const value: any[] = values[name] || [];
+    let value: any[] = values[name] || [];
+    if (!Array.isArray(value)) {
+      value = [value];
+    }
     const tks = [];
     const items = [];
     for (const item of value) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where updating m2m array fields in single relation collection does not take effect          |
| 🇨🇳 Chinese | 修复更新对一关联表中多对多（数组）字段不生效的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
