### PR TITLE
fix(data-vi): fix the issue when formatting timezone-aware date fields in MySQL

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/formatter/mysql-formatter.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/formatter/mysql-formatter.ts
@@ -8,6 +8,7 @@
  */
 
 import { Col, Formatter } from './formatter';
+import moment from 'moment-timezone';
 
 export class MySQLFormatter extends Formatter {
   convertFormat(format: string) {
@@ -21,14 +22,10 @@ export class MySQLFormatter extends Formatter {
   }
 
   formatDate(field: Col, format: string, timezoneOffset?: string) {
-    const timezone = this.getTimezoneByOffset(timezoneOffset);
+    const tz = moment.tz(process.env.TZ || 'UTC').format('Z');
     format = this.convertFormat(format);
-    if (timezone) {
-      return this.sequelize.fn(
-        'date_format',
-        this.sequelize.fn('convert_tz', field, process.env.TZ || 'UTC', timezone),
-        format,
-      );
+    if (timezoneOffset && tz !== timezoneOffset) {
+      return this.sequelize.fn('date_format', this.sequelize.fn('convert_tz', field, tz, timezoneOffset), format);
     }
     return this.sequelize.fn('date_format', field, format);
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue when formatting timezone-aware date fields in MySQL        |
| 🇨🇳 Chinese | 修复在 MySQL 中格式化带时区的日期字段的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
