### PR TITLE
fix: adjust empty state text for subtable in read-pretty  mode

### DIFF
--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -1032,5 +1032,6 @@
   "Bulk enable": "批量激活",
   "Search plugin...": "搜索插件...",
   "Package name": "包名",
-  "Please add or select record":"请添加或选择数据"
+  "Please add or select record":"请添加或选择数据",
+  "No data":"暂无数据"
 }

--- a/packages/core/client/src/schema-component/antd/association-field/SubTable.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/SubTable.tsx
@@ -240,7 +240,9 @@ export const SubTable: any = observer(
                   pagination={paginationConfig}
                   rowSelection={{ type: 'none', hideSelectAll: true }}
                   isSubTable={true}
-                  locale={{ emptyText: <span>{t('Please add or select record')}</span> }}
+                  locale={{
+                    emptyText: <span> {field.editable ? t('Please add or select record') : t('No data')}</span>,
+                  }}
                 />
                 {field.editable && (
                   <Space


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
