### PR TITLE
fix(user-data-sync): skip unsupported data types during synchronization instead of throwing an error

### DIFF
--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/__tests__/api.test.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/__tests__/api.test.ts
@@ -51,4 +51,23 @@ describe('api', async () => {
       nickname: 'test',
     });
   });
+
+  it('push data with unsupported type', async () => {
+    const res = await agent.resource('userData').push({
+      values: {
+        dataType: 'unsupported',
+        records: [
+          {
+            uid: '1',
+            nickname: 'test',
+          },
+        ],
+      },
+    });
+    expect(res.status).toBe(500);
+    expect(res.body.data).toMatchObject({
+      code: 500,
+      message: 'dataType unsupported is not supported',
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/actions/user-data.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/actions/user-data.ts
@@ -26,6 +26,15 @@ export default {
     const data = ctx.action.params.values || {};
     const plugin = ctx.app.pm.get(PluginUserDataSyncServer) as PluginUserDataSyncServer;
     try {
+      let supported = false;
+      for (const resource of plugin.resourceManager.resources.nodes) {
+        if (resource.accepts.includes(data.dataType)) {
+          supported = true;
+        }
+      }
+      if (!supported) {
+        throw new Error(`dataType ${data.dataType} is not supported`);
+      }
       const result = await plugin.syncService.push(data);
       ctx.body = { code: 0, message: 'success', result };
     } catch (error) {

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/plugin.ts
@@ -55,7 +55,7 @@ export class PluginUserDataSyncServer extends Plugin {
 
     this.app.acl.registerSnippet({
       name: `pm.${this.name}`,
-      actions: ['userData:*', 'userDataSyncSources:*'],
+      actions: ['userData:*', 'userDataSyncSources:*', 'userDataSyncTasks:*'],
     });
   }
 

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts
@@ -194,14 +194,12 @@ export class UserDataResourceManager {
     await this.saveOriginRecords(data);
     const { dataType, sourceName, records, matchKey } = data;
     const sourceUks = records.map((record) => record.uid);
-    let processed = false;
     const syncResults: SyncResult[] = [];
     for (const resource of this.resources.nodes) {
       if (!resource.accepts.includes(dataType)) {
         continue;
       }
       const associateResource = resource.name;
-      processed = true;
       const originRecords = await this.findOriginRecords({ sourceName, sourceUks, dataType });
       if (!(originRecords && originRecords.length)) {
         continue;
@@ -265,9 +263,6 @@ export class UserDataResourceManager {
           failedRecords,
         },
       });
-    }
-    if (!processed && data.sourceName === 'api') {
-      throw new Error(`dataType "${dataType}" is not support`);
     }
     return syncResults;
   }

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts
@@ -266,7 +266,7 @@ export class UserDataResourceManager {
         },
       });
     }
-    if (!processed) {
+    if (!processed && data.sourceName === 'api') {
       throw new Error(`dataType "${dataType}" is not support`);
     }
     return syncResults;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Skip unsupported data types during synchronization instead of throwing an error.          |
| 🇨🇳 Chinese | 同步数据时跳过不支持的数据类型，而不是直接报错。          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
