### PR TITLE
fix(users): the form should be reset after adding or editing a user in the user management

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/hooks.ts
+++ b/packages/core/client/src/schema-component/antd/action/hooks.ts
@@ -18,6 +18,7 @@ export const useActionContext = () => {
   const ctx = useContext(ActionContext);
   const { t } = useTranslation();
   const { modal } = App.useApp();
+  const form = useForm();
 
   return {
     ...ctx,
@@ -30,6 +31,7 @@ export const useActionContext = () => {
             async onOk() {
               ctx.setFormValueChanged(false);
               ctx.setVisible?.(false);
+              form?.reset?.();
             },
           });
         } else {

--- a/packages/plugins/@nocobase/plugin-users/src/client/UsersManagement.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/UsersManagement.tsx
@@ -30,10 +30,12 @@ import { PasswordField } from './PasswordField';
 
 const useCancelActionProps = () => {
   const { setVisible } = useActionContext();
+  const form = useForm();
   return {
     type: 'default',
     onClick() {
       setVisible(false);
+      form.reset();
     },
   };
 };
@@ -63,6 +65,7 @@ const useSubmitActionProps = () => {
       await runAsync();
       message.success(t('Saved successfully'));
       setVisible(false);
+      form.reset();
     },
   };
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the form is not reset after adding or editing a user in user management.          |
| 🇨🇳 Chinese | 修复用户管理中添加或修改用户后表单没有被重置的问题 。         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
