### PR TITLE
fix(NocoBaseRecursionField): ignore x-read-pretty when merging schemas

### DIFF
--- a/packages/core/client/src/formily/NocoBaseRecursionField.tsx
+++ b/packages/core/client/src/formily/NocoBaseRecursionField.tsx
@@ -152,12 +152,12 @@ const createMergedSchemaInstance = (schema: Schema, uiSchema: ISchema, onlyRende
     const firstPropertyKey = Object.keys(clonedSchema.properties)[0];
     const firstPropertyValue = Object.values(clonedSchema.properties)[0];
     // Some uiSchema's type value is "void", which can cause exceptions, so we need to ignore the type field
-    clonedSchema.properties[firstPropertyKey] = merge(_.omit(uiSchema, 'type'), firstPropertyValue);
+    clonedSchema.properties[firstPropertyKey] = merge(_.omit(uiSchema, 'type', 'x-read-pretty'), firstPropertyValue);
     return new Schema(clonedSchema);
   }
 
   // Some uiSchema's type value is "void", which can cause exceptions, so we need to ignore the type field
-  return new Schema(merge(_.omit(uiSchema, 'type'), clonedSchema));
+  return new Schema(merge(_.omit(uiSchema, 'type', 'x-read-pretty'), clonedSchema));
 };
 
 const propertiesToReactElement = ({

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/client/__e2e__/fields/createdAt/schemaInitializer.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/client/__e2e__/fields/createdAt/schemaInitializer.test.ts
@@ -62,6 +62,25 @@ test.describe('form item & edit form', () => {
   });
 });
 
+test.describe('form item & filter form', () => {
+  test('should be editable', async ({ page, mockPage, mockRecord }) => {
+    await mockPage().goto();
+
+    // 1. 添加一个 filter form 区块
+    await page.getByLabel('schema-initializer-Grid-page:').hover();
+    await page.getByRole('menuitem', { name: 'Form right' }).nth(1).hover();
+    await page.getByRole('menuitem', { name: 'Users' }).click();
+
+    // 2. 为 filter form 添加一个 createdAt 字段
+    await page.getByLabel('schema-initializer-Grid-filterForm:configureFields-users').hover();
+    await page.getByRole('menuitem', { name: 'Created at' }).first().click();
+    await page.mouse.move(300, 0);
+
+    // 3. createdAt 字段字段应该是可编辑的
+    await expect(page.getByPlaceholder('Select date')).toBeVisible();
+  });
+});
+
 test.describe('form item & view form', () => {
   test('configure fields', async ({ page, mockPage, mockRecord }) => {
     const nocoPage = await mockPage(oneTableBlockWithAddNewAndViewAndEditAndSystemInfoFields).waitForInit();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Fix the issue where system fields in the filter form block cannot be edited   |
| 🇨🇳 Chinese |      修复筛选表单中的系统字段无法编辑的问题     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
