### PR TITLE
fix(users): refresh issue after editing user profiles

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client/UsersManagement.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/UsersManagement.tsx
@@ -13,11 +13,11 @@ import {
   useActionContext,
   useCollection,
   useCollectionRecordData,
-  useDataBlockRequest,
   useDataBlockResource,
   useSchemaComponentContext,
   useRequest,
   useAPIClient,
+  useBlockRequestContext,
 } from '@nocobase/client';
 import React, { createContext, useEffect, useMemo, useContext } from 'react';
 import { App, Tabs, message } from 'antd';
@@ -45,7 +45,7 @@ const useSubmitActionProps = () => {
   const { message } = App.useApp();
   const form = useForm();
   const resource = useDataBlockResource();
-  const { runAsync } = useDataBlockRequest();
+  const { service } = useBlockRequestContext();
   const { t } = useUsersTranslation();
   const collection = useCollection();
 
@@ -62,7 +62,7 @@ const useSubmitActionProps = () => {
       } else {
         await resource.create({ values });
       }
-      await runAsync();
+      await service.refresh();
       message.success(t('Saved successfully'));
       setVisible(false);
       form.reset();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the issues where pagination settings are reset after editing and submitting user profiles on the user management  following a page switch or a change of page size. |
| 🇨🇳 Chinese |  修复用户管理页面翻页或修改分页数量后，编辑用户资料并提交，分页设置会被重置的问题。         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
