### PR TITLE
fix(data-vi): query error when filtering with nested m2m associations

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/issues.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/issues.test.ts
@@ -1,0 +1,67 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Database, Repository } from '@nocobase/database';
+import { MockServer, createMockServer } from '@nocobase/test';
+import compose from 'koa-compose';
+import { parseFieldAndAssociations, queryData } from '../actions/query';
+import { createQueryParser } from '../query-parser';
+
+describe('api', () => {
+  let app: MockServer;
+  let db: Database;
+
+  beforeAll(async () => {
+    app = await createMockServer({
+      plugins: ['users', 'auth', 'data-visualization', 'data-source-manager', 'acl', 'error-handler'],
+    });
+    db = app.db;
+  });
+
+  afterAll(async () => {
+    await app.destroy();
+  });
+
+  test('query with nested m2m filter', async () => {
+    const ctx = {
+      app,
+      db,
+      action: {
+        params: {
+          values: {
+            collection: 'users',
+            measures: [
+              {
+                field: ['id'],
+                aggregation: 'count',
+                alias: 'id',
+              },
+            ],
+            filter: {
+              $and: [
+                {
+                  createdBy: {
+                    roles: {
+                      name: {
+                        $includes: 'member',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    } as any;
+    const queryParser = createQueryParser(db);
+    await compose([parseFieldAndAssociations, queryParser.parse(), queryData])(ctx, async () => {});
+    expect(ctx.action.params.values.data).toBeDefined();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts
@@ -18,9 +18,7 @@ import {
   postProcess,
 } from '../actions/query';
 import { Database } from '@nocobase/database';
-import * as formatter from '../formatter';
 import { createQueryParser } from '../query-parser';
-import { QueryParser } from '../query-parser/query-parser';
 
 describe('query', () => {
   describe('parseBuilder', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error when filtering with nested many to many associations in chart query.         |
| 🇨🇳 Chinese | 修复在图表查询中使用嵌套的多对多关系进行过滤时的报错。          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
