### PR TITLE
fix(NocoBaseReactiveField): remove disable and readOnly

### DIFF
--- a/packages/core/client/src/formily/NocoBaseReactiveField.tsx
+++ b/packages/core/client/src/formily/NocoBaseReactiveField.tsx
@@ -59,14 +59,10 @@ const NocoBaseReactiveInternal: React.FC<IReactiveFieldProps> = (props) => {
 
   const renderComponent = () => {
     if (!field.componentType) return content;
-    const disabled = true;
-    const readOnly = true;
 
     return React.createElement(
       getComponent(field.componentType),
       {
-        disabled,
-        readOnly,
         ...field.componentProps,
         value: field.value,
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where the delete button is disabled in the block template management page    |
| 🇨🇳 Chinese |     修复区块模板管理页面中，删除按钮被禁用的问题      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
