### PR TITLE
fix(plugin-workflow): fix schedule trigger on date field without tz

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/DateFieldScheduleTrigger.ts
@@ -57,7 +57,7 @@ function getDataOptionTime(record, on, dir = 1) {
       if (!field || !record.get(field)) {
         return null;
       }
-      const second = new Date(record.get(field).getTime());
+      const second = new Date(record.get(field));
       second.setMilliseconds(0);
       return second.getTime() + offset * unit * dir;
     }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix schedule trigger on date field without timezone.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix schedule trigger on date field without timezone |
| 🇨🇳 Chinese | 修复定时任务使用无时区字段存在错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
