### PR TITLE
fix(database): fix unix timestamp input value on number type

### DIFF
--- a/packages/core/database/src/__tests__/fields/unix-timestamp-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/unix-timestamp-field.test.ts
@@ -91,7 +91,7 @@ describe('unix timestamp field', () => {
     expect(date1.getTime()).toBe(second * 1000);
   });
 
-  describe.only('timezone', () => {
+  describe('timezone', () => {
     test('custom', async () => {
       db.collection({
         name: 'tests',

--- a/packages/core/database/src/__tests__/fields/unix-timestamp-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/unix-timestamp-field.test.ts
@@ -68,7 +68,30 @@ describe('unix timestamp field', () => {
     expect(date).toBe('2021-01-01 00:00:00');
   });
 
-  describe('timezone', () => {
+  it('number as second input should be kept as same', async () => {
+    const c1 = db.collection({
+      name: 'test13',
+      fields: [
+        {
+          name: 'date1',
+          type: 'unixTimestamp',
+          accuracy: 'second',
+        },
+      ],
+    });
+
+    await db.sync();
+
+    const d = new Date();
+    const second = Math.floor(d.getTime() / 1000);
+
+    const instance = await c1.repository.create({ values: { date1: second } });
+    const date1 = instance.get('date1');
+    expect(date1 instanceof Date).toBe(true);
+    expect(date1.getTime()).toBe(second * 1000);
+  });
+
+  describe.only('timezone', () => {
     test('custom', async () => {
       db.collection({
         name: 'tests',

--- a/packages/core/database/src/fields/unix-timestamp-field.ts
+++ b/packages/core/database/src/fields/unix-timestamp-field.ts
@@ -61,18 +61,21 @@ export class UnixTimestampField extends DateField {
     return {
       get() {
         const value = this.getDataValue(name);
-        if (value === null || value === undefined) {
+        if (value == null) {
           return value;
         }
 
         return new Date(value * rationalNumber);
       },
       set(value) {
-        if (value === null || value === undefined) {
+        if (value == null) {
           this.setDataValue(name, value);
         } else {
           // date to unix timestamp
-          this.setDataValue(name, Math.floor(new Date(value).getTime() / rationalNumber));
+          this.setDataValue(
+            name,
+            Math.floor(typeof value === 'number' ? value : new Date(value).getTime() / rationalNumber),
+          );
         }
       },
     };


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix unix timestamp input value on number type.

### Description 

When input type is number, save as what it is (no / 1000).

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix unix timestamp input value on number type |
| 🇨🇳 Chinese | 修复 Unix 时间戳字段输入值为数字时的处理方式 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
