### PR TITLE
fix(notification-in-app-message): include user ID filter in in-app channels query

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
@@ -73,6 +73,7 @@ export default function defineMyInAppChannels({ app }: { app: Application }) {
               SELECT  messages.${messagesFieldName.channelName}
               FROM ${messagesTableName} AS messages
               WHERE messages.${messagesFieldName.status} = '${status}'
+              AND messages.${messagesFieldName.userId} = ${userId}
           )`);
             return { name: { [Op.in]: sql } };
           };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix the bug in the in-app messaging feature where filtering unread messages is not functioning correctly due to interference with other user data.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Fix the bug in the in-app message feature where filtering unread channels is not functioning correctly due to interference with other user data.
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the bug in the in-app message feature where filtering unread channels is not functioning correctly due to interference with other user data.         |
| 🇨🇳 Chinese |   修复应用内消息功能中的一个错误，该错误导致筛选未读频道时，由于其他用户数据的干扰而无法正常工作。        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
