### PR TITLE
fix(action-import): Resolving Excel Import: Determining the Values Co…

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
@@ -142,6 +142,9 @@ export class XlsxImporter extends EventEmitter {
 
     for (const chunkRows of chunks) {
       for (const row of chunkRows) {
+        //记录当前行外键的多个关联条件，如联合字段确定一条记录的对应字段
+        //如：字典的code和字典的类型，确定他的唯一上级
+        const keysMap = new Map();
         const rowValues = {};
         handingRowIndex += 1;
         try {
@@ -180,9 +183,37 @@ export class XlsxImporter extends EventEmitter {
               ctx.associationField = field;
               ctx.targetCollection = (field as IRelationField).targetCollection();
               ctx.filterKey = column.dataIndex[1];
+              //给对应的条件值赋值
+              if(str!== undefined && str!== null && str!== '') {
+                keysMap.has(column.dataIndex[0])? keysMap.get(column.dataIndex[0]).push(str+'&'+column.dataIndex[1]) : keysMap.set(column.dataIndex[0],[str+'&'+column.dataIndex[1]]);
+              }
             }
+            if(rowValues[dataKey] === undefined) {//如果dataKey的值不存在或者一个值确定一条记录，则赋值
+              rowValues[dataKey] = await interfaceInstance.toValue(this.trimString(str), ctx);
+            }
+          }
 
-            rowValues[dataKey] = await interfaceInstance.toValue(this.trimString(str), ctx);
+          for (const [key, value] of keysMap) {
+            const rowKeys = {};
+            for (const element of value) {
+              const keyArr = element.split('&');
+              rowKeys[keyArr[1]] = keyArr[0];
+            }
+            if (Object.keys(rowKeys).length > 1) {
+              //联合字段确定一条记录的对应字段
+              const filter = {};
+              for (const key in rowKeys) {
+                filter[key] = rowKeys[key];
+              }
+              const field = this.options.collection.getField(key);
+              const targetModel = (field as IRelationField).targetCollection().model;
+              const targetRecord = await targetModel.findOne({
+                where: filter,
+              });
+              if (targetRecord) {
+                rowValues[key] = targetRecord.id;
+              }
+            }
           }
 
           await this.repository.create({


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [√ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
Excel import currently only supports using one associated field to determine a record. It does not support using multiple associated fields to determine a record. For example, in a tree-structured data dictionary, the codes of different types of dictionaries can be duplicated. However, the codes of the same type cannot be duplicated. Therefore, to determine the parent level, a record needs to be determined by both the code and the type.

### Related issues
[https://forum.nocobase.com/t/excel/2018](url)
### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
