### PR TITLE
fix(plugin-workflow-manual): fix details block context

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/FormBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/FormBlockProvider.tsx
@@ -10,6 +10,7 @@
 import { createForm } from '@formily/core';
 import { useField, useFieldSchema } from '@formily/react';
 import {
+  BlockProvider,
   BlockRequestContext_deprecated,
   CollectionManagerProvider,
   CollectionProvider_deprecated,
@@ -82,20 +83,20 @@ export function FormBlockProvider(props) {
   return !userJob?.status || values ? (
     <CollectionManagerProvider dataSource={dataSource}>
       <CollectionProvider_deprecated collection={props.collection}>
-        <RecordProvider record={values} parent={null}>
-          <RerenderDataBlockProvider>
-            <FormActiveFieldsProvider name="form">
-              <BlockRequestContext_deprecated.Provider
-                value={{ block: 'form', props, field, service, resource, __parent }}
-              >
-                <FormBlockContext.Provider value={formBlockValue}>
+        <BlockProvider name={props.name || 'form'} {...props} block={'form'} parentRecord={null}>
+          <FormActiveFieldsProvider name="form">
+            <BlockRequestContext_deprecated.Provider
+              value={{ block: 'form', props, field, service, resource, __parent }}
+            >
+              <FormBlockContext.Provider value={formBlockValue}>
+                <RecordProvider record={values} parent={null}>
                   <FormV2.Templates style={{ marginBottom: token.margin }} form={form} />
                   <div ref={formBlockRef}>{props.children}</div>
-                </FormBlockContext.Provider>
-              </BlockRequestContext_deprecated.Provider>
-            </FormActiveFieldsProvider>
-          </RerenderDataBlockProvider>
-        </RecordProvider>
+                </RecordProvider>
+              </FormBlockContext.Provider>
+            </BlockRequestContext_deprecated.Provider>
+          </FormActiveFieldsProvider>
+        </BlockProvider>
       </CollectionProvider_deprecated>
     </CollectionManagerProvider>
   ) : null;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/DetailsBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/DetailsBlockProvider.tsx
@@ -16,6 +16,7 @@ import {
   CollectionProvider_deprecated,
   FormBlockContext,
   RecordProvider,
+  RerenderDataBlockProvider,
   parseCollectionName,
   useAPIClient,
   useAssociationNames,
@@ -86,20 +87,22 @@ export function DetailsBlockProvider({ collection, dataPath, children }) {
   return (
     <CollectionProvider_deprecated dataSource={dataSourceName} collection={resolvedCollection}>
       <RecordProvider record={values} parent={null}>
-        <BlockRequestContext_deprecated.Provider value={{ block: 'form', field, service, resource, __parent }}>
-          <FormBlockContext.Provider
-            value={{
-              params,
-              form,
-              field,
-              service,
-              updateAssociationValues,
-              formBlockRef,
-            }}
-          >
-            {children}
-          </FormBlockContext.Provider>
-        </BlockRequestContext_deprecated.Provider>
+        <RerenderDataBlockProvider>
+          <BlockRequestContext_deprecated.Provider value={{ block: 'form', field, service, resource, __parent }}>
+            <FormBlockContext.Provider
+              value={{
+                params,
+                form,
+                field,
+                service,
+                updateAssociationValues,
+                formBlockRef,
+              }}
+            >
+              {children}
+            </FormBlockContext.Provider>
+          </BlockRequestContext_deprecated.Provider>
+        </RerenderDataBlockProvider>
       </RecordProvider>
     </CollectionProvider_deprecated>
   );


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix sub-details block throwing error in manual node UI configuration.

### Description 

```
useRerenderDataBlock() must be used within a DataBlockProvider
```

### Related issues

#5366.

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix sub-details block throwing error in manual node UI configuration |
| 🇨🇳 Chinese | 修复关系字段子详情区块在人工节点界面配置中报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
