### PR TITLE
fix: prevent creation of collection with existing name

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/collections.repository.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/collections.repository.test.ts
@@ -31,6 +31,40 @@ describe('collections repository', () => {
     await app.destroy();
   });
 
+  it('should not create collection already exists', async () => {
+    db.collection({
+      name: 'jobs',
+      fields: [
+        {
+          type: 'string',
+          name: 'title',
+        },
+      ],
+    });
+
+    await db.sync();
+
+    let err;
+
+    try {
+      await Collection.repository.create({
+        values: {
+          name: 'jobs',
+          fields: [
+            {
+              type: 'string',
+              name: 'title',
+            },
+          ],
+        },
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeTruthy();
+  });
+
   it('should load through table with foreignKey', async () => {
     await Collection.repository.create({
       values: {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Filter, InheritedCollection, UniqueConstraintError } from '@nocobase/database';
+import { Filter, InheritedCollection, snakeCase, UniqueConstraintError } from '@nocobase/database';
 import PluginErrorHandler from '@nocobase/plugin-error-handler';
 import { Plugin } from '@nocobase/server';
 import { Mutex } from 'async-mutex';
@@ -70,6 +70,12 @@ export class PluginDataSourceMainServer extends Plugin {
     });
 
     this.app.db.on('collections.beforeCreate', beforeCreateForViewCollection(this.db));
+
+    this.app.db.on('collections.beforeCreate', async (model: CollectionModel, options) => {
+      if (this.app.db.getCollection(model.get('name'))) {
+        throw new Error(`Collection named ${model.get('name')} already exists`);
+      }
+    });
 
     this.app.db.on(
       'collections.afterSaveWithAssociations',

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -72,7 +72,7 @@ export class PluginDataSourceMainServer extends Plugin {
     this.app.db.on('collections.beforeCreate', beforeCreateForViewCollection(this.db));
 
     this.app.db.on('collections.beforeCreate', async (model: CollectionModel, options) => {
-      if (this.app.db.getCollection(model.get('name')) && model.get('from') !== 'db2cm') {
+      if (this.app.db.getCollection(model.get('name')) && model.get('from') !== 'db2cm' && !model.get('isThrough')) {
         throw new Error(`Collection named ${model.get('name')} already exists`);
       }
     });

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Filter, InheritedCollection, snakeCase, UniqueConstraintError } from '@nocobase/database';
+import { Filter, InheritedCollection, UniqueConstraintError } from '@nocobase/database';
 import PluginErrorHandler from '@nocobase/plugin-error-handler';
 import { Plugin } from '@nocobase/server';
 import { Mutex } from 'async-mutex';
@@ -72,7 +72,7 @@ export class PluginDataSourceMainServer extends Plugin {
     this.app.db.on('collections.beforeCreate', beforeCreateForViewCollection(this.db));
 
     this.app.db.on('collections.beforeCreate', async (model: CollectionModel, options) => {
-      if (this.app.db.getCollection(model.get('name'))) {
+      if (this.app.db.getCollection(model.get('name')) && model.get('from') !== 'db2cm') {
         throw new Error(`Collection named ${model.get('name')} already exists`);
       }
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Added name conflict validation to prevent users from creating Collections with the same name as system Collections |
| 🇨🇳 Chinese | 新增名称冲突校验，防止用户创建与系统 Collection 同名的 Collection      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
