### PR TITLE
chore: migrate old version unixtimestamp fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/migrations/update-bigint-to-unixtimestamp.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/migrations/update-bigint-to-unixtimestamp.test.ts
@@ -1,0 +1,101 @@
+import { Database, MigrationContext } from '@nocobase/database';
+import { MockServer } from '@nocobase/test';
+import { createApp } from '..';
+import Migrator from '../../migrations/20241230000001-update-bigint-to-unixtimestamp';
+
+describe('update bigint to unixTimestamp', () => {
+  let app: MockServer;
+  let db: Database;
+
+  beforeEach(async () => {
+    app = await createApp();
+    db = app.db;
+    await app.db.sync();
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+  });
+
+  it('should update bigInt fields with unixTimestamp interface', async () => {
+    const collectionsRepository = db.getRepository('collections');
+    const fieldsRepository = db.getRepository('fields');
+
+    // Create a test collection
+    await collectionsRepository.create({
+      values: {
+        name: 'test',
+        title: 'Test Collection',
+      },
+    });
+
+    const oldUiSchema = {
+      'x-component-props': {
+        accuracy: 'second',
+        showTime: true,
+      },
+      type: 'number',
+      'x-component': 'UnixTimestamp',
+      title: 'unix-time',
+    };
+
+    // Create test fields
+    await fieldsRepository.create({
+      values: {
+        collectionName: 'test',
+        type: 'bigInt',
+        name: 'timestamp_field',
+        interface: 'unixTimestamp',
+        uiSchema: oldUiSchema,
+      },
+    });
+
+    // Create a control field that should not be updated
+    await fieldsRepository.create({
+      values: {
+        collectionName: 'test',
+        type: 'bigInt',
+        name: 'normal_bigint',
+        interface: 'integer',
+      },
+    });
+
+    // Run the migration
+    const migration = new Migrator({ db } as MigrationContext);
+    migration.context.app = app;
+    await migration.up();
+
+    // Verify the results
+    const updatedField = await fieldsRepository.findOne({
+      filter: {
+        name: 'timestamp_field',
+        collectionName: 'test',
+      },
+    });
+
+    const controlField = await fieldsRepository.findOne({
+      filter: {
+        name: 'normal_bigint',
+        collectionName: 'test',
+      },
+    });
+
+    // Check if the target field was updated
+    expect(updatedField.get('type')).toBe('unixTimestamp');
+
+    // Check if the uiSchema was updated correctly
+    const updatedUiSchema = updatedField.get('uiSchema');
+    expect(updatedUiSchema).toMatchObject({
+      ...oldUiSchema,
+      'x-component-props': {
+        ...oldUiSchema['x-component-props'],
+        showTime: true,
+        dateFormat: 'YYYY-MM-DD',
+        timeFormat: 'HH:mm:ss',
+      },
+    });
+
+    // Check if the control field remained unchanged
+    expect(controlField.get('type')).toBe('bigInt');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/migrations/20241230000001-update-bigint-to-unixtimestamp.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/migrations/20241230000001-update-bigint-to-unixtimestamp.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/* istanbul ignore file -- @preserve */
+
+import { Migration } from '@nocobase/server';
+
+export default class extends Migration {
+  async up() {
+    const Field = this.context.db.getRepository('fields');
+    const fields = await Field.find({
+      filter: {
+        interface: 'unixTimestamp',
+        type: 'bigInt',
+      },
+    });
+
+    for (const field of fields) {
+      // Update field type to unixTimestamp
+      const uiSchema = field.get('uiSchema');
+
+      uiSchema['x-component-props'] = {
+        picker: 'date',
+        dateFormat: 'YYYY-MM-DD',
+        timeFormat: 'HH:mm:ss',
+        showTime: uiSchema['x-component-props']?.showTime,
+        accuracy: uiSchema['x-component-props']?.accuracy,
+      };
+
+      field.set('type', 'unixTimestamp');
+      field.set('uiSchema', uiSchema);
+      await field.save();
+    }
+  }
+}

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/migrations/20241230000001-update-bigint-to-unixtimestamp.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/migrations/20241230000001-update-bigint-to-unixtimestamp.ts
@@ -12,6 +12,8 @@
 import { Migration } from '@nocobase/server';
 
 export default class extends Migration {
+  on = 'beforeLoad';
+
   async up() {
     const Field = this.context.db.getRepository('fields');
     const fields = await Field.find({

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/migrations/20241230000001-update-bigint-to-unixtimestamp.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/migrations/20241230000001-update-bigint-to-unixtimestamp.ts
@@ -12,7 +12,7 @@
 import { Migration } from '@nocobase/server';
 
 export default class extends Migration {
-  on = 'beforeLoad';
+  on = 'afterLoad';
 
   async up() {
     const Field = this.context.db.getRepository('fields');
@@ -31,8 +31,8 @@ export default class extends Migration {
         picker: 'date',
         dateFormat: 'YYYY-MM-DD',
         timeFormat: 'HH:mm:ss',
-        showTime: uiSchema['x-component-props']?.showTime,
-        accuracy: uiSchema['x-component-props']?.accuracy,
+        showTime: uiSchema['x-component-props']?.showTime || true,
+        accuracy: uiSchema['x-component-props']?.accuracy || 'second',
       };
 
       field.set('type', 'unixTimestamp');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix legacy support issues with the unixTimestamp field.        |
| 🇨🇳 Chinese |  修复旧版 unixTimestamp 字段的支持问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
