### PR TITLE
fix(plugin-workflow-test): fix date fields precision

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/categories.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/categories.ts
@@ -20,5 +20,13 @@ export default {
       type: 'hasMany',
       name: 'posts',
     },
+    {
+      type: 'date',
+      name: 'createdAt',
+    },
+    {
+      type: 'date',
+      name: 'updatedAt',
+    },
   ],
 } as CollectionOptions;

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/comments.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/comments.ts
@@ -11,6 +11,8 @@ import { CollectionOptions } from '@nocobase/database';
 
 export default {
   name: 'comments',
+  createdBy: true,
+  updatedBy: true,
   fields: [
     {
       type: 'belongsTo',
@@ -28,6 +30,14 @@ export default {
     {
       type: 'hasMany',
       name: 'replies',
+    },
+    {
+      type: 'date',
+      name: 'createdAt',
+    },
+    {
+      type: 'date',
+      name: 'updatedAt',
     },
   ],
 } as CollectionOptions;

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/posts.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/posts.ts
@@ -45,5 +45,13 @@ export default {
       name: 'read',
       defaultValue: 0,
     },
+    {
+      type: 'date',
+      name: 'createdAt',
+    },
+    {
+      type: 'date',
+      name: 'updatedAt',
+    },
   ],
 } as CollectionOptions;

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/replies.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/replies.ts
@@ -9,10 +9,20 @@
 
 export default {
   name: 'replies',
+  createdBy: true,
+  updatedBy: true,
   fields: [
     {
       type: 'string',
       name: 'content',
+    },
+    {
+      type: 'date',
+      name: 'createdAt',
+    },
+    {
+      type: 'date',
+      name: 'updatedAt',
     },
   ],
 };

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/tags.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/tags.ts
@@ -11,6 +11,8 @@ import { CollectionOptions } from '@nocobase/database';
 
 export default {
   name: 'tags',
+  createdBy: true,
+  updatedBy: true,
   fields: [
     {
       type: 'belongsToMany',
@@ -19,6 +21,14 @@ export default {
     {
       type: 'string',
       name: 'name',
+    },
+    {
+      type: 'date',
+      name: 'createdAt',
+    },
+    {
+      type: 'date',
+      name: 'updatedAt',
     },
   ],
 } as CollectionOptions;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Test cases fails under MySQL because date fields precision.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix date fields precision in test collection |
| 🇨🇳 Chinese | 修复测试表中日期字段的精度 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
