### PR TITLE
fix(data-vi): "Current popup record" variable issue

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
@@ -9,17 +9,28 @@
 
 import React from 'react';
 import { BlockRefreshButton } from '../initializers/BlockRefreshAction';
-import { SchemaComponentOptions } from '@nocobase/client';
+import { SchemaComponentOptions, useCurrentPopupContext, useLocalVariables } from '@nocobase/client';
 import { GlobalAutoRefreshProvider } from './GlobalAutoRefreshProvider';
+import _ from 'lodash';
 
 export const ChartBlockProvider: React.FC = (props) => {
+  const currentPopupContext = useCurrentPopupContext();
+  const localVariables = useLocalVariables();
+  const popUpCtxReady =
+    _.isEmpty(currentPopupContext) ||
+    localVariables?.some((variable) => variable.name === '$nPopupRecord' && variable.ctx);
+
+  if (!popUpCtxReady) {
+    return null;
+  }
+
   return (
     <SchemaComponentOptions
       components={{
         BlockRefreshButton,
       }}
     >
-      <GlobalAutoRefreshProvider> {props.children}</GlobalAutoRefreshProvider>
+      <GlobalAutoRefreshProvider>{props.children}</GlobalAutoRefreshProvider>
     </SchemaComponentOptions>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where "current popup variables" used on charts in subpages became empty after refreshing the page          |
| 🇨🇳 Chinese | 修复在子页面的图表中使用“上级弹窗变量”时，刷新页面后变量失效的问题  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
