### PR TITLE
fix: parent collection fields not loaded in the kanban

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/details-single/ReadPrettyFormItemInitializers.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/details-single/ReadPrettyFormItemInitializers.tsx
@@ -19,7 +19,7 @@ import {
   useInheritsFormItemInitializerFields,
 } from '../../../../schema-initializer/utils';
 
-const ParentCollectionFields = () => {
+export const ParentCollectionFields = () => {
   const inheritFields = useInheritsFormItemInitializerFields();
   const { t } = useTranslation();
   const compile = useCompile();

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/Kanban.Card.Designer.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/Kanban.Card.Designer.tsx
@@ -21,6 +21,7 @@ import {
   useGetAriaLabelOfDesigner,
   useOpenModeContext,
   useSchemaInitializerRender,
+  ParentCollectionFields,
 } from '@nocobase/client';
 import { Space } from 'antd';
 import React from 'react';
@@ -116,6 +117,10 @@ const commonOptions = {
       title: '{{t("Display fields")}}',
       name: 'displayFields',
       useChildren: useFormItemInitializerFields,
+    },
+    {
+      name: 'parentCollectionFields',
+      Component: ParentCollectionFields,
     },
     {
       type: 'itemGroup',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix parent collection fields not loaded in the kanban       |
| 🇨🇳 Chinese |    修复看板未加载数据表的父表字段       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
