### PR TITLE
fix: date range picker in filter form/action not showing time picker …

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
@@ -12,7 +12,7 @@ import { DatePicker as AntdDatePicker, DatePickerProps as AntdDatePickerProps, S
 import { RangePickerProps } from 'antd/es/date-picker';
 import dayjs from 'dayjs';
 import React, { useState } from 'react';
-import { getPickerFormat } from '@nocobase/utils/client';
+import { getPickerFormat, getDateTimeFormat } from '@nocobase/utils/client';
 import { useTranslation } from 'react-i18next';
 import { ReadPretty, ReadPrettyComposed } from './ReadPretty';
 import { getDateRanges, mapDatePicker, mapRangePicker, inferPickerType } from './util';
@@ -63,7 +63,7 @@ export const DatePicker: ComposedDatePicker = (props: any) => {
 DatePicker.ReadPretty = ReadPretty.DatePicker;
 
 DatePicker.RangePicker = function RangePicker(props: any) {
-  const { value, picker = 'date', format } = props;
+  const { value, picker = 'date', format, showTime, timeFormat } = props;
   const { t } = useTranslation();
   const fieldSchema = useFieldSchema();
   const field: any = useField();
@@ -94,17 +94,16 @@ DatePicker.RangePicker = function RangePicker(props: any) {
   ];
 
   const targetPicker = value ? inferPickerType(value?.[0]) : picker;
-  const targetFormat = getPickerFormat(targetPicker) || format;
+  const targetDateFormat = getPickerFormat(targetPicker) || format;
   const newProps: any = {
     utc,
     presets,
     ...props,
-    format: targetFormat,
+    format: getDateTimeFormat(targetPicker, targetDateFormat, showTime, timeFormat),
     picker: targetPicker,
-    showTime: props.showTime ? { defaultValue: [dayjs('00:00:00', 'HH:mm:ss'), dayjs('00:00:00', 'HH:mm:ss')] } : false,
+    showTime: showTime ? { defaultValue: [dayjs('00:00:00', 'HH:mm:ss'), dayjs('00:00:00', 'HH:mm:ss')] } : false,
   };
   const [stateProps, setStateProps] = useState(newProps);
-
   if (isFilterAction) {
     return (
       <Space.Compact>
@@ -136,17 +135,19 @@ DatePicker.RangePicker = function RangePicker(props: any) {
           ])}
           onChange={(value) => {
             const format = getPickerFormat(value);
+            const dateTimeFormat = getDateTimeFormat(value, format, showTime, timeFormat);
+
             field.setComponentProps({
               picker: value,
               format,
             });
             newProps.picker = value;
-            newProps.format = format;
+            newProps.format = dateTimeFormat;
             setStateProps(newProps);
             fieldSchema['x-component-props'] = {
               ...props,
               picker: value,
-              format,
+              format: dateTimeFormat,
             };
             field.value = undefined;
           }}
@@ -159,19 +160,19 @@ DatePicker.RangePicker = function RangePicker(props: any) {
 };
 
 DatePicker.FilterWithPicker = function FilterWithPicker(props: any) {
-  const { picker = 'date', format } = props;
+  const { picker = 'date', format, showTime, timeFormat } = props;
   const { utc = true } = useDatePickerContext();
   const value = Array.isArray(props.value) ? props.value[0] : props.value;
   const compile = useCompile();
   const fieldSchema = useFieldSchema();
   const targetPicker = value ? inferPickerType(value) : picker;
-  const targetFormat = getPickerFormat(targetPicker) || format;
+  const targetDateFormat = getPickerFormat(targetPicker) || format;
   const newProps = {
     utc,
     ...props,
     underFilter: true,
-    showTime: props.showTime ? { defaultValue: dayjs('00:00:00', 'HH:mm:ss') } : false,
-    format: targetFormat,
+    showTime: showTime ? { defaultValue: dayjs('00:00:00', 'HH:mm:ss') } : false,
+    format: getDateTimeFormat(targetPicker, targetDateFormat, showTime, timeFormat),
     picker: targetPicker,
     onChange: (val) => {
       props.onChange(undefined);
@@ -212,17 +213,19 @@ DatePicker.FilterWithPicker = function FilterWithPicker(props: any) {
         ])}
         onChange={(value) => {
           const format = getPickerFormat(value);
+          const dateTimeFormat = getDateTimeFormat(value, format, showTime, timeFormat);
+
           field.setComponentProps({
             picker: value,
             format,
           });
           newProps.picker = value;
-          newProps.format = format;
+          newProps.format = dateTimeFormat;
           setStateProps(newProps);
           fieldSchema['x-component-props'] = {
             ...props,
             picker: value,
-            format,
+            format: dateTimeFormat,
           };
           field.value = null;
         }}

--- a/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
@@ -521,6 +521,7 @@ export const EditOperator = () => {
           componentProps = {
             ...fieldSchema['x-component-props'],
             component: operator.schema['x-component'],
+            ...field.componentProps,
             ...operator.schema?.['x-component-props'],
           };
         } else if (fieldSchema['x-component-props']?.component) {

--- a/packages/core/utils/src/date.ts
+++ b/packages/core/utils/src/date.ts
@@ -225,3 +225,13 @@ export const getPickerFormat = (picker) => {
       return 'YYYY-MM-DD';
   }
 };
+
+export const getDateTimeFormat = (picker, format, showTime, timeFormat) => {
+  if (picker === 'date') {
+    if (showTime) {
+      return format + timeFormat || 'HH:mm:ss';
+    }
+    return format;
+  }
+  return format;
+};


### PR DESCRIPTION
…when showTime is set

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix date range picker in filter form/action not showing time picker when showTime is set       |
| 🇨🇳 Chinese |     修 复 筛选表单/筛选操作中日期范围选择器设置 showTime=true 时未显示时间     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
