### PR TITLE
refactor(client): set default end time for time range in filter block to 23:59:59"

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
@@ -101,7 +101,7 @@ DatePicker.RangePicker = function RangePicker(props: any) {
     ...props,
     format: getDateTimeFormat(targetPicker, targetDateFormat, showTime, timeFormat),
     picker: targetPicker,
-    showTime: showTime ? { defaultValue: [dayjs('00:00:00', 'HH:mm:ss'), dayjs('00:00:00', 'HH:mm:ss')] } : false,
+    showTime: showTime ? { defaultValue: [dayjs('00:00:00', 'HH:mm:ss'), dayjs('23:59:59', 'HH:mm:ss')] } : false,
   };
   const [stateProps, setStateProps] = useState(newProps);
   if (isFilterAction) {

--- a/packages/core/utils/src/date.ts
+++ b/packages/core/utils/src/date.ts
@@ -229,7 +229,7 @@ export const getPickerFormat = (picker) => {
 export const getDateTimeFormat = (picker, format, showTime, timeFormat) => {
   if (picker === 'date') {
     if (showTime) {
-      return format + timeFormat || 'HH:mm:ss';
+      return `${format} ${timeFormat || 'HH:mm:ss'}`;
     }
     return format;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Set default end time for time scope component in filter block to 23:59:59"        |
| 🇨🇳 Chinese |    筛选区块中时间范围的结束时分秒默认到 23:59:59     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
