### PR TITLE
feat(plugin-workflow): allow to sort workflows when binding to action button

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -561,6 +561,17 @@ export function WorkflowConfig() {
               items: {
                 type: 'object',
                 properties: {
+                  sort: {
+                    type: 'void',
+                    'x-component': 'ArrayTable.Column',
+                    'x-component-props': { width: 50, title: '', align: 'center' },
+                    properties: {
+                      sort: {
+                        type: 'void',
+                        'x-component': 'ArrayTable.SortHandle',
+                      },
+                    },
+                  },
                   context: {
                     type: 'void',
                     'x-component': 'ArrayTable.Column',


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow to sort workflows when binding to action button.

### Description 

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow to sort workflows when binding to action button |
| 🇨🇳 Chinese | 支持绑定工作流时进行排序 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
