### PR TITLE
fix(plugin-workflow): fix duplicate triggering

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -161,13 +161,14 @@ export default class extends Instruction {
       .finally(() => {
         processor.logger.debug(`request (#${node.id}) ended, resume workflow...`);
         setImmediate(() => {
+          job.execution = processor.execution;
           this.workflow.resume(job);
         });
       });
 
     processor.logger.info(`request (#${node.id}) sent to "${config.url}", waiting for response...`);
 
-    return processor.exit();
+    return null;
   }
 
   async resume(node: FlowNodeModel, job, processor: Processor) {

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -160,7 +160,7 @@ export default class extends Instruction {
       })
       .finally(() => {
         processor.logger.debug(`request (#${node.id}) ended, resume workflow...`);
-        setImmediate(() => {
+        setTimeout(() => {
           job.execution = processor.execution;
           this.workflow.resume(job);
         });
@@ -168,7 +168,7 @@ export default class extends Instruction {
 
     processor.logger.info(`request (#${node.id}) sent to "${config.url}", waiting for response...`);
 
-    return null;
+    return job;
   }
 
   async resume(node: FlowNodeModel, job, processor: Processor) {

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/instructions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/instructions.ts
@@ -78,6 +78,30 @@ export default {
     },
   },
 
+  asyncResume: {
+    async run(node, input, processor) {
+      const job = await processor.saveJob({
+        status: 0,
+        nodeId: node.id,
+        nodeKey: node.key,
+        upstreamId: input?.id ?? null,
+      });
+
+      setTimeout(() => {
+        job.set({
+          status: 1,
+        });
+
+        processor.options.plugin.resume(job);
+      }, 100);
+
+      return null;
+    },
+    resume(node, job, processor) {
+      return job;
+    },
+  },
+
   customizedSuccess: {
     run(node, input, processor) {
       return {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -351,6 +351,9 @@ describe('workflow > Plugin', () => {
         },
       });
 
+      const e1s = await w1.getExecutions();
+      expect(e1s.length).toBe(1);
+
       await app.start();
 
       await sleep(500);

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -273,7 +273,7 @@ describe('workflow > Plugin', () => {
 
       const p1 = await PostRepo.create({ values: { title: 't1' } });
 
-      await sleep(1000);
+      await sleep(500);
 
       const [e1] = await w1.getExecutions();
       expect(e1.status).toBe(EXECUTION_STATUS.RESOLVED);
@@ -299,11 +299,32 @@ describe('workflow > Plugin', () => {
       const p2 = await PostRepo.create({ values: { title: 't2' } });
       const p3 = await PostRepo.create({ values: { title: 't3' } });
 
-      await sleep(1000);
+      await sleep(500);
 
       const executions = await w1.getExecutions();
       expect(executions.length).toBe(3);
       expect(executions.map((item) => item.status)).toEqual(Array(3).fill(EXECUTION_STATUS.RESOLVED));
+    });
+
+    it('duplicated event trigger', async () => {
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+
+      const n1 = await w1.createNode({
+        type: 'asyncResume',
+      });
+
+      plugin.trigger(w1, {}, { eventKey: 'a' });
+      plugin.trigger(w1, {}, { eventKey: 'a' });
+
+      await sleep(1000);
+
+      const executions = await w1.getExecutions();
+      expect(executions.length).toBe(1);
+      const jobs = await executions[0].getJobs();
+      expect(jobs.length).toBe(1);
     });
 
     it('when server starts, process all created executions', async () => {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Add defensive code to avoid duplicate triggering.

### Description 

* Raise transaction isolation level to repeatable-read when fetching next queueing execution.
* Check event key in events cache.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add defensive logic to avoid duplicate triggering |
| 🇨🇳 Chinese | 为避免重复触发增加防御性逻辑 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
