### PR TITLE
chore(evaluators): upgrade formulajs version to 4.4.9

### DIFF
--- a/packages/core/evaluators/package.json
+++ b/packages/core/evaluators/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@formulajs/formulajs": "4.2.0",
+    "@formulajs/formulajs": "4.4.9",
     "@nocobase/utils": "1.4.21",
     "mathjs": "^10.6.0"
   },


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

To fix expression not works as expected in formula.js.

### Description 

In v4.2.0 of formula.js:

```
WORKDAY('2025-01-10T12:37:55.192Z', 1); // works
WORKDAY('2025-01-10T12:37:55.192Z', -1); // throws error
```

In v4.4.9 it works.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upgrade version of library formula.js to 4.4.9 |
| 🇨🇳 Chinese | 升级 formula.js 库的版本至 4.4.9 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
