### PR TITLE
fix(users): disable browser autofill when setting passwords for users in user management

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client/PasswordField.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/PasswordField.tsx
@@ -39,7 +39,7 @@ export const PasswordField: React.FC = () => {
           }}
           value={field.value}
           onChange={(e: any) => field.setValue(e.target.value)}
-          autoComplete="off"
+          autoComplete="new-password"
         />
       </Col>
       <Col span={4}>

--- a/packages/plugins/@nocobase/plugin-users/src/client/PasswordField.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/PasswordField.tsx
@@ -31,8 +31,6 @@ export const PasswordField: React.FC = () => {
   return (
     <Row gutter={10}>
       <Col span={18}>
-        {/* used for preventing autofill */}
-        <input type="password" name="password-hide" autoComplete="new-password" hidden />
         <Password
           checkStrength={true}
           visibilityToggle={{

--- a/packages/plugins/@nocobase/plugin-users/src/client/PasswordField.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/PasswordField.tsx
@@ -31,6 +31,8 @@ export const PasswordField: React.FC = () => {
   return (
     <Row gutter={10}>
       <Col span={18}>
+        {/* used for preventing autofill */}
+        <input type="password" name="password-hide" autoComplete="new-password" hidden />
         <Password
           checkStrength={true}
           visibilityToggle={{

--- a/packages/plugins/@nocobase/plugin-users/src/client/schemas/users.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/client/schemas/users.ts
@@ -230,6 +230,9 @@ export const usersSchema: ISchema = {
                     password: {
                       'x-component': 'CollectionField',
                       'x-decorator': 'FormItem',
+                      'x-component-props': {
+                        autoComplete: 'new-password',
+                      },
                       required: true,
                     },
                     roles: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Disable browser autofill when setting passwords for users in user management         |
| 🇨🇳 Chinese | 在用户管理中给用户设置密码的时候关闭浏览器自动填充          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
