### PR TITLE
fix: missing current popup variable in the field enable link modal

### DIFF
--- a/packages/core/client/src/schema-component/common/withPopupWrapper/index.tsx
+++ b/packages/core/client/src/schema-component/common/withPopupWrapper/index.tsx
@@ -14,9 +14,9 @@ import { ActionContextProvider, SchemaComponentOptions, useActionContext, useDes
 import { PopupVisibleProvider } from '../../antd/page/PagePopups';
 import { usePopupUtils } from '../../antd/page/pagePopupUtils';
 import { popupSchema } from './schema';
-
 import { CollectionProvider, useCollection } from '../../../data-source';
 import { NocoBaseRecursionField } from '../../../formily/NocoBaseRecursionField';
+import { VariablePopupRecordProvider } from '../../../modules/variable/variablesProvider/VariablePopupRecordProvider';
 
 const useInsertSchema = () => {
   const fieldSchema = useFieldSchema();
@@ -109,12 +109,14 @@ function withPopupWrapper<T>(WrappedComponent: React.ComponentType<T>) {
         >
           <CollectionProvider name={collection.name}>
             <SchemaComponentOptions>
-              <NocoBaseRecursionField
-                onlyRenderProperties
-                basePath={field?.address}
-                schema={fieldSchema}
-                filterProperties={filterProperties}
-              />
+              <VariablePopupRecordProvider>
+                <NocoBaseRecursionField
+                  onlyRenderProperties
+                  basePath={field?.address}
+                  schema={fieldSchema}
+                  filterProperties={filterProperties}
+                />
+              </VariablePopupRecordProvider>
             </SchemaComponentOptions>
           </CollectionProvider>
           <a onClick={handleClick}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix missing current popup variable in the field enable link modal         |
| 🇨🇳 Chinese |   修复 字段启用连接的弹窗中缺少当前弹窗变量        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
