### PR TITLE
fix: number field format in readPretty mode affecting edit mode

### DIFF
--- a/packages/core/client/src/schema-component/antd/input-number/InputNumber.tsx
+++ b/packages/core/client/src/schema-component/antd/input-number/InputNumber.tsx
@@ -12,6 +12,7 @@ import { InputNumber as AntdNumber, InputNumberProps as AntdInputNumberProps } f
 import React from 'react';
 import { InputNumberReadPrettyProps, ReadPretty } from './ReadPretty';
 import BigNumber from 'bignumber.js';
+import { omit } from 'lodash';
 
 type ComposedInputNumber = React.ForwardRefExoticComponent<
   Pick<Partial<any>, string | number | symbol> & React.RefAttributes<unknown>
@@ -37,7 +38,14 @@ export const InputNumber: ComposedInputNumber = connect((props: AntdInputNumberP
       onChange(toSafeNumber(v));
     }
   };
-  return <AntdNumber onChange={handleChange} {...others} />;
+  let inputNumberProps = {
+    onChange: handleChange,
+    ...others,
+  };
+  if (others['formatStyle']) {
+    inputNumberProps = omit(inputNumberProps, ['addonAfter', 'addonBefore']);
+  }
+  return <AntdNumber {...inputNumberProps} />;
 }, mapReadPretty(ReadPretty));
 
 InputNumber.ReadPretty = ReadPretty;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix number field format in readPretty mode affecting edit mode        |
| 🇨🇳 Chinese |   整数字段在阅读模式下设置的格式也会影响编辑模式        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
