### PR TITLE
feat: datePicker component field settings add date input readOnly

### DIFF
--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -865,6 +865,7 @@
   "Allow add new, update and delete actions": "允许增删改操作",
   "Date display format": "日期显示格式",
   "Date range limit": "日期限定范围",
+  "Date Input Read only": "日期输入框只读",
   "MinDate": "最小日期",
   "MaxDate": "最大日期",
   "Please select time or variable": "请选择时间或变量",

--- a/packages/core/client/src/modules/fields/component/DatePicker/datePickerComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/DatePicker/datePickerComponentFieldSettings.tsx
@@ -11,6 +11,7 @@ import { useFieldSchema } from '@formily/react';
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
 import { SchemaSettingsDateFormat } from '../../../../schema-settings/SchemaSettingsDateFormat';
 import { SchemaSettingsDateRange } from '../../../../schema-settings/SchemaSettingsDateRange';
+import { SchemaSettingsDateInputReadOnly } from '../../../../schema-settings/SchemaSettingsDateInputReadOnly';
 import { useColumnSchema } from '../../../../schema-component/antd/table-v2/Table.Column.Decorator';
 import { ellipsisSettingsItem, enableLinkSettingsItem, openModeSettingsItem } from '../Input/inputComponentSettings';
 
@@ -45,6 +46,24 @@ export const datePickerComponentFieldSettings = new SchemaSettings({
         const schema = useFieldSchema();
         const fieldSchema = columnSchema || schema;
         return !fieldSchema?.['x-read-pretty'];
+      },
+    },
+    {
+      name: 'dateInputReadOnly',
+      Component: SchemaSettingsDateInputReadOnly as any,
+      useComponentProps() {
+        const schema = useFieldSchema();
+        const { fieldSchema: tableColumnSchema } = useColumnSchema();
+        const fieldSchema = tableColumnSchema || schema;
+        return {
+          fieldSchema,
+        };
+      },
+      useVisible() {
+        const { fieldSchema: columnSchema } = useColumnSchema();
+        const schema = useFieldSchema();
+        const fieldSchema = columnSchema || schema;
+        return !fieldSchema?.['x-read-pretty'] && !fieldSchema?.['x-disabled'];
       },
     },
     ellipsisSettingsItem,

--- a/packages/core/client/src/schema-settings/SchemaSettingsDateInputReadOnly.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDateInputReadOnly.tsx
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Schema, useField } from '@formily/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDesignable } from '..';
+import { SchemaSettingsSwitchItem } from './SchemaSettings';
+
+export const SchemaSettingsDateInputReadOnly = function DateInputReadOnlyConfig(props: { fieldSchema: Schema }) {
+  const { fieldSchema } = props;
+  const field: any = useField();
+  const { dn } = useDesignable();
+  const { t } = useTranslation();
+  return (
+    <SchemaSettingsSwitchItem
+      title={t('Date Input Read only')}
+      checked={fieldSchema['x-component-props']?.['inputReadOnly']}
+      onChange={(checked) => {
+        const schema: any = {
+          ['x-uid']: fieldSchema['x-uid'],
+        };
+        schema['x-component-props'] = field.componentProps || {};
+        fieldSchema['x-component-props'] = {
+          ...(field.componentProps || {}),
+          inputReadOnly: checked,
+        };
+        schema['x-component-props'] = fieldSchema['x-component-props'];
+        field.componentProps = fieldSchema['x-component-props'];
+
+        const parts = (field.path.entire as string).split('.');
+        parts.pop();
+        const modifiedString = parts.join('.');
+        field.query(`${modifiedString}.*[0:].${fieldSchema.name}`).forEach((f) => {
+          if (f.props.name === fieldSchema.name) {
+            f.setComponentProps({
+              inputReadOnly: checked,
+            });
+          }
+        });
+        dn.emit('patch', {
+          schema,
+        });
+        dn.refresh();
+      }}
+    />
+  );
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    date field component settings add date input read-only option   |
| 🇨🇳 Chinese |      日期字段组件设置项添加日期输入框只读配置     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
