### PR TITLE
fix(data-vi): remove the `LIMIT` clause when using aggregate functions without dimensions

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/query-parser/query-parser.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/query-parser/query-parser.ts
@@ -100,18 +100,21 @@ export class QueryParser {
       } = this.parseDimensions(ctx, dimensions, hasAgg, ctx.get?.('x-timezone'));
       const order = this.parseOrders(ctx, orders, hasAgg);
 
+      const queryParams = {
+        where,
+        attributes: [...measureAttributes, ...dimensionAttributes],
+        include,
+        group,
+        order,
+        subQuery: false,
+        raw: true,
+      };
+      if (!hasAgg || dimensions.length) {
+        queryParams['limit'] = limit || 2000;
+      }
       ctx.action.params.values = {
         ...ctx.action.params.values,
-        queryParams: {
-          where,
-          attributes: [...measureAttributes, ...dimensionAttributes],
-          include,
-          group,
-          order,
-          limit: limit || 2000,
-          subQuery: false,
-          raw: true,
-        },
+        queryParams,
         fieldMap: { ...measureFieldMap, ...dimensionFieldMap },
       };
       await next();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove the `LIMIT` clause when using aggregate functions without setting dimensions in chart queries         |
| 🇨🇳 Chinese |  在图表查询中使用聚合函数且没有设置维度的时候去除 `LIMIT` 语句         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
