### PR TITLE
refactor(resourcer): allow empty object as values

### DIFF
--- a/packages/core/resourcer/src/resourcer.ts
+++ b/packages/core/resourcer/src/resourcer.ts
@@ -377,7 +377,7 @@ export class ResourceManager {
           ctx.action.mergeParams({
             ...query,
             ...params,
-            ...(_.isEmpty(ctx.request.body) ? {} : { values: ctx.request.body }),
+            values: ctx.request.body,
           });
         }
         return compose(ctx.action.getHandlers())(ctx, next);

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/server/__tests__/actions.test.ts
@@ -57,7 +57,7 @@ describe('actions', () => {
         filterByTk: 'test',
       });
       expect(res.status).toBe(200);
-      expect(params).toMatchSnapshot();
+      expect(params).toMatchObject({});
     });
 
     test('currentRecord.data', async () => {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow empty object as values in action.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow empty object as values in action |
| 🇨🇳 Chinese | 支持 API 请求中传入空对象作为 values 的值 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
