### PR TITLE
feat: add validateConfig to trigger (#6040)

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
@@ -232,4 +232,20 @@ export default class extends Trigger {
       options,
     );
   }
+
+  validateConfig(values) {
+    if (!values.data) {
+      return {
+        data: 'Data property is required',
+      };
+    }
+
+    if (!values.userId) {
+      return {
+        userId: 'UserId property is required',
+      };
+    }
+
+    return null;
+  }
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -235,4 +235,14 @@ export default class CollectionTrigger extends Trigger {
       transaction: this.workflow.useDataSourceTransaction(dataSourceName, transaction),
     });
   }
+
+  validateConfig(values) {
+    if (!values.data) {
+      return {
+        data: 'Data property is required',
+      };
+    }
+
+    return null;
+  }
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/index.ts
@@ -68,4 +68,26 @@ export default class ScheduleTrigger extends Trigger {
   //   });
   //   return !existed.length;
   // }
+
+  validateConfig(values) {
+    if (!values.mode) {
+      return {
+        mode: 'Mode property is required',
+      };
+    }
+
+    if (!values.startsOn) {
+      return {
+        startsOn: 'StartsOn property is required',
+      };
+    }
+
+    if (values.mode === SCHEDULE_MODE.DATE_FIELD && !values.collection) {
+      return {
+        collection: 'Collection property is required',
+      };
+    }
+
+    return null;
+  }
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
@@ -20,6 +20,7 @@ export abstract class Trigger {
     return true;
   }
   duplicateConfig?(workflow: WorkflowModel, options: Transactionable): object | Promise<object>;
+  validateConfig?(values: any): null | void | { [key: string]: string };
   sync?: boolean;
   execute?(
     workflow: WorkflowModel,


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add validate API for triggers to validate configurations.

### Description 

* feat: add validateConfig to trigger
* refactor: validateConfig
* fix: validate config

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add validate API for triggers to validate configurations |
| 🇨🇳 Chinese | 为触发器基类增加验证配置的 API |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
