### PR TITLE
fix: refresh association field data after page switching

### DIFF
--- a/packages/core/client/src/data-source/data-block/DataBlockProvider.tsx
+++ b/packages/core/client/src/data-source/data-block/DataBlockProvider.tsx
@@ -13,7 +13,6 @@ import { ACLCollectionProvider } from '../../acl/ACLProvider';
 import { UseRequestOptions, UseRequestService } from '../../api-client';
 import { DataBlockCollector, FilterParam } from '../../filter-provider/FilterProvider';
 import { withDynamicSchemaProps } from '../../hoc/withDynamicSchemaProps';
-import { KeepAliveContextCleaner } from '../../route-switch/antd/admin-layout/KeepAlive';
 import { Designable, useDesignable } from '../../schema-component';
 import {
   AssociationProvider,
@@ -192,12 +191,9 @@ export const DataBlockProvider: FC<Partial<AllDataBlockProps>> = withDynamicSche
             <ACLCollectionProvider>
               <DataBlockResourceProvider>
                 <BlockRequestProvider>
-                  {/* Must be placed inside BlockRequestProvider because BlockRequestProvider uses KeepAliveContext */}
-                  <KeepAliveContextCleaner>
-                    <DataBlockCollector params={props.params}>
-                      <RerenderDataBlockProvider>{children}</RerenderDataBlockProvider>
-                    </DataBlockCollector>
-                  </KeepAliveContextCleaner>
+                  <DataBlockCollector params={props.params}>
+                    <RerenderDataBlockProvider>{children}</RerenderDataBlockProvider>
+                  </DataBlockCollector>
                 </BlockRequestProvider>
               </DataBlockResourceProvider>
             </ACLCollectionProvider>

--- a/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
@@ -14,6 +14,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useAPIClient, useRequest } from '../../../api-client';
 import { useCollectionManager } from '../../../data-source/collection';
 import { markRecordAsNew } from '../../../data-source/collection-record/isNewRecord';
+import { useKeepAlive } from '../../../route-switch/antd/admin-layout/KeepAlive';
 import { useSchemaComponentContext } from '../../hooks';
 import { AssociationFieldContext } from './context';
 
@@ -85,7 +86,13 @@ export const AssociationFieldProvider = observer(
       },
     );
 
+    const { active } = useKeepAlive();
+
     useEffect(() => {
+      if (!active) {
+        return;
+      }
+
       setLoading(true);
       if (!collectionField) {
         setLoading(false);
@@ -136,7 +143,7 @@ export const AssociationFieldProvider = observer(
       }
 
       setLoading(false);
-    }, [currentMode, collectionField, field]);
+    }, [currentMode, collectionField, field, active]);
 
     if (loading || rLoading) {
       return null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Fix the issue where association field default values are not refreshed after switching pages   |
| 🇨🇳 Chinese |      修复切换页面后，不刷新关系字段默认值的问题     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
