### PR TITLE
fix: refresh entire block after adding field

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/Nester.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/Nester.tsx
@@ -26,7 +26,11 @@ import {
 } from '../../../data-source/collection-record/CollectionRecordProvider';
 import { isNewRecord, markRecordAsNew } from '../../../data-source/collection-record/isNewRecord';
 import { FlagProvider } from '../../../flag-provider';
-import { NocoBaseRecursionField, RefreshComponentProvider } from '../../../formily/NocoBaseRecursionField';
+import {
+  NocoBaseRecursionField,
+  RefreshComponentProvider,
+  useRefreshComponent,
+} from '../../../formily/NocoBaseRecursionField';
 import { RecordIndexProvider, RecordProvider } from '../../../record-provider';
 import { isPatternDisabled, isSystemField } from '../../../schema-settings';
 import {
@@ -116,6 +120,12 @@ const ToManyNester = observer(
     const recordData = useCollectionRecordData();
     const collection = useCollection();
     const update = useUpdate();
+    const refreshComponent = useRefreshComponent();
+
+    const refresh = useCallback(() => {
+      update();
+      refreshComponent?.();
+    }, [update, refreshComponent]);
 
     if (!Array.isArray(field.value)) {
       field.value = [];
@@ -156,7 +166,7 @@ const ToManyNester = observer(
           }
         `}
       >
-        <RefreshComponentProvider refresh={update}>
+        <RefreshComponentProvider refresh={refresh}>
           {field.value.map((value, index) => {
             let allowed = allowDissociate;
             if (!allowDissociate) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where association fields are not displaying data after adding them in sub-details    |
| 🇨🇳 Chinese |     修复在子详情中添加关系字段后，不显示关系字段数据的问题      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
