### PR TITLE
fix: filter button nonfilterable field settings affecting other table…

### DIFF
--- a/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -150,7 +150,7 @@ const field2option = (field, depth, nonfilterable, dataSourceManager, collection
   return option;
 };
 
-const getOptions = _.memoize((fields, depth, nonfilterable, dataSourceManager, collectionManager) => {
+const getOptions = (fields, depth, nonfilterable, dataSourceManager, collectionManager) => {
   const options = [];
   fields.forEach((field) => {
     const option = field2option(field, depth, nonfilterable, dataSourceManager, collectionManager);
@@ -159,7 +159,7 @@ const getOptions = _.memoize((fields, depth, nonfilterable, dataSourceManager, c
     }
   });
   return options;
-});
+};
 
 export const useFilterFieldOptions = (fields) => {
   const fieldSchema = useFieldSchema();
@@ -192,6 +192,7 @@ export const removeNullCondition = (filter, customFlat = flat) => {
 export const useFilterActionProps = () => {
   const collection = useCollection();
   const options = useFilterOptions(collection?.name);
+  console.log(options);
   const props = useDataBlockProps();
   return useFilterFieldProps({ options, params: props?.params });
 };


### PR DESCRIPTION
… block with the same collection

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix filter button nonfilterable field settings affecting other table with the same collection        |
| 🇨🇳 Chinese |    修复筛选按钮中非筛选字段设置影响同一数据表的其他表格区块的筛选按钮       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
