### PR TITLE
fix(tree): should not set a tree collection node as its own parent

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-tree/src/server/__tests__/issues.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-tree/src/server/__tests__/issues.test.ts
@@ -1,0 +1,66 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Database } from '@nocobase/database';
+import { MockServer, createMockServer } from '@nocobase/test';
+
+describe('issues', async () => {
+  let app: MockServer;
+  let db: Database;
+  beforeEach(async () => {
+    app = await createMockServer({
+      plugins: ['collection-tree'],
+    });
+    db = app.db;
+    db.collection({
+      name: 'tree',
+      tree: 'adjacency-list',
+      fields: [
+        {
+          type: 'string',
+          name: 'name',
+        },
+        {
+          type: 'belongsTo',
+          name: 'parent',
+          foreignKey: 'parentId',
+          treeParent: true,
+        },
+        {
+          type: 'hasMany',
+          name: 'children',
+          foreignKey: 'parentId',
+          treeChildren: true,
+        },
+      ],
+    });
+    await db.sync();
+  });
+
+  afterEach(async () => {
+    await db.clean({ drop: true });
+    await app.destroy();
+  });
+
+  it('should not set itself as parent', async () => {
+    expect.assertions(1);
+    const root = await db.getRepository('tree').create({
+      values: {
+        name: 'root',
+      },
+    });
+    try {
+      await root.update({
+        parentId: root.get('id'),
+      });
+    } catch (error) {
+      expect(error.message).toBe('Cannot set itself as the parent node');
+    }
+  });
+});

--- a/packages/plugins/@nocobase/plugin-collection-tree/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-collection-tree/src/server/plugin.ts
@@ -102,6 +102,13 @@ class PluginCollectionTreeServer extends Plugin {
               transaction: options.transaction,
             });
           });
+
+          this.db.on(`${collection.name}.beforeSave`, async (model: Model) => {
+            const tk = collection.filterTargetKey as string;
+            if (model.get(parentForeignKey) === model.get(tk)) {
+              throw new Error('Cannot set itself as the parent node');
+            }
+          });
         });
       }
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Disallow setting a node of tree collection as its own parent         |
| 🇨🇳 Chinese | 禁止将树表节点自身设置为其父节点          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
