### PR TITLE
fix: button linkage rule is not taking effect

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -1577,7 +1577,7 @@ export const getAppends = ({
       }
     } else if (
       ![
-        'ActionBar',
+        // 'ActionBar',
         'Action',
         'Action.Link',
         'Action.Modal',
@@ -1622,8 +1622,6 @@ export const useAssociationNames = (dataSource?: string) => {
       dataSource,
     });
     appends = fillParentFields(appends);
-
-    console.log('appends', appends);
 
     return { appends: [...appends], updateAssociationValues: [...updateAssociationValues] };
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       When the linkage rule's conditions involve association fields that are not displayed, the button's linkage rule becomes ineffective    |
| 🇨🇳 Chinese |     当联动规则的条件中使用了没有显示出来的关系字段时，按钮的联动规则无效      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
