### PR TITLE
fix(sql-collection): filtering SQL Collection throws an error when `DB_TABLE_PREFIX` is set

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/select-query.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/select-query.test.ts
@@ -80,3 +80,74 @@ describe('select query', () => {
     );
   });
 });
+
+describe('select query with DB_TABLE_PREFIX', () => {
+  const model = class extends SQLModel {};
+  model.init(null, {
+    modelName: 'users',
+    tableName: 'd_users',
+    sequelize: new Sequelize({
+      dialect: 'postgres',
+    }),
+  });
+  model.sql = 'SELECT * FROM "d_users"';
+  model.collection = {
+    fields: new Map(
+      Object.entries({
+        id: {},
+        name: {},
+      }),
+    ),
+  } as any;
+  const queryGenerator = model.queryInterface.queryGenerator as any;
+
+  test('plain sql', () => {
+    const query = queryGenerator.selectQuery('d_users', {}, model);
+    expect(query).toBe('SELECT * FROM "d_users";');
+  });
+
+  test('attributes', () => {
+    const query = queryGenerator.selectQuery('d_users', { attributes: ['id', 'name'] }, model);
+    expect(query).toBe('SELECT "id", "name" FROM (SELECT * FROM "d_users") AS "users";');
+  });
+
+  test('where', () => {
+    const query = queryGenerator.selectQuery('d_users', { where: { id: 1 } }, model);
+    expect(query).toBe('SELECT * FROM (SELECT * FROM "d_users") AS "users" WHERE "users"."id" = 1;');
+  });
+
+  test('group', () => {
+    const query1 = queryGenerator.selectQuery('d_users', { group: 'id' }, model);
+    expect(query1).toBe('SELECT * FROM (SELECT * FROM "d_users") AS "users" GROUP BY "id";');
+    const query2 = queryGenerator.selectQuery('d_users', { group: ['id', 'name'] }, model);
+    expect(query2).toBe('SELECT * FROM (SELECT * FROM "d_users") AS "users" GROUP BY "id", "name";');
+  });
+
+  test('order', () => {
+    const query = queryGenerator.selectQuery('d_users', { order: ['id'] }, model);
+    expect(query).toBe('SELECT * FROM (SELECT * FROM "d_users") AS "users" ORDER BY "users"."id";');
+  });
+
+  test('limit, offset', () => {
+    const query = queryGenerator.selectQuery('d_users', { limit: 1, offset: 0 }, model);
+    expect(query).toBe('SELECT * FROM (SELECT * FROM "d_users") AS "users" LIMIT 1 OFFSET 0;');
+  });
+
+  test('complex sql', () => {
+    const query = queryGenerator.selectQuery(
+      'd_users',
+      {
+        attributes: ['id', 'name'],
+        where: { id: 1 },
+        group: 'id',
+        order: ['id'],
+        limit: 1,
+        offset: 0,
+      },
+      model,
+    );
+    expect(query).toBe(
+      'SELECT "id", "name" FROM (SELECT * FROM "d_users") AS "users" WHERE "users"."id" = 1 GROUP BY "id" ORDER BY "users"."id" LIMIT 1 OFFSET 0;',
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/query-generator.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/query-generator.ts
@@ -39,7 +39,7 @@ export function selectQuery(
 
   // Add WHERE to sub or main query
   if (Object.prototype.hasOwnProperty.call(options, 'where')) {
-    options.where = this.getWhereConditions(options.where, tableName, model, options);
+    options.where = this.getWhereConditions(options.where, model.name, model, options);
     if (options.where) {
       queryItems.push(` WHERE ${options.where}`);
     }
@@ -48,8 +48,8 @@ export function selectQuery(
   // Add GROUP BY to sub or main query
   if (options.group) {
     options.group = Array.isArray(options.group)
-      ? options.group.map((t) => this.aliasGrouping(t, model, tableName, options)).join(', ')
-      : this.aliasGrouping(options.group, model, tableName, options);
+      ? options.group.map((t) => this.aliasGrouping(t, model, model.name, options)).join(', ')
+      : this.aliasGrouping(options.group, model, model.name, options);
 
     if (options.group) {
       queryItems.push(` GROUP BY ${options.group}`);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the issue where filtering SQL Collection throws an error when `DB_TABLE_PREFIX` is set        |
| 🇨🇳 Chinese |  修复设置了 `DB_TABLE_PREFIX` 时过滤 SQL Collection 报错的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
