### PR TITLE
fix(notification): notifications failed to send when user input contained Handlebars-like syntax

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-notification/src/server/NotificationInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-notification/src/server/NotificationInstruction.ts
@@ -14,7 +14,13 @@ import { Processor, Instruction, JOB_STATUS, FlowNodeModel } from '@nocobase/plu
 export default class extends Instruction {
   async run(node: FlowNodeModel, prevJob, processor: Processor) {
     const options = processor.getParsedValue(node.config, node.id);
-    const sendParams = { channelName: options.channelName, message: options, triggerFrom: 'workflow' };
+    const scope = processor.getScope(node.id);
+    const sendParams = {
+      channelName: options.channelName,
+      message: { ...options, content: node.config.content },
+      triggerFrom: 'workflow',
+      data: scope,
+    };
     const notificationServer = this.workflow.pm.get(NotificationsServerPlugin) as NotificationsServerPlugin;
 
     const { workflow } = processor.execution;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fixed an issue where notifications failed to send when user input contained Handlebars-like syntax.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Ensured notifications are sent correctly when user input contains Handlebars-like syntax.    |
| 🇨🇳 Chinese |   确保当用户输入包含 Handlebars 语法时，通知能够正确发送。       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
