### PR TITLE
fix: time field operator set to between in filter form, component did…

### DIFF
--- a/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
+++ b/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
@@ -55,9 +55,9 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
   const { uiSchema: uiSchemaOrigin, defaultValue, interface: collectionInterface } = useCollectionField();
   const { isAllowToSetDefaultValue } = useIsAllowToSetDefaultValue();
   const targetInterface = getInterface(collectionInterface);
-  const operator = targetInterface?.filterable?.operators?.find(
-    (v, index) => v.value === fieldSchema['x-filter-operator'] || index === 0,
-  );
+  const operator =
+    targetInterface?.filterable?.operators?.find((v, index) => v.value === fieldSchema?.['x-filter-operator']) ||
+    targetInterface?.filterable?.operators?.[0];
   const Component = useComponent(
     operator?.schema?.['x-component'] ||
       fieldSchema['x-component-props']?.['component'] ||

--- a/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
@@ -289,7 +289,7 @@ DatePicker.FilterWithPicker = function FilterWithPicker(props: any) {
   const field: any = useField();
   const [stateProps, setStateProps] = useState(newProps);
   return (
-    <Space.Compact>
+    <Space.Compact style={{ width: '100%' }}>
       <Select
         // @ts-ignore
         role="button"

--- a/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
+++ b/packages/core/client/src/schema-component/antd/filter/useFilterActionProps.ts
@@ -192,7 +192,6 @@ export const removeNullCondition = (filter, customFlat = flat) => {
 export const useFilterActionProps = () => {
   const collection = useCollection();
   const options = useFilterOptions(collection?.name);
-  console.log(options);
   const props = useDataBlockProps();
   return useFilterFieldProps({ options, params: props?.params });
 };


### PR DESCRIPTION
…n't change to time range picker

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   time field operator set to "between" in filter form, but component didn't change to time range picker        |
| 🇨🇳 Chinese |    筛选表单时间字段运算符设置成“介于”，组件未变成时间范围选择器       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
