### PR TITLE
chore: hide the header when no permissions are configured

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/desktop-mode/DesktopMode.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/desktop-mode/DesktopMode.tsx
@@ -7,23 +7,27 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { FC } from 'react';
 import { Layout } from 'antd';
+import React, { FC } from 'react';
 import { isDesktop } from 'react-device-detect';
 
-import { DesktopModeHeader } from './Header';
-import { DesktopModeContent } from './Content';
-import { SizeContextProvider } from './sizeContext';
+import { useUIConfigurationPermissions } from '@nocobase/client';
 import { PageBackgroundColor } from '../constants';
+import { DesktopModeContent } from './Content';
+import { DesktopModeHeader } from './Header';
+import { SizeContextProvider } from './sizeContext';
 
 interface DesktopModeProps {
   children?: React.ReactNode;
 }
 
 export const DesktopMode: FC<DesktopModeProps> = ({ children }) => {
-  if (!isDesktop) {
+  const { allowConfigUI } = useUIConfigurationPermissions();
+
+  if (!isDesktop || !allowConfigUI) {
     return <>{children}</>;
   }
+
   return (
     <SizeContextProvider>
       <Layout style={{ height: '100%', background: PageBackgroundColor }}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Hide mobile config page header when no config permission    |
| 🇨🇳 Chinese |     当没有配置权限时，隐藏移动端配置页 header      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
