### PR TITLE
fix: kanban and calendar block popup edit form didn't show 'Unsaved c…

### DIFF
--- a/packages/core/client/src/modules/popup/PopupContextProvider.tsx
+++ b/packages/core/client/src/modules/popup/PopupContextProvider.tsx
@@ -23,6 +23,7 @@ export const PopupContextProvider: React.FC<{
 }> = (props) => {
   const { visible: visibleFromProps, setVisible: setVisibleFromProps } = props;
   const [visible, setVisible] = useState(false);
+  const [formValueChanged, setFormValueChanged] = useState(false);
   const { visible: visibleWithURL, setVisible: setVisibleWithURL } = useContext(PopupVisibleProviderContext) || {
     visible: false,
     setVisible: () => {},
@@ -46,6 +47,8 @@ export const PopupContextProvider: React.FC<{
         setVisible={_setVisible}
         openMode={openMode}
         openSize={openSize}
+        formValueChanged={formValueChanged}
+        setFormValueChanged={setFormValueChanged}
       >
         {props.children}
       </ActionContextProvider>


### PR DESCRIPTION
…hanges' warning

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Kanban and calendar block popup edit form didn't show "Unsaved changes"        |
| 🇨🇳 Chinese |  看板、日历区块的弹窗编辑表单未显示 "Unsaved changes"         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
