### PR TITLE
fix: should show 'Allow multiple selection' in filter form

### DIFF
--- a/packages/core/client/src/modules/fields/component/Select/selectComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/Select/selectComponentFieldSettings.tsx
@@ -443,13 +443,7 @@ export const filterSelectComponentFieldSettings = new SchemaSettings({
         return isSelectFieldMode && !isFieldReadPretty;
       },
     },
-    {
-      ...getAllowMultiple({ title: 'Allow multiple selection' }),
-      useVisible() {
-        const field = useField();
-        return field.componentProps.multiple !== false;
-      },
-    },
+    getAllowMultiple({ title: 'Allow multiple selection' }),
     {
       ...titleField,
       useVisible: useIsAssociationField,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       The 'Allow Multiple Selection' configuration option for association fields is not displayed in Filter Forms    |
| 🇨🇳 Chinese |     筛选表单中的关系字段不显示“允许多选”配置项      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
