### PR TITLE
fix: add user filter to message timestamp and title subqueries

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
@@ -55,6 +55,7 @@ export default function defineMyInAppChannels({ app }: { app: Application }) {
                                 FROM ${messagesTableName} AS messages
                                 WHERE
                                     messages.${messagesFieldName.channelName} = ${channelsTableAliasName}.${channelsFieldName.name}
+                                    AND messages.${messagesFieldName.userId} = ${userId}
                                 ORDER BY messages.${messagesFieldName.receiveTimestamp} DESC
                                 LIMIT 1
                             )`;
@@ -118,6 +119,7 @@ export default function defineMyInAppChannels({ app }: { app: Application }) {
                               FROM ${messagesTableName} AS messages
                               WHERE
                                   messages.${messagesFieldName.channelName} = ${channelsTableAliasName}.${channelsFieldName.name}
+                                  AND messages.${messagesFieldName.userId} = ${userId}
                               ORDER BY messages.${messagesFieldName.receiveTimestamp} DESC
                               LIMIT 1
                   )`),


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The channel list API's subqueries for retrieving message timestamps and titles currently lack user filtering conditions. This security issue could potentially expose message information from other users to the current user.

### Description 
This PR fixes two security vulnerabilities in the channel list query:

1. Added user filtering to the latest message timestamp subquery:
2. Added user filtering to the latest message title subquery:



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: Add user filter to message timestamp and title subqueries in channel list API to ensure data isolation. |
| 🇨🇳 Chinese | 修复：在渠道列表 API 的消息时间戳和标题子查询中添加用户过滤条件，确保数据隔离。 |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
