### PR TITLE
fix(client): fix variable component disabled height

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextArea.tsx
@@ -9,7 +9,7 @@
 
 import { css, cx } from '@emotion/css';
 import { useForm } from '@formily/react';
-import { Space } from 'antd';
+import { Space, theme } from 'antd';
 import useInputStyle from 'antd/es/input/style';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -238,6 +238,7 @@ export function TextArea(props) {
   // NOTE: e.g. [startElementIndex, startOffset, endElementIndex, endOffset]
   const [range, setRange] = useState<[number, number, number, number]>([-1, 0, -1, 0]);
   useInputStyle('ant-input');
+  const { token } = theme.useToken();
   const delimitersString = delimiters.join(' ');
 
   useEffect(() => {
@@ -440,6 +441,7 @@ export function TextArea(props) {
           { 'ant-input-disabled': disabled },
           // NOTE: `pre-wrap` here for avoid the `&nbsp;` (\x160) issue when paste content, we need normal space (\x32).
           css`
+            min-height: ${token.controlHeight}px;
             overflow: auto;
             white-space: pre-wrap;
 
@@ -461,15 +463,14 @@ export function TextArea(props) {
         contentEditable={!disabled}
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      {!disabled ? (
-        <VariableSelect
-          options={options}
-          setOptions={setOptions}
-          onInsert={onInsert}
-          changeOnSelect={changeOnSelect}
-          fieldNames={fieldNames || defaultFieldNames}
-        />
-      ) : null}
+      <VariableSelect
+        options={options}
+        setOptions={setOptions}
+        onInsert={onInsert}
+        changeOnSelect={changeOnSelect}
+        fieldNames={fieldNames || defaultFieldNames}
+        disabled={disabled}
+      />
     </Space.Compact>,
   );
 }

--- a/packages/core/client/src/schema-component/antd/variable/VariableSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/VariableSelect.tsx
@@ -22,6 +22,7 @@ export function VariableSelect({
   changeOnSelect = false,
   fieldNames = {},
   className,
+  disabled,
 }: {
   options: any[];
   setOptions: (options: any) => void;
@@ -29,6 +30,7 @@ export function VariableSelect({
   changeOnSelect?: boolean;
   fieldNames?: any;
   className?: string;
+  disabled: boolean;
 }): JSX.Element {
   const { t } = useTranslation();
   const [selectedVar, setSelectedVar] = useState<string[]>([]);
@@ -44,8 +46,9 @@ export function VariableSelect({
   }
 
   return wrapSSR(
-    <XButton className={cx('x-button', componentCls, hashId, className)}>
+    <XButton disabled={disabled} className={cx('x-button', componentCls, hashId, className)}>
       <Cascader
+        disabled={disabled}
         placeholder={t('Select a variable')}
         value={[]}
         options={options}

--- a/packages/core/client/src/schema-component/antd/variable/VariableSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/VariableSelect.tsx
@@ -30,7 +30,7 @@ export function VariableSelect({
   changeOnSelect?: boolean;
   fieldNames?: any;
   className?: string;
-  disabled: boolean;
+  disabled?: boolean;
 }): JSX.Element {
   const { t } = useTranslation();
   const [selectedVar, setSelectedVar] = useState<string[]>([]);


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Show `<Variable.TextArea />` component correctly in disabled mode.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show `<Variable.TextArea />` component correctly in disabled mode |
| 🇨🇳 Chinese | 在禁用状态下正确展示 `<Variable.TextArea />` 组件 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
