### PR TITLE
fix(data-vi): chart blocks do not display when added to the popups of action panel

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
@@ -16,11 +16,13 @@ import _ from 'lodash';
 export const ChartBlockProvider: React.FC = (props) => {
   const currentPopupContext = useCurrentPopupContext();
   const localVariables = useLocalVariables();
-  const popUpCtxReady =
+  const popupRecordVariable = localVariables?.find((variable) => variable.name === '$nPopupRecord');
+  const popupCtxReady =
     _.isEmpty(currentPopupContext) ||
-    localVariables?.some((variable) => variable.name === '$nPopupRecord' && variable.ctx);
+    !popupRecordVariable.collectionName ||
+    (popupRecordVariable && popupRecordVariable.ctx);
 
-  if (!popUpCtxReady) {
+  if (!popupCtxReady) {
     return null;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Chart blocks do not display when added to the popups of action panel         |
| 🇨🇳 Chinese |  在操作面板弹窗中添加图表区块不显示         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
