### PR TITLE
fix: missing drag setting in quick-create operation modal

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -24,11 +24,21 @@ import {
   useCollectionRecordData,
   SchemaComponentContext,
 } from '../../../';
+import { Action } from '../action';
 import { isVariable } from '../../../variables/utils/isVariable';
 import { getInnermostKeyAndValue } from '../../common/utils/uitls';
 import { RemoteSelect, RemoteSelectProps } from '../remote-select';
 import useServiceOptions, { useAssociationFieldContext } from './hooks';
 import { VariablePopupRecordProvider } from '../../../modules/variable/variablesProvider/VariablePopupRecordProvider';
+
+export const AssociationFieldAddNewer = (props) => {
+  const schemaComponentCtxValue = useContext(SchemaComponentContext);
+  return (
+    <SchemaComponentContext.Provider value={{ ...schemaComponentCtxValue, draggable: true }}>
+      <Action.Container {...props} />
+    </SchemaComponentContext.Provider>
+  );
+};
 
 export type AssociationSelectProps<P = any> = RemoteSelectProps<P> & {
   addMode?: 'quickAdd' | 'modalAdd';
@@ -141,6 +151,7 @@ const InternalAssociationSelect = observer(
         </div>
       );
     };
+    console.log(fieldSchema);
     return (
       <div key={fieldSchema.name}>
         <Space.Compact style={{ display: 'flex' }}>

--- a/packages/core/client/src/schema-component/antd/association-field/__tests__/AssociationFieldModeProvider.test.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/__tests__/AssociationFieldModeProvider.test.tsx
@@ -18,6 +18,7 @@ import {
 
 vi.mock('../AssociationSelect', () => ({
   AssociationSelect: () => <div>Association Select</div>,
+  AssociationFieldAddNewer: vi.fn(() => <div> AssociationFieldAddNewer</div>),
 }));
 
 vi.mock('../InternalPicker', () => ({

--- a/packages/core/client/src/schema-component/antd/association-field/index.ts
+++ b/packages/core/client/src/schema-component/antd/association-field/index.ts
@@ -15,6 +15,7 @@ import { InternalPicker } from './InternalPicker';
 import { Nester } from './Nester';
 import { ReadPretty } from './ReadPretty';
 import { SubTable } from './SubTable';
+import { AssociationFieldAddNewer } from './AssociationSelect';
 
 export {
   AssociationFieldMode,
@@ -26,7 +27,7 @@ export const AssociationField: any = connect(Editable, mapReadPretty(ReadPretty)
 
 AssociationField.SubTable = SubTable;
 AssociationField.Nester = Nester;
-AssociationField.AddNewer = Action.Container;
+AssociationField.AddNewer = AssociationFieldAddNewer;
 AssociationField.Selector = Action.Container;
 AssociationField.Viewer = Action.Container;
 AssociationField.InternalSelect = InternalPicker;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   missing drag setting in relation data quick-create operation modal      |
| 🇨🇳 Chinese |    关系数据快捷创建操作的弹窗中组件缺少拖动设置项       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
