### PR TITLE
feat(acl): support global role display all role actions

### DIFF
--- a/packages/core/acl/src/__tests__/acl.test.ts
+++ b/packages/core/acl/src/__tests__/acl.test.ts
@@ -439,4 +439,31 @@ describe('acl', () => {
 
     expect(acl.can({ role: 'admin', resource: 'users', action: 'create' })).toBeTruthy();
   });
+
+  it('should return global-role with merged permissions', () => {
+    acl.define({
+      role: 'admin',
+      actions: {
+        'posts:edit': { own: true },
+        'posts:delete': { own: true },
+      },
+    });
+
+    acl.define({
+      role: 'editor',
+      actions: {
+        'posts:read': { fields: ['title', 'content'] },
+        'comments:write': { own: true },
+      },
+    });
+
+    const globalRole = acl.getRole('global-role');
+    expect(globalRole).not.toBeNull();
+    expect(globalRole.getResource('posts').getAction('edit').own).toBe(true);
+    expect(globalRole.getResource('posts').getAction('delete').own).toBe(true);
+    expect(globalRole.getResource('comments').getAction('write').own).toBe(true);
+
+    expect(globalRole.getResource('posts').getAction('read').fields).toContain('title');
+    expect(globalRole.getResource('posts').getAction('read').fields).toContain('content');
+  });
 });

--- a/packages/core/acl/src/acl-role.ts
+++ b/packages/core/acl/src/acl-role.ts
@@ -211,4 +211,27 @@ export class ACLRole {
       action,
     };
   }
+
+  public merge(role: ACLRole) {
+    for (const [resourceName, resource] of role.resources.entries()) {
+      let currentResource = this.resources.get(resourceName);
+
+      if (!currentResource) {
+        currentResource = new ACLResource({ role: this, name: resourceName });
+        this.resources.set(resourceName, currentResource);
+      }
+
+      for (const [actionName, actionParams] of Object.entries(resource.getActions())) {
+        const existingAction = currentResource.getAction(actionName) || {};
+
+        const safeActionParams = (actionParams ?? {}) as RoleActionParams;
+
+        currentResource.setAction(actionName, {
+          ...existingAction,
+          ...safeActionParams,
+          fields: Array.from(new Set([...(existingAction.fields || []), ...(safeActionParams.fields || [])])),
+        });
+      }
+    }
+  }
 }

--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -19,6 +19,7 @@ import { AllowManager, ConditionFunc } from './allow-manager';
 import FixedParamsManager, { Merger } from './fixed-params-manager';
 import SnippetManager, { SnippetOptions } from './snippet-manager';
 import { NoPermissionError } from './errors/no-permission-error';
+import { GlobalRoleName } from './constants';
 
 interface CanResult {
   role: string;
@@ -166,7 +167,20 @@ export class ACL extends EventEmitter {
   }
 
   getRole(name: string): ACLRole {
+    if (name === GlobalRoleName) {
+      return this.getGlobalRole();
+    }
     return this.roles.get(name);
+  }
+
+  private getGlobalRole() {
+    const globalRole = new ACLRole(this, GlobalRoleName);
+
+    for (const role of this.roles.values()) {
+      globalRole.merge(role);
+    }
+
+    return globalRole;
   }
 
   removeRole(name: string) {

--- a/packages/core/acl/src/constants.ts
+++ b/packages/core/acl/src/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export const GlobalRoleName = 'global-role';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Support role global view of all role permissions
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
整体选择了一种，在使用 特殊的角色key/name（global-role）获取所有角色的 actions/permissions。内部没有采用在初始化环节定义这样一个角色并将合并的权限缓存起来，而是在获取时进行合并。
1. acl-role.ts  提供 merge 函数，该函数合并单个角色的 action 合并
2. acl.ts 提供 getGlobalRole 函数，构造 global-role 的 ACLRole 实例，结合 merge 函数，合并所有角色的 action
3. act.ts 在原来的 getRole，匹配 name 是 global-role，来识别是获取所有角色的意图
4. act.test.ts 添加测试用例，断言多个角色的 action 匹配情况
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
