### PR TITLE
fix: linked field value persisting on submission after relation field…

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -96,8 +96,8 @@ const InternalAssociationSelect = observer(
             isEqual(fieldPath?.indexes, field?.indexes) &&
             fieldPath?.props?.name !== field.props.name
           ) {
-            field.setValue(undefined);
-            setInnerValue(undefined);
+            field.setValue(null);
+            setInnerValue(null);
           }
         });
       });


### PR DESCRIPTION
… reset

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   linked field value persisting on submission after relation field reset        |
| 🇨🇳 Chinese |   关系字段清空后，范围联动的关系字段UI数据显示清空但提交时值依然存在        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
