### PR TITLE
fix: edit form association collection field value not change

### DIFF
--- a/packages/core/client/src/modules/fields/component/Picker/__e2e__/schemaSettings.test.ts
+++ b/packages/core/client/src/modules/fields/component/Picker/__e2e__/schemaSettings.test.ts
@@ -18,7 +18,7 @@ test.describe('SchemaSettings of Picker', () => {
       page,
       showMenu: async () => {
         await page.getByLabel('block-item-CollectionField-').hover();
-        await page.getByLabel('designer-schema-settings-CollectionField-fieldSettings:FormItem-users-users.').hover();
+        await page.getByLabel('designer-schema-settings-CollectionField-fieldSettings:FormItem-users-users.').click();
       },
       supportedOptions: ['Popup size', 'Allow add new data', 'Title field', 'Allow multiple', 'Field component'],
     });

--- a/packages/core/client/src/schema-component/antd/form-item/hooks/useLazyLoadDisplayAssociationFieldsOfForm.ts
+++ b/packages/core/client/src/schema-component/antd/form-item/hooks/useLazyLoadDisplayAssociationFieldsOfForm.ts
@@ -13,6 +13,7 @@ import { untracked } from '@formily/reactive';
 import { nextTick } from '@nocobase/utils/client';
 import _ from 'lodash';
 import { useEffect, useMemo, useRef } from 'react';
+import { useFormBlockType } from '../../../../block-provider';
 import { useAssociationNames } from '../../../../block-provider/hooks';
 import { useCollectionManager_deprecated, useCollection_deprecated } from '../../../../collection-manager';
 import { useCollectionRecordData } from '../../../../data-source/collection-record/CollectionRecordProvider';
@@ -39,6 +40,7 @@ const useLazyLoadDisplayAssociationFieldsOfForm = () => {
   const { formValue: subFormValue } = useSubFormValue();
   const { isInSubForm, isInSubTable } = useFlag() || {};
   const { getAssociationAppends } = useAssociationNames();
+  const { type } = useFormBlockType() || {};
 
   const schemaName = fieldSchema.name.toString();
 
@@ -57,7 +59,11 @@ const useLazyLoadDisplayAssociationFieldsOfForm = () => {
 
   const shouldNotLazyLoad = useMemo(() => {
     return (
-      !isDisplayField(schemaName) || !variables || name === 'fields' || !collectionFieldRef.current || hasPreloadData
+      !isDisplayField(schemaName) ||
+      !variables ||
+      name === 'fields' ||
+      !collectionFieldRef.current ||
+      (hasPreloadData && type !== 'update')
     );
   }, [schemaName, variables, name, collectionFieldRef.current, hasPreloadData]);
 

--- a/packages/core/client/src/schema-component/antd/form-item/hooks/useLazyLoadDisplayAssociationFieldsOfForm.ts
+++ b/packages/core/client/src/schema-component/antd/form-item/hooks/useLazyLoadDisplayAssociationFieldsOfForm.ts
@@ -13,10 +13,8 @@ import { untracked } from '@formily/reactive';
 import { nextTick } from '@nocobase/utils/client';
 import _ from 'lodash';
 import { useEffect, useMemo, useRef } from 'react';
-import { useFormBlockType } from '../../../../block-provider';
 import { useAssociationNames } from '../../../../block-provider/hooks';
 import { useCollectionManager_deprecated, useCollection_deprecated } from '../../../../collection-manager';
-import { useCollectionRecordData } from '../../../../data-source/collection-record/CollectionRecordProvider';
 import { useFlag } from '../../../../flag-provider';
 import { useVariables } from '../../../../variables';
 import { transformVariableValue } from '../../../../variables/utils/transformVariableValue';
@@ -33,19 +31,17 @@ const useLazyLoadDisplayAssociationFieldsOfForm = () => {
   const { name } = useCollection_deprecated();
   const { getCollectionJoinField } = useCollectionManager_deprecated();
   const form = useForm();
-  const recordData = useCollectionRecordData();
   const fieldSchema = useFieldSchema();
   const variables = useVariables();
   const field = useField<Field>();
   const { formValue: subFormValue } = useSubFormValue();
   const { isInSubForm, isInSubTable } = useFlag() || {};
   const { getAssociationAppends } = useAssociationNames();
-  const { type } = useFormBlockType() || {};
 
   const schemaName = fieldSchema.name.toString();
 
   // 是否已经预加载了数据（通过 appends 的形式）
-  const hasPreloadData = useMemo(() => hasPreload(recordData, schemaName), [recordData, schemaName]);
+  // const hasPreloadData = useMemo(() => hasPreload(recordData, schemaName), [recordData, schemaName]);
 
   const collectionFieldRef = useRef(null);
   const sourceCollectionFieldRef = useRef(null);
@@ -58,14 +54,8 @@ const useLazyLoadDisplayAssociationFieldsOfForm = () => {
   }
 
   const shouldNotLazyLoad = useMemo(() => {
-    return (
-      !isDisplayField(schemaName) ||
-      !variables ||
-      name === 'fields' ||
-      !collectionFieldRef.current ||
-      (hasPreloadData && type !== 'update')
-    );
-  }, [schemaName, variables, name, collectionFieldRef.current, hasPreloadData]);
+    return !isDisplayField(schemaName) || !variables || name === 'fields' || !collectionFieldRef.current;
+  }, [schemaName, variables, name, collectionFieldRef.current]);
 
   const formValue = shouldNotLazyLoad
     ? {}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     In the edit form, the displayed association field value does not change when the associated field updates      |
| 🇨🇳 Chinese |      编辑表单中，显示的关系字段值不会随着关联字段变化而变化     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
