### PR TITLE
fix(notification-mail): html tag character in the mail channel config form input field

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/TextAreaWithGlobalScope.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/TextAreaWithGlobalScope.tsx
@@ -35,13 +35,14 @@ interface TextAreaWithGlobalScopeProps {
   password?: boolean;
   number?: boolean;
   boolean?: boolean;
+  expression?: boolean;
   value?: any;
   scope?: string | object;
   [key: string]: any;
 }
 
 export const TextAreaWithGlobalScope = connect((props: TextAreaWithGlobalScopeProps) => {
-  const { supportsLineBreak, password, number, boolean, ...others } = props;
+  const { supportsLineBreak, password, number, boolean, input, expression = true, ...others } = props;
   const scope = useEnvironmentVariableOptions(props.scope);
   const fieldNames = { value: 'name', label: 'title' };
 
@@ -57,5 +58,13 @@ export const TextAreaWithGlobalScope = connect((props: TextAreaWithGlobalScopePr
   if (boolean) {
     return <Variable.Input {...props} scope={scope} fieldNames={fieldNames} />;
   }
-  return <TextArea {...others} scope={scope} fieldNames={fieldNames} />;
+
+  if (input) {
+    return <Variable.Input {...others} scope={scope} fieldNames={fieldNames} />;
+  }
+  if (expression) {
+    return <TextArea {...others} scope={scope} fieldNames={fieldNames} />;
+  }
+
+  return <Variable.Input {...others} scope={scope} fieldNames={fieldNames} />;
 }, mapReadPretty(Input.ReadPretty));

--- a/packages/plugins/@nocobase/plugin-notification-email/src/client/ConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/client/ConfigForm.tsx
@@ -174,8 +174,9 @@ export const ChannelConfigForm = () => {
                         'x-decorator': 'FormItem',
                         'x-component': 'TextAreaWithGlobalScope',
                         'x-component-props': {
-                          // useTypedConstant: ['string'],
+                          useTypedConstant: ['string'],
                           placeholder: `noreply <example@domain.com>`,
+                          expression: false,
                         },
                       },
                     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix input html tag character error in mail channel config form.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fixed html tag character in the mail channel config form input field.    |
| 🇨🇳 Chinese |    修复邮件通道配置表单中输入标签的字符编码错误。       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
