### PR TITLE
fix: missing unique keys of association fields

### DIFF
--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -239,6 +239,7 @@ function getGroupItemForTable({
 
       return {
         type: 'item',
+        key: `${field.target}_${subField.name}_${newSchemaName}`,
         name: newSchemaName,
         title: subField?.uiSchema?.title || subField.name,
         Component: 'TableCollectionFieldInitializer',
@@ -259,6 +260,7 @@ function getGroupItemForTable({
 
   const displayCollectionFields = {
     type: 'itemGroup',
+    key: `${field.target}_${schemaName}_displayFields`,
     name: `${schemaName}-displayCollectionFields`,
     title: t('Display fields'),
     children: items,
@@ -287,6 +289,7 @@ function getGroupItemForTable({
     if (subChildren.length) {
       const group: any = {
         type: 'itemGroup',
+        key: `${field.target}_${schemaName}_associationFields`,
         name: `${schemaName}-associationFields`,
         title: t('Display association fields'),
         children: subChildren,
@@ -298,7 +301,8 @@ function getGroupItemForTable({
 
   return {
     type: 'subMenu',
-    name: `${schemaName}`,
+    key: `${field.target}_${schemaName}_submenu`,
+    name: schemaName,
     title: field.uiSchema?.title,
     children,
   } as SchemaInitializerItemType;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Missing unique key for association fields submenu in UI |
| 🇨🇳 Chinese | 界面上关联字段菜单缺少唯一性 key 属性 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
