### PR TITLE
fix(plugin-workflow-loop): fix pending nodes in loop but resolved

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-loop/src/server/LoopInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-loop/src/server/LoopInstruction.ts
@@ -97,7 +97,12 @@ export default class extends Instruction {
     const { result, status } = job;
     // NOTE: if loop has been done (resolved / rejected), do not care newly executed branch jobs.
     if (status !== JOB_STATUS.PENDING) {
-      return processor.exit();
+      processor.logger.warn(`loop (${job.nodeId}) has been done, ignore newly resumed event`);
+      return null;
+    }
+
+    if (branchJob.id !== job.id && branchJob.status === JOB_STATUS.PENDING) {
+      return null;
     }
 
     const nextIndex = result.looped + 1;

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/instructions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/instructions.ts
@@ -46,6 +46,12 @@ export default {
         status: 0,
       };
     },
+    resume(node, job) {
+      if (node.config.status != null) {
+        job.set('status', node.config.status);
+      }
+      return job;
+    },
     test() {
       return {
         status: 0,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -234,7 +234,7 @@ export default class Processor {
     if (parentNode) {
       this.logger.debug(`not on main, recall to parent entry node (${node.id})})`);
       await this.recall(parentNode, job);
-      return job;
+      return null;
     }
 
     // really done for all nodes

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
@@ -41,6 +41,29 @@ describe('workflow > Processor', () => {
   afterEach(() => app.destroy());
 
   describe('base', () => {
+    it.skip('saveJob', async () => {
+      const execution = await workflow.createExecution({
+        key: workflow.key,
+        context: {},
+        status: EXECUTION_STATUS.STARTED,
+        eventKey: '123',
+      });
+
+      const processor = plugin.createProcessor(execution);
+
+      const job1 = await processor.saveJob({
+        status: JOB_STATUS.RESOLVED,
+        result: null,
+      });
+
+      const job2 = await processor.saveJob({
+        status: JOB_STATUS.RESOLVED,
+        result: 'abc',
+      });
+
+      expect(job2).toBeDefined();
+    });
+
     it('empty workflow without any nodes', async () => {
       const post = await PostRepo.create({ values: { title: 't1' } });
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix loop exit earlier when node inside pending.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix loop exit earlier when node inside pending |
| 🇨🇳 Chinese | 修复循环内部有等待节点时提前退出的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
