### PR TITLE
feat(plugin-workflow): add api to register group of instruction

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/AddNodeContext.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/AddNodeContext.tsx
@@ -45,15 +45,10 @@ export function AddButton(props: AddButtonProps) {
   const instructionList = Array.from(engine.instructions.getValues()) as Instruction[];
   const { styles } = useStyles();
   const { onCreate, creating } = useAddNodeContext();
+  const groupOptions = engine.useInstructionGroupOptions();
 
   const groups = useMemo(() => {
-    const result = [
-      { key: 'control', label: `{{t("Control", { ns: "${NAMESPACE}" })}}` },
-      { key: 'calculation', label: `{{t("Calculation", { ns: "${NAMESPACE}" })}}` },
-      { key: 'collection', label: `{{t("Collection operations", { ns: "${NAMESPACE}" })}}` },
-      { key: 'manual', label: `{{t("Manual", { ns: "${NAMESPACE}" })}}` },
-      { key: 'extended', label: `{{t("Extended types", { ns: "${NAMESPACE}" })}}` },
-    ]
+    return groupOptions
       .map((group) => {
         const groupInstructions = instructionList.filter(
           (item) =>
@@ -68,15 +63,13 @@ export function AddButton(props: AddButtonProps) {
             role: 'button',
             'aria-label': item.type,
             key: item.type,
-            label: item.title,
+            label: compile(item.title),
             icon: item.icon,
           })),
         };
       })
       .filter((group) => group.children.length);
-
-    return compile(result);
-  }, [branchIndex, compile, engine, instructionList, upstream, workflow]);
+  }, [branchIndex, compile, engine, groupOptions, instructionList, upstream, workflow]);
 
   const onClick = useCallback(
     async ({ keyPath }) => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
@@ -38,9 +38,15 @@ import { lang, NAMESPACE } from './locale';
 import { customizeSubmitToWorkflowActionSettings } from './settings/customizeSubmitToWorkflowActionSettings';
 import { VariableOption } from './variable';
 
+type InstructionGroup = {
+  key: string;
+  label: string;
+};
+
 export default class PluginWorkflowClient extends Plugin {
   triggers = new Registry<Trigger>();
   instructions = new Registry<Instruction>();
+  instructionGroups = new Registry<InstructionGroup>();
   systemVariables = new Registry<VariableOption>();
 
   useTriggersOptions = () => {
@@ -51,6 +57,16 @@ export default class PluginWorkflowClient extends Plugin {
         label: compile(title),
         color: 'gold',
         options,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  };
+
+  useInstructionGroupOptions = () => {
+    const compile = useCompile();
+    return Array.from(this.instructionGroups.getEntities())
+      .map(([key, { label }]) => ({
+        key,
+        label: compile(label),
       }))
       .sort((a, b) => a.label.localeCompare(b.label));
   };
@@ -77,6 +93,10 @@ export default class PluginWorkflowClient extends Plugin {
     } else {
       throw new TypeError('invalid instruction type to register');
     }
+  }
+
+  registerInstructionGroup(key: string, group: InstructionGroup) {
+    this.instructionGroups.register(key, group);
   }
 
   registerSystemVariable(option: VariableOption) {
@@ -109,6 +129,21 @@ export default class PluginWorkflowClient extends Plugin {
         const fieldSchema = useFieldSchema();
         return isValid(fieldSchema?.['x-action-settings']?.triggerWorkflows);
       },
+    });
+
+    this.registerInstructionGroup('control', { key: 'control', label: `{{t("Control", { ns: "${NAMESPACE}" })}}` });
+    this.registerInstructionGroup('calculation', {
+      key: 'calculation',
+      label: `{{t("Calculation", { ns: "${NAMESPACE}" })}}`,
+    });
+    this.registerInstructionGroup('collection', {
+      key: 'collection',
+      label: `{{t("Collection operations", { ns: "${NAMESPACE}" })}}`,
+    });
+    this.registerInstructionGroup('manual', { key: 'manual', label: `{{t("Manual", { ns: "${NAMESPACE}" })}}` });
+    this.registerInstructionGroup('extended', {
+      key: 'extended',
+      label: `{{t("Extended types", { ns: "${NAMESPACE}" })}}`,
     });
 
     this.registerTrigger('collection', CollectionTrigger);

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/index.tsx
@@ -39,7 +39,7 @@ import { customizeSubmitToWorkflowActionSettings } from './settings/customizeSub
 import { VariableOption } from './variable';
 
 type InstructionGroup = {
-  key: string;
+  key?: string;
   label: string;
 };
 


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to extend group of instruction in workflow.

### Description 

```js
export default class YourPluginClient extends Plugin {
  load() {
    const pluginWorkflow = this.app.pm.get(PluginWorkflowClient);

    pluginWorkflow.registerInstructionGroup('ai', { label: `{{t("AI", { ns: "${NAMESPACE}" })}}` });
  }
}
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to extend group of instruction in workflow |
| 🇨🇳 Chinese | 支持扩展工作流节点分组 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | [Extends Node Group](https://docs.nocobase.com/handbook/workflow/development/api#registerinstructiongroup) |
| 🇨🇳 Chinese | [扩展节点分组](https://docs-cn.nocobase.com/handbook/workflow/development/api#registerinstructiongroup) |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
