### PR TITLE
fix(plugin-auth): support to trigger workflow when change password

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/server/actions/auth.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/actions/auth.ts
@@ -60,7 +60,7 @@ export default {
     if (!isValid) {
       ctx.throw(401, ctx.t('The password is incorrect, please re-enter', { ns: namespace }));
     }
-    UserRepo.update({
+    await UserRepo.update({
       filterByTk: user.id,
       values: {
         password: newPassword,

--- a/packages/plugins/@nocobase/plugin-auth/src/server/actions/auth.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/actions/auth.ts
@@ -49,7 +49,8 @@ export default {
     } else {
       key = 'email';
     }
-    const user = await ctx.db.getRepository('users').findOne({
+    const UserRepo = ctx.db.getRepository('users');
+    const user = await UserRepo.findOne({
       where: {
         [key]: currentUser[key],
       },
@@ -59,8 +60,12 @@ export default {
     if (!isValid) {
       ctx.throw(401, ctx.t('The password is incorrect, please re-enter', { ns: namespace }));
     }
-    user.password = newPassword;
-    await user.save();
+    UserRepo.update({
+      filterByTk: user.id,
+      values: {
+        password: newPassword,
+      },
+    });
     ctx.body = currentUser;
     await next();
   },

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -28,7 +28,7 @@ describe('workflow > triggers > collection', () => {
 
   beforeEach(async () => {
     app = await getApp({
-      plugins: ['error-handler', 'data-source-main', 'users', 'auth'],
+      plugins: ['error-handler', 'data-source-main', 'users', 'auth', 'system-settings'],
     });
 
     db = app.db;
@@ -315,6 +315,33 @@ describe('workflow > triggers > collection', () => {
 
       const executions = await workflow.getExecutions();
       expect(executions.length).toBe(0);
+    });
+
+    it('password changed in users', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 2,
+          collection: 'users',
+          changed: ['passwordChangeTz'],
+        },
+      });
+
+      const res = await (await app.agent().login(1)).resource('auth').changePassword({
+        values: {
+          oldPassword: 'admin123',
+          newPassword: 'abc123',
+          confirmPassword: 'abc123',
+        },
+      });
+
+      await sleep(500);
+
+      expect(res.status).toBe(200);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -320,6 +320,7 @@ describe('workflow > triggers > collection', () => {
     it('password changed in users', async () => {
       const workflow = await WorkflowModel.create({
         enabled: true,
+        sync: true,
         type: 'collection',
         config: {
           mode: 2,
@@ -335,8 +336,6 @@ describe('workflow > triggers > collection', () => {
           confirmPassword: 'abc123',
         },
       });
-
-      await sleep(500);
 
       expect(res.status).toBe(200);
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Support to trigger workflow when change password

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to trigger workflow when change password |
| 🇨🇳 Chinese | 支持修改密码时触发用户表的工作流 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
