### PR TITLE
chore(server): adjust max listeners number

### DIFF
--- a/packages/core/server/src/application.ts
+++ b/packages/core/server/src/application.ts
@@ -1314,6 +1314,11 @@ export class Application<StateT = DefaultState, ContextT = DefaultContext> exten
       },
       logger: this._logger.child({ module: 'database' }),
     });
+
+    // NOTE: to avoid listener number warning (default to 10)
+    // See: https://nodejs.org/api/events.html#emittersetmaxlistenersn
+    db.setMaxListeners(100);
+
     return db;
   }
 }

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -363,6 +363,10 @@ export class Gateway extends EventEmitter {
 
     const mainApp = AppSupervisor.getInstance().bootMainApp(options.mainAppOptions);
 
+    // NOTE: to avoid listener number warning (default to 10)
+    // See: https://nodejs.org/api/events.html#emittersetmaxlistenersn
+    mainApp.setMaxListeners(50);
+
     let runArgs: any = [process.argv, { throwError: true, from: 'node' }];
 
     if (!isMainThread) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation

Adjust max number of event listeners to avoid warnings.

### Description 

https://nodejs.org/api/events.html#emittersetmaxlistenersn

We are using a lot of events on the instance of app and db. Trying to increase the numbers. We could set them to infinity (0) if required.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjust max number of event listeners to avoid warnings |
| 🇨🇳 Chinese | 调整事件监听函数最大数量以避免警告 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
