### PR TITLE
fix(plugin-field-sequence): fix read only mode

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-sequence/src/client/sequence.tsx
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/client/sequence.tsx
@@ -121,9 +121,11 @@ const RuleTypes = {
           number: t('Number', { ns: NAMESPACE }),
           lowercase: t('Lowercase letters', { ns: NAMESPACE }),
           uppercase: t('Uppercase letters', { ns: NAMESPACE }),
-          symbol: t('Symbols', { ns: NAMESPACE })
+          symbol: t('Symbols', { ns: NAMESPACE }),
         };
-        return <code>{value?.map(charset => charsetLabels[charset]).join(', ') || t('Number', { ns: NAMESPACE })}</code>;
+        return (
+          <code>{value?.map((charset) => charsetLabels[charset]).join(', ') || t('Number', { ns: NAMESPACE })}</code>
+        );
       },
     },
     fieldset: {
@@ -154,14 +156,14 @@ const RuleTypes = {
           { value: 'number', label: `{{t("Number", { ns: "${NAMESPACE}" })}}` },
           { value: 'lowercase', label: `{{t("Lowercase letters", { ns: "${NAMESPACE}" })}}` },
           { value: 'uppercase', label: `{{t("Uppercase letters", { ns: "${NAMESPACE}" })}}` },
-          { value: 'symbol', label: `{{t("Symbols", { ns: "${NAMESPACE}" })}}` }
+          { value: 'symbol', label: `{{t("Symbols", { ns: "${NAMESPACE}" })}}` },
         ],
         required: true,
         default: ['number'],
         'x-validator': {
           minItems: 1,
-          message: `{{t("At least one character set should be selected", { ns: "${NAMESPACE}" })}}`
-        }
+          message: `{{t("At least one character set should be selected", { ns: "${NAMESPACE}" })}}`,
+        },
       },
     },
     defaults: {
@@ -365,14 +367,6 @@ export class SequenceFieldInterface extends CollectionFieldInterface {
     operators: interfacesProperties.operators.string,
   };
   titleUsable = true;
-  schemaInitialize(schema: ISchema, { block, field }) {
-    if (block === 'Form') {
-      Object.assign(schema['x-component-props'], {
-        disabled: !field.inputable,
-      });
-    }
-    return schema;
-  }
   properties = {
     ...interfacesProperties.defaultProps,
     unique: interfacesProperties.unique,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix sequence field not disabled when on read-only mode.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix sequence field not disabled when on read-only mode |
| 🇨🇳 Chinese | 修复自动编号字段在只读模式下未禁用 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
