### PR TITLE
fix: auth check failed before api token expired

### DIFF
--- a/packages/core/auth/src/base/auth.ts
+++ b/packages/core/auth/src/base/auth.ts
@@ -112,6 +112,10 @@ export class BaseAuth extends Auth {
         )
       : null;
 
+    if (roleName) {
+      this.ctx.headers['x-role'] = roleName;
+    }
+
     const blocked = await this.jwt.blacklist.has(jti ?? token);
     if (blocked) {
       this.ctx.throw(401, {
@@ -143,10 +147,6 @@ export class BaseAuth extends Auth {
 
     if (tokenStatus === 'valid' && Date.now() - iat * 1000 > tokenPolicy.tokenExpirationTime) {
       tokenStatus = 'expired';
-    }
-
-    if (roleName) {
-      this.ctx.headers['x-role'] = roleName;
     }
 
     if (tokenStatus === 'valid' && user.passwordChangeTz && iat * 1000 < user.passwordChangeTz) {

--- a/packages/core/auth/src/base/auth.ts
+++ b/packages/core/auth/src/base/auth.ts
@@ -121,15 +121,15 @@ export class BaseAuth extends Auth {
     }
 
     // api token check first
-    if (!temp && tokenStatus !== 'valid') {
-      this.ctx.throw(401, {
-        message: this.ctx.t('Your session has expired. Please sign in again.', { ns: localeNamespace }),
-        code: AuthErrorCode.INVALID_TOKEN,
-      });
-    }
-
-    if (!temp && tokenStatus === 'valid') {
-      return user;
+    if (!temp) {
+      if (tokenStatus === 'valid') {
+        return user;
+      } else {
+        this.ctx.throw(401, {
+          message: this.ctx.t('Your session has expired. Please sign in again.', { ns: localeNamespace }),
+          code: AuthErrorCode.INVALID_TOKEN,
+        });
+      }
     }
 
     const tokenPolicy = await this.tokenController.getConfig();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Skip user auth check when token is api key.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Skip user auth check when token is api key      |
| 🇨🇳 Chinese |    当令牌是 API 密钥时跳过用户身份验证检查。       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
