### PR TITLE
fix: editFormLinkageRuleInvalid

### DIFF
--- a/packages/core/client/src/variables/VariablesProvider.tsx
+++ b/packages/core/client/src/variables/VariablesProvider.tsx
@@ -367,6 +367,9 @@ function shouldToRequest(value, variableCtx: Record<string, any>, variablePath: 
   // value may be a reactive object, using untracked to avoid unexpected autorun
   untracked(() => {
     // fix https://nocobase.height.app/T-2502
+    if (value === null) {
+      return false;
+    }
     // Compatible with `xxx to many` and `xxx to one` subform fields and subtable fields
     if (JSON.stringify(value) === '[{}]' || JSON.stringify(value) === '{}') {
       result = true;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Invalid value for setting linkage rules for editing forms      |
| 🇨🇳 Chinese |     编辑表单联动规则设置值失效      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
