### PR TITLE
fix(acl): incorrect data records when using m2m fields in collection permission data scope

### DIFF
--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/list-action.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/list-action.test.ts
@@ -216,6 +216,78 @@ describe('list action with acl', () => {
     expect(data.meta.allowedActions.destroy).toEqual([]);
   });
 
+  it('should list items meta permissions by m2m association field', async () => {
+    const userRole = app.acl.define({
+      role: 'user',
+    });
+
+    const Tag = app.db.collection({
+      name: 'tags',
+      fields: [{ type: 'string', name: 'name' }],
+    });
+
+    app.db.extendCollection({
+      name: 'posts',
+      fields: [
+        {
+          type: 'belongsToMany',
+          name: 'tags',
+          through: 'posts_tags',
+        },
+      ],
+    });
+    await app.db.sync();
+
+    await Tag.repository.create({
+      values: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+    });
+    await Post.repository.create({
+      values: [
+        { title: 'p1', tags: [1, 2] },
+        { title: 'p2', tags: [1, 3] },
+        { title: 'p3', tags: [2, 3] },
+      ],
+    });
+
+    userRole.grantAction('posts:view', {});
+
+    userRole.grantAction('posts:update', {
+      filter: {
+        $and: [
+          {
+            tags: {
+              name: {
+                $includes: 'c',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    app.resourcer.use(
+      (ctx, next) => {
+        ctx.state.currentRole = 'user';
+        ctx.state.currentUser = {
+          id: 1,
+          tag: 'c',
+        };
+
+        return next();
+      },
+      {
+        before: 'acl',
+        after: 'auth',
+      },
+    );
+
+    const response = await (app as any).agent().set('X-With-ACL-Meta', true).resource('posts').list();
+    const data = response.body;
+    expect(data.meta.allowedActions.view).toEqual([1, 2, 3]);
+    expect(data.meta.allowedActions.update).toEqual([2, 3]);
+    expect(data.meta.allowedActions.destroy).toEqual([]);
+  });
+
   it('should list items with meta permission', async () => {
     const userRole = app.acl.define({
       role: 'user',

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/with-acl-meta.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/with-acl-meta.ts
@@ -265,6 +265,7 @@ function createWithACLMetaMiddleware() {
         }),
       ],
       include: conditions.map((condition) => condition.include).flat(),
+      raw: true,
     });
 
     const allowedActions = inspectActions
@@ -273,7 +274,7 @@ function createWithACLMetaMiddleware() {
           return [action, ids];
         }
 
-        return [action, results.filter((item) => Boolean(item.get(action))).map((item) => item.get(primaryKeyField))];
+        return [action, results.filter((item) => Boolean(item[action])).map((item) => item[primaryKeyField])];
       })
       .reduce((acc, [action, ids]) => {
         acc[action] = ids;

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/with-acl-meta.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/with-acl-meta.ts
@@ -274,7 +274,9 @@ function createWithACLMetaMiddleware() {
           return [action, ids];
         }
 
-        return [action, results.filter((item) => Boolean(item[action])).map((item) => item[primaryKeyField])];
+        let actionIds = results.filter((item) => Boolean(item[action])).map((item) => item[primaryKeyField]);
+        actionIds = Array.from(new Set(actionIds));
+        return [action, actionIds];
       })
       .reduce((acc, [action, ids]) => {
         acc[action] = ids;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Incorrect data records when using many to many fields as data scope in collection permissions          |
| 🇨🇳 Chinese | 配置数据表权限，使用多对多字段作为数据范围筛选条件，响应的数据记录不正确          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
