### PR TITLE
fix(devtools): ensure X-Forwarded-For header is set only if req.ip is not undefined

### DIFF
--- a/packages/core/devtools/umiConfig.js
+++ b/packages/core/devtools/umiConfig.js
@@ -64,7 +64,9 @@ function getUmiConfig() {
           }
         },
         onProxyReq: (proxyReq, req, res) => {
-          proxyReq.setHeader('X-Forwarded-For', req.ip);
+          if (req?.ip) {
+            proxyReq.setHeader('X-Forwarded-For', req.ip);
+          }
         },
       },
       // for local storage


### PR DESCRIPTION
… available

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Ensure X-Forwarded-For header is set only if req.ip is not undefined.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Ensure X-Forwarded-For header is set only if req.ip is not undefined.       |
| 🇨🇳 Chinese |     确保仅在 req.ip 不为 undefined 时，设置 X-Forwarded-For 头部。      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
