### PR TITLE
fix(users): add loading state for users management tab

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client/UsersManagement.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/UsersManagement.tsx
@@ -11,21 +11,21 @@ import { css } from '@emotion/css';
 import { createForm } from '@formily/core';
 import { useForm } from '@formily/react';
 import {
+  ExtendCollectionsProvider,
+  RemoteSchemaComponent,
   SchemaComponent,
   SchemaComponentContext,
   useAPIClient,
   useActionContext,
   useCollection,
+  useCollectionManager,
   useCollectionRecordData,
   useDataBlockRequest,
   useDataBlockResource,
   useRequest,
-  RemoteSchemaComponent,
-  useCollectionManager,
-  ExtendCollectionsProvider,
   useSchemaComponentContext,
 } from '@nocobase/client';
-import { App, Tabs, message } from 'antd';
+import { App, Spin, Tabs, message } from 'antd';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import { useUsersTranslation } from './locale';
 import { PasswordField } from './PasswordField';
@@ -134,6 +134,11 @@ const FilterAction = () => {
 
 const UsersManagementTab: React.FC = () => {
   const { t } = useUsersTranslation();
+  const collectionManager = useCollectionManager();
+  const usersCollection = useMemo(() => collectionManager?.getCollection('users'), [collectionManager]);
+
+  if (!usersCollection) return <Spin />;
+
   return (
     <SchemaComponent
       schema={usersSchema}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      An error UI briefly flashes when the user permission management table loads for the first time     |
| 🇨🇳 Chinese |     用户权限管理表格在首次加载页面时，有一个报错的 UI 一闪而过      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
