### PR TITLE
fix(plugin-workflow-aggregate): add precision process after query

### DIFF
--- a/packages/core/evaluators/src/utils/formulajs.ts
+++ b/packages/core/evaluators/src/utils/formulajs.ts
@@ -22,7 +22,7 @@ export default evaluate.bind(function (expression: string, scope = {}) {
     if (Number.isNaN(result) || !Number.isFinite(result)) {
       return null;
     }
-    return round(result, 15);
+    return round(result, 14);
   }
   return result;
 }, {});

--- a/packages/core/evaluators/src/utils/formulajs.ts
+++ b/packages/core/evaluators/src/utils/formulajs.ts
@@ -22,7 +22,7 @@ export default evaluate.bind(function (expression: string, scope = {}) {
     if (Number.isNaN(result) || !Number.isFinite(result)) {
       return null;
     }
-    return round(result, 9);
+    return round(result, 15);
   }
   return result;
 }, {});

--- a/packages/core/evaluators/src/utils/mathjs.ts
+++ b/packages/core/evaluators/src/utils/mathjs.ts
@@ -18,7 +18,7 @@ export default evaluate.bind(
       if (Number.isNaN(result) || !Number.isFinite(result)) {
         return null;
       }
-      return math.round(result, 9);
+      return math.round(result, 15);
     }
     if (result instanceof math.Matrix) {
       return result.toArray();

--- a/packages/core/evaluators/src/utils/mathjs.ts
+++ b/packages/core/evaluators/src/utils/mathjs.ts
@@ -18,7 +18,7 @@ export default evaluate.bind(
       if (Number.isNaN(result) || !Number.isFinite(result)) {
         return null;
       }
-      return math.round(result, 15);
+      return math.round(result, 14);
     }
     if (result instanceof math.Matrix) {
       return result.toArray();

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/package.json
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/package.json
@@ -11,6 +11,7 @@
   "homepage.zh-CN": "https://docs-cn.nocobase.com/handbook/workflow-aggregate",
   "devDependencies": {
     "antd": "5.x",
+    "mathjs": "^10.6.0",
     "react": "18.x",
     "react-i18next": "^11.15.1"
   },

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/AggregateInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/AggregateInstruction.tsx
@@ -338,9 +338,9 @@ export default class extends Instruction {
       properties: {
         distinct: {
           type: 'boolean',
-          title: `{{t("Distinct", { ns: "${NAMESPACE}" })}}`,
           'x-decorator': 'FormItem',
           'x-component': 'Checkbox',
+          'x-content': `{{t("Distinct", { ns: "${NAMESPACE}" })}}`,
           'x-reactions': [
             {
               dependencies: ['collection', 'aggregator'],

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/__e2e__/DataOfCollection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client/__e2e__/DataOfCollection.test.ts
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { round } from 'mathjs';
 import { faker } from '@faker-js/faker';
 import {
   AggregateNode,
@@ -350,7 +351,7 @@ test.describe('filter', () => {
       aggregateNodeCollectionData.reduce((total, currentValue) => {
         return currentValue.staffnum > 3 ? total + currentValue.staffnum : total;
       }, 0) / aggregateNodeCollectionDataCount;
-    expect(aggregateNodeJobResult).toBe(aggregateNodeCollectionDataAvg);
+    expect(aggregateNodeJobResult).toBe(round(aggregateNodeCollectionDataAvg, 14));
     // 4、后置处理：删除工作流
     await apiDeleteWorkflow(workflowId);
   });

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
@@ -7,6 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { round } from 'mathjs';
+
 import { parseCollectionName } from '@nocobase/data-source-manager';
 import { DataTypes } from '@nocobase/database';
 import { Processor, Instruction, JOB_STATUS, FlowNodeModel } from '@nocobase/plugin-workflow';
@@ -47,7 +49,7 @@ export default class extends Instruction {
     });
 
     return {
-      result: options.dataType === DataTypes.DOUBLE ? Number(result) : result,
+      result: options.dataType === DataTypes.DOUBLE ? round(Number(result), 15) : result,
       status: JOB_STATUS.RESOLVED,
     };
   }

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
@@ -49,7 +49,7 @@ export default class extends Instruction {
     });
 
     return {
-      result: options.dataType === DataTypes.DOUBLE ? round(Number(result), 15) : result,
+      result: round(options.dataType === DataTypes.DOUBLE ? Number(result) : result, 15),
       status: JOB_STATUS.RESOLVED,
     };
   }

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/AggregateInstruction.ts
@@ -49,7 +49,7 @@ export default class extends Instruction {
     });
 
     return {
-      result: round(options.dataType === DataTypes.DOUBLE ? Number(result) : result, 15),
+      result: round(options.dataType === DataTypes.DOUBLE ? Number(result) : result, 14),
       status: JOB_STATUS.RESOLVED,
     };
   }

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/__tests__/instruction.test.ts
@@ -48,7 +48,7 @@ describe('workflow > instructions > aggregate', () => {
   afterEach(() => app.destroy());
 
   describe('based on collection', () => {
-    it('count', async () => {
+    it('count with data matched', async () => {
       const n1 = await workflow.createNode({
         type: 'aggregate',
         config: {
@@ -67,6 +67,30 @@ describe('workflow > instructions > aggregate', () => {
       const [execution] = await workflow.getExecutions();
       const [job] = await execution.getJobs();
       expect(job.result).toBe(1);
+    });
+
+    it('count without data matched', async () => {
+      const n1 = await workflow.createNode({
+        type: 'aggregate',
+        config: {
+          aggregator: 'count',
+          collection: 'posts',
+          params: {
+            field: 'id',
+            filter: {
+              id: 0,
+            },
+          },
+        },
+      });
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      const [job] = await execution.getJobs();
+      expect(job.result).toBe(0);
     });
 
     it('sum', async () => {
@@ -96,6 +120,64 @@ describe('workflow > instructions > aggregate', () => {
       const [e2] = await workflow.getExecutions({ order: [['id', 'desc']] });
       const [j2] = await e2.getJobs();
       expect(j2.result).toBe(3);
+    });
+
+    it('sum double field', async () => {
+      const n1 = await workflow.createNode({
+        type: 'aggregate',
+        config: {
+          aggregator: 'sum',
+          collection: 'posts',
+          params: {
+            field: 'score',
+          },
+        },
+      });
+
+      const p1 = await PostRepo.create({ values: { title: 't1', score: 0.1 } });
+
+      await sleep(500);
+
+      const [e1] = await workflow.getExecutions();
+      const [j1] = await e1.getJobs();
+      expect(j1.result).toBe(0.1);
+
+      const p2 = await PostRepo.create({ values: { title: 't2', score: 0.2 } });
+
+      await sleep(500);
+
+      const [e2] = await workflow.getExecutions({ order: [['id', 'desc']] });
+      const [j2] = await e2.getJobs();
+      expect(j2.result).toBe(0.3);
+    });
+
+    it('sum number will be rounded', async () => {
+      const n1 = await workflow.createNode({
+        type: 'aggregate',
+        config: {
+          aggregator: 'sum',
+          collection: 'posts',
+          params: {
+            field: 'score',
+          },
+        },
+      });
+
+      const p1 = await PostRepo.create({ values: { title: 't1', score: 0.1000000000000001 } });
+
+      await sleep(500);
+
+      const [e1] = await workflow.getExecutions();
+      const [j1] = await e1.getJobs();
+      expect(j1.result).toBe(0.1);
+
+      const p2 = await PostRepo.create({ values: { title: 't2', score: 0.2000000000000001 } });
+
+      await sleep(500);
+
+      const [e2] = await workflow.getExecutions({ order: [['id', 'desc']] });
+      const [j2] = await e2.getJobs();
+      expect(j2.result).toBe(0.3);
     });
 
     it('avg', async () => {

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/server/__tests__/instruction.test.ts
@@ -163,7 +163,7 @@ describe('workflow > instructions > aggregate', () => {
         },
       });
 
-      const p1 = await PostRepo.create({ values: { title: 't1', score: 0.1000000000000001 } });
+      const p1 = await PostRepo.create({ values: { title: 't1', score: 0.100000000000001 } });
 
       await sleep(500);
 
@@ -171,7 +171,7 @@ describe('workflow > instructions > aggregate', () => {
       const [j1] = await e1.getJobs();
       expect(j1.result).toBe(0.1);
 
-      const p2 = await PostRepo.create({ values: { title: 't2', score: 0.2000000000000001 } });
+      const p2 = await PostRepo.create({ values: { title: 't2', score: 0.200000000000001 } });
 
       await sleep(500);
 

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/e2e/e2ePageObjectModel.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/e2e/e2ePageObjectModel.ts
@@ -571,7 +571,7 @@ export class AggregateNode {
       .getByLabel('block-item-FieldsSelect-workflows-Field to aggregate')
       .locator('.ant-select-selection-search-input');
     this.distinctCheckBox = page
-      .getByLabel('block-item-Checkbox-workflows-Distinct')
+      .getByLabel('block-item-Checkbox-workflows')
       .locator('input.ant-checkbox-input[type="checkbox"]');
     this.submitButton = page.getByLabel('action-Action-Submit-workflows');
     this.cancelButton = page.getByLabel('action-Action-Cancel-workflows');

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/posts.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/collections/posts.ts
@@ -46,6 +46,11 @@ export default {
       defaultValue: 0,
     },
     {
+      type: 'double',
+      name: 'score',
+      defaultValue: 0,
+    },
+    {
       type: 'date',
       name: 'createdAt',
     },


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add round process for aggregated number based on double type.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add round process for aggregated number based on double type |
| 🇨🇳 Chinese | 对聚合后的数字进行小数四舍五入的处理 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
