### PR TITLE
fix(db): the string sourceKeyValue in relation repository is being converted to a number

### DIFF
--- a/packages/core/database/src/__tests__/relation-repository/relation-repository.test.ts
+++ b/packages/core/database/src/__tests__/relation-repository/relation-repository.test.ts
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { MockDatabase, mockDatabase } from '../../mock-database';
+
+describe('relation repository', () => {
+  let db: MockDatabase;
+  beforeEach(() => {
+    db = mockDatabase();
+  });
+
+  afterEach(async () => {
+    await db.clean({ drop: true });
+    await db.close();
+  });
+
+  it('should not convert string source id to number', async () => {
+    db.collection({
+      name: 'tags',
+      fields: [{ type: 'string', name: 'name' }],
+    });
+    const User = db.collection({
+      name: 'users',
+      autoGenId: false,
+      fields: [
+        { type: 'string', name: 'name' },
+        { type: 'hasMany', name: 'tags', sourceKey: 'name', target: 'tags', foreignKey: 'userId' },
+      ],
+    });
+    await db.sync();
+    await User.repository.create({
+      values: { name: '123', tags: [{ name: 'tag1' }] },
+    });
+    const repo = db.getRepository('users.tags', '123');
+    await expect(repo.find()).resolves.not.toThrow();
+  });
+});

--- a/packages/core/database/src/relation-repository/relation-repository.ts
+++ b/packages/core/database/src/relation-repository/relation-repository.ts
@@ -57,7 +57,8 @@ export abstract class RelationRepository {
   decodeMultiTargetKey(str: string) {
     try {
       const decoded = decodeURIComponent(str);
-      return JSON.parse(decoded);
+      const parsed = JSON.parse(decoded);
+      return typeof parsed === 'object' && parsed !== null ? parsed : decoded;
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix error when retrieving relation collection records if the source key in relation fields is a numeric string        |
| 🇨🇳 Chinese |  修复当关系字段的源表标识字段值为数字型字符串时，获取关系数据记录报错的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
