### PR TITLE
fix: attachment field storage setting dropdown not displaying options

### DIFF
--- a/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/remote-select/RemoteSelect.tsx
@@ -72,7 +72,6 @@ const InternalRemoteSelect = withDynamicSchemaProps(
       } = props;
       const dataSource = useDataSourceKey();
       const headers = useDataSourceHeaders(propsDataSource || dataSource);
-      const [open, setOpen] = useState(false);
       const firstRun = useRef(false);
       const fieldSchema = useFieldSchema();
       const isQuickAdd = fieldSchema['x-component-props']?.addMode === 'quickAdd';
@@ -197,7 +196,6 @@ const InternalRemoteSelect = withDynamicSchemaProps(
               search={searchData.current}
               callBack={() => {
                 searchData.current = null;
-                setOpen(false);
               }}
             />
           );
@@ -244,7 +242,6 @@ const InternalRemoteSelect = withDynamicSchemaProps(
       }, [value, defaultValue, data?.data, fieldNames.value, optionFilter]);
 
       const onDropdownVisibleChange = (visible) => {
-        setOpen(visible);
         searchData.current = null;
         if (visible) {
           run();
@@ -254,7 +251,6 @@ const InternalRemoteSelect = withDynamicSchemaProps(
 
       return (
         <Select
-          open={open}
           popupMatchSelectWidth={popupMatchSelectWidth}
           autoClearSearchValue
           filterOption={false}

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/editActionSchema.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/editActionSchema.ts
@@ -9,7 +9,7 @@
 
 export const editActionSchema = {
   type: 'void',
-  title: 'Edit',
+  title: "{{t('Edit')}}",
   'x-component': 'Action.Link',
   'x-component-props': {
     openMode: 'drawer',

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/publicForms.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/publicForms.tsx
@@ -238,7 +238,7 @@ export const publicFormsSchema: ISchema = {
                 editActionSchema,
                 delete: {
                   type: 'void',
-                  title: 'Delete',
+                  title: "{{t('Delete')}}",
                   'x-component': 'Action.Link',
                   'x-use-component-props': 'useDeleteActionProps',
                 },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  attachment field storage setting dropdown not displaying options         |
| 🇨🇳 Chinese |   附件字段存储空间设置下拉不显示选项        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
