### PR TITLE
fix: import button should not include Pro import logic 

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/client/useImportAction.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/client/useImportAction.ts
@@ -149,22 +149,6 @@ export const useImportStartAction = () => {
       formData.append('columns', JSON.stringify(columns));
       formData.append('explain', explain);
 
-      const { triggerWorkflow, identifyDuplicates, uniqueField, duplicateStrategy } = form.values;
-
-      if (triggerWorkflow !== undefined) {
-        formData.append('triggerWorkflow', JSON.stringify(triggerWorkflow));
-      }
-
-      if (identifyDuplicates) {
-        formData.append(
-          'duplicateOption',
-          JSON.stringify({
-            uniqueField,
-            mode: duplicateStrategy,
-          }),
-        );
-      }
-
       const importMode = importSchema?.['x-action-settings']?.importMode || 'auto';
 
       setVisible(false);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        import button should not include Pro import logic     |
| 🇨🇳 Chinese |     导入按钮插件中不应包含pro 导入按钮的逻辑    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
