### PR TITLE
refactor(plugin-workflow): add option to skip triggering in collection event

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -161,6 +161,23 @@ describe('workflow > triggers > collection', () => {
       expect(executions.length).toBe(1);
       expect(executions[0].context.data.title).toBe('c1');
     });
+
+    it('skipWorkflow', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        sync: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      const post = await PostRepo.create({ values: { title: 't1' }, context: { skipWorkflow: true } });
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(0);
+    });
   });
 
   describe('config.mode', () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -53,13 +53,17 @@ export default class CollectionTrigger extends Trigger {
 
   // async function, should return promise
   private static async handler(this: CollectionTrigger, workflow: WorkflowModel, data: Model, options) {
+    const { skipWorkflow = false, stack } = options.context ?? {};
+    if (skipWorkflow) {
+      return;
+    }
     const [dataSourceName] = parseCollectionName(workflow.config.collection);
     const transaction = this.workflow.useDataSourceTransaction(dataSourceName, options.transaction);
     const ctx = await this.prepare(workflow, data, { ...options, transaction });
     if (!ctx) {
       return;
     }
-    const { stack } = options.context ?? {};
+
     if (workflow.sync) {
       await this.workflow.trigger(workflow, ctx, {
         transaction,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Allow skip to trigger collection workflow in database event.

### Description 

```diff
  const post = await PostRepo.create({
    values: { title: 'post1' },
    context: {
+     skipWorkflow: true,
    }
  });
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Allow skip to trigger collection workflow in database event |
| 🇨🇳 Chinese | 支持在数据表事件中不触发工作流 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
