### PR TITLE
feat(data-vi): support nulls sorting in chart queries

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/configure/schemas/configure.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/configure/schemas/configure.ts
@@ -424,15 +424,33 @@ export const querySchema: ISchema = {
                         order: {
                           type: 'string',
                           'x-decorator': 'FormItem',
-                          'x-component': 'Radio.Group',
+                          'x-component': 'Select',
                           'x-component-props': {
                             defaultValue: 'ASC',
-                            optionType: 'button',
-                            style: {
-                              width: '128px',
-                            },
                           },
                           enum: ['ASC', 'DESC'],
+                        },
+                        nulls: {
+                          type: 'string',
+                          'x-decorator': 'FormItem',
+                          'x-component': 'Select',
+                          'x-component-props': {
+                            defaultValue: 'default',
+                          },
+                          enum: [
+                            {
+                              label: lang('Default'),
+                              value: 'default',
+                            },
+                            {
+                              label: lang('NULLS first'),
+                              value: 'first',
+                            },
+                            {
+                              label: lang('NULLS last'),
+                              value: 'last',
+                            },
+                          ],
                         },
                       },
                       {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/query-parser/query-parser.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/query-parser/query-parser.ts
@@ -84,7 +84,9 @@ export class QueryParser {
     orders.forEach((item: OrderProps) => {
       const alias = sequelize.getQueryInterface().quoteIdentifier(item.alias);
       const name = hasAgg ? sequelize.literal(alias) : sequelize.col(item.field as string);
-      order.push([name, item.order || 'ASC']);
+      let sort = item.order || 'ASC';
+      sort = item.nulls !== 'default' ? `${sort} NULLS ${item.nulls}` : sort;
+      order.push([name, sort]);
     });
     return order;
   }

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/query-parser/query-parser.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/query-parser/query-parser.ts
@@ -85,7 +85,12 @@ export class QueryParser {
       const alias = sequelize.getQueryInterface().quoteIdentifier(item.alias);
       const name = hasAgg ? sequelize.literal(alias) : sequelize.col(item.field as string);
       let sort = item.order || 'ASC';
-      sort = item.nulls !== 'default' ? `${sort} NULLS ${item.nulls}` : sort;
+      if (item.nulls === 'first') {
+        sort += ' NULLS FIRST';
+      }
+      if (item.nulls === 'last') {
+        sort += ' NULLS LAST';
+      }
       order.push([name, sort]);
     });
     return order;

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/types.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/types.ts
@@ -27,6 +27,7 @@ export type OrderProps = {
   field: string | string[];
   alias?: string;
   order?: 'asc' | 'desc';
+  nulls?: 'default' | 'first' | 'last';
 };
 
 export type QueryParams = Partial<{


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

Close #6282 

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c1ad6213-95d9-4d74-91ac-ef30eac641c8" />


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support NULLS sorting in chart queries          |
| 🇨🇳 Chinese |  支持在图表查询中设置 NULLS 排序         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
