### PR TITLE
fix(plugin-file-manager): use global meta request for storage basic info

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/FileManagerProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/FileManagerProvider.tsx
@@ -7,15 +7,28 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { SchemaComponentOptions } from '@nocobase/client';
-import React, { FC } from 'react';
+import React, { createContext, FC, useContext } from 'react';
+import { SchemaComponentOptions, useRequest } from '@nocobase/client';
 import * as hooks from './hooks';
 import { UploadActionInitializer } from './initializers';
 
+export const FileManagerContext = createContext({ storages: [] });
+
+export function useFileManagerContext() {
+  return useContext(FileManagerContext);
+}
+
 export const FileManagerProvider: FC = (props) => {
+  const { data } = useRequest<any>({
+    resource: 'storages',
+    action: 'listBasicInfo',
+  });
+
   return (
-    <SchemaComponentOptions scope={hooks} components={{ UploadActionInitializer }}>
-      {props.children}
-    </SchemaComponentOptions>
+    <FileManagerContext.Provider value={{ storages: data?.data || [] }}>
+      <SchemaComponentOptions scope={hooks} components={{ UploadActionInitializer }}>
+        {props.children}
+      </SchemaComponentOptions>
+    </FileManagerContext.Provider>
   );
 };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageRules.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageRules.ts
@@ -7,32 +7,11 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { useEffect } from 'react';
-import { useField } from '@formily/react';
-import { useAPIClient, useCollectionField, useCollectionManager, useRequest } from '@nocobase/client';
-import { useStorageUploadProps } from './useStorageUploadProps';
+import { useCollectionField, useCollectionManager } from '@nocobase/client';
+import { useStorage, useStorageUploadProps } from './useStorageUploadProps';
 
-export function useStorageRules(storage) {
-  const name = storage ?? '';
-  const apiClient = useAPIClient();
-  const field = useField<any>();
-  const { loading, data, run } = useRequest<any>(
-    {
-      url: `storages:getBasicInfo/${name}`,
-    },
-    {
-      manual: true,
-      refreshDeps: [name],
-      cacheKey: name,
-    },
-  );
-  useEffect(() => {
-    if (field.pattern !== 'editable') {
-      return;
-    }
-    run();
-  }, [field.pattern, run]);
-  return (!loading && data?.data?.rules) || null;
+export function useStorageRules(storage: string) {
+  return useStorage(storage)?.rules || null;
 }
 
 export function useAttachmentFieldProps() {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageUploadProps.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageUploadProps.ts
@@ -7,38 +7,26 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import {
-  Input,
-  Upload,
-  useCollection,
-  useCollectionField,
-  useCollectionManager,
-  useCollectionRecordData,
-  usePlugin,
-  useRequest,
-  withDynamicSchemaProps,
-} from '@nocobase/client';
-import React, { useEffect } from 'react';
-import { connect, mapProps, mapReadPretty, useField } from '@formily/react';
-import FileManagerPlugin from '../';
+import { useCollection, useCollectionField, useCollectionManager, usePlugin } from '@nocobase/client';
 
-export function useStorage(storage) {
+import FileManagerPlugin from '../';
+import { useFileManagerContext } from '../FileManagerProvider';
+
+export function useStorage(storage: string) {
+  const { storages } = useFileManagerContext();
   const name = storage ?? '';
-  const url = `storages:getBasicInfo/${name}`;
-  const { loading, data, run } = useRequest<any>(
-    {
-      url,
-    },
-    {
-      manual: true,
-      refreshDeps: [name],
-      cacheKey: url,
-    },
-  );
-  useEffect(() => {
-    run();
-  }, [run]);
-  return (!loading && data?.data) || null;
+  const isNumber = /^\d+$/.test(name);
+  const result = storages.find((item) => {
+    if (isNumber) {
+      return item.id === Number.parseInt(name, 10);
+    } else if (name) {
+      return item.name === name;
+    } else {
+      return item.default;
+    }
+  });
+
+  return result;
 }
 
 export function useStorageCfg() {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/index.tsx
@@ -8,13 +8,13 @@
  */
 
 import { Plugin, useCollection } from '@nocobase/client';
-import { FileManagerProvider } from './FileManagerProvider';
+import { FileManagerProvider, useFileManagerContext } from './FileManagerProvider';
 import { FileStoragePane } from './FileStorage';
 import { NAMESPACE } from './locale';
 import { storageTypes } from './schemas/storageTypes';
 import { AttachmentFieldInterface } from './interfaces/attachment';
 import { FileCollectionTemplate } from './templates';
-import { useAttachmentFieldProps, useFileCollectionStorageRules } from './hooks';
+import { useAttachmentFieldProps, useFileCollectionStorageRules, useStorageRules } from './hooks';
 import { FileSizeField } from './FileSizeField';
 import { STORAGE_TYPE_ALI_OSS, STORAGE_TYPE_LOCAL, STORAGE_TYPE_S3, STORAGE_TYPE_TX_COS } from '../constants';
 
@@ -75,3 +75,5 @@ export class PluginFileManagerClient extends Plugin {
 }
 
 export default PluginFileManagerClient;
+
+export { useFileManagerContext, useStorageRules };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
@@ -524,40 +524,11 @@ describe('action', () => {
   });
 
   describe('storage actions', () => {
-    describe('getBasicInfo', () => {
-      it('get default storage', async () => {
-        const { body, status } = await agent.resource('storages').getBasicInfo();
+    describe('listBasicInfo', () => {
+      it('get all storage', async () => {
+        const { body, status } = await agent.resource('storages').listBasicInfo();
         expect(status).toBe(200);
-        expect(body.data).toMatchObject({ id: 1 });
-      });
-
-      it('get storage by unexisted id as 404', async () => {
-        const { body, status } = await agent.resource('storages').getBasicInfo({ filterByTk: -1 });
-        expect(status).toBe(404);
-      });
-
-      it('get by storage local id', async () => {
-        const { body, status } = await agent.resource('storages').getBasicInfo({ filterByTk: local1.id });
-        expect(status).toBe(200);
-        expect(body.data).toMatchObject({
-          id: local1.id,
-          title: local1.title,
-          name: local1.name,
-          type: local1.type,
-          rules: local1.rules,
-        });
-      });
-
-      it('get storage by name', async () => {
-        const { body, status } = await agent.resource('storages').getBasicInfo({ filterByTk: local1.name });
-        expect(status).toBe(200);
-        expect(body.data).toMatchObject({
-          id: local1.id,
-          title: local1.title,
-          name: local1.name,
-          type: local1.type,
-          rules: local1.rules,
-        });
+        expect(body.data).toMatchObject([{ id: 1 }, { id: local1.id }]);
       });
     });
   });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/storages.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/storages.ts
@@ -9,28 +9,18 @@
 
 import Plugin from '..';
 
-export async function getBasicInfo(context, next) {
+export async function listBasicInfo(context, next) {
   const { storagesCache } = context.app.pm.get(Plugin) as Plugin;
-  let result;
-  const { filterByTk } = context.action.params;
-  if (!filterByTk) {
-    result = Array.from(storagesCache.values()).find((item) => item.default);
-  } else {
-    const isNumber = /^[1-9]\d*$/.test(filterByTk);
-    result = isNumber
-      ? storagesCache.get(Number.parseInt(filterByTk, 10))
-      : Array.from(storagesCache.values()).find((item) => item.name === filterByTk);
-  }
-  if (!result) {
-    return context.throw(404);
-  }
-  context.body = {
-    id: result.id,
-    title: result.title,
-    name: result.name,
-    type: result.type,
-    rules: result.rules,
-  };
+  const result = Array.from(storagesCache.values()).map((item) => ({
+    id: item.id,
+    title: item.title,
+    name: item.name,
+    type: item.type,
+    rules: item.rules,
+    default: item.default,
+  }));
+
+  context.body = result;
 
   next();
 }

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
@@ -260,7 +260,7 @@ export class PluginFileManagerServer extends Plugin {
     initActions(this);
 
     this.app.acl.allow('attachments', ['upload', 'create'], 'loggedIn');
-    this.app.acl.allow('storages', 'getBasicInfo', 'loggedIn');
+    this.app.acl.allow('storages', 'listBasicInfo', 'loggedIn');
 
     this.app.acl.appendStrategyResource('attachments');
 

--- a/packages/plugins/@nocobase/plugin-public-forms/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/server/plugin.ts
@@ -170,7 +170,6 @@ export class PluginPublicFormsServer extends Plugin {
     } else if (
       (actionName === 'list' && ctx.PublicForm['targetCollections'].includes(resourceName)) ||
       (collection.options.template === 'file' && actionName === 'create') ||
-      (resourceName === 'storages' && actionName === 'getBasicInfo') ||
       (resourceName === 'map-configuration' && actionName === 'get')
     ) {
       ctx.permission = {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

To avoid multiple requests for storage basic info.

### Description 

Use global meta request for storage basic info.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | To avoid multiple requests for storage basic info |
| 🇨🇳 Chinese | 避免对存储引擎基本信息的重复请求 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
