### PR TITLE
refactor(plugin-workflow-action-trigger): support to use end node to determine status

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/__tests__/trigger.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/__tests__/trigger.test.ts
@@ -9,7 +9,7 @@
 
 import { omit } from 'lodash';
 import Database from '@nocobase/database';
-import { EXECUTION_STATUS } from '@nocobase/plugin-workflow';
+import { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { MockServer } from '@nocobase/test';
 
@@ -30,7 +30,7 @@ describe('workflow > action-trigger', () => {
 
   beforeEach(async () => {
     app = await getApp({
-      plugins: ['users', 'auth', 'acl', 'data-source-manager', 'system-settings', Plugin],
+      plugins: ['users', 'auth', 'acl', 'data-source-manager', 'system-settings', 'error-handler', Plugin],
     });
     await app.pm.get('auth').install();
     agent = app.agent();
@@ -660,6 +660,72 @@ describe('workflow > action-trigger', () => {
       const e3s = await w1.getExecutions();
       expect(e3s.length).toBe(1);
       expect(e3s[0].status).toBe(EXECUTION_STATUS.RESOLVED);
+    });
+
+    it('execution failed on node error', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'action',
+        sync: true,
+        config: {
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await workflow.createNode({
+        type: 'error',
+      });
+
+      const res1 = await userAgents[0].resource('posts').create({
+        values: { title: 't1' },
+        triggerWorkflows: `${workflow.key}`,
+      });
+      expect(res1.status).toBe(500);
+    });
+
+    it('execution failed on end node success', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'action',
+        sync: true,
+        config: {
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await workflow.createNode({
+        type: 'end',
+      });
+
+      const res1 = await userAgents[0].resource('posts').create({
+        values: { title: 't1' },
+        triggerWorkflows: `${workflow.key}`,
+      });
+      expect(res1.status).toBe(200);
+    });
+
+    it('execution failed on end node success', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'action',
+        sync: true,
+        config: {
+          collection: 'posts',
+        },
+      });
+
+      const n1 = await workflow.createNode({
+        type: 'end',
+        config: {
+          endStatus: JOB_STATUS.FAILED,
+        },
+      });
+
+      const res1 = await userAgents[0].resource('posts').create({
+        values: { title: 't1' },
+        triggerWorkflows: `${workflow.key}`,
+      });
+      expect(res1.status).toBe(400);
     });
   });
 


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to use end node to determine status.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to use end node to determine status |
| 🇨🇳 Chinese | 支持通过结束节点决定操作的结果状态 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
