### PR TITLE
fix(in-app message): differentiate the in-app message list background color from the message cards

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
@@ -155,7 +155,9 @@ const InnerInboxContent = () => {
           }}
         />
       </Layout.Sider>
-      <Layout.Content style={{ padding: token.paddingLG, height: '100%', overflowY: 'auto' }}>
+      <Layout.Content
+        style={{ padding: token.paddingLG, height: '100%', overflowY: 'auto', backgroundColor: token.colorBgLayout }}
+      >
         {selectedChannelName ? <MessageList /> : null}
       </Layout.Content>
     </Layout>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Differentiate the in-app message list background color from the message cards to enhance visual hierarchy and readability.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Differentiate the in-app message list background color from the message cards to enhance visual hierarchy and readability.      |
| 🇨🇳 Chinese |     在站内信列表中，将背景颜色与消息卡片的颜色区分开，以提升视觉层次感和可读性。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
