### PR TITLE
fix: date field range selection excludes the max date

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
@@ -90,13 +90,13 @@ export const DatePicker: ComposedDatePicker = (props: any) => {
 
     // 根据最小日期和最大日期限定日期时间
     const disabledDate = (current) => {
-      if (!current || (!minDateTime && !maxDateTime)) {
-        return false;
-      }
-      // 确保 current 是一个 dayjs 对象
+      if (!dayjs.isDayjs(current)) return false;
+
       const currentDate = dayjs(current);
-      //在minDateTime或maxDateTime为null时 dayjs的比较函数会默认返回false 所以不做特殊判断
-      return currentDate.isBefore(minDateTime, 'minute') || currentDate.isAfter(maxDateTime, 'minute');
+      const min = minDateTime ? dayjs(minDateTime) : null;
+      const max = maxDateTime ? dayjs(maxDateTime).endOf('day') : null; // 设为 23:59:59
+
+      return (min && currentDate.isBefore(min, 'minute')) || (max && currentDate.isAfter(max, 'minute'));
     };
 
     // 禁用时分秒
@@ -153,6 +153,8 @@ export const DatePicker: ComposedDatePicker = (props: any) => {
       return disabledTime;
     });
   };
+
+  console.log(disabledDate);
 
   const newProps = {
     utc,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     date field range selection excludes the max date      |
| 🇨🇳 Chinese |      表单日期字段日期范围，最大日期可选范围少一天      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
