### PR TITLE
fix: mobile saveas template not correctly

### DIFF
--- a/packages/core/client/src/locale/it-IT.json
+++ b/packages/core/client/src/locale/it-IT.json
@@ -857,5 +857,6 @@
     "Notification": "Notifica",
     "Ellipsis overflow content": "Contenuto Ellipsis overflow",
     "Hide column": "Nascondi colonna",
-    "In configuration mode, the entire column becomes transparent. In non-configuration mode, the entire column will be hidden. Even if the entire column is hidden, its configured default values and other settings will still take effect.": "In modalità di configurazione, l'intera colonna diventa trasparente. In modalità non di configurazione, l'intera colonna verrà nascosta. Anche se l'intera colonna è nascosta, i suoi valori predefiniti configurati e le altre impostazioni avranno comunque effetto."
+    "In configuration mode, the entire column becomes transparent. In non-configuration mode, the entire column will be hidden. Even if the entire column is hidden, its configured default values and other settings will still take effect.": "In modalità di configurazione, l'intera colonna diventa trasparente. In modalità non di configurazione, l'intera colonna verrà nascosta. Anche se l'intera colonna è nascosta, i suoi valori predefiniti configurati e le altre impostazioni avranno comunque effetto.",
+    "The following old template features have been deprecated and will be removed in next version.": "Le seguenti funzionalità dei modelli vecchi sono state deprecate e saranno rimosse nella prossima versione."
 }

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -1083,5 +1083,5 @@
   "Are you sure you want to hide this tab?": "你确定要隐藏该标签页吗？",
   "After hiding, this tab will no longer appear in the tab bar. To show it again, you need to go to the route management page to set it.": "隐藏后，该标签将不再显示在标签栏中。要想再次显示它，你需要到路由管理页面进行设置。",
   "Deprecated": "已弃用",
-  "The following old templates have been deprecated and will be removed in next version.": "以下旧的模板功能已弃用，将在下个版本移除。"
+  "The following old template features have been deprecated and will be removed in next version.": "以下旧的模板功能已弃用，将在下个版本移除。"
 }

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplatePage.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplatePage.tsx
@@ -35,6 +35,7 @@ export const BlockTemplatePage = () => {
       <div
         style={{
           margin: -token.margin,
+          marginTop: -token.marginXL,
           padding: token.paddingSM,
           background: token.colorBgContainer,
           display: 'flex',

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/hooks/useIsPageBlock.ts
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/hooks/useIsPageBlock.ts
@@ -19,10 +19,10 @@ export const useIsPageBlock = () => {
     if (!fieldSchema || fieldSchema['x-template-uid']) {
       return false;
     }
-    const isPage = location.pathname.includes('/admin/') || location.pathname.includes('/m/');
+    const isPage = location.pathname.startsWith('/admin/') || location.pathname.startsWith('/page/');
     const notInPopup = !location.pathname.includes('/popups/');
-    const notInSetting = !location.pathname.includes('/admin/settings/');
-    const notInBlockTemplate = !location.pathname.includes('/m/block-templates/');
+    const notInSetting = !location.pathname.startsWith('/admin/settings/');
+    const notInBlockTemplate = !location.pathname.startsWith('/block-templates/');
     return isPage && notInPopup && notInSetting && notInBlockTemplate;
   }, [location.pathname, fieldSchema]);
 

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/utils/setting.ts
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/utils/setting.ts
@@ -16,6 +16,7 @@ import {
   SchemaSettingsTemplate,
   SchemaSettingsConnectDataBlocks,
   usePlugin,
+  useSchemaSettings,
 } from '@nocobase/client';
 
 export const hideConvertToBlockSettingItem = (
@@ -27,14 +28,15 @@ export const hideConvertToBlockSettingItem = (
     settingItem['Component'] === SchemaSettingsTemplate ||
     settingItem['Component'] === SchemaSettingsFormItemTemplate
   ) {
-    // const visible = schemaSetting.items[i]['useVisible'] || (() => true);
-    // schemaSetting.items[i]['useVisible'] = () => {
-    //   const notInBlockTemplate = !window.location.pathname.includes('admin/settings/block-templates');
-    //   return notInBlockTemplate && visible();
-    // };
-
     // hide covert to block setting item
-    settingItem['useVisible'] = () => false;
+    settingItem['useVisible'] = function useVisible() {
+      const { template: deprecatedTemplate } = useSchemaSettings();
+      if (deprecatedTemplate && ['formItemTemplate', 'ConvertReferenceToDuplicate'].includes(settingItem['name'])) {
+        // still allow user to convert reference to duplicate, this way user can migrate to new template easily
+        return true;
+      }
+      return false;
+    };
     if (preSettingItem?.['type'] === 'divider') {
       preSettingItem['useVisible'] = () => false;
     }

--- a/packages/plugins/@nocobase/plugin-block-template/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-block-template/src/locale/en-US.json
@@ -34,5 +34,6 @@
   "Please select the records you want to delete": "Please select the records you want to delete",
   "Search and select template": "Search and select template",
   "This is part of a template, deletion is not allowed": "This is part of a template, deletion is not allowed",
-  "This block is using some reference templates, please convert to duplicate template first.": "This block is using some reference templates, please convert to duplicate template first."
+  "This block is using some reference templates, please convert to duplicate template first.": "This block is using some reference templates, please convert to duplicate template first.",
+  "Save as template successfully": "Save as template successfully"
 }

--- a/packages/plugins/@nocobase/plugin-block-template/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-block-template/src/locale/zh-CN.json
@@ -34,5 +34,6 @@
   "Please select the records you want to delete": "请选择要删除的记录",
   "Search and select template": "搜索并选择模板",
   "This is part of a template, deletion is not allowed": "这是模板的一部分，不允许删除",
-  "This block is using some reference templates, please convert to duplicate template first.": "该区块使用了引用模板，请先将其转换为复制模板。"
+  "This block is using some reference templates, please convert to duplicate template first.": "该区块使用了引用模板，请先将其转换为复制模板。",
+  "Save as template successfully": "保存为模板成功"
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Save as template incorrect behavior in mobile client |
| 🇨🇳 Chinese | 移动端页面区块另存为模板不正确 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
