### PR TITLE
fix: public form settings not accessible without UI config permission

### DIFF
--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/index.tsx
@@ -57,7 +57,6 @@ export class PluginPublicFormsClient extends Plugin {
     });
     this.app.pluginSettingsManager.add('public-forms', {
       title: `{{t("Public forms", { ns: "${NAMESPACE}" })}}`,
-
       icon: 'TableOutlined',
       Component: AdminPublicFormList,
     });
@@ -66,6 +65,8 @@ export class PluginPublicFormsClient extends Plugin {
       pluginKey: 'public-forms',
       isTopLevel: false,
       Component: AdminPublicFormPage,
+      skipAclConfigure: true,
+      aclSnippet: 'pm.public-forms:name',
     });
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  public form settings not accessible without UI config permission         |
| 🇨🇳 Chinese |   角色未配置 UI 配置权限时，公开表单无法进入配置        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
