### PR TITLE
fix: avoid wrong receivers configuration query all users

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/MessageConfigForm.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { SchemaComponent, css } from '@nocobase/client';
-import { useLocalTranslation } from '../../locale';
+import { useLocalTranslation, NAMESPACE } from '../../locale';
 import { UsersSelect } from './UsersSelect';
 import { UsersAddition } from './UsersAddition';
 import { tval } from '@nocobase/utils/client';
@@ -26,6 +26,10 @@ export const MessageConfigForm = ({ variableOptions }) => {
           receivers: {
             type: 'array',
             title: `{{t("Receivers")}}`,
+            description: tval(
+              'When select receivers from node result, only support ID of user (or IDs array of users). Others will not match any user.',
+              { ns: NAMESPACE },
+            ),
             'x-decorator': 'FormItem',
             'x-component': 'ArrayItems',
             items: {

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/locale/en-US.json
@@ -24,5 +24,6 @@
   "Mark as read": "Mark as read",
   "Support two types of links: internal links and external links. If using an internal link, the link starts with\"/\", for example, \"/m\". If using an external link, the link starts with \"http\", for example, \"https://example.com\".": "Support two types of links: internal links and external links. If using an internal link, the link starts with \"/\", for example, \"/m\". If using an external link, the link starts with \"http\", for example, \"https://example.com\".",
   "Details page for mobile": "Details page for mobile",
-  "The message page has already been created.": "The message page has already been created."
+  "The message page has already been created.": "The message page has already been created.",
+  "When select receivers from node result, only support ID of user (or IDs array of users). Others will not match any user.": "When select receivers from node result, only support ID of user (or IDs array of users). Others will not match any user."
 }

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/locale/zh-CN.json
@@ -24,5 +24,6 @@
   "Mark as read": "标记为已读",
   "Support two types of links: internal links and external links. If using an internal link, the link starts with\"/\", for example, \"/m\". If using an external link, the link starts with \"http\", for example, \"https://example.com\".": "支持两种链接类型：内部链接和外部链接。如果使用内部链接，链接以“/”开头，例如“/m”。如果使用外部链接，链接以“http”开头，例如“https://example.com”。",
   "Details page for mobile": "移动端详情页",
-  "The message page has already been created.": "站内信页面已创建。"
+  "The message page has already been created.": "站内信页面已创建。",
+  "When select receivers from node result, only support ID of user (or IDs array of users). Others will not match any user.": "从节点结果中选择接收者时，仅支持用户ID（或用户ID数组）。其他将不匹配任何用户。"
 }

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/parseUserSelectionConf.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/parseUserSelectionConf.ts
@@ -8,6 +8,7 @@
  */
 
 import { Repository } from '@nocobase/database';
+import { isValidFilter } from '@nocobase/utils';
 export async function parseUserSelectionConf(
   userSelectionConfig: Array<Record<any, any> | string>,
   UserRepo: Repository,
@@ -16,6 +17,9 @@ export async function parseUserSelectionConf(
   const users = new Set<string>();
   for (const item of SelectionConfigs) {
     if (typeof item === 'object') {
+      if (!isValidFilter(item.filter)) {
+        continue;
+      }
       const result = await UserRepo.find({
         ...item,
         fields: ['id'],

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/compile.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/compile.ts
@@ -8,6 +8,7 @@
  */
 
 import { Handlebars } from '@nocobase/utils';
+import { isPlainObject } from '@nocobase/utils';
 
 function deepCompile(template: unknown, data: Record<string, any>): unknown {
   if (typeof template === 'string') {
@@ -15,7 +16,7 @@ function deepCompile(template: unknown, data: Record<string, any>): unknown {
     return c(data);
   } else if (Array.isArray(template)) {
     return template.map((item) => deepCompile(item, data));
-  } else if (typeof template === 'object') {
+  } else if (isPlainObject(template)) {
     const result = Object.keys(template).reduce((object, key) => {
       const value = deepCompile(template[key], data);
       return Object.assign(object, { [key]: value });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Avoid wrong receivers configuration query all users.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid wrong receivers configuration query all users |
| 🇨🇳 Chinese | 避免错误的接收人配置导致查询出全部用户 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
