### PR TITLE
fix: replace all instances of ctx.state.currentRole with ctx.state.currentRoles

### DIFF
--- a/packages/core/server/src/middlewares/parse-variables.ts
+++ b/packages/core/server/src/middlewares/parse-variables.ts
@@ -62,7 +62,7 @@ export async function parseVariables(ctx, next) {
       // 新的命名方式，防止和 formily 内置变量冲突
       $nDate: getDateVars(),
       $user: getUser(ctx),
-      $nRole: ctx.state.currentRole,
+      $nRole: ctx.state.currentRole === 'union' ? ctx.state.currentRoles : ctx.state.currentRole,
     },
   });
   await next();

--- a/packages/core/server/src/middlewares/parse-variables.ts
+++ b/packages/core/server/src/middlewares/parse-variables.ts
@@ -62,7 +62,7 @@ export async function parseVariables(ctx, next) {
       // 新的命名方式，防止和 formily 内置变量冲突
       $nDate: getDateVars(),
       $user: getUser(ctx),
-      $nRole: ctx.state.currentRole === 'union' ? ctx.state.currentRoles : ctx.state.currentRole,
+      $nRole: ctx.state.currentRole === '__union__' ? ctx.state.currentRoles : ctx.state.currentRole,
     },
   });
   await next();

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/actions.test.ts
@@ -143,7 +143,7 @@ describe('destroy action with acl', () => {
     expect(response.statusCode).toEqual(200);
   });
 
-  it.only('should throw error when user has no permission to destroy record', async () => {
+  it('should throw error when user has no permission to destroy record', async () => {
     const userRole = app.acl.define({
       role: 'user',
     });

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/actions.test.ts
@@ -126,6 +126,7 @@ describe('destroy action with acl', () => {
     app.resourcer.use(
       (ctx, next) => {
         ctx.state.currentRole = 'user';
+        ctx.state.currentRoles = ['user'];
         ctx.state.currentUser = {
           id: 1,
         };
@@ -142,7 +143,7 @@ describe('destroy action with acl', () => {
     expect(response.statusCode).toEqual(200);
   });
 
-  it('should throw error when user has no permission to destroy record', async () => {
+  it.only('should throw error when user has no permission to destroy record', async () => {
     const userRole = app.acl.define({
       role: 'user',
     });
@@ -162,6 +163,7 @@ describe('destroy action with acl', () => {
     app.resourcer.use(
       (ctx, next) => {
         ctx.state.currentRole = 'user';
+        ctx.state.currentRoles = ['user'];
         ctx.state.currentUser = {
           id: 1,
         };
@@ -178,7 +180,7 @@ describe('destroy action with acl', () => {
     });
 
     // should throw errors
-    expect(response.statusCode).toEqual(403);
+    expect(response.statusCode).toEqual(200);
   });
 
   it.skip('should throw error when user has no permissions with array query', async () => {
@@ -218,6 +220,7 @@ describe('destroy action with acl', () => {
     app.resourcer.use(
       (ctx, next) => {
         ctx.state.currentRole = 'user';
+        ctx.state.currentRoles = ['user'];
         ctx.state.currentUser = {
           id: 1,
         };

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/actions.test.ts
@@ -180,7 +180,7 @@ describe('destroy action with acl', () => {
     });
 
     // should throw errors
-    expect(response.statusCode).toEqual(200);
+    expect(response.statusCode).toEqual(403);
   });
 
   it.skip('should throw error when user has no permissions with array query', async () => {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/actions/role-check.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/actions/role-check.ts
@@ -50,7 +50,7 @@ export async function checkAction(ctx, next) {
   );
   let uiButtonSchemasBlacklist = [];
   const currentRole = ctx.state.currentRole;
-  if (!currentRoles.some((x) => x === 'root')) {
+  if (!currentRoles.includes('root')) {
     const eqCurrentRoleList = await ctx.db
       .getRepository('uiButtonSchemasRoles')
       .find({

--- a/packages/plugins/@nocobase/plugin-acl/src/server/actions/role-check.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/actions/role-check.ts
@@ -50,18 +50,18 @@ export async function checkAction(ctx, next) {
   );
   let uiButtonSchemasBlacklist = [];
   const currentRole = ctx.state.currentRole;
-  if (currentRole !== 'root') {
+  if (!currentRoles.some((x) => x === 'root')) {
     const eqCurrentRoleList = await ctx.db
       .getRepository('uiButtonSchemasRoles')
       .find({
-        filter: { 'roleName.$eq': currentRole },
+        filter: { roleName: currentRoles },
       })
       .then((list) => list.map((v) => v.uid));
 
     const NECurrentRoleList = await ctx.db
       .getRepository('uiButtonSchemasRoles')
       .find({
-        filter: { 'roleName.$ne': currentRole },
+        filter: { 'roleName.$notIn': currentRoles },
       })
       .then((list) => list.map((v) => v.uid));
     uiButtonSchemasBlacklist = NECurrentRoleList.filter((uid) => !eqCurrentRoleList.includes(uid));

--- a/packages/plugins/@nocobase/plugin-acl/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/index.ts
@@ -11,5 +11,6 @@ export * from './middlewares/setCurrentRole';
 export * from './middlewares/with-acl-meta';
 export { RoleResourceActionModel } from './model/RoleResourceActionModel';
 export { RoleResourceModel } from './model/RoleResourceModel';
-export { UNION_ROLE_KEY } from './constants';
+export * from './constants';
+export * from './enum';
 export { default } from './server';

--- a/packages/plugins/@nocobase/plugin-acl/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/server.ts
@@ -450,7 +450,7 @@ export class PluginACLServer extends Plugin {
     this.app.acl.allow('roles', 'getSystemRoleMode', 'loggedIn');
 
     this.app.acl.allow('*', '*', (ctx) => {
-      return ctx.state.currentRole.includes('root');
+      return ctx.state.currentRoles?.includes('root');
     });
 
     this.app.acl.addFixedParams('collections', 'destroy', () => {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/server.ts
@@ -450,7 +450,7 @@ export class PluginACLServer extends Plugin {
     this.app.acl.allow('roles', 'getSystemRoleMode', 'loggedIn');
 
     this.app.acl.allow('*', '*', (ctx) => {
-      return ctx.state.currentRole === 'root';
+      return ctx.state.currentRole.includes('root');
     });
 
     this.app.acl.addFixedParams('collections', 'destroy', () => {

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts
@@ -76,7 +76,7 @@ export async function send(this: CustomRequestPlugin, ctx: Context, next: Next) 
   } = values;
 
   // root role has all permissions
-  if (!ctx.state.currentRoles.some((x) => x === 'root')) {
+  if (!ctx.state.currentRoles.includes('root')) {
     const crRepo = ctx.db.getRepository('customRequestsRoles');
     const hasRoles = await crRepo.find({
       filter: {

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts
@@ -76,7 +76,7 @@ export async function send(this: CustomRequestPlugin, ctx: Context, next: Next) 
   } = values;
 
   // root role has all permissions
-  if (ctx.state.currentRole !== 'root') {
+  if (!ctx.state.currentRoles.some((x) => x === 'root')) {
     const crRepo = ctx.db.getRepository('customRequestsRoles');
     const hasRoles = await crRepo.find({
       filter: {
@@ -85,7 +85,7 @@ export async function send(this: CustomRequestPlugin, ctx: Context, next: Next) 
     });
 
     if (hasRoles.length) {
-      if (!hasRoles.find((item) => item.roleName === ctx.state.currentRole)) {
+      if (!hasRoles.some((item) => ctx.state.currentRoles.includes(item.roleName))) {
         return ctx.throw(403, 'custom request no permission');
       }
     }

--- a/packages/plugins/@nocobase/plugin-client/src/server/__tests__/desktopRoutes-union-role.test.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/__tests__/desktopRoutes-union-role.test.ts
@@ -6,8 +6,7 @@
  * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
-
-import { UNION_ROLE_KEY } from '@nocobase/plugin-acl';
+import { UNION_ROLE_KEY, SystemRoleMode } from '@nocobase/plugin-acl';
 import { MockServer, createMockServer, ExtendedAgent } from '@nocobase/test';
 
 describe('Web client desktopRoutes', async () => {
@@ -241,5 +240,20 @@ describe('Web client desktopRoutes', async () => {
     const accessibleMenus = await getAccessibleMenus(agent);
     expect(accessibleMenus.length).toBe(1);
     expect(accessibleMenus[0].title).toBe(page1.title);
+  });
+
+  it('should display desktop menu when roles include root', async () => {
+    let rootAgent = await app.agent().login(rootUser);
+    const page1 = await createUiMenu(rootAgent, { title: 'page1' });
+    let accessibleMenus = await getAccessibleMenus(rootAgent);
+    expect(accessibleMenus.some((x) => x.title === page1.title)).toBeTruthy();
+    await rootAgent.resource('roles').setSystemRoleMode({
+      values: {
+        roleMode: SystemRoleMode.allowUseUnion,
+      },
+    });
+    rootAgent = await app.agent().login(rootUser, UNION_ROLE_KEY);
+    accessibleMenus = await getAccessibleMenus(rootAgent);
+    expect(accessibleMenus.some((x) => x.title === page1.title)).toBeTruthy();
   });
 });

--- a/packages/plugins/@nocobase/plugin-client/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/server.ts
@@ -252,7 +252,7 @@ export class PluginClientServer extends Plugin {
       const desktopRoutesRepository = ctx.db.getRepository('desktopRoutes');
       const rolesRepository = ctx.db.getRepository('roles');
 
-      if (ctx.state.currentRole === 'root') {
+      if (ctx.state.currentRoles.includes('root')) {
         ctx.body = await desktopRoutesRepository.find({
           tree: true,
           ...ctx.query,

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/models/data-source.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/models/data-source.ts
@@ -125,7 +125,7 @@ export class DataSourceModel extends Model {
       }
 
       acl.allow('*', '*', (ctx) => {
-        return ctx.state.currentRoles.include('root');
+        return ctx.state.currentRoles.includes('root');
       });
 
       dataSource.resourceManager.use(setCurrentRole, { tag: 'setCurrentRole', before: 'acl', after: 'auth' });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/models/data-source.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/models/data-source.ts
@@ -125,7 +125,7 @@ export class DataSourceModel extends Model {
       }
 
       acl.allow('*', '*', (ctx) => {
-        return ctx.state.currentRoles.includes('root');
+        return ctx.state.currentRoles?.includes('root');
       });
 
       dataSource.resourceManager.use(setCurrentRole, { tag: 'setCurrentRole', before: 'acl', after: 'auth' });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/models/data-source.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/models/data-source.ts
@@ -125,7 +125,7 @@ export class DataSourceModel extends Model {
       }
 
       acl.allow('*', '*', (ctx) => {
-        return ctx.state.currentRole === 'root';
+        return ctx.state.currentRoles.include('root');
       });
 
       dataSource.resourceManager.use(setCurrentRole, { tag: 'setCurrentRole', before: 'acl', after: 'auth' });

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/external-data-source.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/external-data-source.test.ts
@@ -54,6 +54,7 @@ describe('external data source', () => {
       ...ctx,
       state: {
         currentRole: 'test',
+        currentRoles: ['test'],
       },
       action: {
         params: {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
@@ -204,7 +204,7 @@ export const checkPermission = (ctx: Context, next: Next) => {
   const { collection, dataSource } = ctx.action.params.values as QueryParams;
   const roleNames = ctx.state.currentRoles || ['anonymous'];
   const acl = ctx.app.dataSourceManager.get(dataSource)?.acl || ctx.app.acl;
-  const can = acl.can({ role: roleNames, resource: collection, action: 'list' });
+  const can = acl.can({ roles: roleNames, resource: collection, action: 'list' });
   if (!can && !roleNames.includes('root')) {
     ctx.throw(403, 'No permissions');
   }

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
@@ -202,10 +202,10 @@ export const cacheMiddleware = async (ctx: Context, next: Next) => {
 
 export const checkPermission = (ctx: Context, next: Next) => {
   const { collection, dataSource } = ctx.action.params.values as QueryParams;
-  const roleName = ctx.state.currentRole || 'anonymous';
+  const roleNames = ctx.state.currentRoles || ['anonymous'];
   const acl = ctx.app.dataSourceManager.get(dataSource)?.acl || ctx.app.acl;
-  const can = acl.can({ role: roleName, resource: collection, action: 'list' });
-  if (!can && roleName !== 'root') {
+  const can = acl.can({ role: roleNames, resource: collection, action: 'list' });
+  if (!can && !roleNames.includes('root')) {
     ctx.throw(403, 'No permissions');
   }
   return next();

--- a/packages/plugins/@nocobase/plugin-mobile/src/server/__tests__/union-role-mobileRoutes.test.ts
+++ b/packages/plugins/@nocobase/plugin-mobile/src/server/__tests__/union-role-mobileRoutes.test.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { UNION_ROLE_KEY } from '@nocobase/plugin-acl';
+import { SystemRoleMode, UNION_ROLE_KEY } from '@nocobase/plugin-acl';
 import { MockServer, createMockServer, ExtendedAgent } from '@nocobase/test';
 
 describe('union role mobileRoutes', async () => {
@@ -251,5 +251,20 @@ describe('union role mobileRoutes', async () => {
     // auto can see new menu
     const accessibleMenus = await getAccessibleMenus(agent);
     expect(accessibleMenus[0].title).toBe(page1.title);
+  });
+
+  it('should display desktop menu when roles include root', async () => {
+    let rootAgent = await app.agent().login(rootUser);
+    const page1 = await createUiMenu(rootAgent, { title: 'page1' });
+    let accessibleMenus = await getAccessibleMenus(rootAgent);
+    expect(accessibleMenus.some((x) => x.title === page1.title)).toBeTruthy();
+    await rootAgent.resource('roles').setSystemRoleMode({
+      values: {
+        roleMode: SystemRoleMode.allowUseUnion,
+      },
+    });
+    rootAgent = await app.agent().login(rootUser, UNION_ROLE_KEY);
+    accessibleMenus = await getAccessibleMenus(rootAgent);
+    expect(accessibleMenus.some((x) => x.title === page1.title)).toBeTruthy();
   });
 });

--- a/packages/plugins/@nocobase/plugin-mobile/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-mobile/src/server/plugin.ts
@@ -125,7 +125,7 @@ export class PluginMobileServer extends Plugin {
       const mobileRoutesRepository = ctx.db.getRepository('mobileRoutes');
       const rolesRepository = ctx.db.getRepository('roles');
 
-      if (ctx.state.currentRole === 'root') {
+      if (ctx.state.currentRoles.includes('root')) {
         ctx.body = await mobileRoutesRepository.find({
           tree: true,
           ...ctx.query,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Incorrect adjustment of the role - permission calculation logic might lead to over - or under - restricting access in other, untested role - combination scenarios. 

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Replace all instances of ctx.state.currentRole (single role) with ctx.state.currentRoles (supports multiple roles). |
| 🇨🇳 Chinese |  将所有使用 ctx.state.currentRole（单角色）的地方替换为 ctx.state.currentRoles（支持多角色）。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
