### PR TITLE
fix: resolve error when query has createdById but table lacks it

### DIFF
--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -453,9 +453,28 @@ export class ACL extends EventEmitter {
    * @internal
    */
   filterParams(ctx, resourceName, params) {
-    if (params?.filter?.createdById) {
-      const collection = ctx.db.getCollection(resourceName);
-      if (!collection || !collection.getField('createdById')) {
+    const collection = ctx.db.getCollection(resourceName);
+    if (!collection) {
+      throw new NoPermissionError('createdById field not found');
+    }
+    const hasCreatedById = collection.getField('createdById');
+    if (params?.filter?.createdById && !hasCreatedById) {
+      throw new NoPermissionError('createdById field not found');
+    }
+    if (params?.filter?.createdById && !hasCreatedById) {
+      throw new NoPermissionError('createdById field not found');
+    }
+
+    // 检查 $or 条件中的 createdById
+    if (params?.filter?.$or?.length && !hasCreatedById) {
+      const checkCreatedById = (items) => {
+        return items.some(
+          (x) =>
+            'createdById' in x || x.$or?.some((y) => 'createdById' in y) || x.$and?.some((y) => 'createdById' in y),
+        );
+      };
+
+      if (checkCreatedById(params.filter.$or)) {
         throw new NoPermissionError('createdById field not found');
       }
     }

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/union-role.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/union-role.test.ts
@@ -425,4 +425,42 @@ describe('union role: full permissions', async () => {
     expect(getSystemSettingsResponse.status).toBe(200);
     expect(getSystemSettingsResponse.body.data.roleMode).toStrictEqual(SystemRoleMode.allowUseUnion);
   });
+
+  it(`should response no permission when createdById field is missing in data tables`, async () => {
+    let getRolesResponse = await agent.resource('roles').list({ pageSize: 30 });
+    expect(getRolesResponse.statusCode).toBe(403);
+
+    const dataSourceRoleRepo = db.getRepository('dataSourcesRoles');
+    const dataSourceRole1 = await dataSourceRoleRepo.findOne({
+      where: { dataSourceKey: 'main', roleName: role1.name },
+    });
+    await dataSourceRoleRepo.update({
+      filter: { id: dataSourceRole1.id },
+      values: {
+        strategy: { actions: ['view:own'] },
+      },
+    });
+
+    const dataSourceRole2 = await dataSourceRoleRepo.findOne({
+      where: { dataSourceKey: 'main', roleName: role2.name },
+    });
+    await dataSourceRoleRepo.update({
+      filter: { id: dataSourceRole2.id },
+      values: {
+        strategy: { actions: ['view:own'] },
+      },
+    });
+
+    agent = await app.agent().login(user, role1.name);
+    getRolesResponse = await agent.resource('roles').list({ pageSize: 30 });
+    expect(getRolesResponse.statusCode).toBe(403);
+
+    agent = await app.agent().login(user, role2.name);
+    getRolesResponse = await agent.resource('roles').list({ pageSize: 30 });
+    expect(getRolesResponse.statusCode).toBe(403);
+
+    agent = await app.agent().login(user, UNION_ROLE_KEY);
+    getRolesResponse = await agent.resource('roles').list({ pageSize: 30 });
+    expect(getRolesResponse.statusCode).toBe(403);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Fixed the error that occurred when querying data with a createdById condition on a table lacking the createdById field.  

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fixed the error that occurred when querying data with a createdById condition on a table lacking the createdById field.   |
| 🇨🇳 Chinese | 修复了在没有createdById字段的数据表上使用包含createdById条件进行数据查询时发生的错误。  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
