### PR TITLE
fix(plugin-workflow-manual): fix migration version

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/migrations/20250312100512-change-table-name.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/migrations/20250312100512-change-table-name.test.ts
@@ -7,12 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { createMockServer, MockServer } from '@nocobase/test';
+import { createMockServer } from '@nocobase/test';
 import { describe, test } from 'vitest';
 import workflowManualTasks from '../../collections/workflowManualTasks';
 import Migration from '../../migrations/20250312100512-change-table-name';
-
-const pgOnly = (schema) => (schema && process.env.DB_DIALECT == 'postgres' ? it : it.skip);
 
 const matrix: [string, string][] = [
   // schema, tablePrefix
@@ -24,7 +22,10 @@ const matrix: [string, string][] = [
 
 function matrixTest() {
   for (const [schema, tablePrefix] of matrix) {
-    pgOnly(schema)(`schema: ${schema}, tablePrefix: ${tablePrefix}`, async () => {
+    if (schema && process.env.DB_DIALECT !== 'postgres') {
+      continue;
+    }
+    test(`schema: ${schema}, tablePrefix: ${tablePrefix}`, async () => {
       const app = await createMockServer({
         database: {
           schema,

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/migrations/20250312100512-change-table-name.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/migrations/20250312100512-change-table-name.ts
@@ -10,7 +10,7 @@
 import { Migration } from '@nocobase/server';
 
 export default class extends Migration {
-  appVersion = '<1.6.2';
+  appVersion = '<1.7.0';
   on = 'beforeLoad';
   async up() {
     const { db } = this.context;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Change version limit of migration to `<1.7.0`.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Change version limit of migration to `<1.7.0` |
| 🇨🇳 Chinese | 调整迁移脚本版本范围限制为 `<1.7.0` |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
