### PR TITLE
fix(plugin-workflow-action-trigger): fix bulk edit action to trigger …

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/utils.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/utils.tsx
@@ -108,10 +108,13 @@ export const useCustomizeBulkEditActionProps = () => {
       actionField.data = field.data || {};
       actionField.data.loading = true;
       try {
-        const updateData: { filter?: any; values: any; forceUpdate: boolean } = {
+        const updateData: { filter?: any; values: any; forceUpdate: boolean; triggerWorkflows?: string } = {
           values: form.values,
           filter,
           forceUpdate: false,
+          triggerWorkflows: triggerWorkflows?.length
+            ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
+            : undefined,
         };
         if (updateMode === 'selected') {
           if (!selectedRecordKeys?.length) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix workflow can not be triggered in bulk edit submission.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix workflow can not be triggered in bulk edit submission |
| 🇨🇳 Chinese | 修复批量编辑提交时未能触发工作流的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
