### PR TITLE
fix(plugin-workflow): remove bind workflow settings button from data picker

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/settings/BindWorkflowConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/settings/BindWorkflowConfig.tsx
@@ -171,6 +171,11 @@ export function BindWorkflowConfig() {
     }),
   }[fieldSchema?.['x-action']];
 
+  // NOTE(refactor): hard code
+  if (fieldSchema['x-use-component-props'] === 'usePickActionProps') {
+    return null;
+  }
+
   return (
     <SchemaSettingsActionModalItem
       title={t('Bind workflows', { ns: 'workflow' })}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Remove bind workflow settings button from data picker.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove bind workflow settings button from data picker |
| 🇨🇳 Chinese | 在数据选择器中移除绑定工作流的配置按钮 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
