### PR TITLE
fix: the relationship fields are not displayed under the role union

### DIFF
--- a/packages/core/acl/src/__tests__/acl-role.test.ts
+++ b/packages/core/acl/src/__tests__/acl-role.test.ts
@@ -397,6 +397,34 @@ describe('multiple roles merge', () => {
         },
       });
     });
+    test('should union appends(params={ appends: [a,b]}) when appends = [a,b], appends =[]', () => {
+      acl.setAvailableAction('update');
+      acl.define({
+        role: 'role1',
+        actions: {
+          'posts:update': {
+            appends: ['a', 'b'],
+          },
+        },
+      });
+      acl.define({
+        role: 'role2',
+        actions: {
+          'posts:update': {
+            appends: [],
+          },
+        },
+      });
+      const canResult = acl.can({ resource: 'posts', action: 'update', roles: ['role1', 'role2'] });
+      expect(canResult).toStrictEqual({
+        role: 'role1',
+        resource: 'posts',
+        action: 'update',
+        params: {
+          appends: expect.arrayContaining(['a', 'b']),
+        },
+      });
+    });
   });
 
   describe('filter & fields merge', () => {

--- a/packages/core/acl/src/utils/acl-role.ts
+++ b/packages/core/acl/src/utils/acl-role.ts
@@ -184,7 +184,7 @@ export function mergeAclActionParams(sourceParams, targetParams) {
     },
     fields: andMerge,
     whitelist: andMerge,
-    appends: andMerge,
+    appends: 'union',
   });
   removeEmptyParams(mergedParams);
   return mergedParams;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Fixed the issue where relationship fields are not displayed under the role union.
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where relationship fields are not displayed under the role union.          |
| 🇨🇳 Chinese |      修复角色并集下关系字段不显示     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
