### PR TITLE
fix(evaluator): fix round decimal places

### DIFF
--- a/packages/core/evaluators/src/utils/__tests__/formulajs.test.ts
+++ b/packages/core/evaluators/src/utils/__tests__/formulajs.test.ts
@@ -7,14 +7,18 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import mathjs from '../mathjs';
+import formulajs from '../formulajs';
 
-describe('evaluators > mathjs', () => {
-  it('matrix type should be to array', () => {
-    expect(mathjs('range(1, 3, 1)')).toEqual([1, 2, 3]);
+describe('evaluators > formulajs', () => {
+  it('add new line in string', () => {
+    expect(formulajs(`CONCATENATE('a', '\\n', 'b')`)).toBe('a\nb');
+  });
+
+  it('calculate null with number', () => {
+    expect(formulajs('null + 1')).toBe(1);
   });
 
   it('precision should be 9', () => {
-    expect(mathjs('100*2.3')).toBe(230);
+    expect(formulajs('100*2.3')).toBe(230);
   });
 });

--- a/packages/core/evaluators/src/utils/formulajs.ts
+++ b/packages/core/evaluators/src/utils/formulajs.ts
@@ -22,7 +22,7 @@ export default evaluate.bind(function (expression: string, scope = {}) {
     if (Number.isNaN(result) || !Number.isFinite(result)) {
       return null;
     }
-    return round(result, 14);
+    return round(result, 9);
   }
   return result;
 }, {});

--- a/packages/core/evaluators/src/utils/mathjs.ts
+++ b/packages/core/evaluators/src/utils/mathjs.ts
@@ -18,7 +18,7 @@ export default evaluate.bind(
       if (Number.isNaN(result) || !Number.isFinite(result)) {
         return null;
       }
-      return math.round(result, 14);
+      return math.round(result, 9);
     }
     if (result instanceof math.Matrix) {
       return result.toArray();


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Revert round decimal places to 9, to avoid double number precision issues.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Revert round decimal places to 9 |
| 🇨🇳 Chinese | 将表达式计算保留小数调整回 9 位 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
