### PR TITLE
fix: add child button not displaying icon-only mode

### DIFF
--- a/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
+++ b/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
@@ -272,7 +272,6 @@ function FinallyButton({
       opacity: designable && (field?.data?.hidden || !aclCtx) && 0.1,
     };
   }, [designable, field?.data?.hidden]);
-
   if (inheritsCollections?.length > 0) {
     if (!linkageFromForm) {
       return allowAddToCurrent === undefined || allowAddToCurrent ? (
@@ -358,7 +357,7 @@ function FinallyButton({
         ...buttonStyle,
       }}
     >
-      {props.children}
+      {props.onlyIcon ? props.children[1] : props.children}
     </Button>
   );
 }

--- a/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
+++ b/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
@@ -272,6 +272,7 @@ function FinallyButton({
       opacity: designable && (field?.data?.hidden || !aclCtx) && 0.1,
     };
   }, [designable, field?.data?.hidden]);
+
   if (inheritsCollections?.length > 0) {
     if (!linkageFromForm) {
       return allowAddToCurrent === undefined || allowAddToCurrent ? (
@@ -357,7 +358,7 @@ function FinallyButton({
         ...buttonStyle,
       }}
     >
-      {props.onlyIcon ? props.children[1] : props.children}
+      {props.onlyIcon ? props?.children?.[1] : props?.children}
     </Button>
   );
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   add chi ld button not displaying icon-only mode        |
| 🇨🇳 Chinese |    添加子记录按钮设置只显示图标不生效      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
