### PR TITLE
fix: ensure ellipsis property is correctly set in schema component props

### DIFF
--- a/packages/core/client/src/modules/fields/component/Input/inputComponentSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/Input/inputComponentSettings.tsx
@@ -45,10 +45,11 @@ export const ellipsisSettingsItem: SchemaSettingsItemType = {
           tableFieldInstanceList.forEach((fieldInstance) => {
             fieldInstance.componentProps.ellipsis = checked;
           });
-          schema['x-component-props']['ellipsis'] = checked;
         } else {
           formField.componentProps.ellipsis = checked;
         }
+
+        schema['x-component-props']['ellipsis'] = checked;
 
         await dn.emit('patch', {
           schema: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      The 'Ellipsis overflow content' option requires a page refresh for the toggle state to take effect     |
| 🇨🇳 Chinese |      选项“省略超出长度的内容”需要刷新页面，开关的状态才生效     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
