### PR TITLE
fix: save as template not working if fields containing nest properties

### DIFF
--- a/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
+++ b/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
@@ -50,7 +50,7 @@ describe('CollectionSelect', () => {
         >
           <div
             aria-label="block-item-demo title"
-            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-11aiz3o"
+            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-1rquknz"
             role="button"
           >
             <div
@@ -191,7 +191,7 @@ describe('CollectionSelect', () => {
         >
           <div
             aria-label="block-item-demo title"
-            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-11aiz3o"
+            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-1rquknz"
             role="button"
           >
             <div

--- a/packages/core/client/src/schema-component/antd/table-v2/TableBlockDesigner.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/TableBlockDesigner.tsx
@@ -343,14 +343,14 @@ export const TableBlockDesigner = () => {
         }}
       />
       <SchemaSettingsConnectDataBlocks type={FilterBlockType.TABLE} emptyDescription={t('No blocks to connect')} />
-      {supportTemplate && <SchemaSettingsDivider />}
+      {/* {supportTemplate && <SchemaSettingsDivider />}
       {supportTemplate && (
         <SchemaSettingsTemplate
           componentName={`${componentNamePrefix}Table`}
           collectionName={name}
           resourceName={defaultResource}
         />
-      )}
+      )} */}
       <SchemaSettingsDivider />
       <SchemaSettingsRemove
         removeParentsIfNoChildren

--- a/packages/core/client/src/schema-component/antd/table-v2/__tests__/Table.settings.test.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/__tests__/Table.settings.test.tsx
@@ -233,10 +233,10 @@ describe('Table.settings', () => {
             },
           ],
         },
-        {
-          title: 'Save as template',
-          type: 'modal',
-        },
+        // {
+        //   title: 'Save as template',
+        //   type: 'modal',
+        // },
         {
           title: 'Delete',
           type: 'delete',

--- a/packages/core/client/src/schema-component/antd/table-v2/__tests__/Table.settings.test.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/__tests__/Table.settings.test.tsx
@@ -299,7 +299,12 @@ describe('Table.settings', () => {
 
   test('menu list', async () => {
     await renderSettings(getRenderSettingsOptions());
-    await checkTableSettings();
+    await checkTableSettings([
+      {
+        title: 'Save as template',
+        type: 'modal',
+      },
+    ]);
   });
 
   test('old schema', async () => {

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/SaveAsTemplateSetting.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/SaveAsTemplateSetting.tsx
@@ -23,7 +23,7 @@ import { useLocation } from 'react-router-dom';
 
 const blockDecoratorMenuMaps = {
   TableBlockProvider: ['Table', 'table'],
-  FormBlockProvider: ['Form', 'form'],
+  FormBlockProvider: ['FormItem', 'form'],
   DetailsBlockProvider: ['Details', 'details'],
   'List.Decorator': ['List', 'list'],
   'GridCard.Decorator': ['GridCard', 'gridCard'],

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/SaveAsTemplateSetting.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/SaveAsTemplateSetting.tsx
@@ -281,6 +281,7 @@ function getTemplateSchemaFromPage(schema: ISchema) {
     if (s['x-template-root-uid']) {
       return;
     }
+    t = t || {};
     _.merge(t, _.omit(s, ['x-uid', 'properties']));
     t['x-uid'] = uid();
     if (s.properties) {
@@ -288,7 +289,7 @@ function getTemplateSchemaFromPage(schema: ISchema) {
         if (s.properties[key]['x-template-root-uid']) {
           continue;
         }
-        _.set(t, `properties.${key}`, {});
+        _.set(t, `properties.['${key}']`, {});
         traverseSchema(s.properties[key], t.properties[key]);
       }
     }

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/index.tsx
@@ -169,6 +169,9 @@ export class PluginBlockTemplateClient extends Plugin {
             'blockSettings:createForm',
             'blockSettings:details',
             'blockSettings:detailsWithPagination',
+            'blockSettings:multiDataDetails',
+            'blockSettings:singleDataDetails',
+            'blockSettings:stepsForm',
             'blockSettings:filterCollapse',
             'blockSettings:filterForm',
             'blockSettings:gantt',
@@ -176,6 +179,13 @@ export class PluginBlockTemplateClient extends Plugin {
             'blockSettings:kanban',
             'blockSettings:list',
             'blockSettings:table',
+            'blockSettings:tree',
+            'ReadPrettyFormSettings',
+            'GanttBlockSettings',
+            'FormV1Settings',
+            'FormSettings',
+            'FormItemSettings',
+            'FormDetailsSettings',
           ];
           if (blockSettings.includes(key)) {
             // schemaSetting.add('template-saveAsTemplateItem', saveAsTemplateSetting);

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/initializers/TemplateBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/initializers/TemplateBlockInitializer.tsx
@@ -154,8 +154,12 @@ export function formSchemaPatch(currentSchema: ISchema, options?: any) {
         return key !== 'grid';
       });
       if (actionKey) {
-        _.set(currentSchema, `properties.${comKey}.x-use-component-props`, 'useEditFormBlockProps');
-        _.set(currentSchema, `properties.${comKey}.properties.${actionKey}.x-initializer`, 'editForm:configureActions');
+        _.set(currentSchema, `properties.['${comKey}'].x-use-component-props`, 'useEditFormBlockProps');
+        _.set(
+          currentSchema,
+          `properties.['${comKey}'].properties.['${actionKey}'].x-initializer`,
+          'editForm:configureActions',
+        );
 
         const actionBarSchema = _.get(currentSchema, `properties.${comKey}.properties.${actionKey}.properties`, {});
         for (const key in actionBarSchema) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Save as template action will be failed if containing association field |
| 🇨🇳 Chinese | 存在关联字段的区块另存为模板报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
