### PR TITLE
fix: template linkapge rules not synced for form template

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-template/src/client/initializers/TemplateBlockInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/initializers/TemplateBlockInitializer.tsx
@@ -43,6 +43,10 @@ export function convertTplBlock(
     if (newSchema['x-decorator'] === 'TemplateGridDecorator') {
       delete newSchema['x-decorator'];
     }
+    if (newSchema['x-linkage-rules']) {
+      // linkage rules 有可能保存在Grid组件中
+      delete newSchema['x-linkage-rules'];
+    }
     for (const key in tpl.properties) {
       const t = convertTplBlock(tpl.properties[key], virtual, isRoot, newRootId, templateKey, options);
       if (isRoot) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | linkage rules of the form block have not been synced from template correctly |
| 🇨🇳 Chinese | 表单联动规则未正确从模板同步 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
