### PR TITLE
fix: duplicate saveas template menu for details block

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-template/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/index.tsx
@@ -169,8 +169,6 @@ export class PluginBlockTemplateClient extends Plugin {
             'blockSettings:createForm',
             'blockSettings:details',
             'blockSettings:detailsWithPagination',
-            'blockSettings:multiDataDetails',
-            'blockSettings:singleDataDetails',
             'blockSettings:stepsForm',
             'blockSettings:filterCollapse',
             'blockSettings:filterForm',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | duplicate save as template menu in the details block |
| 🇨🇳 Chinese | 详情区块存在重复的另存为模板菜单 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
