### PR TITLE
fix(plugin-workflow-action-trigger): trigger on multiple records

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
@@ -174,7 +174,7 @@ export default class extends Trigger {
               });
             }
           }
-          event.push({ data: toJSON(payload), ...userInfo });
+          (workflow.sync ? syncGroup : asyncGroup).push([workflow, { data: toJSON(payload), ...userInfo }]);
         }
       } else {
         const { filterTargetKey, repository } = (<Application>context.app).dataSourceManager.dataSources
@@ -188,9 +188,8 @@ export default class extends Trigger {
             appends,
           });
         }
-        event.push({ data, ...userInfo });
+        (workflow.sync ? syncGroup : asyncGroup).push([workflow, { data, ...userInfo }]);
       }
-      (workflow.sync ? syncGroup : asyncGroup).push(event);
     }
 
     for (const event of syncGroup) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Multiple records in bulk action should trigger multiple times.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Multiple records in bulk action should trigger multiple times |
| 🇨🇳 Chinese | 多行记录的批量操作需要触发多次 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
