### PR TITLE
feat(database): add trim option for string field

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/input.ts
+++ b/packages/core/client/src/collection-manager/interfaces/input.ts
@@ -62,6 +62,12 @@ export class InputFieldInterface extends CollectionFieldInterface {
   hasDefaultValue = true;
   properties = {
     ...defaultProps,
+    trim: {
+      type: 'boolean',
+      'x-content': '{{t("Automatically remove heading and tailing spaces")}}',
+      'x-decorator': 'FormItem',
+      'x-component': 'Checkbox',
+    },
     layout: {
       type: 'void',
       title: '{{t("Index")}}',

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -258,6 +258,7 @@
   "Parent collection fields": "父表字段",
   "Basic": "基本类型",
   "Single line text": "单行文本",
+  "Automatically remove heading and tailing spaces": "自动去除首尾空白字符",
   "Long text": "多行文本",
   "Phone": "手机号码",
   "Email": "电子邮箱",

--- a/packages/core/database/src/__tests__/fields/string-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/string-field.test.ts
@@ -105,4 +105,18 @@ describe('string field', () => {
       name2: 'n2111',
     });
   });
+
+  it('trim', async () => {
+    const collection = db.collection({
+      name: 'tests',
+      fields: [{ type: 'string', name: 'name', trim: true }],
+    });
+    await db.sync();
+    const model = await collection.model.create({
+      name: '  n1\n ',
+    });
+    expect(model.toJSON()).toMatchObject({
+      name: 'n1',
+    });
+  });
 });

--- a/packages/core/database/src/fields/string-field.ts
+++ b/packages/core/database/src/fields/string-field.ts
@@ -18,9 +18,27 @@ export class StringField extends Field {
 
     return DataTypes.STRING;
   }
+
+  preprocess = (instance) => {
+    const { name } = this.options;
+    if (this.options.trim && instance[name]) {
+      instance.set(name, instance[name].trim());
+    }
+  };
+
+  bind() {
+    super.bind();
+    this.on('beforeSave', this.preprocess);
+  }
+
+  unbind() {
+    super.unbind();
+    this.off('beforeSave', this.preprocess);
+  }
 }
 
 export interface StringFieldOptions extends BaseColumnFieldOptions {
   type: 'string';
   length?: number;
+  trim?: boolean;
 }

--- a/packages/core/database/src/fields/string-field.ts
+++ b/packages/core/database/src/fields/string-field.ts
@@ -8,32 +8,31 @@
  */
 
 import { DataTypes } from 'sequelize';
-import { BaseColumnFieldOptions, Field } from './field';
+import { BaseColumnFieldOptions, Field, FieldContext } from './field';
 
 export class StringField extends Field {
+  constructor(options?: any, context?: FieldContext) {
+    super(
+      {
+        set(value) {
+          if (value && options.trim) {
+            this.setDataValue(options.name, value.trim());
+          } else {
+            this.setDataValue(options.name, value);
+          }
+        },
+        ...options,
+      },
+      context,
+    );
+  }
+
   get dataType() {
     if (this.options.length) {
       return DataTypes.STRING(this.options.length);
     }
 
     return DataTypes.STRING;
-  }
-
-  preprocess = (instance) => {
-    const { name } = this.options;
-    if (this.options.trim && instance[name]) {
-      instance.set(name, instance[name].trim());
-    }
-  };
-
-  bind() {
-    super.bind();
-    this.on('beforeSave', this.preprocess);
-  }
-
-  unbind() {
-    super.unbind();
-    this.off('beforeSave', this.preprocess);
   }
 }
 

--- a/packages/core/database/src/fields/string-field.ts
+++ b/packages/core/database/src/fields/string-field.ts
@@ -11,28 +11,22 @@ import { DataTypes } from 'sequelize';
 import { BaseColumnFieldOptions, Field, FieldContext } from './field';
 
 export class StringField extends Field {
-  constructor(options?: any, context?: FieldContext) {
-    super(
-      {
-        set(value) {
-          if (value && options.trim) {
-            this.setDataValue(options.name, value.trim());
-          } else {
-            this.setDataValue(options.name, value);
-          }
-        },
-        ...options,
-      },
-      context,
-    );
-  }
-
   get dataType() {
     if (this.options.length) {
       return DataTypes.STRING(this.options.length);
     }
 
     return DataTypes.STRING;
+  }
+
+  additionalSequelizeOptions() {
+    const { name, trim } = this.options;
+
+    return {
+      set(value) {
+        this.setDataValue(name, trim ? value?.trim() : value);
+      },
+    };
   }
 }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add trim option for string field.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4ec36759-8a1c-455f-b1a9-9005357dba94" />

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add trim option for string field |
| 🇨🇳 Chinese | 为单行文本增加自动去除首尾空白字符的选项 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
