### PR TITLE
fix: linkage conflict between same-named association fields in different sub-tables within the same form

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -69,6 +69,11 @@ export const filterAnalyses = (filters): any[] => {
   return results;
 };
 
+function getFieldPath(str) {
+  const lastIndex = str.lastIndexOf('.');
+  return lastIndex === -1 ? str : str.slice(0, lastIndex);
+}
+
 const InternalAssociationSelect = observer(
   (props: AssociationSelectProps) => {
     const { objectValue = true, addMode: propsAddMode, ...rest } = props;
@@ -100,11 +105,14 @@ const InternalAssociationSelect = observer(
         //支持深层次子表单
         onFieldInputValueChange('*', (fieldPath: any) => {
           const linkageFields = filterAnalyses(field.componentProps?.service?.params?.filter) || [];
+          const linageFieldEntire = getFieldPath(fieldPath.address.entire);
+          const targetFieldEntire = getFieldPath(field.address.entire);
           if (
             linkageFields.includes(fieldPath?.props?.name) &&
             field.value &&
             isEqual(fieldPath?.indexes, field?.indexes) &&
-            fieldPath?.props?.name !== field.props.name
+            fieldPath?.props?.name !== field.props.name &&
+            isEqual(linageFieldEntire, targetFieldEntire)
           ) {
             field.setValue(null);
             setInnerValue(null);


### PR DESCRIPTION
…ent sub-tables within same form

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     linkage conflict between same-named association fields in different sub-tables within the same form      |
| 🇨🇳 Chinese |     同一表单中不同关系字段的同名关系字段的联动互相影响      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
