### PR TITLE
fix(database): fix datetimeNoTz field

### DIFF
--- a/packages/core/database/src/fields/datetime-no-tz-field.ts
+++ b/packages/core/database/src/fields/datetime-no-tz-field.ts
@@ -78,9 +78,7 @@ export class DatetimeNoTzField extends Field {
         const momentVal = moment(val);
         if ((typeof val === 'string' && isIso8601(val)) || val instanceof Date) {
           momentVal.utcOffset(timezone);
-          if (isPg) {
-            momentVal.utcOffset(-dateOffset, true);
-          }
+          momentVal.utcOffset(-dateOffset, true);
         }
 
         if (isMySQLCompatibleDialect) {

--- a/packages/core/database/src/fields/datetime-no-tz-field.ts
+++ b/packages/core/database/src/fields/datetime-no-tz-field.ts
@@ -29,26 +29,24 @@ export class DatetimeNoTzField extends Field {
       return DatetimeNoTzTypeMySQL;
     }
 
-    return DataTypes.STRING;
+    return DataTypes.DATE;
   }
 
-  init() {
+  beforeSave = async (instance, options) => {
     const { name, defaultToCurrentTime, onUpdateToCurrentTime } = this.options;
 
-    this.beforeSave = async (instance, options) => {
-      const value = instance.get(name);
+    const value = instance.get(name);
 
-      if (!value && instance.isNewRecord && defaultToCurrentTime) {
-        instance.set(name, new Date());
-        return;
-      }
+    if (!value && instance.isNewRecord && defaultToCurrentTime) {
+      instance.set(name, new Date());
+      return;
+    }
 
-      if (onUpdateToCurrentTime) {
-        instance.set(name, new Date());
-        return;
-      }
-    };
-  }
+    if (onUpdateToCurrentTime) {
+      instance.set(name, new Date());
+      return;
+    }
+  };
 
   additionalSequelizeOptions(): {} {
     const { name } = this.options;
@@ -57,17 +55,14 @@ export class DatetimeNoTzField extends Field {
     const timezone = this.database.options.rawTimezone || '+00:00';
 
     const isPg = this.database.inDialect('postgres');
+    const isMySQLCompatibleDialect = this.database.isMySQLCompatibleDialect();
 
     return {
       get() {
         const val = this.getDataValue(name);
 
         if (val instanceof Date) {
-          if (isPg) {
-            return moment(val).format('YYYY-MM-DD HH:mm:ss');
-          }
-          // format to YYYY-MM-DD HH:mm:ss
-          const momentVal = moment(val).utcOffset(timezone);
+          const momentVal = moment(val);
           return momentVal.format('YYYY-MM-DD HH:mm:ss');
         }
 
@@ -75,18 +70,26 @@ export class DatetimeNoTzField extends Field {
       },
 
       set(val) {
-        if (typeof val === 'string' && isIso8601(val)) {
-          const momentVal = moment(val).utcOffset(timezone);
-          val = momentVal.format('YYYY-MM-DD HH:mm:ss');
+        if (val == null) {
+          return this.setDataValue(name, null);
         }
 
-        if (val && val instanceof Date) {
-          // format to YYYY-MM-DD HH:mm:ss
-          const momentVal = moment(val).utcOffset(timezone);
-          val = momentVal.format('YYYY-MM-DD HH:mm:ss');
+        const dateOffset = new Date().getTimezoneOffset();
+        const momentVal = moment(val);
+        if ((typeof val === 'string' && isIso8601(val)) || val instanceof Date) {
+          momentVal.utcOffset(timezone);
+          if (isPg) {
+            momentVal.utcOffset(-dateOffset, true);
+          }
         }
 
-        return this.setDataValue(name, val);
+        if (isMySQLCompatibleDialect) {
+          momentVal.millisecond(0);
+        }
+
+        const date = momentVal.toDate();
+
+        return this.setDataValue(name, date);
       },
     };
   }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Avoid "datetimeNoTz" field changes when value not changed in updating record.

### Description 

Sequelize is using `_.isEqual` to compare old value and new value. While the implementation in legacy `datetimeNoTz` field always set string value to record, this will cause changed (to Date value), which is not expected.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid "datetimeNoTz" field changes when value not changed in updating record |
| 🇨🇳 Chinese | 避免“日期时间（无时区）”字段在值未变动的更新时触发值改变 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
