### PR TITLE
fix(client): support disabled props for SchemaInitializerItem when has items

### DIFF
--- a/packages/core/client/src/application/schema-initializer/components/SchemaInitializerItem.tsx
+++ b/packages/core/client/src/application/schema-initializer/components/SchemaInitializerItem.tsx
@@ -63,7 +63,7 @@ export const SchemaInitializerItem = memo(
           className: className,
           label: children || compile(title),
           onClick: (info) => {
-            if (info.key !== name) return;
+            if (disabled || info.key !== name) return;
             if (closeInitializerMenuWhenClick) {
               setVisible?.(false);
             }
@@ -73,9 +73,9 @@ export const SchemaInitializerItem = memo(
           children: childrenItems,
         },
       ];
-    }, [name, style, className, children, title, onClick, icon, childrenItems]);
+    }, [name, disabled, style, className, children, title, onClick, icon, childrenItems]);
 
-    if (items && items.length > 0) {
+    if (items && items.length > 0 && !disabled) {
       return <SchemaInitializerMenu items={menuItems}></SchemaInitializerMenu>;
     }
     return (

--- a/packages/core/client/src/application/schema-initializer/components/SchemaInitializerItem.tsx
+++ b/packages/core/client/src/application/schema-initializer/components/SchemaInitializerItem.tsx
@@ -75,8 +75,8 @@ export const SchemaInitializerItem = memo(
       ];
     }, [name, disabled, style, className, children, title, onClick, icon, childrenItems]);
 
-    if (items && items.length > 0 && !disabled) {
-      return <SchemaInitializerMenu items={menuItems}></SchemaInitializerMenu>;
+    if (items && items.length > 0) {
+      return <SchemaInitializerMenu disabled={disabled} items={menuItems}></SchemaInitializerMenu>;
     }
     return (
       <div


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix `disabled` property not works when `SchemaInitializerItem` has items.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `disabled` property not works when `SchemaInitializerItem` has `items` |
| 🇨🇳 Chinese | 修复 `SchemaInitializerItem` 配置了 `items` 时 `disabled` 属性无效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
