### PR TITLE
feat(database): add trim option for text field

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/textarea.ts
+++ b/packages/core/client/src/collection-manager/interfaces/textarea.ts
@@ -31,6 +31,12 @@ export class TextareaFieldInterface extends CollectionFieldInterface {
   titleUsable = true;
   properties = {
     ...defaultProps,
+    trim: {
+      type: 'boolean',
+      'x-content': '{{t("Automatically remove heading and tailing spaces")}}',
+      'x-decorator': 'FormItem',
+      'x-component': 'Checkbox',
+    },
   };
   schemaInitialize(schema: ISchema, { block }) {
     if (['Table', 'Kanban'].includes(block)) {

--- a/packages/core/database/src/__tests__/fields/text-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/text-field.test.ts
@@ -52,4 +52,18 @@ describe('text field', () => {
     });
     await Test.sync();
   });
+
+  it('trim', async () => {
+    const collection = db.collection({
+      name: 'tests',
+      fields: [{ type: 'text', name: 'name', trim: true }],
+    });
+    await db.sync();
+    const model = await collection.model.create({
+      name: '  n1\n ',
+    });
+    expect(model.toJSON()).toMatchObject({
+      name: 'n1',
+    });
+  });
 });

--- a/packages/core/database/src/fields/text-field.ts
+++ b/packages/core/database/src/fields/text-field.ts
@@ -23,9 +23,20 @@ export class TextField extends Field {
       this.options.defaultValue = null;
     }
   }
+
+  additionalSequelizeOptions() {
+    const { name, trim } = this.options;
+
+    return {
+      set(value) {
+        this.setDataValue(name, trim ? value?.trim() : value);
+      },
+    };
+  }
 }
 
 export interface TextFieldOptions extends BaseColumnFieldOptions {
   type: 'text';
   length?: 'tiny' | 'medium' | 'long';
+  trim?: boolean;
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add trim option for text field.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add trim option for text field |
| 🇨🇳 Chinese | 为多行文本类型字段增加去除首尾空白字符的选项 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
