### PR TITLE
refactor(file-manager): add trim option for text fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/collections/storages.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/collections/storages.ts
@@ -21,6 +21,7 @@ export default defineCollection({
       type: 'string',
       name: 'title',
       translation: true,
+      trim: true,
     },
     {
       title: '英文标识',
@@ -28,6 +29,7 @@ export default defineCollection({
       type: 'uid',
       name: 'name',
       unique: true,
+      trim: true,
     },
     {
       comment: '类型标识，如 local/ali-oss 等',
@@ -51,12 +53,14 @@ export default defineCollection({
       type: 'text',
       name: 'path',
       defaultValue: '',
+      trim: true,
     },
     {
       comment: '访问地址前缀',
       type: 'string',
       name: 'baseUrl',
       defaultValue: '',
+      trim: true,
     },
     // TODO(feature): 需要使用一个实现了可设置默认值的字段
     {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add trim option for text fields of storages collection.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add trim option for text fields of storages collection |
| 🇨🇳 Chinese | 为存储引擎表的文本字段增加去除首尾空白字符的选项 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
