### PR TITLE
fix(db): `filterByTk` is ignored when both `filter` and `filterByTk` are used in o2m deletion

### DIFF
--- a/packages/core/database/src/relation-repository/hasmany-repository.ts
+++ b/packages/core/database/src/relation-repository/hasmany-repository.ts
@@ -72,7 +72,13 @@ export class HasManyRepository extends MultipleRelationRepository {
       const filterResult = this.parseFilter(options['filter'], options);
 
       if (filterResult.include && filterResult.include.length > 0) {
-        return await this.destroyByFilter(options['filter'], transaction);
+        return await this.destroyByFilter(
+          {
+            filter: options['filter'],
+            filterByTk: options['filterByTk'],
+          },
+          transaction,
+        );
       }
 
       where.push(filterResult.where);

--- a/packages/core/database/src/relation-repository/multiple-relation-repository.ts
+++ b/packages/core/database/src/relation-repository/multiple-relation-repository.ts
@@ -179,9 +179,15 @@ export abstract class MultipleRelationRepository extends RelationRepository {
     return false;
   }
 
-  protected async destroyByFilter(filter: Filter, transaction?: Transaction) {
+  protected async destroyByFilter(
+    options: {
+      filter?: Filter;
+      filterByTk?: TargetKey | TargetKey[];
+    },
+    transaction?: Transaction,
+  ) {
     const instances = await this.find({
-      filter: filter,
+      ...options,
       transaction,
     });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  When deleting one-to-many records, passing both `filter` and `filterByTk` makes `filterByTk` ineffective         |
| 🇨🇳 Chinese | 删除一对多记录时，同时传递 `filter` 和 `filterByTk` 参数，`filterByTk` 参数失效          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
