### PR TITLE
fix: add headers to API request in AssociationFieldProvider

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
@@ -72,7 +72,7 @@ export const AssociationFieldProvider = observer(
         return api.request({
           resource: collectionField.target,
           action: Array.isArray(ids) ? 'list' : 'get',
-          headers: getDataSourceHeaders(cm.dataSource?.key),
+          headers: getDataSourceHeaders(cm?.dataSource?.key),
           params: {
             filter: {
               [targetKey]: ids,

--- a/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
@@ -14,6 +14,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useAPIClient, useRequest } from '../../../api-client';
 import { useCollectionManager } from '../../../data-source/collection';
 import { markRecordAsNew } from '../../../data-source/collection-record/isNewRecord';
+import { getDataSourceHeaders } from '../../../data-source/utils';
 import { useKeepAlive } from '../../../route-switch/antd/admin-layout/KeepAlive';
 import { useSchemaComponentContext } from '../../hooks';
 import { AssociationFieldContext } from './context';
@@ -67,9 +68,11 @@ export const AssociationFieldProvider = observer(
         if (_.isUndefined(ids) || _.isNil(ids) || _.isNaN(ids)) {
           return Promise.reject(null);
         }
+
         return api.request({
           resource: collectionField.target,
           action: Array.isArray(ids) ? 'list' : 'get',
+          headers: getDataSourceHeaders(cm.dataSource?.key),
           params: {
             filter: {
               [targetKey]: ids,

--- a/packages/core/sdk/src/APIClient.ts
+++ b/packages/core/sdk/src/APIClient.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, RawAxiosRequestHeaders } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, RawAxiosRequestHeaders } from 'axios';
 import qs from 'qs';
 
 export interface ActionParams {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      The relationship fields in the filter form report an error after the page is refreshed because x-data-source is not carried     |
| 🇨🇳 Chinese |       筛选表单中的关系字段在刷新页面后，由于没有携带 x-data-source 而报错    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
