### PR TITLE
refactor(client): add trim API for Input and Variable.TextArea

### DIFF
--- a/packages/core/client/src/schema-component/antd/input/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/input/Input.tsx
@@ -11,22 +11,40 @@ import { LoadingOutlined } from '@ant-design/icons';
 import { connect, mapProps, mapReadPretty } from '@formily/react';
 import { Input as AntdInput } from 'antd';
 import { InputProps, TextAreaProps } from 'antd/es/input';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { JSONTextAreaProps, Json } from './Json';
 import { InputReadPrettyComposed, ReadPretty } from './ReadPretty';
 
 export { ReadPretty as InputReadPretty } from './ReadPretty';
 
-type ComposedInput = React.FC<InputProps> & {
+type ComposedInput = React.FC<NocoBaseInputProps> & {
   ReadPretty: InputReadPrettyComposed['Input'];
   TextArea: React.FC<TextAreaProps> & { ReadPretty: InputReadPrettyComposed['TextArea'] };
   URL: React.FC<InputProps> & { ReadPretty: InputReadPrettyComposed['URL'] };
   JSON: React.FC<JSONTextAreaProps> & { ReadPretty: InputReadPrettyComposed['JSON'] };
 };
 
+export type NocoBaseInputProps = InputProps & {
+  trim?: boolean;
+};
+
+function InputInner(props: NocoBaseInputProps) {
+  const { onChange, trim } = props;
+  const handleChange = useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => {
+      if (trim) {
+        ev.target.value = ev.target.value.trim();
+      }
+      onChange?.(ev);
+    },
+    [onChange, trim],
+  );
+  return <AntdInput {...props} onChange={handleChange} />;
+}
+
 export const Input: ComposedInput = Object.assign(
   connect(
-    AntdInput,
+    InputInner,
     mapProps((props, field) => {
       return {
         ...props,

--- a/packages/core/client/src/schema-component/antd/input/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/input/Input.tsx
@@ -29,7 +29,7 @@ export type NocoBaseInputProps = InputProps & {
 };
 
 function InputInner(props: NocoBaseInputProps) {
-  const { onChange, trim } = props;
+  const { onChange, trim, ...others } = props;
   const handleChange = useCallback(
     (ev: React.ChangeEvent<HTMLInputElement>) => {
       if (trim) {
@@ -39,7 +39,7 @@ function InputInner(props: NocoBaseInputProps) {
     },
     [onChange, trim],
   );
-  return <AntdInput {...props} onChange={handleChange} />;
+  return <AntdInput {...others} onChange={handleChange} />;
 }
 
 export const Input: ComposedInput = Object.assign(

--- a/packages/core/client/src/schema-component/antd/input/demos/new-demos/input.tsx
+++ b/packages/core/client/src/schema-component/antd/input/demos/new-demos/input.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { mockApp } from '@nocobase/client/demo-utils';
 import { SchemaComponent, Plugin, ISchema } from '@nocobase/client';
@@ -15,15 +14,25 @@ const schema: ISchema = {
       'x-decorator': 'FormItem',
       'x-component': 'Input',
     },
+    trim: {
+      type: 'string',
+      title: `Trim heading and tailing spaces`,
+      'x-decorator': 'FormItem',
+      'x-component': 'Input',
+      'x-component-props': {
+        trim: true,
+      },
+    },
   },
-}
+};
+
 const Demo = () => {
   return <SchemaComponent schema={schema} />;
 };
 
 class DemoPlugin extends Plugin {
   async load() {
-    this.app.router.add('root', { path: '/', Component: Demo })
+    this.app.router.add('root', { path: '/', Component: Demo });
   }
 }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add `trim` API for `Input` and `Variable.TextArea`.

### Description 

By default:

* `trim` for `Input` is `false`
* `trim` for `Variable.TextArea` is `true`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `trim` API for `Input` and `Variable.TextArea` |
| 🇨🇳 Chinese | 为 `Input` 和 `Variable.TextArea` 组件增加 `trim` API |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
