### PR TITLE
fix: block template configure page style

### DIFF
--- a/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
+++ b/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
@@ -54,7 +54,7 @@ describe('CollectionSelect', () => {
             role="button"
           >
             <div
-              class="css-vij405 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-1rquknz"
+              class="css-9mlexe ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-1rquknz"
             >
               <div
                 class="ant-formily-item-label"
@@ -84,7 +84,7 @@ describe('CollectionSelect', () => {
                     class="ant-formily-item-control-content-component"
                   >
                     <div
-                      class="ant-select css-dev-only-do-not-override-1rquknz ant-select-focused ant-select-single ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-outlined css-dev-only-do-not-override-1rquknz ant-select-focused ant-select-single ant-select-show-arrow ant-select-show-search"
                       data-testid="select-collection"
                       role="button"
                     >
@@ -98,27 +98,31 @@ describe('CollectionSelect', () => {
                         class="ant-select-selector"
                       >
                         <span
-                          class="ant-select-selection-search"
+                          class="ant-select-selection-wrap"
                         >
-                          <input
-                            aria-autocomplete="list"
-                            aria-controls="rc_select_TEST_OR_SSR_list"
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="rc_select_TEST_OR_SSR_list"
-                            autocomplete="off"
-                            class="ant-select-selection-search-input"
-                            id="rc_select_TEST_OR_SSR"
-                            role="button"
-                            type="search"
-                            value=""
-                          />
-                        </span>
-                        <span
-                          class="ant-select-selection-item"
-                          title="Users"
-                        >
-                          Users
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              role="button"
+                              type="search"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="Users"
+                          >
+                            Users
+                          </span>
                         </span>
                       </div>
                       <span
@@ -191,7 +195,7 @@ describe('CollectionSelect', () => {
             role="button"
           >
             <div
-              class="css-vij405 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-1rquknz"
+              class="css-9mlexe ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-1rquknz"
             >
               <div
                 class="ant-formily-item-label"

--- a/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
+++ b/packages/core/client/src/schema-component/antd/collection-select/__tests__/collection-select.test.tsx
@@ -45,16 +45,16 @@ describe('CollectionSelect', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="css-dev-only-do-not-override-qu8jc9 ant-app"
+          class="css-dev-only-do-not-override-1rquknz ant-app"
           style="height: 100%;"
         >
           <div
             aria-label="block-item-demo title"
-            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-qu8jc9"
+            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-1rquknz"
             role="button"
           >
             <div
-              class="css-vij405 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-qu8jc9"
+              class="css-vij405 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-1rquknz"
             >
               <div
                 class="ant-formily-item-label"
@@ -84,7 +84,7 @@ describe('CollectionSelect', () => {
                     class="ant-formily-item-control-content-component"
                   >
                     <div
-                      class="ant-select css-dev-only-do-not-override-qu8jc9 ant-select-focused ant-select-single ant-select-show-arrow ant-select-show-search"
+                      class="ant-select css-dev-only-do-not-override-1rquknz ant-select-focused ant-select-single ant-select-show-arrow ant-select-show-search"
                       data-testid="select-collection"
                       role="button"
                     >
@@ -182,16 +182,16 @@ describe('CollectionSelect', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          class="css-dev-only-do-not-override-qu8jc9 ant-app"
+          class="css-dev-only-do-not-override-1rquknz ant-app"
           style="height: 100%;"
         >
           <div
             aria-label="block-item-demo title"
-            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-qu8jc9"
+            class="nb-block-item nb-form-item css-9qorhu ant-nb-block-item css-dev-only-do-not-override-1rquknz"
             role="button"
           >
             <div
-              class="css-vij405 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-qu8jc9"
+              class="css-vij405 ant-formily-item ant-formily-item-layout-horizontal ant-formily-item-feedback-layout-loose ant-formily-item-label-align-right ant-formily-item-control-align-left css-dev-only-do-not-override-1rquknz"
             >
               <div
                 class="ant-formily-item-label"
@@ -222,7 +222,7 @@ describe('CollectionSelect', () => {
                   >
                     <div>
                       <span
-                        class="ant-tag css-dev-only-do-not-override-qu8jc9"
+                        class="ant-tag css-dev-only-do-not-override-1rquknz"
                       >
                         Users
                       </span>

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplatePage.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplatePage.tsx
@@ -59,9 +59,7 @@ export const BlockTemplatePage = () => {
       </div>
       <div
         style={{
-          marginTop: token.marginXL,
-          marginLeft: -token.margin,
-          marginRight: -token.margin,
+          marginTop: token.marginMD,
           position: 'relative',
           zIndex: 0 /** create a new z-index context */,
         }}

--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplatePage.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplatePage.tsx
@@ -34,9 +34,12 @@ export const BlockTemplatePage = () => {
     <div>
       <div
         style={{
-          margin: -token.margin,
-          marginTop: -token.marginXL,
-          padding: token.paddingSM,
+          marginTop: -token.marginXXL,
+          marginLeft: -token.marginLG,
+          marginRight: -token.marginLG,
+          padding: token.paddingLG,
+          paddingTop: token.paddingMD,
+          paddingBottom: token.paddingMD,
           background: token.colorBgContainer,
           display: 'flex',
           alignItems: 'center',
@@ -54,7 +57,15 @@ export const BlockTemplatePage = () => {
           ]}
         />
       </div>
-      <div style={{ marginTop: token.marginXL, position: 'relative', zIndex: 0 /** create a new z-index context */ }}>
+      <div
+        style={{
+          marginTop: token.marginXL,
+          marginLeft: -token.margin,
+          marginRight: -token.margin,
+          position: 'relative',
+          zIndex: 0 /** create a new z-index context */,
+        }}
+      >
         <BlockTemplateInfoContext.Provider value={data?.data}>
           <RemoteSchemaComponent uid={schemaUid} />
         </BlockTemplateInfoContext.Provider>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  blank area between the block template configuration page title and the menu |
| 🇨🇳 Chinese | 区块模板配置页面标题与菜单存在空白区域 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
