### PR TITLE
fix: single-select field with 'contains' filter on mobile does not su…

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/properties/operators.ts
+++ b/packages/core/client/src/collection-manager/interfaces/properties/operators.ts
@@ -129,12 +129,12 @@ export const enumType = [
     label: '{{t("is")}}',
     value: '$eq',
     selected: true,
-    schema: { 'x-component': 'Select' },
+    schema: { 'x-component': 'Select', 'x-component-props': { mode: null } },
   },
   {
     label: '{{t("is not")}}',
     value: '$ne',
-    schema: { 'x-component': 'Select' },
+    schema: { 'x-component': 'Select', 'x-component-props': { mode: null } },
   },
   {
     label: '{{t("is any of")}}',

--- a/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
+++ b/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
@@ -96,7 +96,7 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
     const originalProps =
       compile({ ...(operator?.schema?.['x-component-props'] || {}), ...(uiSchema['x-component-props'] || {}) }) || {};
 
-    field.componentProps = merge(originalProps, field.componentProps || {}, dynamicProps || {});
+    field.componentProps = merge(field.componentProps || {}, originalProps, dynamicProps || {});
   }, [uiSchemaOrigin]);
 
   if (!uiSchemaOrigin) return null;

--- a/packages/core/client/src/schema-component/antd/filter/DynamicComponent.tsx
+++ b/packages/core/client/src/schema-component/antd/filter/DynamicComponent.tsx
@@ -65,7 +65,6 @@ export const DynamicComponent = (props: Props) => {
                 ...props.style,
               },
               utc: false,
-              underFilter: true,
             }),
             name: 'value',
             'x-read-pretty': false,

--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -470,7 +470,6 @@ export const useFilterFormItemInitializerFields = (options?: any) => {
         'x-collection-field': `${name}.${field.name}`,
         'x-component-props': {
           utc: false,
-          underFilter: true,
         },
       };
       if (isAssocField(field)) {
@@ -485,7 +484,7 @@ export const useFilterFormItemInitializerFields = (options?: any) => {
           'x-decorator': 'FormItem',
           'x-use-decorator-props': 'useFormItemProps',
           'x-collection-field': `${name}.${field.name}`,
-          'x-component-props': { ...field.uiSchema?.['x-component-props'], utc: false, underFilter: true },
+          'x-component-props': { ...field.uiSchema?.['x-component-props'], utc: false },
         };
       }
       const resultItem = {
@@ -580,7 +579,7 @@ const associationFieldToMenu = (
       interface: field.interface,
     },
     'x-component': 'CollectionField',
-    'x-component-props': { utc: false, underFilter: true },
+    'x-component-props': { utc: false },
     'x-read-pretty': false,
     'x-decorator': 'FormItem',
     'x-collection-field': `${collectionName}.${schemaName}`,
@@ -697,7 +696,7 @@ export const useFilterInheritsFormItemInitializerFields = (options?) => {
             'x-component': 'CollectionField',
             'x-decorator': 'FormItem',
             'x-collection-field': `${name}.${field.name}`,
-            'x-component-props': { utc: false, underFilter: true },
+            'x-component-props': { utc: false },
             'x-read-pretty': field?.uiSchema?.['x-read-pretty'],
           };
           return {

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/components/MobilePicker.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/components/MobilePicker.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 const MobilePicker = connect(
   (props) => {
     const { value, onChange, disabled, options = [], mode } = props;
+    console.log(props);
     const { t } = useTranslation();
     const [visible, setVisible] = useState(false);
     const [selected, setSelected] = useState(value || []);
@@ -42,7 +43,7 @@ const MobilePicker = connect(
             disabled={disabled}
             value={value}
             dropdownStyle={{ display: 'none' }}
-            multiple={mode === 'multiple'}
+            multiple={['multiple', 'tags'].includes(mode)}
             onClear={() => {
               setVisible(false);
               onChange(null);
@@ -77,10 +78,10 @@ const MobilePicker = connect(
             }}
           >
             <CheckList
-              multiple={mode === 'multiple'}
+              multiple={['multiple', 'tags'].includes(mode)}
               value={Array.isArray(selected) ? selected : [selected] || []}
               onChange={(val) => {
-                if (mode === 'multiple') {
+                if (['multiple', 'tags'].includes(mode)) {
                   setSelected(val);
                 } else {
                   setSelected(val[0]);
@@ -96,7 +97,7 @@ const MobilePicker = connect(
               ))}
             </CheckList>
           </div>
-          {mode === 'multiple' && (
+          {['multiple', 'tags'].includes(mode) && (
             <Button block color="primary" onClick={handleConfirm} style={{ marginTop: '16px' }}>
               {t('Confirm')}
             </Button>


### PR DESCRIPTION
…pport multiple selection

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    single-select field with 'contains' filter on mobile does not support multiple selection       |
| 🇨🇳 Chinese |    下拉单选字段在移动端设置筛选符为包含时组件未支持多选       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
