### PR TITLE
fix(plugin-workflow): fix oom when create job with unsafe integer id

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts
@@ -14,7 +14,14 @@ export default {
   migrationRules: ['schema-only'],
   name: 'jobs',
   shared: true,
+  autoGenId: false,
   fields: [
+    {
+      type: 'bigInt',
+      name: 'id',
+      primaryKey: true,
+      autoIncrement: false,
+    },
     {
       type: 'belongsTo',
       name: 'execution',

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -16,6 +16,7 @@ import type Plugin from './Plugin';
 import { EXECUTION_STATUS, JOB_STATUS } from './constants';
 import { Runner } from './instructions';
 import type { ExecutionModel, FlowNodeModel, JobModel } from './types';
+import { toJSON } from './utils';
 
 export interface ProcessorOptions extends Transactionable {
   plugin: Plugin;
@@ -264,7 +265,10 @@ export default class Processor {
         const JobsModel = this.options.plugin.db.getModel('jobs');
         await JobsModel.bulkCreate(
           newJobs.map((job) => job.toJSON()),
-          { transaction: this.mainTransaction },
+          {
+            transaction: this.mainTransaction,
+            returning: false,
+          },
         );
         for (const job of newJobs) {
           job.isNewRecord = false;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
@@ -41,27 +41,19 @@ describe('workflow > Processor', () => {
   afterEach(() => app.destroy());
 
   describe('base', () => {
-    it.skip('saveJob', async () => {
-      const execution = await workflow.createExecution({
-        key: workflow.key,
-        context: {},
-        status: EXECUTION_STATUS.STARTED,
-        eventKey: '123',
-      });
+    it.skipIf(process.env['DB_DIALECT'] === 'sqlite')('job id out of max safe integer', async () => {
+      const JobModel = db.getModel('jobs');
 
-      const processor = plugin.createProcessor(execution);
+      const records = await JobModel.bulkCreate([
+        {
+          id: '10267424896650240',
+        },
+        {
+          id: '10267424930204672',
+        },
+      ]);
 
-      const job1 = await processor.saveJob({
-        status: JOB_STATUS.RESOLVED,
-        result: null,
-      });
-
-      const job2 = await processor.saveJob({
-        status: JOB_STATUS.RESOLVED,
-        result: 'abc',
-      });
-
-      expect(job2).toBeDefined();
+      expect(records.length).toBe(2);
     });
 
     it('empty workflow without any nodes', async () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/migrations/20250320223415-stats.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/migrations/20250320223415-stats.test.ts
@@ -26,7 +26,7 @@ describe('20250320223415-stats', () => {
   describe('legacy stats should be migrated', () => {
     beforeEach(async () => {
       app = await getApp();
-      app.version.update('1.6.0');
+      await app.version.update('1.6.0');
       plugin = app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
       WorkflowRepo = app.db.getRepository('workflows');
       WorkflowStatsRepo = app.db.getRepository('workflowStats');

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/migrations/20250409164913-remove-jobs-auto-increment.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/migrations/20250409164913-remove-jobs-auto-increment.test.ts
@@ -1,0 +1,50 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, test } from 'vitest';
+
+import { MockServer } from '@nocobase/test';
+import { getApp } from '@nocobase/plugin-workflow-test';
+
+import Migration from '../../migrations/20250409164913-remove-jobs-auto-increment';
+import PluginWorkflowServer from '../..';
+
+describe.skipIf(process.env.DB_DIALECT === 'sqlite')('20250409164913-remove-jobs-auto-increment', () => {
+  let app: MockServer;
+  let OldCollection;
+
+  beforeEach(async () => {
+    app = await getApp();
+    await app.version.update('1.6.0');
+    OldCollection = app.db.collection({
+      name: 'jobs',
+      fields: [],
+    });
+    await app.db.sync({ force: true });
+  });
+
+  afterEach(() => app.destroy());
+
+  it('no auto increment any more', async () => {
+    const oldColumns = await app.db.sequelize.getQueryInterface().describeTable(OldCollection.getTableNameWithSchema());
+    expect(oldColumns.id.autoIncrement).toBe(true);
+
+    const JobRepo = app.db.getRepository('jobs');
+    const j1 = await JobRepo.create({});
+    expect(j1.id).toBe(1);
+
+    const migration = new Migration({ app, db: app.db } as any);
+    await migration.up();
+
+    const newColumns = await app.db.sequelize.getQueryInterface().describeTable(OldCollection.getTableNameWithSchema());
+    expect(newColumns.id.autoIncrement).toBe(false);
+
+    await expect(async () => await JobRepo.create({})).rejects.toThrow();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20250409164913-remove-jobs-auto-increment.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/migrations/20250409164913-remove-jobs-auto-increment.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Migration } from '@nocobase/server';
+
+export default class extends Migration {
+  appVersion = '<1.7.0';
+  on = 'beforeLoad';
+  async up() {
+    const { db } = this.context;
+    const jobCollection = db.collection({
+      name: 'jobs',
+    });
+    const tableNameWithQuotes = jobCollection.getRealTableName(true);
+
+    await db.sequelize.transaction(async (transaction) => {
+      if (this.db.isPostgresCompatibleDialect()) {
+        await db.sequelize.query(`ALTER TABLE ${tableNameWithQuotes} ALTER COLUMN id DROP DEFAULT`, {
+          transaction,
+        });
+        return;
+      }
+      if (this.db.isMySQLCompatibleDialect()) {
+        await db.sequelize.query(`ALTER TABLE ${tableNameWithQuotes} MODIFY COLUMN id BIGINT`, {
+          transaction,
+        });
+        return;
+      }
+    });
+  }
+}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix OOM when create job with unsafe integer id.

### Description 

```
<--- Last few GCS --->
[131:0x601fd00]
[131:0x601fd00]
193501 ms: Scavenge (reduce) 2044.4 (2078.5) -> 2043.1(2075.7) MB, 5.01 / 0.00 ms
193554 ms: Scavenge (reduce) 2043.9 (2076.0) -> 2043,.4 (2076.5) MB, 15.75 / 0.00 ms
(average mu = 0.233, current mu = 0.221) allocationfailure;
(average mu = 0.233, current mu = 0.221) allocationfailure;
<--- JS stacktrace --->
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
--- Native stack trace
1: 0xb8cf03 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node /app/nocobase/node_modules/@nocobase/app/lib/index.js]
2: 0xf04140 v8::Utils: ReportOOMFailure(v8::internal:::Isolate*, char const*, v8::OOMDetails const&) [node/app/nocobase/node_modules/@nocobase/app/lib/index.js]
3: 0xf04427 v8:: internal::V8:: FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node /app/nocobase/node_modules/@nocobase/app/lib
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix OOM when create job with unsafe integer id |
| 🇨🇳 Chinese | 修复创建执行记录使用非安全整型 ID 时内存溢出的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
