### PR TITLE
refactor(client): add default type fallback api for `Variable.Input`

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -26,12 +26,13 @@ import { Json } from '../input';
 const JT_VALUE_RE = /^\s*{{\s*([^{}]+)\s*}}\s*$/;
 
 type ParseOptions = {
+  defaultTypeOnNull?: string;
   stringToDate?: boolean;
 };
 
 function parseValue(value: any, options: ParseOptions = {}): string | string[] {
   if (value == null) {
-    return 'null';
+    return options.defaultTypeOnNull ?? 'null';
   }
   const type = typeof value;
   if (type === 'string') {

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/client/DelayInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/client/DelayInstruction.tsx
@@ -57,6 +57,9 @@ export default class extends Instruction {
             placeholder: `{{t("Duration", { ns: "${NAMESPACE}" })}}`,
             useTypedConstant: [['number', { min: 1 }]],
             nullable: false,
+            parseOptions: {
+              defaultTypeOnNull: 'number',
+            },
           },
           default: 1,
           required: true,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add default type fallback API for `Variable.Input`

### Description 

```diff
  <Variable.Input
    parseOptions={{
+     defaultTypeOnNull: 'number'
    }}
  />
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add default type fallback API for `Variable.Input` |
| 🇨🇳 Chinese | 为 `Variable.Input` 组件增加默认退避类型的 API |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
