### PR TITLE
fix(defaultValue): avoid directly displaying variable strings

### DIFF
--- a/packages/core/client/src/data-source/collection-field/CollectionField.tsx
+++ b/packages/core/client/src/data-source/collection-field/CollectionField.tsx
@@ -18,6 +18,7 @@ import { useCollectionFieldUISchema, useIsInNocoBaseRecursionFieldContext } from
 import { useDynamicComponentProps } from '../../hoc/withDynamicSchemaProps';
 import { useCompile, useComponent } from '../../schema-component';
 import { useIsAllowToSetDefaultValue } from '../../schema-settings/hooks/useIsAllowToSetDefaultValue';
+import { isVariable } from '../../variables/utils/isVariable';
 import { CollectionFieldProvider, useCollectionField } from './CollectionFieldProvider';
 
 type Props = {
@@ -131,7 +132,14 @@ const CollectionFieldInternalField = (props) => {
 
   if (!uiSchema) return null;
 
-  return <Component {...props} {...dynamicProps} />;
+  const mergedProps = { ...props, ...dynamicProps };
+
+  // Prevent displaying the variable string first, then the variable value
+  if (isVariable(mergedProps.value) && mergedProps.value === fieldSchema.default) {
+    mergedProps.value = undefined;
+  }
+
+  return <Component {...mergedProps} />;
 };
 
 export const CollectionField = connect((props) => {

--- a/packages/core/client/src/schema-component/antd/form-item/hooks/useParseDefaultValue.ts
+++ b/packages/core/client/src/schema-component/antd/form-item/hooks/useParseDefaultValue.ts
@@ -86,11 +86,6 @@ const useParseDefaultValue = () => {
         field &&
         ((isVariable(fieldSchema.default) && field.value == null) || field.value === fieldSchema.default || forceUpdate)
       ) {
-        // 一个变量字符串如果显示出来会比较奇怪
-        if (isVariable(field.value)) {
-          await field.reset({ forceClear: true });
-        }
-
         field.loading = true;
         const collectionField = !fieldSchema.name.toString().includes('.') && collection?.getField(fieldSchema.name);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       In the form block, the default value of the field configuration will first be displayed as the original variable string and then disappear    |
| 🇨🇳 Chinese |     表单区块中，字段配置的默认值会先显示为原始变量字符串然后再消失      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
