### PR TITLE
fix: should not automatically redirect to hidden pages

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/findFirstPageRoute.test.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/findFirstPageRoute.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { findFirstPageRoute, NocoBaseDesktopRouteType } from '..';
+import { NocoBaseDesktopRoute } from '../convertRoutesToSchema';
+
+describe('findFirstPageRoute', () => {
+  // 基本测试：空路由数组
+  it('should return undefined for empty routes array', () => {
+    const result = findFirstPageRoute([]);
+    expect(result).toBeUndefined();
+  });
+
+  // 基本测试：undefined 路由数组
+  it('should return undefined for undefined routes', () => {
+    const result = findFirstPageRoute(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  // 测试：只有一个页面路由
+  it('should find the first page route when there is only one page', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        schemaUid: 'page1',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 1',
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[0]);
+  });
+
+  // 测试：多个页面路由
+  it('should find the first page route when there are multiple pages', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        schemaUid: 'page1',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 1',
+      },
+      {
+        id: 2,
+        schemaUid: 'page2',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 2',
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[0]);
+  });
+
+  // 测试：不同类型的路由混合
+  it('should find the first page route among mixed route types', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        schemaUid: 'link1',
+        type: NocoBaseDesktopRouteType.link,
+        title: 'Link 1',
+      },
+      {
+        id: 2,
+        schemaUid: 'page1',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 1',
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[1]);
+  });
+
+  // 测试：隐藏的菜单项
+  it('should ignore hidden menu items', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        schemaUid: 'page1',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 1',
+        hideInMenu: true,
+      },
+      {
+        id: 2,
+        schemaUid: 'page2',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 2',
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[1]);
+  });
+
+  // 测试：嵌套路由
+  it('should find page route in nested group', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        type: NocoBaseDesktopRouteType.group,
+        title: 'Group 1',
+        children: [
+          {
+            id: 11,
+            schemaUid: 'page1',
+            type: NocoBaseDesktopRouteType.page,
+            title: 'Page 1',
+          },
+        ],
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[0].children[0]);
+  });
+
+  // 测试：多层嵌套路由
+  it('should find page route in deeply nested groups', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        type: NocoBaseDesktopRouteType.group,
+        title: 'Group 1',
+        children: [
+          {
+            id: 11,
+            type: NocoBaseDesktopRouteType.group,
+            title: 'Group 1-1',
+            children: [
+              {
+                id: 111,
+                schemaUid: 'page1',
+                type: NocoBaseDesktopRouteType.page,
+                title: 'Page 1',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[0].children[0].children[0]);
+  });
+
+  // 测试：复杂路由结构
+  it('should find the first visible page in a complex route structure', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        type: NocoBaseDesktopRouteType.group,
+        title: 'Group 1',
+        hideInMenu: true,
+        children: [
+          {
+            id: 11,
+            schemaUid: 'page1',
+            type: NocoBaseDesktopRouteType.page,
+            title: 'Page 1',
+          },
+        ],
+      },
+      {
+        id: 2,
+        type: NocoBaseDesktopRouteType.group,
+        title: 'Group 2',
+        children: [
+          {
+            id: 21,
+            schemaUid: 'page2',
+            type: NocoBaseDesktopRouteType.page,
+            title: 'Page 2',
+          },
+        ],
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[1].children[0]);
+  });
+
+  // 测试：空组
+  it('should skip empty groups and find page in next group', () => {
+    const routes: NocoBaseDesktopRoute[] = [
+      {
+        id: 1,
+        type: NocoBaseDesktopRouteType.group,
+        title: 'Empty Group',
+        children: [],
+      },
+      {
+        id: 2,
+        schemaUid: 'page1',
+        type: NocoBaseDesktopRouteType.page,
+        title: 'Page 1',
+      },
+    ];
+
+    const result = findFirstPageRoute(routes);
+    expect(result).toEqual(routes[1]);
+  });
+});

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -892,16 +892,17 @@ function findRouteById(id: string, treeArray: any[]) {
   return null;
 }
 
-function findFirstPageRoute(routes: NocoBaseDesktopRoute[]) {
+export function findFirstPageRoute(routes: NocoBaseDesktopRoute[]) {
   if (!routes) return;
 
-  for (const route of routes) {
+  for (const route of routes.filter((item) => !item.hideInMenu)) {
     if (route.type === NocoBaseDesktopRouteType.page) {
       return route;
     }
 
-    if (route.children?.length) {
-      return findFirstPageRoute(route.children);
+    if (route.type === NocoBaseDesktopRouteType.group && route.children?.length) {
+      const result = findFirstPageRoute(route.children);
+      if (result) return result;
     }
   }
 }

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -611,27 +611,11 @@ export const InternalAdminLayout = () => {
   );
 };
 
-function getDefaultPageUid(routes: NocoBaseDesktopRoute[]) {
-  // Find the first route of type "page"
-  for (const route of routes) {
-    if (route.type === NocoBaseDesktopRouteType.page) {
-      return route.schemaUid;
-    }
-
-    if (route.children?.length) {
-      const result = getDefaultPageUid(route.children);
-      if (result) {
-        return result;
-      }
-    }
-  }
-}
-
 const NavigateToDefaultPage: FC = (props) => {
   const { allAccessRoutes } = useAllAccessDesktopRoutes();
   const location = useLocationNoUpdate();
 
-  const defaultPageUid = getDefaultPageUid(allAccessRoutes);
+  const defaultPageUid = findFirstPageRoute(allAccessRoutes)?.schemaUid;
 
   return (
     <>
@@ -740,36 +724,6 @@ export function findRouteBySchemaUid(schemaUid: string, treeArray: any[]) {
   }
   return null;
 }
-
-const MenuItemIcon: FC<{ icon: string; title: string }> = (props) => {
-  const { inHeader } = useContext(headerContext);
-
-  return (
-    <RouteContext.Consumer>
-      {(value: RouteContextType) => {
-        const { collapsed } = value;
-
-        if (collapsed && !inHeader) {
-          return props.icon ? (
-            <Icon type={props.icon} />
-          ) : (
-            <span
-              style={{
-                display: 'inline-block',
-                width: '100%',
-                textAlign: 'center',
-              }}
-            >
-              {props.title.charAt(0)}
-            </span>
-          );
-        }
-
-        return props.icon ? <Icon type={props.icon} /> : null;
-      }}
-    </RouteContext.Consumer>
-  );
-};
 
 const MenuDesignerButton: FC<{ testId: string }> = (props) => {
   const { render: renderInitializer } = useSchemaInitializerRender(menuItemInitializer);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Switching to the group menu should not jump to a page that has already been hidden in menu    |
| 🇨🇳 Chinese |     切换到分组菜单时，不应该跳转到已经在菜单中被隐藏的页面      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
