### PR TITLE
fix: no prompt popup should be displayed after modifying the filter form

### DIFF
--- a/packages/core/client/src/block-provider/FilterFormBlockProvider.tsx
+++ b/packages/core/client/src/block-provider/FilterFormBlockProvider.tsx
@@ -10,11 +10,11 @@
 import { useFieldSchema } from '@formily/react';
 import React from 'react';
 import { withDynamicSchemaProps } from '../hoc/withDynamicSchemaProps';
-import { DatePickerProvider, ActionBarProvider, SchemaComponentOptions } from '../schema-component';
+import { FilterCollectionField } from '../modules/blocks/filter-blocks/FilterCollectionField';
+import { ActionBarProvider, DatePickerProvider, SchemaComponentOptions } from '../schema-component';
 import { DefaultValueProvider } from '../schema-settings';
 import { CollectOperators } from './CollectOperators';
 import { FormBlockProvider } from './FormBlockProvider';
-import { FilterCollectionField } from '../modules/blocks/filter-blocks/FilterCollectionField';
 
 export const FilterFormBlockProvider = withDynamicSchemaProps((props) => {
   const filedSchema = useFieldSchema();
@@ -35,7 +35,7 @@ export const FilterFormBlockProvider = withDynamicSchemaProps((props) => {
             }}
           >
             <DefaultValueProvider isAllowToSetDefaultValue={() => false}>
-              <FormBlockProvider name="filter-form" {...props}></FormBlockProvider>
+              <FormBlockProvider name="filter-form" {...props} confirmBeforeClose={false}></FormBlockProvider>
             </DefaultValueProvider>
           </ActionBarProvider>
         </DatePickerProvider>

--- a/packages/core/client/src/schema-component/antd/form-v2/Form.tsx
+++ b/packages/core/client/src/schema-component/antd/form-v2/Form.tsx
@@ -16,8 +16,10 @@ import { ConfigProvider, theme } from 'antd';
 import React, { useEffect, useMemo } from 'react';
 import { useActionContext } from '..';
 import { useAttach, useComponent } from '../..';
+import { useApp } from '../../../application';
 import { getCardItemSchema } from '../../../block-provider';
 import { useTemplateBlockContext } from '../../../block-provider/TemplateBlockProvider';
+import { useDataBlockProps } from '../../../data-source';
 import { useDataBlockRequest } from '../../../data-source/data-block/DataBlockRequestProvider';
 import { NocoBaseRecursionField } from '../../../formily/NocoBaseRecursionField';
 import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
@@ -27,7 +29,6 @@ import { useToken } from '../../../style';
 import { useLocalVariables, useVariables } from '../../../variables';
 import { useProps } from '../../hooks/useProps';
 import { useFormBlockHeight } from './hook';
-import { useApp } from '../../../application';
 
 export interface FormProps extends IFormLayoutProps {
   form?: FormilyForm;
@@ -141,12 +142,15 @@ const WithForm = (props: WithFormProps) => {
   const linkageRules: any[] =
     (getLinkageRules(fieldSchema) || fieldSchema.parent?.['x-linkage-rules'])?.filter((k) => !k.disabled) || [];
 
+  // 关闭弹窗之前，如果有未保存的数据，是否要二次确认
+  const { confirmBeforeClose = true } = useDataBlockProps() || ({} as any);
+
   useEffect(() => {
     const id = uid();
 
     form.addEffects(id, () => {
       onFormInputChange(() => {
-        setFormValueChanged?.(true);
+        setFormValueChanged?.(confirmBeforeClose);
       });
     });
 
@@ -157,7 +161,7 @@ const WithForm = (props: WithFormProps) => {
     return () => {
       form.removeEffects(id);
     };
-  }, [form, props.disabled, setFormValueChanged]);
+  }, [form, props.disabled, setFormValueChanged, confirmBeforeClose]);
 
   useEffect(() => {
     if (loading) {
@@ -210,17 +214,19 @@ const WithForm = (props: WithFormProps) => {
 const WithoutForm = (props) => {
   const fieldSchema = useFieldSchema();
   const { setFormValueChanged } = useActionContext();
+  // 关闭弹窗之前，如果有未保存的数据，是否要二次确认
+  const { confirmBeforeClose = true } = useDataBlockProps() || ({} as any);
   const form = useMemo(
     () =>
       createForm({
         disabled: props.disabled,
         effects() {
           onFormInputChange((form) => {
-            setFormValueChanged?.(true);
+            setFormValueChanged?.(confirmBeforeClose);
           });
         },
       }),
-    [],
+    [confirmBeforeClose],
   );
   return fieldSchema['x-decorator'] === 'FormV2' ? (
     <FormDecorator form={form} {...props} />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       The filter form should not display the "Unsaved changes" prompt    |
| 🇨🇳 Chinese |     筛选表单不应该显示“未保存修改”提示      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
