### PR TITLE
fix: build output is not correct if plugin using some old amd library

### DIFF
--- a/packages/core/build/package.json
+++ b/packages/core/build/package.json
@@ -17,7 +17,7 @@
     "@lerna/project": "4.0.0",
     "@rsbuild/plugin-babel": "^1.0.3",
     "@rsdoctor/rspack-plugin": "^0.4.8",
-    "@rspack/core": "1.1.1",
+    "@rspack/core": "1.3.2",
     "@svgr/webpack": "^8.1.0",
     "@types/gulp": "^4.0.13",
     "@types/lerna__package": "5.1.0",

--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -347,7 +347,7 @@ export async function buildPluginClient(cwd: string, userConfig: UserConfig, sou
         umdNamedDefine: true,
       },
     },
-    umd: {},
+    amd: {},
     resolve: {
       tsConfig: path.join(process.cwd(), 'tsconfig.json'),
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.less', '.css'],

--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -347,6 +347,7 @@ export async function buildPluginClient(cwd: string, userConfig: UserConfig, sou
         umdNamedDefine: true,
       },
     },
+    umd: {},
     resolve: {
       tsConfig: path.join(process.cwd(), 'tsconfig.json'),
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.less', '.css'],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

After upgrade rspack version and build configuration, the bundle size hasn't changed
![image](https://github.com/user-attachments/assets/c316ae16-d432-4606-aefe-e70d9300b062)



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | build output is incorrect when plugin depends on some AMD libraries |
| 🇨🇳 Chinese | 插件依赖 AMD 库时构建产物不正确 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
