### PR TITLE
fix(plugin-workflow): fix migration

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -115,11 +115,13 @@ export default class PluginWorkflowServer extends Plugin {
 
   private onAfterCreate = async (model: WorkflowModel, { transaction }) => {
     const WorkflowStatsModel = this.db.getModel('workflowStats');
-    const [stats, created] = await WorkflowStatsModel.findOrCreate({
+    let stats = await WorkflowStatsModel.findOne({
       where: { key: model.key },
-      defaults: { key: model.key },
       transaction,
     });
+    if (!stats) {
+      stats = await model.createStats({ executed: 0 }, { transaction });
+    }
     model.stats = stats;
     model.versionStats = await model.createVersionStats({ id: model.id }, { transaction });
     if (model.enabled) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix migration error thrown from MySQL.

### Description 

![img_v3_02lc_4c40d77d-c52a-497d-ac16-719d4bf858bl](https://github.com/user-attachments/assets/d9ca11c2-818a-4ffe-afa4-e24762f7be12)

SQL in migration:

```sql
SAVEPOINT `b2bff5d0-3494-4c94-821a-55e3b5ff64a6-sp-1`;
```

Error:

```log
mysql savepoint syntax error near '-3494-4c94-821a-55e3b5ff64a6-sp-1' at line 1
```

Because `-` is a special character in MySQL.

The code case this is `Model.findOrCreate`, which in docs saying it will create a inner transaction (Savepoint is used in MySQL for nested transaction).

Guessing this is a bug from Sequelize, but no related issue found yet.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix migration error thrown from MySQL |
| 🇨🇳 Chinese | 修复 MySQL 执行迁移脚本的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
