### PR TITLE
fix(client): add fault tolerant when no x-component in schema

### DIFF
--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -767,7 +767,7 @@ export const findSchema = (schema: Schema, key: string, action: string, name?: s
     if (s[key] === action && (!name || s.name === name)) {
       return s;
     }
-    if (s['x-component'] !== 'Action.Container' && !s['x-component'].includes('AssociationField')) {
+    if (s['x-component'] && s['x-component'] !== 'Action.Container' && !s['x-component'].includes('AssociationField')) {
       const c = findSchema(s, key, action, name);
       if (c) {
         return c;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix error thrown when mouse hover on referenced template block in approval node configuration.

### Description 

<img width="715" alt="image" src="https://github.com/user-attachments/assets/ce6075e3-9bad-4eab-929e-5ddde64068fe" />

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/1192cdb5-8c4f-45e6-b81e-65b9752bb0e6" />

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix error thrown when mouse hover on referenced template block in approval node configuration |
| 🇨🇳 Chinese | 修复审批节点配置中引用模板区块的添加按钮报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
