### PR TITLE
fix(linkage-rule): variable conversion in sub-table/sub-form linkage rule conditions

### DIFF
--- a/packages/core/client/src/schema-component/antd/linkageFilter/useValues.ts
+++ b/packages/core/client/src/schema-component/antd/linkageFilter/useValues.ts
@@ -93,7 +93,7 @@ export const useValues = (): UseValuesReturn => {
     }, 100);
   };
 
-  useEffect(value2data, [field.value, scopes]);
+  useEffect(value2data, [field.value.leftVar, scopes]);
 
   const setLeftValue = useCallback(
     (leftVar, paths) => {

--- a/packages/core/client/src/schema-settings/LinkageRules/index.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/index.tsx
@@ -24,6 +24,7 @@ import { useCurrentFormContext } from '../VariableInput/hooks/useFormVariable';
 import { LinkageRuleActionGroup } from './LinkageRuleActionGroup';
 import { EnableLinkage } from './components/EnableLinkage';
 import { ArrayCollapse } from './components/LinkageHeader';
+import { useFlag } from '../../flag-provider';
 
 export interface Props {
   dynamicComponent: any;
@@ -65,11 +66,12 @@ function transformConditionData(condition: Condition, variableKey: '$nForm' | '$
     rightVar: value,
   };
 }
-function getActiveContextName(contextList: { name: string; ctx: any }[]): string | null {
-  const priority = ['$nForm', '$nRecord'];
-  for (const name of priority) {
-    const item = contextList.find((ctx) => ctx.name === name && ctx.ctx);
-    if (item) return name;
+function getActiveContextName(underNester, shouldDisplayCurrentForm): string | null {
+  if (underNester) {
+    return '$iteration';
+  }
+  if (shouldDisplayCurrentForm) {
+    return '$nForm';
   }
   return '$nRecord';
 }
@@ -84,7 +86,6 @@ const transformDefaultValue = (values, variableKey) => {
         conditionType: variableKey ? 'advanced' : 'basic',
       };
     }
-    return v;
   });
 };
 
@@ -97,15 +98,16 @@ export const FormLinkageRules = withDynamicSchemaProps(
     const { getAllCollectionsInheritChain } = useCollectionManager_deprecated();
     const parentRecordData = useCollectionParentRecordData();
     const { shouldDisplayCurrentForm } = useCurrentFormContext();
-    const variableKey = getActiveContextName(localVariables);
     const components = useMemo(() => ({ ArrayCollapse }), []);
+    const { isInSubTable, isInSubForm } = useFlag();
+    const variableKey = getActiveContextName(isInSubTable || isInSubForm, shouldDisplayCurrentForm);
     const schema = useMemo(
       () => ({
         type: 'object',
         properties: {
           rules: {
             type: 'array',
-            default: transformDefaultValue(defaultValues, shouldDisplayCurrentForm ? variableKey : '$nRecord'),
+            default: transformDefaultValue(defaultValues, variableKey),
             'x-component': 'ArrayCollapse',
             'x-decorator': 'FormItem',
             'x-component-props': {

--- a/packages/core/client/src/schema-settings/LinkageRules/index.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/index.tsx
@@ -86,6 +86,7 @@ const transformDefaultValue = (values, variableKey) => {
         conditionType: variableKey ? 'advanced' : 'basic',
       };
     }
+    return v;
   });
 };
 

--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -84,7 +84,7 @@ import { AssociationOrCollectionProvider, useDataBlockProps } from '../data-sour
 import { useDataSourceManager } from '../data-source/data-source/DataSourceManagerProvider';
 import { useDataSourceKey } from '../data-source/data-source/DataSourceProvider';
 import { useFilterBlock } from '../filter-provider/FilterProvider';
-import { FlagProvider } from '../flag-provider';
+import { FlagProvider, useFlag } from '../flag-provider';
 import { useGlobalTheme } from '../global-theme';
 import { useCollectMenuItem, useCollectMenuItems, useMenuItem } from '../hooks/useMenuItem';
 import {
@@ -1129,6 +1129,7 @@ export const SchemaSettingsLinkageRules = function LinkageRules(props) {
     return gridSchema?.[dataKey] || fieldSchema?.[dataKey] || [];
   }, [gridSchema, fieldSchema, dataKey]);
   const title = titleMap[category] || t('Linkage rules');
+  const flagVales = useFlag();
   const schema = useMemo<ISchema>(
     () => ({
       type: 'object',
@@ -1180,7 +1181,16 @@ export const SchemaSettingsLinkageRules = function LinkageRules(props) {
   );
 
   return (
-    <SchemaSettingsModalItem title={title} components={components} width={770} schema={schema} onSubmit={onSubmit} />
+    <SchemaSettingsModalItem
+      title={title}
+      components={components}
+      width={770}
+      schema={schema}
+      onSubmit={onSubmit}
+      ModalContextProvider={(props) => {
+        return <FlagProvider {...flagVales}>{props.children}</FlagProvider>;
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    variable conversion in sub-table/sub-form linkage rule conditions       |
| 🇨🇳 Chinese |    子表格、子表单中左侧变量转换历史数据异常，应为「当前对象  」     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
