### PR TITLE
fix: integer overflow when attachment size is larger than 2 GB

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/collections/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/collections/attachments.ts
@@ -38,7 +38,7 @@ export default defineCollection({
     },
     {
       comment: '文件体积（字节）',
-      type: 'integer',
+      type: 'bigInt',
       name: 'size',
     },
     // TODO: 使用暂不明确，以后再考虑


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Previous PR #6436 changed maximum allowed attachment size from 1 GB to infinity. But attachment size in bytes is stored in the "attachments" table with integer data type. This causes PostgreSQL to throw errors when attachment size is larger than 2 GB.
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix integer overflow issue when attachment size is larger than 2 GB |
| 🇨🇳 Chinese |  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
