### PR TITLE
fix(build): tar cli

### DIFF
--- a/packages/core/build/src/tarPlugin.ts
+++ b/packages/core/build/src/tarPlugin.ts
@@ -8,7 +8,7 @@
  */
 
 import path from 'path';
-import tar from 'tar';
+import { create } from 'tar';
 import fg from 'fast-glob';
 import fs from 'fs-extra';
 
@@ -38,5 +38,5 @@ export function tarPlugin(cwd: string, log: PkgLog) {
 
   fs.mkdirpSync(path.dirname(tarball));
   fs.rmSync(tarball, { force: true });
-  return tar.c({ gzip: true, file: tarball, cwd }, tarFiles);
+  return create({ gzip: true, file: tarball, cwd }, tarFiles);
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix error thrown in tar command.

### Description 

```log
yarn build packages/pro-plugins/@nocobase/plugin-pubsub-adapter-redis --only-tar                                                                                                                                                      
yarn run v1.22.22                                                                                                                                                                                                                                              
$ nocobase build packages/pro-plugins/@nocobase/plugin-pubsub-adapter-redis --only-tar                                                                                                                                                                         
$ tsup                                                                                                                                                                                                                                                         
@nocobase/plugin-pubsub-adapter-redis: tar package                                                                                                                                                                                                             
/app/nocobase/packages/core/build/lib/tarPlugin.js:53                                                                                                                                                                     
  return import_tar.default.c({ gzip: true, file: tarball, cwd }, tarFiles);                                                                                                                                                                                   
                            ^                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                               
TypeError: Cannot read properties of undefined (reading 'c')                                                                                                                                                                                                   
    at tarPlugin (/app/nocobase/packages/core/build/lib/tarPlugin.js:53:29)                                                                                                                                               
    at buildPackage (/app/nocobase/packages/core/build/lib/build.js:103:42)                                                                                                                                               
    at buildPackages (/app/nocobase/packages/core/build/lib/build.js:92:11)                                                                                                                                               
    at async build (/app/nocobase/packages/core/build/lib/build.js:78:3)                                                                                                                                                  
                                                                                                                                                                                                                                                               
Node.js v20.10.0                                                                                                                                                                                                                                               
/app/nocobase/node_modules/execa/lib/error.js:60                                                                                                                                                                          
                error = new Error(message);                                                                                                                                                                                                                    
                        ^                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                               
Error: Command failed with exit code 1: nocobase-build packages/pro-plugins/@nocobase/plugin-pubsub-adapter-redis --only-tar                                                                                                                                   
    at makeError (/app/nocobase/node_modules/execa/lib/error.js:60:11)                                                                                                                                                    
    at handlePromise (/app/nocobase/node_modules/execa/index.js:118:26)                                                                                                                                                   
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                                                                                                                              
    at async Command.<anonymous> (/app/nocobase/packages/core/cli/src/commands/build.js:40:7) {                                                                                                                           
  shortMessage: 'Command failed with exit code 1: nocobase-build packages/pro-plugins/@nocobase/plugin-pubsub-adapter-redis --only-tar    ',                                                                                                                   
  command: 'nocobase-build packages/pro-plugins/@nocobase/plugin-pubsub-adapter-redis --only-tar    ',                                                                                                                                                         
  escapedCommand: 'nocobase-build "packages/pro-plugins/@nocobase/plugin-pubsub-adapter-redis" --only-tar "" "" "" ""',                                                                                                                                        
  exitCode: 1,                                                                                                                                                                                                                                                 
  signal: undefined,                                                                                                                                                                                                                                           
  signalDescription: undefined,                                                                                                                                                                                                                                
  stdout: undefined,                                                                                                                                                                                                                                           
  stderr: undefined,                                                                                                                                                                                                                                           
  failed: true,                                                                                                                                                                                                                                                
  timedOut: false,                                                                                                                                                                                                                                             
  isCanceled: false,                                                                                                                                                                                                                                           
  killed: false                                                                                                                                                                                                                                                
}                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                               
Node.js v20.10.0                                                                                                                                                                                                                                               
error Command failed with exit code 1.
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix error thrown in tar command |
| 🇨🇳 Chinese | 修复 tar 命令报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
