### PR TITLE
fix: missing action option constraints when reopening linkage rules

### DIFF
--- a/packages/core/client/src/schema-settings/LinkageRules/ValueDynamicComponent.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/ValueDynamicComponent.tsx
@@ -100,6 +100,14 @@ export const ValueDynamicComponent = (props: ValueDynamicComponentProps) => {
           .ant-checkbox-wrapper {
             margin-left: 50%;
           }
+          .ant-select-selector {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+          }
+          .ant-picker {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+          }
         `}
       >
         {React.createElement(DynamicComponent, {

--- a/packages/core/client/src/schema-settings/LinkageRules/useValues.ts
+++ b/packages/core/client/src/schema-settings/LinkageRules/useValues.ts
@@ -33,7 +33,12 @@ export const useValues = (options) => {
     const dataIndex = field.data?.targetFields;
     const option = (dataIndex && findOption(dataIndex, options)) || {};
     const operators = option?.operators || [];
-    field.data.operators = operators;
+    field.data.operators = operators?.filter((v) => {
+      if (dataIndex.length > 1) {
+        return v.value !== 'value';
+      }
+      return true;
+    });
     field.data.schema = option?.schema;
   };
   useEffect(value2data, [logic]);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   missing action option constraints when reopening linkage rules        |
| 🇨🇳 Chinese |   重新打开联动规则时缺少操作选项约束        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
