### PR TITLE
fix: block templates not shown for mysql env

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplateMenusProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplateMenusProvider.tsx
@@ -68,7 +68,7 @@ export const BlockTemplateMenusProvider = ({ children }) => {
       method: 'get',
       params: {
         filter: {
-          configured: true,
+          configured: { $isTruly: true },
           type: isMobile ? 'Mobile' : { $ne: 'Mobile' },
         },
         paginate: false,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | block templates can't be used in mysql envrionment |
| 🇨🇳 Chinese | mysql 环境下无法使用区块模板 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
