### PR TITLE
fix: update min and max date limits in MobileDateTimePicker

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/components/MobileDatePicker.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/components/MobileDatePicker.tsx
@@ -140,8 +140,8 @@ const MobileDateTimePicker = connect(
           }}
           precision={showTime && picker === 'date' ? getPrecision(timeFormat) : picker === 'date' ? 'day' : picker}
           renderLabel={labelRenderer}
-          min={minDate || rest.min || new Date(1000, 0, 1)}
-          max={maxDate || rest.max || new Date(9999, 11, 31)}
+          min={minDate || rest.min || new Date(1950, 0, 1)}
+          max={maxDate || rest.max || new Date(2050, 11, 31)}
           onConfirm={(val) => {
             handleConfirm(val);
           }}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Improve rendering performance by reducing the selectable range. Users can customize the selectable range through the "Date range limit" option：

![image](https://github.com/user-attachments/assets/30cfe280-e6bf-4952-9e36-0d30b8b5ceff)


### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Optimize the opening speed of the mobile date picker popup    |
| 🇨🇳 Chinese |     优化移动端日期选择弹窗的打开速度      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
