### PR TITLE
fix: missing filter for already associated data when adding association data

### DIFF
--- a/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
+++ b/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
@@ -41,7 +41,7 @@ const useTableSelectorProps = () => {
 export const AssociateActionProvider = (props) => {
   const [selectedRows, setSelectedRows] = useState([]);
   const collection = useCollection();
-  const { resource, service, block, __parent } = useBlockRequestContext();
+  const { resource, block, __parent } = useBlockRequestContext();
   const actionCtx = useActionContext();
   const { isMobile } = useOpenModeContext() || {};
   const [associationData, setAssociationData] = useState([]);
@@ -49,7 +49,7 @@ export const AssociateActionProvider = (props) => {
     resource?.list?.().then((res) => {
       setAssociationData(res.data?.data || []);
     });
-  }, []);
+  }, [resource]);
 
   const pickerProps = {
     size: 'small',

--- a/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
+++ b/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { RecordPickerProvider, RecordPickerContext } from '../../../schema-component/antd/record-picker';
 import {
   SchemaComponentOptions,
@@ -44,6 +44,13 @@ export const AssociateActionProvider = (props) => {
   const { resource, service, block, __parent } = useBlockRequestContext();
   const actionCtx = useActionContext();
   const { isMobile } = useOpenModeContext() || {};
+  const [associationData, setAssociationData] = useState([]);
+  useEffect(() => {
+    resource?.list?.().then((res) => {
+      setAssociationData(res.data?.data || []);
+    });
+  }, []);
+
   const pickerProps = {
     size: 'small',
     onChange: props?.onChange,
@@ -73,8 +80,8 @@ export const AssociateActionProvider = (props) => {
   };
   const getFilter = () => {
     const targetKey = collection?.filterTargetKey || 'id';
-    if (service.data?.data) {
-      const list = service.data?.data.map((option) => option[targetKey]).filter(Boolean);
+    if (associationData) {
+      const list = associationData.map((option) => option[targetKey]).filter(Boolean);
       const filter = list.length ? { $and: [{ [`${targetKey}.$ne`]: list }] } : {};
       return filter;
     }


### PR DESCRIPTION
…on collection table

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    missing filter for already associated data when adding association data       |
| 🇨🇳 Chinese |      添加关联表格时未过滤已关联的数据
     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
