### PR TITLE
fix:  tree table 'Add Child' button linkage rule missing 'current record'

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -321,11 +321,7 @@ const InternalAction: React.FC<InternalActionProps> = observer(function Com(prop
   }
 
   if (addChild) {
-    return wrapSSR(
-      <RecordProvider record={null} parent={parentRecordData}>
-        <TreeRecordProvider parent={recordData}>{result}</TreeRecordProvider>
-      </RecordProvider>,
-    ) as React.ReactElement;
+    return wrapSSR(<TreeRecordProvider parent={recordData}>{result}</TreeRecordProvider>) as React.ReactElement;
   }
 
   return wrapSSR(result) as React.ReactElement;


### PR DESCRIPTION
…ord' variable

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  tree table 'Add Child' button linkage rule missing 'current record'         |
| 🇨🇳 Chinese |       树表格中添加子记录按钮的联动规则缺失「当前记录」变量    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
