### PR TITLE
style(gantt): gantt chart block overlapping months in calendar header for month view

### DIFF
--- a/packages/plugins/@nocobase/plugin-gantt/src/client/components/calendar/calendar.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/components/calendar/calendar.tsx
@@ -52,12 +52,7 @@ export const Calendar: React.FC<CalendarProps> = ({
       const date = dateSetup.dates[i];
       const bottomValue = date.getFullYear();
       bottomValues.push(
-        <text
-          key={date.getTime()}
-          y={headerHeight * 0.8}
-          x={columnWidth * i + columnWidth * 0.5}
-          className={cx('calendarBottomText')}
-        >
+        <text key={date.getTime()} y={headerHeight * 0.8} x={columnWidth * i + columnWidth * 0.5}>
           {bottomValue}
         </text>,
       );
@@ -98,7 +93,7 @@ export const Calendar: React.FC<CalendarProps> = ({
           key={date.getTime()}
           y={headerHeight * 0.8}
           x={columnWidth * i + columnWidth * 0.5}
-          className={cx('calendarBottomText')}
+          className={styles.calendarBottomText}
         >
           {quarter}
         </text>,
@@ -118,7 +113,7 @@ export const Calendar: React.FC<CalendarProps> = ({
             x1Line={columnWidth * i}
             y1Line={0}
             y2Line={topDefaultHeight}
-            xText={Math.abs(xText)}
+            xText={Math.abs(xText) - 200}
             yText={topDefaultHeight * 0.9}
           />,
         );
@@ -139,7 +134,7 @@ export const Calendar: React.FC<CalendarProps> = ({
           key={bottomValue + date.getFullYear()}
           y={headerHeight * 0.8}
           x={columnWidth * i + columnWidth * 0.5}
-          className={cx('calendarBottomText')}
+          className={styles.calendarBottomText}
         >
           {bottomValue}
         </text>,
@@ -189,7 +184,7 @@ export const Calendar: React.FC<CalendarProps> = ({
           key={date.getTime()}
           y={headerHeight * 0.8}
           x={columnWidth * (i + +rtl)}
-          className={cx('calendarBottomText')}
+          className={styles.calendarBottomText}
         >
           {bottomValue}
         </text>,

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/components/calendar/style.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/components/calendar/style.tsx
@@ -24,7 +24,7 @@ const useStyles = createStyles(({ token, css }) => {
       border-bottom: 1px solid ${token.colorBorderSecondary};
     `,
     calendarBottomText: css`
-      font-size: 9px;
+      font-size: 11px;
     `,
     nbGanttCalendar: css`
       .calendarbottomtext: {

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/components/calendar/style.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/components/calendar/style.tsx
@@ -23,6 +23,9 @@ const useStyles = createStyles(({ token, css }) => {
       background: ${colorFillAlterSolid};
       border-bottom: 1px solid ${token.colorBorderSecondary};
     `,
+    calendarBottomText: css`
+      font-size: 9px;
+    `,
     nbGanttCalendar: css`
       .calendarbottomtext: {
         textanchor: middle;

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/components/gantt/gantt.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/components/gantt/gantt.tsx
@@ -47,7 +47,7 @@ import { TaskGantt } from './task-gantt';
 import { TaskGanttContentProps } from './task-gantt-content';
 
 const getColumnWidth = (dataSetLength: any, clientWidth: any) => {
-  const columnWidth = clientWidth / dataSetLength > 50 ? Math.floor(clientWidth / dataSetLength) + 20 : 50;
+  const columnWidth = clientWidth / dataSetLength > 50 ? Math.floor(clientWidth / dataSetLength) + 20 : 60;
   return columnWidth;
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     gantt chart block overlapping months in calendar header for month view      |
| 🇨🇳 Chinese |    甘特图区块设置月份视图时，日历头部月份重叠       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
