### PR TITLE
fix: action panel icon missing when icon-only is enabled

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-workbench/src/client/WorkbenchAction.tsx
+++ b/packages/plugins/@nocobase/plugin-block-workbench/src/client/WorkbenchAction.tsx
@@ -42,31 +42,35 @@ const useStyles = createStyles(({ token, css }) => ({
   `,
 }));
 
-function Button() {
+function Button({ onlyIcon }) {
   const fieldSchema = useFieldSchema();
-  const icon = fieldSchema['x-component-props']?.['icon'];
-  const backgroundColor = fieldSchema['x-component-props']?.['iconColor'];
+  const { icon, iconColor: backgroundColor } = fieldSchema['x-component-props'] || {};
   const { layout, ellipsis = true } = useContext(WorkbenchBlockContext);
   const { styles, cx } = useStyles();
   const { t } = useTranslation();
   const title = t(fieldSchema.title, { ns: NAMESPACE_UI_SCHEMA });
-  return layout === WorkbenchLayout.Grid ? (
-    <div title={title} className={cx(styles.avatar)}>
-      <Avatar style={{ backgroundColor }} size={48} icon={<Icon type={icon} />} />
-      <div
-        className={cx(styles.title)}
-        style={{
-          whiteSpace: ellipsis ? 'nowrap' : 'normal',
-          textOverflow: ellipsis ? 'ellipsis' : 'clip',
-          overflow: ellipsis ? 'hidden' : 'visible',
-        }}
-      >
-        {title}
+
+  const shouldShowTitle = !onlyIcon;
+
+  if (layout === WorkbenchLayout.Grid) {
+    return (
+      <div title={title} className={cx(styles.avatar)}>
+        <Avatar style={{ backgroundColor }} size={48} icon={<Icon type={icon} />} />
+        <div
+          className={cx(styles.title)}
+          style={{
+            whiteSpace: ellipsis ? 'nowrap' : 'normal',
+            textOverflow: ellipsis ? 'ellipsis' : 'clip',
+            overflow: ellipsis ? 'hidden' : 'visible',
+          }}
+        >
+          {shouldShowTitle && title}
+        </div>
       </div>
-    </div>
-  ) : (
-    <span>{title}</span>
-  );
+    );
+  }
+
+  return <span>{shouldShowTitle && title}</span>;
 }
 
 export const WorkbenchAction = withDynamicSchemaProps((props) => {
@@ -79,9 +83,10 @@ export const WorkbenchAction = withDynamicSchemaProps((props) => {
       <Component
         className={cx(className, styles.action, 'nb-action-panel')}
         {...others}
+        onlyIcon={false}
         type="text"
         icon={null}
-        title={<Button />}
+        title={<Button onlyIcon={others?.onlyIcon} />}
         confirmTitle={fieldSchema.title}
         style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
       />

--- a/packages/plugins/@nocobase/plugin-block-workbench/src/client/WorkbenchBlock.tsx
+++ b/packages/plugins/@nocobase/plugin-block-workbench/src/client/WorkbenchBlock.tsx
@@ -85,6 +85,7 @@ const InternalIcons = () => {
                   key={key}
                   prefix={<Avatar style={{ backgroundColor }} icon={<Icon type={icon} />} />}
                   onClick={() => {}}
+                  style={{ marginTop: '5px' }}
                 >
                   <NocoBaseRecursionField name={key} schema={s} />
                 </List.Item>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   action panel icon missing when icon-only is enabled        |
| 🇨🇳 Chinese |    操作面板 icon-only 配置下图标未显示     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
