### PR TITLE
fix(utils): support unicode to be used in template key

### DIFF
--- a/packages/core/utils/src/__tests__/json-templates.test.ts
+++ b/packages/core/utils/src/__tests__/json-templates.test.ts
@@ -10,7 +10,7 @@
 import { parse } from '../json-templates';
 
 describe('json-templates', () => {
-  it('parse json with string template', async () => {
+  it('parse json with string template', () => {
     const template = {
       name: '{{id}}-{{name}}.',
       age: 18,
@@ -22,6 +22,29 @@ describe('json-templates', () => {
     expect(result).toEqual({
       name: '1-test.',
       age: 18,
+    });
+  });
+
+  it('parse nested key with options.nestedKey as true', () => {
+    expect(parse('{{a.b}}', { nestedKey: true })({ a: { b: 1 } })).toBe(1);
+  });
+
+  it('not parse nested key without options.nestedKey as true', () => {
+    expect(parse('{{a.b}}')({ 'a.b': 2 })).toBe(2);
+  });
+
+  it('parse with variable path contains chinese characters', () => {
+    const template = {
+      name: '{{中文id}}-{{user.中文name}}.',
+    };
+    const result = parse(template, { nestedKey: true })({
+      中文id: 123,
+      user: {
+        中文name: 'abc',
+      },
+    });
+    expect(result).toEqual({
+      name: '123-abc.',
     });
   });
 });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Support unicode to be used in template key.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support unicode to be used in template key |
| 🇨🇳 Chinese | 支持模板变量名使用 unicode 字符 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
