### PR TITLE
fix: refreshing the page after switching operators causes an error

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
@@ -535,11 +535,16 @@ export const EditOperator = () => {
         }
 
         field.componentProps = componentProps;
+        _.set(fieldSchema, 'default', null);
+
         dn.emit('patch', {
           schema: {
             ['x-uid']: fieldSchema['x-uid'],
             ['x-component-props']: componentProps,
             ['x-filter-operator']: v,
+            // Clear default value when switching operators. Some operators require the default value to be an array,
+            // while others don't. Without clearing it, the filtering API would throw an error
+            default: null,
           },
         });
         dn.refresh();

--- a/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
@@ -537,6 +537,8 @@ export const EditOperator = () => {
         field.componentProps = componentProps;
         fieldSchema['x-component-props'] = componentProps;
         fieldSchema.default = null;
+        field.value = null;
+        field.initialValue = null;
 
         dn.emit('patch', {
           schema: {

--- a/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/SchemaSettingOptions.tsx
@@ -535,7 +535,8 @@ export const EditOperator = () => {
         }
 
         field.componentProps = componentProps;
-        _.set(fieldSchema, 'default', null);
+        fieldSchema['x-component-props'] = componentProps;
+        fieldSchema.default = null;
 
         dn.emit('patch', {
           schema: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      In the filter form, switching the field operator and then refreshing the page causes an error     |
| 🇨🇳 Chinese |     筛选表单中，切换字段操作符后，刷新页面会报错      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
