### PR TITLE
fix(Collapse): issue with data scope being cleared

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -1451,6 +1451,7 @@ export const useAssociationFilterBlockProps = () => {
     run,
     valueKey,
     labelKey,
+    dataScopeFilter: filter,
   };
 };
 async function doReset({

--- a/packages/core/client/src/schema-component/antd/association-filter/AssociationFilter.Item.tsx
+++ b/packages/core/client/src/schema-component/antd/association-filter/AssociationFilter.Item.tsx
@@ -41,6 +41,7 @@ export const AssociationFilterItem = withDynamicSchemaProps(
       handleSearchInput: _handleSearchInput,
       params,
       run,
+      dataScopeFilter,
       valueKey: _valueKey,
       labelKey: _labelKey,
       defaultCollapse,
@@ -94,7 +95,7 @@ export const AssociationFilterItem = withDynamicSchemaProps(
       if (searchVisible || filter) {
         run({
           ...params?.[0],
-          filter: undefined,
+          filter: dataScopeFilter,
         });
       }
       setSearchVisible(!searchVisible);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       In the collapse block, clicking the clear button in the relationship field search box should not delete the data range    |
| 🇨🇳 Chinese |     折叠面板区块中，当点击关系字段搜索框的清空按钮后，不应该删除数据范围      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
