### PR TITLE
fix: alignment issue of the add child record button in the tree table

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Link.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Link.tsx
@@ -10,25 +10,9 @@
 import { observer } from '@formily/react';
 import classnames from 'classnames';
 import React from 'react';
-import { Space, Tooltip } from 'antd';
 import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
 import Action from './Action';
 import { ComposedAction } from './types';
-import { Icon } from '../../../icon';
-
-const WrapperComponent = React.forwardRef(
-  ({ component: Component = 'a', icon, onlyIcon, children, ...restProps }: any, ref) => {
-    return (
-      <Component ref={ref} {...restProps}>
-        <Tooltip title={restProps.title}>
-          <span style={{ marginRight: 3 }}>{icon && typeof icon === 'string' ? <Icon type={icon} /> : icon}</span>
-        </Tooltip>
-        {onlyIcon ? children[1] : children}
-      </Component>
-    );
-  },
-);
-WrapperComponent.displayName = 'WrapperComponentLink';
 
 export const ActionLink: ComposedAction = withDynamicSchemaProps(
   observer((props: any) => {

--- a/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
+++ b/packages/core/client/src/schema-initializer/components/CreateRecordAction.tsx
@@ -357,7 +357,7 @@ function FinallyButton({
       }}
       style={{
         ...props?.style,
-        display: !designable && field?.data?.hidden && 'none',
+        display: !designable && field?.data?.hidden ? 'none' : 'inline-block',
         opacity: designable && field?.data?.hidden && 0.1,
         ...buttonStyle,
       }}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     alignment issue of the add child record button in the tree table      |
| 🇨🇳 Chinese |     树表中添加子记录按钮未与其他按钮对齐    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
