### PR TITLE
fix(custom-request): custom request response set to variable not displaying correctly

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client/hooks/useCustomizeRequestActionProps.ts
@@ -89,7 +89,7 @@ export const useCustomizeRequestActionProps = () => {
             variables,
             localVariables: [
               ...localVariables,
-              { name: '$nResponse', ctx: new Proxy({ ...res?.data, ...res?.data?.data }, {}) },
+              { name: '$nResponse', ctx: new Proxy({ ...res?.data?.data, ...res?.data }, {}) },
             ],
           });
           successMessage = interpolateVariables(exp, expScope);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  custom request response set to variable not displaying correctly         |
| 🇨🇳 Chinese |   自定义请求成功后返回信息设置为变量未正确显示        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
