### PR TITLE
fix: field linkage rules in filter form block missing 'current form'  variable

### DIFF
--- a/packages/core/client/src/schema-settings/LinkageRules/index.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/index.tsx
@@ -116,7 +116,6 @@ export const FormLinkageRules = withDynamicSchemaProps(
       returnScope ??
       ((options) =>
         options.filter((v) => {
-          console.log(category);
           if (category === LinkageRuleCategory.block) {
             return !['$nForm', '$nRecord'].includes(v.value);
           }

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useFormVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useFormVariable.ts
@@ -78,7 +78,10 @@ export const useCurrentFormContext = ({ form: _form }: Pick<Props, 'form'> = {})
     currentFormCtx: formInstance?.values,
     /** 用来判断是否可以显示`当前表单`变量 */
     shouldDisplayCurrentForm:
-      name === 'form' && formInstance && !formInstance.readPretty && !isVariableParsedInOtherContext,
+      ['form', 'filter-form'].includes(name) &&
+      formInstance &&
+      !formInstance.readPretty &&
+      !isVariableParsedInOtherContext,
   };
 };
 


### PR DESCRIPTION
…variable

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     field linkage rules in filter form block missing 'current form'  variable      |
| 🇨🇳 Chinese |      筛选表单区块的字段联动规则缺少 "当前表单" 变量     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
