### PR TITLE
fix(database): fix trim option for string and text field

### DIFF
--- a/packages/core/database/src/__tests__/fields/string-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/string-field.test.ts
@@ -119,4 +119,32 @@ describe('string field', () => {
       name: 'n1',
     });
   });
+
+  it('trim when value is null should be null', async () => {
+    const collection = db.collection({
+      name: 'tests',
+      fields: [{ type: 'string', name: 'name', trim: true }],
+    });
+    await db.sync();
+    const model = await collection.model.create({
+      name: null,
+    });
+    expect(model.toJSON()).toMatchObject({
+      name: null,
+    });
+  });
+
+  it('when value is number should be convert to string', async () => {
+    const collection = db.collection({
+      name: 'tests',
+      fields: [{ type: 'string', name: 'name', trim: true }],
+    });
+    await db.sync();
+    const model = await collection.model.create({
+      name: 123,
+    });
+    expect(model.toJSON()).toMatchObject({
+      name: '123',
+    });
+  });
 });

--- a/packages/core/database/src/__tests__/fields/text-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/text-field.test.ts
@@ -66,4 +66,32 @@ describe('text field', () => {
       name: 'n1',
     });
   });
+
+  it('trim when value is null should be null', async () => {
+    const collection = db.collection({
+      name: 'tests',
+      fields: [{ type: 'string', name: 'name', trim: true }],
+    });
+    await db.sync();
+    const model = await collection.model.create({
+      name: null,
+    });
+    expect(model.toJSON()).toMatchObject({
+      name: null,
+    });
+  });
+
+  it('when value is number should be convert to string', async () => {
+    const collection = db.collection({
+      name: 'tests',
+      fields: [{ type: 'string', name: 'name', trim: true }],
+    });
+    await db.sync();
+    const model = await collection.model.create({
+      name: 123,
+    });
+    expect(model.toJSON()).toMatchObject({
+      name: '123',
+    });
+  });
 });

--- a/packages/core/database/src/fields/string-field.ts
+++ b/packages/core/database/src/fields/string-field.ts
@@ -24,7 +24,13 @@ export class StringField extends Field {
 
     return {
       set(value) {
-        this.setDataValue(name, trim ? value?.trim() : value);
+        if (value == null) {
+          return value;
+        }
+        if (typeof value !== 'string') {
+          value = value.toString();
+        }
+        this.setDataValue(name, trim ? value.trim() : value);
       },
     };
   }

--- a/packages/core/database/src/fields/text-field.ts
+++ b/packages/core/database/src/fields/text-field.ts
@@ -29,7 +29,13 @@ export class TextField extends Field {
 
     return {
       set(value) {
-        this.setDataValue(name, trim ? value?.trim() : value);
+        if (value == null) {
+          return value;
+        }
+        if (typeof value !== 'string') {
+          value = value.toString();
+        }
+        this.setDataValue(name, trim ? value.trim() : value);
       },
     };
   }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Avoid error thrown when data type is not string.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid error thrown when data type is not string |
| 🇨🇳 Chinese | 避免文本类型输入数据不是字符串时的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
