### PR TITLE
fix: missing field property settings in field linkage rules for subform (popup) in subtable

### DIFF
--- a/packages/core/client/src/modules/fields/component/SubTable/subTablePopoverComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/SubTable/subTablePopoverComponentFieldSettings.tsx
@@ -29,6 +29,7 @@ import { useIsAssociationField } from '../../../../schema-component/antd/form-it
 import { FormLinkageRules } from '../../../../schema-settings/LinkageRules';
 import { SchemaSettingsLinkageRules } from '../../../../schema-settings/SchemaSettings';
 import { SchemaSettingsItemType } from '../../../../application';
+import { useColumnSchema } from '../../../../schema-component';
 
 const enabledIndexColumn: SchemaSettingsItemType = {
   name: 'enableIndexColumn',
@@ -338,11 +339,12 @@ export const linkageRules = {
   Component: SchemaSettingsLinkageRules,
   useComponentProps() {
     const field = useField();
-    const fieldSchema = useFieldSchema();
+    const schema = useFieldSchema();
+    const { fieldSchema: columnSchema } = useColumnSchema();
+    const fieldSchema = columnSchema || schema;
     const cm = useCollectionManager();
     const collectionField = cm.getCollectionField(fieldSchema['x-collection-field']);
     const { rerenderDataBlock } = useRerenderDataBlock();
-
     return {
       collectionName: collectionField?.target,
       Component: LinkageRulesComponent,

--- a/packages/core/client/src/schema-component/antd/association-field/SubTable.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/SubTable.tsx
@@ -218,7 +218,6 @@ export const SubTable: any = observer(
         },
       };
     };
-    console.log(props);
     return (
       <div className={subTableContainer}>
         <FlagProvider isInSubTable>

--- a/packages/core/client/src/schema-component/antd/form-item/hooks/useLinkageRulesForSubTableOrSubForm.ts
+++ b/packages/core/client/src/schema-component/antd/form-item/hooks/useLinkageRulesForSubTableOrSubForm.ts
@@ -104,6 +104,7 @@ function getLinkageRules(fieldSchema) {
   if (!fieldSchema) {
     return;
   }
+  const result = fieldSchema['x-linkage-rules'] || fieldSchema?.parent?.['x-linkage-rules'] || [];
 
-  return fieldSchema['x-linkage-rules']?.filter((k) => !k.disabled);
+  return result?.filter((k) => !k.disabled);
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 子表格中子表单（弹窗）联动规则缺少字段属性设置      |
| 🇨🇳 Chinese |   missing field property settings in field linkage rules for subform (popup) in subtable        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
