### PR TITLE
fix: incorrect variable selection when first click to load data

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -484,7 +484,7 @@ export function Input(props: VariableInputProps) {
             value={variable ?? cValue}
             onChange={onSwitch}
             loadData={loadData as any}
-            changeOnSelect={changeOnSelect}
+            changeOnSelect={changeOnSelect ?? true}
             fieldNames={fieldNames}
             disabled={disabled}
           >

--- a/packages/core/client/src/schema-component/antd/variable/Input.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/Input.tsx
@@ -303,35 +303,17 @@ export function Input(props: VariableInputProps) {
   const loadData = async (selectedOptions: DefaultOptionType[]) => {
     const option = selectedOptions[selectedOptions.length - 1];
     if (!option.children?.length && !option.isLeaf && option.loadChildren) {
-      // Call the modified loadChildren which returns { children, isLeaf, disabled }
-      // Remove extra arguments (activeKey, variable) as they are no longer needed
-      const loadedData = await option.loadChildren(option);
-
-      // Update local options state immutably
-      setOptions((prev) => {
-        const updateNode = (nodes) =>
-          nodes.map((node) => {
-            // Use the correct key from the names mapping
-            if (node[names.value] === option[names.value]) {
-              // Found the target node, update it with new data
-              return {
-                ...node,
-                children: loadedData.children,
-                isLeaf: loadedData.isLeaf,
-                disabled: loadedData.disabled,
-                // loadChildren is implicitly handled by Cascader based on isLeaf/children
-              };
-            }
-            // Recursively update children if they exist
-            if (node.children) {
-              return { ...node, children: updateNode(node.children) };
-            }
-            // Return node unchanged
-            return node;
-          });
-        // Apply the update to the previous state
-        return updateNode(prev);
-      });
+      let activeKey;
+      if (variable && variable.length >= 2) {
+        for (const key of variable) {
+          if (key === option[names.value]) {
+            activeKey = key;
+            break;
+          }
+        }
+      }
+      await option.loadChildren(option, activeKey, variable);
+      setOptions((prev) => [...prev]);
     }
   };
 
@@ -394,7 +376,7 @@ export function Input(props: VariableInputProps) {
             if (prevOption.loadChildren && !prevOption.children?.length) {
               await prevOption.loadChildren(prevOption, key, variable);
             }
-            prevOption = prevOption.children?.find((item) => item[names.value] === key);
+            prevOption = prevOption.children.find((item) => item[names.value] === key);
           }
 
           // 如果为空则说明相关字段已被删除
@@ -502,7 +484,7 @@ export function Input(props: VariableInputProps) {
             value={variable ?? cValue}
             onChange={onSwitch}
             loadData={loadData as any}
-            changeOnSelect={true} // Force changeOnSelect to true
+            changeOnSelect={changeOnSelect}
             fieldNames={fieldNames}
             disabled={disabled}
           >

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -308,27 +308,18 @@ function loadChildren(option) {
     types: option.types,
     appends,
     depth: option.depth - 1,
-    ...this, // 'this' contains compile, getCollectionFields, fieldNames
+    ...this,
   });
-
-  let isLeaf = false;
-  let children = null;
-  let disabled = option.disabled; // Preserve original disabled state unless overridden
-
+  option.loadChildren = null;
   if (result.length) {
-    children = result;
-    isLeaf = false;
+    option.children = result;
   } else {
-    isLeaf = true;
+    option.isLeaf = true;
     const matchingType = option.types ? option.types.some((type) => matchFieldType(option.field, type)) : true;
     if (!matchingType) {
-      // If the parent itself doesn't match the type and has no matching children, disable it.
-      disabled = true;
+      option.disabled = true;
     }
   }
-
-  // Return the new state instead of mutating
-  return { children, isLeaf, disabled };
 }
 
 export function getCollectionFieldOptions(options): VariableOption[] {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -308,18 +308,27 @@ function loadChildren(option) {
     types: option.types,
     appends,
     depth: option.depth - 1,
-    ...this,
+    ...this, // 'this' contains compile, getCollectionFields, fieldNames
   });
-  option.loadChildren = null;
+
+  let isLeaf = false;
+  let children = null;
+  let disabled = option.disabled; // Preserve original disabled state unless overridden
+
   if (result.length) {
-    option.children = result;
+    children = result;
+    isLeaf = false;
   } else {
-    option.isLeaf = true;
+    isLeaf = true;
     const matchingType = option.types ? option.types.some((type) => matchFieldType(option.field, type)) : true;
     if (!matchingType) {
-      option.disabled = true;
+      // If the parent itself doesn't match the type and has no matching children, disable it.
+      disabled = true;
     }
   }
+
+  // Return the new state instead of mutating
+  return { children, isLeaf, disabled };
 }
 
 export function getCollectionFieldOptions(options): VariableOption[] {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | when variable selection requires async loading, the last selected menu is lost. |
| 🇨🇳 Chinese | 变量选择时，若需要异步加载，则会丢失最后选中的菜单 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
