### PR TITLE
fix: exclude 'attachmentURL' from associated form item filter

### DIFF
--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -599,9 +599,9 @@ const associationFieldToMenu = (
 export const useFilterAssociatedFormItemInitializerFields = () => {
   const { name, fields } = useCollection_deprecated();
   const { getCollectionFields } = useCollectionManager_deprecated();
-  const interfaces = ['o2o', 'oho', 'obo', 'm2o', 'm2m'];
+  const excludedInterfaces = ['attachmentURL'];
   return fields
-    ?.filter((field) => field.target && field.uiSchema && interfaces.includes(field.interface))
+    ?.filter((field) => field.target && field.uiSchema && !excludedInterfaces.includes(field.interface))
     .map((field) => associationFieldToMenu(field, field.name, name, getCollectionFields, []))
     .filter(Boolean);
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where one-to-many field sub-fields cannot be selected as filtering options in filter forms    |
| 🇨🇳 Chinese |     修复无法在筛选表单中选择一对多字段的子字段作为筛选项的问题      |


### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
