### PR TITLE
docs(README): add Spanish translation

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,54 @@
+English | 中文 | 日本語
+
+https://github.com/user-attachments/assets/a50c100a-4561-4e06-b2d2-d48098659ec0
+
+<p align="center"> <a href="https://trendshift.io/repositories/4112" target="_blank"><img src="https://trendshift.io/api/badge/repositories/4112" alt="nocobase%2Fnocobase | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a> <a href="https://www.producthunt.com/posts/nocobase?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_souce=badge-nocobase" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-topic-badge.svg?post_id=456520&theme=light&period=weekly&topic_id=267" alt="NocoBase - Scalability&#0045;first&#0044;&#0032;open&#0045;source&#0032;no&#0045;code&#0032;platform | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a> </p>
+¿Qué es NocoBase?
+NocoBase es una plataforma de desarrollo sin código, de código abierto y orientada a la extensibilidad.
+En lugar de invertir años y millones en investigación y desarrollo, puedes desplegar NocoBase en solo unos minutos y tendrás una plataforma sin código privada, controlable y altamente escalable.
+
+Página principal:
+https://www.nocobase.com/
+
+Demostración en línea:
+https://demo.nocobase.com/new
+
+Documentación:
+https://docs.nocobase.com/
+
+Foro:
+https://forum.nocobase.com/
+
+Tutoriales:
+https://www.nocobase.com/en/tutorials
+
+Casos de uso:
+https://www.nocobase.com/en/blog/tags/customer-stories
+
+Notas de lanzamiento
+Nuestro blog se actualiza regularmente con notas de lanzamiento y resúmenes semanales.
+
+Características distintivas
+
+1. Basado en modelos de datos
+   La mayoría de los productos sin código orientados a formularios, tablas o procesos crean estructuras de datos directamente en la interfaz de usuario, como Airtable, donde agregar una nueva columna equivale a añadir un nuevo campo. Esto es sencillo, pero limita la funcionalidad y flexibilidad para escenarios más complejos.
+
+NocoBase adopta el enfoque de separar la estructura de datos de la interfaz de usuario, lo que permite crear múltiples bloques (vistas de datos) para las colecciones, cada uno con diferentes tipos, estilos, contenido y acciones. Esto equilibra la simplicidad del uso sin código con la flexibilidad del desarrollo tradicional.
+
+2. Lo que ves es lo que obtienes (WYSIWYG)
+   Aunque permite desarrollar sistemas empresariales complejos y personalizados, NocoBase no requiere operaciones complicadas. Con un solo clic, se muestran las opciones de configuración directamente en la interfaz de uso, permitiendo a los administradores con privilegios configurar la UI de forma visual e intuitiva.
+
+3. Todo se implementa como plugins
+   NocoBase utiliza una arquitectura basada en plugins. Todas las nuevas funcionalidades se pueden desarrollar e instalar como plugins, lo que hace que ampliar funciones sea tan fácil como instalar una app en tu teléfono.
+
+Instalación
+NocoBase admite tres métodos de instalación:
+
+<a target="_blank" href="https://docs.nocobase.com/welcome/getting-started/installation/docker-compose">Instalación con Docker (👍Recomendado)</a>
+Ideal para escenarios sin código, no requiere escribir código. Para actualizar, simplemente descarga la imagen más reciente y reinicia.
+
+<a target="_blank" href="https://docs.nocobase.com/welcome/getting-started/installation/create-nocobase-app">Instalación con CLI create-nocobase-app</a>
+El código del proyecto es completamente independiente y permite desarrollo con bajo código (low-code).
+
+<a target="_blank" href="https://docs.nocobase.com/welcome/getting-started/installation/git-clone">Instalación desde el código fuente (Git)</a>
+Si deseas experimentar la versión más reciente (aún no publicada) o contribuir al proyecto, este método es ideal. Requiere habilidades avanzadas de desarrollo. Puedes hacer git pull para obtener las últimas actualizaciones del código.


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ x ] Others

### Motivation
Added a full Spanish translation of the main README file to improve accessibility for Spanish-speaking users and encourage broader international adoption of the project.

### Description 
Created `README.es-ES.md`, a new file that mirrors the content of the original README, translated into Spanish. This translation follows the same formatting and structure as the English and other localized versions. No code changes were made.

### Related issues
None.

### Showcase
Not applicable (documentation update only).

### Changelog

| Language   | Changelog                                         |
| ---------- | ------------------------------------------------- |
| 🇺🇸 English |                                                   |
| 🇨🇳 Chinese |                                                   |
| 🇪🇸 Spanish | Added `README.es-ES.md` — full Spanish translation of the main README |