### PR TITLE
fix(database): eager load belongsTo got null on bigint foreign key

### DIFF
--- a/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
+++ b/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
@@ -381,6 +381,69 @@ describe('Eager loading tree', () => {
     expect(p1User.get('name')).toBe('u1');
   });
 
+  it.skip('should load belongs to on bigint foreign key', async () => {
+    const Post = db.collection({
+      name: 'posts',
+      fields: [
+        { type: 'string', name: 'title' },
+        {
+          type: 'belongsTo',
+          name: 'user',
+        },
+      ],
+    });
+
+    const User = db.collection({
+      name: 'users',
+      fields: [{ type: 'string', name: 'name' }],
+    });
+
+    await db.sync();
+
+    await Post.repository.create({
+      values: [
+        {
+          title: 'p1',
+          user: {
+            name: 'u1',
+          },
+        },
+        {
+          title: 'p2',
+          user: {
+            id: '19051207196672111',
+            name: 'u2',
+          },
+        },
+      ],
+    });
+
+    const findOptions = Post.repository.buildQueryOptions({
+      appends: ['user'],
+    });
+
+    const eagerLoadingTree = EagerLoadingTree.buildFromSequelizeOptions({
+      model: Post.model,
+      rootAttributes: findOptions.attributes,
+      includeOption: findOptions.include,
+      db: db,
+      rootQueryOptions: findOptions,
+    });
+
+    await eagerLoadingTree.load();
+
+    const root = eagerLoadingTree.root;
+    const p1 = root.instances.find((item) => item.get('title') === 'p1');
+    const p1User = p1.get('user') as any;
+    expect(p1User).toBeDefined();
+    expect(p1User.get('name')).toBe('u1');
+
+    const p2 = root.instances.find((item) => item.get('title') === 'p2');
+    const p2User = p2.get('user') as any;
+    expect(p2User).toBeDefined();
+    expect(p2User.get('name')).toBe('u2');
+  });
+
   it('should load belongs to many', async () => {
     const Post = db.collection({
       name: 'posts',

--- a/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
+++ b/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
@@ -381,7 +381,7 @@ describe('Eager loading tree', () => {
     expect(p1User.get('name')).toBe('u1');
   });
 
-  it.skip('should load belongs to on bigint foreign key', async () => {
+  it('should load belongs to on bigint foreign key', async () => {
     const Post = db.collection({
       name: 'posts',
       fields: [

--- a/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
+++ b/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
@@ -10,6 +10,8 @@
 import Database, { createMockDatabase } from '@nocobase/database';
 import { EagerLoadingTree } from '../../eager-loading/eager-loading-tree';
 
+const skipSqlite = process.env.DB_DIALECT == 'sqlite' ? it.skip : it;
+
 describe('Eager loading tree', () => {
   let db: Database;
   beforeEach(async () => {
@@ -381,7 +383,7 @@ describe('Eager loading tree', () => {
     expect(p1User.get('name')).toBe('u1');
   });
 
-  it('should load belongs to on bigint foreign key', async () => {
+  skipSqlite('should load belongs to on bigint foreign key', async () => {
     const Post = db.collection({
       name: 'posts',
       fields: [

--- a/packages/core/database/src/dialects/mariadb-dialect.ts
+++ b/packages/core/database/src/dialects/mariadb-dialect.ts
@@ -7,10 +7,16 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { DatabaseOptions } from '../database';
 import { BaseDialect } from './base-dialect';
 
 export class MariadbDialect extends BaseDialect {
   static dialectName = 'mariadb';
+
+  getSequelizeOptions(options: DatabaseOptions) {
+    options.dialectOptions = { ...(options.dialectOptions || {}), supportBigNumbers: true, bigNumberStrings: true };
+    return options;
+  }
 
   getVersionGuard() {
     return {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix belongs-to association not loaded in appends when foreign key is bigInt under MariaDB.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

https://github.com/sequelize/sequelize/issues/12390

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix belongs-to association not loaded in appends when foreign key is bigInt under MariaDB |
| 🇨🇳 Chinese | 修复多对一关系字段在 MariaDB 下外键为大整数配置了 appends 时无法加载的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
