### PR TITLE
fix: attachment (URL) field should not allow value configuration in …

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/client/component/AttachmentUrl.tsx
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/client/component/AttachmentUrl.tsx
@@ -113,7 +113,6 @@ const InnerAttachmentUrl = (props) => {
   if (underFilter) {
     return <Input {...props} />;
   }
-  console.log(collectionField);
   return (
     <div style={{ width: '100%', overflow: 'auto' }}>
       <AssociationField.FileSelector

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/client/interfaces/attachment-url.tsx
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/client/interfaces/attachment-url.tsx
@@ -73,6 +73,7 @@ export class AttachmentURLFieldInterface extends CollectionFieldInterface {
     }
   }
   filterable = {
+    nested: true,
     operators: operators.bigField,
   };
   titleUsable = true;


### PR DESCRIPTION
…linkage rules

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  attachment (URL) fields should not allow value configuration in linkage rule         |
| 🇨🇳 Chinese |       联动规则中附件（URL）字段不应支持配置 value    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
