### PR TITLE
fix: variable parsing incompatibility with {{title}} data in secondary confirm

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -739,9 +739,11 @@ export function SecondConFirm() {
       title={t('Secondary confirmation')}
       initialValues={{
         title:
+          t(fieldSchema?.['x-component-props']?.confirm?.title, { title: compile(fieldSchema.title) }) ||
           compile(fieldSchema?.['x-component-props']?.confirm?.title) ||
           t('Perform the {{title}}', { title: compile(fieldSchema.title) }),
         content:
+          t(fieldSchema?.['x-component-props']?.confirm?.content, { title: compile(fieldSchema.title) }) ||
           compile(fieldSchema?.['x-component-props']?.confirm?.content) ||
           t('Are you sure you want to perform the {{title}} action?', { title: compile(fieldSchema.title) }),
       }}

--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -454,6 +454,7 @@ const RenderButton = ({
   const variables = useVariables();
   const localVariables = useLocalVariables();
   const openPopupRef = useRef(null);
+  const compile = useCompile();
   openPopupRef.current = openPopup;
   const scopes = {
     variables,
@@ -467,8 +468,9 @@ const RenderButton = ({
       }
       e.preventDefault();
       e.stopPropagation();
-      const resultTitle = await getVariableValue(confirm?.title, scopes);
-      const resultContent = await getVariableValue(confirm?.content, scopes);
+
+      const resultTitle = await getVariableValue(t(confirm?.title, { title: compile(fieldSchema.title) }), scopes);
+      const resultContent = await getVariableValue(t(confirm?.content, { title: compile(fieldSchema.title) }), scopes);
       if (!disabled && aclCtx) {
         const onOk = () => {
           if (onClick) {


### PR DESCRIPTION
…y confirmation

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     variable parsing incompatibility with {{title}} data in secondary confirm      |
| 🇨🇳 Chinese |      二次确认变量解析不兼容{{title}}数据     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
