### PR TITLE
fix(duplicate-action): modal closes on first input click when editing duplicated data

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client/DuplicateAction.tsx
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client/DuplicateAction.tsx
@@ -163,7 +163,6 @@ export const DuplicateAction = observer(
         }
       }
     };
-
     return (
       <div
         ref={others.setNodeRef}
@@ -230,7 +229,9 @@ export const DuplicateAction = observer(
               <CollectionProvider_deprecated name={duplicateCollection || name}>
                 {/* 这里的 record 就是弹窗中创建表单的 sourceRecord */}
                 <RecordProvider record={{ ...parentRecordData, __collection: duplicateCollection || __collection }}>
-                  <ActionContextProvider value={{ ...ctx, visible, setVisible }}>
+                  <ActionContextProvider
+                    value={{ visible, setVisible, openMode: ctx.openMode, openSize: ctx.openSize }}
+                  >
                     <PopupSettingsProvider enableURL={false}>
                       <RefreshComponentProvider refresh={_.noop}>
                         <NocoBaseRecursionField schema={fieldSchema} basePath={field.address} onlyRenderProperties />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   modal closes on first input click when editing duplicated data        |
| 🇨🇳 Chinese |  复制数据后编辑时，首次点击字段输入会关闭弹窗的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
