### PR TITLE
fix: missing operator in linkage rule

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/password.ts
+++ b/packages/core/client/src/collection-manager/interfaces/password.ts
@@ -9,7 +9,7 @@
 
 import { CollectionFieldInterface } from '../../data-source/collection-field-interface/CollectionFieldInterface';
 import { i18n } from '../../i18n';
-import { defaultProps, unique } from './properties';
+import { defaultProps, unique, operators } from './properties';
 
 export class PasswordFieldInterface extends CollectionFieldInterface {
   name = 'password';
@@ -71,5 +71,8 @@ export class PasswordFieldInterface extends CollectionFieldInterface {
         },
       },
     };
+  };
+  filterable = {
+    operators: operators.string,
   };
 }

--- a/packages/core/client/src/schema-component/antd/linkageFilter/LinkageFilterItem.tsx
+++ b/packages/core/client/src/schema-component/antd/linkageFilter/LinkageFilterItem.tsx
@@ -62,9 +62,11 @@ export const LinkageFilterItem = observer(
             onChange={onOperatorsChange}
             placeholder={t('Comparision')}
           />
-          {!operator?.noValue ? (
+
+          <div style={{ display: !operator?.noValue ? 'inline-flex' : 'none' }}>
             <DynamicComponent value={rightVar} schema={schema} onChange={setRightValue} testid="right-filter-field" />
-          ) : null}
+          </div>
+
           {!props.disabled && (
             <a role="button" aria-label="icon-close">
               <CloseCircleOutlined onClick={remove} style={removeStyle} />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      operator missing when switching in linkage rules     |
| 🇨🇳 Chinese |    联动规则中切换操作符时操作符缺失       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
