### PR TITLE
fix:  clear right-hand value when operator changes in linkage rule

### DIFF
--- a/packages/core/client/src/schema-component/antd/linkageFilter/useValues.ts
+++ b/packages/core/client/src/schema-component/antd/linkageFilter/useValues.ts
@@ -118,7 +118,9 @@ export const useValues = (): UseValuesReturn => {
       const s1 = cloneDeep(field.data.schema);
       const s2 = cloneDeep(operator?.schema);
       field.data.schema = merge(s1, s2);
-      field.data.value = operator.noValue ? operator.default || true : undefined;
+      if (!operator.noValue) {
+        setRightValue(undefined);
+      }
       data2value();
     },
     [data2value, field.data],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    clear right-hand value when operator changes in linkage rule        |
| 🇨🇳 Chinese |      联动规则切换操作符时应清空右侧变量值     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
