### PR TITLE
fix(plugin-file-manager): fix create file record without foreign key permission

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
@@ -216,6 +216,33 @@ describe('action', () => {
         // const res2 = await agent.get(`${DEFAULT_LOCAL_BASE_URL}${body.data.path}/${encodedFilename}`);
         // expect(res2.text).toBe(rawText);
       });
+
+      it('create file record should be ok', async () => {
+        db.collection({
+          name: 'customers',
+          fields: [
+            {
+              name: 'avatar',
+              type: 'belongsTo',
+              target: 'attachments',
+            },
+          ],
+        });
+        const record = {
+          title: 'text',
+          extname: '.txt',
+          path: '',
+          // size: 13,
+          meta: {},
+          storageId: 1,
+        };
+        const { status, body } = await agent.resource('attachments').create({
+          attachmentField: 'customers.avatar',
+          values: record,
+        });
+        expect(status).toBe(200);
+        expect(body.data).toMatchObject(record);
+      });
     });
 
     describe('specific storage', () => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -119,16 +119,30 @@ export async function createMiddleware(ctx: Context, next: Next) {
     return next();
   }
 
-  const storageName = ctx.db.getFieldByPath(attachmentField)?.options?.storage || collection.options.storage;
-  const StorageRepo = ctx.db.getRepository('storages');
-  const storage = await StorageRepo.findOne({ filter: storageName ? { name: storageName } : { default: true } });
-
-  const plugin = ctx.app.pm.get(Plugin);
-  ctx.storage = plugin.parseStorage(storage);
+  const storageName =
+    resourceName === 'attachments'
+      ? ctx.db.getFieldByPath(attachmentField)?.options?.storage
+      : collection.options.storage;
+  // const StorageRepo = ctx.db.getRepository('storages');
+  // const storage = await StorageRepo.findOne({ filter: storageName ? { name: storageName } : { default: true } });
+  const plugin = ctx.app.pm.get(Plugin) as Plugin;
+  const storage = Array.from(plugin.storagesCache.values()).find((storage) =>
+    storageName ? storage.name === storageName : storage.default,
+  );
+  if (!storage) {
+    ctx.logger.error(`[file-manager] no storage found`);
+    return ctx.throw(500);
+  }
+  ctx.storage = storage;
 
   if (ctx?.request.is('multipart/*')) {
     await multipart(ctx, next);
   } else {
+    ctx.action.mergeParams({
+      values: {
+        storage: { id: storage.id },
+      },
+    });
     await next();
   }
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix create file record without foreign key permission.

### Description 

The field permission of `storageId` is not open to configure, then file uploaded will not write `storageId` into record. So the URL will be incorrect.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix create file record without foreign key permission |
| 🇨🇳 Chinese | 修复无外键权限时创建文件记录 URL 无效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
