### PR TITLE
fix(data-vi): chart blocks do not display when added to popups triggered from block-level actions

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
@@ -20,17 +20,15 @@ export const ChartBlockProvider: React.FC = (props) => {
   const popupCtxReady =
     _.isEmpty(currentPopupContext) || !popupRecordVariable?.collectionName || popupRecordVariable?.ctx;
 
-  if (!popupCtxReady) {
-    return null;
-  }
-
   return (
     <SchemaComponentOptions
       components={{
         BlockRefreshButton,
       }}
     >
-      <GlobalAutoRefreshProvider>{props.children}</GlobalAutoRefreshProvider>
+      <GlobalAutoRefreshProvider key={popupCtxReady ? 'ready' : 'not-ready'}>
+        {props.children}
+      </GlobalAutoRefreshProvider>
     </SchemaComponentOptions>
   );
 };

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/block/ChartBlockProvider.tsx
@@ -17,8 +17,7 @@ export const ChartBlockProvider: React.FC = (props) => {
   const currentPopupContext = useCurrentPopupContext();
   const localVariables = useLocalVariables();
   const popupRecordVariable = localVariables?.find((variable) => variable.name === '$nPopupRecord');
-  const popupCtxReady =
-    _.isEmpty(currentPopupContext) || !popupRecordVariable?.collectionName || popupRecordVariable?.ctx;
+  const popupCtxReady = _.isEmpty(currentPopupContext) || popupRecordVariable?.ctx;
 
   return (
     <SchemaComponentOptions


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Chart blocks do not display when added to popups triggered from block-level actions          |
| 🇨🇳 Chinese |  在区块级别操作中打开弹窗，添加图表不显示         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
