### PR TITLE
refactor: add more built-in sizes for read status image

### DIFF
--- a/packages/core/client/src/modules/fields/component/FileManager/previewComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/FileManager/previewComponentFieldSettings.tsx
@@ -13,47 +13,18 @@ import { useTranslation } from 'react-i18next';
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
 import { useColumnSchema } from '../../../../schema-component/antd/table/Table.Column.Decorator';
 import { useDesignable } from '../../../../schema-component/hooks/useDesignable';
-import { showFileName } from './fileManagerComponentFieldSettings';
+import { showFileName, fileSizeSetting } from './fileManagerComponentFieldSettings';
+import { useCompile } from '../../../../schema-component';
 
 export const previewComponentFieldSettings = new SchemaSettings({
   name: 'fieldSettings:component:Preview',
   items: [
     {
-      name: 'size',
-      type: 'select',
+      ...fileSizeSetting,
       useVisible() {
         const { fieldSchema: tableColumnSchema } = useColumnSchema();
         const isInTable = tableColumnSchema?.parent?.['x-component'] === 'TableV2.Column';
         return !isInTable;
-      },
-      useComponentProps() {
-        const { t } = useTranslation();
-        const field = useField<Field>();
-        const fieldSchema = useFieldSchema();
-        const { dn } = useDesignable();
-        return {
-          title: t('Size'),
-          options: [
-            { label: t('Large'), value: 'large' },
-            { label: t('Default'), value: 'default' },
-            { label: t('Small'), value: 'small' },
-          ],
-          value: field?.componentProps?.size || 'default',
-          onChange(size) {
-            const schema = {
-              ['x-uid']: fieldSchema['x-uid'],
-            };
-            fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
-            fieldSchema['x-component-props']['size'] = size;
-            schema['x-component-props'] = fieldSchema['x-component-props'];
-            field.componentProps = field.componentProps || {};
-            field.componentProps.size = size;
-            dn.emit('patch', {
-              schema,
-            });
-            dn.refresh();
-          },
-        };
       },
     },
     showFileName,

--- a/packages/core/client/src/modules/fields/component/FileManager/uploadAttachmentComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/FileManager/uploadAttachmentComponentFieldSettings.tsx
@@ -8,52 +8,23 @@
  */
 
 import { Field } from '@formily/core';
-import { useField, useFieldSchema, useForm } from '@formily/react';
+import { useField, useFieldSchema } from '@formily/react';
 import { useTranslation } from 'react-i18next';
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
-import { useColumnSchema, useDesignable } from '../../../../schema-component';
+import { useColumnSchema, useDesignable, useCompile } from '../../../../schema-component';
 import { useIsFieldReadPretty } from '../../../../schema-component/antd/form-item/FormItem.Settings';
-import { showFileName } from './fileManagerComponentFieldSettings';
+import { showFileName, fileSizeSetting } from './fileManagerComponentFieldSettings';
+
 export const uploadAttachmentComponentFieldSettings = new SchemaSettings({
   name: 'fieldSettings:component:Upload.Attachment',
   items: [
     {
-      name: 'size',
-      type: 'select',
+      ...fileSizeSetting,
       useVisible() {
         const { fieldSchema: tableColumnSchema } = useColumnSchema();
         const isInTable = tableColumnSchema?.parent?.['x-component'] === 'TableV2.Column';
         const readPretty = useIsFieldReadPretty();
         return readPretty && !isInTable;
-      },
-      useComponentProps() {
-        const { t } = useTranslation();
-        const field = useField<Field>();
-        const fieldSchema = useFieldSchema();
-        const { dn } = useDesignable();
-        return {
-          title: t('Size'),
-          options: [
-            { label: t('Large'), value: 'large' },
-            { label: t('Default'), value: 'default' },
-            { label: t('Small'), value: 'small' },
-          ],
-          value: field?.componentProps?.size || 'default',
-          onChange(size) {
-            const schema = {
-              ['x-uid']: fieldSchema['x-uid'],
-            };
-            fieldSchema['x-component-props'] = fieldSchema['x-component-props'] || {};
-            fieldSchema['x-component-props']['size'] = size;
-            schema['x-component-props'] = fieldSchema['x-component-props'];
-            field.componentProps = field.componentProps || {};
-            field.componentProps.size = size;
-            dn.emit('patch', {
-              schema,
-            });
-            dn.refresh();
-          },
-        };
       },
     },
     showFileName,

--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -14,6 +14,7 @@ import { Alert, Upload as AntdUpload, Button, Modal, Progress, Space, Tooltip } 
 import { createGlobalStyle } from 'antd-style';
 import useUploadStyle from 'antd/es/upload/style';
 import cls from 'classnames';
+import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import filesize from 'filesize';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -203,6 +204,12 @@ function ReadPretty({ value, onChange, disabled, multiple, size, ...others }: Up
         `nb-upload`,
         size ? `nb-upload-${size}` : null,
         hashId,
+        css`
+          .ant-upload-list-picture-card-container {
+            width: ${size}px !important;
+            height: ${size}px !important;
+          }
+        `,
       )}
     >
       <div className={cls(`${prefixCls}-list`, `${prefixCls}-list-picture-card`)}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add more built-in size settings for read status image         |
| 🇨🇳 Chinese |    增加阅读状态图片的内置尺寸选项       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
