### PR TITLE
fix(scanner): read the route basename from the scanner to adapt for the desktop environment

### DIFF
--- a/packages/core/client/src/application/RouterManager.tsx
+++ b/packages/core/client/src/application/RouterManager.tsx
@@ -49,7 +49,7 @@ export class RouterManager {
   protected routes: Record<string, RouteType> = {};
   protected options: RouterOptions;
   public app: Application;
-  private router;
+  public router;
   get basename() {
     return this.router.basename;
   }

--- a/packages/plugins/@nocobase/plugin-block-workbench/src/client/components/qrcode-scanner/useScanner.ts
+++ b/packages/plugins/@nocobase/plugin-block-workbench/src/client/components/qrcode-scanner/useScanner.ts
@@ -23,7 +23,11 @@ function removeStringIfStartsWith(text: string, prefix: string): string {
 export function useScanner({ onScannerSizeChanged, elementId, onScanSuccess }) {
   const app = useApp();
   const mobileManager = app.pm.get(MobileManager);
-  const basename = mobileManager.mobileRouter.basename.replace(/\/+$/, '');
+  const { mobileRouter } = mobileManager;
+  const appRouter = app.router;
+
+  const rawBasename = mobileRouter?.router ? mobileRouter?.basename : appRouter.basename;
+  const basename = rawBasename.replace(/\/+$/, '');
 
   const [scanner, setScanner] = useState<Html5Qrcode>();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Read the route basename from the scanner to adapt for the desktop environment.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Read the route basename from the scanner to adapt for the desktop environment.      |
| 🇨🇳 Chinese |   读取扫码器中的路由 basename，以适配桌面端。        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
