### PR TITLE
fix: missing current form variables in data scope of data selector table

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettingsDataScope.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDataScope.tsx
@@ -20,6 +20,7 @@ import { SchemaSettingsModalItem } from './SchemaSettings';
 import { VariableInput, getShouldChange } from './VariableInput/VariableInput';
 import { BaseVariableProvider, IsDisabledParams } from './VariableInput/hooks/useBaseVariable';
 import { DataScopeProps } from './types';
+import { BlockContext, useBlockContext } from '../block-provider';
 
 export const SchemaSettingsDataScope: FC<DataScopeProps> = function DataScopeConfigure(props) {
   const { t } = useTranslation();
@@ -30,6 +31,7 @@ export const SchemaSettingsDataScope: FC<DataScopeProps> = function DataScopeCon
   const localVariables = useLocalVariables();
   const { getAllCollectionsInheritChain } = useCollectionManager_deprecated();
   const { isInSubForm, isInSubTable } = useFlag() || {};
+  const blockOptions = useBlockContext();
 
   const dynamicComponent = useCallback(
     (props: DynamicComponentProps) => {
@@ -63,7 +65,9 @@ export const SchemaSettingsDataScope: FC<DataScopeProps> = function DataScopeCon
           'x-decorator': (props) => (
             <BaseVariableProvider {...props}>
               <FlagProvider isInSubForm={isInSubForm} isInSubTable={isInSubTable}>
-                {props.children}
+                <BlockContext.Provider value={{ name: form ? 'form' : blockOptions?.name }}>
+                  {props.children}
+                </BlockContext.Provider>
               </FlagProvider>
             </BaseVariableProvider>
           ),
@@ -79,7 +83,6 @@ export const SchemaSettingsDataScope: FC<DataScopeProps> = function DataScopeCon
       },
     };
   };
-
   return (
     <SchemaSettingsModalItem
       title={t('Set the data scope')}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   missing current form variables in data scope of data selector table        |
| 🇨🇳 Chinese |    表单中数据选择器表格的数据范围应支持当前表单变量       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
