### PR TITLE
fix: handle non-array values in select onChange

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -184,7 +184,7 @@ const InternalAssociationSelect = observer(
             value={removeIfKeyEmpty(value || innerValue, filterTargetKey)}
             service={service}
             onChange={(value) => {
-              const val = value?.length !== 0 ? value : null;
+              const val = Array.isArray(value) && value?.length === 0 ? null : value;
               props.onChange?.(val);
             }}
             CustomDropdownRender={addMode === 'quickAdd' && QuickAddContent}

--- a/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationSelect.tsx
@@ -22,8 +22,8 @@ import {
   RecordProvider,
   SchemaComponentContext,
   useAPIClient,
-  useCollectionRecordData,
   useCollectionManager_deprecated,
+  useCollectionRecordData,
 } from '../../../';
 import { VariablePopupRecordProvider } from '../../../modules/variable/variablesProvider/VariablePopupRecordProvider';
 import { isVariable } from '../../../variables/utils/isVariable';
@@ -184,7 +184,7 @@ const InternalAssociationSelect = observer(
             value={removeIfKeyEmpty(value || innerValue, filterTargetKey)}
             service={service}
             onChange={(value) => {
-              const val = Array.isArray(value) && value?.length === 0 ? null : value;
+              const val = Array.isArray(value) && value.length === 0 ? null : value;
               props.onChange?.(val);
             }}
             CustomDropdownRender={addMode === 'quickAdd' && QuickAddContent}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x]  Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
在 Select 组件的 `onChange` 回调中，原使用 `value?.length !== 0 ? value : null` 来判断输入值是否为空。
这种写法适用于数组类型，但若传入的是一个包含 `length: 0` 属性的对象，则会被错误地识别为“空值”，导致数据被转换为 `null` 并丢失值。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
- 修改了 `onChange` 中对空值的判断逻辑

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->
- 前提条件：关联的对象中有一个名为length的数字类型的字段
![image](https://github.com/user-attachments/assets/b0a038ca-d172-444e-8615-ea6243a4b72a)

- 修改前
将含有length=0的对象判断为控制，值丢失
![20250516220619_rec_](https://github.com/user-attachments/assets/9b56846f-98c3-4b95-b3e4-82915908d635)

- 修改后 
   能正确读取值
![20250516220455_rec_](https://github.com/user-attachments/assets/dd4f9df3-6da4-40b4-8857-8bd277ef073a)



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix issue where objects with `length: 0` are incorrectly converted to null in the Select component       |
| 🇨🇳 Chinese |  修复 Select 组件中对具有 `length: 0` 的对象被错误转为 null 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese | <!-- [Title](link) -->    |
### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
