### PR TITLE
fix:  cascade component in modal not loading association data initially

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
@@ -243,8 +243,8 @@ export const InternalCascadeSelect = observer(
     const field: any = useField();
     const fieldSchema = useFieldSchema();
     const { loading, data: formData } = useDataBlockRequest() || {};
-    const initialValue = formData?.data?.[fieldSchema.name];
-
+    const initialValue = useMemo(() => formData?.data?.[fieldSchema.name], [loading]);
+    const associationDataFlag = fieldSchema.name in (formData?.data || {});
     const handleFormValuesChange = debounce((form) => {
       if (collectionField.interface === 'm2o') {
         // 对 m2o 类型字段，提取最后一个非 null 值
@@ -349,7 +349,8 @@ export const InternalCascadeSelect = observer(
     };
 
     return (
-      !loading && (
+      !loading &&
+      associationDataFlag && (
         <FormProvider form={selectForm}>
           {collectionField.interface === 'm2o' ? (
             <SchemaComponent

--- a/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
@@ -244,7 +244,7 @@ export const InternalCascadeSelect = observer(
     const fieldSchema = useFieldSchema();
     const { loading, data: formData } = useDataBlockRequest() || {};
     const initialValue = useMemo(() => formData?.data?.[fieldSchema.name], [loading]);
-    const associationDataFlag = fieldSchema.name in (formData?.data || {});
+    const associationDataFlag = !formData || fieldSchema.name in (formData?.data || {});
     const handleFormValuesChange = debounce((form) => {
       if (collectionField.interface === 'm2o') {
         // 对 m2o 类型字段，提取最后一个非 null 值


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      cascade component in modal not loading association data initially      |
| 🇨🇳 Chinese |      关系字段使用级联组件时，在弹窗首次打开未显示数据     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
