### PR TITLE
fix: fix: incorrect empty value check for toMany association field in linkage rule

### DIFF
--- a/packages/core/client/src/application/globalOperators.js
+++ b/packages/core/client/src/application/globalOperators.js
@@ -88,7 +88,7 @@ export function getOperators() {
       return jsonLogic.truthy(a);
     },
     $empty: function (a) {
-      if (Array.isArray(a)) return a.some((k) => !jsonLogic.truthy(k));
+      if (Array.isArray(a)) return a.length === 0;
       return !jsonLogic.truthy(a);
     },
     $notExists: function (a) {


### PR DESCRIPTION
…kage rules

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   incorrect empty value check for toMany association field in linkage rule        |
| 🇨🇳 Chinese |   联动规则中对多关系字段的为空判断不正确        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
