### PR TITLE
fix: missing current object variable in linkage rule inside subtable

### DIFF
--- a/packages/core/client/src/schema-settings/LinkageRules/LinkageRuleAction.tsx
+++ b/packages/core/client/src/schema-settings/LinkageRules/LinkageRuleAction.tsx
@@ -23,7 +23,7 @@ import { LinkageLogicContext, RemoveActionContext } from './context';
 import { ActionType } from './type';
 import { useValues } from './useValues';
 import { DateScopeComponent } from './DateScopeComponent';
-import { FlagProvider } from '../../flag-provider';
+import { FlagProvider, useFlag } from '../../flag-provider';
 
 export const FormFieldLinkageRuleAction = observer(
   (props: any) => {
@@ -31,6 +31,7 @@ export const FormFieldLinkageRuleAction = observer(
     const { t } = useTranslation();
     const compile = useCompile();
     const remove = useContext(RemoveActionContext);
+    const ctx = useFlag();
     const {
       schema,
       fields,
@@ -108,7 +109,7 @@ export const FormFieldLinkageRuleAction = observer(
               placeholder={t('action')}
             />
             {[ActionType.Value].includes(operator) && (
-              <FlagProvider collectionField={{ uiSchema: schema }}>
+              <FlagProvider {...ctx} collectionField={{ uiSchema: schema }}>
                 <ValueDynamicComponent
                   fieldValue={fieldValue}
                   schema={schema}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   missing current object variable in linkage rule inside subtable         |
| 🇨🇳 Chinese |    子表格中联动规则缺少当前对象变量       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
