### PR TITLE
fix: the copy button in the error pop-up copying out as [object Object]

### DIFF
--- a/packages/core/client/src/schema-component/antd/error-fallback/ErrorFallback.tsx
+++ b/packages/core/client/src/schema-component/antd/error-fallback/ErrorFallback.tsx
@@ -86,7 +86,7 @@ export const ErrorFallback: FC<FallbackProps> & {
           </Button>,
         ]}
       >
-        <Paragraph copyable>
+        <Paragraph copyable={{ text: error.stack }}>
           <Text type="danger" style={{ whiteSpace: 'pre-line', textAlign: 'center' }}>
             {error.stack}
           </Text>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Fix the issue with the copy button in the error pop-up copying out as [object Object].

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the issue with the copy button in the error pop-up copying out as [object Object].      |
| 🇨🇳 Chinese |      修复错误弹窗里的复制按钮复制出来是[object Object]的问题     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
