### PR TITLE
fix(tree-collection): avoid incorrect updates to similar path prefixes during path updates

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-tree/src/server/commands/sync-path.ts
+++ b/packages/plugins/@nocobase/plugin-collection-tree/src/server/commands/sync-path.ts
@@ -1,0 +1,105 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Application } from '@nocobase/server';
+import { Database, Model, Transaction } from '@nocobase/database';
+import lodash from 'lodash';
+
+async function getTreePath(
+  db: Database,
+  model: Model,
+  path: string,
+  collection: string,
+  pathCollectionName: string,
+  transaction?: Transaction,
+): Promise<string> {
+  if (model.get('parentId') !== null) {
+    const parent = await db.getRepository(collection).findOne({
+      filter: { id: model.get('parentId') },
+      transaction,
+    });
+
+    if (parent && parent.get('parentId') !== model.get('id')) {
+      path = `/${parent.get('id')}${path}`;
+      const collectionTreePath = db.getCollection(pathCollectionName);
+      const nodePkColumnName = collectionTreePath.getField('nodePk').columnName();
+      const parentPathData = await db.getRepository(pathCollectionName).findOne({
+        filter: { [nodePkColumnName]: parent.get('id') },
+        transaction,
+      });
+      const parentPath = lodash.get(parentPathData, 'path', null);
+      if (parentPath == null) {
+        path = await getTreePath(db, parent, path, collection, pathCollectionName, transaction);
+      } else {
+        path = `${parentPath}/${model.get('id')}`;
+      }
+    }
+  }
+  return path;
+}
+
+export default function (app: Application) {
+  app
+    .command('tree-collection:sync-path')
+    .preload()
+    .option('-c, --collection [collection]')
+    .action(async (options) => {
+      const { collection: name } = options || {};
+      const mainData = app.pm.get('data-source-main') as any;
+      mainData.setLoadFilter({
+        name,
+      });
+      await app.emitAsync('beforeStart');
+      if (!name) {
+        throw new Error('Collection name is required');
+      }
+
+      const collection = app.db.getCollection(name);
+      if (!collection) {
+        throw new Error(`Collection ${name} not found`);
+      }
+
+      const isTree = collection.options.tree;
+      if (!isTree) {
+        throw new Error(`Collection ${name} is not a tree collection`);
+      }
+
+      const pathTableName = `main_${name}_path`;
+
+      const pathRepo = app.db.getRepository(pathTableName);
+      const nodeRepo = app.db.getRepository(name);
+
+      const chunkSize = 1000;
+      await app.db.sequelize.transaction(async (transaction) => {
+        await pathRepo.destroy({ truncate: true, transaction });
+        console.log(`Truncated table ${pathTableName}`);
+        await nodeRepo.chunk({
+          chunkSize,
+          callback: async (records, options) => {
+            const toInsert = [];
+            for (const record of records) {
+              const id = record.get('id');
+              let path = `/${id}`;
+              path = await getTreePath(app.db, record, path, name, pathTableName, transaction);
+              toInsert.push({
+                nodePk: id,
+                path,
+                rootPk: path.split('/')[1],
+              });
+            }
+            if (toInsert.length > 0) {
+              await app.db.getModel(pathTableName).bulkCreate(toInsert, { transaction });
+              console.log(`Inserted ${toInsert.length} records into ${pathTableName}`);
+            }
+          },
+          transaction,
+        });
+      });
+    });
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Previously, path updates used `$startsWith` on path strings, which could mistakenly include nodes with similar prefixes (e.g. `/1/21` matched when updating `/1/2`). This caused unintended path changes. Now uses precise matching: `$or` with both exact path and strict prefix.

Also provide a command for re-syncing path collection.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid incorrect updates to similar path prefixes during path updates          |
| 🇨🇳 Chinese |  更新路径表的时候避免由于匹配到相似前缀，导致错误更新         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
