### PR TITLE
fix: disable ellipsis not working for association field

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/InternalViewer.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalViewer.tsx
@@ -248,6 +248,7 @@ interface ReadPrettyInternalViewerProps {
     label: string;
     value: string;
   };
+  ellipsis?: boolean;
 }
 
 /**
@@ -289,7 +290,7 @@ export const ReadPrettyInternalViewer: React.FC<ReadPrettyInternalViewerProps> =
   }, []);
 
   const btnElement = (
-    <EllipsisWithTooltip ellipsis={true}>
+    <EllipsisWithTooltip ellipsis={props.ellipsis}>
       <CollectionRecordProvider isNew={false} record={getSourceData(parentRecordData, fieldSchema)}>
         <ButtonList setBtnHover={setBtnHover} value={value} fieldNames={props.fieldNames} onClick={onClickItem} />
       </CollectionRecordProvider>

--- a/packages/core/client/src/schema-component/antd/input/EllipsisWithTooltip.tsx
+++ b/packages/core/client/src/schema-component/antd/input/EllipsisWithTooltip.tsx
@@ -74,7 +74,7 @@ export const EllipsisWithTooltip = forwardRef((props: Partial<IEllipsisWithToolt
           {props.children}
         </div>
       ) : (
-        props.children
+        <div style={{ overflowWrap: 'break-word', whiteSpace: 'normal' }}>{props.children}</div>
       ),
     [handleMouseEnter, props.children, props.ellipsis, props.role],
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
关系字段显示时，关闭[省略超出长度的内容]选项，文本还是会被省略

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
1. 为 ReadPrettyInternalViewerProps增加ellipsis选项支持；
2. EllipsisWithTooltip中ellipsis为false时添加自动换行样式；

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix disable ellipsis not working for association field |
| 🇨🇳 Chinese | 修复关系字段显示时禁用省略超长文本选项不生效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
