### PR TITLE
fix: the copy button in edit mode doesn't need external margin.  

### DIFF
--- a/packages/plugins/@nocobase/plugin-input-copy-button/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-input-copy-button/src/client/index.tsx
@@ -52,7 +52,7 @@ const InputCopyButton: FC = observer(
         copyable={{
           text: field.value,
         }}
-        style={{ marginLeft: token.marginXXS, opacity: hidden ? 0 : 1 }}
+        style={{ marginLeft: field.readPretty ? token.marginXXS : 0, opacity: hidden ? 0 : 1 }}
       />
     );
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
The copy button in edit mode doesn't need external margin. 

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The copy button in edit mode doesn't need external margin       |
| 🇨🇳 Chinese |     编辑模式下的复制按钮不需要外边距      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
