### PR TITLE
fix: issue where filter form default values are invalid in sub-pages

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -536,7 +536,7 @@ const useDoFilter = () => {
     setTimeout(() => {
       doFilter({ doNothingWhenFilterIsEmpty: true });
     }, 500);
-  }, [getDataBlocks().length]);
+  }, [doFilter]);
 
   return {
     /**


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix the issue where filter form default values are invalid in sub-pages. When using filtering functionality in sub-pages, default values cannot be applied correctly, causing filter operations to fail.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
This fix includes two main changes:

1. **Delay time adjustment**: Increased the filter operation delay from 100ms to 500ms to ensure data blocks are fully loaded before executing filters
2. **Dependency optimization**: Changed useEffect dependency from `[getDataBlocks().length]` to `[doFilter]` to avoid unnecessary re-executions

**Technical details**:
- The original 100ms delay was insufficient in some cases to wait for data blocks to fully update
- Depending on `getDataBlocks().length` would cause re-execution every time data length changes; depending on the `doFilter` function is more reasonable

**Potential risks**: Increased delay time may make filtering response slightly slower, but ensures functional correctness

**Testing suggestions**:
- Set default values for filter forms in sub-pages
- Verify that default values are correctly applied to filter results
- Test filtering response time with different data volumes

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix issue where filter form default values are invalid in sub-pages          |
| 🇨🇳 Chinese | 修复子页面中筛选表单默认值无效的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
