### PR TITLE
fix: fix the issue that blocks cannot be created normally in popups

### DIFF
--- a/packages/core/client/src/modules/actions/view-edit-popup/PopupActionInitializer.tsx
+++ b/packages/core/client/src/modules/actions/view-edit-popup/PopupActionInitializer.tsx
@@ -7,12 +7,22 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
+import { ACLActionProvider } from '../../../acl/ACLProvider';
 import { useSchemaInitializerItem } from '../../../application';
+import { ClearCollectionFieldContext } from '../../../data-source/collection-field/CollectionFieldProvider';
 import { usePopupUtils } from '../../../schema-component/antd/page/pagePopupUtils';
 import { CONTEXT_SCHEMA_KEY } from '../../../schema-component/antd/page/usePopupContextInActionOrAssociationField';
 import { BlockInitializer } from '../../../schema-initializer/items';
 import { useOpenModeContext } from '../../popup/OpenModeProvider';
+
+export const PopupActionDecorator: FC = (props) => {
+  return (
+    <ClearCollectionFieldContext>
+      <ACLActionProvider>{props.children}</ACLActionProvider>
+    </ClearCollectionFieldContext>
+  );
+};
 
 export const PopupActionInitializer = (props) => {
   const { defaultOpenMode } = useOpenModeContext();
@@ -28,7 +38,7 @@ export const PopupActionInitializer = (props) => {
       openMode: defaultOpenMode,
       refreshDataBlockRequest: true,
     },
-    'x-decorator': 'ACLActionProvider',
+    'x-decorator': 'PopupActionDecorator',
     properties: {
       drawer: {
         type: 'void',

--- a/packages/core/client/src/modules/blocks/data-blocks/table/TableBlockInitializer.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/TableBlockInitializer.tsx
@@ -10,7 +10,6 @@
 import { TableOutlined } from '@ant-design/icons';
 import React from 'react';
 import { useSchemaInitializer, useSchemaInitializerItem } from '../../../../application/schema-initializer/context';
-import { useCollectionManager_deprecated } from '../../../../collection-manager/hooks/useCollectionManager_deprecated';
 import { Collection, CollectionFieldOptions } from '../../../../data-source/collection/Collection';
 import { DataBlockInitializer } from '../../../../schema-initializer/items/DataBlockInitializer';
 import { createTableBlockUISchema } from './createTableBlockUISchema';

--- a/packages/core/client/src/schema-initializer/index.ts
+++ b/packages/core/client/src/schema-initializer/index.ts
@@ -23,13 +23,18 @@ import { DestroyActionInitializer } from '../modules/actions/delete/DestroyActio
 import { DisassociateActionInitializer } from '../modules/actions/disassociate/DisassociateActionInitializer';
 import { ExpandableActionInitializer } from '../modules/actions/expand-collapse/ExpandableActionInitializer';
 import { FilterActionInitializer } from '../modules/actions/filter/FilterActionInitializer';
+import { LinkActionInitializer } from '../modules/actions/link/LinkActionInitializer';
 import { RefreshActionInitializer } from '../modules/actions/refresh/RefreshActionInitializer';
 import { CreateSubmitActionInitializer } from '../modules/actions/submit/CreateSubmitActionInitializer';
 import { UpdateSubmitActionInitializer } from '../modules/actions/submit/UpdateSubmitActionInitializer';
 import { UpdateRecordActionInitializer } from '../modules/actions/update-record/UpdateRecordActionInitializer';
-import { PopupActionInitializer } from '../modules/actions/view-edit-popup/PopupActionInitializer';
-import { LinkActionInitializer } from '../modules/actions/link/LinkActionInitializer';
+import {
+  PopupActionDecorator,
+  PopupActionInitializer,
+} from '../modules/actions/view-edit-popup/PopupActionInitializer';
 
+import { AssociateActionInitializer } from '../modules/actions/associate/AssociateActionInitializer';
+import { AssociateActionProvider } from '../modules/actions/associate/AssociateActionProvider';
 import { recordFormBlockInitializers } from '../modules/actions/view-edit-popup/RecordFormBlockInitializers';
 import { UpdateActionInitializer } from '../modules/actions/view-edit-popup/UpdateActionInitializer';
 import { ViewActionInitializer } from '../modules/actions/view-edit-popup/ViewActionInitializer';
@@ -104,6 +109,7 @@ import {
   filterFormItemInitializers,
   filterFormItemInitializers_deprecated,
 } from '../modules/blocks/filter-blocks/form/filterFormItemInitializers';
+import { DividerFormItemInitializer } from '../modules/blocks/other-blocks/divider/DividerFormItemInitializer';
 import { MarkdownBlockInitializer } from '../modules/blocks/other-blocks/markdown/MarkdownBlockInitializer';
 import { MarkdownFormItemInitializer } from '../modules/blocks/other-blocks/markdown/MarkdownFormItemInitializer';
 import {
@@ -114,9 +120,6 @@ import { CollectionFieldInitializer } from '../modules/fields/initializer/Collec
 import { TableCollectionFieldInitializer } from '../modules/fields/initializer/TableCollectionFieldInitializer';
 import { menuItemInitializer, menuItemInitializer_deprecated } from '../modules/menu/menuItemInitializer';
 import { blockInitializers, blockInitializers_deprecated } from '../modules/page/BlockInitializers';
-import { DividerFormItemInitializer } from '../modules/blocks/other-blocks/divider/DividerFormItemInitializer';
-import { AssociateActionInitializer } from '../modules/actions/associate/AssociateActionInitializer';
-import { AssociateActionProvider } from '../modules/actions/associate/AssociateActionProvider';
 import {
   customFormItemInitializers,
   customFormItemInitializers_deprecated,
@@ -188,6 +191,7 @@ export class SchemaInitializerPlugin extends Plugin {
       DividerFormItemInitializer,
       AssociateActionInitializer,
       AssociateActionProvider,
+      PopupActionDecorator,
     } as any);
 
     this.app.schemaInitializerManager.add(blockInitializers_deprecated);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where blocks created in popups have incorrect collection    |
| 🇨🇳 Chinese |     修复在弹窗中创建的区块，其数据表错误的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [X] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
