### PR TITLE
fix: handle array values in ReadPretty.Input component

### DIFF
--- a/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
@@ -48,10 +48,13 @@ ReadPretty.Input = (props: InputReadPrettyProps) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const compile = useCompile();
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const content = useMemo(
-    () => (props.value && typeof props.value === 'object' ? JSON.stringify(props.value) : compile(props.value)),
-    [props.value],
-  );
+  const content = useMemo(() => {
+    if (Array.isArray(props.value)) {
+      return props.value.join(',');
+    }
+
+    return props.value && typeof props.value === 'object' ? JSON.stringify(props.value) : compile(props.value);
+  }, [props.value]);
 
   return (
     <div


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue where single-line text field values are displayed as an array in esay-reading mode     |
| 🇨🇳 Chinese |     修复单行文本字段阅读模式下，值会显示成一个数组的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
