### PR TITLE
fix：issue where select association field popup closes on first input when adding new data

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/components/CreateRecordAction.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/components/CreateRecordAction.tsx
@@ -29,6 +29,8 @@ export const CreateRecordAction = observer(
     const targetCollection = getCollection(collectionField?.target);
     const [currentCollection, setCurrentCollection] = useState(targetCollection?.name);
     const [currentDataSource, setCurrentDataSource] = useState(targetCollection?.dataSource);
+    const [formValueChanged, setFormValueChanged] = useState(false);
+
     const addbuttonClick = (collectionData) => {
       insertAddNewer(schema.AddNewer);
       setVisibleAddNewer(true);
@@ -38,7 +40,15 @@ export const CreateRecordAction = observer(
     return (
       <CollectionProvider_deprecated name={collectionField?.target}>
         <CreateAction {...props} onClick={(arg) => addbuttonClick(arg)} />
-        <ActionContextProvider value={{ ...ctx, visible: visibleAddNewer, setVisible: setVisibleAddNewer }}>
+        <ActionContextProvider
+          value={{
+            ...ctx,
+            visible: visibleAddNewer,
+            setVisible: setVisibleAddNewer,
+            formValueChanged,
+            setFormValueChanged,
+          }}
+        >
           <CollectionProvider_deprecated name={currentCollection} dataSource={currentDataSource}>
             <TabsContextProvider>
               <NocoBaseRecursionField

--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client/DuplicateAction.tsx
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client/DuplicateAction.tsx
@@ -94,6 +94,7 @@ export const DuplicateAction = observer(
     const { designable } = useDesignable();
     const [visible, setVisible] = useState(false);
     const [loading, setLoading] = useState(false);
+    const [formValueChanged, setFormValueChanged] = useState(false);
     const { service, __parent, block, resource } = useBlockRequestContext();
     const { duplicateFields, duplicateMode = 'quickDulicate', duplicateCollection } = fieldSchema['x-component-props'];
     const record = useRecord();
@@ -229,9 +230,7 @@ export const DuplicateAction = observer(
               <CollectionProvider_deprecated name={duplicateCollection || name}>
                 {/* 这里的 record 就是弹窗中创建表单的 sourceRecord */}
                 <RecordProvider record={{ ...parentRecordData, __collection: duplicateCollection || __collection }}>
-                  <ActionContextProvider
-                    value={{ visible, setVisible, openMode: ctx.openMode, openSize: ctx.openSize }}
-                  >
+                  <ActionContextProvider value={{ ...ctx, visible, setVisible, formValueChanged, setFormValueChanged }}>
                     <PopupSettingsProvider enableURL={false}>
                       <RefreshComponentProvider refresh={_.noop}>
                         <NocoBaseRecursionField schema={fieldSchema} basePath={field.address} onlyRenderProperties />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     issue where select association field popup closes on first input when adding new data      |
| 🇨🇳 Chinese |     修复下拉关系字段组件新增数据时，首次打开弹窗输入内容会自动关闭弹窗的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
