### PR TITLE
fix(plugin-action-bulk-edit): use filterByTk instead of filter under selected mode

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/utils.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/utils.tsx
@@ -88,9 +88,8 @@ export const useCustomizeBulkEditActionProps = () => {
   const actionField = useField();
   const tableBlockContext = useTableBlockContext();
   const { modal } = App.useApp();
-  const { rowKey } = tableBlockContext;
   const selectedRecordKeys =
-    tableBlockContext.field?.data?.selectedRowKeys ?? expressionScope?.selectedRecordKeys ?? {};
+    tableBlockContext.field?.data?.selectedRowKeys ?? expressionScope?.selectedRecordKeys ?? [];
   const { setVisible, fieldSchema: actionSchema, setSubmitted } = actionContext;
   const fieldSchema = useFieldSchema();
   return {
@@ -108,9 +107,14 @@ export const useCustomizeBulkEditActionProps = () => {
       actionField.data = field.data || {};
       actionField.data.loading = true;
       try {
-        const updateData: { filter?: any; values: any; forceUpdate: boolean; triggerWorkflows?: string } = {
+        const updateData: {
+          filter?: any;
+          filterByTk?: any[];
+          values: any;
+          forceUpdate: boolean;
+          triggerWorkflows?: string;
+        } = {
           values: form.values,
-          filter,
           forceUpdate: false,
           triggerWorkflows: triggerWorkflows?.length
             ? triggerWorkflows.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
@@ -121,9 +125,11 @@ export const useCustomizeBulkEditActionProps = () => {
             message.error(t('Please select the records to be updated'));
             return;
           }
-          updateData.filter = { $and: [{ [rowKey || 'id']: { $in: selectedRecordKeys } }] };
+          updateData.filterByTk = selectedRecordKeys;
+        } else {
+          updateData.filter = filter;
         }
-        if (!updateData.filter) {
+        if (!updateData.filter && !updateData.filterByTk) {
           updateData.forceUpdate = true;
         }
         await resource.update(updateData);


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Use `filterByTk` instead of `filter` under selected mode.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Use `filterByTk` instead of `filter` under selected mode |
| 🇨🇳 Chinese | 在选择模式下使用 `filterByTk` 代替 `filter` 作为筛选参数 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
