### PR TITLE
fix: hovering title-type association field in detail block incorrectly triggers subform rendering

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/InternalViewer.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalViewer.tsx
@@ -288,7 +288,7 @@ export const ReadPrettyInternalViewer: React.FC<ReadPrettyInternalViewerProps> =
   // value 做了转换，但 props.value 和原来 useField().value 的值不一致
   const field = useField();
   const [visible, setVisible] = useState(false);
-  const { options: collectionField } = useAssociationFieldContext();
+  const { options: collectionField, currentMode } = useAssociationFieldContext();
   const associationName = useAssociationName();
   const { visibleWithURL, setVisibleWithURL } = usePopupUtils();
   const [btnHover, setBtnHover] = useState(!!visibleWithURL);
@@ -380,7 +380,7 @@ export const ReadPrettyInternalViewer: React.FC<ReadPrettyInternalViewerProps> =
     <PopupVisibleProvider visible={false}>
       <ActionContextProvider value={actionContextValue}>
         {btnElement}
-        {btnHover && renderWithoutTableFieldResourceProvider()}
+        {btnHover && currentMode !== 'Select' && renderWithoutTableFieldResourceProvider()}
       </ActionContextProvider>
     </PopupVisibleProvider>
   );


### PR DESCRIPTION
…y triggers subform rendering

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  hovering title-type association field in detail block incorrectly triggers subform rendering         |
| 🇨🇳 Chinese |  修复详情区块中关系字段为 title 类型时，hover 数据会误渲染子表单         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
