### PR TITLE
fix: switching page in subtable of detail block within modal triggers unsaved changes warning

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/SubTable.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/SubTable.tsx
@@ -186,6 +186,7 @@ export const SubTable: any = observer(
     //分页
     const [currentPage, setCurrentPage] = useState(1);
     const [pageSize, setPageSize] = useState(field.componentProps?.pageSize || 10); // 每页条数
+    const { setFormValueChanged } = useActionContext();
     useEffect(() => {
       setPageSize(field.componentProps?.pageSize);
     }, [field.componentProps?.pageSize]);
@@ -201,6 +202,7 @@ export const SubTable: any = observer(
           setPageSize(pageSize);
           field.componentProps.pageSize = pageSize;
           field.onInput(field.value);
+          setFormValueChanged(false);
         },
         showSizeChanger: true,
         pageSizeOptions: ['10', '20', '50', '100'],


### PR DESCRIPTION
… unsaved changes warning

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   switching page in subtable of detail block within modal triggers unsaved changes warning   |
| 🇨🇳 Chinese |     修复弹窗详情区块子表格翻页触发未保存提示的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
