### PR TITLE
fix: markdown block linkage rules not working when triggered by popup action

### DIFF
--- a/packages/core/client/src/schema-component/antd/block-item/BlockItemCard.tsx
+++ b/packages/core/client/src/schema-component/antd/block-item/BlockItemCard.tsx
@@ -10,10 +10,11 @@
 import { Card, CardProps } from 'antd';
 import React, { useMemo, useRef, useEffect, createContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFieldSchema } from '@formily/react';
 import { useToken } from '../../../style';
 import { MarkdownReadPretty } from '../markdown';
 import { NAMESPACE_UI_SCHEMA } from '../../../i18n/constant';
-import { useCollection } from '../../../data-source';
+import { BlockLinkageRuleProvider } from '../../../modules/blocks/BlockLinkageRuleProvider';
 
 export const BlockItemCardContext = createContext({});
 
@@ -26,8 +27,8 @@ export const BlockItemCard = React.forwardRef<HTMLDivElement, CardProps | any>((
   const [titleHeight, setTitleHeight] = useState(0);
   const titleRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
-  const collection = useCollection();
-  console.log();
+  const fieldSchema = useFieldSchema();
+  const isBlockLinkage = fieldSchema['x-block-linkage-rules'];
   useEffect(() => {
     const timer = setTimeout(() => {
       if (titleRef.current) {
@@ -59,13 +60,14 @@ export const BlockItemCard = React.forwardRef<HTMLDivElement, CardProps | any>((
       )}
     </div>
   );
-  return (
+  const content = (
     <BlockItemCardContext.Provider value={{ titleHeight: titleHeight }}>
       <Card ref={ref} bordered={false} style={style} {...others} title={title}>
         {children}
       </Card>
     </BlockItemCardContext.Provider>
   );
+  return !isBlockLinkage ? content : <BlockLinkageRuleProvider>{content}</BlockLinkageRuleProvider>;
 });
 
 BlockItemCard.displayName = 'BlockItemCard';


### PR DESCRIPTION
…modal button

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     markdown block linkage rules not working when triggered by popup action       |
| 🇨🇳 Chinese |    修复弹窗按钮中的 Markdown 区块联动规则不生效的问题
       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
