### PR TITLE
fix: remove database dependency for possibleTypes, enforce API-driven…

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/CollectionFields.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/CollectionFields.tsx
@@ -121,6 +121,9 @@ export const CollectionFields = () => {
   };
 
   const handleFieldChange = async (value, filterByTk, flag = true) => {
+    if (value.possibleTypes) {
+      delete value.possibleTypes;
+    }
     await api.request({
       url: `dataSourcesCollections/${dataSourceKey}.${name}/fields:update?filterByTk=${filterByTk}`,
       method: 'post',

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/data-sources.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/data-sources.test.ts
@@ -693,5 +693,46 @@ describe('data source', async () => {
       const collection2 = dataSource2.collectionManager.getCollection('comments');
       expect(collection2.getField('post')).toBeFalsy();
     });
+
+    it(`should not return possibleTypes field when creating field`, async () => {
+      const createResp = await app
+        .agent()
+        .resource('dataSourcesCollections.fields', 'mockInstance1.comments')
+        .create({
+          values: {
+            type: 'string',
+            name: 'title',
+            possibleTypes: ['123', '456'],
+          },
+        });
+
+      expect(createResp.status).toBe(200);
+      const data = createResp.body.data;
+      expect(data.possibleTypes).not.exist;
+
+      const fieldModel = await app.db.getRepository('dataSourcesFields').findOne({
+        filter: {
+          dataSourceKey: 'mockInstance1',
+        },
+      });
+      expect(fieldModel.get('options').possibleTypes).not.exist;
+    });
+
+    it(`should not return possibleTypes field when update field`, async () => {
+      const fieldUpdateResp = await app
+        .agent()
+        .resource('dataSourcesCollections.fields', 'mockInstance1.posts')
+        .update({
+          filterByTk: 'title',
+          values: {
+            title: '标题 Field',
+            possibleTypes: ['123', '456'],
+          },
+        });
+
+      expect(fieldUpdateResp.status).toBe(200);
+      const data = fieldUpdateResp.body.data;
+      expect(data.possibleTypes).not.exist;
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/resourcers/data-sources-collections-fields.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/resourcers/data-sources-collections-fields.ts
@@ -56,7 +56,9 @@ export default {
           dataSourceKey,
         },
       });
-
+      if (values.possibleTypes) {
+        delete values.possibleTypes;
+      }
       if (!fieldRecord) {
         fieldRecord = await mainDb.getRepository('dataSourcesFields').create({
           values: {
@@ -109,7 +111,9 @@ export default {
           `Field name ${name} already exists in collection ${collectionName} of data source ${dataSourceKey}`,
         );
       }
-
+      if (values.possibleTypes) {
+        delete values.possibleTypes;
+      }
       const fieldRecord = await mainDb.getRepository('dataSourcesFields').create({
         values: {
           ...values,


### PR DESCRIPTION
… configuration

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Remove database dependency for possibleTypes, enforce API-driven configuration    |
| 🇨🇳 Chinese |    修复将 possibleTypes 从数据库固定值改为动态配置，解决应用升级后兼容性问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
