### PR TITLE
fix(data-vi): checkbox group fields in charts should display labels instead of raw values

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/index.tsx
@@ -71,6 +71,7 @@ class PluginDataVisualiztionClient extends Plugin {
     select: { valueFormatter },
     multipleSelect: { valueFormatter },
     radioGroup: { valueFormatter },
+    checkboxGroup: { valueFormatter },
   };
 
   registerFieldInterfaceConfig(key: string, config: fieldInterfaceConfig) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Checkbox group fields in charts should display labels instead of raw values          |
| 🇨🇳 Chinese | 复选框字段在图表中应该显示标签值而不是原始值          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
