### PR TITLE
fix(pluginw-workflow): fix error thrown in manual execute action

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/TriggerCollectionRecordSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/TriggerCollectionRecordSelect.tsx
@@ -21,21 +21,22 @@ export function TriggerCollectionRecordSelect(props) {
   const [dataSourceName, collectionName] = parseCollectionName(workflow.config.collection);
   const { collectionManager } = app.dataSourceManager.getDataSource(dataSourceName);
   const collection = collectionManager.getCollection(collectionName);
-  const render = (p) => (
-    <RemoteSelect
-      objectValue
-      dataSource={dataSourceName}
-      fieldNames={{
-        label: collection.titleField || 'id',
-        value: 'id',
-      }}
-      service={{
-        resource: collectionName,
-      }}
-      manual={false}
-      {...p}
-    />
-  );
+  const render = (p) =>
+    collection ? (
+      <RemoteSelect
+        objectValue
+        dataSource={dataSourceName}
+        fieldNames={{
+          label: collection.titleField || 'id',
+          value: 'id',
+        }}
+        service={{
+          resource: collectionName,
+        }}
+        manual={false}
+        {...p}
+      />
+    ) : null;
   return (
     <WorkflowVariableWrapper
       value={props.value}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix error thrown in manual execute action when trigger not configured correctly.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix error thrown in manual execute action when trigger not configured correctly |
| 🇨🇳 Chinese | 修复触发器未正确配置时手动执行的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
