### PR TITLE
fix: auto-closing issue when configuring fields in the secondary popup form

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -656,21 +656,27 @@ const RenderButtonInner = observer(
     const actionTitle = typeof rawTitle === 'string' ? t(rawTitle, { ns: NAMESPACE_UI_SCHEMA }) : rawTitle;
     const { opacity, ...restButtonStyle } = buttonStyle;
     const linkStyle = isLink && opacity ? { opacity } : undefined;
-    const WrapperComponent = React.forwardRef(
-      ({ component: Component = tarComponent || Button, icon, onlyIcon, children, ...restProps }: any, ref) => {
-        return (
-          <Component ref={ref} {...restProps}>
-            {onlyIcon ? (
-              <Tooltip title={restProps.title}>
-                <span style={{ padding: 3 }}>{icon && typeof icon === 'string' ? <Icon type={icon} /> : icon}</span>
-              </Tooltip>
-            ) : (
-              <span style={{ paddingRight: 3 }}>{icon && typeof icon === 'string' ? <Icon type={icon} /> : icon}</span>
-            )}
-            {onlyIcon ? children[1] : children}
-          </Component>
-        );
-      },
+    const WrapperComponent = useMemo(
+      () =>
+        React.forwardRef(
+          ({ component: Component = tarComponent || Button, icon, onlyIcon, children, ...restProps }: any, ref) => {
+            return (
+              <Component ref={ref} {...restProps}>
+                {onlyIcon ? (
+                  <Tooltip title={restProps.title}>
+                    <span style={{ padding: 3 }}>{icon && typeof icon === 'string' ? <Icon type={icon} /> : icon}</span>
+                  </Tooltip>
+                ) : (
+                  <span style={{ paddingRight: 3 }}>
+                    {icon && typeof icon === 'string' ? <Icon type={icon} /> : icon}
+                  </span>
+                )}
+                {onlyIcon ? children[1] : children}
+              </Component>
+            );
+          },
+        ),
+      [onlyIcon],
     );
     return (
       <SortableItem


### PR DESCRIPTION
…p form

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    auto-closing issue when configuring fields in the secondary popup form        |
| 🇨🇳 Chinese |     修复二级弹窗配置表单字段时自动关闭弹窗的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
