### PR TITLE
fix: block non-string data in xlsx textarea fields

### DIFF
--- a/packages/core/database/src/interfaces/index.ts
+++ b/packages/core/database/src/interfaces/index.ts
@@ -16,3 +16,4 @@ export * from './datetime-no-tz-interface';
 export * from './boolean-interface';
 export * from './date-interface';
 export * from './time-interface';
+export * from './textarea-interface';

--- a/packages/core/database/src/interfaces/textarea-interface.ts
+++ b/packages/core/database/src/interfaces/textarea-interface.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import _ from 'lodash';
+import { BaseInterface } from './base-interface';
+
+export class TextareaInterface extends BaseInterface {
+  toValue(value) {
+    if (value === null || value === undefined || typeof value === 'string') {
+      return value;
+    }
+
+    if (this.validate(value)) {
+      return value.toString();
+    }
+    throw new Error(`Invalid value ${value}, expected textarea value`);
+  }
+
+  validate(value): boolean {
+    return _.isString(value) || _.isNumber(value);
+  }
+}

--- a/packages/core/database/src/interfaces/utils.ts
+++ b/packages/core/database/src/interfaces/utils.ts
@@ -16,6 +16,7 @@ import {
   MultipleSelectInterface,
   PercentInterface,
   SelectInterface,
+  TextareaInterface,
   TimeInterface,
 } from './index';
 import { ManyToOneInterface } from './many-to-one-interface';
@@ -54,6 +55,7 @@ const interfaces = {
   m2m: ManyToManyInterface,
   time: TimeInterface,
   input: InputInterface,
+  textarea: TextareaInterface,
 };
 
 export function registerInterfaces(db: Database) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed xlsx import to restrict textarea fields from accepting non-string formatted data  |
| 🇨🇳 Chinese |      导入 xlsx 禁止多行文本字段插入非字符串格式数据    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
