### PR TITLE
fix(chart-filter): incorrect display of between date field in chart filter

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/settings/chartFilterItem.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/settings/chartFilterItem.tsx
@@ -204,7 +204,7 @@ const EditOperator = () => {
             content: Schema.compile(operator.label, { t }),
           });
         } else if (operator.schema?.['x-component']) {
-          setOperatorComponent(operator, operator.schema['x-component']);
+          setOperatorComponent(operator, operator.schema['x-component'], operator.schema['x-component-props']);
         } else {
           setOperatorComponent(operator, defaultComponent);
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    incorrect display of between date field in chart filter       |
| 🇨🇳 Chinese |     修复图表区块中筛选表单的日期字段设置为“介于”时组件未正确显示的问题  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
