### PR TITLE
fix: add optional chaining to handler rejection check in APIClient

### DIFF
--- a/packages/core/client/src/api-client/APIClient.ts
+++ b/packages/core/client/src/api-client/APIClient.ts
@@ -72,7 +72,7 @@ export class APIClient extends APIClientSDK {
     api.notification = this.notification;
     const handlers = [];
     for (const handler of this.axios.interceptors.response['handlers']) {
-      if (handler.rejected['_name'] === 'handleNotificationError') {
+      if (handler?.rejected?.['_name'] === 'handleNotificationError') {
         handlers.push({
           ...handler,
           rejected: api.handleNotificationError.bind(api),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Currently, the APIClient may throw a runtime error when attempting to access the `reject` method of a possibly undefined handler. Adding optional chaining prevents this and ensures more robust error handling.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
- Added optional chaining (`?.`) when calling the `reject` method on the handler object in APIClient.
- This prevents potential TypeErrors when `handler` is undefined or null.

**Potential Risks**: Minimal. Change is backwards-compatible and improves safety.

**Testing Suggestions**:
- Simulate a missing or undefined handler during a request rejection and ensure no runtime error is thrown.
- Confirm existing APIClient functionality remains unaffected.

### Related issues
<!-- Add any related issue numbers here -->
None reported, but discovered during defensive error analysis.

### Showcase
<!-- Including any screenshots of the changes. -->
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: use optional chaining to safely reject requests in APIClient when handler may be undefined |
| 🇨🇳 Chinese | 修复：在 APIClient 中添加可选链以避免 handler 未定义时报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
