### PR TITLE
fix: make eq operator for string fields compatible with number type

### DIFF
--- a/packages/core/database/src/__tests__/operator/eq.test.ts
+++ b/packages/core/database/src/__tests__/operator/eq.test.ts
@@ -70,4 +70,32 @@ describe('eq operator', () => {
 
     expect(results).toEqual(0);
   });
+
+  it('should eq string field with number value', async () => {
+    await db.getRepository('tests').create({
+      values: [{ name: '123' }, { name: '234' }, { name: '345' }],
+    });
+
+    const results = await db.getRepository('tests').count({
+      filter: {
+        'name.$eq': 123,
+      },
+    });
+
+    expect(results).toEqual(1);
+  });
+
+  it('should eq string field with number value (array)', async () => {
+    await db.getRepository('tests').create({
+      values: [{ name: '123' }, { name: '234' }, { name: '345' }],
+    });
+
+    const results = await db.getRepository('tests').count({
+      filter: {
+        'name.$eq': [123],
+      },
+    });
+
+    expect(results).toEqual(1);
+  });
 });

--- a/packages/core/database/src/operators/eq.ts
+++ b/packages/core/database/src/operators/eq.ts
@@ -14,6 +14,11 @@ export default {
     if (ctx?.fieldPath) {
       const field = ctx.db.getFieldByPath(ctx.fieldPath);
       if (field?.type === 'string' && typeof val !== 'string') {
+        if (Array.isArray(val)) {
+          return {
+            [Op.in]: val.map((v) => String(v)),
+          };
+        }
         return {
           [Op.eq]: String(val),
         };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  make eq operator for string fields compatible with number type  |
| 🇨🇳 Chinese |  string 类型字段的 eq 操作符兼容 number 类型  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
