### PR TITLE
feat:  auto-hide grid card block action bar when empty 

### DIFF
--- a/packages/core/client/src/block-provider/BlockSchemaComponentProvider.tsx
+++ b/packages/core/client/src/block-provider/BlockSchemaComponentProvider.tsx
@@ -19,9 +19,10 @@ import { useDetailsProps } from '../modules/blocks/data-blocks/details-single/ho
 import { FormItemSchemaToolbar } from '../modules/blocks/data-blocks/form/FormItemSchemaToolbar';
 import { useCreateFormBlockDecoratorProps } from '../modules/blocks/data-blocks/form/hooks/useCreateFormBlockDecoratorProps';
 import { useCreateFormBlockProps } from '../modules/blocks/data-blocks/form/hooks/useCreateFormBlockProps';
+import { useDataFormItemProps } from '../modules/blocks/data-blocks/form/hooks/useDataFormItemProps';
 import { useEditFormBlockDecoratorProps } from '../modules/blocks/data-blocks/form/hooks/useEditFormBlockDecoratorProps';
 import { useEditFormBlockProps } from '../modules/blocks/data-blocks/form/hooks/useEditFormBlockProps';
-import { useDataFormItemProps } from '../modules/blocks/data-blocks/form/hooks/useDataFormItemProps';
+import { useGridCardActionBarProps } from '../modules/blocks/data-blocks/grid-card/hooks/useGridCardActionBarProps';
 import {
   useGridCardBlockDecoratorProps,
   useGridCardBlockItemProps,
@@ -97,6 +98,7 @@ export const BlockSchemaComponentProvider: React.FC = (props) => {
         useGridCardBlockProps,
         useFormItemProps,
         useDataFormItemProps,
+        useGridCardActionBarProps,
       }}
     >
       {props.children}
@@ -161,6 +163,7 @@ export class BlockSchemaComponentPlugin extends Plugin {
       useGridCardBlockItemProps,
       useFormItemProps,
       useDataFormItemProps,
+      useGridCardActionBarProps,
     });
   }
 }

--- a/packages/core/client/src/modules/blocks/data-blocks/grid-card/__tests__/createGridCardBlockSchema.test.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/grid-card/__tests__/createGridCardBlockSchema.test.ts
@@ -27,12 +27,8 @@ describe('createGridCardBlockSchema', () => {
           "actionBar": {
             "type": "void",
             "x-component": "ActionBar",
-            "x-component-props": {
-              "style": {
-                "marginBottom": "var(--nb-spacing)",
-              },
-            },
             "x-initializer": "gridCard:configureActions",
+            "x-use-component-props": "useGridCardActionBarProps",
           },
           "list": {
             "properties": {
@@ -103,12 +99,8 @@ describe('createGridCardBlockSchema', () => {
           "actionBar": {
             "type": "void",
             "x-component": "ActionBar",
-            "x-component-props": {
-              "style": {
-                "marginBottom": "var(--nb-spacing)",
-              },
-            },
             "x-initializer": "gridCard:configureActions",
+            "x-use-component-props": "useGridCardActionBarProps",
           },
           "list": {
             "properties": {

--- a/packages/core/client/src/modules/blocks/data-blocks/grid-card/createGridCardBlockUISchema.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/grid-card/createGridCardBlockUISchema.ts
@@ -49,11 +49,7 @@ export const createGridCardBlockUISchema = (options: {
         type: 'void',
         'x-initializer': 'gridCard:configureActions',
         'x-component': 'ActionBar',
-        'x-component-props': {
-          style: {
-            marginBottom: 'var(--nb-spacing)',
-          },
-        },
+        'x-use-component-props': 'useGridCardActionBarProps',
       },
       list: {
         type: 'array',

--- a/packages/core/client/src/modules/blocks/data-blocks/grid-card/hooks/useGridCardActionBarProps.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/grid-card/hooks/useGridCardActionBarProps.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFieldSchema } from '@formily/react';
+import _ from 'lodash';
+import { useDesignable } from '../../../../../schema-component';
+
+export const useGridCardActionBarProps = () => {
+  const fieldSchema = useFieldSchema();
+  const { designable } = useDesignable();
+
+  return {
+    style: {
+      marginBottom: 'var(--nb-spacing)',
+    },
+
+    // In non-configuration mode, when there are no buttons, ActionBar doesn't need to be displayed
+    hidden: !designable && _.isEmpty(fieldSchema.properties),
+  };
+};

--- a/packages/core/client/src/schema-component/antd/action/ActionBar.tsx
+++ b/packages/core/client/src/schema-component/antd/action/ActionBar.tsx
@@ -147,6 +147,10 @@ const InternalActionBar: FC = (props: any) => {
 
 export const ActionBar = withDynamicSchemaProps(
   (props: any) => {
+    if (props.hidden) {
+      return null;
+    }
+
     return <InternalActionBar {...props} />;
   },
   { displayName: 'ActionBar' },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Need to recreate the Grid card block for this to take effect.
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Auto-hide grid card block action bar when empty    |
| 🇨🇳 Chinese |     网格卡片区块操作栏为空时自动隐藏      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
