### PR TITLE
feat: make logo container width adaptive based on content type

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -177,7 +177,6 @@ const layoutContentClass = css`
 `;
 
 const className1 = css`
-  width: 168px;
   height: var(--nb-header-height);
   margin-right: 4px;
   display: inline-flex;
@@ -185,6 +184,14 @@ const className1 = css`
   color: #fff;
   padding: 0;
   align-items: center;
+`;
+const className1WithFixedWidth = css`
+  ${className1}
+  width: 168px;
+`;
+const className1WithAutoWidth = css`
+  ${className1}
+  width: auto;
 `;
 const className2 = css`
   object-fit: contain;
@@ -263,7 +270,8 @@ const NocoBaseLogo = () => {
   const { token } = useToken();
   const fontSizeStyle = useMemo(() => ({ fontSize: token.fontSizeHeading3 }), [token.fontSizeHeading3]);
 
-  const logo = result?.data?.data?.logo?.url ? (
+  const hasLogo = result?.data?.data?.logo?.url;
+  const logo = hasLogo ? (
     <img className={className2} src={result?.data?.data?.logo?.url} />
   ) : (
     <span style={fontSizeStyle} className={className3}>
@@ -271,7 +279,9 @@ const NocoBaseLogo = () => {
     </span>
   );
 
-  return <div className={className1}>{result?.loading ? null : logo}</div>;
+  return (
+    <div className={hasLogo ? className1WithFixedWidth : className1WithAutoWidth}>{result?.loading ? null : logo}</div>
+  );
 };
 
 /**


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Logo container width adapts to content type (fixed 168px for images, auto width for text)     |
| 🇨🇳 Chinese |     Logo容器宽度根据内容类型自适应（图片固定168px，文本自动宽度）      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
