### PR TITLE
fix(m2m-array): updating a m2m (array) field throws an error when the `updatedBy` field is present

### DIFF
--- a/packages/core/database/src/belongs-to-array/belongs-to-array-repository.ts
+++ b/packages/core/database/src/belongs-to-array/belongs-to-array-repository.ts
@@ -30,6 +30,7 @@ export class BelongsToArrayAssociation {
   targetKey: string;
   identifierField: string;
   as: string;
+  options: any;
 
   constructor(options: {
     db: Database;
@@ -40,6 +41,7 @@ export class BelongsToArrayAssociation {
     targetKey: string;
   }) {
     const { db, source, as, foreignKey, target, targetKey } = options;
+    this.options = options;
     this.associationType = 'BelongsToArray';
     this.db = db;
     this.source = source;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Updating a many to many (array) field throws an error when the `updatedBy` field is present         |
| 🇨🇳 Chinese | 存在 `updatedBy` 字段的时，更新多对多（数组）字段报错          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
