### PR TITLE
fix(ReadPretty): apply conditional flex styling based on ellipsis prop

### DIFF
--- a/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
@@ -56,12 +56,13 @@ ReadPretty.Input = (props: InputReadPrettyProps) => {
     return props.value && typeof props.value === 'object' ? JSON.stringify(props.value) : compile(props.value);
   }, [props.value]);
 
+  const flexStyle = props.ellipsis ? { display: 'flex', alignItems: 'center' } : {};
+
   return (
     <div
       className={cls(prefixCls, props.className)}
       style={{
-        display: 'flex',
-        alignItems: 'center',
+        ...flexStyle,
         overflowWrap: 'break-word',
         whiteSpace: 'normal',
         ...props.style,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Table column text alignment function is not working    |
| 🇨🇳 Chinese |     表格列的文本对齐功能无效      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
