### PR TITLE
fix(plugin-workflow): fix node can not be created when stats is bigint

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/nodes.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/nodes.ts
@@ -20,8 +20,7 @@ export async function create(context: Context, next) {
   context.body = await db.sequelize.transaction(async (transaction) => {
     const workflow = (await repository.getSourceModel(transaction)) as WorkflowModel;
     workflow.versionStats = await workflow.getVersionStats({ transaction });
-    const { executed } = workflow.versionStats;
-    if (executed) {
+    if (workflow.versionStats.executed > 0) {
       context.throw(400, 'Node could not be created in executed workflow');
     }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix incorrectly executed checking on big integer number.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrectly executed checking on big integer number |
| 🇨🇳 Chinese | 修复已执行数在大整型数时检查错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
