### PR TITLE
fix(useLocalVariables): add defaultValue to URL search params context

### DIFF
--- a/packages/core/client/src/variables/hooks/useLocalVariables.tsx
+++ b/packages/core/client/src/variables/hooks/useLocalVariables.tsx
@@ -53,7 +53,7 @@ const useLocalVariables = (props?: Props) => {
     dataSource: parentPopupDataSource,
     defaultValue: defaultValueOfParentPopupRecord,
   } = useParentPopupVariableContext();
-  const { urlSearchParamsCtx, shouldDisplay: shouldDisplayURLSearchParams } = useURLSearchParamsVariable();
+  const { urlSearchParamsCtx, shouldDisplay: shouldDisplayURLSearchParams, defaultValue: defaultValueOfURLSearchParams } = useURLSearchParamsVariable();
   const { datetimeCtx } = useDatetimeVariableContext();
   const { currentFormCtx } = useCurrentFormContext({ form: props?.currentForm });
   const { name: currentCollectionName } = useCollection_deprecated();
@@ -151,6 +151,7 @@ const useLocalVariables = (props?: Props) => {
         shouldDisplayURLSearchParams && {
           name: '$nURLSearchParams',
           ctx: urlSearchParamsCtx,
+          defaultValue: defaultValueOfURLSearchParams,
         },
       ] as VariableOption[]
     ).filter(Boolean);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       When URL query parameter variables are empty, the data scope conditions are not removed    |
| 🇨🇳 Chinese |     URL 查询参数变量为空时，数据范围的条件没有被移除      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
