### PR TITLE
fix: filtering error on DateOnly or Datetime (without time zone) using Exact day variable

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/dateOnly.ts
+++ b/packages/core/client/src/collection-manager/interfaces/dateOnly.ts
@@ -24,6 +24,7 @@ export class DateFieldInterface extends CollectionFieldInterface {
       'x-component': 'DatePicker',
       'x-component-props': {
         dateOnly: true,
+        showTime: false,
       },
     },
   };

--- a/packages/core/client/src/schema-component/antd/date-picker/util.ts
+++ b/packages/core/client/src/schema-component/antd/date-picker/util.ts
@@ -10,6 +10,7 @@
 import { getDefaultFormat, str2moment, toGmt, toLocal, getPickerFormat } from '@nocobase/utils/client';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import { dayjsable, formatDayjsValue } from '@formily/antd-v5/esm/__builtins__';
 
 const toStringByPicker = (value, picker = 'date', timezone: 'gmt' | 'local') => {
   if (!dayjs.isDayjs(value)) return value;
@@ -89,7 +90,7 @@ export const handleDateChangeOnForm = (value, dateOnly, utc, picker, showTime, g
     return value;
   }
   if (dateOnly) {
-    return dayjs(value).startOf(picker).format('YYYY-MM-DD');
+    return formatDayjsValue(value, 'YYYY-MM-DD');
   }
   if (utc) {
     if (gmt) {
@@ -114,6 +115,7 @@ export const mapDatePicker = function () {
     const { dateOnly, showTime, picker = 'date', utc, gmt, underFilter } = props;
     const format = getDefaultFormat(props);
     const onChange = props.onChange;
+
     return {
       ...props,
       inputReadOnly: isMobileMedia,

--- a/packages/core/database/src/operators/date.ts
+++ b/packages/core/database/src/operators/date.ts
@@ -33,7 +33,7 @@ const toDate = (date, options: any = {}) => {
   }
 
   if (field.constructor.name === 'DateOnlyField') {
-    val = moment(val).format('YYYY-MM-DD HH:mm:ss');
+    val = moment.utc(val).format('YYYY-MM-DD HH:mm:ss');
   }
 
   const eventObj = {
@@ -69,7 +69,6 @@ export default {
     const r = parseDate(value, {
       timezone: parseDateTimezone(ctx),
     });
-
     if (typeof r === 'string') {
       return {
         [Op.eq]: toDate(r, { ctx }),
@@ -77,6 +76,9 @@ export default {
     }
 
     if (Array.isArray(r)) {
+      console.log(11111111, {
+        [Op.and]: [{ [Op.gte]: toDate(r[0], { ctx }) }, { [Op.lt]: toDate(r[1], { ctx }) }],
+      });
       return {
         [Op.and]: [{ [Op.gte]: toDate(r[0], { ctx }) }, { [Op.lt]: toDate(r[1], { ctx }) }],
       };

--- a/packages/core/database/src/operators/date.ts
+++ b/packages/core/database/src/operators/date.ts
@@ -53,13 +53,13 @@ function parseDateTimezone(ctx) {
     return ctx.db.options.timezone;
   }
 
-  if (field.constructor.name === 'DatetimeNoTzField') {
-    return '+00:00';
-  }
+  // if (field.constructor.name === 'DatetimeNoTzField') {
+  //   return '+00:00';
+  // }
 
-  if (field.constructor.name === 'DateOnlyField') {
-    return '+00:00';
-  }
+  // if (field.constructor.name === 'DateOnlyField') {
+  //   return '+00:00';
+  // }
 
   return ctx.db.options.timezone;
 }

--- a/packages/core/database/src/operators/date.ts
+++ b/packages/core/database/src/operators/date.ts
@@ -53,13 +53,13 @@ function parseDateTimezone(ctx) {
     return ctx.db.options.timezone;
   }
 
-  // if (field.constructor.name === 'DatetimeNoTzField') {
-  //   return '+00:00';
-  // }
+  if (field.constructor.name === 'DatetimeNoTzField') {
+    return '+00:00';
+  }
 
-  // if (field.constructor.name === 'DateOnlyField') {
-  //   return '+00:00';
-  // }
+  if (field.constructor.name === 'DateOnlyField') {
+    return '+00:00';
+  }
 
   return ctx.db.options.timezone;
 }

--- a/packages/core/utils/src/date.ts
+++ b/packages/core/utils/src/date.ts
@@ -15,6 +15,7 @@ export interface Str2momentOptions {
   picker?: 'year' | 'month' | 'week' | 'quarter';
   utcOffset?: number;
   utc?: boolean;
+  dateOnly?: boolean;
 }
 
 export type Str2momentValue = string | string[] | dayjs.Dayjs | dayjs.Dayjs[];
@@ -83,10 +84,14 @@ const toMoment = (val: any, options?: Str2momentOptions) => {
     return;
   }
   const offset = options.utcOffset;
-  const { gmt, picker, utc = true } = options;
+  const { gmt, picker, utc = true, dateOnly } = options;
+
   if (dayjs(val).isValid()) {
+    if (dateOnly) {
+      return dayjs.utc(val, 'YYYY-MM-DD');
+    }
     if (!utc) {
-      return dayjs(val);
+      return dayjs.utc(val);
     }
 
     if (dayjs.isDayjs(val)) {

--- a/packages/core/utils/src/parse-filter.ts
+++ b/packages/core/utils/src/parse-filter.ts
@@ -188,9 +188,11 @@ export const parseFilter = async (filter: any, opts: ParseFilterOptions = {}) =>
         const field = getField?.(path);
 
         if (field?.constructor.name === 'DateOnlyField' || field?.constructor.name === 'DatetimeNoTzField') {
+          if (value.type) {
+            return getDayRangeByParams({ ...value, timezone: field?.timezone || timezone });
+          }
           return value;
         }
-
         return dateValueWrapper(value, field?.timezone || timezone);
       }
       return value;


### PR DESCRIPTION
…ds using Exact day variable

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   filtering issue on DateOnly or Datetime (without time zone) using Exact day variable   |
| 🇨🇳 Chinese |    修复使用 Exact day 变量过滤 DateOnly 或 Datetime (without time zone) 字段时筛选错误的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
