### PR TITLE
fix: missing sort field selection when duplicating records

### DIFF
--- a/packages/core/client/src/schema-settings/DataTemplates/hooks/useCollectionState.ts
+++ b/packages/core/client/src/schema-settings/DataTemplates/hooks/useCollectionState.ts
@@ -61,7 +61,7 @@ export const useCollectionState = (currentCollectionName: string, displayType = 
         if (!field.interface) {
           return;
         }
-        if (['sort', 'password', 'sequence'].includes(field.type)) {
+        if (['password', 'sequence'].includes(field.type)) {
           return;
         }
         if (filterFields && filterFields(field)) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   missing sort field selection when duplicating records        |
| 🇨🇳 Chinese |    修复了在复制操作中缺少排序字段的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
