### PR TITLE
fix: association field default value overrides existing data in sub-table

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationFieldProvider.tsx
@@ -19,6 +19,7 @@ import { useKeepAlive } from '../../../route-switch/antd/admin-layout/KeepAlive'
 import { useSchemaComponentContext } from '../../hooks';
 import { AssociationFieldContext } from './context';
 import { FormItem, useSchemaOptionsContext } from '../../../schema-component';
+import { useCollectionRecord } from '../../../data-source';
 
 export const AssociationFieldProvider = observer(
   (props) => {
@@ -28,6 +29,7 @@ export const AssociationFieldProvider = observer(
     const api = useAPIClient();
     const option = useSchemaOptionsContext();
     const rootRef = useRef<HTMLDivElement>(null);
+    const record = useCollectionRecord();
 
     // 这里有点奇怪，在 Table 切换显示的组件时，这个组件并不会触发重新渲染，所以增加这个 Hooks 让其重新渲染
     useSchemaComponentContext();
@@ -71,7 +73,9 @@ export const AssociationFieldProvider = observer(
         if (_.isUndefined(ids) || _.isNil(ids) || _.isNaN(ids)) {
           return Promise.reject(null);
         }
-
+        if (record && !record.isNew) {
+          return Promise.reject(null);
+        }
         return api.request({
           resource: collectionField.target,
           action: Array.isArray(ids) ? 'list' : 'get',

--- a/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
@@ -227,7 +227,7 @@ export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: 
       };
       fieldSchema.default = v.default ?? null;
       if (!isVariable(v.default)) {
-        field.setInitialValue?.(v.default);
+        !field.initialValue && field.setInitialValue?.(v.default);
       }
       schema.default = v.default ?? null;
       dn.emit('patch', {

--- a/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
@@ -64,7 +64,7 @@ export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: 
   const localVariables = useLocalVariables();
   const collection = useCollection_deprecated();
   const record = useRecord();
-  const { form } = useFormBlockContext();
+  const { form, type } = useFormBlockContext();
   const { getFields } = useCollectionFilterOptionsV2(collection);
   const { isInSubForm, isInSubTable } = useFlag() || {};
 
@@ -219,7 +219,6 @@ export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: 
     targetField,
     variables,
   ]);
-
   const handleSubmit: (values: any) => void = useCallback(
     (v) => {
       const schema: ISchema = {
@@ -227,7 +226,7 @@ export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: 
       };
       fieldSchema.default = v.default ?? null;
       if (!isVariable(v.default)) {
-        !field.initialValue && field.setInitialValue?.(v.default);
+        (record.__isNewRecord__ || type === 'create') && field.setInitialValue?.(v.default);
       }
       schema.default = v.default ?? null;
       dn.emit('patch', {


### PR DESCRIPTION
…able

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     association field default value overrides existing data in sub-table      |
| 🇨🇳 Chinese |   修复 编辑表单中子表格的关系字段设置的默认值覆盖已有数据的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
