### PR TITLE
fix: update collection name handling in useCurrentFormVariable

### DIFF
--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useFormVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useFormVariable.ts
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { useBlockContext } from '../../../block-provider';
 import { useFormBlockContext } from '../../../block-provider/FormBlockProvider';
 import { CollectionFieldOptions_deprecated } from '../../../collection-manager';
-import { useDataBlockRequestData, useDataSource } from '../../../data-source';
+import { useCollection, useDataSource } from '../../../data-source';
 import { useFlag } from '../../../flag-provider/hooks/useFlag';
 import { useBaseVariable } from './useBaseVariable';
 
@@ -100,6 +100,7 @@ export const useCurrentFormVariable = ({
   const { currentFormCtx, shouldDisplayCurrentForm } = useCurrentFormContext({ form: _form });
   const { t } = useTranslation();
   const { collectionName } = useFormBlockContext();
+  const collection = useCollection();
   const dataSource = useDataSource();
   const currentFormSettings = useBaseVariable({
     collectionField,
@@ -108,7 +109,7 @@ export const useCurrentFormVariable = ({
     maxDepth: 4,
     name: '$nForm',
     title: t('Current form'),
-    collectionName: collectionName,
+    collectionName: collectionName || collection?.name,
     noDisabled,
     dataSource: dataSource?.key,
     returnFields: (fields, option) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Workflow manual node UI configuration: linkage rules cannot select Current form variables    |
| 🇨🇳 Chinese |      工作流人工节点的 UI 配置，设置联动规则不能选择当前表单变量     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
