### PR TITLE
fix: background color style issue  in subtable on detail block

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/form/hooks/useDataFormItemProps.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/form/hooks/useDataFormItemProps.ts
@@ -11,14 +11,21 @@ import { useCollectionRecordData } from '../../../../../data-source/collection-r
 import { useSatisfiedActionValues } from '../../../../../schema-settings/LinkageRules/useActionValues';
 import { useFormBlockContext } from '../../../../../block-provider';
 import { useSubFormValue } from '../../../../../schema-component/antd/association-field/hooks';
+import { useFlag } from '../../../../../flag-provider/hooks/useFlag';
+
 export function useDataFormItemProps() {
   const record = useCollectionRecordData();
   const { form } = useFormBlockContext();
   const subForm = useSubFormValue();
+  const { isInSubTable } = useFlag();
+
   const { valueMap: style } = useSatisfiedActionValues({
     category: 'style',
     formValues: subForm?.formValue || form?.values || record,
     form,
   });
-  return { wrapperStyle: style };
+  const wrapperStyle = isInSubTable
+    ? Object.fromEntries(Object.entries(style || {}).filter(([key]) => key !== 'backgroundColor'))
+    : style;
+  return { wrapperStyle };
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     background color style issue  in subtable on detail block       |
| 🇨🇳 Chinese |       修复详情区块中子表格设置背景颜色时样式重复的问题    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
