### PR TITLE
fix: resolve conflict between on-demand data source loading and table…

### DIFF
--- a/packages/core/data-source-manager/src/data-source-manager.ts
+++ b/packages/core/data-source-manager/src/data-source-manager.ts
@@ -66,13 +66,12 @@ export class DataSourceManager {
       hook(dataSource);
     }
 
+    await dataSource.load(options);
     const oldDataSource = this.dataSources.get(dataSource.name);
 
     if (oldDataSource) {
       await oldDataSource.close();
     }
-
-    await dataSource.load(options);
     this.dataSources.set(dataSource.name, dataSource);
 
     for (const hook of this.onceHooks) {

--- a/packages/core/data-source-manager/src/sequelize-collection-manager.ts
+++ b/packages/core/data-source-manager/src/sequelize-collection-manager.ts
@@ -97,9 +97,7 @@ export class SequelizeCollectionManager implements ICollectionManager {
     return this.db.getCollection(name);
   }
 
-  removeCollection(name: string) {
-    this.db.removeCollection(name);
-  }
+  removeCollection(name: string) {}
 
   getCollections() {
     const collectionsFilter = this.collectionsFilter();


### PR DESCRIPTION
… prefix causing closed connection error

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed an issue where the combination of on-demand data source loading and table prefix configuration caused a “ConnectionManager.getConnection was called after the connection manager was closed” error.      |
| 🇨🇳 Chinese |     修复了按需加载数据源与表前缀配置冲突导致的 “ConnectionManager.getConnection was called after the connection manager was closed” 错误。      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
