### PR TITLE
fix(plugin-workflow-manual): fix error thrown when use variable

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/instruction/index.tsx
@@ -13,6 +13,7 @@ import { SolutionOutlined } from '@ant-design/icons';
 import {
   joinCollectionName,
   SchemaInitializerItemType,
+  useApp,
   useCollectionManager_deprecated,
   useCompile,
   useDataSourceManager,
@@ -42,7 +43,7 @@ const MULTIPLE_ASSIGNED_MODE = {
 
 function useVariables({ key, title, config }, { types, fieldNames = defaultFieldNames }) {
   const compile = useCompile();
-  const { getCollectionFields } = useCollectionManager_deprecated();
+  const app = useApp();
   const formKeys = Object.keys(config.forms ?? {});
   if (!formKeys.length) {
     return null;
@@ -51,13 +52,17 @@ function useVariables({ key, title, config }, { types, fieldNames = defaultField
   const options = formKeys
     .map((formKey) => {
       const form = config.forms[formKey];
+      let collectionManager;
+      if (form.dataSource) {
+        collectionManager = app.dataSourceManager.getDataSource(form.dataSource).collectionManager;
+      }
 
       const fieldsOptions = getCollectionFieldOptions({
         fields: form.collection?.fields,
         collection: form.collection,
         types,
         compile,
-        getCollectionFields,
+        collectionManager,
       });
       const label = compile(form.title) || formKey;
       return fieldsOptions.length


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix error thrown when use variable.

### Description 

TypeError: Cannot read properties of undefined (reading 'getCollectionAllFields')

```
getNormalizedFields
.nocobase/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx:261:35
  258 | // NOTE: for compatibility with legacy version
  259 | const [dataSourceName, collection] = parseCollectionName(collectionName);
  260 | // NOTE: `dataSourceName` will be ignored in new version
> 261 | const fields = collectionManager.getCollectionAllFields(collection);
      |                                 ^  262 | const fkFields: any[] = [];
  263 | const result: any[] = [];
  264 | fields.forEach((field) => {
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix error thrown when use variable |
| 🇨🇳 Chinese | 修复使用节点变量时的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
