### PR TITLE
fix(PagePopups): clean up popup layer state on unmount

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/PagePopups.tsx
+++ b/packages/core/client/src/schema-component/antd/page/PagePopups.tsx
@@ -29,6 +29,7 @@ import {
   getStoredPopupContext,
   usePopupUtils,
 } from './pagePopupUtils';
+import { removePopupLayerState } from './popupState';
 import {
   PopupContext,
   getPopupContextFromActionOrAssociationFieldSchema,
@@ -160,6 +161,12 @@ const PagePopupsItemProvider: FC<{
   currentLevel: number;
 }> = ({ params, context, currentLevel, children }) => {
   const storedContext = { ...getStoredPopupContext(params.popupuid) };
+
+  useEffect(() => {
+    return () => {
+      removePopupLayerState(currentLevel);
+    };
+  }, [currentLevel]);
 
   if (!context) {
     context = _.omitBy(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where clicking buttons cannot open popups    |
| 🇨🇳 Chinese |     修复点击按钮无法打开弹窗的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
