### PR TITLE
fix: cli ignore mac address verification

### DIFF
--- a/packages/core/cli/src/util.js
+++ b/packages/core/cli/src/util.js
@@ -495,11 +495,14 @@ async function isEnvMatch(keyData) {
   const env = await getEnvAsync();
   if (env?.container?.id && keyData?.instanceData?.container?.id) {
     return (
-      JSON.stringify(omit(env, ['timestamp', 'container', 'hostname'])) ===
-      JSON.stringify(omit(keyData?.instanceData, ['timestamp', 'container', 'hostname']))
+      JSON.stringify(omit(env, ['timestamp', 'container', 'hostname', 'mac'])) ===
+      JSON.stringify(omit(keyData?.instanceData, ['timestamp', 'container', 'hostname', 'mac']))
     );
   }
-  return JSON.stringify(omit(env, ['timestamp'])) === JSON.stringify(omit(keyData?.instanceData, ['timestamp']));
+  return (
+    JSON.stringify(omit(env, ['timestamp', 'mac'])) ===
+    JSON.stringify(omit(keyData?.instanceData, ['timestamp', 'mac']))
+  );
 }
 
 exports.getAccessKeyPair = async function () {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Before installing the plugin, the environment verification ignores the mac address verification

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
安装插件前环境校验忽略mac地址校验

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
