### PR TITLE
fix(plugin-workflow): convert value to string before logic calculation

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/logicCalculate.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/logicCalculate.test.ts
@@ -1,0 +1,173 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { logicCalculate, calculators, Calculation } from '../logicCalculate';
+
+describe('workflow > logic calculate', () => {
+  it('should return true when calculation is null or undefined', () => {
+    expect(logicCalculate(null)).toBe(true);
+    expect(logicCalculate(undefined)).toBe(true);
+  });
+
+  it('should return true for empty calculation item', () => {
+    expect(logicCalculate({})).toBe(true);
+  });
+
+  it('should throw error for unregistered calculator', () => {
+    expect(() => logicCalculate({ calculator: 'foo', operands: [1, 1] })).toThrow(
+      'no calculator function registered for "foo"',
+    );
+  });
+
+  describe('single calculation', () => {
+    it.each([
+      ['equal', 1, 1, true],
+      ['equal', 1, '1', true],
+      ['equal', 1, 2, false],
+      ['==', 1, 1, true],
+      ['notEqual', 1, 2, true],
+      ['notEqual', 1, 1, false],
+      ['!=', 1, 2, true],
+      ['gt', 2, 1, true],
+      ['gt', 1, 2, false],
+      ['>', 2, 1, true],
+      ['gte', 2, 1, true],
+      ['gte', 2, 2, true],
+      ['gte', 1, 2, false],
+      ['>=', 2, 2, true],
+      ['lt', 1, 2, true],
+      ['lt', 2, 1, false],
+      ['<', 1, 2, true],
+      ['lte', 1, 2, true],
+      ['lte', 2, 2, true],
+      ['lte', 2, 1, false],
+      ['<=', 2, 2, true],
+      ['includes', [1, 2, 3], 2, true],
+      ['includes', [1, 2, 3], 4, false],
+      ['includes', 'abc', 'b', true],
+      ['notIncludes', [1, 2, 3], 4, true],
+      ['notIncludes', [1, 2, 3], 2, false],
+      ['startsWith', 'abc', 'a', true],
+      ['startsWith', 'abc', 'b', false],
+      ['notStartsWith', 'abc', 'b', true],
+      ['notStartsWith', 'abc', 'a', false],
+      ['endsWith', 'abc', 'c', true],
+      ['endsWith', 'abc', 'b', false],
+      ['notEndsWith', 'abc', 'b', true],
+      ['notEndsWith', 'abc', 'c', false],
+    ])('should support %s operator', (calculator, a, b, expected) => {
+      expect(logicCalculate({ calculator, operands: [a, b] })).toBe(expected);
+    });
+  });
+
+  describe('grouped calculations', () => {
+    it('should handle "and" group', () => {
+      const calculation: Calculation = {
+        group: {
+          type: 'and',
+          calculations: [
+            { calculator: 'equal', operands: [1, 1] },
+            { calculator: 'gt', operands: [2, 1] },
+          ],
+        },
+      };
+      expect(logicCalculate(calculation)).toBe(true);
+
+      calculation.group.calculations.push({ calculator: 'lt', operands: [1, 0] });
+      expect(logicCalculate(calculation)).toBe(false);
+    });
+
+    it('should handle "or" group', () => {
+      const calculation: Calculation = {
+        group: {
+          type: 'or',
+          calculations: [
+            { calculator: 'equal', operands: [1, 2] },
+            { calculator: 'gt', operands: [1, 2] },
+          ],
+        },
+      };
+      expect(logicCalculate(calculation)).toBe(false);
+
+      calculation.group.calculations.push({ calculator: 'lt', operands: [1, 2] });
+      expect(logicCalculate(calculation)).toBe(true);
+    });
+
+    it('should handle empty calculations in group', () => {
+      const andGroup: Calculation = {
+        group: {
+          type: 'and',
+          calculations: [],
+        },
+      };
+      expect(logicCalculate(andGroup)).toBe(true);
+
+      const orGroup: Calculation = {
+        group: {
+          type: 'or',
+          calculations: [],
+        },
+      };
+      expect(logicCalculate(orGroup)).toBe(false);
+    });
+  });
+
+  describe('nested grouped calculations', () => {
+    it('should handle nested "and" and "or" groups', () => {
+      const calculation: Calculation = {
+        group: {
+          type: 'and',
+          calculations: [
+            { calculator: 'equal', operands: [1, 1] },
+            {
+              group: {
+                type: 'or',
+                calculations: [
+                  { calculator: 'gt', operands: [1, 2] },
+                  { calculator: 'lt', operands: [1, 2] },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      expect(logicCalculate(calculation)).toBe(true);
+
+      const calculation2: Calculation = {
+        group: {
+          type: 'and',
+          calculations: [
+            { calculator: 'equal', operands: [1, 1] },
+            {
+              group: {
+                type: 'or',
+                calculations: [
+                  { calculator: 'gt', operands: [1, 2] },
+                  { calculator: 'lt', operands: [2, 1] },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      expect(logicCalculate(calculation2)).toBe(false);
+    });
+  });
+
+  describe('custom calculator', () => {
+    beforeAll(() => {
+      calculators.register('isOdd', (a) => a % 2 !== 0);
+    });
+
+    it('should support custom registered calculator', () => {
+      expect(logicCalculate({ calculator: 'isOdd', operands: [3] })).toBe(true);
+      expect(logicCalculate({ calculator: 'isOdd', operands: [2] })).toBe(false);
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/logicCalculate.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/logicCalculate.ts
@@ -61,19 +61,19 @@ function notIncludes(a, b) {
 }
 
 function startsWith(a: string, b: string) {
-  return a.startsWith(b);
+  return a.toString().startsWith(b.toString());
 }
 
 function notStartsWith(a: string, b: string) {
-  return !a.startsWith(b);
+  return !a.toString().startsWith(b.toString());
 }
 
 function endsWith(a: string, b: string) {
-  return a.endsWith(b);
+  return a.toString().endsWith(b.toString());
 }
 
 function notEndsWith(a: string, b: string) {
-  return !a.endsWith(b);
+  return !a.toString().endsWith(b.toString());
 }
 
 calculators.register('includes', includes);
@@ -95,7 +95,7 @@ type CalculationGroup = {
   };
 };
 
-type Calculation = CalculationItem | CalculationGroup;
+export type Calculation = CalculationItem | CalculationGroup;
 
 function calculate(calculation: CalculationItem = {}): boolean {
   let fn: Comparer;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Convert operands to string before string comparison in logic calculation.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Convert operands to string before string comparison in logic calculation |
| 🇨🇳 Chinese | 字符串比较运算前将操作数转换为字符串 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
