### PR TITLE
fix(plugin-notification-in-app-message): fix bigint timestamp issue

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
@@ -129,7 +129,7 @@ const InnerInboxContent = () => {
                       color: textColor,
                     }}
                   >
-                    {dayjs(item.latestMsgReceiveTimestamp).fromNow()}
+                    {dayjs(Number.parseInt(item.latestMsgReceiveTimestamp.toString(), 10)).fromNow()}
                   </div>
                 </Flex>
                 <Flex justify="space-between" style={{ width: '100%', marginTop: token.margin }}>

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/MessageList.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/MessageList.tsx
@@ -168,7 +168,9 @@ const MessageList = observer(() => {
                     {message.content?.slice(0, 100) + (message.content?.length > 100 ? '...' : '')}{' '}
                   </Tooltip>
                 </Descriptions.Item>
-                <Descriptions.Item label={t('Datetime')}>{dayjs(message.receiveTimestamp).fromNow()}</Descriptions.Item>
+                <Descriptions.Item label={t('Datetime')}>
+                  {dayjs(Number.parseInt(message.receiveTimestamp.toString(), 10)).fromNow()}
+                </Descriptions.Item>
                 <Descriptions.Item label={t('Status')}>
                   <div style={{ height: token.controlHeight }}>
                     {hoveredMessageId === message.id ? (

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/types/index.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/types/index.ts
@@ -12,7 +12,7 @@ export interface Channel {
   userId: string;
   unreadMsgCnt: number;
   totalMsgCnt: number;
-  latestMsgReceiveTimestamp: number;
+  latestMsgReceiveTimestamp: number | string;
   latestMsgTitle: string;
 }
 
@@ -22,7 +22,7 @@ export interface Message {
   userId: string;
   channelName: string;
   content: string;
-  receiveTimestamp: number;
+  receiveTimestamp: number | string;
   status: 'read' | 'unread';
   url: string;
   options: Record<string, any>;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix BigInt timestamp in string format causes dayjs issue.

### Description 

```
dayjs('1752202196154').fromNow(); // 272 years ago
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix BigInt timestamp in string format causes dayjs issue |
| 🇨🇳 Chinese | 修复字符串格式的大整型时间戳导致的 dayjs 问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
