### PR TITLE
feat(plugin-multi-app-manager): add auth options

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/AppManager.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/AppManager.tsx
@@ -12,6 +12,7 @@ import { Card } from 'antd';
 import React from 'react';
 import { schema } from './settings/schemas/applications';
 import { usePluginUtils } from './utils';
+import { JwtSecretInput } from './JwtSecretInput';
 
 const useLink = () => {
   const record = useRecord();
@@ -35,7 +36,7 @@ const AppVisitor = () => {
 export const AppManager = () => {
   return (
     <Card bordered={false}>
-      <SchemaComponent schema={schema} components={{ AppVisitor }} />
+      <SchemaComponent schema={schema} components={{ AppVisitor, JwtSecretInput }} />
     </Card>
   );
 };

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/JwtSecretInput.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/JwtSecretInput.tsx
@@ -1,0 +1,30 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { Checkbox } from 'antd';
+import { usePluginUtils } from './utils';
+import { uid } from '@formily/shared';
+
+export const JwtSecretInput = ({ value, onChange }) => {
+  const { t } = usePluginUtils();
+  const checked = !!value;
+  const onCheck = (e: any) => {
+    if (e.target.checked) {
+      onChange(`${uid()}${uid()}${uid()}${uid()}`);
+    } else {
+      onChange('');
+    }
+  };
+  return (
+    <Checkbox onChange={onCheck} checked={checked}>
+      {t('Automatically generate a JWT secret')}
+    </Checkbox>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/settings/schemas/applications.ts
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/client/settings/schemas/applications.ts
@@ -22,6 +22,7 @@ import {
 } from '@nocobase/client';
 import React from 'react';
 import { i18nText } from '../../utils';
+import { NAMESPACE } from '../../../locale';
 
 const collection = {
   name: 'applications',
@@ -418,6 +419,21 @@ export const schema: ISchema = {
               },
             },
           },
+        },
+      },
+    },
+    'options.authManager': {
+      type: 'object',
+      'x-decorator': 'FormItem',
+      'x-component': 'Fieldset',
+      title: `{{t("Authentication options", { ns: "${NAMESPACE}" })}}`,
+      properties: {
+        'jwt.secret': {
+          type: 'string',
+          title: `{{t("JWT secret", { ns: "${NAMESPACE}" })}}`,
+          description: `{{t("An independent JWT secret ensures data and session isolation from other applications.", { ns: "${NAMESPACE}" })}}`,
+          'x-decorator': 'FormItem',
+          'x-component': 'JwtSecretInput',
         },
       },
     },

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/locale/zh-CN.json
@@ -10,5 +10,9 @@
   "Auto start": "自动启动",
   "Start mode": "启动方式",
   "Start on first visit": "首次访问时启动",
-  "Start with main application": "随主应用一同启动"
+  "Start with main application": "随主应用一同启动",
+  "Authentication options": "认证选项",
+  "JWT secret": "JWT 密钥",
+  "Automatically generate a JWT secret": "自动生成 JWT 密钥",
+  "An independent JWT secret ensures data and session isolation from other applications.": "独立的 JWT 密钥，保证与其他应用的数据与会话隔离。"
 }


### PR DESCRIPTION
### This is a ...

- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to configure independent auth secret for sub-apps.

Add auth options

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to configure independent auth secret for sub-apps |
| 🇨🇳 Chinese | 支持为子应用配置独立的认证密钥 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
