### PR TITLE
fix(DocumentTitleProvider): add setTimeout to update document title

### DIFF
--- a/packages/core/client/src/document-title/index.tsx
+++ b/packages/core/client/src/document-title/index.tsx
@@ -33,9 +33,11 @@ export const DocumentTitleProvider: React.FC<{ addonBefore?: string; addonAfter?
   const getTitle = useCallback(() => titleRef.current, []);
   const setTitle = useCallback(
     (title) => {
-      document.title = titleRef.current = `${addonBefore ? ` - ${t(addonBefore)}` : ''}${routeT(title || '')}${
-        addonAfter ? ` - ${titleT(addonAfter)}` : ''
-      }`;
+      setTimeout(() => {
+        document.title = titleRef.current = `${addonBefore ? ` - ${t(addonBefore)}` : ''}${routeT(title || '')}${
+          addonAfter ? ` - ${titleT(addonAfter)}` : ''
+        }`;
+      });
     },
     [addonAfter, addonBefore, t, routeT, titleT],
   );

--- a/packages/core/client/src/schema-component/antd/page/Page.tsx
+++ b/packages/core/client/src/schema-component/antd/page/Page.tsx
@@ -20,7 +20,7 @@ import React, { FC, memo, useCallback, useContext, useEffect, useMemo, useRef, u
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { NavigateFunction, Outlet, useOutletContext } from 'react-router-dom';
-import { FormDialog, Variable, withSearchParams } from '..';
+import { FormDialog, withSearchParams } from '..';
 import { antTableCell } from '../../../acl/style';
 import {
   CurrentTabUidContext,
@@ -33,6 +33,8 @@ import {
 import { AppNotFound } from '../../../common/AppNotFound';
 import { useDocumentTitle } from '../../../document-title';
 import { useGlobalTheme } from '../../../global-theme';
+import { useEvaluatedExpression } from '../../../hooks/useParsedValue';
+import { NAMESPACE_UI_SCHEMA } from '../../../i18n/constant';
 import { Icon } from '../../../icon';
 import {
   NocoBaseDesktopRouteType,
@@ -40,8 +42,10 @@ import {
   useCurrentRoute,
   useMobileLayout,
 } from '../../../route-switch/antd/admin-layout';
+import { NocoBaseDesktopRoute } from '../../../route-switch/antd/admin-layout/convertRoutesToSchema';
 import { KeepAlive, useKeepAlive } from '../../../route-switch/antd/admin-layout/KeepAlive';
 import { useGetAriaLabelOfSchemaInitializer } from '../../../schema-initializer/hooks/useGetAriaLabelOfSchemaInitializer';
+import { VariableScope } from '../../../variables/VariableScope';
 import { DndContext } from '../../common';
 import { SortableItem } from '../../common/sortable-item';
 import { RemoteSchemaComponent, SchemaComponent, SchemaComponentOptions } from '../../core';
@@ -53,10 +57,6 @@ import { AllDataBlocksProvider } from './AllDataBlocksProvider';
 import { useStyles } from './Page.style';
 import { PageDesigner, PageTabDesigner } from './PageTabDesigner';
 import { PopupRouteContextResetter } from './PopupRouteContextResetter';
-import { NAMESPACE_UI_SCHEMA } from '../../../i18n/constant';
-import { NocoBaseDesktopRoute } from '../../../route-switch/antd/admin-layout/convertRoutesToSchema';
-import { useEvaluatedExpression } from '../../../hooks/useParsedValue';
-import { VariableScope } from '../../../variables/VariableScope';
 
 interface PageProps {
   currentTabUid: string;
@@ -408,6 +408,7 @@ const NocoBasePageHeader = React.memo(({ activeKey, className }: { activeKey: st
   const { t } = useTranslation();
   const { t: routeT } = useRouteTranslation();
   const [pageTitle, setPageTitle] = useState(() => t(fieldSchema.title));
+  const { active } = useKeepAlive();
 
   const disablePageHeader = fieldSchema['x-component-props']?.disablePageHeader;
   const currentRoute = useCurrentRoute();
@@ -419,11 +420,11 @@ const NocoBasePageHeader = React.memo(({ activeKey, className }: { activeKey: st
   useEffect(() => {
     const title =
       t(fieldSchema.title, { ns: NAMESPACE_UI_SCHEMA }) || t(currentRoute?.title, { ns: NAMESPACE_UI_SCHEMA });
-    if (title) {
+    if (title && active) {
       setDocumentTitle(title);
       setPageTitle(title);
     }
-  }, [fieldSchema.title, pageTitle, setDocumentTitle, t, currentRoute?.title]);
+  }, [fieldSchema.title, pageTitle, setDocumentTitle, t, currentRoute?.title, active]);
 
   return (
     <>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Browser tab title is not synchronized when switching between submenus    |
| 🇨🇳 Chinese |     子菜单切换时浏览器标签标题未同步更新      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
