### PR TITLE
fix: value assignment fails in edit form when both value and options …

### DIFF
--- a/packages/core/client/src/schema-settings/LinkageRules/bindLinkageRulesToFiled.ts
+++ b/packages/core/client/src/schema-settings/LinkageRules/bindLinkageRulesToFiled.ts
@@ -294,7 +294,7 @@ function getSubscriber(
         } else if (fieldName === 'dataSource') {
           const lastValues = lastState?.value?.map((v) => v.value) || [];
           if (
-            (!Array.isArray(field.value) && !lastValues.includes(field.value)) ||
+            (field.value && !Array.isArray(field.value) && !lastValues.includes(field.value)) ||
             (Array.isArray(field.value) && _.difference(field.value, lastValues).length > 0)
           ) {
             field.value = field.initialValue;


### PR DESCRIPTION
…are set for select field

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  value assignment fails in edit form when both value and options are set for select field         |
| 🇨🇳 Chinese |   修复编辑表单中联动规则为选项字段同时设置赋值和选项内容时赋值失效的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
