### PR TITLE
fix(client): avoid non-association fields to be selected

### DIFF
--- a/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/appends-tree-select/AppendsTreeSelect.tsx
@@ -55,7 +55,11 @@ function loadChildren(this, option) {
 }
 
 function isAssociation(field) {
-  return field.target && field.interface;
+  return (
+    ['belongsTo', 'hasMany', 'hasOne', 'belongsToMany', 'belongsToArray'].includes(field.type) &&
+    field.target &&
+    field.interface
+  );
 }
 
 function trueFilter(field) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Avoid non-association fields to be selected in appends.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid non-association fields to be selected in appends |
| 🇨🇳 Chinese | 避免非关系字段在预加载关系字段配置中被选择 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
