### PR TITLE
fix(auth): use the `APP_KEY` environment variable as a fallback for the app secret key

### DIFF
--- a/packages/core/auth/src/base/jwt-service.ts
+++ b/packages/core/auth/src/base/jwt-service.ts
@@ -24,7 +24,7 @@ export class JwtService {
   ) {
     const { secret, expiresIn } = options;
     this.options = {
-      secret: secret,
+      secret: secret || process.env.APP_KEY,
       expiresIn: expiresIn || process.env.JWT_EXPIRES_IN || '7d',
     };
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the issue where an empty `secret` in sub-application configuration prevents sign-in         |
| 🇨🇳 Chinese | 修复子应用配置中 `secret` 为空，无法登录的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
