### PR TITLE
fix: correct DateOnlyField formatting to avoid timezone offset

### DIFF
--- a/packages/core/database/src/operators/date.ts
+++ b/packages/core/database/src/operators/date.ts
@@ -11,6 +11,21 @@ import { parseDate } from '@nocobase/utils';
 import { Op, Sequelize } from 'sequelize';
 import moment from 'moment';
 
+/**
+ * 自动识别时间是否为 UTC，统一输出为本地时间格式字符串
+ * @param val - 原始时间字符串或 Date 对象
+ * @param format - 输出格式，默认 'YYYY-MM-DD HH:mm:ss'
+ */
+function formatAsLocalTime(val: string | Date, format = 'YYYY-MM-DD HH:mm:ss'): string {
+  const m = moment(val);
+
+  // 判断是否为 ISO UTC 格式，例如 2025-07-20T00:00:00Z 或含有 Z、+00:00 后缀
+  const isLikelyUTC = typeof val === 'string' && /Z$|[+-]00:00$/.test(val);
+
+  // 若 moment 对象是 UTC 或原始字符串看起来是 UTC，就转本地
+  return m.isUTC() || isLikelyUTC ? m.local().format(format) : m.format(format);
+}
+
 function isDate(input) {
   return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
 }
@@ -33,7 +48,7 @@ const toDate = (date, options: any = {}) => {
   }
 
   if (field.constructor.name === 'DateOnlyField') {
-    val = moment.utc(val).format('YYYY-MM-DD HH:mm:ss');
+    val = formatAsLocalTime(val);
   }
 
   const eventObj = {


### PR DESCRIPTION
> ### This is a ...
> * [ ]  New feature
> * [ ]  Improvement
> * [x]  Bug fix
> * [ ]  Others
> 
> ### Motivation
> Fix: correct DateOnlyField formatting to avoid timezone offset
> 
> ### Description
> ### Related issues
> ### Showcase
> ### Changelog
> Language	Changelog
> 🇺🇸 English	Fix: correct DateOnlyField formatting to avoid timezone offset
> 🇨🇳 Chinese	修复因 .utc() 导致的时间偏移问题，确保 DateOnlyField 格式化为本地时间，避免“今天”实际查询为“昨天”的问题。
> ### Docs
> Language	Link
> 🇺🇸 English	
> 🇨🇳 Chinese	
> ### Checklists
> * [ ]  All changes have been self-tested and work as expected
> * [x]  Test cases are updated/provided or not needed
> * [x]  Doc is updated/provided or not needed
> * [x]  Component demo is updated/provided or not needed
> * [x]  Changelog is provided or not needed
> * [x]  Request a code review if it is necessary

