### PR TITLE
fix: add useTableSelectorContext to bulk edit and update action props

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/utils.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client/utils.tsx
@@ -7,10 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { SchemaExpressionScopeContext, useField, useForm, useFieldSchema } from '@formily/react';
+import { SchemaExpressionScopeContext, useField, useFieldSchema, useForm } from '@formily/react';
 import {
   SchemaInitializerItemType,
-  TableFieldResource,
   useActionContext,
   useBlockRequestContext,
   useCollectionManager_deprecated,
@@ -19,6 +18,7 @@ import {
   useNavigateNoUpdate,
   useRemoveGridFormItem,
   useTableBlockContext,
+  useTableSelectorContext,
 } from '@nocobase/client';
 import { isURL } from '@nocobase/utils/client';
 import { App, message } from 'antd';
@@ -87,9 +87,13 @@ export const useCustomizeBulkEditActionProps = () => {
   const compile = useCompile();
   const actionField = useField();
   const tableBlockContext = useTableBlockContext();
+  const tableSelectorContext = useTableSelectorContext();
   const { modal } = App.useApp();
   const selectedRecordKeys =
-    tableBlockContext.field?.data?.selectedRowKeys ?? expressionScope?.selectedRecordKeys ?? [];
+    tableBlockContext.field?.data?.selectedRowKeys ??
+    expressionScope?.selectedRecordKeys ??
+    tableSelectorContext.field?.data?.selectedRowKeys ??
+    [];
   const { setVisible, fieldSchema: actionSchema, setSubmitted } = actionContext;
   const fieldSchema = useFieldSchema();
   return {

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/utils.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/utils.tsx
@@ -18,6 +18,7 @@ import {
   useLocalVariables,
   useNavigateNoUpdate,
   useTableBlockContext,
+  useTableSelectorContext,
   useVariables,
 } from '@nocobase/client';
 import { isURL } from '@nocobase/utils/client';
@@ -30,6 +31,7 @@ export const useCustomizeBulkUpdateActionProps = () => {
   const expressionScope = useContext(SchemaExpressionScopeContext);
   const actionSchema = useFieldSchema();
   const tableBlockContext = useTableBlockContext();
+  const tableSelectorContext = useTableSelectorContext();
   const { rowKey } = tableBlockContext;
 
   const navigate = useNavigateNoUpdate();
@@ -51,7 +53,10 @@ export const useCustomizeBulkUpdateActionProps = () => {
         actionField.data = field.data || {};
         actionField.data.loading = true;
         const selectedRecordKeys =
-          tableBlockContext.field?.data?.selectedRowKeys ?? expressionScope?.selectedRecordKeys ?? {};
+          tableBlockContext.field?.data?.selectedRowKeys ??
+          expressionScope?.selectedRecordKeys ??
+          tableSelectorContext.field?.data?.selectedRowKeys ??
+          {};
 
         const assignedValues = {};
         const waitList = Object.keys(originalAssignedValues).map(async (key) => {
@@ -148,7 +153,6 @@ export const useCustomizeBulkUpdateActionProps = () => {
           },
         });
       });
-
     },
   };
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Unable to perform bulk edit and bulk update in data selector     |
| 🇨🇳 Chinese |     数据选择器中无法进行批量编辑和批量更新      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
