### PR TITLE
fix:  incorrect display of historical date variables in date fields

### DIFF
--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -1138,5 +1138,6 @@
   "Calendar Year":"日历年",
   "Scan to input":"扫码录入",
   "Disable manual input":"禁止手动输入",
-  "Enable Scan":"启用扫码录入"
+  "Enable Scan":"启用扫码录入",
+  "Date variables(Deprecated)":"日期变量(废弃)"
 }

--- a/packages/core/client/src/schema-component/common/date-filter-dynamic-component/DateFilterDynamicComponent.tsx
+++ b/packages/core/client/src/schema-component/common/date-filter-dynamic-component/DateFilterDynamicComponent.tsx
@@ -53,7 +53,7 @@ type SmartDatePickerProps = {
 );
 
 const SmartDatePicker: React.FC<SmartDatePickerProps> = (props) => {
-  const { isRange, ...rest } = props as any;
+  const { isRange, defaultValue, ...rest } = props as any;
   return isRange ? <DatePicker.RangePicker {...rest} /> : <DatePicker.FilterWithPicker {...rest} />;
 };
 

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useDateVariable.ts
@@ -14,6 +14,8 @@ import { useOperators } from '../../../block-provider/CollectOperators';
 import { useDatePickerContext } from '../../../schema-component/antd/date-picker/DatePicker';
 import { getDateRanges } from '../../../schema-component/antd/date-picker/util';
 import { datetime } from '../../../collection-manager/interfaces/properties/operators';
+import { useFlag } from '../../../flag-provider';
+
 interface Props {
   operator?: {
     value: string;
@@ -233,6 +235,7 @@ export const useDatetimeVariableContext = () => {
 export const useDatetimeVariable = ({ operator, schema, noDisabled, targetFieldSchema }: Props = {}) => {
   const { t } = useTranslation();
   const { getOperator } = useOperators();
+  const { collectionField } = useFlag();
 
   const datetimeSettings = useMemo(() => {
     const operatorValue = operator?.value || getOperator(targetFieldSchema?.name) || '';
@@ -397,10 +400,10 @@ export const useDatetimeVariable = ({ operator, schema, noDisabled, targetFieldS
     ];
 
     return {
-      label: t('Date variables'),
+      label: collectionField ? t('Date variables(Deprecated)') : t('Date variables'),
       value: '$nDate',
       key: '$nDate',
-      disabled: dateOptions.every((option) => option.disabled),
+      disabled: dateOptions.every((option) => option.disabled) || collectionField,
       children: dateOptions,
     };
   }, [schema?.['x-component'], targetFieldSchema]);

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useVariableOptions.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useVariableOptions.ts
@@ -149,7 +149,7 @@ export const useVariableOptions = ({
       currentUserSettings,
       currentRoleSettings,
       apiTokenSettings,
-      !shouldDisplayExactDate && datetimeSettings,
+      datetimeSettings,
       shouldDisplayExactDate && exactDateTimeSettings,
       shouldDisplayCurrentForm && currentFormSettings,
       shouldDisplayCurrentObject && currentObjectSettings,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     display issue when deprecated date variables are used in date fields of historical data       |
| 🇨🇳 Chinese |    修复历史数据中日期字段使用废弃的日期变量时显示异常的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
