### PR TITLE
fix: fix list loading error when using MSSQL external data source wit…

### DIFF
--- a/packages/core/database/src/options-parser.ts
+++ b/packages/core/database/src/options-parser.ts
@@ -151,7 +151,7 @@ export class OptionsParser {
     if (defaultSortField && !this.options?.group) {
       defaultSortField = lodash.castArray(defaultSortField);
       for (const key of defaultSortField) {
-        if (!sort.includes(key)) {
+        if (!sort.includes(key) && !sort.includes(`-${key}`)) {
           sort.push(key);
         }
       }


### PR DESCRIPTION
…h default primary key sorting

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix issue where default primary key sorting causes list loading failure when using MSSQL external data source in table block.     |
| 🇨🇳 Chinese |     表格区块设置mssql外部数据源默认主键排序，读取列表报错      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
