### PR TITLE
fix: add check for isNew before resetting field in useServiceOptions

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/hooks.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/hooks.tsx
@@ -14,7 +14,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import React, { createContext, FC, useCallback, useContext, useMemo } from 'react';
 import { useParsedFilter } from '../../../block-provider/hooks/useParsedFilter';
 import { useCollection_deprecated, useCollectionManager_deprecated } from '../../../collection-manager';
-import { Collection } from '../../../data-source';
+import { Collection, useCollectionRecord } from '../../../data-source';
 import { isInFilterFormBlock } from '../../../filter-provider';
 import { mergeFilter } from '../../../filter-provider/utils';
 import { useRecord } from '../../../record-provider';
@@ -68,6 +68,7 @@ export default function useServiceOptions(props) {
   const { getField } = useCollection_deprecated();
   const { getCollectionJoinField } = useCollectionManager_deprecated();
   const record = useRecord();
+  const { isNew } = useCollectionRecord() || {};
   const filterParams =
     (isString(fieldSchema?.['x-component-props']?.service?.params?.filter)
       ? field.componentProps?.service?.params?.filter
@@ -76,7 +77,9 @@ export default function useServiceOptions(props) {
   const { filter: parsedFilterParams } = useParsedFilter({
     filterOption: filterParams,
     onFilterChange: () => {
-      field.reset();
+      if (isNew) {
+        field.reset();
+      }
     },
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       After field changes, the association fields that depend on this field have not cleared their values    |
| 🇨🇳 Chinese |     字段变更后，依赖该字段的关系字段没有清空值      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
