### PR TITLE
fix: enhance popup context storage to use default values when missing

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
+++ b/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
@@ -68,7 +68,7 @@ export const getStoredPopupContext = (popupUid: string) => {
  * will directly retrieve the context information from the cache instead of making an API request.
  * @param popupUid
  * @param params
- * @param isDefault - When the context is missing, the default value will be used
+ * @param isDefault - Determines whether to store the context as a default value in `defaultPopupsContextStorage`
  */
 export const storePopupContext = (popupUid: string, params: PopupContextStorage, isDefault = false) => {
   if (isDefault) {

--- a/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
+++ b/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
@@ -55,9 +55,10 @@ export interface PopupContextStorage extends PopupContext {
 }
 
 const popupsContextStorage: Record<string, PopupContextStorage> = {};
+const defaultPopupsContextStorage: Record<string, PopupContextStorage> = {};
 
 export const getStoredPopupContext = (popupUid: string) => {
-  return popupsContextStorage[popupUid];
+  return popupsContextStorage[popupUid] || defaultPopupsContextStorage[popupUid];
 };
 
 /**
@@ -67,8 +68,13 @@ export const getStoredPopupContext = (popupUid: string) => {
  * will directly retrieve the context information from the cache instead of making an API request.
  * @param popupUid
  * @param params
+ * @param isDefault - When the context is missing, the default value will be used
  */
-export const storePopupContext = (popupUid: string, params: PopupContextStorage) => {
+export const storePopupContext = (popupUid: string, params: PopupContextStorage, isDefault = false) => {
+  if (isDefault) {
+    defaultPopupsContextStorage[popupUid] = params;
+    return;
+  }
   popupsContextStorage[popupUid] = params;
 };
 

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowManualProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/client/WorkflowManualProvider.tsx
@@ -9,9 +9,9 @@
 
 import { ExtendCollectionsProvider, storePopupContext } from '@nocobase/client';
 import React, { FC } from 'react';
-import { getWorkflowTodoViewActionSchema } from './WorkflowTodo';
 import { TaskStatusOptions } from '../common/constants';
 import { NAMESPACE } from '../locale';
+import { getWorkflowTodoViewActionSchema } from './WorkflowTodo';
 
 const todoCollection = {
   title: `{{t("Workflow todos", { ns: "${NAMESPACE}" })}}`,
@@ -122,10 +122,14 @@ function cacheSchema(collectionNameList: string[]) {
     const defaultOpenMode = isMobile() ? 'page' : 'modal';
     const workflowTodoViewActionSchema = getWorkflowTodoViewActionSchema({ defaultOpenMode, collectionName });
 
-    storePopupContext(workflowTodoViewActionSchema['x-uid'], {
-      schema: workflowTodoViewActionSchema,
-      ...workflowTodoViewActionSchema['x-action-context'],
-    });
+    storePopupContext(
+      workflowTodoViewActionSchema['x-uid'],
+      {
+        schema: workflowTodoViewActionSchema,
+        ...workflowTodoViewActionSchema['x-action-context'],
+      },
+      true,
+    );
   });
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      storePopupContext supports saving default context     |
| 🇨🇳 Chinese |     storePopupContext 支持保存默认的上下文      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
