### PR TITLE
fix: missing current object variable in sub-table linkage rules

### DIFF
--- a/packages/core/client/src/schema-component/antd/linkageFilter/LinkageFilterItem.tsx
+++ b/packages/core/client/src/schema-component/antd/linkageFilter/LinkageFilterItem.tsx
@@ -14,7 +14,7 @@ import { Select, Space } from 'antd';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCompile } from '../../hooks';
-import { FlagProvider } from '../../../flag-provider';
+import { FlagProvider, useFlag } from '../../../flag-provider';
 import { DynamicComponent } from './DynamicComponent';
 import { RemoveConditionContext } from './context';
 import { useValues } from './useValues';
@@ -36,11 +36,12 @@ export const LinkageFilterItem = observer(
       [setOperator],
     );
     const removeStyle = useMemo(() => ({ color: '#bfbfbf' }), []);
+    const ctx = useFlag();
     return (
       // 添加 nc-filter-item 类名是为了帮助编写测试时更容易选中该元素
       <div style={style} className="nc-filter-item">
         <Space wrap>
-          <FlagProvider isLeftVariable={true}>
+          <FlagProvider isLeftVariable={true} {...ctx}>
             <DynamicComponent
               value={leftVar}
               onChange={setLeftValue}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  missing current object variable in sub-table linkage rules         |
| 🇨🇳 Chinese |    修复 子表单联动规则中缺失当前对象变量的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
