### PR TITLE
fix: data scope not preselected when configuring permissions separately

### DIFF
--- a/packages/core/client/src/schema-component/antd/record-picker/InputRecordPicker.tsx
+++ b/packages/core/client/src/schema-component/antd/record-picker/InputRecordPicker.tsx
@@ -58,9 +58,11 @@ const useTableSelectorProps = () => {
     rowKey,
     rowSelection: {
       type: multiple ? 'checkbox' : 'radio',
-      selectedRowKeys: rcSelectRows
-        ?.filter((item) => options.every((row) => row[rowKey] !== item[rowKey]))
-        .map((item) => item[rowKey]),
+      selectedRowKeys: multiple
+        ? rcSelectRows
+            ?.filter((item) => options.every((row) => row[rowKey] !== item[rowKey]))
+            .map((item) => item[rowKey])
+        : rcSelectRows?.map((item) => item[rowKey]) || [],
     },
     onRowSelectionChange(selectedRowKeys, selectedRows) {
       if (multiple) {
@@ -140,6 +142,10 @@ export const InputRecordPicker: React.FC<any> = (props: IRecordPickerProps) => {
         };
       });
       setOptions(opts);
+      setSelectedRows(opts);
+    } else {
+      setOptions([]);
+      setSelectedRows([]);
     }
   }, [value, fieldNames?.label]);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         Fixed issue where previously saved data scope was not preselected when configuring permissions individually.   |
| 🇨🇳 Chinese |       修复单独配置权限时未默认选中已保存数据范围的问题。    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
