### PR TITLE
feat(input): add auto focus setting to input components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ ncc-cache/
 yarn--**
 v8-compile-cache-**
 vitest.config.mts.timestamp-*
+.github/copilot-instructions.md

--- a/packages/core/client/src/locale/en-US.json
+++ b/packages/core/client/src/locale/en-US.json
@@ -774,6 +774,7 @@
   "Column width": "Column width",
   "Sortable": "Sortable",
   "Enable link": "Enable link",
+  "Auto focus": "Auto focus",
   "This is likely a NocoBase internals bug. Please open an issue at <1>here</1>": "This is likely a NocoBase internals bug. Please open an issue at <1>here</1>",
   "Render Failed": "Render Failed",
   "App error": "App error",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -1139,5 +1139,6 @@
   "Scan to input":"扫码录入",
   "Disable manual input":"禁止手动输入",
   "Enable Scan":"启用扫码录入",
+  "Auto focus":"自动聚焦",
   "Date variables(Deprecated)":"日期变量(废弃)"
 }

--- a/packages/core/client/src/modules/fields/component/Input.TextArea/inputTextAreaSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/Input.TextArea/inputTextAreaSettings.tsx
@@ -8,9 +8,9 @@
  */
 
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
-import { ellipsisSettingsItem } from '../Input/inputComponentSettings';
+import { autoFocusSettingsItem, ellipsisSettingsItem } from '../Input/inputComponentSettings';
 
 export const inputTextAreaSettings = new SchemaSettings({
   name: 'fieldSettings:component:Input.TextArea',
-  items: [ellipsisSettingsItem],
+  items: [ellipsisSettingsItem, autoFocusSettingsItem],
 });

--- a/packages/core/client/src/modules/fields/component/Input.URL/inputURLSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/Input.URL/inputURLSettings.tsx
@@ -8,9 +8,9 @@
  */
 
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
-import { ellipsisSettingsItem } from '../Input/inputComponentSettings';
+import { autoFocusSettingsItem, ellipsisSettingsItem } from '../Input/inputComponentSettings';
 
 export const inputURLSettings = new SchemaSettings({
   name: 'fieldSettings:component:Input.URL',
-  items: [ellipsisSettingsItem],
+  items: [ellipsisSettingsItem, autoFocusSettingsItem],
 });

--- a/packages/core/client/src/modules/fields/component/Input/inputComponentSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/Input/inputComponentSettings.tsx
@@ -206,6 +206,46 @@ export const openModeSettingsItem: SchemaSettingsItemType = {
     return (fieldSchema?.['x-read-pretty'] || field.readPretty) && fieldSchema?.['x-component-props']?.enableLink;
   },
 };
+
+export const autoFocusSettingsItem: SchemaSettingsItemType = {
+  name: 'autoFocus',
+  type: 'switch',
+  useVisible() {
+    const field = useField();
+    const { fieldSchema: columnSchema } = useColumnSchema();
+    const schema = useFieldSchema();
+    const fieldSchema = columnSchema || schema;
+    return !fieldSchema?.['x-read-pretty'] && !field.readPretty;
+  },
+  useComponentProps() {
+    const { t } = useTranslation();
+    const field = useField();
+    const { fieldSchema: columnSchema } = useColumnSchema();
+    const schema = useFieldSchema();
+    const fieldSchema = columnSchema || schema;
+    const { dn } = useDesignable();
+    return {
+      title: t('Auto focus'),
+      checked: fieldSchema?.['x-component-props']?.autoFocus,
+      onChange(flag) {
+        fieldSchema['x-component-props'] = {
+          ...fieldSchema?.['x-component-props'],
+          autoFocus: flag,
+        };
+        field.componentProps['autoFocus'] = flag;
+        dn.emit('patch', {
+          schema: {
+            'x-uid': fieldSchema['x-uid'],
+            'x-component-props': {
+              ...fieldSchema?.['x-component-props'],
+            },
+          },
+        });
+      },
+    };
+  },
+};
+
 export const inputComponentSettings = new SchemaSettings({
   name: 'fieldSettings:component:Input',
   items: [
@@ -214,5 +254,6 @@ export const inputComponentSettings = new SchemaSettings({
     openModeSettingsItem,
     enableScanSettingsItem,
     disableManualInputSettingsItem,
+    autoFocusSettingsItem,
   ],
 });

--- a/packages/core/client/src/modules/fields/component/InputNumber/inputNumberComponentFieldSettings.tsx
+++ b/packages/core/client/src/modules/fields/component/InputNumber/inputNumberComponentFieldSettings.tsx
@@ -9,10 +9,10 @@
 
 import { useFieldSchema } from '@formily/react';
 import { SchemaSettings } from '../../../../application/schema-settings/SchemaSettings';
-import { SchemaSettingsNumberFormat } from '../../../../schema-settings/SchemaSettingsNumberFormat';
-import { useColumnSchema } from '../../../../schema-component/antd/table-v2/Table.Column.Decorator';
 import { useIsFieldReadPretty } from '../../../../schema-component/antd/form-item/FormItem.Settings';
-import { enableLinkSettingsItem, openModeSettingsItem } from '../Input/inputComponentSettings';
+import { useColumnSchema } from '../../../../schema-component/antd/table-v2/Table.Column.Decorator';
+import { SchemaSettingsNumberFormat } from '../../../../schema-settings/SchemaSettingsNumberFormat';
+import { autoFocusSettingsItem, enableLinkSettingsItem, openModeSettingsItem } from '../Input/inputComponentSettings';
 
 export const inputNumberComponentFieldSettings = new SchemaSettings({
   name: 'fieldSettings:component:InputNumber',
@@ -35,5 +35,6 @@ export const inputNumberComponentFieldSettings = new SchemaSettings({
     },
     enableLinkSettingsItem,
     openModeSettingsItem,
+    autoFocusSettingsItem,
   ],
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Added "Auto focus" option for Input, TextArea, URL, and InputNumber components that automatically focuses the input field during initial page rendering when enabled    |
| 🇨🇳 Chinese |     为 Input、TextArea、URL 和 InputNumber 组件添加了"自动聚焦"选项，启用后输入框在页面初始渲染时会自动获得焦点      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
