### PR TITLE
fix(filter): prevent variable string display issue

### DIFF
--- a/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
+++ b/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
@@ -14,15 +14,15 @@ import { merge } from '@formily/shared';
 import { concat } from 'lodash';
 import React, { useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { isVariable, useCollectionManager_deprecated } from '../../../';
 import { useFormBlockContext } from '../../../block-provider/FormBlockProvider';
-import { useDynamicComponentProps } from '../../../hoc/withDynamicSchemaProps';
-import { ErrorFallback, useCompile, useComponent } from '../../../schema-component';
-import { useIsAllowToSetDefaultValue } from '../../../schema-settings/hooks/useIsAllowToSetDefaultValue';
-import { useCollectionManager_deprecated } from '../../../';
 import {
   CollectionFieldProvider,
   useCollectionField,
 } from '../../../data-source/collection-field/CollectionFieldProvider';
+import { useDynamicComponentProps } from '../../../hoc/withDynamicSchemaProps';
+import { ErrorFallback, useCompile, useComponent } from '../../../schema-component';
+import { useIsAllowToSetDefaultValue } from '../../../schema-settings/hooks/useIsAllowToSetDefaultValue';
 
 type Props = {
   component: any;
@@ -107,12 +107,18 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
 
   if (!uiSchemaOrigin) return null;
 
-  return <Component {...props} {...dynamicProps} />;
+  const mergedProps = { ...props, ...dynamicProps };
+
+  // Prevent displaying the variable string first, then the variable value
+  if (isVariable(mergedProps.value) && mergedProps.value === fieldSchema.default) {
+    mergedProps.value = undefined;
+  }
+
+  return <Component {...mergedProps} />;
 };
 
 export const FilterCollectionField = connect((props) => {
   const fieldSchema = useFieldSchema();
-  const field = useField<Field>();
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback.Modal} onError={(err) => console.log(err)}>
       <CollectionFieldProvider name={fieldSchema.name}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues
<img width="1364" height="506" alt="image" src="https://github.com/user-attachments/assets/274acd9a-9944-49d6-9883-5a3a432c31cb" />

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       When using variables to set field default values in filter forms, if the variable value is empty, the input box will display the original variable string    |
| 🇨🇳 Chinese |     当在筛选表单中使用变量设置字段默认值，且变量值为空时，输入框中会显示变量的原始字符串      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
