### PR TITLE
fix(plugin-file-previewer-office): fix type matching

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-previewer-office/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-previewer-office/src/client/index.tsx
@@ -19,7 +19,11 @@ function IframePreviewer({ index, list, onSwitchIndex }) {
   const file = list[index];
   const url = useMemo(() => {
     const u = new URL('https://view.officeapps.live.com/op/embed.aspx');
-    u.searchParams.set('src', file.url);
+    const src =
+      file.url.startsWith('https://') || file.url.startsWith('http://')
+        ? file.url
+        : `${location.origin}/${file.url.replace(/^\//, '')}`;
+    u.searchParams.set('src', src);
     return u.href;
   }, [file.url]);
   const onOpen = useCallback(
@@ -92,11 +96,13 @@ export class PluginFilePreviewerOfficeClient extends Plugin {
   async load() {
     attachmentFileTypes.add({
       match(file) {
-        return [
-          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-          'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-        ].includes(file.mimetype);
+        return (
+          [
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          ].includes(file.mimetype) || ['docx', 'xlsx', 'pptx'].includes(file.url?.split('.').pop())
+        );
       },
       Previewer: IframePreviewer,
     });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Allow `.docx`, `.xlsx` and `.pptx` file with only URL to be previewed.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support `.docx`, `.xlsx` and `.pptx` file with only URL to be previewed |
| 🇨🇳 Chinese | 支持 URL 中包含 `.docx`, `.xlsx` 和 `.pptx` 的文件预览 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
