### PR TITLE
fix(plugin-workflow): show normal title when disabled

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/WorkflowTitle.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/WorkflowTitle.tsx
@@ -7,17 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React from 'react';
-import { Tooltip } from 'antd';
-
-import { lang } from '../locale';
-
 export function WorkflowTitle(workflow) {
-  return workflow.enabled ? (
-    workflow.title
-  ) : (
-    <Tooltip title={lang('New version enabled')}>
-      <span style={{ textDecoration: 'line-through' }}>{workflow.title}</span>
-    </Tooltip>
-  );
+  return workflow.title;
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Show normal title when disabled.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show normal title when disabled |
| 🇨🇳 Chinese | 工作流禁用后也展示正常的标题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
