### PR TITLE
fix(plugin-workflow-parallel): fix suspend

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/ParallelInstruction.ts
@@ -113,7 +113,8 @@ export default class extends Instruction {
     const { result, status } = job;
     // if parallel has been done (resolved / rejected), do not care newly executed branch jobs.
     if (status !== JOB_STATUS.PENDING) {
-      return processor.exit();
+      processor.logger.warn(`parallel (${job.nodeId}) has been done, ignore newly resumed event`);
+      return null;
     }
 
     // find the index of the node which start the branch
@@ -130,8 +131,8 @@ export default class extends Instruction {
     });
 
     if (job.status === JOB_STATUS.PENDING) {
-      await job.save({ transaction: processor.transaction });
-      return processor.exit();
+      processor.saveJob(job);
+      return null;
     }
 
     return job;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -433,7 +433,7 @@ export default class Processor {
     for (let n = this.findBranchEndNode(node); n && n !== node.upstream; n = n.upstream) {
       branchJobs.push(...allJobs.filter((item) => item.nodeId === n.id));
     }
-    branchJobs.sort((a, b) => a.updatedAt.getTime() - b.updatedAt.getTime());
+    branchJobs.sort((a, b) => a.id - b.id);
     return branchJobs[branchJobs.length - 1] || null;
   }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix parallel node suspend after resume under MySQL.

### Description 

`await job.save()` may cause BigInt issue in MySQL.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix parallel node suspend after resume under MySQL |
| 🇨🇳 Chinese | 修复 MySQL 下并行分支节点在恢复执行后假死的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
