### PR TITLE
fix(plugin-workflow): avoid error thrown when stopping

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -682,7 +682,9 @@ export default class PluginWorkflowServer extends Plugin {
           this.pending.push([execution]);
         } else {
           logger.info(`local pending list is not empty, sending execution (${execution.id}) to queue`);
-          this.app.backgroundJobManager.publish(`${this.name}.pendingExecution`, { executionId: execution.id });
+          if (this.ready) {
+            this.app.backgroundJobManager.publish(`${this.name}.pendingExecution`, { executionId: execution.id });
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Avoid error thrown caused by publishing to event queue when stopping.

### Description 

Should not use event queue when app stopping.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid error thrown caused by publishing to event queue when stopping |
| 🇨🇳 Chinese | 避免应用停止时调用队列报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
