### PR TITLE
fix(plugin-file-manager): add storageId field to file collection

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/common/collections/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/common/collections/attachments.ts
@@ -7,6 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { NAMESPACE } from '../constants';
+
 export default {
   dumpRules: {
     group: 'user',
@@ -59,7 +61,7 @@ export default {
       interface: 'm2o',
       uiSchema: {
         type: 'object',
-        title: 'Storage',
+        title: `{{t('Storage', { ns: '${NAMESPACE}' })}}`,
         'x-component': 'AssociationField',
         'x-component-props': {
           fieldNames: {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/common/constants.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/common/constants.ts
@@ -7,4 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+export const NAMESPACE = 'file-manager';
+
 export const INVALID_FILENAME_CHARS = '<>?*~\\/';

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/migrations/20250807155912-add-storage-id.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/migrations/20250807155912-add-storage-id.ts
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Migration } from '@nocobase/server';
+import { CollectionRepository } from '@nocobase/plugin-data-source-main';
+import { InheritedCollection } from '@nocobase/database';
+
+export default class extends Migration {
+  on = 'afterLoad'; // 'beforeLoad' or 'afterLoad'
+  appVersion = '<1.9.0';
+
+  async up() {
+    const CollectionRepo = this.db.getRepository('collections') as CollectionRepository;
+    const FieldRepo = this.db.getRepository('fields');
+    await CollectionRepo.load({
+      filter: {
+        'options.template': 'file',
+      },
+    });
+    const collections = Array.from(this.db.collections.values()).filter(
+      (item) => item.name === 'attachments' || item.options.template === 'file',
+    );
+
+    await this.db.sequelize.transaction(async (transaction) => {
+      const toAddFields = [];
+      for (const collection of collections) {
+        if (collection instanceof InheritedCollection) {
+          continue;
+        }
+        const exist = await FieldRepo.findOne({
+          filter: {
+            collectionName: collection.name,
+            name: 'storageId',
+          },
+          transaction,
+        });
+        if (!exist) {
+          toAddFields.push({
+            collectionName: collection.name,
+            name: 'storageId',
+            type: 'bigInt',
+            required: true,
+            visible: true,
+            index: true,
+          });
+        }
+      }
+      if (toAddFields.length) {
+        await FieldRepo.create({ values: toAddFields, transaction });
+      }
+    });
+  }
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
@@ -245,6 +245,18 @@ export class PluginFileManagerServer extends Plugin {
       this.sendSyncMessage({ type: 'reloadStorages' }, { transaction });
     });
 
+    this.db.on('afterDefineCollection', (collection: Collection) => {
+      const { template } = collection.options;
+      if (template === 'file') {
+        collection.setField('storageId', {
+          type: 'bigInt',
+          createOnly: true,
+          visible: true,
+          index: true,
+        });
+      }
+    });
+
     this.app.acl.registerSnippet({
       name: `pm.${this.name}.storages`,
       actions: ['storages:*'],


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Add `storageId` field to file collection to support permission configuration.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `storageId` field to file collection to support permission configuration |
| 🇨🇳 Chinese | 为文件表增加 `storageId` 字段以支持权限配置 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
