### PR TITLE
fix: calendar event item tooltip showing [object Object]

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calendar.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calendar.tsx
@@ -162,13 +162,13 @@ const useEvents = (
           targetTitleCollectionField,
           targetTitle?.TitleRenderer,
         );
-
-        const event: Event = {
+        const event: Event | any = {
           id: get(item, fieldNames.id || 'id'),
           colorFieldValue: item[fieldNames.colorFieldName],
           title: title || t('Untitle'),
           start: eventStart.toDate(),
           end: eventStart.add(intervalTime, 'millisecond').toDate(),
+          rawTitle: get(item, fieldNames.title),
         };
 
         events.push(event);
@@ -472,6 +472,9 @@ export const Calendar: any = withDynamicSchemaProps(
               }}
               components={components}
               localizer={localizer}
+              tooltipAccessor={(val) => {
+                return val.rawTitle ? val.rawTitle : '';
+              }}
             />
           </PopupContextProvider>
           <ActionContextProvider


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   calendar event item tooltip showing [object Object]        |
| 🇨🇳 Chinese |    修复了日历事件悬停提示框未显示事件标题字段内容，显示为 “[object Object]” 的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
