### PR TITLE
fix: issue where sub-tables are loaded in Column Settings

### DIFF
--- a/packages/core/client/src/block-provider/hooks/index.ts
+++ b/packages/core/client/src/block-provider/hooks/index.ts
@@ -1280,7 +1280,7 @@ export const useTableColumns = (): ColumnInfo[] => {
 
     // More comprehensive search for table columns
     const findColumnsInSchema = (schema: any, depth = 0): void => {
-      if (!schema) return;
+      if (!schema || depth > 1) return;
 
       // Direct table column check
       if (
@@ -1341,15 +1341,15 @@ export const useTableColumns = (): ColumnInfo[] => {
         columns.push(columnInfo);
       }
 
-      // Search in properties, avoid actions column
-      if (schema.properties && schema.name !== 'actions') {
+      // Search in properties
+      if (schema.properties) {
         Object.keys(schema.properties).forEach((key) => {
           findColumnsInSchema(schema.properties[key], depth + 1);
         });
       }
 
-      // Search in items (for array schemas), avoid actions column
-      if (schema.items && schema.name !== 'actions') {
+      // Search in items (for array schemas)
+      if (schema.items) {
         findColumnsInSchema(schema.items, depth + 1);
       }
     };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix an issue where the "Column settings" button loads columns from the table inside the modal dialog    |
| 🇨🇳 Chinese |      修复“列设置”按钮会加载弹窗中的表格列的问题    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
