### PR TITLE
fix(plugin-file-manager): fix error when show storages collection as target

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/FileManagerProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/FileManagerProvider.tsx
@@ -12,10 +12,11 @@ import React, { FC } from 'react';
 import * as hooks from './hooks';
 import { UploadActionInitializer } from './initializers';
 import attachmentsCollection from '../common/collections/attachments';
+import storagesCollection from '../common/collections/storages';
 
 export const FileManagerProvider: FC = (props) => {
   return (
-    <ExtendCollectionsProvider collections={[attachmentsCollection]}>
+    <ExtendCollectionsProvider collections={[attachmentsCollection, storagesCollection]}>
       <SchemaComponentOptions scope={hooks} components={{ UploadActionInitializer }}>
         {props.children}
       </SchemaComponentOptions>


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the error when editing the `storage` field in the file collection.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error when editing the `storage` field in the file collection. |
| 🇨🇳 Chinese | 修复文件表的 storage 字段编辑时的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
