### PR TITLE
fix: import failure when primary key is single-line text

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
@@ -13,8 +13,10 @@ import { ICollection, ICollectionManager, IRelationField } from '@nocobase/data-
 import {
   Collection as DBCollection,
   Database,
+  IntegerField,
   Model,
   MultipleRelationRepository,
+  NumberField,
   RelationRepository,
   Repository,
   UpdateGuard,
@@ -146,6 +148,10 @@ export class XlsxImporter extends EventEmitter {
     // @ts-ignore
     const autoIncrementAttribute = collection.model.autoIncrementAttribute;
     if (!autoIncrementAttribute) {
+      return;
+    }
+    const field = this.options.collection.getField(autoIncrementAttribute);
+    if (field && !(field instanceof NumberField)) {
       return;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         Fixed an issue where import failed when the table primary key was a single-line text  |
| 🇨🇳 Chinese |      修复了当表的主键为单行文本时导入失败的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
