### PR TITLE
fix: relation block error with non-ID primary key as record unique key

### DIFF
--- a/packages/core/database/src/relation-repository/relation-repository.ts
+++ b/packages/core/database/src/relation-repository/relation-repository.ts
@@ -44,9 +44,6 @@ export abstract class RelationRepository {
     this.sourceCollection = sourceCollection;
 
     this.setSourceKeyValue(sourceKeyValue);
-    if (this.sourceKeyValue === '0ab1800f-d175-4118-a529-e42368a17e85') {
-      console.log(this.sourceKeyValue);
-    }
     this.associationName = association;
     this.association = this.sourceCollection.model.associations[association];
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         Fixed an error that occurred in relation blocks when using a non-ID primary key as the record unique key  |
| 🇨🇳 Chinese |       修复了在使用非 ID 主键作为记录唯一键时，关联区块报错的问题    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
