### PR TITLE
refactor(client): support read-pretty select to use string icon

### DIFF
--- a/packages/core/client/src/schema-component/antd/select/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/select/ReadPretty.tsx
@@ -16,6 +16,7 @@ import { useCollectionField } from '../../../data-source/collection-field/Collec
 import { EllipsisWithTooltip } from '../input/EllipsisWithTooltip';
 import { FieldNames, defaultFieldNames, getCurrentOptions } from './utils';
 import { withPopupWrapper } from '../../common/withPopupWrapper';
+import { Icon } from '../../../icon';
 
 export interface SelectReadPrettyProps {
   value: any;
@@ -54,7 +55,11 @@ const ReadPrettyInternal = observer(
       const content =
         field.value !== null &&
         currentOptions.map((option, index) => (
-          <Tag key={index} color={option[fieldNames.color]} icon={option.icon}>
+          <Tag
+            key={index}
+            color={option[fieldNames.color]}
+            icon={typeof option.icon === 'string' ? <Icon type={option.icon} /> : option.icon}
+          >
             {option[fieldNames.label]}
           </Tag>
         ));


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support displaying icons identified by strings in the Select component when in read-only mode.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support displaying icons identified by strings in the Select component when in read-only mode |
| 🇨🇳 Chinese | 支持 Select 组件在阅读态时可以展示字符串标识的图标 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
