### PR TITLE
fix: invisible mail block if inside inherited block template

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-template/src/client/utils/template.ts
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/utils/template.ts
@@ -187,7 +187,12 @@ function cleanSchema(schema?: any) {
   const properties = schema?.properties || {};
   for (const key of Object.keys(properties)) {
     // 如果x-component是undefined/null
-    if (schema.properties[key]['x-component'] == null && shouldDeleteNoComponentSchema(schema.properties[key])) {
+    if (
+      schema.properties[key]['x-component'] == null &&
+      schema.properties[key]['x-template-id'] &&
+      !schema.properties[key]['x-template-root-id'] &&
+      shouldDeleteNoComponentSchema(schema.properties[key])
+    ) {
       delete schema.properties[key];
     }
     if (properties[key]?.['x-component-props'] === null) {

--- a/packages/plugins/@nocobase/plugin-block-template/src/server/utils/template.ts
+++ b/packages/plugins/@nocobase/plugin-block-template/src/server/utils/template.ts
@@ -381,16 +381,10 @@ function shouldDeleteNoComponentSchema(schema: Schema) {
 
 export function cleanSchema(schema?: Schema, templateId?: string) {
   const properties = schema?.properties || {};
-  if (schema) {
-    delete schema['x-template-root-uid'];
-    delete schema['x-template-uid'];
-    delete schema['x-block-template-key'];
-    delete schema['x-virtual'];
-    delete schema['x-template-version'];
-  }
   for (const key of Object.keys(properties)) {
     if (
       schema.properties[key]['x-component'] == null &&
+      schema.properties[key]['x-template-id'] &&
       !schema.properties[key]['x-template-root-uid'] &&
       shouldDeleteNoComponentSchema(schema.properties[key])
     ) {
@@ -418,6 +412,13 @@ export function cleanSchema(schema?: Schema, templateId?: string) {
       }
     }
     cleanSchema(properties[key], templateId);
+  }
+  if (schema) {
+    delete schema['x-template-root-uid'];
+    delete schema['x-template-uid'];
+    delete schema['x-block-template-key'];
+    delete schema['x-virtual'];
+    delete schema['x-template-version'];
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Resolved an issue where mail blocks were not visible when placed inside an inherited template block |
| 🇨🇳 Chinese | 修复了邮件区块在继承模版中不可见的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
