### PR TITLE
fix(client): fix file icon

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -100,7 +100,15 @@ const testOpts = (ext: RegExp, options: { exclude?: string[]; include?: string[]
 
 export function getThumbnailPlaceholderURL(file, options: any = {}) {
   for (let i = 0; i < UPLOAD_PLACEHOLDER.length; i++) {
-    if (UPLOAD_PLACEHOLDER[i].ext.test(file.extname || file.filename || file.url || file.name)) {
+    const url = file.url
+      ? new URL(
+          file.url.startsWith('http://') || file.url.startsWith('https://')
+            ? file.url
+            : `${location.origin}/${file.url.replace(/^\//, '')}`,
+        )
+      : { pathname: file.filename };
+
+    if (UPLOAD_PLACEHOLDER[i].ext.test(file.extname || file.filename || url.pathname || file.name)) {
       if (testOpts(UPLOAD_PLACEHOLDER[i].ext, options)) {
         return UPLOAD_PLACEHOLDER[i].icon || UNKNOWN_FILE_ICON;
       } else {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

To show file icon based on extname correctly.

### Description 

File URL with search parameters not show correct icon.

### Related issues

https://forum.nocobase.com/t/url/6821

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the icon was displayed incorrectly when the URL in the attachment URL field contained query parameters |
| 🇨🇳 Chinese | 修复附件 URL 字段的 URL 中包含查询参数时图标展示不正确的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
