### PR TITLE
fix: association field render error when switched to tag component in…

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/AssociationFieldModeProvider.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/AssociationFieldModeProvider.tsx
@@ -15,6 +15,7 @@ import { InternalNester } from './InternalNester';
 import { InternalPicker } from './InternalPicker';
 import { InternalPopoverNester } from './InternalPopoverNester';
 import { InternalSubTable } from './InternalSubTable';
+import { ReadPrettyInternalTag } from './InternalTag';
 
 export enum AssociationFieldMode {
   Picker = 'Picker',
@@ -39,6 +40,7 @@ const defaultModeToComponent = {
   SubTable: InternalSubTable,
   FileManager: InternalFileManager,
   CascadeSelect: InternalCascadeSelect,
+  Tag: ReadPrettyInternalTag,
 };
 
 const AssociationFieldModeContext = createContext<{


### PR DESCRIPTION
… edit form block

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | association field render error when switched to tag component in edit form block
      |
| 🇨🇳 Chinese |  修复 编辑表单区块中，阅读态关系字段在切换为标签组件时渲染失败的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
