### PR TITLE
fix: mobile date field without timezone not showing date time correctly

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/components/MobileDatePicker.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/components/MobileDatePicker.tsx
@@ -104,9 +104,10 @@ const MobileDateTimePicker = connect(
           onChange(dayjs(value).format('YYYY-MM-DD'));
         } else if (!utc) {
           if (showTime) {
-            onChange(dayjs(value).format('YYYY-MM-DD'));
+            onChange(dayjs(value).format('YYYY-MM-DD HH:mm:ss'));
+          } else {
+            onChange(dayjs(value).startOf(picker).format('YYYY-MM-DD'));
           }
-          onChange(dayjs(value).startOf(picker).format('YYYY-MM-DD'));
         } else {
           const selectedDateTime = new Date(value);
           onChange(selectedDateTime);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   mobile date field without timezone not showing date time correctly        |
| 🇨🇳 Chinese |   修复移动端不含时区的日期字段未正确显示时分秒        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
