### PR TITLE
fix: incorrect 'not empty' check for numeric fields in linkage rule

### DIFF
--- a/packages/core/client/src/application/globalOperators.js
+++ b/packages/core/client/src/application/globalOperators.js
@@ -88,7 +88,7 @@ export function getOperators() {
       return jsonLogic.truthy(a);
     },
     $notEmpty: function (a) {
-      return jsonLogic.truthy(a);
+      return a === 0 || jsonLogic.truthy(a);
     },
     $empty: function (a) {
       if (Array.isArray(a)) return a.length === 0;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    incorrect 'not empty' check for numeric fields in linkage rule       |
| 🇨🇳 Chinese |    联动规则数值字段「不为空」判断错误        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
