### PR TITLE
fix(plugin-workflow): fix logger cache

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -231,6 +231,8 @@ export default class PluginWorkflowServer extends Plugin {
     if (this.checker) {
       clearInterval(this.checker);
     }
+
+    this.loggerCache.clear();
   };
 
   async handleSyncMessage(message) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix a potential error related to workflow log caching.

### Description 

```
{"level":"info","message":"response /api/app:restart","method":"POST","path":"/api/app:restart","res":{"status":200},"action":{"actionName":"restart","resourceName":"app","params":{"resourceName":"app","actionName":"restart","values":{}}},"userId":50,"status":200,"cost":231,"app":"a_ajxshflzx","reqId":"65d28605-3b43-4a55-a450-5a4b59944882","bodySize":2,"timestamp":"2025-09-09 10:24:44"}
{"level":"info","message":{"uuid":"65d28605-3b43-4a55-a450-5a4b59944882","dataSource":"main","resource":"app","action":"restart","userId":50,"roleName":"admin","ip":"172.18.0.3","ua":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36","status":200,"metadata":{"request":{"query":{},"body":{},"path":"/api/app:restart","headers":{"x-authenticator":"lewanyun","x-locale":"zh-CN","x-timezone":"+08:00"}},"response":{"body":{}}}},"timestamp":"2025-09-09 10:24:44"}
{"level":"warn","message":"app is not ready, event of workflow 10000027 will be ignored","timestamp":"2025-09-09 10:24:44"}
{"level":"error","message":"write after end","stack":"Error: write after end
    at writeAfterEnd (/app/nocobase/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:264:12)
    at Writable.write (/app/nocobase/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:300:21)
    at DerivedLogger.log (/app/nocobase/node_modules/winston/lib/winston/logger.js:253:14)
    at DerivedLogger.<computed> [as error] (/app/nocobase/node_modules/winston/lib/winston/create-logger.js:95:19)
    at PluginWorkflowServer.process (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Plugin.js:645:14)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Plugin.js:616:9
    at async _AsyncEmitter.onBeforeStop (/app/nocobase/node_modules/@nocobase/plugin-workflow/dist/server/Plugin.js:187:7)
    at async _AsyncEmitter.emitAsync (/app/nocobase/node_modules/@nocobase/utils/lib/mixin/AsyncEmitter.js:66:7)
    at async _AsyncEmitter.restart (/app/nocobase/node_modules/@nocobase/server/lib/application.js:644:5)
    at async _AppCommand.<anonymous> (/app/nocobase/node_modules/@nocobase/server/lib/commands/restart.js:40:5)
    at async _AppCommand.parseAsync (/app/nocobase/node_modules/commander/lib/command.js:935:5)
    at async _AsyncEmitter.runAsCLI (/app/nocobase/node_modules/@nocobase/server/lib/application.js:557:23)","meta":{},"module":"application","submodule":"","method":"","app":"a_ajxshflzx","reqId":"83fc9aff-110a-46e9-9b52-6fb5d973617d","dataSourceKey":"main","timestamp":"2025-09-09 10:24:44"}
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix a potential error related to workflow log caching |
| 🇨🇳 Chinese | 修复潜在的工作流日志缓存报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
