### PR TITLE
refactor(plugin-workflow-manual): show manual tasks of disabled workflow

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/Plugin.ts
@@ -245,25 +245,7 @@ export default class extends Plugin {
   async load() {
     this.app.resourceManager.define({
       name: 'workflowManualTasks',
-      actions: {
-        list: {
-          filter: {
-            $or: [
-              {
-                'workflow.enabled': true,
-              },
-              {
-                'workflow.enabled': false,
-                status: {
-                  $ne: JOB_STATUS.PENDING,
-                },
-              },
-            ],
-          },
-          handler: actions.list as HandlerType,
-        },
-        ...jobActions,
-      },
+      actions: jobActions,
     });
 
     this.app.acl.allow('workflowManualTasks', ['list', 'listMine', 'get', 'submit'], 'loggedIn');

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/actions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/actions.ts
@@ -47,7 +47,7 @@ export async function submit(context: Context, next) {
     task.status !== JOB_STATUS.PENDING ||
     task.job.status !== JOB_STATUS.PENDING ||
     task.execution.status !== EXECUTION_STATUS.STARTED ||
-    !task.workflow.enabled ||
+    // !task.workflow.enabled ||
     !actionKey ||
     actionItem?.status == null
   ) {
@@ -117,19 +117,19 @@ export async function listMine(context: Context, next) {
     filter: {
       $and: [
         { userId: context.state.currentUser.id },
-        {
-          $or: [
-            {
-              'workflow.enabled': true,
-            },
-            {
-              'workflow.enabled': false,
-              status: {
-                $ne: JOB_STATUS.PENDING,
-              },
-            },
-          ],
-        },
+        // {
+        //   $or: [
+        //     {
+        //       'workflow.enabled': true,
+        //     },
+        //     {
+        //       'workflow.enabled': false,
+        //       status: {
+        //         $ne: JOB_STATUS.PENDING,
+        //       },
+        //     },
+        //   ],
+        // },
       ],
     },
   });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to view and resume pending manual tasks within disabled workflows.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to view and resume pending manual tasks within disabled workflows |
| 🇨🇳 Chinese | 支持查看和继续执行已停用工作流中的人工待办任务 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
