### PR TITLE
fix(schema-settings): add zIndex context to prevent overlay issues

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettings.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettings.tsx
@@ -108,6 +108,7 @@ import { Designable, createDesignable, useDesignable } from '../schema-component
 import { useSchemaTemplateManager } from '../schema-templates';
 import { useBlockTemplateContext } from '../schema-templates/BlockTemplateProvider';
 import { useLocalVariables, useVariables } from '../variables';
+import { VariableScopeContext } from '../variables/VariableScope';
 import { FormDataTemplates } from './DataTemplates';
 import { EnableChildCollections } from './EnableChildCollections';
 import { ChildDynamicComponent } from './EnableChildCollections/DynamicComponent';
@@ -115,7 +116,6 @@ import { FormLinkageRules } from './LinkageRules';
 import { useLinkageCollectionFieldOptions } from './LinkageRules/action-hooks';
 import { LinkageRuleCategory, LinkageRuleDataKeyMap } from './LinkageRules/type';
 import { CurrentRecordContextProvider, useCurrentRecord } from './VariableInput/hooks/useRecordVariable';
-import { VariableScopeContext } from '../variables/VariableScope';
 export interface SchemaSettingsProps {
   title?: any;
   dn?: Designable;
@@ -938,11 +938,14 @@ export const SchemaSettingsModalItem: FC<SchemaSettingsModalItemProps> = (props)
                                                     <ApplicationContext.Provider value={app}>
                                                       <APIClientProvider apiClient={apiClient}>
                                                         <ConfigProvider locale={locale}>
-                                                          <SchemaComponent
-                                                            components={components}
-                                                            scope={scope}
-                                                            schema={schema}
-                                                          />
+                                                          {/* 防止按钮的配置弹窗的图标弹窗被遮挡 */}
+                                                          <zIndexContext.Provider value={2000}>
+                                                            <SchemaComponent
+                                                              components={components}
+                                                              scope={scope}
+                                                              schema={schema}
+                                                            />
+                                                          </zIndexContext.Provider>
                                                         </ConfigProvider>
                                                       </APIClientProvider>
                                                     </ApplicationContext.Provider>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues
![img_v3_02q6_addcf7c3-a430-4b57-927a-48f04d2c736g](https://github.com/user-attachments/assets/c6fea94c-85e4-48a1-b30f-a32402206f69)


### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue where button icon configuration popup is being covered/overlapped     |
| 🇨🇳 Chinese |     修复按钮的图标配置弹窗被遮挡的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
