### PR TITLE
fix(plugin-notification-in-app-messag): fix delimiters

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/configFormCommonFieldset.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/configFormCommonFieldset.ts
@@ -49,7 +49,7 @@ export function getConfigFormCommonFieldset({ variableOptions }) {
           'x-component-props': {
             scope: variableOptions,
             useTypedConstant: ['string'],
-            delimiters: ['{{{', '}}}'],
+            // delimiters: ['{{{', '}}}'],
           },
           description: tval(
             'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
@@ -65,7 +65,7 @@ export function getConfigFormCommonFieldset({ variableOptions }) {
           'x-component-props': {
             scope: variableOptions,
             useTypedConstant: ['string'],
-            delimiters: ['{{{', '}}}'],
+            // delimiters: ['{{{', '}}}'],
           },
           description: tval(
             'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/m". If using an external link, the link starts with "http", for example, "https://example.com".',


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue of incorrect notification link parsing.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue of incorrect notification link parsing |
| 🇨🇳 Chinese | 修复通知链接解析错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
