### PR TITLE
fix(plugin-notification-in-app-message): fix message loading when popup open

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
@@ -12,17 +12,16 @@ import { Schema } from '@formily/react';
 import { observer } from '@formily/reactive-react';
 import { useApp } from '@nocobase/client';
 import { dayjs } from '@nocobase/utils/client';
-import { Badge, Button, ConfigProvider, Flex, Layout, List, Tabs, theme } from 'antd';
-import React from 'react';
+import { Badge, Button, Flex, Layout, List, theme } from 'antd';
+import React, { useCallback, useEffect } from 'react';
 import { useLocalTranslation } from '../../locale';
 import {
   channelListObs,
-  ChannelStatus,
   channelStatusFilterObs,
   fetchChannels,
+  inboxVisible,
   isFetchingChannelsObs,
   selectedChannelNameObs,
-  selectedMessageListObs,
   showChannelLoadingMoreObs,
 } from '../observables';
 import FilterTab from './FilterTab';
@@ -35,7 +34,7 @@ const InnerInboxContent = () => {
   const channels = channelListObs.value;
   const selectedChannelName = selectedChannelNameObs.value;
 
-  const onLoadChannelsMore = () => {
+  const onLoadChannelsMore = useCallback(() => {
     const filter: Record<string, any> = {};
     const lastChannel = channels[channels.length - 1];
     if (lastChannel?.latestMsgReceiveTimestamp) {
@@ -44,7 +43,13 @@ const InnerInboxContent = () => {
       };
     }
     fetchChannels({ filter, limit: 30 });
-  };
+  }, [channels]);
+
+  useEffect(() => {
+    if (inboxVisible.value) {
+      fetchChannels({ limit: 30 });
+    }
+  }, [inboxVisible.value]);
 
   const loadChannelsMore = showChannelLoadingMoreObs.value ? (
     <div


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where recent messages are not displayed when opening the notification popup.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where recent messages are not displayed when opening the notification popup |
| 🇨🇳 Chinese | 修复打开通知弹窗不展示最近消息的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
