### PR TITLE
fix(menu): add zIndexContext to prevent icon popup overlap

### DIFF
--- a/packages/core/client/src/modules/menu/GroupItem.tsx
+++ b/packages/core/client/src/modules/menu/GroupItem.tsx
@@ -21,6 +21,7 @@ import {
   SchemaComponentOptions,
   useNocoBaseRoutes,
   useParentRoute,
+  zIndexContext,
 } from '../../schema-component';
 import { useStyles } from '../../schema-component/antd/menu/MenuItemInitializers';
 
@@ -39,23 +40,26 @@ export const GroupItem = () => {
         return (
           <SchemaComponentOptions scope={options.scope} components={{ ...options.components }}>
             <FormLayout layout={'vertical'}>
-              <SchemaComponent
-                schema={{
-                  properties: {
-                    title: {
-                      title: t('Menu item title'),
-                      'x-component': 'Input',
-                      'x-decorator': 'FormItem',
-                      required: true,
+              {/* 防止图标弹窗被遮挡 */}
+              <zIndexContext.Provider value={2000}>
+                <SchemaComponent
+                  schema={{
+                    properties: {
+                      title: {
+                        title: t('Menu item title'),
+                        'x-component': 'Input',
+                        'x-decorator': 'FormItem',
+                        required: true,
+                      },
+                      icon: {
+                        title: t('Icon'),
+                        'x-component': 'IconPicker',
+                        'x-decorator': 'FormItem',
+                      },
                     },
-                    icon: {
-                      title: t('Icon'),
-                      'x-component': 'IconPicker',
-                      'x-decorator': 'FormItem',
-                    },
-                  },
-                }}
-              />
+                  }}
+                />
+              </zIndexContext.Provider>
             </FormLayout>
           </SchemaComponentOptions>
         );

--- a/packages/core/client/src/modules/menu/LinkMenuItem.tsx
+++ b/packages/core/client/src/modules/menu/LinkMenuItem.tsx
@@ -30,6 +30,7 @@ import {
   SchemaComponentOptions,
   useNocoBaseRoutes,
   useParentRoute,
+  zIndexContext,
 } from '../../schema-component';
 import { useStyles } from '../../schema-component/antd/menu/MenuItemInitializers';
 import { useURLAndHTMLSchema } from '../actions/link/useURLAndHTMLSchema';
@@ -56,26 +57,29 @@ export const LinkMenuItem = () => {
               <Router location={history.location} navigator={history}>
                 <SchemaComponentOptions scope={options.scope} components={{ ...options.components }}>
                   <FormLayout layout={'vertical'}>
-                    <SchemaComponent
-                      schema={{
-                        properties: {
-                          title: {
-                            title: t('Menu item title'),
-                            required: true,
-                            'x-component': 'Input',
-                            'x-decorator': 'FormItem',
+                    {/* 防止图标弹窗被遮挡 */}
+                    <zIndexContext.Provider value={2000}>
+                      <SchemaComponent
+                        schema={{
+                          properties: {
+                            title: {
+                              title: t('Menu item title'),
+                              required: true,
+                              'x-component': 'Input',
+                              'x-decorator': 'FormItem',
+                            },
+                            icon: {
+                              title: t('Icon'),
+                              'x-component': 'IconPicker',
+                              'x-decorator': 'FormItem',
+                            },
+                            href: urlSchema,
+                            params: paramsSchema,
+                            openInNewWindow: openInNewWindowSchema,
                           },
-                          icon: {
-                            title: t('Icon'),
-                            'x-component': 'IconPicker',
-                            'x-decorator': 'FormItem',
-                          },
-                          href: urlSchema,
-                          params: paramsSchema,
-                          openInNewWindow: openInNewWindowSchema,
-                        },
-                      }}
-                    />
+                        }}
+                      />
+                    </zIndexContext.Provider>
                   </FormLayout>
                 </SchemaComponentOptions>
               </Router>

--- a/packages/core/client/src/modules/menu/PageMenuItem.tsx
+++ b/packages/core/client/src/modules/menu/PageMenuItem.tsx
@@ -22,6 +22,7 @@ import {
   SchemaComponentOptions,
   useNocoBaseRoutes,
   useParentRoute,
+  zIndexContext,
 } from '../../schema-component';
 import { useStyles } from '../../schema-component/antd/menu/MenuItemInitializers';
 
@@ -55,23 +56,26 @@ export const PageMenuItem = () => {
         return (
           <SchemaComponentOptions scope={options.scope} components={{ ...options.components }}>
             <FormLayout layout={'vertical'}>
-              <SchemaComponent
-                schema={{
-                  properties: {
-                    title: {
-                      title: t('Menu item title'),
-                      required: true,
-                      'x-component': 'Input',
-                      'x-decorator': 'FormItem',
+              {/* 防止图标弹窗被遮挡 */}
+              <zIndexContext.Provider value={2000}>
+                <SchemaComponent
+                  schema={{
+                    properties: {
+                      title: {
+                        title: t('Menu item title'),
+                        required: true,
+                        'x-component': 'Input',
+                        'x-decorator': 'FormItem',
+                      },
+                      icon: {
+                        title: t('Icon'),
+                        'x-component': 'IconPicker',
+                        'x-decorator': 'FormItem',
+                      },
                     },
-                    icon: {
-                      title: t('Icon'),
-                      'x-component': 'IconPicker',
-                      'x-decorator': 'FormItem',
-                    },
-                  },
-                }}
-              />
+                  }}
+                />
+              </zIndexContext.Provider>
             </FormLayout>
           </SchemaComponentOptions>
         );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where the menu icon configuration popover is being obscured    |
| 🇨🇳 Chinese |     修复菜单的图标配置弹窗被遮挡的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
