### PR TITLE
fix(plugin-workflow): fix workflow list loading incorrectly on associated context

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/settings/BindWorkflowConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/settings/BindWorkflowConfig.tsx
@@ -16,8 +16,8 @@ import {
   joinCollectionName,
   RemoteSelect,
   SchemaSettingsActionModalItem,
+  useCollection,
   useCollection_deprecated,
-  useCollectionManager_deprecated,
   useCompile,
   useDataSourceKey,
   useDesignable,
@@ -30,11 +30,17 @@ import { Alert, Flex, Tag } from 'antd';
 function WorkflowSelect({ formAction, buttonAction, actionType, ...props }) {
   const { t } = useTranslation();
   const index = ArrayTable.useIndex();
+  const row = ArrayTable.useRecord();
   const { setValuesIn } = useForm();
-  const baseCollection = useCollection_deprecated();
-  const { getCollection } = useCollectionManager_deprecated();
+  const baseCollection = useCollection();
   const dataSourceKey = useDataSourceKey();
-  const [workflowCollection, setWorkflowCollection] = useState(joinCollectionName(dataSourceKey, baseCollection.name));
+  const [workflowCollection, setWorkflowCollection] = useState(() => {
+    const { target } = baseCollection.getField(row.context) || {};
+    return joinCollectionName(
+      dataSourceKey,
+      target ? baseCollection.collectionManager.getCollection(target).name : baseCollection.name,
+    );
+  });
   const compile = useCompile();
 
   const workflowPlugin = usePlugin('workflow') as any;
@@ -58,7 +64,7 @@ function WorkflowSelect({ formAction, buttonAction, actionType, ...props }) {
           const path = paths[i];
           const associationField = collection.fields.find((f) => f.name === path);
           if (associationField) {
-            collection = getCollection(associationField.target, dataSourceKey);
+            collection = baseCollection.collectionManager.getCollection(associationField.target);
           }
         }
       }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where the workflow list condition is incorrect when loading associated field context in the bound workflow configuration.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the workflow list condition is incorrect when loading associated field context in the bound workflow configuration |
| 🇨🇳 Chinese | 修复绑定工作流配置中加载关系字段上下文的工作流列表条件错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
