### PR TITLE
fix: sidebar submenu highlight

### DIFF
--- a/packages/core/client/src/global.less
+++ b/packages/core/client/src/global.less
@@ -80,8 +80,8 @@
           }
         }
 
-        .ant-menu-submenu-selected {
-          .ant-menu-submenu-title {
+        &.ant-menu-submenu-selected {
+          & > .ant-menu-submenu-title {
             color: var(--colorTextSiderMenuActive) !important;
           }
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix the issue where sidebar submenus cannot highlight correctly        |
| 🇨🇳 Chinese |  修复左侧菜单栏子菜单不能正确高亮的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
