### PR TITLE
fix(plugin-workflow-loop): fix continue logic

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-loop/src/server/LoopInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-loop/src/server/LoopInstruction.ts
@@ -52,19 +52,19 @@ export default class extends Instruction {
     const [branch] = processor.getBranches(node);
     const target = processor.getParsedValue(node.config.target, node.id);
     const length = getTargetLength(target);
-    const looped = 0;
+    const result = { looped: 0, done: 0 };
 
     if (!branch || !length) {
       return {
         status: JOB_STATUS.RESOLVED,
-        result: { looped },
+        result,
       };
     }
 
     // NOTE: save job for condition calculation
     const job = processor.saveJob({
       status: JOB_STATUS.PENDING,
-      result: { looped },
+      result,
       nodeId: node.id,
       nodeKey: node.key,
       upstreamId: prevJob?.id ?? null,
@@ -73,18 +73,31 @@ export default class extends Instruction {
     if (node.config.condition) {
       const { checkpoint, calculation, expression, continueOnFalse } = node.config.condition ?? {};
       if ((calculation || expression) && !checkpoint) {
-        const condition = calculateCondition(node, processor);
-        if (!condition) {
-          if (continueOnFalse) {
-            job.set('result', { looped: 1 });
-            processor.saveJob(job);
-          } else {
-            job.set({
-              status: JOB_STATUS.RESOLVED,
-              result: { looped, broken: true },
-            });
-            return job;
+        while (result.looped < length) {
+          const condition = calculateCondition(node, processor);
+          if (condition) {
+            // NOTE: if condition matches, run inner branch
+            break;
           }
+          result.looped += 1;
+          job.set('result', result);
+          if (continueOnFalse) {
+            // NOTE: if `continueOnFalse` is true, continue next loop directly
+            processor.saveJob(job);
+            continue;
+          }
+          job.set({
+            status: JOB_STATUS.RESOLVED,
+            result: { ...result, broken: true },
+          });
+          return job;
+        }
+        if (result.looped >= length) {
+          job.set({
+            status: JOB_STATUS.RESOLVED,
+            result,
+          });
+          return job;
         }
       }
     }
@@ -108,7 +121,7 @@ export default class extends Instruction {
       return null;
     }
 
-    const nextIndex = result.looped + 1;
+    result.looped += 1;
 
     const target = processor.getParsedValue(loop.config.target, node.id);
     // NOTE: branchJob.status === JOB_STATUS.RESOLVED means branchJob is done, try next loop or exit as resolved
@@ -116,24 +129,37 @@ export default class extends Instruction {
       branchJob.status === JOB_STATUS.RESOLVED ||
       (branchJob.status < JOB_STATUS.PENDING && loop.config.exit === EXIT.CONTINUE)
     ) {
-      job.set({ result: { looped: nextIndex } });
-      processor.saveJob(job);
-
+      result.done += 1;
       const length = getTargetLength(target);
-      if (nextIndex < length) {
-        if (loop.config.condition) {
-          const { calculation, expression, continueOnFalse } = loop.config.condition ?? {};
-          if (calculation || expression) {
+
+      if (loop.config.condition) {
+        const { calculation, expression, continueOnFalse } = loop.config.condition ?? {};
+        if (calculation || expression) {
+          while (result.looped < length) {
             const condition = calculateCondition(loop, processor);
-            if (!condition && !continueOnFalse) {
+            if (condition) {
+              // NOTE: if condition matched, run inner branch
+              processor.logger.debug(`loop condition matched, continue inner branch (looped: ${result.looped})`);
+              break;
+            }
+            if (!continueOnFalse) {
+              processor.logger.debug(`loop condition not matches, break (looped: ${result.looped})`);
               job.set({
                 status: JOB_STATUS.RESOLVED,
-                result: { looped: nextIndex, broken: true },
+                result: { ...result, broken: true },
               });
               return job;
             }
+            // NOTE: if `continueOnFalse` is true, continue next loop directly
+            result.looped += 1;
+            processor.logger.debug(`loop condition not matches, try next loop item (looped: ${result.looped})`);
           }
         }
+      }
+      job.set({ result });
+      job.changed('result', true);
+      processor.saveJob(job);
+      if (result.looped < length) {
         await processor.run(branch, job);
         return;
       } else {
@@ -146,7 +172,7 @@ export default class extends Instruction {
       job.set(
         loop.config.exit
           ? {
-              result: { looped: result.looped, broken: true },
+              result: { ...result, broken: true },
               status: JOB_STATUS.RESOLVED,
             }
           : {

--- a/packages/plugins/@nocobase/plugin-workflow-loop/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-loop/src/server/__tests__/instruction.test.ts
@@ -66,7 +66,7 @@ describe('workflow > instructions > loop', () => {
       const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
       expect(jobs.length).toBe(2);
       expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-      expect(jobs[0].result).toEqual({ looped: 0 });
+      expect(jobs[0].result).toEqual({ looped: 0, done: 0 });
     });
 
     it('should exit when branch meets error', async () => {
@@ -97,7 +97,7 @@ describe('workflow > instructions > loop', () => {
       const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
       expect(jobs.length).toBe(2);
       expect(jobs[0].status).toBe(JOB_STATUS.ERROR);
-      expect(jobs[0].result).toEqual({ looped: 0 });
+      expect(jobs[0].result).toEqual({ looped: 1, done: 0 });
       expect(jobs[1].status).toBe(JOB_STATUS.ERROR);
     });
   });
@@ -129,7 +129,7 @@ describe('workflow > instructions > loop', () => {
         const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 0 });
+        expect(jobs[0].result).toEqual({ looped: 0, done: 0 });
       });
 
       it('null target just pass', async () => {
@@ -160,7 +160,7 @@ describe('workflow > instructions > loop', () => {
         const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 0 });
+        expect(jobs[0].result).toEqual({ looped: 0, done: 0 });
       });
 
       it('empty array just pass', async () => {
@@ -191,7 +191,7 @@ describe('workflow > instructions > loop', () => {
         const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 0 });
+        expect(jobs[0].result).toEqual({ looped: 0, done: 0 });
       });
 
       it('null value in array will not be passed', async () => {
@@ -222,7 +222,7 @@ describe('workflow > instructions > loop', () => {
         const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
         expect(jobs.length).toBe(3);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 1 });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 1 });
       });
 
       it('target is number, cycle number times', async () => {
@@ -254,7 +254,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(4);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 2 });
       });
 
       it('target is no array, set as an array', async () => {
@@ -286,7 +286,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(3);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 1 });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 1 });
       });
 
       it('multiple targets', async () => {
@@ -318,7 +318,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(4);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 2 });
         expect(jobs.filter((j) => j.nodeId === n2.id).length).toBe(2);
       });
     });
@@ -359,7 +359,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(5);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 2 });
         expect(jobs[1].result).toBe(0);
         expect(jobs[2].result).toBe(0);
         expect(jobs[3].result).toBe(1);
@@ -402,7 +402,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(5);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 2 });
         expect(jobs[1].result).toBe(1);
         expect(jobs[2].result).toBe(1);
         expect(jobs[3].result).toBe(2);
@@ -436,7 +436,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(3);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 2 });
       });
 
       it('condition engine basic before each: true with loop variable', async () => {
@@ -480,7 +480,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 1, broken: true });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 1, broken: true });
       });
 
       it('condition engine basic after each: true with loop variable', async () => {
@@ -525,7 +525,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 1, broken: true });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 1, broken: true });
       });
 
       it('condition engine basic before each: first false', async () => {
@@ -565,7 +565,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(1);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 0, broken: true });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 0, broken: true });
       });
 
       it('condition engine basic after each: first false', async () => {
@@ -606,7 +606,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 1, broken: true });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 1, broken: true });
       });
 
       it('continueOnFalse as true', async () => {
@@ -642,9 +642,9 @@ describe('workflow > instructions > loop', () => {
         expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
         const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
 
-        expect(jobs.length).toBe(2);
+        expect(jobs.length).toBe(1);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 0 });
       });
 
       it('continueOnFalse as true, second false', async () => {
@@ -662,7 +662,7 @@ describe('workflow > instructions > loop', () => {
                   calculations: [
                     {
                       calculator: 'equal',
-                      operands: [1, '{{$scopes.' + n1.key + '.item}}'],
+                      operands: [0, '{{$scopes.' + n1.key + '.item}}'],
                     },
                   ],
                 },
@@ -684,7 +684,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 1 });
       });
     });
 
@@ -718,7 +718,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.ERROR);
-        expect(jobs[0].result).toEqual({ looped: 0 });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 0 });
       });
 
       it('exit as failed', async () => {
@@ -751,7 +751,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(2);
         expect(jobs[0].status).toBe(JOB_STATUS.ERROR);
-        expect(jobs[0].result).toEqual({ looped: 0 });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 0 });
       });
 
       it('exit as break', async () => {
@@ -784,7 +784,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(3);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 0, broken: true });
+        expect(jobs[0].result).toEqual({ looped: 1, done: 0, broken: true });
       });
 
       it('exit as continue', async () => {
@@ -817,7 +817,7 @@ describe('workflow > instructions > loop', () => {
 
         expect(jobs.length).toBe(4);
         expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
-        expect(jobs[0].result).toEqual({ looped: 2 });
+        expect(jobs[0].result).toEqual({ looped: 2, done: 2 });
       });
 
       it('exit as continue with async node inside', async () => {
@@ -858,7 +858,7 @@ describe('workflow > instructions > loop', () => {
         const j2s = await e2.getJobs({ order: [['id', 'ASC']] });
 
         expect(j2s.length).toBe(3);
-        expect(j2s[0].result).toEqual({ looped: 1 });
+        expect(j2s[0].result).toEqual({ looped: 1, done: 1 });
         expect(j2s[1].status).toBe(JOB_STATUS.RESOLVED);
         expect(j2s[2].status).toBe(JOB_STATUS.PENDING);
 
@@ -872,7 +872,7 @@ describe('workflow > instructions > loop', () => {
         const j3s = await e3.getJobs({ order: [['id', 'ASC']] });
 
         expect(j3s.length).toBe(3);
-        expect(j3s[0].result).toEqual({ looped: 2 });
+        expect(j3s[0].result).toEqual({ looped: 2, done: 2 });
         expect(j3s[1].status).toBe(JOB_STATUS.RESOLVED);
         expect(j3s[2].status).toBe(JOB_STATUS.RESOLVED);
       });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the logic of proceeding to the next item when loop node conditions are not met.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the logic of proceeding to the next item when loop node conditions are not met |
| 🇨🇳 Chinese | 修复循环节点条件不满足时继续下一项的逻辑 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
