### PR TITLE
feat(plugin-workflow): add node limit env

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/.env.example
+++ b/packages/plugins/@nocobase/plugin-workflow/.env.example
@@ -1,0 +1,6 @@
+# Services splitting for workflow processing
+# WORKER_MODE=workflow:process
+
+# Limit of workflow nodes executed in one workflow instance
+# By default, no limit
+# WORKFLOW_NODES_LIMIT=100

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/nodes.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/nodes.test.ts
@@ -193,6 +193,43 @@ describe('workflow > actions > workflows', () => {
       expect(nodes[0].downstreamId).toBeNull();
       expect(nodes[1].upstreamId).toBe(nodes[0].id);
     });
+
+    it('create with nodes limit', async () => {
+      const NODES_LIMIT = process.env.WORKFLOW_NODES_LIMIT ? parseInt(process.env.WORKFLOW_NODES_LIMIT, 10) : null;
+      process.env.WORKFLOW_NODES_LIMIT = '2';
+
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+
+      const res1 = await agent.resource('workflows.nodes', workflow.id).create({
+        values: {
+          type: 'echo',
+        },
+      });
+      expect(res1.status).toBe(200);
+
+      const res2 = await agent.resource('workflows.nodes', workflow.id).create({
+        values: {
+          type: 'echo',
+        },
+      });
+      expect(res2.status).toBe(200);
+
+      const res3 = await agent.resource('workflows.nodes', workflow.id).create({
+        values: {
+          type: 'echo',
+        },
+      });
+      expect(res3.status).toBe(400);
+
+      if (NODES_LIMIT) {
+        process.env.WORKFLOW_NODES_LIMIT = NODES_LIMIT.toString();
+      } else {
+        delete process.env.WORKFLOW_NODES_LIMIT;
+      }
+    });
   });
 
   describe('destroy', () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to limit the maximum number of nodes in a workflow through environment variables.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to limit the maximum number of nodes in a workflow through environment variables |
| 🇨🇳 Chinese | 支持通过环境变量限制一个工作流中的最大节点数 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
