### PR TITLE
feat(plugin-workflow-loop): add loop limit

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-loop/.env.example
+++ b/packages/plugins/@nocobase/plugin-workflow-loop/.env.example
@@ -1,0 +1,3 @@
+# Limit of workflow loops executed in one loop node
+# By default, no limit
+# WORKFLOW_LOOP_LIMIT=100

--- a/packages/plugins/@nocobase/plugin-workflow-loop/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-loop/src/server/__tests__/instruction.test.ts
@@ -11,7 +11,6 @@ import Database from '@nocobase/database';
 import { Application } from '@nocobase/server';
 import { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
-
 import Plugin from '..';
 import { EXIT } from '../../constants';
 
@@ -1048,6 +1047,153 @@ describe('workflow > instructions > loop', () => {
       const jobs = await e1.getJobs({ order: [['id', 'ASC']] });
       expect(jobs.length).toBe(5);
       expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
+    });
+  });
+});
+
+describe('process.env.WORKFLOW_LOOP_LIMIT', () => {
+  let app: Application;
+  let db: Database;
+  let PostRepo;
+  let WorkflowModel;
+  let workflow;
+  let plugin;
+
+  afterEach(() => app.destroy());
+
+  describe('limit = 1', () => {
+    let original: string | undefined;
+
+    beforeEach(async () => {
+      original = process.env.WORKFLOW_LOOP_LIMIT;
+      process.env.WORKFLOW_LOOP_LIMIT = '1';
+
+      app = await getApp({
+        plugins: [Plugin],
+      });
+      plugin = app.pm.get('workflow');
+
+      db = app.db;
+      WorkflowModel = db.getCollection('workflows').model;
+      PostRepo = db.getCollection('posts').repository;
+
+      workflow = await WorkflowModel.create({
+        enabled: true,
+        sync: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+    });
+
+    afterEach(() => {
+      process.env.WORKFLOW_LOOP_LIMIT = original;
+    });
+
+    it('limit exceeded should stop loop', async () => {
+      const n1 = await workflow.createNode({
+        type: 'loop',
+        config: {
+          target: 10,
+        },
+      });
+
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+        branchIndex: 0,
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toBe(EXECUTION_STATUS.ERROR);
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.length).toBe(2);
+      expect(jobs[0].status).toBe(JOB_STATUS.ERROR);
+      expect(jobs[0].result).toEqual({ looped: 1, done: 1, exceeded: true });
+    });
+
+    it('limit not exceeded should be resolved', async () => {
+      const n1 = await workflow.createNode({
+        type: 'loop',
+        config: {
+          target: 10,
+        },
+      });
+
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+        branchIndex: 0,
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toBe(EXECUTION_STATUS.ERROR);
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.length).toBe(2);
+      expect(jobs[0].status).toBe(JOB_STATUS.ERROR);
+      expect(jobs[0].result).toEqual({ looped: 1, done: 1, exceeded: true });
+    });
+  });
+
+  describe('limit = 0', () => {
+    let original: string | undefined;
+
+    beforeEach(async () => {
+      original = process.env.WORKFLOW_LOOP_LIMIT;
+      process.env.WORKFLOW_LOOP_LIMIT = '0';
+
+      app = await getApp({
+        plugins: [Plugin],
+      });
+      plugin = app.pm.get('workflow');
+
+      db = app.db;
+      WorkflowModel = db.getCollection('workflows').model;
+      PostRepo = db.getCollection('posts').repository;
+
+      workflow = await WorkflowModel.create({
+        enabled: true,
+        sync: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+    });
+
+    afterEach(() => {
+      process.env.WORKFLOW_LOOP_LIMIT = original;
+    });
+
+    it('zero disables limit', async () => {
+      const n1 = await workflow.createNode({
+        type: 'loop',
+        config: {
+          target: 10,
+        },
+      });
+
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+        branchIndex: 0,
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.length).toBe(11);
+      expect(jobs[0].status).toBe(JOB_STATUS.RESOLVED);
+      expect(jobs[0].result).toEqual({ looped: 10, done: 10 });
     });
   });
 });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support to limit the maximum number of cycles for loop nodes through environment variables.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support to limit the maximum number of cycles for loop nodes through environment variables |
| 🇨🇳 Chinese | 支持通过环境变量限制循环节点的最大循环次数 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
