### PR TITLE
refactor(plugin-workflow): use terminated instead of end node for checking

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-action-trigger/src/server/ActionTrigger.ts
@@ -200,18 +200,17 @@ export default class extends Trigger {
         return context.throw(500);
       }
 
-      const { lastSavedJob, nodesMap } = processor;
-      const lastNode = nodesMap.get(lastSavedJob?.nodeId);
+      const { terminated } = processor;
       // NOTE: passthrough
       if (processor.execution.status === EXECUTION_STATUS.RESOLVED) {
-        if (lastNode?.type === 'end') {
+        if (terminated) {
           return;
         }
         continue;
       }
       // NOTE: intercept
       if (processor.execution.status < EXECUTION_STATUS.STARTED) {
-        if (lastNode?.type !== 'end') {
+        if (!terminated) {
           return context.throw(500, 'Workflow on your action failed, please contact the administrator');
         }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -66,6 +66,11 @@ export default class Processor {
    */
   lastSavedJob: JobModel | null = null;
 
+  /**
+   * @experimental
+   */
+  terminated = false;
+
   constructor(
     public execution: ExecutionModel,
     public options: ProcessorOptions,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/EndInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/EndInstruction.ts
@@ -25,7 +25,8 @@ export default class extends Instruction {
       nodeKey: node.key,
       upstreamId: prevJob?.id ?? null,
     });
+    processor.terminated = true;
 
-    return processor.exit(endStatus);
+    await processor.exit(endStatus);
   }
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Refactor the end node processing logic to prevent incorrect handling of the final workflow state in parallel branches.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Refactor the end node processing logic to prevent incorrect handling of the final workflow state in parallel branches |
| 🇨🇳 Chinese | 重构结束节点的流程处理，以避免在并行分支中未能正确处理流程最终状态的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
