### PR TITLE
fix(client): add dynamic props for AssignedField

### DIFF
--- a/packages/core/client/src/schema-initializer/components/assigned-field/AssignedField.tsx
+++ b/packages/core/client/src/schema-initializer/components/assigned-field/AssignedField.tsx
@@ -28,6 +28,7 @@ import { VariableInput, getShouldChange } from '../../../schema-settings/Variabl
 import { Option } from '../../../schema-settings/VariableInput/type';
 import { formatVariableScop } from '../../../schema-settings/VariableInput/utils/formatVariableScop';
 import { useLocalVariables, useVariables } from '../../../variables';
+import { withDynamicSchemaProps } from '../../../hoc/withDynamicSchemaProps';
 interface AssignedFieldProps {
   value: any;
   onChange: (value: any) => void;
@@ -154,6 +155,7 @@ export const AssignedFieldInner = (props: AssignedFieldProps) => {
     }
     field.title = typeof field.title === 'undefined' ? uiSchema?.title || field.name : field.title;
   }, [JSON.stringify(uiSchema)]);
+
   return (
     <FlagProvider collectionField={collectionField}>
       <VariableInput
@@ -171,8 +173,4 @@ export const AssignedFieldInner = (props: AssignedFieldProps) => {
   );
 };
 
-export const AssignedField = (props) => {
-  const { form } = useFormBlockContext();
-  const { name } = useBlockContext() || {};
-  return <AssignedFieldInner {...props} />;
-};
+export const AssignedField = withDynamicSchemaProps(AssignedFieldInner);


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where missing dynamic properties in the `AssignedField` component caused file upload errors in "Create record" or "Update record" nodes.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where missing dynamic properties in the `AssignedField` component caused file upload errors in "Create record" or "Update record" nodes |
| 🇨🇳 Chinese | 修复 AssignedField 组件未实现动态属性导致的新增、更新节点上传文件错误问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
