### PR TITLE
fix: redundant block template list requests when toggling modals

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplateMenusProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-block-template/src/client/components/BlockTemplateMenusProvider.tsx
@@ -94,7 +94,7 @@ export const BlockTemplateMenusProvider = ({ children }) => {
     if (user?.data) {
       refresh();
     }
-  }, [user, refresh]);
+  }, [user?.data, refresh]);
 
   const handleTemplateClick = useMemoizedFn(async ({ item }, options?: any, insert?: any) => {
     const { uid } = item;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where unnecessary requests for block templates were triggered when opening or closing modals |
| 🇨🇳 Chinese | 修复了打开或关闭弹窗时会触发多余区块模板请求的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
