### PR TITLE
fix(modal): prevent close button from overlapping Add tab in UI Editor

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Modal.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Modal.tsx
@@ -20,6 +20,7 @@ import { useCurrentPopupContext } from '../page/PagePopups';
 import { TabsContextProvider, useTabsContext } from '../tabs/context';
 import { ActionContextNoRerender } from './context';
 import { useActionContext } from './hooks';
+import { useDesignable } from '../../';
 import { useSetAriaLabelForModal } from './hooks/useSetAriaLabelForModal';
 import { ActionDrawerProps, ComposedActionDrawer, OpenSize } from './types';
 import { getZIndex, useZIndexContext, zIndexContext } from './zIndexContext';
@@ -106,6 +107,7 @@ export const InternalActionModal: React.FC<ActionDrawerProps<ModalProps>> = obse
 
     const zIndex = getZIndex('modal', _zIndex || parentZIndex, props.level || 0);
     const ready = useDelayedVisible(visible, delay); // 200ms 与 Modal 动画时间一致
+    const { designable } = useDesignable();
 
     return (
       <ActionContextNoRerender>
@@ -133,6 +135,10 @@ export const InternalActionModal: React.FC<ActionDrawerProps<ModalProps>> = obse
                   &.nb-action-popup {
                     .ant-modal-header {
                       display: none;
+                    }
+
+                    .ant-modal-body {
+                      margin-top: ${designable ? '30px' : 0};
                     }
 
                     .ant-modal-content {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Fixes overlapping buttons in Dialog (Close and Add tab) when UI Editor is enabled.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->
<img width="436" height="195" alt="before" src="https://github.com/user-attachments/assets/1f4cdef7-5666-43a5-9033-028260344b4e" />
<img width="436" height="195" alt="after" src="https://github.com/user-attachments/assets/8f1b4515-9e7c-4f4b-84bd-56d21a709894" />


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
