### PR TITLE
fix: preserve field.targetKey when copying reference fields

### DIFF
--- a/packages/core/server/src/middlewares/data-template.ts
+++ b/packages/core/server/src/middlewares/data-template.ts
@@ -128,8 +128,8 @@ const traverseJSON = (data, options: TraverseOptions) => {
     } else if (field.type === 'belongsTo') {
       result[key] = traverseJSON(data[key], {
         collection: collection.db.getCollection(field.target),
-        exclude: [field.targetKey],
-        include: subInclude,
+        // exclude: [field.targetKey],
+        include: [...subInclude, field.targetKey],
         excludePk: false,
       });
     } else if (field.type === 'belongsToMany') {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Preserve field.targetKey when copying reference fields  |
| 🇨🇳 Chinese | 保留复制引用字段时的 field.targetKey 值  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
