### PR TITLE
fix: add copy button option to all text-based field types (#7145)

### DIFF
--- a/packages/plugins/@nocobase/plugin-text-copy/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-text-copy/src/client/index.tsx
@@ -70,42 +70,58 @@ class PluginTextCopy extends Plugin {
       TextCopyButton: copyButton,
     });
 
-    // Add the schema settings to enable/disable the copy functionality
-    this.app.schemaSettingsManager.addItem('fieldSettings:component:Input', 'enableCopier', {
-      type: 'switch',
-      useComponentProps() {
-        const { t } = useTranslation(NAMESPACE);
-        const { fieldSchema: tableFieldSchema } = useColumnSchema();
-        const fieldSchema = useFieldSchema();
-        const field = useField();
-        const { dn } = useDesignable();
+    // Add the schema settings to enable/disable the copy functionality for all text-based fields
+    const addCopyButtonSetting = (fieldType: string) => {
+      this.app.schemaSettingsManager.addItem(`fieldSettings:component:${fieldType}`, 'enableCopier', {
+        type: 'switch',
+        useComponentProps() {
+          const { t } = useTranslation(NAMESPACE);
+          const { fieldSchema: tableFieldSchema } = useColumnSchema();
+          const fieldSchema = useFieldSchema();
+          const field = useField();
+          const { dn } = useDesignable();
 
-        const schema = tableFieldSchema || fieldSchema;
+          const schema = tableFieldSchema || fieldSchema;
 
-        return {
-          title: t('Display copy button'),
-          checked: !!schema['x-component-props']?.addonAfter,
-          onChange: async (checked) => {
-            if (checked) {
-              field.componentProps.addonAfter = copyButton;
-              _.set(schema, 'x-component-props.addonAfter', '{{TextCopyButton}}');
-            } else {
-              field.componentProps.addonAfter = null;
-              _.unset(schema, 'x-component-props.addonAfter');
-            }
+          return {
+            title: t('Display copy button'),
+            checked: !!schema['x-component-props']?.addonAfter,
+            onChange: async (checked) => {
+              if (checked) {
+                field.componentProps.addonAfter = copyButton;
+                _.set(schema, 'x-component-props.addonAfter', '{{TextCopyButton}}');
+              } else {
+                field.componentProps.addonAfter = null;
+                _.unset(schema, 'x-component-props.addonAfter');
+              }
 
-            await dn.emit('patch', {
-              schema: {
-                'x-uid': schema['x-uid'],
-                'x-component-props': {
-                  ...schema['x-component-props'],
+              await dn.emit('patch', {
+                schema: {
+                  'x-uid': schema['x-uid'],
+                  'x-component-props': {
+                    ...schema['x-component-props'],
+                  },
                 },
-              },
-            });
-          },
-        };
-      },
-    });
+              });
+            },
+          };
+        },
+      });
+    };
+
+    // Add copy button setting to all text-based field types
+    const textBasedFieldTypes = [
+      'Input',
+      'Input.TextArea',
+      'Input.URL',
+      'Input.JSON',
+      'InputNumber',
+      'Markdown',
+      'MarkdownVditor',
+      'RichText',
+    ];
+
+    textBasedFieldTypes.forEach(addCopyButtonSetting);
   }
 }
 


### PR DESCRIPTION
- Extend text-copy plugin to support all text-based field types
- Add copy button setting for Input.TextArea, Input.URL, Input.JSON, InputNumber, Markdown, MarkdownVditor, RichText
- Create reusable addCopyButtonSetting function to reduce code duplication
- Maintain backward compatibility with existing Input field functionality
- Fix MariaDB field context menu missing copy button option

Fixes #7145

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Users reported that the "display a copy button" option was missing for fields in MariaDB connections. The issue occurred because the text-copy plugin only registered copy button settings for `Input` fields, but MariaDB and other databases often use different field types like `Input.TextArea`, `Input.URL`, `Input.JSON`, etc. This limited the copy functionality to only basic input fields.

### Description 
**Key changes:**
- Extended the text-copy plugin to support 8 text-based field types instead of just `Input`
- Created a reusable `addCopyButtonSetting` function to reduce code duplication
- Added support for: `Input.TextArea`, `Input.URL`, `Input.JSON`, `InputNumber`, `Markdown`, `MarkdownVditor`, `RichText`
- Maintained backward compatibility with existing `Input` field functionality

**Potential risks:**
- Low risk. The changes only extend existing functionality without modifying core behavior
- All changes are additive and maintain existing API contracts

**Testing suggestions:**
1. Connect to MariaDB (or any database)
2. Create fields of different types (TextArea, URL, JSON, Number, Markdown, RichText)
3. Open context menu for each field type and verify "Display copy button" option appears
4. Enable copy button for different field types and verify functionality works
5. Test with both new and existing Input fields to ensure backward compatibility

### Related issues
Fixes #7145

### Showcase
**Before:** Only Input fields had "Display copy button" option in context menu
**After:** All text-based field types (Input, TextArea, URL, JSON, Number, Markdown, RichText) have "Display copy button" option

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Extended copy button functionality to all text-based field types |
| 🇨🇳 Chinese | 扩展了所有文本字段类型的复制按钮功能 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed - bug fix only |
| 🇨🇳 Chinese | 不需要 - 仅修复bug |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary