### PR TITLE
fix(plugin-calendar): show enum label for event title instead of raw value

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/index.tsx
@@ -27,8 +27,11 @@ import {
   useCreateCalendarBlock,
 } from './schema-initializer/items';
 
-const TitleRenderer = ({ value }) => {
-  return <span aria-label="event-title">{value || 'N/A'}</span>;
+const TitleRenderer = ({ value, collectionField }) => {
+  const options = collectionField?.uiSchema?.enum;
+  const label =
+    Array.isArray(options) && options.length ? options.find((opt) => opt?.value === value)?.label ?? value : value;
+  return <span aria-label="event-title">{label || 'N/A'}</span>;
 };
 interface ColorFunctions {
   loading: boolean;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
Currently, when the calendar block displays event titles using enum fields, it shows the enum's value instead of its label.
This PR fixes the display to show the label instead of the raw value for better readability.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->
before: 
https://github.com/user-attachments/assets/cbbaa879-318d-4b43-9e24-41b4412671a2

after:
https://github.com/user-attachments/assets/68e7f479-53f4-4958-98ff-6bee54e15550



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     When the calendar block’s event title field is an enum, display the enum label instead of the raw value.      |
| 🇨🇳 Chinese |     当日历区块事件标题字段为枚举时，展示枚举label而非原始值      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
