### PR TITLE
chore: be able to skip runjs code by specifying some query string

### DIFF
--- a/packages/core/flow-engine/src/JSRunner.ts
+++ b/packages/core/flow-engine/src/JSRunner.ts
@@ -55,6 +55,9 @@ export class JSRunner {
     error?: any;
     timeout?: boolean;
   }> {
+    if (location?.search.includes('skipRunJs=true')) {
+      return { success: true, value: null };
+    }
     const wrapped = `(async () => {
       try {
         ${code};

--- a/packages/core/flow-engine/src/__tests__/JSRunner.test.ts
+++ b/packages/core/flow-engine/src/__tests__/JSRunner.test.ts
@@ -7,86 +7,95 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { JSRunner } from '../JSRunner';
 
 describe('JSRunner', () => {
-  it('should run simple code successfully', async () => {
+  let originalSearch: string;
+
+  beforeEach(() => {
+    originalSearch = globalThis.location?.search || '';
+  });
+
+  afterEach(() => {
+    // 恢复 URL 查询参数，避免影响其他用例
+    try {
+      if (typeof window !== 'undefined' && typeof window.history?.replaceState === 'function') {
+        window.history.replaceState({}, '', originalSearch || '');
+      }
+    } catch (_) {
+      // ignore
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('executes simple code and returns value', async () => {
+    const runner = new JSRunner();
+    const result = await runner.run('return 1 + 2 + 3');
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(6);
+  });
+
+  it('injects custom globals and supports register()', async () => {
+    const runner = new JSRunner({ globals: { foo: 42 } });
+    const res1 = await runner.run('return foo');
+    expect(res1.success).toBe(true);
+    expect(res1.value).toBe(42);
+
+    runner.register('bar', 'baz');
+    const res2 = await runner.run('return bar');
+    expect(res2.success).toBe(true);
+    expect(res2.value).toBe('baz');
+  });
+
+  it('exposes console in sandbox by default', async () => {
+    const runner = new JSRunner();
+    const result = await runner.run('return typeof console !== "undefined"');
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(true);
+  });
+
+  it('supports timers (setTimeout) inside evaluated code', async () => {
     const runner = new JSRunner();
     const result = await runner.run(`
-      const x = 10;
-      return x + 5;    
+      return new Promise((resolve) => {
+        setTimeout(() => resolve('ok'), 20);
+      });
     `);
     expect(result.success).toBe(true);
-    expect(result.value).toBe(15);
+    expect(result.value).toBe('ok');
   });
 
-  it('should handle syntax errors in the code', async () => {
+  it('handles thrown errors and marks as non-timeout', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const runner = new JSRunner();
-    const result = await runner.run('const x = 10 x + 5;'); // Syntax error
+    const result = await runner.run('throw new Error("boom")');
     expect(result.success).toBe(false);
-    expect(result.error).toBeInstanceOf(SyntaxError);
-  });
-
-  it('should handle runtime errors in the code', async () => {
-    const runner = new JSRunner();
-    const result = await runner.run(`
-      const x = 10;
-      throw new Error('Test error');
-    `);
-    expect(result.success).toBe(false);
+    expect(result.timeout).toBe(false);
     expect(result.error).toBeInstanceOf(Error);
-    expect(result.error.message).toBe('Test error');
+    expect((result.error as Error).message).toBe('boom');
+    expect(spy).toHaveBeenCalled();
   });
 
-  it('should handle timeout errors', async () => {
-    const runner = new JSRunner({ timeoutMs: 100 }); // Set a short timeout
+  it('respects timeout setting and marks timeout=true', async () => {
+    const runner = new JSRunner({ timeoutMs: 10 });
     const result = await runner.run(`
-      await new Promise(resolve => setTimeout(resolve, 500)); // Exceeds timeout
-      return 'Done';
+      return new Promise((resolve) => setTimeout(() => resolve('late'), 100));
     `);
-    console.log(result);
     expect(result.success).toBe(false);
     expect(result.timeout).toBe(true);
-    expect(result.error.message).toBe('Execution timed out');
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toBe('Execution timed out');
   });
 
-  it('should use registered globals', async () => {
+  it('skips execution when URL contains skipRunJs=true', async () => {
+    // 模拟预览模式下通过 URL 参数跳过代码执行
+    if (typeof window !== 'undefined' && typeof window.history?.pushState === 'function') {
+      window.history.pushState({}, '', '?skipRunJs=true');
+    }
     const runner = new JSRunner();
-    runner.register('globalVar', 42);
-    const result = await runner.run(`
-      return globalVar + 8;
-    `);
+    const result = await runner.run('throw new Error("should not run")');
     expect(result.success).toBe(true);
-    expect(result.value).toBe(50);
-  });
-
-  it('should handle code with async/await', async () => {
-    const runner = new JSRunner();
-    const result = await runner.run(`
-      const fetchData = async () => {
-        return new Promise(resolve => setTimeout(() => resolve(100), 50));
-      };
-      const data = await fetchData();
-      return data + 50;
-    `);
-    expect(result.success).toBe(true);
-    expect(result.value).toBe(150);
-  });
-
-  it('should handle empty code', async () => {
-    const runner = new JSRunner();
-    const result = await runner.run('');
-    expect(result.success).toBe(true);
-    expect(result.value).toBe(undefined);
-  });
-
-  it('should handle code returning undefined explicitly', async () => {
-    const runner = new JSRunner();
-    const result = await runner.run(`
-      const x = 10;
-      return undefined;
-    `);
-    expect(result.success).toBe(true);
-    expect(result.value).toBe(undefined);
+    expect(result.value).toBeNull();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support skipping the runjs flow step by adding skipRunJs=true to the URL query string. |
| 🇨🇳 Chinese | 支持通过在 URL 查询参数中添加 skipRunJs=true 来跳过 runjs 流步骤。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
