### PR TITLE
perf(cache): avoid performance overhead caused by cloning bloom filters

### DIFF
--- a/packages/core/cache/src/cache-manager.ts
+++ b/packages/core/cache/src/cache-manager.ts
@@ -150,14 +150,14 @@ export class CacheManager {
   /**
    * @experimental
    */
-  async createBloomFilter(options?: { store?: string }): Promise<BloomFilter> {
+  async createBloomFilter(options?: { store?: string; [key: string]: any }): Promise<BloomFilter> {
     const name = 'bloom-filter';
-    const { store = this.defaultStore } = options || {};
+    const { store = this.defaultStore, ...opts } = options || {};
     let cache: Cache;
     try {
       cache = this.getCache(name);
     } catch (error) {
-      cache = await this.createCache({ name, store });
+      cache = await this.createCache({ name, store, ...opts });
     }
     switch (store) {
       case 'memory':

--- a/packages/plugins/@nocobase/plugin-auth/src/server/token-blacklist.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/token-blacklist.ts
@@ -25,7 +25,9 @@ export class TokenBlacklistService implements ITokenBlacklistService {
     // Try to create a bloom filter and cache blocked tokens in it
     plugin.app.on('beforeStart', async () => {
       try {
-        this.bloomFilter = await plugin.app.cacheManager.createBloomFilter();
+        this.bloomFilter = await plugin.app.cacheManager.createBloomFilter({
+          shouldCloneBeforeSet: false,
+        });
         // https://redis.io/docs/data-types/probabilistic/bloom-filter/#reserving-bloom-filters
         // 0.1% error rate requires 14.4 bits per item
         // 14.4*1000000/8/1024/1024 = 1.72MB


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Avoid performance overhead caused by cloning Bloom filters         |
| 🇨🇳 Chinese | 避免因 clone 布隆过滤器造成的性能损耗          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
