### PR TITLE
fix(plugin-workflow): fix node key changed after delete outer branching node

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/nodes.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/nodes.test.ts
@@ -288,7 +288,7 @@ describe('workflow > actions > nodes', () => {
         filterByTk: n1.id,
       });
 
-      const nodes = await workflow.getNodes();
+      const nodes = await workflow.getNodes({ order: [['id', 'ASC']] });
       expect(nodes.length).toBe(0);
     });
 
@@ -316,7 +316,7 @@ describe('workflow > actions > nodes', () => {
         filterByTk: n1.id,
       });
 
-      const nodes = await workflow.getNodes();
+      const nodes = await workflow.getNodes({ order: [['id', 'ASC']] });
       expect(nodes.length).toBe(0);
     });
 
@@ -357,7 +357,7 @@ describe('workflow > actions > nodes', () => {
         keepBranch: 0,
       });
 
-      const nodes = await workflow.getNodes();
+      const nodes = await workflow.getNodes({ order: [['id', 'ASC']] });
       expect(nodes.length).toBe(1);
       expect(nodes[0].id).toBe(n2.id);
     });
@@ -393,9 +393,11 @@ describe('workflow > actions > nodes', () => {
         keepBranch: 0,
       });
 
-      const nodes = await workflow.getNodes();
+      const nodes = await workflow.getNodes({ order: [['id', 'ASC']] });
       expect(nodes.length).toBe(1);
       expect(nodes[0].id).toBe(n2.id);
+      // NOTE: ensure key is not updated to new value
+      expect(nodes[0].key).toBe(n2.key);
     });
 
     it('target has no upstream, 2 branches, no downstream, `keepBranch` as branch 2', async () => {
@@ -429,7 +431,7 @@ describe('workflow > actions > nodes', () => {
         keepBranch: 1,
       });
 
-      const nodes = await workflow.getNodes();
+      const nodes = await workflow.getNodes({ order: [['id', 'ASC']] });
       expect(nodes.length).toBe(1);
       expect(nodes[0].id).toBe(n3.id);
     });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/nodes.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/nodes.ts
@@ -145,7 +145,7 @@ export async function destroy(context: Context, next) {
   const { filterByTk, keepBranch } = context.action.params;
   const keepBranchIndex = keepBranch == null || keepBranch === '' ? null : Number.parseInt(keepBranch, 10);
 
-  const fields = ['id', 'upstreamId', 'downstreamId', 'branchIndex'];
+  const fields = ['id', 'upstreamId', 'downstreamId', 'branchIndex', 'key'];
   const instance = await repository.findOne({
     filterByTk,
     fields: [...fields, 'workflowId'],


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where, after deleting a node that enabled branching, the key of the first node retained within the branch was incorrectly changed to a new value.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where, after deleting a node that starts branching, the key of the first node retained within the branch was incorrectly changed to a new value |
| 🇨🇳 Chinese | 修复开启分支的节点删除后，保留的分支内部第一个节点的 key 被改为新值的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
