### PR TITLE
fix: model's action cant be configured

### DIFF
--- a/packages/core/flow-engine/src/components/settings/independents/dropdown/FlowsDropdownButton.tsx
+++ b/packages/core/flow-engine/src/components/settings/independents/dropdown/FlowsDropdownButton.tsx
@@ -132,7 +132,7 @@ const FlowsDropdownButtonWithModel: React.FC<ModelProvidedProps> = observer(
                 // 如果step使用了action，也获取action的uiSchema
                 let actionUiSchema = {};
                 if (actionStep.use) {
-                  const action = model.flowEngine?.getAction?.(actionStep.use);
+                  const action = model.getAction?.(actionStep.use);
                   if (action && action.uiSchema) {
                     actionUiSchema = action.uiSchema;
                   }

--- a/packages/core/flow-engine/src/components/settings/wrappers/contextual/DefaultSettingsIcon.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/contextual/DefaultSettingsIcon.tsx
@@ -278,9 +278,9 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
                 let stepTitle = actionStep.title;
                 if (actionStep.use) {
                   try {
-                    const action = targetModel.flowEngine?.getAction?.(actionStep.use);
+                    const action = targetModel.getAction?.(actionStep.use);
                     hasActionUiSchema = action && action.uiSchema != null;
-                    stepTitle = stepTitle || action.title;
+                    stepTitle = stepTitle || action?.title;
                   } catch (error) {
                     console.warn(t('Failed to get action {{action}}', { action: actionStep.use }), ':', error);
                   }

--- a/packages/core/flow-engine/src/components/settings/wrappers/contextual/FlowsContextMenu.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/contextual/FlowsContextMenu.tsx
@@ -162,7 +162,7 @@ const FlowsContextMenuWithModel: React.FC<ModelProvidedProps> = observer(
                 // 如果step使用了action，也获取action的uiSchema
                 let actionUiSchema = {};
                 if (actionStep.use) {
-                  const action = model.flowEngine?.getAction?.(actionStep.use);
+                  const action = model.getAction?.(actionStep.use);
                   if (action && action.uiSchema) {
                     actionUiSchema = action.uiSchema;
                   }

--- a/packages/core/flow-engine/src/flowSettings.ts
+++ b/packages/core/flow-engine/src/flowSettings.ts
@@ -604,7 +604,7 @@ export class FlowSettings {
         let actionDefaultParams: Record<string, any> = {};
         let uiMode;
         if (step.use) {
-          const action = (model as any).flowEngine?.getAction?.(step.use);
+          const action = model.getAction?.(step.use);
           if (action) {
             actionDefaultParams = action.defaultParams || {};
             stepTitle = stepTitle || action.title;

--- a/packages/core/flow-engine/src/utils/schema-utils.ts
+++ b/packages/core/flow-engine/src/utils/schema-utils.ts
@@ -181,7 +181,7 @@ export async function resolveStepUiSchema<TModel extends FlowModel = FlowModel>(
 
   if (step.use) {
     try {
-      const action = model.flowEngine?.getAction?.(step.use);
+      const action = model.getAction?.(step.use);
       if (action && action.uiSchema) {
         stepUiSchema = stepUiSchema || action.uiSchema;
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Resolved an issue where flow actions defined by a flow model could not be configured, ensuring users can now customize flow actions as intended. |
| 🇨🇳 Chinese | 修复了 FlowModel 无法配置自定义 flow action 的问题，现在用户可以正常配置流程操作。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
