### PR TITLE
fix(china-regions): data import fails when the city and area have the same name

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-china-region/src/server/interfaces/china-region-interface.ts
+++ b/packages/plugins/@nocobase/plugin-field-china-region/src/server/interfaces/china-region-interface.ts
@@ -25,7 +25,7 @@ export class ChinaRegionInterface extends BaseInterface {
     });
 
     for (let i = 0; i < items.length; i++) {
-      const instance = instances.find((item) => item.name === items[i]);
+      const instance = instances.find((item) => item.name === items[i] && item.level === i + 1);
       if (!instance) {
         throw new Error(`china region "${items[i]}" does not exist`);
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Data import fails when the city and area have the same name         |
| 🇨🇳 Chinese | 城市和县区相同时，无法导入数据   |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
