### PR TITLE
fix(plugin-workflow-manual): fix manual tasks calculate after workflow status changed

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/Plugin.ts
@@ -256,6 +256,7 @@ export default class extends Plugin {
     this.db.on('workflowManualTasks.afterSave', this.onTaskSave);
     this.db.on('workflowManualTasks.afterDestroy', this.onTaskSave);
     this.db.on('executions.afterUpdate', this.onExecutionStatusChange);
-    this.db.on('workflows.afterUpdate', this.onWorkflowStatusChange);
+    // NOTE: no need re-calculate tasks after workflow status changed
+    // this.db.on('workflows.afterUpdate', this.onWorkflowStatusChange);
   }
 }

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/tasks.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/tasks.test.ts
@@ -208,8 +208,8 @@ describe('workflow > instructions > manual > tasks', () => {
       const s2s = await UserTaskRepo.find();
       expect(s2s.length).toBe(1);
       expect(s2s[0].get('stats')).toMatchObject({
-        pending: 0,
-        all: 0,
+        pending: 1,
+        all: 1,
       });
     });
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where manual tasks disappear after workflow disabled.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

#7493 involved.

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where manual tasks disappear after workflow disabled |
| 🇨🇳 Chinese | 修复工作流停用后人工处理任务从待办中心消失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
