### PR TITLE
fix: js block fields menu can't be loaded in filter form block

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
@@ -24,7 +24,7 @@ import { FilterFormFieldModel } from './fields';
 
 const getModelFields = async (model: CollectionBlockModel) => {
   const collection = model.context.collection as Collection;
-  const fields = (await model?.getFilterFields()) || [];
+  const fields = (await model?.getFilterFields?.()) || [];
   return fields
     .map((field: any) => {
       const binding = FilterableItemModel.getDefaultBindingByField(model.context, field);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | js block fields menu can't be loaded in filter form block |
| 🇨🇳 Chinese | 筛选表单中 JS 区块的字段无法被加载 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
