### PR TITLE
fix(plugin-workflow): incorrect handling pending list when not serving

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/common/collections/executions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/common/collections/executions.ts
@@ -89,13 +89,25 @@ export default {
       name: 'output',
     },
     {
-      interface: 'createdAt',
       type: 'datetime',
       name: 'createdAt',
+      interface: 'createdAt',
       uiSchema: {
         type: 'datetime',
         title: `{{t("Triggered at", { ns: "${NAMESPACE}" })}}`,
         'x-component': 'DatePicker',
+        'x-component-props': {},
+        'x-read-pretty': true,
+      },
+    },
+    {
+      type: 'boolean',
+      name: 'manual',
+      interface: 'checkbox',
+      uiSchema: {
+        type: 'boolean',
+        title: `{{t("Triggered manually", { ns: "${NAMESPACE}" })}}`,
+        'x-component': 'Checkbox',
         'x-component-props': {},
         'x-read-pretty': true,
       },

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -19,7 +19,7 @@ import { EXECUTION_STATUS } from './constants';
 import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import type PluginWorkflowServer from './Plugin';
 
-type Pending = { execution: ExecutionModel; job?: JobModel; force?: boolean };
+type Pending = { execution: ExecutionModel; job?: JobModel; loaded?: boolean };
 
 type CachedEvent = [WorkflowModel, any, EventOptions];
 
@@ -72,8 +72,8 @@ export default class Dispatcher {
     this.ready = ready;
   }
 
-  public isReady() {
-    return this.ready;
+  private serving() {
+    return this.plugin.app.serving(WORKER_JOB_WORKFLOW_PROCESS);
   }
 
   public getEventsCount() {
@@ -137,7 +137,7 @@ export default class Dispatcher {
       .getLogger(execution.workflowId)
       .info(`execution (${execution.id}) resuming from job (${job.id}) added to pending list`);
 
-    this.run({ execution, job, force: true });
+    this.run({ execution, job, loaded: true });
   }
 
   public async start(execution: ExecutionModel) {
@@ -146,7 +146,7 @@ export default class Dispatcher {
     }
     this.plugin.getLogger(execution.workflowId).info(`starting deferred execution (${execution.id})`);
 
-    this.run({ execution, force: true });
+    this.run({ execution, loaded: true });
   }
 
   public async beforeStop() {
@@ -165,13 +165,6 @@ export default class Dispatcher {
       return;
     }
 
-    if (!this.plugin.app.serving(WORKER_JOB_WORKFLOW_PROCESS)) {
-      this.plugin
-        .getLogger('dispatcher')
-        .warn(`${WORKER_JOB_WORKFLOW_PROCESS} is not serving, new dispatching will be ignored`);
-      return;
-    }
-
     if (this.executing) {
       this.plugin.getLogger('dispatcher').warn(`workflow executing is not finished, new dispatching will be ignored`);
       return;
@@ -186,12 +179,18 @@ export default class Dispatcher {
       let execution: ExecutionModel | null = null;
       if (this.pending.length) {
         const pending = this.pending.shift() as Pending;
-        execution = pending.force ? pending.execution : await this.acquirePendingExecution(pending.execution);
+        execution = pending.loaded ? pending.execution : await this.acquirePendingExecution(pending.execution);
         if (execution) {
           next = [execution, pending.job];
           this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
         }
       } else {
+        if (!this.serving()) {
+          this.plugin
+            .getLogger('dispatcher')
+            .warn(`${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance, new dispatching will be ignored`);
+          return;
+        }
         execution = await this.acquireQueueingExecution();
         if (execution) {
           next = [execution];
@@ -292,6 +291,7 @@ export default class Dispatcher {
           key: workflow.key,
           eventKey: options.eventKey ?? randomUUID(),
           stack: options.stack,
+          manually: options.manually,
           status: deferred ? EXECUTION_STATUS.STARTED : EXECUTION_STATUS.QUEUEING,
         },
         { transaction },
@@ -347,11 +347,13 @@ export default class Dispatcher {
     try {
       const execution = await this.createExecution(...event);
       if (execution?.status === EXECUTION_STATUS.QUEUEING) {
-        if (!this.executing && !this.pending.length) {
+        if (this.serving() && !this.executing && !this.pending.length) {
           logger.info(`local pending list is empty, adding execution (${execution.id}) to pending list`);
           this.pending.push({ execution });
         } else {
-          logger.info(`local pending list is not empty, sending execution (${execution.id}) to queue`);
+          logger.info(
+            `instance is not serving as worker or local pending list is not empty, sending execution (${execution.id}) to queue`,
+          );
           if (this.ready) {
             this.plugin.app.backgroundJobManager.publish(`${this.plugin.name}.pendingExecution`, {
               executionId: execution.id,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where, in service-splitting mode, improper handling of the in-memory pending queue caused some workflows to not execute。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where, in service-splitting mode, improper handling of the in-memory pending queue caused some workflows to not execute |
| 🇨🇳 Chinese | 修复在服务拆分模式下，工作流内存等待队列处理不当导致部分工作流不执行的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
