### PR TITLE
fix(db): skip default value synchronization for MySQL JSON columns

### DIFF
--- a/packages/core/database/src/sync-runner.ts
+++ b/packages/core/database/src/sync-runner.ts
@@ -192,6 +192,10 @@ export class SyncRunner {
 
     for (const columnName in columns) {
       const column = columns[columnName];
+
+      if (isJSONColumn(column) && this.database.inDialect('mysql')) {
+        continue;
+      }
       const isPrimaryKey = () => {
         const attribute = this.findAttributeByColumnName(columnName);
         return (attribute && attribute.primaryKey) || column.primaryKey;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Skip default value synchronization for MySQL JSON columns         |
| 🇨🇳 Chinese | 跳过 MySQL JSON 列的默认值同步处理          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
