### PR TITLE
fix(client): fix DatePicker

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
@@ -248,7 +248,7 @@ DatePicker.RangePicker = function RangePicker(props: any) {
             newProps.format = dateTimeFormat;
             setStateProps(newProps);
             fieldSchema['x-component-props'] = {
-              ...props,
+              ...(fieldSchema['x-component-props'] || {}),
               picker: value,
               format: dateTimeFormat,
             };
@@ -338,7 +338,7 @@ DatePicker.FilterWithPicker = function FilterWithPicker(props: any) {
           newProps.format = dateTimeFormat;
           setStateProps(newProps);
           fieldSchema['x-component-props'] = {
-            ...props,
+            ...(fieldSchema['x-component-props'] || {}),
             picker: value,
             format: dateTimeFormat,
           };

--- a/packages/core/utils/src/date.ts
+++ b/packages/core/utils/src/date.ts
@@ -29,14 +29,14 @@ export interface GetDefaultFormatProps {
 }
 
 export const getDefaultFormat = (props: GetDefaultFormatProps) => {
-  if (props.format) {
-    return props.format;
-  }
   if (props.dateFormat) {
     if (props['showTime']) {
       return `${props.dateFormat} ${props.timeFormat || 'HH:mm:ss'}`;
     }
     return props.dateFormat;
+  }
+  if (props.format) {
+    return props.format;
   }
   if (props['picker'] === 'month') {
     return 'YYYY-MM';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Noticed DatePicker on filter form was showing ISO date format, not the one for the form field or locally modified. Also noticed React warnings from passing props to the wrong component. 

### Description 
When setting a custom date format for a collection, using the DatePicker component defaulted to 'YYYY-MM-DD' instead of any of the other formats available. While testing, I noticed several warnings from React that some date-related props were being passed somewhere they shouldn't, so I fixed that to better see any possible errors from testing.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed DatePicker field format not being used |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
