### PR TITLE
fix: not able to set to one field value if resolving variable to array

### DIFF
--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -32,6 +32,7 @@ import { CodeEditor } from '../components/code-editor';
 import { FieldAssignValueInput } from '../components/FieldAssignValueInput';
 import _ from 'lodash';
 import { SubFormFieldModel } from '../models';
+import { coerceForToOneField } from '../internal/utils/associationValueCoercion';
 
 interface LinkageRule {
   /** 随机生成的字符串 */
@@ -606,12 +607,14 @@ export const linkageAssignField = defineAction({
       const gridModels = ctx.model?.subModels?.grid?.subModels?.items || [];
       const fieldModel = gridModels.find((model: any) => model.uid === field);
       if (!fieldModel) return;
+      const collectionField = (fieldModel as any)?.collectionField;
+      const finalValue = coerceForToOneField(collectionField, assignValue);
       // 若赋值为空（如切换字段后清空），调用一次 setProps 触发清空临时 props，避免旧值残留
-      if (typeof assignValue === 'undefined') {
+      if (typeof finalValue === 'undefined') {
         setProps(fieldModel as FlowModel, {});
         return;
       }
-      setProps(fieldModel as FlowModel, { value: assignValue });
+      setProps(fieldModel as FlowModel, { value: finalValue });
     } catch (error) {
       console.warn(`Failed to assign value to field ${field}:`, error);
     }
@@ -696,12 +699,15 @@ export const subFormLinkageAssignField = defineAction({
 
       if (!model) return;
 
+      const collectionField = (formItemModel as any)?.collectionField;
+      const finalValue = coerceForToOneField(collectionField, assignValue);
+
       // 若赋值为空（如切换字段后清空），调用一次 setProps 触发清空临时 props，避免旧值残留
-      if (typeof assignValue === 'undefined') {
+      if (typeof finalValue === 'undefined') {
         setProps(model, {});
         return;
       }
-      setProps(model, { value: assignValue });
+      setProps(model, { value: finalValue });
     } catch (error) {
       console.warn(`Failed to assign value to field ${field}:`, error);
     }
@@ -775,12 +781,14 @@ export const setFieldsDefaultValue = defineAction({
       const gridModels = ctx.model?.subModels?.grid?.subModels?.items || [];
       const fieldModel = gridModels.find((model: any) => model.uid === field);
       if (!fieldModel) return;
+      const collectionField = (fieldModel as any)?.collectionField;
+      const finalInitialValue = coerceForToOneField(collectionField, initialValue);
       // 若赋值为空（如切换字段后清空），调用一次 setProps 触发清空临时 props，避免旧值残留
-      if (typeof initialValue === 'undefined') {
+      if (typeof finalInitialValue === 'undefined') {
         setProps(fieldModel as FlowModel, {});
         return;
       }
-      setProps(fieldModel as FlowModel, { initialValue });
+      setProps(fieldModel as FlowModel, { initialValue: finalInitialValue });
     } catch (error) {
       console.warn(`Failed to assign value to field ${field}:`, error);
     }

--- a/packages/core/client/src/flow/internal/utils/__tests__/associationValueCoercion.test.ts
+++ b/packages/core/client/src/flow/internal/utils/__tests__/associationValueCoercion.test.ts
@@ -1,0 +1,57 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { coerceForToOneField, isToManyAssociation } from '../associationValueCoercion';
+
+describe('associationValueCoercion', () => {
+  const mkField = (opts: any) => ({
+    isAssociationField: () => !!opts.association,
+    type: opts.type,
+    interface: opts.interface,
+  });
+
+  it('isToManyAssociation returns true for to-many', () => {
+    expect(isToManyAssociation(mkField({ association: true, type: 'hasMany' }))).toBe(true);
+    expect(isToManyAssociation(mkField({ association: true, type: 'belongsToMany' }))).toBe(true);
+    expect(isToManyAssociation(mkField({ association: true, type: 'belongsToArray' }))).toBe(true);
+  });
+
+  it('isToManyAssociation returns false for to-one or non-association', () => {
+    expect(isToManyAssociation(mkField({ association: true, type: 'belongsTo', interface: 'm2o' }))).toBe(false);
+    expect(isToManyAssociation(mkField({ association: true, type: 'hasOne' }))).toBe(false);
+    expect(isToManyAssociation(mkField({ association: false, type: 'string', interface: 'input' }))).toBe(false);
+    expect(isToManyAssociation(undefined as any)).toBe(false);
+  });
+
+  it('coerceForToOneField keeps original value for to-many association', () => {
+    const field = mkField({ association: true, type: 'hasMany' });
+    const val = [1, 2];
+    expect(coerceForToOneField(field, val)).toBe(val);
+  });
+
+  it('coerceForToOneField extracts first element for to-one association when value is array', () => {
+    const field = mkField({ association: true, type: 'belongsTo', interface: 'm2o' });
+    expect(coerceForToOneField(field, [1, 2])).toBe(1);
+    expect(coerceForToOneField(field, [])).toBeUndefined();
+  });
+
+  it('coerceForToOneField keeps scalar values unchanged for to-one association', () => {
+    const field = mkField({ association: true, type: 'belongsTo' });
+    expect(coerceForToOneField(field, 123)).toBe(123);
+    const obj = { id: 9 };
+    expect(coerceForToOneField(field, obj)).toBe(obj);
+  });
+
+  it('coerceForToOneField keeps any value unchanged for non-association', () => {
+    const field = mkField({ association: false, type: 'string', interface: 'input' });
+    const arr = [1, 2, 3];
+    expect(coerceForToOneField(field, arr)).toBe(arr);
+  });
+});

--- a/packages/core/client/src/flow/internal/utils/associationValueCoercion.ts
+++ b/packages/core/client/src/flow/internal/utils/associationValueCoercion.ts
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+// 判断集合字段是否为“对多”关联
+export function isToManyAssociation(collectionField: any): boolean {
+  if (!collectionField) return false;
+  const relationType = collectionField?.type;
+  return relationType === 'belongsToMany' || relationType === 'hasMany' || relationType === 'belongsToArray';
+}
+
+/**
+ * 若目标字段为“对一”关联且传入值为数组，则取第一个元素
+ * - 对多关联/非关联字段：不处理，原样返回
+ * - 传入空数组：返回 undefined
+ */
+export function coerceForToOneField(collectionField: any, value: any) {
+  const isAssociation = !!collectionField?.isAssociationField?.();
+  const toMany = isToManyAssociation(collectionField);
+  if (isAssociation && !toMany && Array.isArray(value)) {
+    return value.length ? value[0] : undefined;
+  }
+  return value;
+}

--- a/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
@@ -23,6 +23,7 @@ import { FieldModel } from '../../base';
 import { DetailsItemModel } from '../details/DetailsItemModel';
 import { EditFormModel } from './EditFormModel';
 import _ from 'lodash';
+import { coerceForToOneField } from '../../../internal/utils/associationValueCoercion';
 
 const interfacesOfUnsupportedDefaultValue = [
   'o2o',
@@ -283,7 +284,9 @@ FormItemModel.registerFlow({
         if (interfacesOfUnsupportedDefaultValue?.includes?.(iface)) {
           return;
         }
-        ctx.model.setProps({ initialValue: params.defaultValue });
+        const collectionField = ctx.model.collectionField;
+        const finalDefault = coerceForToOneField(collectionField, params.defaultValue);
+        ctx.model.setProps({ initialValue: finalDefault });
       },
     },
     required: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Resolved an issue where assigning an array as the value or default value to a "toOne" field resulted in an error. This ensures proper handling of variable resolution results, improving system stability and accuracy. |
| 🇨🇳 Chinese | 当变量解析结果为数组并被设置为“对一”字段的值或默认值时会导致错误的问题现已修复。此修复确保了对变量解析结果的正确处理，提高了系统的稳定性和准确性。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
