### PR TITLE
feat(plugin-workflow-notification): add `ignoreFail` option

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-notification/src/client/NotificationInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-notification/src/client/NotificationInstruction.tsx
@@ -29,6 +29,12 @@ export default class extends Instruction {
       type: 'void',
       'x-component': 'LocalProvider',
     },
+    ignoreFail: {
+      type: 'boolean',
+      'x-content': `{{t("Ignore failure and continue workflow", { ns: "${NAMESPACE}" })}}`,
+      'x-decorator': 'FormItem',
+      'x-component': 'Checkbox',
+    },
   };
   components = {
     LocalProvider,

--- a/packages/plugins/@nocobase/plugin-workflow-notification/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow-notification/src/locale/zh-CN.json
@@ -1,4 +1,5 @@
 {
   "Notification": "通知",
-  "Send notification. You can use the variables in the upstream nodes as content and ohter config.": "发送通知。您可以使用上游节点中的变量作为通知的内容和其他配置。"
+  "Send notification. You can use the variables in the upstream nodes as content and ohter config.": "发送通知。您可以使用上游节点中的变量作为通知的内容和其他配置。",
+  "Ignore failure and continue workflow": "忽略失败并继续工作流"
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add `ignoreFail` option for notification node, which allow to continue workflow when notification sending failed.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `ignoreFail` option for notification node, which allow to continue workflow when notification sending failed |
| 🇨🇳 Chinese | 通知节点增加“忽略失败”选项，以支持发送失败时继续执行工作流 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
