### PR TITLE
fix: missing required field indicator after setting frontend validation

### DIFF
--- a/packages/core/client/src/flow/actions/required.tsx
+++ b/packages/core/client/src/flow/actions/required.tsx
@@ -49,6 +49,12 @@ export const required = defineAction({
         message: ctx.t('The field value is required'),
       });
     }
+    if (hasRequiredInCollection && !rules.some((v) => v.required)) {
+      rules.push({
+        required: true,
+        message: ctx.t('The field value is required'),
+      });
+    }
     ctx.model.setProps({ rules, required: params.required || hasRequiredInCollection });
   },
 });

--- a/packages/core/client/src/flow/actions/validation.tsx
+++ b/packages/core/client/src/flow/actions/validation.tsx
@@ -38,7 +38,7 @@ export const validation = defineAction({
   },
   handler(ctx, params) {
     if (params.validation) {
-      const rules = ctx.model.getProps().rules || [];
+      const rules = [];
       const schema = jioToJoiSchema(params.validation);
       const label = ctx.model.props.label;
       rules.push({
@@ -57,9 +57,14 @@ export const validation = defineAction({
         },
       });
       const hasRequiredInCollection = params.validation.rules.some((rule) => rule.name === 'required');
+      if (hasRequiredInCollection) {
+        ctx.model.setProps({
+          required: hasRequiredInCollection,
+        });
+      }
+      console.log(rules);
       ctx.model.setProps({
         rules,
-        required: hasRequiredInCollection,
         validation: params.validation,
       });
     }

--- a/packages/core/client/src/flow/models/blocks/assign-form/AssignFormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/assign-form/AssignFormItemModel.tsx
@@ -374,13 +374,13 @@ AssignFormItemModel.registerFlow({
         ctx.model.setProps({ extra: params.description });
       },
     },
-    required: {
-      title: escapeT('Required'),
-      use: 'required',
-    },
     validation: {
       title: escapeT('Validation'),
       use: 'validation',
+    },
+    required: {
+      title: escapeT('Required'),
+      use: 'required',
     },
   },
 });

--- a/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
@@ -289,6 +289,10 @@ FormItemModel.registerFlow({
         ctx.model.setProps({ initialValue: finalDefault });
       },
     },
+    validation: {
+      title: escapeT('Validation'),
+      use: 'validation',
+    },
     required: {
       title: escapeT('Required'),
       use: 'required',
@@ -303,10 +307,6 @@ FormItemModel.registerFlow({
       use: 'pattern',
     },
 
-    validation: {
-      title: escapeT('Validation'),
-      use: 'validation',
-    },
     fieldNames: {
       use: 'titleField',
       uiSchema: async (ctx) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix missing required field indicator after setting frontend validation        |
| 🇨🇳 Chinese |   修复设置前端字段验证后，同时设置必填时，必填标志缺失的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
