### PR TITLE
fix(server): add app name in channel name

### DIFF
--- a/packages/core/server/src/pub-sub-manager/pub-sub-manager.ts
+++ b/packages/core/server/src/pub-sub-manager/pub-sub-manager.ts
@@ -44,16 +44,12 @@ export class PubSubManager {
     this.handlerManager = new HandlerManager(this.publisherId);
   }
 
-  get channelPrefix() {
-    return this.options?.channelPrefix ? `${this.options.channelPrefix}.` : '';
-  }
-
   setAdapter(adapter: IPubSubAdapter) {
     this.adapter = adapter;
   }
 
   getFullChannel(channel: string) {
-    return [this.app.name, this.channelPrefix, channel].filter(Boolean).join('.');
+    return [this.app.name, this.options?.channelPrefix, channel].filter(Boolean).join('.');
   }
 
   async isConnected() {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Isolate Pub-Sub channel by app name.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Isolate Pub-Sub channel by app name |
| 🇨🇳 Chinese | 使用应用名称隔离发布订阅的频道 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
