### PR TITLE
fix: enum options have not been translated in variable component

### DIFF
--- a/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
@@ -25,6 +25,7 @@ import {
 import _ from 'lodash';
 import { NumberPicker } from '@formily/antd-v5';
 import { lazy } from '../../../lazy-helper';
+import { enumToOptions } from '../../internal/utils/enumOptionsUtils';
 import { FormProvider, SchemaComponent } from '../../../schema-component/core';
 
 const { DateFilterDynamicComponent: DateFilterDynamicComponentLazy } = lazy(
@@ -70,7 +71,7 @@ function createStaticInputRenderer(
   const fieldProps = meta?.uiSchema?.['x-component-props'] || {};
   const opProps = schema?.['x-component-props'] || {};
   const combinedProps = merge({}, fieldProps, opProps);
-  const selectOptions = schema?.enum || [];
+  const selectOptions = enumToOptions(schema?.enum as any, t) || [];
 
   // 这里保持 any，避免在不同组件 props 上产生不必要的类型冲突
   const commonProps: any = {

--- a/packages/core/client/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts
+++ b/packages/core/client/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts
@@ -1,0 +1,58 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { enumToOptions, translateOptions } from '../enumOptionsUtils';
+
+// 一个极简的 t：
+// - 直接返回传入 key；
+// - 支持形如 {{t('Yes')}} 的模板，提取 'Yes' 并给出模拟翻译。
+function mockT(input: string) {
+  const tpl = /\{\{\s*t\s*\(\s*['"](.+?)['"][^)]*\)\s*\}\}/;
+  const m = input?.match?.(tpl);
+  const key = m ? m[1] : input;
+  if (key === 'Yes') return '是';
+  if (key === 'No') return '否';
+  if (key === 'Draft') return '草稿';
+  return key;
+}
+
+describe('enumOptions utils', () => {
+  it('enumToOptions: converts primitive enum and translates labels', () => {
+    const uiEnum = ['{{t("Yes")}}', '{{t("No")}}'];
+    const options = enumToOptions(uiEnum as any, mockT)!;
+    expect(options).toHaveLength(2);
+    expect(options[0]).toEqual({ label: '是', value: '{{t("Yes")}}' });
+    expect(options[1]).toEqual({ label: '否', value: '{{t("No")}}' });
+  });
+
+  it('enumToOptions: keeps object value and translates object label', () => {
+    const uiEnum = [
+      { label: '{{t("Yes")}}', value: true },
+      { label: '{{t("No")}}', value: false },
+    ];
+    const options = enumToOptions(uiEnum as any, mockT)!;
+    expect(options).toEqual([
+      { label: '是', value: true },
+      { label: '否', value: false },
+    ]);
+  });
+
+  it('translateOptions: maps given options labels through t()', () => {
+    const options = [
+      { label: '{{t("Draft")}}', value: 'draft' },
+      { label: 'No', value: false },
+    ];
+    const out = translateOptions(options as any, mockT);
+    expect(out).toEqual([
+      { label: '草稿', value: 'draft' },
+      { label: '否', value: false },
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the labels of enum types in variable-related components were not displayed in the correct language. |
| 🇨🇳 Chinese | 修复了变量相关组件中枚举类型的标签未正确显示为对应语言的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
