### PR TITLE
fix(plugin-workflow): fix workflow not resume when service splitting

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -185,26 +185,28 @@ export default class Dispatcher {
           this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
         }
       } else {
-        if (!this.serving()) {
+        if (this.serving()) {
+          execution = await this.acquireQueueingExecution();
+          if (execution) {
+            next = [execution];
+          }
+        } else {
           this.plugin
             .getLogger('dispatcher')
             .warn(`${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance, new dispatching will be ignored`);
-          return;
-        }
-        execution = await this.acquireQueueingExecution();
-        if (execution) {
-          next = [execution];
         }
       }
       if (next) {
         await this.process(...next);
       }
-      this.executing = null;
+      setImmediate(() => {
+        this.executing = null;
 
-      if (next || this.pending.length) {
-        this.plugin.getLogger('dispatcher').debug(`last process finished, will do another dispatch`);
-        this.dispatch();
-      }
+        if (next || this.pending.length) {
+          this.plugin.getLogger('dispatcher').debug(`last process finished, will do another dispatch`);
+          this.dispatch();
+        }
+      });
     })();
   }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/service-splitting.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/service-splitting.test.ts
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { MockDatabase } from '@nocobase/database';
+import { MockServer } from '@nocobase/test';
+import { getApp, sleep } from '@nocobase/plugin-workflow-test';
+import { EXECUTION_STATUS, JOB_STATUS } from '../constants';
+
+describe('workflow > service splitting > only dispatcher', () => {
+  let app: MockServer;
+  let db: MockDatabase;
+  let PostRepo;
+  let WorkflowModel;
+  let workflow;
+  let plugin;
+  let workerMode;
+
+  beforeEach(async () => {
+    workerMode = process.env.WORKER_MODE;
+    process.env.WORKER_MODE = '!';
+    app = await getApp();
+    plugin = app.pm.get('workflow');
+
+    db = app.db;
+    WorkflowModel = db.getCollection('workflows').model;
+    PostRepo = db.getCollection('posts').repository;
+
+    workflow = await WorkflowModel.create({
+      enabled: true,
+      type: 'asyncTrigger',
+    });
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+    process.env.WORKER_MODE = workerMode;
+  });
+
+  describe('manually execute', () => {
+    it('pending node should resume', async () => {
+      await workflow.createNode({
+        type: 'asyncResume',
+      });
+
+      await plugin.execute(workflow, {}, { manually: true });
+
+      const [e1] = await workflow.getExecutions();
+      expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+
+      const j1s = await e1.getJobs();
+      expect(j1s.length).toBe(1);
+      expect(j1s[0].status).toBe(JOB_STATUS.PENDING);
+
+      await sleep(500);
+
+      const [e2] = await workflow.getExecutions();
+      expect(e2.status).toBe(EXECUTION_STATUS.RESOLVED);
+
+      const j2s = await e2.getJobs();
+      expect(j2s.length).toBe(1);
+      expect(j2s[0].status).toBe(JOB_STATUS.RESOLVED);
+    });
+  });
+});


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix an issue where, in service-splitting mode, manually executing a workflow containing an interrupt node would remain stuck in a pending status.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where, in service-splitting mode, manually executing a workflow containing an interrupt node would remain stuck in a pending status |
| 🇨🇳 Chinese | 修复在服务拆分模式下，手动执行带中断节点的工作流一直等待的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
