### PR TITLE
fix(plugin-workflow): fix idle check of dispatcher before ready

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -44,7 +44,7 @@ export default class Dispatcher {
   private eventsCount = 0;
 
   get idle() {
-    return !this.executing && !this.pending.length && !this.events.length;
+    return this.ready && !this.executing && !this.pending.length && !this.events.length;
   }
 
   constructor(private readonly plugin: PluginWorkflowServer) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Resolved an issue where the workflow dispatcher in cluster mode failed to correctly identify idle states, which could lead to unnecessary queue event consuming before plugin is ready.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Resolved an issue where the workflow dispatcher in cluster mode failed to correctly identify idle states, which could lead to unnecessary queue event consuming before plugin is ready |
| 🇨🇳 Chinese | 修复了集群模式下工作流调度器无法正确识别空闲状态的问题，该问题可能导致插件未就绪就开始消费队列事件 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
