### PR TITLE
fix: association field title field ellipsis not applied

### DIFF
--- a/packages/core/client/src/flow/models/fields/ClickableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/ClickableFieldModel.tsx
@@ -51,7 +51,7 @@ export class ClickableFieldModel extends FieldModel {
     return value;
   }
 
-  renderInDisplayStyle(value, record?) {
+  renderInDisplayStyle(value, record?, isToMany?) {
     const { clickToOpen = false, displayStyle, titleField, overflowMode, ...restProps } = this.props;
     if (value && typeof value === 'object' && restProps.target) {
       return;
@@ -67,6 +67,7 @@ export class ClickableFieldModel extends FieldModel {
       cursor: clickToOpen ? 'pointer' : 'default',
       alignItems: 'center',
       gap: 4,
+      display: isToMany && 'inline-block',
     };
 
     if (isTag) {
@@ -107,12 +108,12 @@ export class ClickableFieldModel extends FieldModel {
         return <EllipsisWithTooltip ellipsis={ellipsis}>{result}</EllipsisWithTooltip>;
       } else {
         const result = castArray(value).flatMap((v, idx) => {
-          const node = this.renderInDisplayStyle(v?.[titleField], v);
+          const node = this.renderInDisplayStyle(v?.[titleField], v, Array.isArray(value));
           return idx === 0 ? [node] : [<span key={`sep-${idx}`}>, </span>, node];
         });
         return (
           <EllipsisWithTooltip ellipsis={ellipsis}>
-            <span style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>{result}</span>
+            <span style={{ flexWrap: 'nowrap' }}>{result}</span>
           </EllipsisWithTooltip>
         );
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix association field title field ellipsis not applied       |
| 🇨🇳 Chinese |   关系字段标题字段设置超出省略不生效        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
