### PR TITLE
fix(db): add `multipleStatements` option for mariadb

### DIFF
--- a/packages/core/database/src/dialects/mariadb-dialect.ts
+++ b/packages/core/database/src/dialects/mariadb-dialect.ts
@@ -14,7 +14,12 @@ export class MariadbDialect extends BaseDialect {
   static dialectName = 'mariadb';
 
   getSequelizeOptions(options: DatabaseOptions) {
-    options.dialectOptions = { ...(options.dialectOptions || {}), supportBigNumbers: true, bigNumberStrings: true };
+    options.dialectOptions = {
+      ...(options.dialectOptions || {}),
+      multipleStatements: true,
+      supportBigNumbers: true,
+      bigNumberStrings: true,
+    };
     return options;
   }
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add the `multipleStatements` option to the MariaDB connection instance to support invoking multiple statements in a single query.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add the `multipleStatements` option to the MariaDB connection instance to support invoking multiple statements in a single query |
| 🇨🇳 Chinese | 对 MariaDB 连接实例增加 `multipleStatements` 选项，以支持一次查询中调用多条语句 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
