### PR TITLE
fix(plugin-mobile): select datepicker by device

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/pages/dynamic-page/MobilePage.tsx
@@ -8,25 +8,26 @@
  */
 
 import {
-  RemoteSchemaComponent,
-  AssociationField,
-  useDesignable,
-  Select,
-  DatePicker,
   Action,
+  AssociationField,
+  DatePicker,
+  RemoteSchemaComponent,
   SchemaComponentOptions,
+  Select,
   TimePicker,
+  useDesignable,
 } from '@nocobase/client';
-import React, { useCallback } from 'react';
-import { Outlet, useParams } from 'react-router-dom';
 import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
-import { MobilePicker } from './components/MobilePicker';
+import React, { useCallback } from 'react';
+import { isMobile } from 'react-device-detect';
+import { Outlet, useParams } from 'react-router-dom';
 import {
+  MobileDateFilterWithPicker,
   MobileDateTimePicker,
   MobileRangePicker,
-  MobileDateFilterWithPicker,
   MobileTimePicker,
 } from './components/MobileDatePicker';
+import { MobilePicker } from './components/MobilePicker';
 
 const AssociationFieldMobile = (props) => {
   return <AssociationField {...props} popupMatchSelectWidth={true} />;
@@ -42,11 +43,10 @@ AssociationFieldMobile.ReadPretty = AssociationField.ReadPretty;
 AssociationFieldMobile.FileSelector = AssociationField.FileSelector;
 
 const DatePickerMobile = (props) => {
-  const { designable } = useDesignable();
-  if (designable !== false) {
-    return <DatePicker {...props} />;
-  } else {
+  if (isMobile) {
     return <MobileDateTimePicker {...props} />;
+  } else {
+    return <DatePicker {...props} />;
   }
 };
 DatePickerMobile.FilterWithPicker = (props) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where the date field default value popup on mobile cannot select a date    |
| 🇨🇳 Chinese |     修复移动端的日期字段默认值弹窗无法选中日期的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
