### PR TITLE
fix: page's event flow can't set block data scope

### DIFF
--- a/packages/core/client/src/flow/actions/setTargetDataScope.tsx
+++ b/packages/core/client/src/flow/actions/setTargetDataScope.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { ActionScene, defineAction, MultiRecordResource, useFlowContext } from '@nocobase/flow-engine';
+import { ActionScene, defineAction, FlowModel, MultiRecordResource, useFlowContext } from '@nocobase/flow-engine';
 import { isEmptyFilter, transformFilter, tval } from '@nocobase/utils/client';
 import { pruneFilter } from '@nocobase/flow-engine';
 import _ from 'lodash';
@@ -60,25 +60,21 @@ export const setTargetDataScope = defineAction({
     if (!targetBlockUid) {
       return;
     }
+    const model: FlowModel = ctx.model;
+    model.scheduleModelOperation(targetBlockUid, (targetModel) => {
+      const resource = targetModel['resource'] as MultiRecordResource;
+      if (!resource) {
+        return;
+      }
 
-    const targetModel = ctx.engine.getModel(targetBlockUid, true);
-    if (!targetModel) {
-      return;
-    }
+      const filter = pruneFilter(transformFilter(params.filter));
 
-    // @ts-ignore
-    const resource = targetModel.resource as MultiRecordResource;
-    if (!resource) {
-      return;
-    }
-
-    const filter = pruneFilter(transformFilter(params.filter));
-
-    if (isEmptyFilter(filter)) {
-      resource.removeFilterGroup(`setTargetDataScope_${ctx.model.uid}`);
-    } else {
-      resource.addFilterGroup(`setTargetDataScope_${ctx.model.uid}`, filter);
-    }
+      if (isEmptyFilter(filter)) {
+        resource.removeFilterGroup(`setTargetDataScope_${ctx.model.uid}`);
+      } else {
+        resource.addFilterGroup(`setTargetDataScope_${ctx.model.uid}`, filter);
+      }
+    });
   },
 });
 

--- a/packages/core/flow-engine/src/__tests__/modelOperationScheduler.test.ts
+++ b/packages/core/flow-engine/src/__tests__/modelOperationScheduler.test.ts
@@ -234,6 +234,21 @@ describe('ModelOperationScheduler', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('should remove scheduled item after execution (cancel returns false)', async () => {
+    const engine = newEngine();
+    const from = engine.createModel<FlowModel>({ use: 'FlowModel', uid: 'from-auto-remove-1' });
+    const to = engine.createModel<FlowModel>({ use: 'FlowModel', uid: 'to-auto-remove-1' });
+
+    const fn = vi.fn();
+    const cancel = engine.scheduleModelOperation(from, to.uid, fn, { when: 'event:beforeRender:end' });
+
+    await engine.executor.dispatchEvent(to, 'beforeRender');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fn).toHaveBeenCalledTimes(1);
+    // 执行完成后应自动移除，再次取消应返回 false
+    expect(cancel()).toBe(false);
+  });
+
   it('should still execute once even if source model destroyed later', async () => {
     const engine = newEngine();
     const from = engine.createModel<FlowModel>({ use: 'FlowModel', uid: 'from-4' });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | block's data scope is not working if set by page event flow |
| 🇨🇳 Chinese | 页面的事件流设置页面区块数据范围不生效 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
