### PR TITLE
fix(server): fix event queue error when not serving

### DIFF
--- a/packages/core/server/src/event-queue.ts
+++ b/packages/core/server/src/event-queue.ts
@@ -354,12 +354,12 @@ export class EventQueue {
     return this.adapter.isConnected();
   }
   async connect() {
-    if (!this.adapter) {
-      throw new Error('no adapter set, cannot connect');
-    }
     if (!this.app.serving()) {
       this.app.logger.warn('app is not serving, will not connect to event queue');
       return;
+    }
+    if (!this.adapter) {
+      throw new Error('no adapter set, cannot connect');
     }
     await this.adapter.connect();
     this.app.logger.debug(`connected to adapter, using memory? ${this.adapter instanceof MemoryEventQueueAdapter}`);
@@ -399,6 +399,10 @@ export class EventQueue {
     }
   }
   async publish(channel: string, message: any, options: QueueMessageOptions = {}) {
+    if (!this.app.serving()) {
+      this.app.logger.warn('app is not serving, will not publish message to event queue');
+      return;
+    }
     if (!this.adapter) {
       throw new Error('no adapter set, cannot publish');
     }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix an issue where, after enabling service-splitting mode, worker processes sending messages through the message queue would cause errors.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where, after enabling service-splitting mode, worker processes sending messages through the message queue would cause errors |
| 🇨🇳 Chinese | 修复消息队列在启用服务拆分模式后，工作进程发消息导致报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
