### PR TITLE
fix: subform fields variable not resolved correctly if has modified from UI

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/FormBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormBlockModel.tsx
@@ -121,7 +121,10 @@ export class FormBlockModel<
       },
       cache: false,
       meta: formValuesMeta,
-      resolveOnServer: createAssociationSubpathResolver(() => this.collection),
+      resolveOnServer: createAssociationSubpathResolver(
+        () => this.collection,
+        () => this.form.getFieldsValue(),
+      ),
       serverOnlyWhenContextParams: true,
     });
   }

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubFormFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubFormFieldModel.tsx
@@ -89,7 +89,10 @@ export class SubFormFieldModel extends FormAssociationFieldModel {
         this.context.t('Current object'),
         () => this.context.form.getFieldValue(this.props.name),
       ),
-      resolveOnServer: createAssociationSubpathResolver(() => this.context.collection),
+      resolveOnServer: createAssociationSubpathResolver(
+        () => this.context.collection,
+        () => this.context.form.getFieldValue(this.props.name),
+      ),
       serverOnlyWhenContextParams: true,
     });
   }
@@ -189,7 +192,10 @@ const ArrayNester = ({ name, value, disabled }: any) => {
                   currentFork.context.t('Current object'),
                   () => currentFork.context.form.getFieldValue([name, fieldName]),
                 ),
-                resolveOnServer: createAssociationSubpathResolver(() => currentFork.context.collection),
+                resolveOnServer: createAssociationSubpathResolver(
+                  () => currentFork.context.collection,
+                  () => currentFork.context.form.getFieldValue([name, fieldName]),
+                ),
                 serverOnlyWhenContextParams: true,
               });
 
@@ -250,7 +256,10 @@ export class SubFormListFieldModel extends FormAssociationFieldModel {
         this.context.t('Current object'),
         (ctx) => ctx['currentObject'],
       ),
-      resolveOnServer: createAssociationSubpathResolver(() => this.context.collection),
+      resolveOnServer: createAssociationSubpathResolver(
+        () => this.context.collection,
+        () => this.context['currentObject'],
+      ),
       serverOnlyWhenContextParams: true,
     });
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where variables in subform association fields were not correctly resolved when the field was modified via the user interface. |
| 🇨🇳 Chinese | 修复了子表单关系字段通过用户界面修改后，其变量无法正确解析的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
