### PR TITLE
fix: actions column should be able to hide

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableActionsColumnModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableActionsColumnModel.tsx
@@ -94,6 +94,10 @@ export class TableActionsColumnModel extends TableCustomColumnModel {
   }
 
   getColumnProps() {
+    // 非配置态且列被标记为隐藏时，直接返回 null，从表格列中移除整列
+    if (this.hidden && !this.flowEngine.flowSettings?.enabled) {
+      return null;
+    }
     const titleContent = (
       <Droppable model={this}>
         <FlowsFloatContextMenu


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | can't hide table block's actions column |
| 🇨🇳 Chinese | 表格区块操作列无法被隐藏 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
