### PR TITLE
fix(database): remove UTC time zone processing in time conversion

### DIFF
--- a/packages/core/database/src/interfaces/time-interface.ts
+++ b/packages/core/database/src/interfaces/time-interface.ts
@@ -14,7 +14,7 @@ dayjs.extend(utc);
 export class TimeInterface extends BaseInterface {
   toValue(value: any, ctx?: any) {
     if (this.validate(value)) {
-      const result = dayjs.utc(value).format('HH:mm:ss');
+      const result = dayjs(value).format('HH:mm:ss');
       return result;
     }
     return value;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
现有的 time 字段在转换时使用了 dayjs.utc(value)，会将纯时间（无日期）的值按 UTC 进行处理，从而在有时区偏移的环境中出现时间被“挪动”的问题（例如本地为 UTC+8 时，导入/显示的时间会被错误地偏移）。对于仅包含时间的字段（例如 10:00:00），不应进行时区换算。
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
测试建议：

- 导入场景：在非 UTC 时区环境（例如 UTC+8）导入包含 time 字段，确认显示值不发生偏移。
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: remove UTC processing in time conversion for time-only fields to prevent timezone-induced shifts.|
| 🇨🇳 Chinese |修复：移除 time 字段转换中的 UTC 处理，避免因时区导致的纯时间值偏移 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
