### PR TITLE
refactor(database): use repository save method to trigger events

### DIFF
--- a/packages/core/database/src/__tests__/update-associations-source-key.test.ts
+++ b/packages/core/database/src/__tests__/update-associations-source-key.test.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Collection, Database, createMockDatabase } from '@nocobase/database';
+import { Collection, Database, createMockDatabase, updateAssociations } from '@nocobase/database';
 
 describe('update associations', () => {
   let db: Database;
@@ -236,5 +236,19 @@ describe('update associations', () => {
     const field = await Field.repository.findById('f1');
     expect(await Table.repository.count()).toBe(1);
     expect(field.table_name).toBe('tn1');
+  });
+
+  it('should throw when unique targetKey value is missing but primary key provided', async () => {
+    const table = await Table.model.create({ key: 'tk1', name: 'tn1' });
+
+    await expect(
+      updateAssociations(table, {
+        fields: [
+          {
+            key: 'fk1',
+          },
+        ],
+      }),
+    ).rejects.toThrow('name field value is empty');
   });
 });

--- a/packages/core/database/src/__tests__/update-associations.test.ts
+++ b/packages/core/database/src/__tests__/update-associations.test.ts
@@ -346,9 +346,11 @@ describe('update associations', () => {
       await User.model.create<any>({ name: 'user02' });
       const user1 = await User.model.create<any>({ name: 'user1' });
       await updateAssociations(user1, {
-        posts: {
-          name: 'post1',
-        },
+        posts: [
+          {
+            name: 'post1',
+          },
+        ],
       });
       expect(user1.toJSON()).toMatchObject({
         name: 'user1',
@@ -571,6 +573,11 @@ describe('update associations', () => {
       const comment1 = await Comment.model.findOne({
         where: { name: 'comment1' },
       });
+      const posts = await Post.model.findAll();
+      const comments = await Comment.model.findAll();
+
+      expect(posts.length).toBe(2);
+      expect(comments.length).toBe(4);
 
       expect(post1).toMatchObject({
         userId: user.get('id'),

--- a/packages/core/database/src/__tests__/update-associations.test.ts
+++ b/packages/core/database/src/__tests__/update-associations.test.ts
@@ -63,6 +63,34 @@ describe('update associations', () => {
       expect(profile1['userId']).toBe(user.id);
     });
 
+    it('should reject array payload for single association updates', async () => {
+      const User = db.collection({
+        name: 'users',
+        fields: [
+          { type: 'string', name: 'name' },
+          { type: 'hasOne', name: 'profile', foreignKey: 'userId', target: 'profiles' },
+        ],
+      });
+
+      db.collection({
+        name: 'profiles',
+        fields: [
+          { type: 'string', name: 'nickname' },
+          { type: 'belongsTo', name: 'user', foreignKey: 'userId', target: 'users' },
+        ],
+      });
+
+      await db.sync();
+
+      const user = await User.repository.create({ values: { name: 'user1' } });
+
+      await expect(
+        updateAssociations(user, {
+          profile: [],
+        }),
+      ).rejects.toThrow("The value of 'profile' cannot be in array format");
+    });
+
     it('should update has many association with foreign key', async () => {
       const User = db.collection({
         name: 'users',
@@ -103,6 +131,34 @@ describe('update associations', () => {
 
       const profile1 = await Profile.repository.findOne({ filterByTk: profile.id });
       expect(profile1['userId']).toBe(user.id);
+    });
+
+    it('should throw when hasOne source key is missing', async () => {
+      const User = db.collection({
+        name: 'users',
+        fields: [
+          { type: 'string', name: 'name' },
+          { type: 'hasOne', name: 'profile', foreignKey: 'userId', target: 'profiles' },
+        ],
+      });
+
+      db.collection({
+        name: 'profiles',
+        fields: [
+          { type: 'string', name: 'nickname' },
+          { type: 'belongsTo', name: 'user', foreignKey: 'userId', target: 'users' },
+        ],
+      });
+
+      await db.sync();
+
+      const user = User.model.build({ name: 'user-without-id' });
+
+      await expect(
+        updateAssociations(user, {
+          profile: { nickname: 'p1' },
+        }),
+      ).rejects.toThrow(/source key .* is not set/);
     });
 
     test('update belongs to with foreign key and object', async () => {
@@ -318,6 +374,52 @@ describe('update associations', () => {
     });
     afterEach(async () => {
       await db.close();
+    });
+
+    it('should clear hasMany associations when payload is empty or null', async () => {
+      const user = await User.repository.create({
+        values: {
+          name: 'user1',
+          posts: [{ name: 'p1' }, { name: 'p2' }],
+        },
+      });
+
+      await User.repository.update({
+        filterByTk: user.id,
+        values: {
+          posts: [],
+        },
+      });
+
+      let posts = await Post.repository.find();
+      expect(posts.every((post) => post.get('userId') == null)).toBe(true);
+
+      await User.repository.update({
+        filterByTk: user.id,
+        values: {
+          posts: [{ name: 'p3' }],
+        },
+      });
+
+      await User.repository.update({
+        filterByTk: user.id,
+        values: {
+          posts: null,
+        },
+      });
+
+      posts = await Post.repository.find();
+      expect(posts.every((post) => post.get('userId') == null)).toBe(true);
+    });
+
+    it('should throw when hasMany source key is missing', async () => {
+      const user = User.model.build({ name: 'ghost' });
+
+      await expect(
+        updateAssociations(user, {
+          posts: [{ name: 'orphan' }],
+        }),
+      ).rejects.toThrow(/source key .* is not set/);
     });
 
     it('should update association values', async () => {

--- a/packages/core/database/src/repository.ts
+++ b/packages/core/database/src/repository.ts
@@ -634,7 +634,7 @@ export class Repository<TModelAttributes extends {} = any, TCreationAttributes e
       const filterByTk =
         Array.isArray(filterTargetKey) && filterTargetKey.length > 1
           ? lodash.pick(instance, filterTargetKey)
-          : instance.get(filterTargetKey as string);
+          : instance.get(filterTargetKey.toString());
       return await this.update({
         filterByTk,
         values,

--- a/packages/core/database/src/repository.ts
+++ b/packages/core/database/src/repository.ts
@@ -630,8 +630,13 @@ export class Repository<TModelAttributes extends {} = any, TCreationAttributes e
     const instance = await this.findOne({ filter, transaction, context });
 
     if (instance) {
+      const filterTargetKey = this.collection.filterTargetKey ?? this.collection.model.primaryKeyAttributes;
+      const filterByTk =
+        Array.isArray(filterTargetKey) && filterTargetKey.length > 1
+          ? lodash.pick(instance, filterTargetKey)
+          : instance.get(filterTargetKey as string);
       return await this.update({
-        filterByTk: instance.get(this.collection.filterTargetKey || this.collection.model.primaryKeyAttribute),
+        filterByTk,
         values,
         transaction,
         context,

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -359,7 +359,7 @@ export async function updateSingleAssociation(
 
         const { repository, filterTargetKey } = instance.constructor['collection'];
         const filterByTk = Array.isArray(filterTargetKey)
-          ? filterTargetKey.reduce((keys, key) => (keys[key] = instance.get(key)), {})
+          ? filterTargetKey.reduce((keys, key) => { keys[key] = instance.get(key); return keys; }, {})
           : instance.get(filterTargetKey);
         await repository.update({ ...options, filterByTk, values: updateValues, transaction });
       }

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -521,7 +521,7 @@ export async function updateMultipleAssociation(
       });
 
       if (association instanceof HasMany) {
-        item[association.foreignKey] = model.get((model.constructor as ModelStatic<Model>).primaryKeyAttribute);
+        item[association.foreignKey] = model.get(association.sourceKey);
       }
       const instance = await targetCollection.repository.create({ ...accessorOptions, values: item });
       if (association instanceof BelongsToMany) {

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -520,6 +520,13 @@ export async function updateMultipleAssociation(
       });
 
       if (association instanceof HasMany) {
+        const reverseAssociation = Object.values(association.target.associations).find(
+          (association) =>
+            association.target === model.constructor && association.foreignKey === association.foreignKey,
+        );
+        if (reverseAssociation && item[reverseAssociation.as] == null) {
+          delete item[reverseAssociation.as];
+        }
         // @ts-ignore
         item[association.foreignKey] = model.get(association.sourceKey);
       }

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -628,8 +628,15 @@ export async function updateMultipleAssociation(
         const filterByTk = Array.isArray(filterTargetKey)
           ? filterTargetKey.reduce((keys, key) => (keys[key] = instance.get(key)), {})
           : instance.get(filterTargetKey);
-        await repository.update({ ...options, filterByTk, values: item, transaction });
+        await repository.update({ ...accessorOptions, filterByTk, values: item, transaction });
       }
+
+      await updateAssociations(instance, item, {
+        ...options,
+        transaction,
+        associationContext: association,
+        updateAssociationValues: keys,
+      });
 
       newItems.push(instance);
     }

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -633,7 +633,7 @@ export async function updateMultipleAssociation(
         });
         const { repository, filterTargetKey } = instance.constructor['collection'];
         const filterByTk = Array.isArray(filterTargetKey)
-          ? filterTargetKey.reduce((keys, key) => (keys[key] = instance.get(key)), {})
+          ? filterTargetKey.reduce((keys, key) => { keys[key] = instance.get(key); return keys; }, {})
           : instance.get(filterTargetKey);
         await repository.update({ ...accessorOptions, filterByTk, values: item, transaction });
       }

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -521,8 +521,8 @@ export async function updateMultipleAssociation(
 
       if (association instanceof HasMany) {
         const reverseAssociation = Object.values(association.target.associations).find(
-          (association) =>
-            association.target === model.constructor && association.foreignKey === association.foreignKey,
+          (assoc) =>
+            assoc.target === model.constructor && assoc.foreignKey === association.foreignKey,
         );
         if (reverseAssociation && item[reverseAssociation.as] == null) {
           delete item[reverseAssociation.as];

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/view/view-collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/view/view-collection.test.ts
@@ -547,7 +547,8 @@ describe('view collection', function () {
     if (!db.options.underscored) {
       return;
     }
-    const tableName = db.inDialect('postgres') ? `${process.env.DB_SCHEMA}.users` : 'users';
+    const schemaName = db.utils.schema() || process.env.DB_SCHEMA || 'public';
+    const tableName = db.inDialect('postgres') ? `${schemaName}.users` : 'users';
     const dropViewSQL = `DROP VIEW IF EXISTS test_view`;
     await db.sequelize.query(dropViewSQL);
     const viewSQL = `CREATE VIEW test_view AS select * from ${tableName}`;

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -185,14 +185,7 @@ export class PluginDataSourceMainServer extends Plugin {
 
     this.app.db.on('fields.beforeCreate', beforeCreateForValidateField(this.app.db));
 
-    const afterCreateForForeignKeyFieldHook = afterCreateForForeignKeyField(this.app.db);
-    this.app.db.on('fields.afterCreate', async (model, options) => {
-      const { context, transaction } = options;
-      if (context) {
-        await model.load({ transaction });
-        await afterCreateForForeignKeyFieldHook(model, options);
-      }
-
+    this.app.db.on('fields.afterCreate', async (model, { transaction }) => {
       const Field = this.app.db.getCollection('fields');
       const reverseKey = model.get('reverseKey');
 
@@ -291,6 +284,16 @@ export class PluginDataSourceMainServer extends Plugin {
 
       if (model.get('type') === 'hasMany' && model.get('sortable') && model.get('sortBy')) {
         await model.syncSortByField({ transaction });
+      }
+    });
+
+    const afterCreateForForeignKeyFieldHook = afterCreateForForeignKeyField(this.app.db);
+
+    this.app.db.on('fields.afterCreate', async (model: FieldModel, options) => {
+      const { context, transaction } = options;
+      if (context) {
+        await model.load({ transaction });
+        await afterCreateForForeignKeyFieldHook(model, options);
       }
     });
 

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -185,7 +185,14 @@ export class PluginDataSourceMainServer extends Plugin {
 
     this.app.db.on('fields.beforeCreate', beforeCreateForValidateField(this.app.db));
 
-    this.app.db.on('fields.afterCreate', async (model, { transaction }) => {
+    const afterCreateForForeignKeyFieldHook = afterCreateForForeignKeyField(this.app.db);
+    this.app.db.on('fields.afterCreate', async (model, options) => {
+      const { context, transaction } = options;
+      if (context) {
+        await model.load({ transaction });
+        await afterCreateForForeignKeyFieldHook(model, options);
+      }
+
       const Field = this.app.db.getCollection('fields');
       const reverseKey = model.get('reverseKey');
 
@@ -287,16 +294,6 @@ export class PluginDataSourceMainServer extends Plugin {
       }
     });
 
-    const afterCreateForForeignKeyFieldHook = afterCreateForForeignKeyField(this.app.db);
-
-    this.app.db.on('fields.afterCreate', async (model: FieldModel, options) => {
-      const { context, transaction } = options;
-      if (context) {
-        await model.load({ transaction });
-        await afterCreateForForeignKeyFieldHook(model, options);
-      }
-    });
-
     this.app.db.on('fields.afterUpdate', async (model: FieldModel, options) => {
       const { context, transaction } = options;
       if (context) {
@@ -306,28 +303,36 @@ export class PluginDataSourceMainServer extends Plugin {
 
     this.app.db.on('fields.afterSaveWithAssociations', async (model: FieldModel, options) => {
       const { context, transaction } = options;
-      if (context) {
-        const collection = this.app.db.getCollection(model.get('collectionName'));
-        const syncOptions = {
-          transaction,
-          force: false,
-          alter: {
-            drop: false,
-          },
-        };
 
-        await collection.sync(syncOptions);
-
-        this.sendSyncMessage(
-          {
-            type: 'syncCollection',
-            collectionName: model.get('collectionName'),
-          },
-          {
-            transaction,
-          },
-        );
+      if (!context) {
+        return;
       }
+
+      const collection = this.app.db.getCollection(model.get('collectionName'));
+      if (!collection) {
+        // collection 尚未 load（通常发生在批量创建集合时），由集合钩子完成同步
+        return;
+      }
+
+      const syncOptions = {
+        transaction,
+        force: false,
+        alter: {
+          drop: false,
+        },
+      };
+
+      await collection.sync(syncOptions);
+
+      this.sendSyncMessage(
+        {
+          type: 'syncCollection',
+          collectionName: model.get('collectionName'),
+        },
+        {
+          transaction,
+        },
+      );
     });
 
     // before field remove


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Adjust the core method for updating association data to support triggering workflow collection events within subforms.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjust the core method for updating association data to support triggering workflow collection events within subforms |
| 🇨🇳 Chinese | 调整内核更新关系数据的方法以支持工作流数据表事件在子表单中触发 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
