### PR TITLE
fix: remove collection context selector from ui

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/dataScope.leftMetaTree.test.tsx
+++ b/packages/core/client/src/flow/actions/__tests__/dataScope.leftMetaTree.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlowEngine, FlowModel, FlowSettingsContextProvider } from '@nocobase/flow-engine';
+import { dataScope } from '../dataScope';
+import { Application } from '../../../application/Application';
+import { CollectionFieldInterface } from '../../../data-source/collection-field-interface/CollectionFieldInterface';
+
+// Mock VariableInput used inside VariableFilterItem
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<any>('@nocobase/flow-engine');
+  const MockVariableInput = ({ onChange }: any) => (
+    <button
+      type="button"
+      data-testid="variable-input"
+      onClick={() =>
+        onChange?.(
+          (globalThis as any).__TEST_PATH__ || 'title',
+          (globalThis as any).__TEST_META__ || {
+            interface: 'input',
+            uiSchema: { 'x-component': 'Input', 'x-component-props': { placeholder: 'Enter value' } },
+            paths: ['collection', 'title'],
+          },
+        )
+      }
+    >
+      mock-variable-input
+    </button>
+  );
+  return { ...actual, VariableInput: MockVariableInput };
+});
+
+function createContextWithCollection() {
+  const engine = new FlowEngine();
+  const model = new FlowModel({ uid: 'm-data-scope', flowEngine: engine });
+  const app = new Application({});
+  model.context.defineProperty('app', { value: app });
+  class InputInterface extends CollectionFieldInterface {
+    name = 'input';
+    group = 'basic';
+    filterable = {
+      operators: [
+        { value: '$eq', label: 'Equals' },
+        { value: '$null', label: 'Is null', noValue: true },
+      ],
+    };
+  }
+  app.addFieldInterfaces([InputInterface]);
+
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'posts',
+    fields: [
+      { name: 'title', type: 'string', interface: 'input', uiSchema: { 'x-component': 'Input' } },
+      { name: 'published', type: 'boolean', interface: 'switch', uiSchema: { 'x-component': 'Switch' } },
+    ],
+  });
+  model.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+
+  return { engine, model } as const;
+}
+
+describe('dataScope action with leftMetaTree', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as any).__TEST_PATH__ = undefined;
+    (globalThis as any).__TEST_META__ = undefined;
+  });
+
+  function renderAction(value: any, model: any) {
+    const Comp: any = (dataScope as any).uiSchema.filter['x-component'];
+    return render(
+      <FlowSettingsContextProvider value={model.context}>
+        <Comp value={value} />
+      </FlowSettingsContextProvider>,
+    );
+  }
+
+  it('renders FilterGroup and variable inputs', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(value, model);
+    // at least one variable input button (left; right may also present)
+    expect(await screen.findAllByTestId('variable-input')).toBeTruthy();
+  });
+
+  it('left selection updates path (slice without collection prefix)', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(value, model);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    expect(value.items[0].path).toBe('title');
+  });
+
+  it('rightAsVariable renders right input and noValue hides it (smoke)', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(value, model);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    // now with rightAsVariable in action, there are 2 variable-inputs
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(2);
+    // set operator to noValue and rerender
+    value.items[0].operator = '$null';
+    renderAction(value, model);
+    // at least left remains (mock is smoke-tested only)
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('FilterGroup toggles logic via select', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [] };
+    renderAction(value, model);
+    const select = await screen.findByTestId('filter-select-all-or-any');
+    // AntD mocking: directly call onChange via fireEvent is hard; just mutate value to simulate and rerender
+    value.logic = '$or';
+    renderAction(value, model);
+    expect(value.logic).toBe('$or');
+  });
+
+  it('add condition works', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [] };
+    renderAction(value, model);
+    fireEvent.click(screen.getByText('Add condition'));
+    expect(value.items.length).toBe(1);
+  });
+
+  it('add group works', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [] };
+    renderAction(value, model);
+    fireEvent.click(screen.getByText('Add condition group'));
+    expect(value.items.length).toBe(1);
+    expect(value.items[0].logic).toBe('$and');
+  });
+
+  it('remove condition button exists and clickable (smoke)', async () => {
+    const { model } = createContextWithCollection();
+    const value = {
+      logic: '$and',
+      items: [
+        { path: '', operator: '', value: '' },
+        { path: '', operator: '', value: '' },
+      ],
+    };
+    renderAction(value, model);
+    const close = await screen.findAllByLabelText('icon-close');
+    expect(close.length).toBeGreaterThan(0);
+    fireEvent.click(close[close.length - 1]);
+    expect(close.length).toBeGreaterThan(0);
+  });
+
+  it('right constant mapping does not crash (smoke)', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [{ path: '', operator: '$eq', value: 'x' }] };
+    renderAction(value, model);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]); // left
+    (globalThis as any).__TEST_META__ = { paths: ['constant'] };
+    fireEvent.click(screen.getAllByTestId('variable-input')[1]); // right
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('right null mapping does not crash (smoke)', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [{ path: '', operator: '$eq', value: 'x' }] };
+    renderAction(value, model);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]); // left
+    (globalThis as any).__TEST_META__ = { paths: ['null'] };
+    fireEvent.click(screen.getAllByTestId('variable-input')[1]); // right
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('works without global collection meta at root', async () => {
+    const { model } = createContextWithCollection();
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    // ensure root meta tree has no collection node
+    const root = model.context.getPropertyMetaTree();
+    const rootNodes = Array.isArray(root) ? root : await (root as any)();
+    expect(rootNodes.map((n) => n.name)).not.toContain('collection');
+    renderAction(value, model);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    expect(value.items[0].path).toBe('title');
+  });
+});

--- a/packages/core/client/src/flow/actions/__tests__/setTargetDataScope.leftMetaTree.test.tsx
+++ b/packages/core/client/src/flow/actions/__tests__/setTargetDataScope.leftMetaTree.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlowEngine, FlowModel, FlowSettingsContextProvider } from '@nocobase/flow-engine';
+import { setTargetDataScope } from '../setTargetDataScope';
+import { Application } from '../../../application/Application';
+import { CollectionFieldInterface } from '../../../data-source/collection-field-interface/CollectionFieldInterface';
+
+// Mock VariableInput used inside VariableFilterItem and left field selector
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<any>('@nocobase/flow-engine');
+  const MockVariableInput = ({ onChange }: any) => (
+    <button
+      type="button"
+      data-testid="variable-input"
+      onClick={() =>
+        onChange?.(
+          (globalThis as any).__TEST_PATH__ || 'title',
+          (globalThis as any).__TEST_META__ || {
+            interface: 'input',
+            uiSchema: { 'x-component': 'Input', 'x-component-props': { placeholder: 'Enter value' } },
+            paths: ['collection', (globalThis as any).__TEST_PATH__ || 'title'],
+          },
+        )
+      }
+    >
+      mock-variable-input
+    </button>
+  );
+  return { ...actual, VariableInput: MockVariableInput };
+});
+
+function createEngineWithCollections() {
+  const engine = new FlowEngine();
+  const app = new Application({});
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'posts',
+    fields: [
+      { name: 'title', type: 'string', interface: 'input', uiSchema: { 'x-component': 'Input' } },
+      { name: 'published', type: 'boolean', interface: 'switch', uiSchema: { 'x-component': 'Switch' } },
+    ],
+  });
+  return { engine, app } as const;
+}
+
+function registerFieldInterface(app: Application) {
+  class InputInterface extends CollectionFieldInterface {
+    name = 'input';
+    group = 'basic';
+    filterable = {
+      operators: [
+        { value: '$eq', label: 'Equals' },
+        { value: '$null', label: 'Is null', noValue: true },
+      ],
+    };
+  }
+  app.addFieldInterfaces([InputInterface]);
+}
+
+describe('setTargetDataScope with leftMetaTree', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as any).__TEST_PATH__ = undefined;
+    (globalThis as any).__TEST_META__ = undefined;
+  });
+
+  function renderAction(ctxModel: FlowModel, targetUid: string, value: any) {
+    const Comp: any = (setTargetDataScope as any).uiSchema.filter['x-component'];
+    return render(
+      <FlowSettingsContextProvider value={ctxModel.context}>
+        <Comp value={value} uid={targetUid} />
+      </FlowSettingsContextProvider>,
+    );
+  }
+
+  it('shows warning when target model not found', async () => {
+    const { engine, app } = createEngineWithCollections();
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-1', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    ctxModel.context.defineProperty('themeToken', { value: { colorError: '#f00' } });
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(ctxModel, 'non-exist', value);
+    expect(screen.getByText(/Cannot find the model instance with UID/i)).toBeTruthy();
+  });
+
+  it('renders FilterGroup when target model exists', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-2', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-1', use: FlowModel });
+    // inject collection getter on target
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(ctxModel, target.uid, value);
+    expect(await screen.findAllByTestId('variable-input')).toBeTruthy();
+  });
+
+  it('left selection updates path (no collection prefix)', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-3', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-2', use: FlowModel });
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(ctxModel, target.uid, value);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    expect(value.items[0].path).toBe('title');
+  });
+
+  it('rightAsVariable shows RHS then hides for noValue operator', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-4', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-3', use: FlowModel });
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(ctxModel, target.uid, value);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(2);
+    value.items[0].operator = '$null';
+    renderAction(ctxModel, target.uid, value);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('RHS constant mapping sets empty string', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-5', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-4', use: FlowModel });
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    const value = { logic: '$and', items: [{ path: '', operator: '$eq', value: 'x' }] };
+    renderAction(ctxModel, target.uid, value);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    (globalThis as any).__TEST_META__ = { paths: ['constant'] };
+    fireEvent.click(screen.getAllByTestId('variable-input')[1]);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('RHS null mapping sets null', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-6', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-5', use: FlowModel });
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    const value = { logic: '$and', items: [{ path: '', operator: '$eq', value: 'x' }] };
+    renderAction(ctxModel, target.uid, value);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    (globalThis as any).__TEST_META__ = { paths: ['null'] };
+    fireEvent.click(screen.getAllByTestId('variable-input')[1]);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('root meta tree does not contain collection globally', async () => {
+    const { engine, app } = createEngineWithCollections();
+    const ctxModel = new FlowModel({ uid: 'ctx-7', flowEngine: engine });
+    ctxModel.context.defineProperty('app', { value: app });
+    const root = ctxModel.context.getPropertyMetaTree();
+    const nodes = Array.isArray(root) ? root : await (root as any)();
+    expect(nodes.map((n) => n.name)).not.toContain('collection');
+  });
+
+  it('child operator via x-filter-operators preferred', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-8', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-6', use: FlowModel });
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    (globalThis as any).__TEST_PATH__ = 'containsText';
+    (globalThis as any).__TEST_META__ = {
+      interface: 'input',
+      uiSchema: { 'x-component': 'Input', 'x-filter-operators': [{ value: '$includes', label: 'contains' }] },
+      paths: ['collection', 'containsText'],
+    };
+    const value = { logic: '$and', items: [{ path: '', operator: '', value: '' }] };
+    renderAction(ctxModel, target.uid, value);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    value.items[0].operator = '$includes';
+    renderAction(ctxModel, target.uid, value);
+    expect(value.items[0].operator).toBe('$includes');
+  });
+
+  it('works across re-renders with same target', async () => {
+    const { engine, app } = createEngineWithCollections();
+    registerFieldInterface(app);
+    const ctxModel = engine.createModel<FlowModel>({ uid: 'ctx-9', use: FlowModel });
+    ctxModel.context.defineProperty('app', { value: app });
+    const target = engine.createModel<FlowModel>({ uid: 'target-7', use: FlowModel });
+    const ds = engine.dataSourceManager.getDataSource('main');
+    target.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+    target.context.defineProperty('app', { value: app });
+    const value = { logic: '$and', items: [{ path: '', operator: '$eq', value: '' }] };
+    const view = renderAction(ctxModel, target.uid, value);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    expect(value.items[0].path).toBe('title');
+    renderAction(ctxModel, target.uid, value);
+    expect(value.items[0].path).toBe('title');
+  });
+});

--- a/packages/core/client/src/flow/components/filter/__tests__/VariableFilterItem.leftMetaTree.test.tsx
+++ b/packages/core/client/src/flow/components/filter/__tests__/VariableFilterItem.leftMetaTree.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VariableFilterItem } from '../VariableFilterItem';
+import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import { Application } from '../../../../application/Application';
+import { CollectionFieldInterface } from '../../../../data-source/collection-field-interface/CollectionFieldInterface';
+
+// Mock VariableInput same as the base spec
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<any>('@nocobase/flow-engine');
+  const MockVariableInput = ({ onChange }: any) => (
+    <button
+      type="button"
+      data-testid="variable-input"
+      onClick={() =>
+        onChange?.(
+          (globalThis as any).__TEST_PATH__ || 'title',
+          (globalThis as any).__TEST_META__ || {
+            interface: 'input',
+            uiSchema: { 'x-component': 'Input', 'x-component-props': { placeholder: 'Enter value' } },
+            paths: ['collection', 'title'],
+          },
+        )
+      }
+    >
+      mock-variable-input
+    </button>
+  );
+  return { ...actual, VariableInput: MockVariableInput };
+});
+
+function createModelWithCollection() {
+  const engine = new FlowEngine();
+  const model = new FlowModel({ uid: 'm-variable-filter-left', flowEngine: engine });
+  const app = new Application({});
+  model.context.defineProperty('app', { value: app });
+
+  // Register a minimal 'input' interface with operators used in tests
+  class InputInterface extends CollectionFieldInterface {
+    name = 'input';
+    group = 'basic';
+    filterable = {
+      operators: [
+        { value: '$eq', label: 'Equals' },
+        { value: '$null', label: 'Is null', noValue: true },
+      ],
+      children: [
+        {
+          name: 'containsText',
+          title: 'Contains text',
+          schema: { 'x-component': 'Input' },
+          operators: [{ value: '$includes', label: 'contains' }],
+        },
+      ],
+    };
+  }
+  app.addFieldInterfaces([InputInterface]);
+
+  // prepare collection without injecting meta globally
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'posts',
+    fields: [
+      { name: 'title', type: 'string', interface: 'input', uiSchema: { 'x-component': 'Input' } },
+      { name: 'status', type: 'string', interface: 'select', uiSchema: { 'x-component': 'Select' } },
+    ],
+  });
+  model.context.defineProperty('collection', { get: () => ds.getCollection('posts') });
+
+  return model as any;
+}
+
+describe('VariableFilterItem with leftMetaTree', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as any).__TEST_PATH__ = undefined;
+    (globalThis as any).__TEST_META__ = undefined;
+  });
+
+  it('resolves field path from collection (implicit left tree)', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+
+    fireEvent.click(screen.getByTestId('variable-input'));
+    // meta.paths=['collection','title'] -> value.path becomes 'title'
+    expect(value.path).toBe('title');
+  });
+
+  it('noValue operator hides RHS VariableInput (smoke)', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+    const view = render(<VariableFilterItem value={value} model={model} rightAsVariable />);
+
+    // choose left -> RHS appears
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(2);
+
+    // set operator to noValue and re-render -> RHS should disappear (only left remains)
+    value.operator = '$null';
+    view.rerender(<VariableFilterItem value={value} model={model} rightAsVariable />);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('prefers child operators injected via x-filter-operators when child field selected', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+
+    (globalThis as any).__TEST_PATH__ = 'containsText';
+    (globalThis as any).__TEST_META__ = {
+      interface: 'input',
+      uiSchema: { 'x-component': 'Input', 'x-filter-operators': [{ value: '$includes', label: 'contains' }] },
+      paths: ['collection', 'containsText'],
+    };
+
+    const { rerender } = render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+    value.operator = '$includes';
+    rerender(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    expect(value.operator).toBe('$includes');
+  });
+
+  it('renders right VariableInput when rightAsVariable=true', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} rightAsVariable />);
+    fireEvent.click(screen.getAllByTestId('variable-input')[0]);
+    // left + right inputs
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('right constant mapping does not crash (smoke)', async () => {
+    const value = { path: '', operator: '$eq', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} rightAsVariable />);
+    // right variable input select constant root
+    (globalThis as any).__TEST_META__ = { paths: ['constant'] };
+    fireEvent.click(screen.getAllByTestId('variable-input')[1]);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('right null mapping does not crash (smoke)', async () => {
+    const value = { path: '', operator: '$eq', value: 'x' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} rightAsVariable />);
+    (globalThis as any).__TEST_META__ = { paths: ['null'] };
+    fireEvent.click(screen.getAllByTestId('variable-input')[1]);
+    expect(screen.getAllByTestId('variable-input').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('default operator options are translated from interface operators', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+    // default interface has $eq and $null; selecting field will populate options
+    value.operator = '$eq';
+    render(<VariableFilterItem value={value} model={model} />);
+    expect(value.operator).toBe('$eq');
+  });
+
+  it('merges schema from field and operator for RHS rendering without errors', async () => {
+    const value = { path: '', operator: '$eq', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+    // RHS should render an input without crash
+    const input = await screen.findByPlaceholderText('Enter value');
+    expect(input).toBeTruthy();
+  });
+
+  it('keeps selection to leafs only (simulated by mock)', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+    expect(typeof value.path).toBe('string');
+  });
+
+  it('still updates path even without providing leftMetaTree (mocked VariableInput bypasses tree)', async () => {
+    const value = { path: '', operator: '', value: '' } as any;
+    const model = createModelWithCollection();
+    render(<VariableFilterItem value={value} model={model} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+    expect(value.path).toBe('title');
+  });
+});

--- a/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
+++ b/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
@@ -11,7 +11,6 @@ import {
   buildSubModelItems,
   Collection,
   CollectionField,
-  createCollectionContextMeta,
   DataSource,
   DefaultStructure,
   escapeT,
@@ -288,10 +287,6 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
         const params = this.getResourceSettingsInitParams();
         return this.context.dataSourceManager.getCollection(params.dataSourceKey, params.collectionName);
       },
-      meta: createCollectionContextMeta(() => {
-        const params = this.getResourceSettingsInitParams();
-        return this.context.dataSourceManager.getCollection(params.dataSourceKey, params.collectionName);
-      }, this.context.t('Current collection')),
     });
     this.context.defineProperty('resource', {
       get: () => {

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
@@ -9,7 +9,6 @@
 
 import {
   CollectionField,
-  createCollectionContextMeta,
   EditableItemModel,
   escapeT,
   FlowModel,
@@ -134,10 +133,6 @@ export class RecordPickerFieldModel extends FieldModel {
     // For association fields, expose target collection to variable selectors
     this.context.defineProperty('collection', {
       get: () => this.context.collectionField?.targetCollection,
-      meta: createCollectionContextMeta(
-        () => this.context.collectionField?.targetCollection,
-        this.context.t('Current collection'),
-      ),
     });
   }
   protected onMount(): void {

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -8,7 +8,6 @@
  */
 import {
   CollectionField,
-  createCollectionContextMeta,
   createCurrentRecordMetaFactory,
   EditableItemModel,
   escapeT,
@@ -127,10 +126,6 @@ export class RecordSelectFieldModel extends AssociationFieldModel {
     // For association fields, expose target collection to variable selectors
     this.context.defineProperty('collection', {
       get: () => this.context.collectionField?.targetCollection,
-      meta: createCollectionContextMeta(
-        () => this.context.collectionField?.targetCollection,
-        this.context.t('Current collection'),
-      ),
     });
   }
 

--- a/packages/core/flow-engine/src/utils/index.ts
+++ b/packages/core/flow-engine/src/utils/index.ts
@@ -63,6 +63,9 @@ export { buildSettingsViewInputArgs } from './buildSettingsViewInputArgs';
 // 安全全局对象（window/document）
 export { createSafeDocument, createSafeWindow, createSafeNavigator } from './safeGlobals';
 
+// Ephemeral context helper（用于临时注入属性/方法，避免污染父级 ctx）
+export { createEphemeralContext } from './createEphemeralContext';
+
 // Filter helpers
 export { pruneFilter } from './pruneFilter';
 export { isBeforeRenderFlow } from './flows';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | current collection variable should not be selectable from filter component's variable selector |
| 🇨🇳 Chinese | 当前数据表变量不应该可以从筛选组件的变量选择器中被选择 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
