### PR TITLE
fix(plugin-workflow): serving check

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -72,10 +72,6 @@ export default class Dispatcher {
     this.ready = ready;
   }
 
-  private serving() {
-    return this.plugin.app.serving(WORKER_JOB_WORKFLOW_PROCESS);
-  }
-
   public getEventsCount() {
     return this.eventsCount;
   }
@@ -185,7 +181,7 @@ export default class Dispatcher {
           this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
         }
       } else {
-        if (this.serving()) {
+        if (this.plugin.serving()) {
           execution = await this.acquireQueueingExecution();
           if (execution) {
             next = [execution];
@@ -352,7 +348,7 @@ export default class Dispatcher {
       const execution = await this.createExecution(...event);
       // NOTE: cache first execution for most cases
       if (!execution?.dispatched) {
-        if (this.serving() && !this.executing && !this.pending.length) {
+        if (this.plugin.serving() && !this.executing && !this.pending.length) {
           logger.info(`local pending list is empty, adding execution (${execution.id}) to pending list`);
           this.pending.push({ execution });
         } else {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -213,6 +213,10 @@ export default class PluginWorkflowServer extends Plugin {
     }
   }
 
+  public serving() {
+    return this.app.serving(WORKER_JOB_WORKFLOW_PROCESS);
+  }
+
   /**
    * @experimental
    */
@@ -305,11 +309,6 @@ export default class PluginWorkflowServer extends Plugin {
     this.snowflake = new Snowflake({
       custom_epoch: pluginRecord?.createdAt.getTime(),
     });
-
-    this.app.backgroundJobManager.subscribe(`${this.name}.pendingExecution`, {
-      idle: () => this.app.serving(WORKER_JOB_WORKFLOW_PROCESS) && this.dispatcher.idle,
-      process: this.dispatcher.onQueueExecution,
-    });
   }
 
   /**
@@ -377,6 +376,13 @@ export default class PluginWorkflowServer extends Plugin {
 
     this.app.on('afterStart', this.onAfterStart);
     this.app.on('beforeStop', this.onBeforeStop);
+
+    if (this.serving()) {
+      this.app.backgroundJobManager.subscribe(`${this.name}.pendingExecution`, {
+        idle: () => this.dispatcher.idle,
+        process: this.dispatcher.onQueueExecution,
+      });
+    }
   }
 
   private toggle(


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where the workflow plugin still consumes the queue event when it is not in worker mode under the service splitting mode.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the workflow plugin still consumes the queue event when it is not in worker mode under the service splitting mode |
| 🇨🇳 Chinese | 修复服务拆分模式下，工作流插件不处于服务模式时仍然消费队列的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
