### PR TITLE
fix: toggle action support for filterByTks parameter

### DIFF
--- a/packages/core/actions/src/actions/toggle.ts
+++ b/packages/core/actions/src/actions/toggle.ts
@@ -18,7 +18,9 @@ export async function toggle(ctx: Context, next) {
     return await next();
   }
 
-  await (<BelongsToManyRepository>repository).toggle(ctx.action.params.values);
+  const filterByTk = ctx.action.params.filterByTk || ctx.action.params.filterByTks || ctx.action.params.values;
+
+  await (<BelongsToManyRepository>repository).toggle(filterByTk);
   ctx.body = 'ok';
   await next();
 }

--- a/packages/core/database/src/relation-repository/belongs-to-many-repository.ts
+++ b/packages/core/database/src/relation-repository/belongs-to-many-repository.ts
@@ -179,7 +179,7 @@ export class BelongsToManyRepository extends MultipleRelationRepository {
     const transaction = await this.getTransaction(options);
     const sourceModel = await this.getSourceModel(transaction);
 
-    const has = await sourceModel[this.accessors().hasSingle](options['tk'], {
+    const has = await sourceModel[this.accessors().hasSingle](this.convertTks(options), {
       transaction,
     });
 

--- a/packages/core/server/src/swagger/index.json
+++ b/packages/core/server/src/swagger/index.json
@@ -92,7 +92,7 @@
         "in": "query",
         "description": "filter by TK(default by ID)",
         "schema": {
-          "type": "string"
+          "type": "integer"
         }
       },
       "filterByTks": {
@@ -100,7 +100,10 @@
         "in": "query",
         "description": "filter by TKs(default by ID), example: `1,2,3`",
         "schema": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
         }
       },
       "filter": {

--- a/packages/plugins/@nocobase/plugin-api-doc/src/server/swagger/collections/components/parameters.ts
+++ b/packages/plugins/@nocobase/plugin-api-doc/src/server/swagger/collections/components/parameters.ts
@@ -37,7 +37,7 @@ export default (collection: Collection) => {
       },
 
       filterByTks: {
-        name: 'filterByTk',
+        name: 'filterByTks',
         in: 'query',
         description: 'filter by TKs(default by ID), example: `1,2,3`',
         schema: {


### PR DESCRIPTION
**Overview**
This PR fixes issue #7823 by updating the toggle action to properly handle the `filterByTks` parameter. The changes ensure that the toggle functionality works correctly when multiple primary keys are provided, and updates the API documentation accordingly.

**Checklist**
- [x] Code changes implemented
- [x] API documentation updated
- [x] Swagger schema updated

**Proof**
The fix has been implemented in the toggle action to handle both `filterByTk` and `filterByTks` parameters, ensuring that the toggle functionality works as expected. The API documentation has been updated to reflect the correct parameter types for `filterByTk` (integer) and `filterByTks` (array of integers). The component parameter name has been corrected from `filterByTk` to `filterByTks` in the API documentation plugin.

**Closes** #7823