### PR TITLE
fix(plugin-field-markdown-vditor): prevent autoscroll when field doesn't end with newline (#7819)

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Edit.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Edit.tsx
@@ -72,7 +72,20 @@ export const Edit = withDynamicSchemaProps((props) => {
       after: () => {
         vdRef.current = vditor;
         setEditorReady(true); // Notify that the editor is ready
+        
+        // Save scroll positions before setting initial value to prevent unwanted autoscroll
+        // This is especially important when adding empty fields or fields without '\n' at the end
+        const savedScrollX = window.scrollX || window.pageXOffset;
+        const savedScrollY = window.scrollY || window.pageYOffset;
+        
         vditor.setValue(value ?? '');
+        
+        // Restore scroll position to prevent autoscroll during initialization
+        // This fixes the issue where fields without '\n' at the end cause unwanted scrolling
+        requestAnimationFrame(() => {
+          window.scrollTo(savedScrollX, savedScrollY);
+        });
+        
         if (disabled) {
           vditor.disabled();
         } else {
@@ -155,13 +168,31 @@ export const Edit = withDynamicSchemaProps((props) => {
     if (editorReady && vdRef.current) {
       const editor = vdRef.current;
       if (value !== editor.getValue()) {
+        // Save scroll positions before setting value to prevent unwanted autoscroll
+        // This fixes the issue where fields without '\n' at the end cause unwanted scrolling
+        const savedScrollX = window.scrollX || window.pageXOffset;
+        const savedScrollY = window.scrollY || window.pageYOffset;
+        
         editor.setValue(value ?? '');
         // editor.focus();
 
+        // Query for preArea after setValue as DOM may have been updated by vditor
         const preArea = containerRef.current?.querySelector(
           'div.vditor-content > div.vditor-ir > pre',
         ) as HTMLPreElement;
-        if (preArea) {
+        
+        // Check if the editor is currently focused
+        // Only set cursor position if user is actively editing to avoid unwanted scroll
+        const vditorContent = containerRef.current?.querySelector('.vditor-content');
+        const isEditorFocused = preArea && (
+          document.activeElement === preArea || 
+          preArea.contains(document.activeElement) ||
+          (document.activeElement as HTMLElement)?.closest?.('.vditor-content') === vditorContent
+        );
+        
+        if (preArea && isEditorFocused) {
+          // User is actively editing - set cursor position at the end
+          // We don't prevent scroll here as the user is actively interacting with the field
           const range = document.createRange();
           const selection = window.getSelection();
           if (selection) {
@@ -170,6 +201,16 @@ export const Edit = withDynamicSchemaProps((props) => {
             selection.removeAllRanges();
             selection.addRange(range);
           }
+        }
+        // If editor is not focused, don't set selection to avoid unwanted autoscroll
+        
+        // Restore scroll position if field was not focused to prevent autoscroll
+        // This is crucial for fields without '\n' at the end which may trigger scroll
+        if (!isEditorFocused) {
+          // Use requestAnimationFrame to ensure DOM updates are complete before restoring scroll
+          requestAnimationFrame(() => {
+            window.scrollTo(savedScrollX, savedScrollY);
+          });
         }
       }
     }


### PR DESCRIPTION
## Description

Fixes #7819

This PR fixes an issue where markdown (vditor) fields without a `\n` symbol at the end would automatically scroll the page to that field. This behavior occurred for both empty and non-empty fields when they were added to an edit block.

## Problem

When a markdown vditor field was initialized or its value was updated programmatically, the code would set the cursor selection to the end of the content. This programmatic selection change caused the browser to automatically scroll to the field, which was particularly noticeable for fields without a trailing newline character.

## Solution

1. **Focus-aware selection**: Only set the cursor position when the editor is actively focused by the user
2. **Scroll position restoration**: Save and restore scroll position after `setValue()` when the field is not focused
3. **Initialization handling**: Prevent autoscroll during editor initialization in the `after` callback

## Changes

- Modified `Edit.tsx` to check if editor is focused before setting selection
- Added scroll position save/restore logic to prevent unwanted scrolling
- Applied fix to both initialization (`after` callback) and value update scenarios

## Testing

- [x] Verified empty markdown fields no longer cause autoscroll
- [x] Verified fields without trailing `\n` no longer cause autoscroll  
- [x] Verified fields with trailing `\n` still work correctly
- [x] Verified normal editing behavior is preserved when field is focused
- [x] Tested in both Firefox and Chrome browsers

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have tested this fix in both Firefox and Chrome