### PR TITLE
fix: incorrect dark theme for plugins docs index page

### DIFF
--- a/docs/theme/components/PluginCard.tsx
+++ b/docs/theme/components/PluginCard.tsx
@@ -87,10 +87,10 @@ export const PluginCard: React.FC<PluginCardProps> = ({
   const navigate = useNavigate();
   const cardStyle: React.CSSProperties = {
     border: '1px solid transparent',
-    borderRadius: '6px',
+    borderRadius: '12px',
     padding: '2rem',
-    background: '#fff',
-    boxShadow: '0 0.25rem 0.5rem rgba(0,0,0,0.1)',
+    background: 'var(--rp-home-feature-bg)',
+    boxShadow: 'none',
     transition: 'all 0.3s',
     display: 'inline-block',
     verticalAlign: 'top',
@@ -106,9 +106,9 @@ export const PluginCard: React.FC<PluginCardProps> = ({
         if (detailLink) {
           navigate(detailLink);
         }
-      }} className="rp-plugin-card rp-home-feature__card--clickable" style={cardStyle} data-plugin-card={float ? 'float' : 'full'}>
+      }} className="rp-plugin-card rp-home-feature__card rp-home-feature__card--clickable" style={cardStyle} data-plugin-card={float ? 'float' : 'full'}>
         <div style={{ marginTop: '0.5rem', flexGrow: 1 }}>
-          <h6 style={{ margin: '0 0 0.25rem 0', fontSize: '16px', fontWeight: 600, color: '#262626' }}>
+          <h6 style={{ margin: '0 0 0.25rem 0', fontSize: '16px', fontWeight: 600, color: 'var(--rp-c-text-1)' }}>
             {name}
             {/* {' '}
             {supportedVersions.length === 1 && supportedVersions[0] === '2.x' && (
@@ -119,14 +119,15 @@ export const PluginCard: React.FC<PluginCardProps> = ({
           </h6>
           <div
             style={{
-              fontSize: '14px', color: '#8c8c8c',
+              fontSize: '14px',
+              color: 'var(--rp-c-text-2)',
               marginBottom: '0.75rem',
               paddingBottom: '0.75rem',
               // borderBottom: '1px solid #f0f0f0'
             }}>
             By <span>{developer}</span>
           </div>
-          <p style={{ minHeight: '4em', margin: '0 0 0.5rem 0', fontSize: '14px', color: '#8c8c8c', lineHeight: 1.4 }}>
+          <p style={{ minHeight: '4em', margin: '0 0 0.5rem 0', fontSize: '14px', color: 'var(--rp-c-text-2)', lineHeight: 1.4 }}>
             {description}
           </p>
         </div>
@@ -161,28 +162,28 @@ export const PluginCard: React.FC<PluginCardProps> = ({
           <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '1rem' }}>
             {pricing.plan1 && (
               <h6 style={{ margin: 0, color: '#2f55d4', fontSize: '14px' }}>
-                <span style={{ fontWeight: 'normal', fontStyle: 'italic', fontSize: '12px', color: '#8c8c8c' }}>
+                <span style={{ fontWeight: 'normal', fontStyle: 'italic', fontSize: '12px', color: 'var(--rp-c-text-2)' }}>
                   {pricing.plan1.label}
                 </span>
                 <br />
                 <a href="/cn/plugins-bundles" style={{ color: '#2f55d4', textDecoration: 'none' }}>
                   {pricing.plan1.points} <i className="uil uil-moon-eclipse" style={{ marginRight: '4px' }}></i>
                 </a>
-                <span style={{ color: '#8c8c8c' }}>/</span>
-                <span style={{ color: '#8c8c8c' }}>{lang === 'cn' ? '￥' : '$'}{pricing.plan1.price.toLocaleString('en-US')}</span>
+                <span style={{ color: 'var(--rp-c-text-2)' }}>/</span>
+                <span style={{ color: 'var(--rp-c-text-2)' }}>{lang === 'cn' ? '￥' : '$'}{pricing.plan1.price.toLocaleString('en-US')}</span>
               </h6>
             )}
             {pricing.plan2 && (
-              <h6 style={{ margin: '0 0 0 8px', fontWeight: 'normal', color: '#8c8c8c', fontSize: '14px' }}>
-                <span style={{ fontWeight: 'normal', fontStyle: 'italic', fontSize: '12px', color: '#8c8c8c' }}>
+              <h6 style={{ margin: '0 0 0 8px', fontWeight: 'normal', color: 'var(--rp-c-text-2)', fontSize: '14px' }}>
+                <span style={{ fontWeight: 'normal', fontStyle: 'italic', fontSize: '12px', color: 'var(--rp-c-text-2)' }}>
                   {pricing.plan2.label}
                 </span>
                 <br />
-                <a href="/cn/plugins-bundles" style={{ color: '#8c8c8c', textDecoration: 'none' }}>
+                <a href="/cn/plugins-bundles" style={{ color: 'var(--rp-c-text-2)', textDecoration: 'none' }}>
                   {pricing.plan2.points} <i className="uil uil-moon-eclipse" style={{ marginRight: '4px' }}></i>
                 </a>
-                <span style={{ color: '#8c8c8c' }}>/</span>
-                <span style={{ color: '#8c8c8c' }}>{lang === 'cn' ? '￥' : '$'}{pricing.plan2.price.toLocaleString('en-US')}</span>
+                <span style={{ color: 'var(--rp-c-text-2)' }}>/</span>
+                <span style={{ color: 'var(--rp-c-text-2)' }}>{lang === 'cn' ? '￥' : '$'}{pricing.plan2.price.toLocaleString('en-US')}</span>
               </h6>
             )}
           </div>

--- a/docs/theme/index.scss
+++ b/docs/theme/index.scss
@@ -17,6 +17,7 @@ html:not(.rp-dark) {
   --rp-code-block-bg: #f6f8fa;
   --rp-code-copy-code-hover-bg: #ffffff0d;
   --rp-code-wrap-code-hover-bg: #ffffff0d;
+  --rp-home-feature-bg: var(--rp-c-bg-soft);
   /* Completely disable gradient on hero title */
   --rp-home-hero-name-background: none;
   --rp-home-hero-name-color: #2e3440;
@@ -29,6 +30,7 @@ html.rp-dark {
   --rp-code-block-bg: #242424;
   --rp-code-copy-code-hover-bg: #ffffff0d;
   --rp-code-wrap-code-hover-bg: #ffffff0d;
+  --rp-home-feature-bg: var(--rp-c-bg-soft);
   /* Completely disable gradient on hero title */
   --rp-home-hero-name-background: none;
   --rp-home-hero-name-color: #e5e7eb;
@@ -430,7 +432,7 @@ h1[class*="rp-text"] {
   &__card {
     height: 100%;
     padding: 2rem;
-    border-radius: 0.375rem;
+    border-radius: 0.75rem; /* 12px */
     border: 1px solid transparent;
     background: var(--rp-home-feature-bg);
     transition: all 0.3s;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue of incorrect styling on the plugin documentation homepage in dark mode. |
| 🇨🇳 Chinese | 修复暗黑模式下的插件文档首页样式不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
