### PR TITLE
fix(multi-app-manager): send sync message after sub app stopped

### DIFF
--- a/packages/core/server/src/gateway/errors.ts
+++ b/packages/core/server/src/gateway/errors.ts
@@ -34,7 +34,7 @@ export const errors: AppErrors = {
   APP_ERROR: {
     status: 503,
     message: ({ app }) => {
-      const error = AppSupervisor.getInstance().appErrors[app.name];
+      const error = AppSupervisor.getInstance().appErrors[app?.name];
       if (!error) {
         return '';
       }
@@ -49,7 +49,7 @@ export const errors: AppErrors = {
     },
 
     code: ({ app }): string => {
-      const error = AppSupervisor.getInstance().appErrors[app.name];
+      const error = AppSupervisor.getInstance().appErrors[app?.name];
       return error['code'] || 'APP_ERROR';
     },
     command: ({ app }) => app.getMaintaining().command,
@@ -110,7 +110,7 @@ export const errors: AppErrors = {
   APP_RUNNING: {
     status: 200,
     maintaining: false,
-    message: ({ message, app }) => message || `application ${app.name} is running`,
+    message: ({ message, app }) => message || `application ${app?.name} is running`,
   },
 
   UNKNOWN_ERROR: {

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/server/server.ts
@@ -191,6 +191,11 @@ export class PluginMultiAppManagerServer extends Plugin {
       subApp.runCommand('start', '--quickstart');
     }
 
+    if (type === 'subAppStopped') {
+      const { appName } = message;
+      await AppSupervisor.getInstance().stopApp(appName);
+    }
+
     if (type === 'removeApp') {
       const { appName } = message;
       await AppSupervisor.getInstance().removeApp(appName);
@@ -287,6 +292,13 @@ export class PluginMultiAppManagerServer extends Plugin {
           });
         });
 
+        subApp.on('afterStop', async () => {
+          this.sendSyncMessage({
+            type: 'subAppStopped',
+            appName: name,
+          });
+        });
+
         const quickstart = async () => {
           // create database
           try {
@@ -374,6 +386,13 @@ export class PluginMultiAppManagerServer extends Plugin {
       subApp.on('afterStart', async () => {
         this.sendSyncMessage({
           type: 'subAppStarted',
+          appName: name,
+        });
+      });
+
+      subApp.on('afterStop', async () => {
+        this.sendSyncMessage({
+          type: 'subAppStopped',
           appName: name,
         });
       });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  After a sub application stops, publish a synchronization message to notify other nodes to stop the corresponding sub application         |
| 🇨🇳 Chinese |  子应用停止后发布同步信号，通知其他节点停止对应子应用         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
