### PR TITLE
fix: readonly and disabled settting not working for default js field code

### DIFF
--- a/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
@@ -27,23 +27,25 @@ const DEFAULT_CODE = `
 function JsEditableField() {
   const React = ctx.React;
   const { Input } = ctx.antd;
-  // const [value, setValue] = React.useState(ctx.getValue?.() ?? '');
+  const [value, setValue] = React.useState(ctx.getValue?.() ?? '');
 
-  // React.useEffect(() => {
-  //   const handler = (ev) => setValue(ev?.detail ?? '');
-  //   ctx.element?.addEventListener('js-field:value-change', handler);
-  //   return () => ctx.element?.removeEventListener('js-field:value-change', handler);
-  // }, []);
+  React.useEffect(() => {
+    const handler = (ev) => setValue(ev?.detail ?? '');
+    ctx.element?.addEventListener('js-field:value-change', handler);
+    return () => ctx.element?.removeEventListener('js-field:value-change', handler);
+  }, []);
 
-  // const onChange = (e) => {
-  //   const v = e?.target?.value ?? '';
-  //   setValue(v);
-  //   ctx.setValue?.(v);
-  // };
+  const onChange = (e) => {
+    const v = e?.target?.value ?? '';
+    setValue(v);
+    ctx.setValue?.(v);
+  };
 
   return (
     <Input
       {...ctx.model.props}
+      value={value}
+      onChange={onChange}
     />
   );
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue the default JS field configuration did not use the display mode setting. |
| 🇨🇳 Chinese | 修复默认的 js field 配置未使用显示模式配置。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
