### PR TITLE
fix: rich text and multiple select default value

### DIFF
--- a/packages/core/client/src/flow/components/__tests__/DefaultValue.test.tsx
+++ b/packages/core/client/src/flow/components/__tests__/DefaultValue.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { act, render, screen, userEvent, waitFor } from '@nocobase/test/client';
+import { act, render, screen, userEvent, waitFor, sleep } from '@nocobase/test/client';
 import { FlowEngine, FlowEngineProvider, FlowModel, FlowModelProvider, FlowModelRenderer } from '@nocobase/flow-engine';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ConfigProvider, App } from 'antd';
@@ -19,6 +19,8 @@ import { InputFieldModel } from '../../models/fields/InputFieldModel';
 import { DateTimeFilterFieldModel } from '../../models/blocks/filter-form/fields/date-time/DateTimeFilterFieldModel';
 import { VariableFieldFormModel } from '../../models/fields/VariableFieldFormModel';
 import { RecordSelectFieldModel } from '../../models/fields/AssociationFieldModel';
+import { SelectFieldModel } from '../../models/fields/SelectFieldModel';
+import { RichTextFieldModel } from '../../models/fields/RichTextFieldModel';
 
 // 简易 Form stub（非 Formily 分支），用于验证写回逻辑
 function createFormStub(initial: any = {}) {
@@ -103,6 +105,8 @@ describe('DefaultValue component', () => {
       VariableFieldFormModel,
       RecordSelectFieldModel,
       DateTimeFilterFieldModel,
+      SelectFieldModel,
+      RichTextFieldModel,
     });
 
     // 每个用例重置表单实例，避免跨用例的值污染（例如上个用例输入的 "hello"）
@@ -593,4 +597,88 @@ describe('DefaultValue component', () => {
 
   // 注：关联字段的“去包装”由 collectionField 决定，真实页面场景下已具备。
   // 这里不再重复校验，仅在前面的用例验证了常量编辑器与关系字段的基本行为。
+
+  it('multipleSelect constant editor: emits array value on change (UI mode not enforced)', async () => {
+    const onChange = vi.fn();
+    const origCreate = engine.createModel.bind(engine);
+    let capturedTempRoot: any;
+    // @ts-ignore
+    engine.createModel = ((options: any, extra?: any) => {
+      const created = origCreate(options, extra);
+      if (options?.use === 'VariableFieldFormModel') {
+        capturedTempRoot = created;
+      }
+      return created;
+    }) as any;
+
+    const host = engine.createModel<HostModel>({
+      use: 'HostModel',
+      props: { name: 'tags', value: [], onChange, metaTree: simpleMetaTree },
+      subModels: { field: { use: 'SelectFieldModel' } },
+    });
+    host.context.defineProperty('collectionField', {
+      value: {
+        interface: 'multipleSelect',
+        type: 'json',
+        uiSchema: { enum: ['A', 'B', 'C'] },
+      },
+    });
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <FlowModelRenderer model={host} />
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => expect(capturedTempRoot?.subModels?.fields?.[0]).toBeTruthy());
+    const fieldModel = capturedTempRoot.subModels.fields[0];
+
+    await act(async () => {
+      fieldModel?.props?.onChange?.(['A', 'C']);
+    });
+    expect(onChange).toHaveBeenCalled();
+    const callArg = (onChange as any).mock.calls.pop()?.[0];
+    expect(callArg).toEqual(['A', 'C']);
+  });
+
+  it('richText constant editor: supports typing (host.setProps mirror not required)', async () => {
+    const onChange = vi.fn();
+    const origCreate = engine.createModel.bind(engine);
+    let capturedTempRoot: any;
+    // @ts-ignore
+    engine.createModel = ((options: any, extra?: any) => {
+      const created = origCreate(options, extra);
+      if (options?.use === 'VariableFieldFormModel') capturedTempRoot = created;
+      return created;
+    }) as any;
+
+    const host = engine.createModel<HostModel>({
+      use: 'HostModel',
+      props: { name: 'content', value: '', onChange, metaTree: simpleMetaTree },
+      subModels: { field: { use: 'RichTextFieldModel' } },
+    });
+    host.context.defineProperty('collectionField', { value: { interface: 'richText', type: 'text' } });
+
+    const { container } = render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <FlowModelRenderer model={host} />
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    // 等待 ReactQuill 异步加载
+    await sleep(300);
+    const editor = container.querySelector('.ql-editor') as HTMLElement;
+    expect(editor).toBeTruthy();
+    editor.focus();
+    await userEvent.type(editor, 'Hello');
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix issue where the rich text field cannot input default value and the multi-select field default value cannot select multiple options. |
| 🇨🇳 Chinese | 修复富文本字段无法输入默认值及多选字段默认值无法选择多个选项的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
