### PR TITLE
fix(router-manager): reorder context providers for proper nesting

### DIFF
--- a/packages/core/client/src/application/RouterManager.tsx
+++ b/packages/core/client/src/application/RouterManager.tsx
@@ -168,12 +168,12 @@ export class RouterManager {
       const BaseLayout = useContext(BaseLayoutContext);
       return (
         <CustomRouterContextProvider>
-          <BaseLayout>
-            <VariablesProvider>
+          <VariablesProvider>
+            <BaseLayout>
               <Outlet />
               {children}
-            </VariablesProvider>
-          </BaseLayout>
+            </BaseLayout>
+          </VariablesProvider>
         </CustomRouterContextProvider>
       );
     };


### PR DESCRIPTION
### This is a ...
- [ ] New feature  
- [ ] Improvement  
- [x] Bug fix  
- [ ] Others

### Motivation
在业务中需要在自定义的 Provider 内部访问全局变量（如 `$env.*`）来执行特定逻辑，但当前实现中该 Provider 无法正确获取全局变量，导致依赖环境变量的业务流程无法正常运行。
为了解决这个问题，需要调整自定义  Provider 的渲染顺序，使其能够正常读取全局变量，从而让后续依赖环境变量的行为能够按预期执行。

### Description
本 PR 做了以下调整：

1. **修复自定义 Provider 中无法读取环境变量的问题**  
   调整自定义 Provider 的渲染顺序，使其能够在渲染与逻辑执行之前正确访问全局环境变量。

#### Testing suggestion
- 在本地环境与构建环境分别测试 Provider 内部是否能读取正确的环境变量值。
- 验证依赖环境变量的逻辑是否按预期执行（如条件渲染）。

### Related issues
<!--  -->

### Showcase
<!--  -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: Custom Provider could not access global variables. |
| 🇨🇳 Chinese | 修复：自定义 Provider 无法获取全局变量的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |   |
| 🇨🇳 Chinese |   |

### Checklists
- [x] All changes have been self-tested and work as expected  
- [ ] Test cases are updated/provided or not needed  
- [ ] Doc is updated/provided or not needed  
- [ ] Component demo is updated/provided or not needed  
- [x] Changelog is provided or not needed  
- [ ] Requested a code review if needed  
