### PR TITLE
refactor(plugin-workflow): deprecate context for trigger action events

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/flows/triggerWorkflows.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/flows/triggerWorkflows.tsx
@@ -54,40 +54,41 @@ export function createTriggerWorkflowsSchema({
                 },
               },
             },
-            ...(usingContext
-              ? {
-                  context: {
-                    type: 'void',
-                    'x-component': 'ArrayTable.Column',
-                    'x-component-props': {
-                      title: `{{t('Trigger data context', { ns: 'workflow' })}}`,
-                      width: 200,
-                    },
-                    properties: {
-                      context: {
-                        type: 'string',
-                        'x-decorator': 'FormItem',
-                        'x-component': AppendsTreeSelect,
-                        'x-component-props': {
-                          placeholder: `{{t('Select context', { ns: 'workflow' })}}`,
-                          popupMatchSelectWidth: false,
-                          collection: workflowCollection,
-                          filter(field) {
-                            return ['belongsTo', 'hasOne'].includes(field.type);
-                          },
-                          rootOption: {
-                            label: `{{t('Full form data', { ns: 'workflow' })}}`,
-                            value: '',
-                          },
-                          allowClear: false,
-                          // loadData: buttonAction === 'destroy' ? null : undefined,
-                        },
-                        default: '',
-                      },
-                    },
-                  },
-                }
-              : {}),
+            // @deprecated
+            // ...(usingContext
+            //   ? {
+            //       context: {
+            //         type: 'void',
+            //         'x-component': 'ArrayTable.Column',
+            //         'x-component-props': {
+            //           title: `{{t('Trigger data context', { ns: 'workflow' })}}`,
+            //           width: 200,
+            //         },
+            //         properties: {
+            //           context: {
+            //             type: 'string',
+            //             'x-decorator': 'FormItem',
+            //             'x-component': AppendsTreeSelect,
+            //             'x-component-props': {
+            //               placeholder: `{{t('Select context', { ns: 'workflow' })}}`,
+            //               popupMatchSelectWidth: false,
+            //               collection: workflowCollection,
+            //               filter(field) {
+            //                 return ['belongsTo', 'hasOne'].includes(field.type);
+            //               },
+            //               rootOption: {
+            //                 label: `{{t('Full form data', { ns: 'workflow' })}}`,
+            //                 value: '',
+            //               },
+            //               allowClear: false,
+            //               // loadData: buttonAction === 'destroy' ? null : undefined,
+            //             },
+            //             default: '',
+            //           },
+            //         },
+            //       },
+            //     }
+            //   : {}),
             workflowKey: {
               type: 'void',
               'x-component': 'ArrayTable.Column',


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation

Deprecate "Trigger context" option in configuration of binding workflow, in order to simplify configuration.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Deprecate "Trigger context" option in configuration of binding workflow, in order to simplify configuration |
| 🇨🇳 Chinese | 对绑定工作流的配置弃用“触发数据上下文”选项，以简化配置 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
