### PR TITLE
fix: js block title and description setting doesn't take effect

### DIFF
--- a/packages/core/client/src/flow/models/blocks/js-block/JSBlock.tsx
+++ b/packages/core/client/src/flow/models/blocks/js-block/JSBlock.tsx
@@ -27,8 +27,19 @@ export class JSBlockModel extends BlockModel {
   // Avoid double-run on first mount; only rerun after remounts
   private _mountedOnce = false;
   render() {
+    const decoratorProps = this.decoratorProps || {};
+    const { className, id: _ignoredId, title, description, ...rest } = decoratorProps;
+    const mergedClassName = ['code-block', className].filter(Boolean).join(' ');
+    const cardTitle =
+      title || description ? (
+        <div>
+          {title && <span>{title}</span>}
+          {description && <div>{description}</div>}
+        </div>
+      ) : undefined;
+
     return (
-      <Card id={`model-${this.uid}`} className="code-block">
+      <Card id={`model-${this.uid}`} className={mergedClassName} title={cardTitle} {...rest}>
         <div ref={this.context.ref} />
       </Card>
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the title and description were not displayed in the JS block. |
| 🇨🇳 Chinese | 修复 JS block 区块中的标题和描述不显示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
