### PR TITLE
Fix Quick Edit cell editing error: Cannot read properties of undefined (reading 'getData')

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/QuickEditFormModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/QuickEditFormModel.tsx
@@ -109,18 +109,6 @@ export class QuickEditFormModel extends FlowModel {
     this.context.defineProperty('blockModel', {
       value: this,
     });
-    const recordMeta: PropertyMetaFactory = createCurrentRecordMetaFactory(this.context, () => this.collection);
-    this.context.defineProperty('record', {
-      get: () => this.resource.getData(),
-      resolveOnServer: createRecordResolveOnServerWithLocal(
-        () => this.collection,
-        () => this.resource.getData(),
-      ),
-      meta: recordMeta,
-    });
-    this.context.defineProperty('collection', {
-      get: () => this.collection,
-    });
   }
 
   addAppends(fieldPath: string, refresh = false) {
@@ -251,6 +239,22 @@ QuickEditFormModel.registerFlow({
           resource.setData(ctx.inputArgs.record);
           ctx.model.form?.setFieldsValue(resource.getData());
         }
+
+        const recordMeta: PropertyMetaFactory = createCurrentRecordMetaFactory(
+          ctx.model.context,
+          () => ctx.model.collection,
+        );
+        ctx.model.context.defineProperty('record', {
+          get: () => ctx.model.resource.getData(),
+          resolveOnServer: createRecordResolveOnServerWithLocal(
+            () => ctx.model.collection,
+            () => ctx.model.resource.getData(),
+          ),
+          meta: recordMeta,
+        });
+        ctx.model.context.defineProperty('collection', {
+          get: () => ctx.model.collection,
+        });
       },
     },
   },


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Grateful for NocoBase, happy to contribute to make it better.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

Fix Quick Edit cell editing error: Cannot read properties of undefined (reading 'getData')

In Nocobase v2.0.0-alpha.42, clicking the edit button next to a table cell to enable Quick Edit triggers a TypeError:

```javascript
TypeError: Cannot read properties of undefined (reading 'getData')
```
This happens in `QuickEditFormModel.tsx` at line 114, where the 'record' context property getter calls `this.resource.getData()`. At the time of access (during `dispatchEvent('beforeRender')` in the base FlowModel), `this.resource` is undefined because it's set later in the 'init' step of the registered 'quickEditFormSettings' flow.

The sequence issue: Model creation calls `onInit()` (defines getter), rendering triggers `beforeRender` (accesses getter before flow runs), and the flow's 'init' handler sets `this.resource`.

#### Solution

- Removed the premature definition of 'record' and 'collection' context properties from `QuickEditFormModel.onInit()`.
- Added these definitions to the end of the 'init' handler in `QuickEditFormModel.registerFlow()`, after `this.resource` and `this.collection` are initialized, and after setting filter/data/form values.

This ensures the getters are only defined post-initialization, avoiding the undefined access during early 'beforeRender' checks.

#### Changes

- Modified `packages/core/client/src/flow/models/blocks/form/QuickEditFormModel.tsx`:

  - Simplified `onInit()` to only define 'blockModel'.
  - Appended context property definitions in the flow's 'init' async handler.

#### Testing

- Ran `yarn dev` to start the development server.
- Navigated to a table view (e.g., Users collection).
- Clicked the edit button next to a cell (e.g., nickname field).
- Verified the popover opens without errors, allowing inline editing and saving.
- Tested with association and non-association fields; no regressions observed.
- Confirmed the fix doesn't impact other form models or flows.

#### Additional Notes

- This is a targeted fix for the initialization timing bug in alpha.42.
- No breaking changes; compatible with existing Quick Edit usage.
- Suggest adding a unit test for QuickEditFormModel initialization sequence.


### Related issues
#7918 

### Showcase
<!-- Including any screenshots of the changes. -->
<img width="731" height="382" alt="image" src="https://github.com/user-attachments/assets/4c9748ad-517c-4b2d-94af-928d2ca8b63a" />


### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Quick Edit error where clicking cell edit button caused TypeError due to undefined resource in beforeRender. Moved context property definitions to init handler for proper initialization order. |
| 🇨🇳 Chinese | 修复了 Quick Edit 功能中点击单元格编辑按钮导致的 TypeError 错误（undefined resource in beforeRender）。将上下文属性定义移动到 init 处理程序中，确保正确的初始化顺序。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | No documentation changes required. |
| 🇨🇳 Chinese | 无需文档更改。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
