### PR TITLE
fix: remove tree-table action from non-tree-collection block

### DIFF
--- a/packages/core/client/src/flow/models/actions/AddChildActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/AddChildActionModel.tsx
@@ -41,6 +41,9 @@ AddChildActionModel.registerFlow({
 
 AddChildActionModel.define({
   label: escapeT('Add child'),
+  hide(ctx) {
+    return ctx.collection?.template !== 'tree';
+  },
 });
 
 RecordActionGroupModel.registerActionModels({

--- a/packages/core/client/src/flow/models/actions/ExpandCollapseActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/ExpandCollapseActionModel.tsx
@@ -99,4 +99,7 @@ ExpandCollapseActionModel.registerFlow({
 
 ExpandCollapseActionModel.define({
   label: escapeT('Expand/Collapse'),
+  hide(ctx) {
+    return ctx.collection?.template !== 'tree';
+  },
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   remove tree-table action from non-tree-collection block     |
| 🇨🇳 Chinese |      修复树表按钮显示在非树表区块中的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
