### PR TITLE
feat: add localization support for secondary confirmation title and c…

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Designer.tsx
@@ -739,11 +739,9 @@ export function SecondConFirm() {
       title={t('Secondary confirmation')}
       initialValues={{
         title:
-          t(fieldSchema?.['x-component-props']?.confirm?.title, { title: compile(fieldSchema.title) }) ||
           compile(fieldSchema?.['x-component-props']?.confirm?.title) ||
           t('Perform the {{title}}', { title: compile(fieldSchema.title) }),
         content:
-          t(fieldSchema?.['x-component-props']?.confirm?.content, { title: compile(fieldSchema.title) }) ||
           compile(fieldSchema?.['x-component-props']?.confirm?.content) ||
           t('Are you sure you want to perform the {{title}} action?', { title: compile(fieldSchema.title) }),
       }}

--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -541,8 +541,8 @@ const RenderButton = ({
         if (confirm?.enable !== false && confirm?.content) {
           await form?.submit?.();
           modal.confirm({
-            title: t(resultTitle, { title: confirmTitle || title || field?.title }),
-            content: t(resultContent, { title: confirmTitle || title || field?.title }),
+            title: t(resultTitle, { title: confirmTitle || title || field?.title, ns: NAMESPACE_UI_SCHEMA }),
+            content: t(resultContent, { title: confirmTitle || title || field?.title, ns: NAMESPACE_UI_SCHEMA }),
             onOk,
           });
         } else {

--- a/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/repository.ts
+++ b/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/repository.ts
@@ -309,6 +309,8 @@ export class UiSchemaRepository extends Repository {
       'x-component-props.content',
       'x-component-props.tooltip',
       'x-component-props.children',
+      'x-component-props.confirm.title',
+      'x-component-props.confirm.content',
     ];
     let r = false;
     for (const key of keys) {

--- a/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/server.ts
@@ -31,6 +31,8 @@ function extractFields(obj) {
     obj['x-component-props']?.children,
     obj['x-decorator-props']?.title,
     obj['x-decorator-props']?.description,
+    obj['x-component-props']?.confirm?.title,
+    obj['x-component-props']?.confirm?.content,
   ];
 
   const content = obj['x-component-props']?.content;


### PR DESCRIPTION
### This is a ...
- [x] New feature  
- [ ] Improvement  
- [ ] Bug fix  
- [ ] Others  

### Motivation
在支持海外业务的过程中，发现二次确认弹窗的标题与内容均未支持本地化配置，导致无法根据语言环境展示对应的国际化文案。  
为了保证海外用户体验，需要补齐该部分的国际化能力。

### Description
本次 PR 主要包含以下改动：

1. **为二次确认弹窗的标题与内容新增本地化支持

**测试建议：**
- 切换多语言环境，验证二次确认弹窗的标题与内容是否正确切换。  

### Related issues
N/A

### Showcase
<!-- 可在此处附上截图 -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add localization support for the secondary confirmation title and content. |
| 🇨🇳 Chinese | 增加二次确认弹窗标题与内容的本地化支持。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected  
- [ ] Test cases are updated/provided or not needed  
- [ ] Doc is updated/provided or not needed  
- [x] Component demo is updated/provided or not needed  
- [x] Changelog is provided or not needed  
- [ ] Request a code review if it is necessary  
