### PR TITLE
Feat/support localization for form validation message

### DIFF
--- a/packages/core/client/src/data-source/collection-field/CollectionField.tsx
+++ b/packages/core/client/src/data-source/collection-field/CollectionField.tsx
@@ -44,17 +44,22 @@ const setRequired = (field: Field, fieldSchema: Schema, uiSchema: Schema) => {
 };
 
 export const translateValidatorMessage = (validator: Field['validator'], t: TFunction) => {
-  if (!Array.isArray(validator)) {
-    return validator;
+  if (Array.isArray(validator)) {
+    return validator.map((valid) => {
+      if (valid['message']) {
+        valid['message'] = t(valid['message'], {
+          ns: NAMESPACE_UI_SCHEMA,
+        });
+      }
+      return valid;
+    });
   }
-  return validator.map((valid) => {
-    if (valid['message']) {
-      valid['message'] = t(valid['message'], {
-        ns: NAMESPACE_UI_SCHEMA,
-      });
-    }
-    return valid;
-  });
+  if (typeof validator === 'object' && validator['message']) {
+    validator['message'] = t(validator['message'], {
+      ns: NAMESPACE_UI_SCHEMA,
+    });
+  }
+  return validator;
 };
 
 /**

--- a/packages/core/client/src/data-source/collection-field/CollectionField.tsx
+++ b/packages/core/client/src/data-source/collection-field/CollectionField.tsx
@@ -20,6 +20,9 @@ import { useCompile, useComponent } from '../../schema-component';
 import { useIsAllowToSetDefaultValue } from '../../schema-settings/hooks/useIsAllowToSetDefaultValue';
 import { isVariable } from '../../variables/utils/isVariable';
 import { CollectionFieldProvider, useCollectionField } from './CollectionFieldProvider';
+import type { TFunction } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
+import { NAMESPACE_UI_SCHEMA } from '../../i18n';
 
 type Props = {
   component: any;
@@ -40,6 +43,20 @@ const setRequired = (field: Field, fieldSchema: Schema, uiSchema: Schema) => {
   }
 };
 
+export const translateValidatorMessage = (validator: Field['validator'], t: TFunction) => {
+  if (!Array.isArray(validator)) {
+    return validator;
+  }
+  return validator.map((valid) => {
+    if (valid['message']) {
+      valid['message'] = t(valid['message'], {
+        ns: NAMESPACE_UI_SCHEMA,
+      });
+    }
+    return valid;
+  });
+};
+
 /**
  * @deprecated
  * Used to handle scenarios that use RecursionField, such as various plugin configuration pages
@@ -56,6 +73,7 @@ const CollectionFieldInternalField_deprecated: React.FC = (props: Props) => {
   );
   const ctx = useFormBlockContext();
   const dynamicProps = useDynamicComponentProps(uiSchemaOrigin?.['x-use-component-props'], props);
+  const { t } = useTranslation();
 
   // TODO: 初步适配
   useEffect(() => {
@@ -73,7 +91,7 @@ const CollectionFieldInternalField_deprecated: React.FC = (props: Props) => {
 
     if (!field.validator && (uiSchema['x-validator'] || fieldSchema['x-validator'])) {
       const concatSchema = concat([], uiSchema['x-validator'] || [], fieldSchema['x-validator'] || []);
-      field.validator = concatSchema;
+      field.validator = translateValidatorMessage(concatSchema, t);
     }
     if (fieldSchema['x-disabled'] === true) {
       field.disabled = true;
@@ -103,6 +121,7 @@ const CollectionFieldInternalField = (props) => {
     fieldSchema['x-component-props']?.['component'] || uiSchema?.['x-component'] || 'Input',
   );
   const dynamicProps = useDynamicComponentProps(uiSchema?.['x-use-component-props'], props);
+  const { t } = useTranslation();
 
   useEffect(() => {
     /**
@@ -132,6 +151,7 @@ const CollectionFieldInternalField = (props) => {
     }
     field.data = field.data || {};
     field.data.dataSource = uiSchema?.enum;
+    field.validator = translateValidatorMessage(field.validator, t);
   }, [field, fieldSchema]);
 
   if (!uiSchema) return null;

--- a/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
+++ b/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
@@ -14,7 +14,7 @@ import { merge } from '@formily/shared';
 import { concat } from 'lodash';
 import React, { useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { isVariable, useCollectionManager_deprecated } from '../../../';
+import { isVariable, useCollectionManager_deprecated, translateValidatorMessage } from '../../../';
 import { useFormBlockContext } from '../../../block-provider/FormBlockProvider';
 import {
   CollectionFieldProvider,
@@ -23,6 +23,7 @@ import {
 import { useDynamicComponentProps } from '../../../hoc/withDynamicSchemaProps';
 import { ErrorFallback, useCompile, useComponent } from '../../../schema-component';
 import { useIsAllowToSetDefaultValue } from '../../../schema-settings/hooks/useIsAllowToSetDefaultValue';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   component: any;
@@ -66,6 +67,7 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
   );
   const ctx = useFormBlockContext();
   const dynamicProps = useDynamicComponentProps(uiSchemaOrigin?.['x-use-component-props'], props);
+  const { t } = useTranslation();
   // TODO: 初步适配
   useEffect(() => {
     if (!uiSchemaOrigin) {
@@ -82,7 +84,7 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
 
     if (!field.validator && (uiSchema['x-validator'] || fieldSchema['x-validator'])) {
       const concatSchema = concat([], uiSchema['x-validator'] || [], fieldSchema['x-validator'] || []);
-      field.validator = concatSchema;
+      field.validator = translateValidatorMessage(concatSchema, t);
     }
     if (fieldSchema['x-disabled'] === true) {
       field.disabled = true;

--- a/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/repository.ts
+++ b/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/repository.ts
@@ -309,6 +309,7 @@ export class UiSchemaRepository extends Repository {
       'x-component-props.content',
       'x-component-props.tooltip',
       'x-component-props.children',
+      'x-validator',
     ];
     let r = false;
     for (const key of keys) {

--- a/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-ui-schema-storage/src/server/server.ts
@@ -31,6 +31,7 @@ function extractFields(obj) {
     obj['x-component-props']?.children,
     obj['x-decorator-props']?.title,
     obj['x-decorator-props']?.description,
+    ...(obj['x-validator']?.map((item) => item?.message) || []),
   ];
 
   const content = obj['x-component-props']?.content;


### PR DESCRIPTION
### This is a ...
- [x] New feature  
- [ ] Improvement  
- [ ] Bug fix  
- [ ] Others  

### Motivation
在支持海外业务的过程中，发现表单验证消息仍为固定文案，未支持本地化配置，导致无法根据当前语言环境展示对应的国际化提示信息。  
为了提升不同地区用户的体验，并保持 UI 文案的一致性，需要为表单验证消息补充国际化能力。

### Description
本次 PR 主要包含以下更新：

1. **为表单验证消息新增本地化支持**  
   - 将原先硬编码的错误提示替换成可配置的 i18n 文案 key。  
   - 支持根据当前语言环境自动加载对应提示内容。

2. **保留原有校验逻辑不变**  
   - 不改变校验规则本身，仅替换展示层文案。

**测试建议：**
- 切换不同语言验证表单校验提示是否正确切换。  
- 验证常见校验类型（required、maxLength、pattern、自定义校验等）。  
- 测试错误信息未配置时的 fallback 文案表现。  
- 覆盖多种表单场景（弹窗表单、独立表单、动态字段表单等）。

### Related issues
N/A

### Showcase
<!-- 可附上切换语言前后的校验提示截图 -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add localization support for form validation messages. |
| 🇨🇳 Chinese | 增加表单验证提示消息的本地化支持。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected  
- [ ] Test cases are updated/provided or not needed  
- [ ] Doc is updated/provided or not needed  
- [x] Component demo is updated/provided or not needed  
- [x] Changelog is provided or not needed  
- [ ] Request a code review if it is necessary  
