### PR TITLE
fix(plugin-workflow): fix form state is refreshed by task context

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowTasks.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowTasks.tsx
@@ -488,15 +488,17 @@ export function WorkflowTasks() {
 
   return (
     <Layout className={layoutClass}>
-      {isMobileLayout ? (
-        <Layout.Header style={{ background: token.colorBgContainer, padding: 0, height: '3em', lineHeight: '3em' }}>
-          <Menu mode="horizontal" selectedKeys={[typeKey]} items={items} />
-        </Layout.Header>
-      ) : (
-        <Layout.Sider breakpoint="md" collapsedWidth="0" zeroWidthTriggerStyle={{ top: 24 }}>
-          <Menu mode="inline" selectedKeys={[typeKey]} items={items} style={{ height: '100%' }} />
-        </Layout.Sider>
-      )}
+      <TasksCountsProvider>
+        {isMobileLayout ? (
+          <Layout.Header style={{ background: token.colorBgContainer, padding: 0, height: '3em', lineHeight: '3em' }}>
+            <Menu mode="horizontal" selectedKeys={[typeKey]} items={items} />
+          </Layout.Header>
+        ) : (
+          <Layout.Sider breakpoint="md" collapsedWidth="0" zeroWidthTriggerStyle={{ top: 24 }}>
+            <Menu mode="inline" selectedKeys={[typeKey]} items={items} style={{ height: '100%' }} />
+          </Layout.Sider>
+        )}
+      </TasksCountsProvider>
       <Layout
         className={css`
           > div {
@@ -525,15 +527,17 @@ function WorkflowTasksLink() {
   const { reload, total } = useContext(TasksCountsContext);
   const items = useAvailableTaskTypeItems();
   return items.length ? (
-    <Tooltip title={lang('Workflow todos')}>
-      <Button>
-        <Link to={`/admin/workflow/tasks`} onClick={reload}>
-          <Badge count={total} size="small">
-            <CheckCircleOutlined />
-          </Badge>
-        </Link>
-      </Button>
-    </Tooltip>
+    <TasksCountsProvider>
+      <Tooltip title={lang('Workflow todos')}>
+        <Button>
+          <Link to={`/admin/workflow/tasks`} onClick={reload}>
+            <Badge count={total} size="small">
+              <CheckCircleOutlined />
+            </Badge>
+          </Link>
+        </Button>
+      </Tooltip>
+    </TasksCountsProvider>
   ) : null;
 }
 
@@ -600,7 +604,7 @@ function TasksCountsProvider(props: any) {
 export function TasksProvider(props: any) {
   const isLoggedIn = useIsLoggedIn();
 
-  const content = (
+  return (
     <PinnedPluginListProvider
       items={{
         todo: { component: 'WorkflowTasksLink', pin: true, snippet: '*' },
@@ -615,8 +619,6 @@ export function TasksProvider(props: any) {
       </SchemaComponentOptions>
     </PinnedPluginListProvider>
   );
-
-  return isLoggedIn ? <TasksCountsProvider>{content}</TasksCountsProvider> : content;
 }
 
 export const tasksSchemaInitializerItem: SchemaInitializerItemType = {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fixed the issue where updating the task count would unintentionally reset the state of forms being filled out.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where updating the task count would unintentionally reset the state of forms being filled out |
| 🇨🇳 Chinese | 修复了更新待办数量时意外导致填写中的表单状态被重置的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
