### PR TITLE
fix(plugin-async-task-manager): fix collection migration rules

### DIFF
--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/common/collections/asyncTasks.ts
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/common/collections/asyncTasks.ts
@@ -10,6 +10,8 @@
 export default {
   name: 'asyncTasks',
   autoGenId: false,
+  dumpRules: 'required',
+  migrationRules: ['schema-only'],
   createdAt: true,
   updatedAt: true,
   createdBy: true,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Add migration rule for `asyncTasks` collection, avoid async tasks records to be migrated.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add migration rule for `asyncTasks` collection, avoid async tasks records to be migrated |
| 🇨🇳 Chinese | 为 `asyncTasks` 数据表增加迁移规则，避免异步任务记录被迁移 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
