### PR TITLE
fix(filter): use cloneDeep for default filter values

### DIFF
--- a/packages/core/client/src/flow/models/actions/FilterActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/FilterActionModel.tsx
@@ -188,7 +188,7 @@ FilterActionModel.registerFlow({
         };
       },
       handler(ctx, params) {
-        ctx.model.setProps('defaultFilterValue', params.defaultFilter);
+        ctx.model.setProps('defaultFilterValue', _.cloneDeep(params.defaultFilter));
         ctx.model.setProps('filterValue', _.cloneDeep(params.defaultFilter));
       },
     },
@@ -236,7 +236,7 @@ FilterActionModel.registerFlow({
         resource.removeFilterGroup(ctx.model.uid);
         resource.refresh();
         ctx.model.setProps('open', false);
-        ctx.model.setProps('filterValue', ctx.model.props.defaultFilterValue);
+        ctx.model.setProps('filterValue', _.cloneDeep(ctx.model.props.defaultFilterValue));
       },
     },
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where default filter values were passed by reference, causing unexpected mutations.

### Description 

Used `_.cloneDeep` when setting `defaultFilterValue` and `filterValue` in `FilterActionModel` to ensure data integrity.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the issue where the filter value is not cleared when clicking the Reset button |
| 🇨🇳 Chinese | 修复点击筛选重置按钮时筛选值未清空的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
