### PR TITLE
fix(plugin-notification-in-app-message): fix variable delimiter

### DIFF
--- a/packages/core/client/src/schema-component/antd/variable/RawTextArea.tsx
+++ b/packages/core/client/src/schema-component/antd/variable/RawTextArea.tsx
@@ -25,7 +25,15 @@ function setNativeInputValue(input, value) {
 
 export function RawTextArea(props): JSX.Element {
   const inputRef = useRef<any>(null);
-  const { changeOnSelect, component: Component = Input.TextArea, fieldNames, scope, buttonClass, ...others } = props;
+  const {
+    changeOnSelect,
+    component: Component = Input.TextArea,
+    fieldNames,
+    scope,
+    buttonClass,
+    delimiters = ['{{', '}}'],
+    ...others
+  } = props;
   const dataScope = typeof scope === 'function' ? scope() : scope;
   const [options, setOptions] = useState(dataScope ? dataScope : []);
 
@@ -34,7 +42,7 @@ export function RawTextArea(props): JSX.Element {
       return;
     }
 
-    const variable = `{{${selected.join('.')}}}`;
+    const variable = `${delimiters[0]}${selected.join('.')}${delimiters[1]}`;
 
     const { textArea } = inputRef.current.resizableTextArea;
     const nextValue =

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/configFormCommonFieldset.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/configFormCommonFieldset.ts
@@ -35,6 +35,7 @@ export function getConfigFormCommonFieldset({ variableOptions }) {
         autoSize: {
           minRows: 10,
         },
+        delimiters: ['{{{', '}}}'],
       },
     },
     options: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Use triple brackets (`{{{` and `}}}`) for variables in message content, to avoid variables been escaped by Handlebars.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Use triple brackets (`{{{` and `}}}`) for variables in message content, to avoid variables been escaped by Handlebars |
| 🇨🇳 Chinese | 对消息内容的变量使用三重括号，以免变量被 Handlerbars 转义 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
