### PR TITLE
fix(plugin-data-source-manager): external data source can`t change password

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/plugin.ts
@@ -364,26 +364,18 @@ export class PluginDataSourceManagerServer extends Plugin {
       }
 
       const { actionName, resourceName, params } = ctx.action;
-      if (resourceName === 'dataSources' && (actionName === 'add' || actionName === 'update')) {
-        const { values, filterByTk: dataSourceKey } = params;
+      if (resourceName === 'dataSources' && (actionName === 'create' || actionName === 'update')) {
+        const { values } = params;
         if (values.options?.addAllCollections) {
           let introspector: { getCollections: () => Promise<string[]> } = null;
           const dataSourceManager = ctx.app['dataSourceManager'] as DataSourceManager;
 
-          if (actionName === 'add') {
-            const klass = dataSourceManager.factory.getClass(values.options.type);
-            // @ts-ignore
-            const dataSource = new klass(dbOptions);
-            introspector = dataSource.collectionManager.dataSource.createDatabaseIntrospector(
-              dataSource.collectionManager.db,
-            );
-          } else {
-            const dataSource = dataSourceManager.dataSources.get(dataSourceKey);
-            if (!dataSource) {
-              throw new Error(`dataSource ${dataSourceKey} not found`);
-            }
-            introspector = dataSource['introspector'];
-          }
+          const klass = dataSourceManager.factory.getClass(values.type);
+          // @ts-ignore
+          const dataSource = new klass(values.options);
+          introspector = dataSource.collectionManager.dataSource.createDatabaseIntrospector(
+            dataSource.collectionManager.db,
+          );
           const allCollections = await introspector.getCollections();
           if (allCollections.length > ALLOW_MAX_COLLECTIONS_COUNT) {
             throw new Error(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fix external data source can`t change password issue

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
`addAllCollections` check will connect db while updating data source, if db password changed, update can`t success.
should use update input to connect db then do the `addAllCollections` check

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed data source password updating failure when database password is changed |
| 🇨🇳 Chinese | 修复外部数据源修改密码后系统内无法更新密码的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
