### PR TITLE
fix(data-vi): filter fields settings for external data source collections do not display specific properties

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterItemInitializers.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/filter/FilterItemInitializers.tsx
@@ -97,21 +97,21 @@ export const ChartFilterFormItem = observer(
     const collectionField = schema?.['x-collection-field'] || '';
     const [collection] = collectionField.split('.');
     return (
-      <BlockItem className={'nb-form-item'}>
-        <CollectionManagerProvider dataSource={dataSource}>
-          <CollectionProvider name={collection} allowNull={!collection}>
-            <CollectionFieldProvider name={schema.name} allowNull={!schema['x-collection-field']}>
-              <ACLCollectionFieldProvider>
-                <ErrorBoundary onError={console.log} FallbackComponent={ErrorFallback}>
-                  <IsInNocoBaseRecursionFieldContext.Provider value={false}>
+      <CollectionManagerProvider dataSource={dataSource}>
+        <CollectionProvider name={collection} allowNull={!collection}>
+          <CollectionFieldProvider name={schema.name} allowNull={!schema['x-collection-field']}>
+            <ACLCollectionFieldProvider>
+              <ErrorBoundary onError={console.log} FallbackComponent={ErrorFallback}>
+                <IsInNocoBaseRecursionFieldContext.Provider value={false}>
+                  <BlockItem className={'nb-form-item'}>
                     <FormItem className={className} {...props} extra={extra} />
-                  </IsInNocoBaseRecursionFieldContext.Provider>
-                </ErrorBoundary>
-              </ACLCollectionFieldProvider>
-            </CollectionFieldProvider>
-          </CollectionProvider>
-        </CollectionManagerProvider>
-      </BlockItem>
+                  </BlockItem>
+                </IsInNocoBaseRecursionFieldContext.Provider>
+              </ErrorBoundary>
+            </ACLCollectionFieldProvider>
+          </CollectionFieldProvider>
+        </CollectionProvider>
+      </CollectionManagerProvider>
     );
   },
   { displayName: 'ChartFilterFormItem' },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Filter fields settings for external data source collections do not display specific properties          |
| 🇨🇳 Chinese | 外部数据源表的筛选字段的配置项不能显示特有属性          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
