### PR TITLE
fix(PageModel): replace tabActiveKey with props

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -35,11 +35,10 @@ type PageModelStructure = {
 
 export class PageModel extends FlowModel<PageModelStructure> {
   tabBarExtraContent: { left?: ReactNode; right?: ReactNode } = {};
-  tabActiveKey: string;
 
   onMount(): void {
     super.onMount();
-    this.tabActiveKey = this.context.view.inputArgs?.tabUid;
+    this.setProps('tabActiveKey', this.context.view.inputArgs?.tabUid);
     if (this.context?.pageInfo) this.context.pageInfo.version = 'v2';
   }
 
@@ -117,7 +116,7 @@ export class PageModel extends FlowModel<PageModelStructure> {
     return (
       <DndProvider onDragEnd={this.handleDragEnd.bind(this)}>
         <Tabs
-          defaultActiveKey={this.context.view.inputArgs?.tabUid}
+          activeKey={this.props.tabActiveKey}
           tabBarStyle={this.props.tabBarStyle}
           items={this.mapTabs()}
           onChange={(activeKey) => {
@@ -126,11 +125,8 @@ export class PageModel extends FlowModel<PageModelStructure> {
             });
 
             this.invokeTabModelLifecycleMethod(activeKey, 'onActive');
-            this.invokeTabModelLifecycleMethod(this.tabActiveKey, 'onInactive');
-            this.tabActiveKey = activeKey;
-            if (this.context.view.inputArgs?.tabUid) {
-              this.context.view.inputArgs.tabUid = activeKey;
-            }
+            this.invokeTabModelLifecycleMethod(this.props.tabActiveKey, 'onInactive');
+            this.setProps('tabActiveKey', activeKey);
           }}
           // destroyInactiveTabPane
           tabBarExtraContent={{

--- a/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
@@ -8,7 +8,7 @@
  */
 
 import { DragEndEvent } from '@dnd-kit/core';
-import { autorun } from '@nocobase/flow-engine';
+import { autorun, reaction } from '@nocobase/flow-engine';
 import _ from 'lodash';
 import { NocoBaseDesktopRoute } from '../../../../route-switch/antd/admin-layout/convertRoutesToSchema';
 import { PageModel } from './PageModel';
@@ -19,29 +19,29 @@ export class RootPageModel extends PageModel {
   onMount() {
     super.onMount();
 
-    autorun(() => {
-      if (this.context.pageActive.value && this.mounted) {
-        if (this.tabActiveKey) {
-          this.invokeTabModelLifecycleMethod(this.tabActiveKey, 'onActive');
-        } else {
+    reaction(
+      () => this.context.pageActive.value,
+      () => {
+        if (this.context.pageActive.value && this.mounted) {
           const firstTab = this.subModels.tabs?.[0];
           if (firstTab) {
+            this.setProps('tabActiveKey', firstTab.uid);
             this.invokeTabModelLifecycleMethod(firstTab.uid, 'onActive');
           }
         }
-      }
-      if (this.context.pageActive.value === false) {
-        if (this.tabActiveKey) {
-          this.invokeTabModelLifecycleMethod(this.tabActiveKey, 'onInactive');
-        } else {
-          const firstTab = this.subModels.tabs?.[0];
-          if (firstTab) {
-            this.invokeTabModelLifecycleMethod(firstTab.uid, 'onInactive');
+        if (this.context.pageActive.value === false) {
+          if (this.props.tabActiveKey) {
+            this.invokeTabModelLifecycleMethod(this.props.tabActiveKey, 'onInactive');
+          } else {
+            const firstTab = this.subModels.tabs?.[0];
+            if (firstTab) {
+              this.invokeTabModelLifecycleMethod(firstTab.uid, 'onInactive');
+            }
           }
         }
-      }
-      this.mounted = true;
-    });
+        this.mounted = true;
+      },
+    );
   }
 
   async saveStepParams() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where the page tab state and route do not correspond when navigating between pages.

### Description

Replace `tabActiveKey` with `props` in `PageModel` to ensure better reactivity and consistency. Updated `RootPageModel` to use `reaction` for page active state. This fixes the synchronization issue between tab state and route.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the page tab state and route do not correspond |
| 🇨🇳 Chinese | 修复跳转页面时页面 tab 的状态和路由不对应的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
