### PR TITLE
fix: display issue when the markdown field is ellipsized in HTML mode

### DIFF
--- a/packages/core/client/src/flow/common/Markdown/Display.tsx
+++ b/packages/core/client/src/flow/common/Markdown/Display.tsx
@@ -19,7 +19,6 @@ function convertToText(markdownText: string) {
   // 使用 DOMParser 来解析 HTML 字符串
   const parser = new DOMParser();
   const doc = parser.parseFromString(markdownText, 'text/html'); // 解析为 HTML 文档
-
   // 提取所有图片标签，并替换为其 src 属性
   const imgTags = doc.querySelectorAll('img');
   imgTags.forEach((img) => {
@@ -195,7 +194,7 @@ export const Display = (props) => {
                 }
               `}
             >
-              <DisplayInner value={value} />
+              <DisplayInner value={value} loadImages={true} />
             </div>
           )}
         </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix display issue when the markdown field is ellipsized in HTML mode       |
| 🇨🇳 Chinese |    修复markdown 字段html 模式下超出宽度省略时显示异常的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
