### PR TITLE
fix(plugin-field-m2m-array): update m2m array field in hasMany/belongsToMany associate data

### DIFF
--- a/packages/core/database/src/relation-repository/single-relation-repository.ts
+++ b/packages/core/database/src/relation-repository/single-relation-repository.ts
@@ -13,7 +13,6 @@ import { Model } from '../model';
 import { FindOptions, TargetKey, UpdateOptions } from './types';
 import { updateModelByValues } from '../update-associations';
 import { RelationRepository, transaction } from './relation-repository';
-import lodash from 'lodash';
 
 interface SetOption extends Transactionable {
   tk?: TargetKey;
@@ -101,7 +100,7 @@ export abstract class SingleRelationRepository extends RelationRepository {
     }
 
     await updateModelByValues(target, options?.values, {
-      ...lodash.omit(options, 'values'),
+      ...options,
       transaction,
     });
 

--- a/packages/core/database/src/update-associations.ts
+++ b/packages/core/database/src/update-associations.ts
@@ -305,12 +305,12 @@ export async function updateSingleAssociation(
   };
 
   if (isStringOrNumber(value)) {
-    await model[setAccessor](value, { context, transaction, associationKey: key });
+    await model[setAccessor](value, { context, transaction });
     return true;
   }
 
   if (value instanceof Model) {
-    await model[setAccessor](value, { context, transaction, associationKey: key });
+    await model[setAccessor](value, { context, transaction });
     model.setDataValue(key, value);
     return true;
   }
@@ -349,7 +349,7 @@ export async function updateSingleAssociation(
           delete updateValues[association.foreignKey];
         }
 
-        await instance.update(updateValues, { ...options, transaction, associationKey: key });
+        await instance.update(updateValues, { ...options, transaction, inputValues: updateValues });
       }
 
       await updateAssociations(instance, value, {
@@ -367,7 +367,7 @@ export async function updateSingleAssociation(
     values: value,
     operation: 'create',
   });
-  const instance = await model[createAccessor](value, { context, transaction, associationKey: key });
+  const instance = await model[createAccessor](value, { context, transaction, inputValues: value });
 
   await updateAssociations(instance, value, {
     ...options,
@@ -508,7 +508,7 @@ export async function updateMultipleAssociation(
         values: item,
         operation: 'create',
       });
-      const instance = await model[createAccessor](item, accessorOptions);
+      const instance = await model[createAccessor](item, { ...accessorOptions, inputValues: item });
 
       await updateAssociations(instance, item, {
         ...options,
@@ -532,7 +532,7 @@ export async function updateMultipleAssociation(
           values: item,
           operation: 'create',
         });
-        instance = await model[createAccessor](item, accessorOptions);
+        instance = await model[createAccessor](item, { ...accessorOptions, inputValues: item });
         await updateAssociations(instance, item, {
           ...options,
           transaction,
@@ -557,7 +557,7 @@ export async function updateMultipleAssociation(
           values: item,
           operation: 'update',
         });
-        await instance.update(item, { ...options, transaction });
+        await instance.update(item, { ...options, transaction, inputValues: item });
       }
       await updateAssociations(instance, item, {
         ...options,

--- a/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/belongs-to-array-field.ts
+++ b/packages/plugins/@nocobase/plugin-field-m2m-array/src/server/belongs-to-array-field.ts
@@ -21,25 +21,15 @@ export class BelongsToArrayField extends RelationField {
     return 'BelongsToArray';
   }
 
-  private setForeignKeyArray = async (model: Model, { values, context, transaction, associationKey }) => {
+  private setForeignKeyArray = async (model: Model, { values, transaction, inputValues }) => {
     const { type, name, foreignKey, target, targetKey } = this.options;
     if (type !== 'belongsToArray') {
       return;
     }
     let value: any[] | undefined;
-    let valuesInParams = values;
-    let valuesInCtx = context?.action?.params?.values;
-    if (associationKey) {
-      valuesInParams = values?.[associationKey]?.[name];
-      valuesInCtx = valuesInCtx?.[associationKey]?.[name];
-    } else {
-      valuesInParams = values?.[name];
-      valuesInCtx = valuesInCtx?.[name];
-    }
+    const valuesInParams = (inputValues ?? values ?? {})[name];
     if (valuesInParams !== undefined) {
       value = _.castArray(valuesInParams || []);
-    } else if (valuesInCtx !== undefined) {
-      value = _.castArray(valuesInCtx || []);
     } else {
       return;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fix issue m2m array field can`t update while field in m2m sub table 

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
In updateMultipleAssociation method add the correct update input data to model`s create / update options

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the m2m array field in the subtable could not be updated |
| 🇨🇳 Chinese | 修复子表格中多对多数组关系字段数据无法更新问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
