### PR TITLE
fix(schema-settings): update cloned schema to use toJSON()

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
@@ -26,6 +26,7 @@ import { useFormBlockContext } from '../block-provider/FormBlockProvider';
 import { useTableBlockContext } from '../block-provider/TableBlockProvider';
 import { useCollectionFilterOptionsV2 } from '../collection-manager/action-hooks';
 import { FlagProvider, useFlag } from '../flag-provider';
+import { SchemaComponentContext } from '../schema-component';
 import { useLocalVariables, useVariables } from '../variables';
 import { isVariable } from '../variables/utils/isVariable';
 import {
@@ -37,7 +38,6 @@ import {
 import { VariableInput, getShouldChange } from './VariableInput/VariableInput';
 import { Option } from './VariableInput/type';
 import { formatVariableScop } from './VariableInput/utils/formatVariableScop';
-import { SchemaComponentContext } from '../schema-component';
 const getActionContext = (context: { fieldSchema?: Schema }) => {
   const actionCtx = (context.fieldSchema?.['x-action-context'] || {}) as { collection?: string; dataSource?: string };
   return actionCtx;
@@ -147,7 +147,7 @@ export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: 
               getAllCollectionsInheritChain,
             }),
             renderSchemaComponent: function Com(props) {
-              const clonedSchema = useMemo(() => _.cloneDeep(fieldSchemaWithoutRequired) || ({} as Schema), []);
+              const clonedSchema = useMemo(() => fieldSchemaWithoutRequired.toJSON() || ({} as Schema), []);
               clonedSchema['x-read-pretty'] = false;
               clonedSchema['x-disabled'] = false;
               _.set(clonedSchema, 'x-decorator-props.showTitle', false);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fixes a client-side error `TypeError: Cannot read properties of undefined (reading '')` that occurs when configuring default values. The issue was caused by `lodash.cloneDeep` failing when processing the `fieldSchema` object directly.

### Description 
Updated `SchemaSettingsDefaultValue.tsx` to use `.toJSON()` on the `fieldSchemaWithoutRequired` object before using it. 

### Related issues
Fixes the error shown in the screenshot.
<img width="2120" height="1576" alt="image" src="https://github.com/user-attachments/assets/d90bacbc-b76c-4936-9b41-54d6af6fa283" />


### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix client error when configuring default values |
| 🇨🇳 Chinese | 修复配置默认值时的客户端报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
