### PR TITLE
fix(collection-tree): unable to find the parent field of the tree collection

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-tree/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-collection-tree/src/server/plugin.ts
@@ -32,7 +32,6 @@ class PluginCollectionTreeServer extends Plugin {
             return;
           }
           const name = `${dataSource.name}_${collection.name}_path`;
-          const parentForeignKey = collection.treeParentField?.foreignKey || 'parentId';
 
           //always define tree path collection
           const options = {};
@@ -71,6 +70,7 @@ class PluginCollectionTreeServer extends Plugin {
           //afterUpdate
           this.db.on(`${collection.name}.afterUpdate`, async (model: Model, options) => {
             const tk = collection.filterTargetKey;
+            const parentForeignKey = collection.treeParentField?.foreignKey || 'parentId';
             // only update parentId and filterTargetKey
             if (!(model._changed.has(tk) || model._changed.has(parentForeignKey))) {
               return;
@@ -109,6 +109,7 @@ class PluginCollectionTreeServer extends Plugin {
 
           this.db.on(`${collection.name}.beforeSave`, async (model: Model) => {
             const tk = collection.filterTargetKey as string;
+            const parentForeignKey = collection.treeParentField?.foreignKey || 'parentId';
             if (model.get(tk) && model.get(parentForeignKey) === model.get(tk)) {
               throw new Error('Cannot set itself as the parent node');
             }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix path table update failures caused by incorrect tree parent-field lookup        |
| 🇨🇳 Chinese |  修复因树表父字段获取不正确导致路径表更新失败的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
