### PR TITLE
fix(plugin-workflow): fix publish to queue when gracefully stop

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -354,7 +354,7 @@ export default class Dispatcher {
             `instance is not serving as worker or local pending list is not empty, sending execution (${execution.id}) to queue`,
           );
           try {
-            this.plugin.app.eventQueue.publish(this.plugin.channelPendingExecution, {
+            await this.plugin.app.eventQueue.publish(this.plugin.channelPendingExecution, {
               executionId: execution.id,
             });
           } catch (qErr) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where queue closed before messages publishing.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where queue closed before messages publishing |
| 🇨🇳 Chinese | 修复发送消息之前队列已关闭的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
