### PR TITLE
fix(plugin-calendar): fix calendar overlay z-index issue in modal

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/global.style.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/global.style.ts
@@ -12,7 +12,7 @@ import { createGlobalStyle } from 'antd-style';
 const GlobalStyle = createGlobalStyle`
   .rbc-overlay {
     position: absolute;
-    z-index: 50;
+    z-index: 1050;
     margin-top: 5px;
     border-radius: ${({ theme }) => `${theme.borderRadius}px`};
     background-color: ${({ theme }) => theme.colorBgElevated};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
Fixes an issue where the "Show more event items" popup in the Calendar plugin becomes unclickable or hidden when the Calendar block is rendered inside a Modal or Drawer.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

https://github.com/user-attachments/assets/2cd775ad-7e6e-49d1-9661-31223a787ec4



### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix the issue where the "Show more event items" popup is unclickable when the calendar is displayed in a Modal/Drawer      |
| 🇨🇳 Chinese |     修复日历组件在弹窗/抽屉中显示时，“更多事项”弹窗无法点击的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
