### PR TITLE
fix(client): fix lazy load bug in Variable.Input

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/UsersSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/UsersSelect.tsx
@@ -44,7 +44,7 @@ function InternalUsersSelect({ value, onChange }) {
   const scope = useWorkflowVariableOptions({ types: [isUserKeyField] });
 
   return (
-    <Variable.Input nullable={false} scope={scope} value={value} onChange={onChange}>
+    <Variable.Input nullable={false} scope={scope} value={value} onChange={onChange} changeOnSelect={false}>
       <RemoteSelect
         fieldNames={{
           label: 'nickname',

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/variable.tsx
@@ -285,10 +285,14 @@ function getNormalizedFields(collectionName, { compile, collectionManager }) {
       if (foreignKeyFieldIndex > -1) {
         const foreignKeyField = foreignKeyFields[foreignKeyFieldIndex];
         result.splice(i, 0, {
-          ...field,
           ...foreignKeyField,
+          target: field.target,
+          targetKey: field.targetKey,
+          interface: foreignKeyField.interface ?? field.interface,
+          isForeignKey: true,
           uiSchema: {
             ...field.uiSchema,
+            ...foreignKeyField.uiSchema,
             title: foreignKeyField.uiSchema?.title ? compile(foreignKeyField.uiSchema?.title) : foreignKeyField.name,
           },
         });


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix lazy load bug in Variable.Input, which will cause variable options menu re-render incorrectly.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix lazy load bug in Variable.Input, which will cause variable options menu re-render incorrectly |
| 🇨🇳 Chinese | 修复 Variable.Input 组件的懒加载问题，该问题会导致变量选项菜单不正常的重渲染 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
