### PR TITLE
refactor(plugin-workflow): add main data source context for user select

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/UsersSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/UsersSelect.tsx
@@ -18,7 +18,14 @@
 
 import React, { useCallback, useState } from 'react';
 import { ArrayItems } from '@formily/antd-v5';
-import { RemoteSelect, SchemaComponent, Variable, useCollectionFilterOptions, useToken } from '@nocobase/client';
+import {
+  CollectionManagerProvider,
+  RemoteSelect,
+  SchemaComponent,
+  Variable,
+  useCollectionFilterOptions,
+  useToken,
+} from '@nocobase/client';
 import { useField } from '@formily/react';
 import { Button, Popover, Space } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
@@ -35,6 +42,14 @@ function isUserKeyField(field) {
 }
 
 export function UsersSelect(props) {
+  return (
+    <CollectionManagerProvider dataSource="main">
+      <UsersSelectContent {...props} />
+    </CollectionManagerProvider>
+  );
+}
+
+function UsersSelectContent(props) {
   const valueType = typeof props.value;
 
   return valueType === 'object' && props.value ? <UsersQuery {...props} /> : <InternalUsersSelect {...props} />;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add "main" data source context for UserSelect, in order to provide a more common component which could be used in other place.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add "main" data source context for UserSelect, in order to provide a more common component which could be used in other place |
| 🇨🇳 Chinese | 为 UserSelect 组件增加主数据源上下文，以提供一个更通用的组件，可以在其他地方使用 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
