### PR TITLE
fix(acl): incorrect ACL meta when external data-source scopes use current-user variables

### DIFF
--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -571,8 +571,10 @@ export class ACL extends EventEmitter {
 }
 
 function getUser(ctx) {
+  const dataSource = ctx.app.dataSourceManager.dataSources.get('main');
+  const db = dataSource.collectionManager.db;
   return async ({ fields }) => {
-    const userFields = fields.filter((f) => f && ctx.db.getFieldByPath('users.' + f));
+    const userFields = fields.filter((f) => f && db.getFieldByPath('users.' + f));
     ctx.logger?.info('filter-parse: ', { userFields });
     if (!ctx.state.currentUser) {
       return;
@@ -580,7 +582,7 @@ function getUser(ctx) {
     if (!userFields.length) {
       return;
     }
-    const user = await ctx.db.getRepository('users').findOne({
+    const user = await db.getRepository('users').findOne({
       filterByTk: ctx.state.currentUser.id,
       fields: userFields,
     });

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/with-acl-meta.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/with-acl-meta.ts
@@ -84,10 +84,13 @@ function createWithACLMetaMiddleware() {
           return undefined;
         },
         app: {
+          dataSourceManager: ctx.app.dataSourceManager,
           getDb() {
             return db;
           },
         },
+        log: ctx.log,
+        logger: ctx.logger,
         getCurrentRepository: ctx.getCurrentRepository,
         action: {
           actionName: action,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix an issue where ACL meta info is incorrect when external data-source permission scopes use current-user related variables         |
| 🇨🇳 Chinese |  修复外部数据源的权限数据范围使用了当前用户相关变量时， acl meta 信息获取不正确的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
