### PR TITLE
fix: data block has not been refreshed after clicking submit button

### DIFF
--- a/packages/core/flow-engine/src/views/createViewMeta.ts
+++ b/packages/core/flow-engine/src/views/createViewMeta.ts
@@ -177,7 +177,7 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
       const parent = stack[idx];
       if (!parent?.viewUid) return undefined;
 
-      let model = useCtx.engine?.getModel?.(parent.viewUid) as PopupModelLike;
+      let model = useCtx.engine?.getModel(parent.viewUid, true) as PopupModelLike;
       if (!model) {
         try {
           model = (await useCtx.engine.loadModel({ uid: parent.viewUid })) as PopupModelLike;
@@ -367,7 +367,7 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
             const stack = Array.isArray(nav?.viewStack) ? nav.viewStack : [];
             const last = stack?.[stack.length - 1];
             if (last?.viewUid) {
-              let model = ctx?.engine?.getModel?.(last.viewUid) as PopupModelLike;
+              let model = ctx?.engine?.getModel(last.viewUid, true) as PopupModelLike;
               if (!model) {
                 model = (await ctx.engine.loadModel({ uid: last.viewUid })) as PopupModelLike;
               }
@@ -452,7 +452,7 @@ export async function buildPopupRuntime(ctx: FlowContext, view: FlowView): Promi
   const buildNode = async (idx: number): Promise<PopupNode | undefined> => {
     if (idx < 0 || !stack[idx]?.viewUid) return undefined;
     const viewUid = stack[idx].viewUid;
-    let model = ctx.engine?.getModel?.(viewUid) as PopupModelLike;
+    let model = ctx.engine?.getModel(viewUid, true) as PopupModelLike;
     if (!model) {
       model = (await ctx.engine?.loadModel({ uid: viewUid })) as PopupModelLike;
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where data blocks did not refresh when closing a popup by clicking the form submit button inside the popup. |
| 🇨🇳 Chinese | 修复点击弹窗中表单提交按钮关闭弹窗时数据区块数据不刷新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
