### PR TITLE
fix(plugin-data-source-manager): external data source can`t change password

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/data-sources.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/data-sources.test.ts
@@ -250,6 +250,13 @@ describe('data source', async () => {
           enabled: true,
         },
       });
+    for (let i = 0; i < 5; i++) {
+      const mockInstance1 = app.dataSourceManager.dataSources.get('mockInstance1');
+      if (mockInstance1) {
+        break;
+      }
+      await waitSecond(200);
+    }
 
     testConnectionFn.mockClear();
 
@@ -308,6 +315,13 @@ describe('data source', async () => {
           key: 'mockInstance1',
         },
       });
+    for (let i = 0; i < 5; i++) {
+      const mockInstance1 = app.dataSourceManager.dataSources.get('mockInstance1');
+      if (mockInstance1) {
+        break;
+      }
+      await waitSecond(200);
+    }
 
     testConnectionFn.mockClear();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fix issue external data source can`t change password

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
In plugin-data-source-manager modify loadDataSourceTablesIntoCollections function`s logic, if options change, always build a new dataSource to do the `max collection check` and `loadTabls` jobs

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix errors when updating passwords for external data sources |
| 🇨🇳 Chinese | 修复外部数据源更新密码报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
