### PR TITLE
fix: default style of details block's js field

### DIFF
--- a/packages/core/client/src/flow/models/fields/JSFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSFieldModel.tsx
@@ -20,7 +20,24 @@ import { FieldModel } from '../base/FieldModel';
 import { resolveRunJsParams } from '../utils/resolveRunJsParams';
 import { CodeEditor } from '../../components/code-editor';
 
-const DEFAULT_CODE = `const value = ctx.value;\nctx.element.innerHTML = \`<span class="nb-js-field-value">${'${'}String(value ?? '')}</span>\`;\n\n`;
+const DEFAULT_CODE = `
+function JsReadonlyField() {
+  const React = ctx.React;
+  const { prefix, suffix, overflowMode } = ctx.model?.props || {};
+  const text = String(ctx.value ?? '');
+  const whiteSpace = overflowMode === 'wrap' ? 'pre-line' : 'nowrap';
+
+  return (
+    <span style={{ whiteSpace }}>
+      {prefix}
+      {text}
+      {suffix}
+    </span>
+  );
+}
+
+ctx.render(<JsReadonlyField />);
+`.trim();
 
 /**
  * JS 字段（只读形态）：
@@ -146,22 +163,7 @@ JSFieldModel.registerFlow({
       defaultParams(ctx) {
         return {
           version: 'v1',
-          code: `
-function JsReadonlyField() {
-  const React = ctx.React;
-  const { Input } = ctx.antd;
-  return (
-    <Input
-      value={String(ctx.value ?? '')}
-      disabled
-      readOnly
-      style={{ width: '100%' }}
-    />
-  );
-}
-
-ctx.render(<JsReadonlyField />);
-`,
+          code: DEFAULT_CODE,
         };
       },
       async handler(ctx, params) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the default style of the JS field in the detail block was incorrect. |
| 🇨🇳 Chinese | 修复详情区块里的 JS field 默认样式不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
