### PR TITLE
fix: edit and add new action popup title

### DIFF
--- a/packages/core/client/src/flow/FlowPage.tsx
+++ b/packages/core/client/src/flow/FlowPage.tsx
@@ -257,10 +257,11 @@ type FlowPageProps = {
   pageModelClass?: string;
   parentId?: string;
   onModelLoaded?: (uid: string, model: FlowModel) => void;
+  defaultTabTitle?: string;
 };
 
 export const FlowPage = (props: FlowPageProps & Record<string, unknown>) => {
-  const { pageModelClass = 'ChildPageModel', parentId, onModelLoaded, ...rest } = props;
+  const { pageModelClass = 'ChildPageModel', parentId, onModelLoaded, defaultTabTitle, ...rest } = props;
   const flowEngine = useFlowEngine();
   const ctx = useFlowViewContext();
   const { loading, data } = useRequest(
@@ -273,6 +274,7 @@ export const FlowPage = (props: FlowPageProps & Record<string, unknown>) => {
         use: pageModelClass,
       };
       if (pageModelClass === 'ChildPageModel') {
+        const tabTitle = defaultTabTitle || flowEngine.translate?.('Details');
         options['subModels'] = {
           tabs: [
             {
@@ -280,7 +282,7 @@ export const FlowPage = (props: FlowPageProps & Record<string, unknown>) => {
               stepParams: {
                 pageTabSettings: {
                   tab: {
-                    title: 'Details',
+                    title: tabTitle,
                   },
                 },
               },

--- a/packages/core/client/src/flow/actions/openView.tsx
+++ b/packages/core/client/src/flow/actions/openView.tsx
@@ -683,6 +683,7 @@ export const openView = defineAction({
               pageModel.invalidateFlowCache('beforeRender', true);
               pageModel['_rerunLastAutoRun'](); // TODO: 临时做法，等上下文重构完成后去掉
             }}
+            defaultTabTitle={ctx.model['defaultPopupTitle']}
           />
         );
       },

--- a/packages/core/client/src/flow/models/actions/AddNewActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/AddNewActionModel.tsx
@@ -14,6 +14,7 @@ import { ActionSceneEnum, PopupActionModel } from '../base';
 export class AddNewActionModel extends PopupActionModel {
   static scene = ActionSceneEnum.collection;
 
+  defaultPopupTitle = tExpr('Add new');
   defaultProps: ButtonProps = {
     type: 'primary',
     title: tExpr('Add new'),

--- a/packages/core/client/src/flow/models/actions/EditActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/EditActionModel.tsx
@@ -14,6 +14,7 @@ import { ActionSceneEnum, PopupActionModel } from '../base';
 export class EditActionModel extends PopupActionModel {
   static scene = ActionSceneEnum.record;
 
+  defaultPopupTitle = tExpr('Edit');
   defaultProps: ButtonProps = {
     title: tExpr('Edit'),
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the default titles of the edit and create new action popups were incorrect. |
| 🇨🇳 Chinese | 修复编辑操作和新增操作弹窗的默认标题不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
