### PR TITLE
fix: quick create throws error when allowMultiple is disabled in association record select

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -578,7 +578,7 @@ RecordSelectFieldModel.registerFlow({
           { refresh: false },
         );
         if (data) {
-          if (['m2m', 'o2m'].includes(ctx.collectionField?.interface) && ctx.model.props.multiple !== false) {
+          if (['m2m', 'o2m'].includes(ctx.collectionField?.interface) && ctx.model.props.allowMultiple !== false) {
             const prev = ctx.model.props.value || [];
             const merged = [...prev, data.data];
 
@@ -674,9 +674,9 @@ RecordSelectFieldModel.registerFlow({
             collectionName: ctx.collectionField?.target,
             collectionField: ctx.collectionField,
             onChange: (e) => {
-              if (toOne) {
+              if (toOne || !ctx.model.props.allowMultiple) {
                 onChange(e);
-                const data = ctx.model.getDataSource();
+                const data = ctx.model.getDataSource() || [];
                 data.push(e);
                 ctx.model.setDataSource(data);
               } else {
@@ -690,7 +690,7 @@ RecordSelectFieldModel.registerFlow({
                     self.findIndex((r) => r[ctx.collection.filterTargetKey] === row[ctx.collection.filterTargetKey]),
                 );
                 onChange(unique);
-                const data = ctx.model.getDataSource();
+                const data = ctx.model.getDataSource() || [];
                 ctx.model.setDataSource(data.concat(unique));
               }
             },


### PR DESCRIPTION
…ciation record select

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix quick create throws error when allowMultiple is disabled in association record select          |
| 🇨🇳 Chinese |   修复对多关系下拉组件在关闭允许多选时快捷新增报错的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
