### PR TITLE
fix(plugin-action-import): null error thrown

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/server/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/locale/zh-CN.json
@@ -7,5 +7,6 @@
   "Incorrect date format": "日期格式不正确",
   "Incorrect email format": "邮箱格式不正确",
   "Illegal percentage format": "百分比格式有误",
-  "Imported template does not match, please download again.": "导入模板不匹配，请检查导入文件标题行或重新下载导入模板"
+  "Imported template does not match, please download again.": "导入模板不匹配，请检查导入文件标题行或重新下载导入模板",
+  "Failed to parse field {{field}} in row {{rowIndex}}": "第 {{rowIndex}} 行的字段 {{field}} 解析失败：{{message}}"
 }

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
@@ -267,7 +267,15 @@ export class XlsxImporter extends EventEmitter {
         ctx.filterKey = column.dataIndex[1];
       }
 
-      rowValues[dataKey] = await interfaceInstance.toValue(this.trimString(str), ctx);
+      try {
+        rowValues[dataKey] = str == null ? null : await interfaceInstance.toValue(this.trimString(str), ctx);
+      } catch (error) {
+        throw new ImportValidationError('Failed to parse field {{field}} in row {{rowIndex}}: {{message}}', {
+          rowIndex: options?.context?.handingRowIndex || 1,
+          field: dataKey,
+          message: error.message,
+        });
+      }
     }
     const model = this.getModel();
     const guard = UpdateGuard.fromOptions(model, {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where error thrown when field in importing xlsx has `null` value.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where error thrown when field in importing xlsx has `null` value |
| 🇨🇳 Chinese | 修复导入时如果字段包含 `null` 值报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
