### PR TITLE
fix: current record menu should not be shown for comments block

### DIFF
--- a/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
+++ b/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
@@ -193,6 +193,10 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
       },
     ];
     if (this._isScene('one')) {
+      const currentCollection = ctx.dataSourceManager.getCollection(dataSourceKey, collectionName);
+      if (!currentCollection || !this.filterCollection(currentCollection)) {
+        return items;
+      }
       const initOptions = {
         dataSourceKey,
         collectionName,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the current record menu appeared when adding a comment block. |
| 🇨🇳 Chinese | 修复添加评论区块时出现当前记录菜单的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
