### PR TITLE
refactor(theme-editor): remove unused useVisible method

### DIFF
--- a/packages/plugins/@nocobase/plugin-theme-editor/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-theme-editor/src/client/index.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Plugin, createStyles, defaultTheme, useGlobalTheme, useOpenModeContext } from '@nocobase/client';
+import { Plugin, createStyles, defaultTheme, useGlobalTheme } from '@nocobase/client';
 import { ConfigProvider } from 'antd';
 import _ from 'lodash';
 import React, { useMemo } from 'react';
@@ -98,11 +98,6 @@ export class PluginThemeEditorClient extends Plugin {
       name: 'theme',
       sort: 310,
       Component: ThemeSettings,
-      useVisible() {
-        // 移动端暂不支持切换主题
-        const { isMobile } = useOpenModeContext() || {};
-        return !isMobile;
-      },
     });
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The theme switcher was previously hidden on mobile devices. This PR enables it.

### Description 
Removed the `useVisible` check in `PluginThemeEditorClient` that was hiding the theme settings on mobile devices.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Enable theme switcher on mobile devices     |
| 🇨🇳 Chinese |    移动端支持切换主题       |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
