### PR TITLE
fix: filter action should be triggered by pressing enter

### DIFF
--- a/packages/core/client/src/flow/components/filter/FilterContainer.tsx
+++ b/packages/core/client/src/flow/components/filter/FilterContainer.tsx
@@ -99,15 +99,22 @@ export const FilterContainer: FC<FilterContentProps> = observer(
     const translate = ctx?.model?.translate || ((text: string) => text);
 
     return (
-      <>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
         <FilterGroup value={value} FilterItem={FilterItem} />
         <Space style={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
-          <Button onClick={handleReset}>{translate('Reset')}</Button>
-          <Button type="primary" onClick={handleSubmit}>
+          <Button htmlType="button" onClick={handleReset}>
+            {translate('Reset')}
+          </Button>
+          <Button type="primary" htmlType="submit">
             {translate('Submit')}
           </Button>
         </Space>
-      </>
+      </form>
     );
   },
   {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the enter key could not be used to trigger the filter action. |
| 🇨🇳 Chinese | 修复无法使用回车按键触发筛选操作的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
