### PR TITLE
fix: set json value to null when content is empty

### DIFF
--- a/packages/core/client/src/flow/models/fields/JsonFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JsonFieldModel.tsx
@@ -60,12 +60,13 @@ export const JsonInput = observer((props: any) => {
 
   // 失焦时格式化 JSON
   const handleBlur = (ev) => {
+    const val = ev.target.value;
     try {
       const parsed = _JSON.parse(text);
       setText(_JSON.stringify(parsed, null, space));
       onChange?.(parsed); // 外部接收对象或 null
     } catch {
-      onChange?.(ev);
+      onChange?.(val.trim() !== '' ? val : null);
     }
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    set json  field value to null when content is empty       |
| 🇨🇳 Chinese |      json 字段 内容为空时设为 null     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
