### PR TITLE
feat(flow-engine): add removeModelWithSubModels method

### DIFF
--- a/packages/core/client/docs/zh-CN/api/flow-engine/flow-model-repository.md
+++ b/packages/core/client/docs/zh-CN/api/flow-engine/flow-model-repository.md
@@ -52,6 +52,7 @@ flowEngine.setModelRepository(new FlowModelRepository(this.app));
 flowEngine.createModel(options); // 创建本地模型实例
 flowEngine.getModel(uid);        // 获取本地模型实例
 flowEngine.removeModel(uid);     // 移除本地模型实例
+flowEngine.removeModelWithSubModels(uid); // 移除本地模型实例及其所有子模型
 ```
 
 ### 远程方法（由 ModelRepository 实现）

--- a/packages/core/flow-engine/src/__tests__/flowEngine.removeModel.test.ts
+++ b/packages/core/flow-engine/src/__tests__/flowEngine.removeModel.test.ts
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { FlowEngine } from '../flowEngine';
+import { FlowModel } from '../models';
+
+describe('FlowEngine removeModel', () => {
+  let engine: FlowEngine;
+
+  beforeEach(() => {
+    engine = new FlowEngine();
+    engine.registerModels({ FlowModel });
+  });
+
+  it('removeModel should remove model but keep sub-models in cache (current behavior)', () => {
+    const parent = engine.createModel({ uid: 'parent', use: 'FlowModel' });
+    const child = engine.createModel({
+      uid: 'child',
+      use: 'FlowModel',
+      parentId: 'parent',
+      subKey: 'child',
+      subType: 'object',
+    });
+
+    expect(engine.getModel('parent')).toBe(parent);
+    expect(engine.getModel('child')).toBe(child);
+
+    engine.removeModel('parent');
+
+    expect(engine.getModel('parent')).toBeUndefined();
+    // Current behavior: child is still in cache
+    expect(engine.getModel('child')).toBeDefined();
+  });
+
+  it('removeModelWithSubModels should remove model and all sub-models from cache', () => {
+    const parent = engine.createModel({ uid: 'parent', use: 'FlowModel' });
+    const child = engine.createModel({
+      uid: 'child',
+      use: 'FlowModel',
+      parentId: 'parent',
+      subKey: 'child',
+      subType: 'object',
+    });
+    parent.setSubModel('child', child);
+
+    const grandChild = engine.createModel({
+      uid: 'grandChild',
+      use: 'FlowModel',
+      parentId: 'child',
+      subKey: 'grandChild',
+      subType: 'object',
+    });
+    child.setSubModel('grandChild', grandChild);
+
+    expect(engine.getModel('parent')).toBe(parent);
+    expect(engine.getModel('child')).toBe(child);
+    expect(engine.getModel('grandChild')).toBe(grandChild);
+
+    engine.removeModelWithSubModels('parent');
+
+    expect(engine.getModel('parent')).toBeUndefined();
+    expect(engine.getModel('child')).toBeUndefined();
+    expect(engine.getModel('grandChild')).toBeUndefined();
+  });
+});

--- a/packages/core/flow-engine/src/flowEngine.ts
+++ b/packages/core/flow-engine/src/flowEngine.ts
@@ -702,6 +702,44 @@ export class FlowEngine {
   }
 
   /**
+   * Remove a local model instance and all its sub-models recursively.
+   * @param {string} uid UID of the model instance to destroy
+   * @returns {boolean} Returns true if successfully destroyed, false otherwise
+   */
+  public removeModelWithSubModels(uid: string): boolean {
+    const model = this.getModel(uid);
+    if (!model) {
+      return false;
+    }
+
+    const collectDescendants = (m: FlowModel, acc: FlowModel[]) => {
+      if (m.subModels) {
+        for (const key in m.subModels) {
+          const sub = m.subModels[key];
+          if (Array.isArray(sub)) {
+            [...sub].forEach((s) => collectDescendants(s, acc));
+          } else if (sub) {
+            collectDescendants(sub, acc);
+          }
+        }
+      }
+      acc.push(m);
+    };
+
+    const allModels: FlowModel[] = [];
+    collectDescendants(model, allModels);
+
+    let success = true;
+    for (const m of allModels) {
+      if (!this.removeModel(m.uid)) {
+        success = false;
+      }
+    }
+
+    return success;
+  }
+
+  /**
    * Check if the model repository is set.
    * @returns {boolean} Returns true if set, false otherwise.
    * @private


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Currently `removeModel` only removes the specific model cache, leaving sub-models in cache. This new method recursively removes the model and all its sub-models.

### Description 
Added `removeModelWithSubModels` method to `FlowEngine` class. This method recursively collects all descendants of a model and removes them from the engine's model instance cache. Also added unit tests and updated documentation.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `removeModelWithSubModels` method to recursively remove model and its sub-models |
| 🇨🇳 Chinese | 新增 `removeModelWithSubModels` 方法，用于递归移除模型及其子模型 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
