### PR TITLE
fix: formula field can't be added to filter form

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-formula/src/client/FormulaFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client/FormulaFieldModel.tsx
@@ -9,7 +9,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { toJS } from '@formily/reactive';
-import { EditableItemModel, DisplayItemModel } from '@nocobase/flow-engine';
+import { EditableItemModel, DisplayItemModel, FilterableItemModel } from '@nocobase/flow-engine';
 import { Form } from 'antd';
 import { Checkbox, DatePicker, FieldModel, InputNumber, Input as InputString } from '@nocobase/client';
 import { Evaluator, evaluators } from '@nocobase/evaluators/client';
@@ -166,3 +166,5 @@ DisplayItemModel.bindModelToInterface('DisplayNumberFieldModel', ['formula'], {
     return true;
   },
 });
+
+FilterableItemModel.bindModelToInterface('FormulaFieldModel', ['formula'], { isDefault: true });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where formula fields could not be added to filter form block. |
| 🇨🇳 Chinese | 修复无法将公式字段添加到筛选表单的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
