### PR TITLE
fix: attachment field not displayed correctly in readPretty subtable

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
@@ -230,8 +230,8 @@ const Preview = (props) => {
 };
 export class DisplayPreviewFieldModel extends FieldModel {
   render(): any {
-    const { value, titleField, template } = this.props;
-    if (titleField && template !== 'file') {
+    const { value, titleField, template, target } = this.props;
+    if (titleField && template !== 'file' && target !== 'attachments') {
       return castArray(value).flatMap((v, idx) => {
         const result = v?.[titleField];
         const content = result ? (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix attachment field not displayed correctly in readPretty subtable       |
| 🇨🇳 Chinese |    修复阅读态子表格中 Attachment 字段数据未正常加载问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
