### PR TITLE
fix: filter form should not use backend validation rules

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
@@ -256,7 +256,11 @@ FilterFormItemModel.registerFlow({
       async handler(ctx, params) {
         const collectionField = ctx.model.collectionField;
         if (collectionField?.getComponentProps) {
-          ctx.model.setProps(collectionField.getComponentProps());
+          const componentProps = collectionField.getComponentProps();
+          const { rules, required, ...restProps } = componentProps || {};
+
+          // 筛选表单不继承字段的后端校验
+          ctx.model.setProps({ ...restProps, rules: undefined, required: undefined });
         }
         ctx.model.setProps({
           name: `${ctx.model.fieldPath}_${ctx.model.uid}`, // 确保每个字段的名称唯一


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where fields in filter forms were restricted by backend validation rules for fields. |
| 🇨🇳 Chinese | 修复筛选表单中的字段被字段后端验证规则限制的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
