### PR TITLE
fix: use $includes operator for string-type formula fields in association Select search

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/CascadeSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/CascadeSelectFieldModel.tsx
@@ -481,7 +481,15 @@ async function originalHandler(ctx, params) {
     const targetInterface = ctx.app.dataSourceManager.collectionFieldInterfaceManager.getFieldInterface(
       targetLabelField.options.interface,
     );
-    const operator = targetInterface?.filterable?.operators?.[0]?.value || '$includes';
+
+    // Determine the appropriate operator based on field type
+    let operator = targetInterface?.filterable?.operators?.[0]?.value || '$includes';
+
+    // For formula fields with string dataType, use $includes for better search experience
+    // This allows searching by partial matches (e.g., typing "3" to find "3 Jackson Hughes")
+    if (targetLabelField.options.interface === 'formula' && targetLabelField.options.dataType === 'string') {
+      operator = '$includes';
+    }
 
     const searchText = ctx.inputArgs.searchText?.trim();
     const resource = ctx.model.resource;

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -405,7 +405,15 @@ async function originalHandler(ctx, params) {
     const targetInterface = ctx.app.dataSourceManager.collectionFieldInterfaceManager.getFieldInterface(
       targetLabelField.options.interface,
     );
-    const operator = targetInterface?.filterable?.operators?.[0]?.value || '$includes';
+
+    // Determine the appropriate operator based on field type
+    let operator = targetInterface?.filterable?.operators?.[0]?.value || '$includes';
+
+    // For formula fields with string dataType, use $includes for better search experience
+    // This allows searching by partial matches (e.g., typing "3" to find "3 Jackson Hughes")
+    if (targetLabelField.options.interface === 'formula' && targetLabelField.options.dataType === 'string') {
+      operator = '$includes';
+    }
 
     const searchText = ctx.inputArgs.searchText?.trim();
 


### PR DESCRIPTION
…#8079

### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Formula fields in NocoBase can have different data types (string, number, boolean, date, etc.). When a formula field with `dataType="string"` is used as the label field in association Select components, the search functionality was using the wrong filter operator.

The issue stems from the `FormulaFieldInterface` always using `operators.number` regardless of the field's actual `dataType`. This causes the search handler to use `$eq` (exact match) instead of `$includes` (partial match) for string-type formula fields, making it impossible to search by partial text.

### Description

This PR fixes the search filtering issue for formula fields with string dataType in association Select components (both RecordSelect and CascadeSelect).

**Changes made:**
1. Updated `RecordSelectFieldModel.tsx` search handler to detect formula fields with string dataType and use `$includes` operator for better search experience
2. Updated `CascadeSelectFieldModel.tsx` search handler with the same logic for consistency

**Key changes:**
- Added logic to check if the label field is a formula field with string dataType
- When detected, explicitly use `$includes` operator instead of the default `$eq` operator
- This allows partial match searching (e.g., typing "3" to find "3 Jackson Hughes")

**Files modified:**
- `packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx`
- `packages/core/client/src/flow/models/fields/AssociationFieldModel/CascadeSelectFieldModel.tsx`

**Potential risks:**
- Low risk: The change only affects formula fields with string dataType, and only improves the search behavior to match user expectations
- The fallback to `$includes` is already the default when no operator is found

**Testing suggestions:**
1. Create a formula field with string dataType (e.g., concatenating multiple fields)
2. Use it as the label field in a many-to-many relationship Select component
3. Test searching with partial text matches
4. Verify that formula fields with other dataTypes (number, boolean, date) still work correctly

### Related issues

N/A

### Showcase

Before fix: Typing "3" in the search box shows "No data"
After fix: Typing "3" in the search box correctly filters and shows "3 Jackson Hughes"

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed search filtering for formula fields with string dataType in association Select components. Now supports partial text matching when searching. |
| 🇨🇳 Chinese | 修复了关联选择组件中字符串类型公式字段的搜索过滤问题。现在支持部分文本匹配搜索。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed - bug fix with no API changes |
| 🇨🇳 Chinese | 不需要 - 错误修复，无API更改 |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

