### PR TITLE
fix: quick create settings should be hidden from association fields in filter form block

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -28,6 +28,7 @@ import { SkeletonFallback } from '../../../components/SkeletonFallback';
 import { AssociationFieldModel } from './AssociationFieldModel';
 import { LabelByField, resolveOptions, toSelectValue, type LazySelectProps } from './recordSelectShared';
 import { MobileLazySelect } from '../mobile-components/MobileLazySelect';
+import { BlockSceneEnum } from '../../base';
 
 function RemoteModelRenderer({ options }) {
   const ctx = useFlowViewContext();
@@ -532,6 +533,9 @@ RecordSelectFieldModel.registerFlow({
       title: tExpr('Quick create'),
       uiSchema(ctx) {
         const t = ctx.t;
+        if (ctx?.blockModel?.constructor?.scene === BlockSceneEnum.filter) {
+          return null;
+        }
         return {
           quickCreate: {
             enum: [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The configuration menu for association fields in filter forms should not display the quick-create option. |
| 🇨🇳 Chinese | 筛选表单中的关系字段的配置菜单不应该显示快捷创建。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
