### PR TITLE
fix: filter form add fields menu has not been refreshed automatically

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -135,6 +135,7 @@ export class FilterFormGridModel extends GridModel {
     // 向筛选表单区块添加字段 model
     return (
       <AddSubModelButton
+        key={this.context.blockGridModel?.subModels?.items?.length}
         subModelKey="items"
         model={this}
         afterSubModelInit={this.onModelCreated.bind(this)}


### PR DESCRIPTION
…block

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where newly added data blocks did not automatically appear in the field menu of the filter form block. |
| 🇨🇳 Chinese | 修复添加数据区块后不会自动出现在筛选表单的字段菜单中的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
