### PR TITLE
fix: non filterable association fields should not be listed in filter action

### DIFF
--- a/packages/core/flow-engine/src/utils/__tests__/createCollectionContextMeta.test.ts
+++ b/packages/core/flow-engine/src/utils/__tests__/createCollectionContextMeta.test.ts
@@ -1,0 +1,51 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createCollectionContextMeta } from '../createCollectionContextMeta';
+import { FlowEngine } from '../../flowEngine';
+import { CollectionFieldInterfaceManager } from '../../../../client/src/data-source/collection-field-interface/CollectionFieldInterfaceManager';
+
+describe('createCollectionContextMeta', () => {
+  it('filters association sub fields when includeNonFilterable is false', async () => {
+    const engine = new FlowEngine();
+    const dm = engine.dataSourceManager as any;
+    dm.collectionFieldInterfaceManager = new CollectionFieldInterfaceManager([], {}, dm);
+    engine.context.defineProperty('app', { value: { dataSourceManager: dm } });
+    const ds = dm.getDataSource('main')!;
+
+    ds.addCollection({
+      name: 'users',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number', filterable: true },
+        { name: 'email', type: 'string', interface: 'text', filterable: true },
+        { name: 'nickname', type: 'string', interface: 'text' }, // 未声明 filterable
+      ],
+    });
+
+    ds.addCollection({
+      name: 'posts',
+      fields: [
+        { name: 'title', type: 'string', interface: 'text', filterable: true },
+        { name: 'author', type: 'belongsTo', target: 'users', interface: 'm2o', filterable: true },
+      ],
+    });
+
+    const posts = ds.getCollection('posts')!;
+    const metaFactory = createCollectionContextMeta(posts, 'Posts', false);
+    const meta = await metaFactory();
+    const props = await (meta?.properties as any)?.();
+    const authorMeta: any = props?.author;
+    const authorFields = await authorMeta?.properties?.();
+
+    expect(authorFields).toBeTruthy();
+    expect(authorFields).toHaveProperty('email');
+    expect(authorFields).not.toHaveProperty('nickname');
+  });
+});

--- a/packages/core/flow-engine/src/utils/createCollectionContextMeta.ts
+++ b/packages/core/flow-engine/src/utils/createCollectionContextMeta.ts
@@ -17,7 +17,7 @@ const NUMERIC_FIELD_TYPES = ['integer', 'float', 'double', 'decimal'] as const;
 /**
  * 创建字段的完整元数据（统一处理关联和非关联字段）
  */
-function createFieldMetadata(field: CollectionField) {
+function createFieldMetadata(field: CollectionField, includeNonFilterable?: boolean) {
   const baseProperties = createMetaBaseProperties(field);
 
   if (field.isAssociationField()) {
@@ -36,7 +36,9 @@ function createFieldMetadata(field: CollectionField) {
       properties: async () => {
         const subProperties: Record<string, any> = {};
         targetCollection.fields.forEach((subField) => {
-          subProperties[subField.name] = createFieldMetadata(subField);
+          if (includeNonFilterable || subField.filterable) {
+            subProperties[subField.name] = createFieldMetadata(subField, includeNonFilterable);
+          }
         });
         return subProperties;
       },
@@ -112,7 +114,7 @@ export function createCollectionContextMeta(
         // 添加所有字段
         collection.fields.forEach((field) => {
           if (includeNonFilterable || field.filterable) {
-            properties[field.name] = createFieldMetadata(field);
+            properties[field.name] = createFieldMetadata(field, includeNonFilterable);
           }
         });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where unsupported association fields appeared in filter operation fields. |
| 🇨🇳 Chinese | 修复筛选操作字段里出现不支持筛选的关系字段的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
