### PR TITLE
fix(flow-model-renderer): update useCache handling in useEffect

### DIFF
--- a/packages/core/flow-engine/src/components/FlowModelRenderer.tsx
+++ b/packages/core/flow-engine/src/components/FlowModelRenderer.tsx
@@ -346,17 +346,19 @@ export const FlowModelRenderer: React.FC<FlowModelRendererProps> = observer(
     extraToolbarItems,
     useCache,
   }) => {
+    useEffect(() => {
+      if (model?.context) {
+        model.context.defineProperty('useCache', {
+          value: typeof useCache === 'boolean' ? useCache : model.context.useCache,
+        });
+      }
+    }, [model?.context, useCache]);
+
     if (!model || typeof model.render !== 'function') {
       // 可以选择渲染 null 或者一个错误/提示信息
       console.warn('FlowModelRenderer: Invalid model or render method not found.', model);
       return null;
     }
-
-    useEffect(() => {
-      model.context.defineProperty('useCache', {
-        value: typeof useCache === 'boolean' ? useCache : model.context.useCache,
-      });
-    }, [model.context, useCache]);
 
     // 构建渲染内容：统一在渲染前触发 beforeRender 事件（带缓存）
     const content = (


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix React Hooks rules violation where `useEffect` was called after a conditional return.

### Description 
Moved `useEffect` before the conditional check `if (!model ...)` to ensure consistent Hook execution order. Added a check for `model?.context` inside the effect.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Move useEffect before conditional return in FlowModelRenderer |
| 🇨🇳 Chinese | 将 useEffect 移至 FlowModelRenderer 中的条件返回之前 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
