### PR TITLE
fix: reset title can't be modified in filter form block

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormResetActionModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormResetActionModel.tsx
@@ -14,7 +14,7 @@ import { tExpr } from '@nocobase/flow-engine';
 
 export class FilterFormResetActionModel extends FilterFormActionModel {
   defaultProps: ButtonProps = {
-    children: tExpr('Reset'),
+    title: tExpr('Reset'),
   };
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the reset button text in filter form block could not be modified. |
| 🇨🇳 Chinese | 修复无法修改筛选表单中的重制按钮文字的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
