### PR TITLE
fix(plugin-workflow): error thrown when node deleted

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
@@ -46,6 +46,9 @@ function attachJobs(nodes, jobs: any[] = []): void {
   });
   jobs.forEach((item) => {
     const node = nodesMap.get(item.nodeId);
+    if (!node) {
+      return;
+    }
     node.jobs.push(item);
     item.node = {
       id: node.id,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where error thrown in execution canvas when node is deleted.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where error thrown in execution canvas when node is deleted |
| 🇨🇳 Chinese | 修复执行记录画布中节点被删除后导致的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
