### PR TITLE
fix: clear filter fields after destroy blocks

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormBlockModel.tsx
@@ -39,6 +39,8 @@ export class FilterFormBlockModel extends FilterBlockModel<{
    */
   autoTriggerFilter = true;
 
+  private removeTargetBlockListener?: () => void;
+
   get form() {
     return this.context.form;
   }
@@ -74,6 +76,47 @@ export class FilterFormBlockModel extends FilterBlockModel<{
     this.context.defineProperty('filterFormGridModel', {
       value: this.subModels.grid,
     });
+
+    // 监听页面区块删除，自动清理已失效的筛选字段
+    const blockGridModel = this.context.blockGridModel;
+    if (blockGridModel?.emitter) {
+      const handleTargetRemoved = (model) => {
+        if (!model?.uid || model.uid === this.uid) return;
+        this.handleTargetBlockRemoved(model.uid);
+      };
+      blockGridModel.emitter.on('onSubModelRemoved', handleTargetRemoved);
+      this.removeTargetBlockListener = () => blockGridModel.emitter.off('onSubModelRemoved', handleTargetRemoved);
+    }
+  }
+
+  onUnmount() {
+    this.removeTargetBlockListener?.();
+    super.onUnmount();
+  }
+
+  private async handleTargetBlockRemoved(targetUid: string) {
+    const filterManager: FilterManager = this.context.filterManager;
+    const gridModel = this.subModels.grid;
+    const fieldModels: FilterFormItemModel[] = gridModel.subModels.items || [];
+
+    for (const fieldModel of [...fieldModels]) {
+      const connectConfig = filterManager.getConnectFieldsConfig(fieldModel.uid);
+      const targets = connectConfig?.targets || [];
+      const hasTarget = targets.some((target) => target.targetId === targetUid);
+      const defaultMatches = fieldModel.defaultTargetUid === targetUid;
+
+      if (!hasTarget && !defaultMatches) continue;
+
+      const remainingTargets = targets.filter((target) => target.targetId !== targetUid);
+
+      if (remainingTargets.length > 0) {
+        await filterManager.saveConnectFieldsConfig(fieldModel.uid, { targets: remainingTargets });
+        continue;
+      }
+
+      await filterManager.removeFilterConfig({ filterId: fieldModel.uid });
+      await fieldModel.destroy();
+    }
   }
 
   async destroy(): Promise<boolean> {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the configured fields from a removed block were not deleted from the filter block. |
| 🇨🇳 Chinese | 修复移除区块后筛选区块里已经配置的该区块的字段未删除的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
