### PR TITLE
fix: filter is incorrect for some operators like is empty

### DIFF
--- a/packages/core/client/src/flow/components/filter/LinkageFilterItem.tsx
+++ b/packages/core/client/src/flow/components/filter/LinkageFilterItem.tsx
@@ -32,6 +32,7 @@ export interface LinkageFilterItemValue {
   path: string | null;
   operator: string;
   value: any;
+  noValue?: boolean;
 }
 
 export interface LinkageFilterItemProps {
@@ -156,7 +157,10 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
         const fallback = operatorMetadataList.find((op) => op.selected) || operatorMetadataList[0];
         value.operator = fallback?.value || '';
         if (fallback?.noValue) {
-          value.value = '';
+          value.value = true;
+          value.noValue = true;
+        } else {
+          value.noValue = false;
         }
         shouldDefaultOperatorRef.current = false;
       }
@@ -168,7 +172,10 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
       const fallback = operatorMetadataList.find((op) => op.selected) || operatorMetadataList[0];
       value.operator = fallback?.value || '';
       if (fallback?.noValue) {
-        value.value = '';
+        value.value = true;
+        value.noValue = true;
+      } else {
+        value.noValue = false;
       }
     }
   }, [operatorMetadataList, selectedOperator, value]);
@@ -272,7 +279,10 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
       value.operator = operatorValue;
       const selectedOperatorMeta = operatorMetadataList.find((o) => o.value === operatorValue);
       if (selectedOperatorMeta?.noValue) {
-        value.value = '';
+        value.value = true;
+        value.noValue = true;
+      } else {
+        value.noValue = false;
       }
     },
     [value, operatorMetadataList],

--- a/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
@@ -69,6 +69,8 @@ export interface VariableFilterItemValue {
   operator: string;
   // 尽量收敛为常见联合类型，避免到处传播 unknown
   value: string | number | boolean | null | Array<string | number> | Record<string, unknown>;
+  /** 操作符是否无右值（用于透传到 transformFilter 等） */
+  noValue?: boolean;
 }
 
 export interface VariableFilterItemProps {
@@ -235,6 +237,9 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
         const first = operatorMetaList[0];
         value.operator = first.value;
         value.value = first.noValue ? true : undefined;
+        value.noValue = !!first.noValue;
+      } else {
+        value.noValue = !!matched.noValue;
       }
     }, [operatorMetaList, value]);
 
@@ -280,8 +285,10 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
         const cur = operatorMetaList.find((op) => op.value === operatorValue);
         if (cur?.noValue) {
           value.value = true;
+          value.noValue = true;
         } else {
           value.value = undefined;
+          value.noValue = false;
         }
       },
       [operatorMetaList, value],

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
@@ -19,7 +19,7 @@ import { Empty } from 'antd';
 import _, { debounce } from 'lodash';
 import React from 'react';
 import { CollectionBlockModel, FieldModel } from '../../base';
-import { getAllDataModels } from '../filter-manager/utils';
+import { getAllDataModels, getDefaultOperator } from '../filter-manager/utils';
 import { FilterFormFieldModel } from './fields';
 
 const getModelFields = async (model: CollectionBlockModel) => {
@@ -148,6 +148,19 @@ export class FilterFormItemModel extends FilterableItemModel<{
     return this.getStepParams('filterFormItemSettings', 'init').defaultTargetUid;
   }
 
+  private getCurrentOperatorMeta() {
+    const operator = getDefaultOperator(this);
+    if (!operator) return null;
+
+    const operatorList = this.collectionField?.filterable?.operators;
+
+    if (!Array.isArray(operatorList)) {
+      return null;
+    }
+
+    return operatorList.find((op) => op.value === operator) || null;
+  }
+
   onInit(options) {
     super.onInit(options);
     // 创建防抖的 doFilter 方法，延迟 300ms
@@ -173,6 +186,11 @@ export class FilterFormItemModel extends FilterableItemModel<{
    * @returns
    */
   getFilterValue() {
+    const operatorMeta = this.getCurrentOperatorMeta();
+    if (operatorMeta?.noValue) {
+      return true;
+    }
+
     if (this.subModels.field.getFilterValue) {
       return this.subModels.field.getFilterValue();
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where some field operators in filter forms failed to filter data correctly. |
| 🇨🇳 Chinese | 修复筛选表单中部分字段操作符无法正确筛选数据的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
