### PR TITLE
refactor(server): export helper

### DIFF
--- a/packages/core/server/src/helper.ts
+++ b/packages/core/server/src/helper.ts
@@ -10,7 +10,7 @@
 import cors from '@koa/cors';
 import { requestLogger } from '@nocobase/logger';
 import { Resourcer } from '@nocobase/resourcer';
-import { uid } from '@nocobase/utils';
+import { getDateVars, uid } from '@nocobase/utils';
 import { Command } from 'commander';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
@@ -169,4 +169,62 @@ export const enablePerfHooks = (app: Application) => {
 
 export function getBodyLimit() {
   return process.env.REQUEST_BODY_LIMIT || '10mb';
+}
+
+function getUser(ctx) {
+  return async ({ fields }) => {
+    const userFields = fields.filter((f) => f && ctx.db.getFieldByPath('users.' + f));
+    ctx.logger?.info('filter-parse: ', { userFields });
+    if (!ctx.state.currentUser) {
+      return;
+    }
+    if (!userFields.length) {
+      return;
+    }
+    const user = await ctx.db.getRepository('users').findOne({
+      filterByTk: ctx.state.currentUser.id,
+      fields: userFields,
+    });
+    ctx.logger?.info('filter-parse: ', {
+      $user: user?.toJSON(),
+    });
+    return user;
+  };
+}
+
+function isNumeric(str: any) {
+  if (typeof str === 'number') return true;
+  if (typeof str != 'string') return false;
+  return !isNaN(str as any) && !isNaN(parseFloat(str));
+}
+
+export function createContextVariablesScope(ctx) {
+  const state = JSON.parse(JSON.stringify(ctx.state));
+  return {
+    timezone: ctx.get('x-timezone'),
+    now: new Date().toISOString(),
+    getField: (path) => {
+      const fieldPath = path
+        .split('.')
+        .filter((p) => !p.startsWith('$') && !isNumeric(p))
+        .join('.');
+      const { resourceName } = ctx.action;
+      return ctx.db.getFieldByPath(`${resourceName}.${fieldPath}`);
+    },
+    vars: {
+      ctx: {
+        state,
+      },
+      // @deprecated
+      $system: {
+        now: new Date().toISOString(),
+      },
+      // @deprecated
+      $date: getDateVars(),
+      // 新的命名方式，防止和 formily 内置变量冲突
+      $nDate: getDateVars(),
+      $user: getUser(ctx),
+      $nRole: ctx.state.currentRole === '__union__' ? ctx.state.currentRoles : ctx.state.currentRole,
+    },
+  };
 }

--- a/packages/core/server/src/index.ts
+++ b/packages/core/server/src/index.ts
@@ -32,3 +32,4 @@ export {
 } from './plugin-manager/findPackageNames';
 
 export { runPluginStaticImports } from './run-plugin-static-imports';
+export { createContextVariablesScope } from './helper';

--- a/packages/core/server/src/middlewares/parse-variables.ts
+++ b/packages/core/server/src/middlewares/parse-variables.ts
@@ -7,67 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { getDateVars, parseFilter } from '@nocobase/utils';
-
-function getUser(ctx) {
-  return async ({ fields }) => {
-    const userFields = fields.filter((f) => f && ctx.db.getFieldByPath('users.' + f));
-    ctx.logger?.info('filter-parse: ', { userFields });
-    if (!ctx.state.currentUser) {
-      return;
-    }
-    if (!userFields.length) {
-      return;
-    }
-    const user = await ctx.db.getRepository('users').findOne({
-      filterByTk: ctx.state.currentUser.id,
-      fields: userFields,
-    });
-    ctx.logger?.info('filter-parse: ', {
-      $user: user?.toJSON(),
-    });
-    return user;
-  };
-}
-
-function isNumeric(str: any) {
-  if (typeof str === 'number') return true;
-  if (typeof str != 'string') return false;
-  return !isNaN(str as any) && !isNaN(parseFloat(str));
-}
+import { parseFilter } from '@nocobase/utils';
+import { createContextVariablesScope } from '../helper';
 
 export async function parseVariables(ctx, next) {
   const filter = ctx.action.params.filter;
   if (!filter) {
     return next();
   }
-  const state = JSON.parse(JSON.stringify(ctx.state));
-  ctx.action.params.filter = await parseFilter(filter, {
-    timezone: ctx.get('x-timezone'),
-    now: new Date().toISOString(),
-    getField: (path) => {
-      const fieldPath = path
-        .split('.')
-        .filter((p) => !p.startsWith('$') && !isNumeric(p))
-        .join('.');
-      const { resourceName } = ctx.action;
-      return ctx.db.getFieldByPath(`${resourceName}.${fieldPath}`);
-    },
-    vars: {
-      ctx: {
-        state,
-      },
-      // @deprecated
-      $system: {
-        now: new Date().toISOString(),
-      },
-      // @deprecated
-      $date: getDateVars(),
-      // 新的命名方式，防止和 formily 内置变量冲突
-      $nDate: getDateVars(),
-      $user: getUser(ctx),
-      $nRole: ctx.state.currentRole === '__union__' ? ctx.state.currentRoles : ctx.state.currentRole,
-    },
-  });
+  ctx.action.params.filter = await parseFilter(filter, createContextVariablesScope(ctx));
   await next();
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation

When use `acl.can` manually, the result parameters contains variables, and the variables need to be parsed manually too.

### Description 

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Provide helper function for building scope of context variables, in order to be used in other modules |
| 🇨🇳 Chinese | 提供构造上下文变量的公共方法，以便其他模块手动解析时调用 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
