### PR TITLE
fix: number field filtering value can't be  refilled correctly

### DIFF
--- a/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
@@ -114,6 +114,17 @@ function createStaticInputRenderer(
     ...combinedProps,
   };
 
+  const resolveNumberValue = (val: VariableFilterItemValue['value']) => {
+    if (typeof val === 'number') {
+      return val;
+    }
+    // stringMode 下 InputNumber/NumberPicker 会返回字符串，直接回填以避免被清空
+    if (combinedProps?.stringMode === true && typeof val === 'string') {
+      return val;
+    }
+    return undefined;
+  };
+
   return (
     p: { value?: VariableFilterItemValue['value']; onChange?: (v: VariableFilterItemValue['value']) => void } & Record<
       string,
@@ -126,7 +137,7 @@ function createStaticInputRenderer(
         <InputNumber
           {...commonProps}
           {...rest}
-          value={typeof value === 'number' ? value : undefined}
+          value={resolveNumberValue(value)}
           onChange={(v) => onChange?.(v as unknown as VariableFilterItemValue['value'])}
         />
       );
@@ -135,7 +146,7 @@ function createStaticInputRenderer(
         <NumberPicker
           {...commonProps}
           {...rest}
-          value={typeof value === 'number' ? value : undefined}
+          value={resolveNumberValue(value)}
           onChange={(v) => onChange?.(v as unknown as VariableFilterItemValue['value'])}
         />
       );

--- a/packages/core/client/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
+++ b/packages/core/client/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { VariableFilterItem, VariableFilterItemValue } from '../VariableFilterItem';
 import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
 import { Application } from '../../../../application/Application';
@@ -130,6 +130,35 @@ describe('VariableFilterItem', () => {
     const input = await screen.findByPlaceholderText('Enter value');
     fireEvent.change(input, { target: { value: 'abc' } });
     expect(value.value).toBe('abc');
+  });
+
+  it('keeps numeric string when x-component uses InputNumber with stringMode', async () => {
+    const prevMeta = (globalThis as any).__TEST_META__;
+    const prevPath = (globalThis as any).__TEST_PATH__;
+    (globalThis as any).__TEST_PATH__ = 'price';
+    (globalThis as any).__TEST_META__ = {
+      interface: 'input',
+      uiSchema: { 'x-component': 'InputNumber', 'x-component-props': { stringMode: true } },
+      paths: ['collection', 'price'],
+      name: 'price',
+      title: 'Price',
+      type: 'number',
+    };
+
+    const value: VariableFilterItemValue = { path: 'price', operator: '$eq', value: '123.45' };
+    const model = CreateModel();
+
+    render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+
+    await waitFor(() => {
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      expect(input.value).toBe('123.45');
+      expect(value.value).toBe('123.45');
+    });
+
+    (globalThis as any).__TEST_META__ = prevMeta;
+    (globalThis as any).__TEST_PATH__ = prevPath;
   });
 
   it('normalizes synthetic event value when formula field renders Input from app components', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where number field value was not correctly pre-filled in filter action. |
| 🇨🇳 Chinese | 修复筛选操作中的 number 字段值未被正确回填的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
