### PR TITLE
fix: custom fields configuration were not shown correctly in filter form

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FieldModelSelect.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FieldModelSelect.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { FilterableItemModel, useFlowContext, useFlowEngine } from '@nocobase/flow-engine';
 import { Select } from '@formily/antd-v5';
 
@@ -23,9 +23,14 @@ export function FieldModelSelect(props) {
     if (!binding) {
       return;
     }
-    onChange(binding.modelName);
     return binding.modelName;
   }, [source.join('.')]);
 
-  return <Select allowClear {...props} value={props.value || defaultValue} />;
+  useEffect(() => {
+    if (!props.value && defaultValue) {
+      onChange?.(defaultValue);
+    }
+  }, [defaultValue, onChange, props.value]);
+
+  return <Select allowClear {...props} value={props.value ?? defaultValue} />;
 }

--- a/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/components/FilterDatePicker.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/components/FilterDatePicker.tsx
@@ -19,7 +19,7 @@ export const FilterDatePicker = (props: any) => {
   const value = Array.isArray(props.value) ? props.value[0] : props.value;
   const initPicker = value ? inferPickerType(value, picker) : picker;
   const [targetPicker, setTargetPicker] = useState(initPicker);
-  const targetDateFormat = getPickerFormat(initPicker) || format;
+  const targetDateFormat = format || getPickerFormat(initPicker);
   const t = ctx.model.translate.bind(ctx.model);
   const newProps = {
     utc: true,
@@ -60,8 +60,8 @@ export const FilterDatePicker = (props: any) => {
         ]}
         onChange={(value) => {
           setTargetPicker(value);
-          const format = getPickerFormat(value);
-          const dateTimeFormat = getDateTimeFormat(value, format, showTime, timeFormat);
+          const nextDateFormat = format || getPickerFormat(value);
+          const dateTimeFormat = getDateTimeFormat(value, nextDateFormat, showTime, timeFormat);
           newProps.picker = value;
           newProps.format = dateTimeFormat;
           setStateProps(newProps);

--- a/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/components/FilterRangePicker.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/components/FilterRangePicker.tsx
@@ -42,7 +42,7 @@ export const FilterRangePicker = (props: any) => {
   ];
 
   const targetPicker = value ? inferPickerType(value?.[0], picker) : picker;
-  const targetDateFormat = getPickerFormat(targetPicker) || format;
+  const targetDateFormat = format || getPickerFormat(targetPicker);
   const newProps: any = {
     utc: true,
     presets,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where custom fields configurations in filter form were not correctly pre-filled and some settings did not take effect. |
| 🇨🇳 Chinese | 修复筛选表单中自定义字段配置无法正确回填及部分配置不生效的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
