### PR TITLE
fix: filter form association fields data is incorrect

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -463,16 +463,17 @@ RecordSelectFieldModel.registerFlow({
         resource.setDataSourceKey(dataSourceKey);
         resource.setResourceName(target);
         resource.setPageSize(paginationState.pageSize);
+        const isFilterScene = ctx?.blockModel?.constructor?.scene === BlockSceneEnum.filter;
         const isOToAny = ['oho', 'o2m'].includes(collectionField.interface);
         const sourceValue = ctx.record?.[collectionField?.sourceKey];
         // 构建 $or 条件数组
         const orFilters: Record<string, any>[] = [];
-        if (sourceValue != null && isOToAny) {
+        if (!isFilterScene && sourceValue != null && isOToAny) {
           const eqKey = `${foreignKey}.$eq`;
           orFilters.push({ [eqKey]: sourceValue });
         }
 
-        if (isOToAny) {
+        if (!isFilterScene && isOToAny) {
           const isKey = `${foreignKey}.$is`;
           orFilters.push({ [isKey]: null });
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the selectable data for association fields in filter form block was incorrect. |
| 🇨🇳 Chinese | 修复筛选表单中关系字段可选数据不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
