### PR TITLE
fix: between date filtering error

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-manager/__tests__/FilterManager.bindToTarget.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-manager/__tests__/FilterManager.bindToTarget.test.ts
@@ -386,6 +386,24 @@ describe('FilterManager.bindToTarget', () => {
       expect(mockTargetModel.resource.addFilterGroup).not.toHaveBeenCalled();
     });
 
+    it('should call removeFilterGroup when filter value array only contains empty values', async () => {
+      mockFilterModel.getFilterValue.mockReturnValue(['', '']);
+
+      const filterConfig = {
+        filterId: 'filter-1',
+        targetId: 'target-model-uid',
+        filterPaths: ['range'],
+        operator: '$dateBetween',
+      };
+      await filterManager.addFilterConfig(filterConfig);
+
+      filterManager.bindToTarget('target-model-uid');
+
+      expect(mockFilterModel.getFilterValue).toHaveBeenCalled();
+      expect(mockTargetModel.resource.removeFilterGroup).toHaveBeenCalledWith('filter-1');
+      expect(mockTargetModel.resource.addFilterGroup).not.toHaveBeenCalled();
+    });
+
     it('should not call removeFilterGroup for non-empty object', async () => {
       mockFilterModel.getFilterValue.mockReturnValue({ key: 'value' });
 

--- a/packages/core/client/src/flow/models/blocks/filter-manager/utils.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-manager/utils.ts
@@ -38,9 +38,20 @@ export function isFilterValueEmpty(value: any): boolean {
     return true;
   }
 
-  // 空数组视为空
-  if (Array.isArray(value) && value.length === 0) {
-    return true;
+  // 空数组或仅包含空值的数组视为空
+  if (Array.isArray(value)) {
+    const nonEmptyItems = value.filter((item) => {
+      if (item === null || item === undefined) {
+        return false;
+      }
+      if (typeof item === 'string' && item.trim() === '') {
+        return false;
+      }
+      return true;
+    });
+    if (nonEmptyItems.length === 0) {
+      return true;
+    }
   }
 
   // 空对象视为空（但不包括 Date、RegExp 等特殊对象）


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where clearing the between time filter values and triggering the filter again caused an error. |
| 🇨🇳 Chinese | 修复筛选操作中介于时间筛选值清空后再次触发筛选会报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
