### PR TITLE
fix: select options in filter action

### DIFF
--- a/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client/src/flow/components/filter/VariableFilterItem.tsx
@@ -27,7 +27,7 @@ import {
 import _ from 'lodash';
 import { NumberPicker } from '@formily/antd-v5';
 import { lazy } from '../../../lazy-helper';
-import { enumToOptions } from '../../internal/utils/enumOptionsUtils';
+import { enumToOptions, translateOptions, UiSchemaEnumItem } from '../../internal/utils/enumOptionsUtils';
 import { FormProvider, SchemaComponent } from '../../../schema-component/core';
 import { resolveOperatorComponent } from '../../internal/utils/operatorSchemaHelper';
 
@@ -381,6 +381,11 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
     }, [t]);
     const stableT = React.useCallback((s: string) => tRef.current?.(s) ?? s, []);
 
+    const enumOptions = useMemo(
+      () => enumToOptions(mergedSchema?.enum as UiSchemaEnumItem[], stableT) || [],
+      [mergedSchema, stableT],
+    );
+
     const staticInputRenderer = useMemo(
       () => createStaticInputRenderer(mergedSchema, leftMeta, stableT, model.context.app),
       [mergedSchema, leftMeta, stableT, model.context.app],
@@ -471,6 +476,9 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
       const supportKeyword = operator === '$in' || operator === '$notIn';
       if (resolved && supportKeyword) {
         const { Comp, props: xProps } = resolved;
+        if ((!xProps?.options || xProps?.options.length === 0) && enumOptions?.length) {
+          xProps.options = enumOptions;
+        }
         const style = {
           flex: '1 1 40%',
           minWidth: 160,
@@ -517,6 +525,7 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
       staticInputRenderer,
       model.context.app,
       setRightValue,
+      enumOptions,
     ]);
 
     // Null 占位组件（仿照 DefaultValue.tsx 的实现）


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the selectable options were not fully listed when using the “is any of” or “is none of” operators for option-based field filtering. |
| 🇨🇳 Chinese | 修复操作符为包含任何一个和不包含任何一个时可选项字段筛选没有列出所有可选项的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
