### PR TITLE
fix(server): remove serving check for middlewares

### DIFF
--- a/packages/core/server/src/pub-sub-manager/pub-sub-manager.ts
+++ b/packages/core/server/src/pub-sub-manager/pub-sub-manager.ts
@@ -20,14 +20,12 @@ import {
 
 export const createPubSubManager = (app: Application, options: PubSubManagerOptions) => {
   const pubSubManager = new PubSubManager(app, options);
-  if (app.serving()) {
-    app.on('afterStart', async () => {
-      await pubSubManager.connect();
-    });
-    app.on('afterStop', async () => {
-      await pubSubManager.close();
-    });
-  }
+  app.on('afterStart', async () => {
+    await pubSubManager.connect();
+  });
+  app.on('afterStop', async () => {
+    await pubSubManager.close();
+  });
   return pubSubManager;
 };
 
@@ -61,10 +59,6 @@ export class PubSubManager {
 
   async connect() {
     if (!this.adapter) {
-      return;
-    }
-    if (!this.app.serving()) {
-      this.app.logger.warn('app is not serving, will not connect to event queue');
       return;
     }
     await this.adapter.connect();


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where triggered workflow not send to queue after data imported.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where triggered workflows were not added to the processing queue after importing data, ensuring that workflows run as expected immediately post-import |
| 🇨🇳 Chinese | 修复了导入数据后已触发的工作流未添加到处理队列的问题，确保工作流在导入后能够正常运行 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
