### PR TITLE
fix: date filter incorrect style

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/components/DateFilterDynamicComponent.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/components/DateFilterDynamicComponent.tsx
@@ -138,6 +138,7 @@ export const DateFilterDynamicComponent = (props) => {
       {['past', 'next'].includes(value?.type) && [
         <InputNumber
           key="number"
+          style={{ flex: 1 }}
           value={value?.number}
           onChange={(val) => {
             const obj = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the UI component width was inconsistent when selecting “Past” or “Next” for date filter fields. |
| 🇨🇳 Chinese | 修复日期筛选字段选“过去”或者“未来”选项时 UI 组件宽度不一致问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
