### PR TITLE
fix: switching label field will remove popup configurations

### DIFF
--- a/packages/core/client/src/flow/internal/utils/rebuildFieldSubModel.ts
+++ b/packages/core/client/src/flow/internal/utils/rebuildFieldSubModel.ts
@@ -36,6 +36,7 @@ type RebuildOptions = {
   targetUse: string;
   defaultProps?: Record<string, unknown>;
   pattern?: string;
+  fieldSettingsInit?: unknown;
 };
 
 export function getFieldBindingUse(fieldModel?: FieldModel): string | undefined {
@@ -43,17 +44,23 @@ export function getFieldBindingUse(fieldModel?: FieldModel): string | undefined 
   return typeof bindingUse === 'string' ? bindingUse : undefined;
 }
 
-export async function rebuildFieldSubModel({ parentModel, targetUse, defaultProps, pattern }: RebuildOptions) {
+export async function rebuildFieldSubModel({
+  parentModel,
+  targetUse,
+  defaultProps,
+  pattern,
+  fieldSettingsInit,
+}: RebuildOptions) {
   const fieldModel = parentModel.subModels['field'];
   const fieldUid = fieldModel?.uid;
   const prevStepParams: FieldStepParams = (fieldModel?.stepParams as FieldStepParams) || {};
-  const prevBindingUse = prevStepParams.fieldBinding?.use;
+  const nextFieldSettingsInit = fieldSettingsInit ?? parentModel.getFieldSettingsInitParams?.();
 
   const nextStepParams: FieldStepParams = {
     ...prevStepParams,
     fieldBinding: { ...prevStepParams.fieldBinding, use: targetUse },
     fieldSettings: {
-      init: parentModel.getFieldSettingsInitParams?.(),
+      init: nextFieldSettingsInit,
     },
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where switching label fields caused popup configurations to be lost. |
| 🇨🇳 Chinese | 修复切换标签字段会造成弹窗配置丢失的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
