### PR TITLE
fix: chinese input in filter select

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-manager/flow-actions/customizeFilterRender.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-manager/flow-actions/customizeFilterRender.tsx
@@ -64,7 +64,9 @@ function applyCustomizeFilterRender(model: FilterFormItemModel) {
     fieldModel['__originalRender'] = fieldModel.render;
   }
 
-  fieldModel.render = () => <Comp {...xProps} {...fieldModel.props} />;
+  fieldModel.render = () => (
+    <Comp {...xProps} {...fieldModel.props} onCompositionStart={null} onCompositionEnd={null} />
+  );
   rewrapReactiveRender(fieldModel);
 }
 

--- a/packages/core/flow-engine/src/components/FieldModelRenderer.tsx
+++ b/packages/core/flow-engine/src/components/FieldModelRenderer.tsx
@@ -62,10 +62,10 @@ export function FieldModelRenderer(props: any) {
   };
 
   const modelProps = {
-    ..._.omit(rest, flowModelRendererPropKeys),
-    onChange: handleChange,
     onCompositionStart: handleCompositionStart,
     onCompositionEnd: handleCompositionEnd,
+    ..._.omit(rest, flowModelRendererPropKeys),
+    onChange: handleChange,
   };
   useEffect(() => {
     model && model.setProps(modelProps);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where entering Chinese text cleared existing options when using multi-select operators on single-select field in filter form block. |
| 🇨🇳 Chinese | 修复筛选表单里单选字段使用多选操作符时输入中文会清空已有的选项的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
