### PR TITLE
refactor: disable variable parsing in Markdown field by default in re…

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/models/DisplayVditorFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/models/DisplayVditorFieldModel.tsx
@@ -11,7 +11,7 @@ import { DisplayItemModel, escapeT } from '@nocobase/flow-engine';
 import { DisplayTitleFieldModel, tval } from '@nocobase/client';
 import React, { useState, useEffect } from 'react';
 
-const Display = ({ value, markdown, liquid, t, textOnly, ctx, overflowMode }) => {
+const Display = ({ value, markdown, liquid, t, textOnly, ctx, overflowMode, parseLiquid = false }) => {
   const [content, setContent] = useState(null);
 
   useEffect(() => {
@@ -19,7 +19,7 @@ const Display = ({ value, markdown, liquid, t, textOnly, ctx, overflowMode }) =>
 
     (async () => {
       try {
-        const result = await liquid.renderWithFullContext(value, ctx);
+        const result = parseLiquid ? await liquid.renderWithFullContext(value, ctx) : value;
         const html = markdown.render(t(result), { ellipsis: overflowMode === 'ellipsis', textOnly });
         setContent(html);
       } catch (err) {


### PR DESCRIPTION
…adPretty  mode

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Disable variable parsing in Markdown field by default in readPretty mode     |
| 🇨🇳 Chinese |   调整Markdown 字段在阅读态下默认不解析变量       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
