### PR TITLE
fix(acl): root can

### DIFF
--- a/packages/core/acl/src/__tests__/acl.test.ts
+++ b/packages/core/acl/src/__tests__/acl.test.ts
@@ -436,4 +436,16 @@ describe('acl', () => {
 
     expect(acl.can({ role: 'admin', resource: 'users', action: 'create' })).toBeTruthy();
   });
+
+  it('should return without params when role is root', () => {
+    const root = acl.define({
+      role: 'root',
+    });
+    const member = acl.define({
+      role: 'member',
+    });
+    expect(acl.can({ role: 'root', resource: 'users', action: 'create' })).toBeTruthy();
+    expect(acl.can({ roles: ['root'], resource: 'users', action: 'create' })).toBeTruthy();
+    expect(acl.can({ roles: ['member', 'root'], resource: 'users', action: 'create' })).toBeTruthy();
+  });
 });

--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -213,11 +213,7 @@ export class ACL extends EventEmitter {
     }
     if (options.roles?.length) {
       if (options.roles.includes('root')) {
-        return {
-          resource: options.resource,
-          action: options.action,
-          role: options.role,
-        };
+        options.roles = ['root'];
       }
       return lodash.cloneDeep(this.getCanByRoles(options));
     }
@@ -250,6 +246,14 @@ export class ACL extends EventEmitter {
 
     if (!aclRole) {
       return null;
+    }
+
+    if (role === 'root') {
+      return {
+        resource,
+        action,
+        role,
+      };
     }
 
     const actionPath = `${rawResourceName ? rawResourceName : resource}:${action}`;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where the API `acl.can` return `null` when role is `root`.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the API `acl.can` return `null` when role is `root` |
| 🇨🇳 Chinese | 修复 `acl.can` API 当角色是 `root` 是返回 `null` 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
