### PR TITLE
fix: association field dropdown being disabled when options field exists

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/recordSelectShared.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/recordSelectShared.tsx
@@ -102,7 +102,7 @@ export function resolveOptions(
 ) {
   if (options?.length) {
     return options.map((v) => {
-      return omit(v, 'disabled');
+      return omit(v, 'disabled', 'options');
     });
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix association field dropdown being disabled when options field exists        |
| 🇨🇳 Chinese |  修复关系字段下拉在存在 options 字段时显示为灰色不可选的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
