### PR TITLE
fix(client): remove extra spacing after tab is hidden

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -76,31 +76,33 @@ export class PageModel extends FlowModel<PageModelStructure> {
 
   mapTabs() {
     return this.mapSubModels('tabs', (model) => {
-      return {
-        key: model.uid,
-        label: (
-          <Droppable model={model}>
-            <FlowModelRenderer
-              model={model}
-              showFlowSettings={{
-                showBackground: true,
-                showBorder: false,
-                toolbarPosition: 'above',
-                style: { transform: 'translateY(8px)' },
-              }}
-              extraToolbarItems={[
-                {
-                  key: 'drag-handler',
-                  component: DragHandler,
-                  sort: 1,
-                },
-              ]}
-            />
-          </Droppable>
-        ),
-        children: model.renderChildren(),
-      };
-    });
+      return !this.context.flowSettingsEnabled && model.hidden
+        ? null
+        : {
+            key: model.uid,
+            label: (
+              <Droppable model={model}>
+                <FlowModelRenderer
+                  model={model}
+                  showFlowSettings={{
+                    showBackground: true,
+                    showBorder: false,
+                    toolbarPosition: 'above',
+                    style: { transform: 'translateY(8px)' },
+                  }}
+                  extraToolbarItems={[
+                    {
+                      key: 'drag-handler',
+                      component: DragHandler,
+                      sort: 1,
+                    },
+                  ]}
+                />
+              </Droppable>
+            ),
+            children: model.renderChildren(),
+          };
+    }).filter(Boolean);
   }
 
   renderFirstTab() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  remove extra spacing after tab is hidden  |
| 🇨🇳 Chinese | 修复标签页隐藏后仍占用间距的问题  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
