### PR TITLE
fix: filter form checkbox “No” being filtered as “Yes”

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
@@ -189,16 +189,20 @@ export class FilterFormItemModel extends FilterableItemModel<{
    * @returns
    */
   getFilterValue() {
+    const rawValue = this.subModels.field.getFilterValue
+      ? this.subModels.field.getFilterValue()
+      : this.context.form?.getFieldValue(this.props.name);
+
     const operatorMeta = this.getCurrentOperatorMeta();
     if (operatorMeta?.noValue) {
+      const options = operatorMeta?.schema?.['x-component-props']?.options;
+      if (Array.isArray(options)) {
+        return rawValue;
+      }
       return true;
     }
 
-    if (this.subModels.field.getFilterValue) {
-      return this.subModels.field.getFilterValue();
-    }
-
-    return this.context.form?.getFieldValue(this.props.name);
+    return rawValue;
   }
 
   /**


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where selecting “No” for a checkbox filter still applied the “Yes” filter. |
| 🇨🇳 Chinese | 修复筛选表单中勾选框选择“否”仍按“是”筛选的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
