### PR TITLE
fix: prevent preview from rewriting JSX source in stepParams

### DIFF
--- a/packages/core/client/src/flow/components/code-editor/__tests__/useCodeRunner.test.tsx
+++ b/packages/core/client/src/flow/components/code-editor/__tests__/useCodeRunner.test.tsx
@@ -213,8 +213,15 @@ ctx.render(<JsReadonlyField />);
 `;
 
     await act(async () => {
+      // Simulate settings form: step params store user's original source (JSX)
+      model.setStepParams('jsSettings', 'runJs', { code: jsxCode, version: 'v1' });
       await result.current.run(jsxCode);
     });
+
+    // Should not rewrite user's source code into compiled output (e.g. ctx.React.createElement)
+    const saved = model.getStepParams('jsSettings', 'runJs')?.code;
+    expect(saved).toContain('<Input');
+    expect(saved).not.toContain('ctx.React.createElement');
 
     // Should succeed and render antd input into the model container
     expect(result.current.logs.some((l) => l.msg?.includes('Execution succeeded'))).toBe(true);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where preview execution wrote compiled JSX output back to stepParams, causing saved source code to be rewritten. |
| 🇨🇳 Chinese | 修复预览运行时将 JSX 编译产物写回 stepParams，导致保存后源码被改写的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
