### PR TITLE
fix: prevent existing subtable/subform data from being cleared when s…

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubFormFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubFormFieldModel.tsx
@@ -450,6 +450,7 @@ SubFormListFieldModel.registerFlow({
         };
         const openMode = ctx.isMobileLayout ? 'embed' : ctx.inputArgs.mode || params.mode || 'drawer';
         const size = ctx.inputArgs.size || params.size || 'medium';
+        ctx.model.selectedRows.value = ctx.model.props.value || [];
         ctx.viewer.open({
           type: openMode,
           width: sizeToWidthMap[openMode][size],

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/index.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/index.tsx
@@ -318,6 +318,7 @@ SubTableFieldModel.registerFlow({
         };
         const openMode = ctx.isMobileLayout ? 'embed' : ctx.inputArgs.mode || params.mode || 'drawer';
         const size = ctx.inputArgs.size || params.size || 'medium';
+        ctx.model.selectedRows.value = ctx.model.props.value || [];
         ctx.viewer.open({
           type: openMode,
           width: sizeToWidthMap[openMode][size],


### PR DESCRIPTION
…ubmit without selecting items

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   prevent existing subtable/subform data from being cleared when submitting without selecting any items        |
| 🇨🇳 Chinese |   修复子表格/子表单从已有数据选择时，未选中项提交导致数据被清空的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
