### PR TITLE
fix(PageModel): update tabUid in inputArgs

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -129,6 +129,9 @@ export class PageModel extends FlowModel<PageModelStructure> {
             this.invokeTabModelLifecycleMethod(activeKey, 'onActive');
             this.invokeTabModelLifecycleMethod(this.props.tabActiveKey, 'onInactive');
             this.setProps('tabActiveKey', activeKey);
+            if (this.context.view.inputArgs) {
+              this.context.view.inputArgs.tabUid = activeKey;
+            }
           }}
           // destroyInactiveTabPane
           tabBarExtraContent={{


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix a regression introduced by the tab switch handling: activating the UI Editor would change the current tab unexpectedly because the tab UID in `inputArgs` stayed stale.

### Description 
- keep the tab UID in `inputArgs` synchronized when the active tab changes so UI Editor activation stays on the intended tab.

### Related issues

### Showcase

### Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where activating the UI Editor would jump to another tab by syncing `inputArgs.tabUid`. |
| 🇨🇳 Chinese | 修复激活 UI 编辑器后标签页跳转到其他标签页的问题，保持 `inputArgs.tabUid` 同步。 |

### Docs
| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
