### PR TITLE
fix(plugin-workflow): record primary key in manually execute select

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/components/TriggerCollectionRecordSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/components/TriggerCollectionRecordSelect.tsx
@@ -21,14 +21,15 @@ export function TriggerCollectionRecordSelect(props) {
   const [dataSourceName, collectionName] = parseCollectionName(workflow.config.collection);
   const { collectionManager } = app.dataSourceManager.getDataSource(dataSourceName);
   const collection = collectionManager.getCollection(collectionName);
+  const id = collection.filterTargetKey;
   const render = (p) =>
     collection ? (
       <RemoteSelect
         objectValue
         dataSource={dataSourceName}
         fieldNames={{
-          label: collection.titleField || 'id',
-          value: 'id',
+          label: collection.titleField || id,
+          value: id,
         }}
         service={{
           resource: collectionName,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where the only one record show in record list to be manually execute.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the only one record show in record list to be manually execute |
| 🇨🇳 Chinese | 修复手动执行时，选择数据组件的加载列表展示不全的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
