### PR TITLE
chore(plugin-workflow): add api to resume job

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/jobs.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/jobs.test.ts
@@ -1,0 +1,178 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { MockServer } from '@nocobase/test';
+import Database from '@nocobase/database';
+import { getApp, sleep } from '@nocobase/plugin-workflow-test';
+import { EXECUTION_STATUS, JOB_STATUS } from '../../constants';
+
+describe('workflow > actions > jobs', () => {
+  let app: MockServer;
+  let rootAgent;
+  let db: Database;
+  let PostRepo;
+  let WorkflowModel;
+  let workflow;
+  let users;
+  let userAgents;
+
+  beforeEach(async () => {
+    app = await getApp({
+      acl: true,
+    });
+    db = app.db;
+    const UserRepo = db.getCollection('users').repository;
+    const user = await UserRepo.findOne();
+    rootAgent = await app.agent().loginUsingId(user.id);
+    WorkflowModel = db.getCollection('workflows').model;
+    PostRepo = db.getCollection('posts').repository;
+
+    workflow = await WorkflowModel.create({
+      enabled: true,
+      type: 'collection',
+      config: {
+        mode: 1,
+        collection: 'posts',
+      },
+    });
+    users = await UserRepo.createMany({
+      records: [
+        { id: 2, nickname: 'a', roles: ['admin'] },
+        { id: 3, nickname: 'b' },
+      ],
+    });
+    userAgents = await Promise.all(users.map((user) => app.agent().login(user)));
+  });
+
+  afterEach(async () => await app.destroy());
+
+  describe('resume', () => {
+    it('only root could resume jobs', async () => {
+      const n1 = await workflow.createNode({
+        type: 'pending',
+      });
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const e1 = await workflow.getExecutions();
+      expect(e1.length).toBe(1);
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.STARTED);
+      const j1s = await e1[0].getJobs();
+      expect(j1s.length).toBe(1);
+      const res1 = await userAgents[0].resource('jobs').resume({
+        filterByTk: j1s[0].id,
+      });
+      expect(res1.status).toBe(403);
+
+      const res2 = await rootAgent.resource('jobs').resume({
+        filterByTk: j1s[0].id,
+        values: {
+          status: JOB_STATUS.RESOLVED,
+        },
+      });
+      expect(res2.status).toBe(202);
+      await sleep(500);
+
+      await e1[0].reload();
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.RESOLVED);
+      const j2s = await e1[0].getJobs({ order: [['id', 'ASC']] });
+      expect(j2s.length).toBe(2);
+      expect(j2s[0].status).toBe(JOB_STATUS.RESOLVED);
+      expect(j2s[1].status).toBe(JOB_STATUS.RESOLVED);
+    });
+
+    it('resume with reject status', async () => {
+      const n1 = await workflow.createNode({
+        type: 'pending',
+      });
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const e1 = await workflow.getExecutions();
+      expect(e1.length).toBe(1);
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.STARTED);
+      const j1s = await e1[0].getJobs();
+      expect(j1s.length).toBe(1);
+
+      const res1 = await rootAgent.resource('jobs').resume({
+        filterByTk: j1s[0].id,
+        values: {
+          status: JOB_STATUS.REJECTED,
+        },
+      });
+      expect(res1.status).toBe(202);
+      await sleep(500);
+
+      await e1[0].reload();
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.REJECTED);
+      const j2s = await e1[0].getJobs({ order: [['id', 'ASC']] });
+      expect(j2s.length).toBe(1);
+      expect(j2s[0].status).toBe(JOB_STATUS.REJECTED);
+    });
+
+    it('resume with pending status', async () => {
+      const n1 = await workflow.createNode({
+        type: 'pending',
+      });
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const e1 = await workflow.getExecutions();
+      expect(e1.length).toBe(1);
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.STARTED);
+      const j1s = await e1[0].getJobs();
+      expect(j1s.length).toBe(1);
+
+      const res1 = await rootAgent.resource('jobs').resume({
+        filterByTk: j1s[0].id,
+      });
+      expect(res1.status).toBe(202);
+      await sleep(500);
+
+      await e1[0].reload();
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.STARTED);
+      const j2s = await e1[0].getJobs({ order: [['id', 'ASC']] });
+      expect(j2s.length).toBe(1);
+      expect(j2s[0].status).toBe(JOB_STATUS.PENDING);
+
+      const res2 = await rootAgent.resource('jobs').resume({
+        filterByTk: j1s[0].id,
+        values: {
+          status: JOB_STATUS.PENDING,
+        },
+      });
+      expect(res2.status).toBe(202);
+      await sleep(500);
+
+      await e1[0].reload();
+      expect(e1[0].get('status')).toBe(EXECUTION_STATUS.STARTED);
+      const j3s = await e1[0].getJobs({ order: [['id', 'ASC']] });
+      expect(j3s.length).toBe(1);
+      expect(j3s[0].status).toBe(JOB_STATUS.PENDING);
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/index.ts
@@ -9,6 +9,7 @@
 
 import * as workflows from './workflows';
 import * as nodes from './nodes';
+import * as jobs from './jobs';
 import * as executions from './executions';
 import * as userWorkflowTasks from './userWorkflowTasks';
 
@@ -33,6 +34,7 @@ export default function ({ app }) {
       destroy: nodes.destroy,
       test: nodes.test,
     }),
+    ...make('jobs', jobs),
     ...make('executions', executions),
     ...make('userWorkflowTasks', userWorkflowTasks),
   });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/jobs.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/jobs.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { utils } from '@nocobase/actions';
+import PluginWorkflowServer from '../Plugin';
+
+export async function resume(context, next) {
+  const repository = utils.getRepositoryFromParams(context);
+  const workflowPlugin = context.app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
+  const { filterByTk, values = {} } = context.action.params;
+  const job = await repository.findOne({
+    filterByTk,
+  });
+  if (!job) {
+    return context.throw(404, 'Job not found');
+  }
+  workflowPlugin.getLogger(job.workflowId).warn(`Resuming job #${job.id}...`);
+  await job.update(values);
+
+  context.body = job;
+  context.status = 202;
+  await next();
+
+  workflowPlugin.resume(job);
+}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation

Add an API for administrator to resume stuck job.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added an API for administrators to resume jobs that were paused or frozen due to execution errors, ensuring execution could be manually intervened in unexpected status |
| 🇨🇳 Chinese | 增加了一个供管理员使用的 API，用于恢复因执行错误而暂停或冻结的任务，从而确保工作在异常情况下可以进行人工干预 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
