### PR TITLE
fix: incorrect map zoom level after menu switch

### DIFF
--- a/packages/plugins/@nocobase/plugin-map/src/client/models/MapBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/models/MapBlockModel.tsx
@@ -49,7 +49,7 @@ export class MapBlockModel extends CollectionBlockModel {
   createResource(ctx, params) {
     return this.context.createResource(MultiRecordResource);
   }
-  renderConfiguireActions() {
+  renderConfigureAction() {
     return (
       <AddSubModelButton
         key={'map-add-actions'}
@@ -158,7 +158,7 @@ export class MapBlockModel extends CollectionBlockModel {
 
                 return null;
               })}
-              {this.renderConfiguireActions()}
+              {this.renderConfigureAction()}
             </Space>
           </div>
         </DndProvider>

--- a/packages/plugins/@nocobase/plugin-map/src/client/models/components/AMap/Block.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/models/components/AMap/Block.tsx
@@ -146,6 +146,7 @@ export const AMapBlock = (props) => {
       .filter(Boolean);
 
     mapRef.current?.map?.setFitView(overlays);
+    mapRef.current?.map?.setZoom(zoom);
 
     const events = overlays.map((o: AMap.Marker) => {
       const onClick = (e) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix incorrect map zoom level after menu switch        |
| 🇨🇳 Chinese |      修复菜单切换后地图缩略等级显示不正确的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
