### PR TITLE
fix(workflow): collection trigger not work after data source reload

### DIFF
--- a/packages/core/data-source-manager/src/data-source-manager.ts
+++ b/packages/core/data-source-manager/src/data-source-manager.ts
@@ -12,7 +12,7 @@ import { ToposortOptions } from '@nocobase/utils';
 import { DataSource } from './data-source';
 import { DataSourceFactory } from './data-source-factory';
 
-type DataSourceHook = (dataSource: DataSource) => void;
+type DataSourceHook = (dataSource: DataSource, oldDataSource?: DataSource) => void;
 
 type DataSourceManagerOptions = {
   logger?: LoggerOptions | Logger;
@@ -75,7 +75,7 @@ export class DataSourceManager {
     this.dataSources.set(dataSource.name, dataSource);
 
     for (const hook of this.onceHooks) {
-      hook(dataSource);
+      hook(dataSource, oldDataSource);
     }
   }
 
@@ -120,12 +120,11 @@ export class DataSourceManager {
     }
   }
 
-  afterAddDataSource(hook: DataSourceHook) {
-    this.addHookAndRun(hook);
-  }
-
-  private addHookAndRun(hook: DataSourceHook) {
+  afterAddDataSource(hook: DataSourceHook, runImmediately?: boolean) {
     this.onceHooks.push(hook);
+    if (runImmediately === false) {
+      return;
+    }
     for (const dataSource of this.dataSources.values()) {
       hook(dataSource);
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
After reload external data source workflow that use collection trigger will invalid

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
1. modify DataSourceManager`s afterAddDataSource hooks, when reload,pass oldDataSource to hooks
2. modify CollectionTrigger add afterAddDataSource hook of DataSourceManager to rebind db events 

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix "Collection Event" workflows not triggering after external data source reload |
| 🇨🇳 Chinese | 修复“数据表事件”类型工作流在外部数据源重载后无法触发的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
