### PR TITLE
fix: column actions can't be deleted

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -682,7 +682,7 @@ TableBlockModel.define({
   group: tExpr('Content'),
   searchable: true,
   searchPlaceholder: tExpr('Search'),
-  createModelOptions: {
+  createModelOptions: () => ({
     use: 'TableBlockModel',
     subModels: {
       columns: [
@@ -691,7 +691,7 @@ TableBlockModel.define({
         },
       ],
     },
-  },
+  }),
   sort: 300,
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the table block's operation column could not be removed. |
| 🇨🇳 Chinese | 修复无法移除表格区块操作列的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
