### PR TITLE
fix(field-sequence): in repair running if collection not exist should skip

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-sequence/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/server/Plugin.ts
@@ -121,6 +121,10 @@ export default class PluginFieldSequenceServer extends Plugin {
       for (const [collectionName, sequencesList] of Object.entries(groupedSequences)) {
         tasks.push(async () => {
           const collection = app.db.getCollection(collectionName);
+          if (!collection) {
+            app.log.warn(`Collection [${collectionName}] not exist. Skipping sequences refresh.`);
+            return;
+          }
           const fields: Field[] = collection.getFields();
           const fieldMap = Object.fromEntries<Field>(fields.map((field) => [field.name, field]));
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
if collection in sequence table not existed repair command will occur error

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an error when the field-sequence repair command encounters a non-existent collection in the current environment. |
| 🇨🇳 Chinese | 修复运行 field-sequence 插件的 repair 命令时遇到当前环境不存在的 collection 时报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
