### PR TITLE
fix(plugin-file-manager): s3 limit

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/package.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/package.json
@@ -14,6 +14,7 @@
   "homepage.zh-CN": "https://docs-cn.nocobase.com/handbook/file-manager",
   "devDependencies": {
     "@aws-sdk/client-s3": "3.750.0",
+    "@aws-sdk/lib-storage": "3.750.0",
     "@formily/antd-v5": "1.x",
     "@formily/core": "2.x",
     "@formily/react": "2.x",


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where error thrown when upload file larger than 5MB to AWS S3.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

* Close #8261.
* Close #7891.
* Close #7866.
* Close #7538.

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where error thrown when upload file larger than 5MB to AWS S3 |
| 🇨🇳 Chinese | 修复上传文件到 AWS S3 大于 5MB 时报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
