### PR TITLE
feat(plugin-field-markdown-vditor): support vditor field in filter form

### DIFF
--- a/packages/core/client/src/flow/models/fields/InputFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/InputFieldModel.tsx
@@ -27,7 +27,20 @@ EditableItemModel.bindModelToInterface('InputFieldModel', ['input', 'email', 'ph
 
 FilterableItemModel.bindModelToInterface(
   'InputFieldModel',
-  ['input', 'email', 'phone', 'uuid', 'url', 'nanoid', 'textarea', 'markdown', 'richText', 'password', 'color'],
+  [
+    'input',
+    'email',
+    'phone',
+    'uuid',
+    'url',
+    'nanoid',
+    'textarea',
+    'markdown',
+    'vditor',
+    'richText',
+    'password',
+    'color',
+  ],
   {
     isDefault: true,
   },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The filter form currently does not support fields of type `vditor`, support needs to be added.

### Description 
Added `vditor` type support in `InputFieldModel`.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Supported `vditor` field in filter form |
| 🇨🇳 Chinese | 筛选表单支持 `vditor` 字段 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
