### PR TITLE
fix(plugin-workflow-manual): error thrown in filter form block settings

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettingsConnectDataBlocks.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsConnectDataBlocks.tsx
@@ -50,7 +50,7 @@ export function SchemaSettingsConnectDataBlocks(props) {
   }
 
   const Content = dataBlocks.map((block) => {
-    const title = `${compile(block.collection.title)} #${block.uid.slice(0, 4)}`;
+    const title = `${compile(block.collection.title)} ${block.uid ? `#${block.uid.slice(0, 4)}` : ''}`;
     const onHover = () => {
       block.highlightBlock();
     };


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where error thrown in in filter form block settings of m2m field.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where error thrown in in filter form block settings of m2m field |
| 🇨🇳 Chinese | 修复人工节点表单中多对多数据选择器的表单区块菜单报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
