### PR TITLE
fix: collection selector incorrect height

### DIFF
--- a/packages/core/flow-engine/src/components/FlowContextSelector.tsx
+++ b/packages/core/flow-engine/src/components/FlowContextSelector.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback, useRef, useMemo, useState, useEffect } from 'react';
 import { Button, Cascader, Tooltip } from 'antd';
 import { QuestionCircleOutlined } from '@ant-design/icons';
+import { cx, css } from '@emotion/css';
 import type { ContextSelectorItem, FlowContextSelectorProps } from './variables/types';
 import {
   buildContextSelectorItems,
@@ -24,6 +25,14 @@ const defaultButtonStyle = {
   fontStyle: 'italic' as const,
   fontFamily: 'New York, Times New Roman, Times, serif',
 };
+
+// 参考 1.x FilterItem 的实现：下拉高度随内容自适应，过长时占用更多可视区以减少滚动。
+const cascaderPopupAutoHeightClassName = css`
+  .ant-cascader-menu {
+    height: fit-content;
+    max-height: 50vh;
+  }
+`;
 
 const FlowContextSelectorComponent: React.FC<FlowContextSelectorProps> = ({
   value,
@@ -238,6 +247,10 @@ const FlowContextSelectorComponent: React.FC<FlowContextSelectorProps> = ({
     [onChange, customFormatPathToValue, onlyLeafSelectable],
   );
 
+  const mergedPopupClassName = useMemo(() => {
+    return cx(cascaderPopupAutoHeightClassName, cascaderProps.popupClassName);
+  }, [cascaderProps.popupClassName]);
+
   return (
     <Cascader
       {...cascaderProps}
@@ -250,6 +263,7 @@ const FlowContextSelectorComponent: React.FC<FlowContextSelectorProps> = ({
       expandTrigger="click"
       open={open}
       showSearch={children === null}
+      popupClassName={mergedPopupClassName}
     >
       {children === null ? null : children || defaultChildren}
     </Cascader>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the collection fields selector dropdown in filter action had an insufficient height. |
| 🇨🇳 Chinese | 修复筛选操作字段选择框高度太小的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
