### PR TITLE
fix: record picker table will not refresh after creating record

### DIFF
--- a/packages/core/client/src/flow/actions/openView.tsx
+++ b/packages/core/client/src/flow/actions/openView.tsx
@@ -263,6 +263,7 @@ export const openView = defineAction({
       typeof inputArgs.preventClose !== 'undefined' ? !!inputArgs.preventClose : !!params.preventClose;
 
     const finalInputArgs: Record<string, unknown> = {
+      viewUid: ctx.model.uid,
       ...ctx.inputArgs,
       ...inputArgs,
       dataSourceKey: runtimeDataSourceKey,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where newly added records did not refresh in the data selector field component popup. |
| 🇨🇳 Chinese | 修复数据选择器字段组件弹窗中新增记录不刷新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
