### PR TITLE
fix: js item not refresh after update record

### DIFF
--- a/packages/core/client/src/flow/models/fields/JSItemModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSItemModel.tsx
@@ -28,7 +28,6 @@ import { resolveRunJsParams } from '../utils/resolveRunJsParams';
  */
 export class JSItemModel extends CommonItemModel {
   private _offResourceRefresh?: () => void;
-  private _lastPage?: number;
   private _mountedOnce = false; // prevent first-mount double-run
 
   getInputArgs() {
@@ -63,14 +62,9 @@ export class JSItemModel extends CommonItemModel {
   protected onMount() {
     const resource = this.context.resource;
     if (resource) {
-      // 订阅 refresh：仅在分页页码改变后触发 jsSettings
-      this._lastPage = resource.getPage?.();
+      // 订阅 refresh：详情记录被编辑后通常会触发 refresh，需要重跑 jsSettings
       const handler = () => {
-        const current = resource?.getPage?.();
-        if (current !== this._lastPage) {
-          this.applyFlow('jsSettings');
-        }
-        this._lastPage = current;
+        this.applyFlow('jsSettings');
       };
       resource.on('refresh', handler);
       this._offResourceRefresh = () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where the JS Item did not refresh after editing a record in the details block. |
| 🇨🇳 Chinese | 修复详情区块里编辑记录后 JS Item 不刷新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
