### PR TITLE
fix: should not be able to add association js field in form block

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/FormJSFieldItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormJSFieldItemModel.tsx
@@ -8,7 +8,7 @@
  */
 
 import { tExpr, FlowModel, FlowModelContext } from '@nocobase/flow-engine';
-import { buildFormAssociationChildren, buildJSFieldMenuChildren } from '../utils/transformChildrenToJS';
+import { buildJSFieldMenuChildren } from '../utils/transformChildrenToJS';
 
 /**
  * “JavaScript 字段（可编辑）”菜单入口（表单）：
@@ -23,7 +23,6 @@ export class FormJSFieldItemModel extends FlowModel {
       fieldUseModel: 'JSEditableFieldModel',
       associationPathName: ctx.prefixFieldPath,
       refreshTargets: ['FormItemModel', 'FilterFormItemModel'],
-      associationProvider: buildFormAssociationChildren,
     });
   }
 }

--- a/packages/core/client/src/flow/models/blocks/utils/__tests__/transformChildrenToJS.test.ts
+++ b/packages/core/client/src/flow/models/blocks/utils/__tests__/transformChildrenToJS.test.ts
@@ -170,6 +170,19 @@ describe('buildJSFieldMenuChildren', () => {
     return ctx as FlowModelContext;
   };
 
+  it('returns only direct collection fields', async () => {
+    const ctx = makeCtx();
+    const result = await buildJSFieldMenuChildren(ctx, {
+      useModel: 'DetailsItemModel',
+      fieldUseModel: 'JSFieldModel',
+      refreshTargets: ['rt'],
+    });
+    // 直接子项等于字段数量
+    expect(result.length).toBe(2);
+    const resolved = await (result[0].createModelOptions as any)(ctx);
+    expect(resolved.subModels.field.use).toBe('JSFieldModel');
+  });
+
   it('when associationProvider returns empty array, do not append association group', async () => {
     const ctx = makeCtx();
     const result = await buildJSFieldMenuChildren(ctx, {
@@ -178,7 +191,6 @@ describe('buildJSFieldMenuChildren', () => {
       refreshTargets: ['rt'],
       associationProvider: async () => [],
     });
-    // 直接子项等于字段数量
     expect(result.length).toBe(2);
   });
 
@@ -195,8 +207,10 @@ describe('buildJSFieldMenuChildren', () => {
     const group = result[2];
     expect(group.type).toBe('group');
     expect(group.label).toBe(tExpr('Display association fields'));
-    // 验证 children 调用可用
+    // 验证 children 调用可用，并完成 JS 化
     const children = await (group.children as any)(makeCtx());
     expect(Array.isArray(children)).toBe(true);
+    const childResolved = await (children[0].createModelOptions as any)(makeCtx());
+    expect(childResolved.subModels.field.use).toBe('JSFieldModel');
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Disallow adding association fields to form block via JS Field. |
| 🇨🇳 Chinese | 不应允许通过 JS Field 为表单添加关联字段。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
