### PR TITLE
fix: nested subtable content not updating when switching pages in edit form

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
@@ -347,7 +347,8 @@ export class SubTableColumnModel<
           `}
         >
           {this.mapSubModels('field', (action: FieldModel) => {
-            const namePath = action.context.fieldPath.split('.').pop();
+            const fieldPath = action.context.fieldPath.split('.');
+            const namePath = fieldPath.pop();
 
             const fork: any = action.createFork({}, `${id}`);
             if (this.props.readPretty) {
@@ -360,10 +361,10 @@ export class SubTableColumnModel<
                 <FormItem
                   {...this.props}
                   key={id}
-                  name={[(this.parent as FieldModel).context.fieldPath, rowIdx, namePath]}
+                  name={[...fieldPath, rowIdx, namePath]}
                   style={{ marginBottom: 0 }}
                   showLabel={false}
-                  initialValue={value}
+                  // initialValue={value}
                   disabled={
                     this.props.disabled ||
                     (!record.isNew && this.props.aclDisabled) ||


### PR DESCRIPTION
…t form

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix nested subtable content not updating when switching pages in edit form       |
| 🇨🇳 Chinese |    修复编辑表单翻页时子表单中嵌套的子表格内容不更新的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
