### PR TITLE
fix: table's quick edit configuration

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -543,6 +543,24 @@ TableBlockModel.registerFlow({
       handler(ctx, params) {
         ctx.model.setProps('editable', params.editable);
       },
+      async afterParamsSave(ctx, params, previousParams) {
+        if (params?.editable === previousParams?.editable) return;
+
+        const blockModel = ctx.model as TableBlockModel;
+        blockModel.mapSubModels('columns', (column: any) => {
+          const flow = column?.getFlow?.('tableColumnSettings');
+          if (!flow?.getStep?.('quickEdit')) return;
+
+          const quickEditParams = column.getStepParams?.('tableColumnSettings', 'quickEdit');
+          if (quickEditParams && Object.prototype.hasOwnProperty.call(quickEditParams, 'editable')) {
+            return;
+          }
+
+          const isReadonly = !!column?.collectionField?.readonly;
+          const hasAssociationPath = !!column?.associationPathName;
+          column.setProps('editable', isReadonly || hasAssociationPath ? false : !!params.editable);
+        });
+      },
     },
     showRowNumbers: {
       title: tExpr('Show row numbers'),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where changes to the quick edit toggle in table blocks required a page refresh to take effect. |
| 🇨🇳 Chinese | 修复表格块快捷编辑开关修改后需要刷新页面才能生效的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
