### PR TITLE
fix: error when closing an embed popup

### DIFF
--- a/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
+++ b/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
@@ -29,13 +29,22 @@ import _ from 'lodash';
 
 export const DynamicFlowsIcon: React.FC<{ model: FlowModel }> = (props) => {
   const { model } = props;
+  const openedDynamicFlowsViewRef = React.useRef<any>(null);
+
+  React.useEffect(() => {
+    return () => {
+      openedDynamicFlowsViewRef.current?.destroy?.();
+      openedDynamicFlowsViewRef.current = null;
+    };
+  }, []);
 
   const handleClick = () => {
-    const target = document.querySelector<HTMLDivElement>('#nocobase-embed-container');
+    const target = document.getElementById('nocobase-embed-container') as HTMLDivElement | null;
+    if (!target) return;
 
-    target.innerHTML = ''; // 清空容器内原有内容
+    openedDynamicFlowsViewRef.current?.destroy?.();
 
-    model.context.viewer.embed({
+    const view = model.context.viewer.embed({
       type: 'embed',
       target,
       title: 'Edit event flows',
@@ -46,9 +55,14 @@ export const DynamicFlowsIcon: React.FC<{ model: FlowModel }> = (props) => {
       onClose() {
         target.style.width = 'auto';
         target.style.maxWidth = 'none';
+        if (openedDynamicFlowsViewRef.current === view) {
+          openedDynamicFlowsViewRef.current = null;
+        }
       },
       content: <DynamicFlowsEditor model={model} />,
     });
+
+    openedDynamicFlowsViewRef.current = view;
   };
 
   return <ThunderboltOutlined style={{ cursor: 'pointer' }} onClick={handleClick} />;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where an error occurred when closing the current popup after consecutively opening the linkage rules and event flow configuration popups. |
| 🇨🇳 Chinese | 修复连续打开弹窗中联动规则和事件流配置弹窗后再关闭当前弹窗时会报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
