### PR TITLE
fix(action-import): if async import occure `Unique constraint error` can`t show correct message

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
@@ -308,6 +308,14 @@ export class XlsxImporter extends EventEmitter {
       rows.push(rowValues);
     }
 
+    const translate = (message: string) => {
+      if (options.context?.t) {
+        return options.context.t(message, { ns: 'action-import' });
+      } else {
+        return message;
+      }
+    };
+
     try {
       await this.loggerService.measureExecutedTime(
         async () =>
@@ -322,11 +330,7 @@ export class XlsxImporter extends EventEmitter {
       handingRowIndex += chunkRows.length;
     } catch (error) {
       if (error.name === 'SequelizeUniqueConstraintError') {
-        throw new Error(
-          `${options.context?.t('Unique constraint error, fields:', { ns: 'action-import' })} ${JSON.stringify(
-            error.fields,
-          )}`,
-        );
+        throw new Error(`${translate('Unique constraint error, fields:')} ${JSON.stringify(error.fields)}`);
       }
 
       if (error.params?.rowIndex) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
when import xlsx in async mode context missing t func, throw `Unique constraint error` use t func to translate message will throw another error:  t is not a function

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect error message when a  unique constraint error is triggered during async XLSX import |
| 🇨🇳 Chinese | 修复异步导入xlsx文件触发唯一约束异常时错误信息不正确的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
