### PR TITLE
fix(acl): allow association fields to associate using the target keys

### DIFF
--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/change-with-association.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/change-with-association.test.ts
@@ -300,6 +300,203 @@ describe('Change with association', async () => {
     });
   });
 
+  test('allow associate one exist record key', async () => {
+    await adminAgent.resource('roles.resources', 'test-role').create({
+      values: {
+        usingActionsConfig: true,
+        name: 'test',
+        actions: [
+          {
+            name: 'create',
+            fields: ['name', 'assoc3'],
+          },
+        ],
+      },
+    });
+
+    const user = await db.getRepository('users').create({
+      values: {
+        roles: ['test-role'],
+      },
+    });
+
+    await db.getRepository('assoc3').create({
+      values: {
+        assoc3_name: 'assoc3-1',
+      },
+    });
+
+    const ctx = app.context;
+    ctx.app = app;
+    ctx.log = app.log;
+    ctx.database = db;
+    ctx.state = {
+      currentUser: user,
+      currentRoles: ['test-role'],
+    };
+    ctx.action = {
+      resourceName: 'test',
+      actionName: 'create',
+      params: {
+        values: {
+          name: 'test-1',
+          assoc3: 'assoc3-1',
+        },
+      },
+    };
+    await compose([app.acl.middleware(), checkChangesWithAssociation])(ctx, async () => {});
+    expect(ctx.action.params.values).toMatchObject({
+      name: 'test-1',
+      assoc3: 'assoc3-1',
+    });
+  });
+
+  test('allow associate one exist record key, update', async () => {
+    await adminAgent.resource('roles.resources', 'test-role').create({
+      values: {
+        usingActionsConfig: true,
+        name: 'test',
+        actions: [
+          {
+            name: 'update',
+            fields: ['name', 'assoc3'],
+          },
+        ],
+      },
+    });
+
+    const user = await db.getRepository('users').create({
+      values: {
+        roles: ['test-role'],
+      },
+    });
+
+    await db.getRepository('assoc3').create({
+      values: {
+        assoc3_name: 'assoc3-1',
+      },
+    });
+
+    const ctx = app.context;
+    ctx.app = app;
+    ctx.log = app.log;
+    ctx.database = db;
+    ctx.state = {
+      currentUser: user,
+      currentRoles: ['test-role'],
+    };
+    ctx.action = {
+      resourceName: 'test',
+      actionName: 'update',
+      params: {
+        values: {
+          name: 'test-1',
+          assoc3: 'assoc3-1',
+        },
+      },
+    };
+    await compose([app.acl.middleware(), checkChangesWithAssociation])(ctx, async () => {});
+    expect(ctx.action.params.values).toMatchObject({
+      name: 'test-1',
+      assoc3: 'assoc3-1',
+    });
+  });
+
+  test('disallow associate not exist record key', async () => {
+    await adminAgent.resource('roles.resources', 'test-role').create({
+      values: {
+        usingActionsConfig: true,
+        name: 'test',
+        actions: [
+          {
+            name: 'create',
+            fields: ['name', 'assoc3'],
+          },
+        ],
+      },
+    });
+
+    const user = await db.getRepository('users').create({
+      values: {
+        roles: ['test-role'],
+      },
+    });
+
+    const ctx = app.context;
+    ctx.app = app;
+    ctx.log = app.log;
+    ctx.database = db;
+    ctx.state = {
+      currentUser: user,
+      currentRoles: ['test-role'],
+    };
+    ctx.action = {
+      resourceName: 'test',
+      actionName: 'create',
+      params: {
+        values: {
+          name: 'test-1',
+          assoc3: 'assoc3-1',
+        },
+      },
+    };
+    await compose([app.acl.middleware(), checkChangesWithAssociation])(ctx, async () => {});
+    expect(ctx.action.params.values).toMatchObject({
+      name: 'test-1',
+    });
+  });
+
+  test('allow associate many exist record key', async () => {
+    await adminAgent.resource('roles.resources', 'test-role').create({
+      values: {
+        usingActionsConfig: true,
+        name: 'test',
+        actions: [
+          {
+            name: 'create',
+            fields: ['name', 'assoc1'],
+          },
+        ],
+      },
+    });
+
+    const user = await db.getRepository('users').create({
+      values: {
+        roles: ['test-role'],
+      },
+    });
+
+    await db.getRepository('assoc1').create({
+      values: {
+        name: 'assoc1-1',
+      },
+    });
+
+    const ctx = app.context;
+    ctx.app = app;
+    ctx.log = app.log;
+    ctx.database = db;
+    ctx.state = {
+      currentUser: user,
+      currentRoles: ['test-role'],
+    };
+    ctx.action = {
+      resourceName: 'test',
+      actionName: 'create',
+      params: {
+        values: {
+          name: 'test-1',
+          assoc1: ['assoc1-1'],
+        },
+      },
+    };
+    await compose([app.acl.middleware(), checkChangesWithAssociation])(ctx, async () => {});
+    expect(ctx.action.params.values).toMatchObject({
+      name: 'test-1',
+      assoc1: ['assoc1-1'],
+    });
+  });
+
   test('allow create association, nested disallow associate', async () => {
     await adminAgent.resource('roles.resources', 'test-role').create({
       values: [

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/check-change-with-association.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/check-change-with-association.ts
@@ -28,10 +28,12 @@ function normalizeAssociationValue(
     return value;
   }
   if (Array.isArray(value)) {
-    const result = value.map((v) => v[recordKey]).filter((v) => v !== null && v !== undefined);
+    const result = value
+      .map((v) => (typeof v === 'number' || typeof v === 'string' ? v : v[recordKey]))
+      .filter((v) => v !== null && v !== undefined);
     return result.length > 0 ? result : undefined;
   } else {
-    return value[recordKey];
+    return typeof value === 'number' || typeof value === 'string' ? value : value[recordKey];
   }
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Allow association fields to associate using the target keys         |
| 🇨🇳 Chinese |  允许关系字段使用目标键进行关联         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
