### PR TITLE
fix(sort): fix data corruption with duplicate sort values

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-sort/src/server/__tests__/move-action.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-sort/src/server/__tests__/move-action.test.ts
@@ -10,6 +10,7 @@
 import { createMockServer, MockServer } from '@nocobase/test';
 import { Collection, Database } from '@nocobase/database';
 import { waitSecond } from '@nocobase/test';
+import { SortableCollection } from '../action';
 
 import Plugin from '..';
 
@@ -1123,8 +1124,6 @@ describe('sort action', () => {
       });
 
       // Get the SortableCollection instance to validate
-      const sortField = Articles.getField('sort');
-      const SortableCollection = require('../action').SortableCollection;
       const sortable = new SortableCollection(Articles);
 
       const issues = await sortable.validateSort();
@@ -1161,7 +1160,6 @@ describe('sort action', () => {
       );
 
       // Rebuild
-      const SortableCollection = require('../action').SortableCollection;
       const sortable = new SortableCollection(Articles);
       const result = await sortable.rebuildSort();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Others

### Motivation
The sort field plugin's move operation breaks when duplicate sort values exist in the database. This happens because the original increment-based algorithm cannot handle duplicates correctly, leading to data corruption where multiple records end up with the same sort value. Users then cannot reorder these records anymore.

### Description 
**Root Cause:** The original `sameScopeMove()` method uses an increment algorithm that relies on sort values being unique. When duplicates exist, the SQL query matches incorrect records and incrementing makes the problem worse.

**Solution:** Replaced the increment algorithm with a complete reorder strategy:
1. Fetch all records in scope, sorted by current sort value
2. Find source and target positions in the array
3. Remove source from array, insert at target position  
4. Atomically update all records with sequential sort values (1, 2, 3, ...)

This approach is independent of current sort values and automatically handles duplicates.

**Key Changes:**
- Rewrote `sameScopeMove()` method in `src/server/action.ts` (lines 120-190)
- Added `validateSort()` method to detect data corruption
- Added `rebuildSort()` method to recover from corrupted state
- Added 8 new test cases covering duplicate handling and edge cases

**Testing:** All existing tests pass. 8 new tests added to verify:
- Moving records with duplicate sort values
- Consecutive rapid moves
- Boundary cases (move to start/end)
- Data validation and repair

### Related issues
Fixes the issue where dragging records with duplicate sort values causes data to become unsortable.

### Showcase
<!-- No UI changes -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | **Fixed:** Sort field data corruption when moving records with duplicate sort values. The move operation now uses a reorder algorithm instead of increment to handle all edge cases correctly. |
| 🇨🇳 Chinese | **修复:** 排序字段在存在重复sort值时移动记录导致的数据混乱问题。move操作现在使用重排算法代替增量算法，正确处理所有边界情况。 |

### Docs
No new documentation needed. Existing API remains unchanged.

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  N/A    |
| 🇨🇳 Chinese |  N/A  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary