### PR TITLE
fix(plugin-workflow): bubble condition branch failures

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/ConditionInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/ConditionInstruction.ts
@@ -75,8 +75,13 @@ export class ConditionInstruction extends Instruction {
       return job;
     }
 
-    // pass control to upper scope by ending current scope
-    return processor.exit(branchJob.status);
+    if (branchJob.status === JOB_STATUS.PENDING) {
+      // still waiting for manual resume (e.g. prompt node)
+      return processor.exit(branchJob.status);
+    }
+
+    // bubble rejected status to parent scope so that caller (loop, etc.) can decide how to handle it
+    return branchJob;
   }
 
   async test({ engine, calculation, expression = '' }) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where failed node in condition branch cannot pass status to upper branching node.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where failed node in condition branch cannot pass status to upper branching node |
| 🇨🇳 Chinese | 修复条件分支中失败的节点无法将状态传递到上层分支导致的流程错误问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
