### PR TITLE
fix(server): serialize memory event queue listening

### DIFF
--- a/packages/core/server/src/__tests__/event-queue.test.ts
+++ b/packages/core/server/src/__tests__/event-queue.test.ts
@@ -317,44 +317,6 @@ describe('memory queue adapter', () => {
     });
   });
 
-  describe('async idle handling', () => {
-    test('should respect async idle locking before consuming more messages', async () => {
-      const processed: number[] = [];
-      let busy = false;
-      let concurrent = 0;
-      let maxConcurrent = 0;
-
-      await app.eventQueue.subscribe('async-idle', {
-        idle: async () => {
-          await sleep(10);
-          if (busy) {
-            return false;
-          }
-          busy = true;
-          return true;
-        },
-        concurrency: 1,
-        process: async (message) => {
-          concurrent += 1;
-          maxConcurrent = Math.max(maxConcurrent, concurrent);
-          await sleep(50);
-          processed.push(message);
-          concurrent -= 1;
-          busy = false;
-        },
-      });
-
-      await app.eventQueue.connect();
-      await app.eventQueue.publish('async-idle', 1);
-      await app.eventQueue.publish('async-idle', 2);
-      await app.eventQueue.publish('async-idle', 3);
-
-      await sleep(400);
-      expect(processed).toEqual([1, 2, 3]);
-      expect(maxConcurrent).toBe(1);
-    });
-  });
-
   describe('storage', () => {
     test('graceful shutdown, will create storage', async () => {
       const mockListener = vi.fn();


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

- The memory adapter relies on `EventEmitter` to trigger `listen()`, so multiple `emit`s in the same event loop tick can re-enter `listen()` repeatedly.
- Each `listen()` call immediately checks `idle()` and invokes `read()`, but the `reading` array has not been written back yet, so every call assumes there is no in-flight job and reads more messages than allowed.
- The actual handler later discovers the overshoot, so plugin-defined `concurrency` cannot be enforced.

### Description 

#### Fix Highlights

1. **Serialize `listen()`**
   - Introduce `listeningTasks` to store the running `tryListen()` Promise per channel.
   - When a new signal arrives while a task is running, mark the channel in `pendingSignals` and trigger another `listen()` once the current task finishes.
2. **Re-check before reading**
   - `tryListen()` re-evaluates `reading.length` and remaining capacity right before `read()`, preventing overshoot caused by stale state.
   - Each processing promise schedules another `listen()` in `finally`, so the queue keeps draining orderly.


#### Other Adapters
- **Redis adapter**: `consume()` is a single async loop that awaits `Promise.all(reading)` when reaching the concurrency limit, so there is no chance for parallel `read()` invocations.
- **RabbitMQ adapter**: relies on `channel.prefetch(concurrency)` so the broker enforces concurrency; there is only one `channel.consume` callback and it cancels/reschedules when `idle()` returns false.

#### Outcome
- Concurrency control now depends on the serialized `reading`/`pendingSignals` flow instead of `idle()` being fast enough in the same tick.
- Subscriber interfaces stay unchanged—`idle()` remains synchronous—but the queue knows exactly how many jobs are already running.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the memory event queue reading more messages than allowed under concurrency pressure by serializing `listen()` execution so the declared `concurrency` is honored |
| 🇨🇳 Chinese | 修复内存事件队列在高并发下会重复读取消息的问题，`listen()` 现在串行执行并准确尊重 `concurrency` 设置 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
