### PR TITLE
fix: preserve field subModels when rebuilding association component

### DIFF
--- a/packages/core/client/src/flow/internal/utils/rebuildFieldSubModel.ts
+++ b/packages/core/client/src/flow/internal/utils/rebuildFieldSubModel.ts
@@ -53,6 +53,7 @@ export async function rebuildFieldSubModel({
 }: RebuildOptions) {
   const fieldModel = parentModel.subModels['field'];
   const fieldUid = fieldModel?.uid;
+  const prevSubModels = fieldModel?.serialize?.()?.subModels;
   const prevStepParams: FieldStepParams = (fieldModel?.stepParams as FieldStepParams) || {};
   const nextFieldSettingsInit = fieldSettingsInit ?? parentModel.getFieldSettingsInitParams?.();
 
@@ -76,6 +77,9 @@ export async function rebuildFieldSubModel({
     use: FieldModel,
     props: { ...(fieldModel?.props || {}), ...(defaultProps || {}), ...(pattern ? { pattern } : {}) },
     stepParams: nextStepParams as StepParams,
+    // Preserve existing subModels (e.g. SubTable columns) so switching field component back and forth
+    // does not require a full page refresh to restore the UI.
+    subModels: prevSubModels,
   });
 
   await subModel.dispatchEvent('beforeRender', undefined, { useCache: false });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where configured sub-table/sub-form's fields would not display during back-and-forth switching of field components. |
| 🇨🇳 Chinese | 修复了在字段组件来回切换过程中已配置子表单/子表格中的字段不显示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
