### PR TITLE
fix: rerun linkages after change pagination

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/linkageRulesRefresh.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRulesRefresh.test.ts
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { linkageRulesRefresh } from '../linkageRulesRefresh';
+
+describe('linkageRulesRefresh action', () => {
+  it('skips master model when forks exist', async () => {
+    const handler = vi.fn(async () => {});
+    const model: any = {
+      isFork: false,
+      forks: new Set([{}]),
+      getFlow: vi.fn(() => ({})),
+      getStepParams: vi.fn(() => ({ value: [] })),
+    };
+    const ctx: any = {
+      model,
+      resolveJsonTemplate: vi.fn(async (p: any) => p),
+      getAction: vi.fn(() => ({ handler })),
+    };
+
+    await linkageRulesRefresh.handler(ctx, {
+      actionName: 'actionLinkageRules',
+      flowKey: 'buttonSettings',
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('runs linkage action on fork model and resolves params', async () => {
+    const handler = vi.fn(async () => {});
+    const model: any = {
+      isFork: true,
+      forks: new Set([{}]),
+      getFlow: vi.fn(() => ({})),
+      getStepParams: vi.fn(() => ({ value: ['x'] })),
+    };
+    const ctx: any = {
+      model,
+      resolveJsonTemplate: vi.fn(async (p: any) => p),
+      getAction: vi.fn(() => ({ handler })),
+    };
+
+    await linkageRulesRefresh.handler(ctx, {
+      actionName: 'actionLinkageRules',
+      flowKey: 'buttonSettings',
+    });
+
+    expect(model.getStepParams).toHaveBeenCalledWith('buttonSettings', 'linkageRules');
+    expect(ctx.resolveJsonTemplate).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(ctx, { value: ['x'] });
+  });
+});

--- a/packages/core/client/src/flow/actions/index.ts
+++ b/packages/core/client/src/flow/actions/index.ts
@@ -30,6 +30,7 @@ export * from './aclCheckRefresh';
 export * from './pattern';
 export * from './validation';
 export * from './columnFixed';
+export * from './linkageRulesRefresh';
 export {
   fieldLinkageRules,
   subFormFieldLinkageRules,

--- a/packages/core/client/src/flow/actions/linkageRulesRefresh.tsx
+++ b/packages/core/client/src/flow/actions/linkageRulesRefresh.tsx
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { defineAction } from '@nocobase/flow-engine';
+import { FlowRuntimeContext } from '@nocobase/flow-engine';
+
+type LinkageRulesRefreshParams = {
+  /**
+   * The action name that actually runs linkage rules.
+   * e.g. 'actionLinkageRules' | 'detailsFieldLinkageRules' | 'fieldLinkageRules'
+   */
+  actionName: string;
+  /** Where linkage rules are stored. e.g. 'buttonSettings' */
+  flowKey: string;
+  /** Defaults to 'linkageRules'. */
+  stepKey?: string;
+};
+
+export const linkageRulesRefresh = defineAction({
+  name: 'linkageRulesRefresh',
+  async handler(ctx, params) {
+    const actionName = params?.actionName;
+    const flowKey = params?.flowKey;
+    const stepKey = params?.stepKey || 'linkageRules';
+
+    if (!actionName || !flowKey) return;
+
+    const model = ctx.model;
+    const hasFlow = !!model.getFlow(flowKey);
+    // Prefer running on the current model; fallback to blockModel when the current model doesn't own the flow.
+    if (!hasFlow) return;
+
+    // If forks exist, skip running on master (template) model to avoid polluting baseline state.
+    if (!model?.isFork && model?.forks?.size) {
+      return;
+    }
+
+    // Dedupe concurrent refreshes triggered by deep dispatch (e.g. many items calling the same refresh).
+    const runKey = `${flowKey}:${stepKey}:${actionName}`;
+    const inflightMap: Map<string, Promise<any>> = (model.__linkageRulesRefreshInflight ||= new Map());
+    const existing = inflightMap.get(runKey);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const run = (async () => {
+      const raw = model?.getStepParams?.(flowKey, stepKey);
+      const resolved = await ctx.resolveJsonTemplate({ value: [], ...(raw || {}) });
+      const action = ctx.getAction?.(actionName);
+      if (action?.handler) {
+        await action.handler(ctx, resolved);
+      }
+    })();
+
+    inflightMap.set(runKey, run);
+    try {
+      await run;
+    } finally {
+      inflightMap.delete(runKey);
+    }
+  },
+});

--- a/packages/core/client/src/flow/models/base/ActionModel.tsx
+++ b/packages/core/client/src/flow/models/base/ActionModel.tsx
@@ -258,13 +258,21 @@ ActionModel.registerFlow({
   },
 });
 
-// 分页切换后需要重新计算 ACL（fork 复用时尤其重要）
+// 分页切换后需要重新计算 ACL 与联动规则（fork 复用时尤其重要）
 ActionModel.registerFlow({
   key: 'paginationChange',
   on: 'paginationChange',
   steps: {
     aclCheckRefresh: {
       use: 'aclCheckRefresh',
+    },
+    linkageRulesRefresh: {
+      use: 'linkageRulesRefresh',
+      defaultParams: {
+        actionName: 'actionLinkageRules',
+        flowKey: 'buttonSettings',
+        stepKey: 'linkageRules',
+      },
     },
   },
 });

--- a/packages/core/client/src/flow/models/blocks/details/DetailsBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/details/DetailsBlockModel.tsx
@@ -216,6 +216,29 @@ DetailsBlockModel.registerFlow({
   },
 });
 
+DetailsBlockModel.registerFlow({
+  key: 'paginationChange',
+  on: 'paginationChange',
+  steps: {
+    blockLinkageRulesRefresh: {
+      use: 'linkageRulesRefresh',
+      defaultParams: {
+        actionName: 'blockLinkageRules',
+        flowKey: 'cardSettings',
+        stepKey: 'linkageRules',
+      },
+    },
+    fieldslinkageRulesRefresh: {
+      use: 'linkageRulesRefresh',
+      defaultParams: {
+        actionName: 'detailsFieldLinkageRules',
+        flowKey: 'detailsSettings',
+        stepKey: 'linkageRules',
+      },
+    },
+  },
+});
+
 DetailsBlockModel.define({
   label: tExpr('Details'),
   searchable: true,

--- a/packages/core/client/src/flow/models/blocks/form/EditFormModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/EditFormModel.tsx
@@ -179,6 +179,29 @@ EditFormModel.registerFlow({
   },
 });
 
+EditFormModel.registerFlow({
+  key: 'paginationChange',
+  on: 'paginationChange',
+  steps: {
+    blockLinkageRulesRefresh: {
+      use: 'linkageRulesRefresh',
+      defaultParams: {
+        actionName: 'blockLinkageRules',
+        flowKey: 'cardSettings',
+        stepKey: 'linkageRules',
+      },
+    },
+    fieldsLinkageRulesRefresh: {
+      use: 'linkageRulesRefresh',
+      defaultParams: {
+        actionName: 'fieldLinkageRules',
+        flowKey: 'eventSettings',
+        stepKey: 'linkageRules',
+      },
+    },
+  },
+});
+
 EditFormModel.define({
   label: tExpr('Form (Edit)'),
   searchable: true,

--- a/packages/core/client/src/flow/utils/__tests__/dispatchEventDeep.test.ts
+++ b/packages/core/client/src/flow/utils/__tests__/dispatchEventDeep.test.ts
@@ -40,6 +40,18 @@ describe('dispatchEventDeep', () => {
       }
     }
 
+    TestRoot.registerFlow({
+      key: 'onPageChangeRoot',
+      on: 'paginationChange',
+      steps: {
+        mark: {
+          handler(ctx) {
+            received.push(ctx.model);
+          },
+        },
+      },
+    });
+
     engine.registerModels({ TestRoot, TestChild });
 
     const root = engine.createModel<TestRoot>({
@@ -55,6 +67,6 @@ describe('dispatchEventDeep', () => {
     await dispatchEventDeep(root, 'paginationChange');
 
     const forkFlags = received.map((m) => Boolean((m as any)?.isFork)).sort();
-    expect(forkFlags).toEqual([false, true]);
+    expect(forkFlags).toEqual([false, false, true]);
   });
 });

--- a/packages/core/client/src/flow/utils/dispatchEventDeep.ts
+++ b/packages/core/client/src/flow/utils/dispatchEventDeep.ts
@@ -12,8 +12,7 @@ import type { DispatchEventOptions } from '@nocobase/flow-engine';
 
 /**
  * 递归向子模型（及其 forks）分发指定事件。
- * - 默认不包含自身（避免误触发当前层的其它逻辑）
- * - 用于类似分页切换等“只需要刷新子层状态”的场景（例如 `paginationChange`）
+ * - 默认包含自身（用于类似分页切换等“整棵树状态刷新”的场景，例如 `paginationChange`）
  */
 export async function dispatchEventDeep(
   root: FlowModel,
@@ -22,7 +21,7 @@ export async function dispatchEventDeep(
   options?: { debounce?: boolean } & DispatchEventOptions,
   deepOptions?: { includeSelf?: boolean; includeForks?: boolean },
 ): Promise<void> {
-  const includeSelf = deepOptions?.includeSelf ?? false;
+  const includeSelf = deepOptions?.includeSelf ?? true;
   const includeForks = deepOptions?.includeForks ?? true;
 
   const visited = new Set<FlowModel>();

--- a/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListBlockModel.tsx
@@ -295,6 +295,21 @@ ListBlockModel.registerFlow({
   },
 });
 
+ListBlockModel.registerFlow({
+  key: 'paginationChange',
+  on: 'paginationChange',
+  steps: {
+    linkageRulesRefresh: {
+      use: 'linkageRulesRefresh',
+      defaultParams: {
+        actionName: 'blockLinkageRules',
+        flowKey: 'cardSettings',
+        stepKey: 'linkageRules',
+      },
+    },
+  },
+});
+
 ListBlockModel.define({
   label: tExpr('List'),
   group: tExpr('Content'),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where linkage rules have not been rerun after change pagination for details block, edit form block and list block. |
| 🇨🇳 Chinese | 修复详情，编辑表单，列表区块翻页后联动规则不重新运行的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
