### PR TITLE
fix(core/logger): fix extra error info being discarded in SystemLoggerTransport

### DIFF
--- a/packages/core/logger/src/system-logger.ts
+++ b/packages/core/logger/src/system-logger.ts
@@ -60,17 +60,30 @@ class SystemLoggerTransport extends Transport {
   }
 
   log(info: any, callback: any) {
-    const { level, message, reqId, app, dataSourceKey, stack, cause, [SPLAT]: args } = info;
+    const {
+      level,
+      message,
+      reqId,
+      app,
+      dataSourceKey,
+      stack,
+      cause,
+      [SPLAT]: args,
+      module: moduleFormInfo,
+      submodule: submoduleFormInfo,
+      ...extra
+    } = info;
     const logger = level === 'error' && this.errorLogger ? this.errorLogger : this.logger;
     const { module, submodule, method, ...meta } = args?.[0] || {};
     if (!cause?.onlyLogCause) {
       logger.log({
         level,
         message,
+        extra,
         stack,
         meta,
-        module: module || info['module'] || '',
-        submodule: submodule || info['submodule'] || '',
+        module: module || moduleFormInfo || '',
+        submodule: submodule || submoduleFormInfo || '',
         method: method || '',
         app,
         reqId,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fix extra error info being discarded in SystemLoggerTransport

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix extra error information being discarded when printing system logs |
| 🇨🇳 Chinese | 修复打印系统日志时额外错误信息被丢弃的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
