### PR TITLE
feat(plugin-file-manager): add request options

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/schemas/storageTypes/ali-oss.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/schemas/storageTypes/ali-oss.tsx
@@ -76,6 +76,7 @@ export default {
     rules: common.rules,
     default: common.default,
     paranoid: common.paranoid,
+    settings: common.settings,
   },
   thumbnailRuleLink: 'https://help.aliyun.com/zh/oss/user-guide/resize-images-4',
 };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/schemas/storageTypes/common.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/schemas/storageTypes/common.ts
@@ -86,4 +86,24 @@ export default {
     ],
     default: 'appendRandomID',
   },
+  settings: {
+    type: 'object',
+    title: `{{t("Advanced Settings", { ns: "${NAMESPACE}" })}}`,
+    'x-component': 'fieldset',
+    properties: {
+      requestOptions: {
+        type: 'object',
+        title: `{{t("Request options", { ns: "${NAMESPACE}" })}}`,
+        description: `{{t("Additional options for HTTP requests when fetching files from remote storage on server side, such as headers.", { ns: "${NAMESPACE}" })}}`,
+        'x-decorator': 'FormItem',
+        'x-component': 'Input.JSON',
+        'x-component-props': {
+          autoSize: {
+            minRows: 5,
+            // maxRows: 20,
+          },
+        },
+      },
+    },
+  },
 };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/common/collections/storages.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/common/collections/storages.ts
@@ -84,5 +84,10 @@ export default {
       name: 'paranoid',
       defaultValue: false,
     },
+    {
+      type: 'json',
+      name: 'settings',
+      defaultValue: {},
+    },
   ],
 };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/locale/en-US.json
@@ -1,4 +1,5 @@
 {
+  "Additional options for HTTP requests when fetching files from remote storage on server side, such as headers.": "Additional options for HTTP requests when fetching files from remote storage on server side, such as headers.",
   "Access base URL": "Access base URL",
   "Aliyun OSS": "Aliyun OSS",
   "Aliyun OSS region part of the bucket. For example: \"oss-cn-beijing\".": "Aliyun OSS region part of the bucket. For example: \"oss-cn-beijing\".",
@@ -36,6 +37,7 @@
   "Region": "Region",
   "Relative path the file will be saved to. Left blank as root path. The leading and trailing slashes \"/\" will be ignored. For example: \"user/avatar\".": "Relative path the file will be saved to. Left blank as root path. The leading and trailing slashes \"/\" will be ignored. For example: \"user/avatar\".",
   "Renaming strategy to avoid filename conflicts when uploading files.": "Renaming strategy to avoid filename conflicts when uploading files.",
+  "Request options": "Request options",
   "See more": "See more",
   "Size": "Size",
   "Storage": "Storage",

--- a/packages/plugins/@nocobase/plugin-file-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/locale/zh-CN.json
@@ -1,4 +1,5 @@
 {
+  "Additional options for HTTP requests when fetching files from remote storage on server side, such as headers.": "在服务器端从远程存储获取文件时，HTTP 请求的附加选项，例如请求头等。",
   "Access base URL": "访问 URL 基础",
   "Aliyun OSS": "阿里云 OSS",
   "Aliyun OSS region part of the bucket. For example: \"oss-cn-beijing\".": "阿里云 OSS 存储桶所在区域。例如：\"oss-cn-beijing\"。",
@@ -36,6 +37,7 @@
   "Relative path the file will be saved to. Left blank as root path. The leading and trailing slashes \"/\" will be ignored. For example: \"user/avatar\".": "文件保存的相对路径。留空则为根路径。开始和结尾的斜杠“/”会被忽略。例如：\"user/avatar\"。",
   "Renaming": "重命名",
   "Renaming strategy to avoid filename conflicts when uploading files.": "上传文件时避免文件名冲突的重命名策略。",
+  "Request options": "请求选项",
   "See more": "更多请查阅",
   "Size": "文件大小",
   "Storage": "存储空间",

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/index.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/index.ts
@@ -26,6 +26,7 @@ export interface StorageModel {
   path?: string;
   default?: boolean;
   paranoid?: boolean;
+  settings?: Record<string, any>;
 }
 
 export interface AttachmentModel {
@@ -93,6 +94,7 @@ export abstract class StorageType {
     try {
       const fileURL = await this.getFileURL(file);
       const requestOptions: AxiosRequestConfig = {
+        ...this.storage.settings?.requestOptions,
         responseType: 'stream',
         validateStatus: (status) => status === 200,
         timeout: 30000, // 30 seconds timeout


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add request options for fetching OSS file on server side if additional parameters or headers are needed.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add request options for fetching OSS file on server side if additional parameters or headers are needed |
| 🇨🇳 Chinese | 为 OSS 存储引擎添加请求配置项，可用于从服务端获取文件时传递额外的请求参数 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
