### PR TITLE
feat(table): per-table custom page size (client-only)

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -856,6 +856,8 @@
     "Record unique key": "Record unique key",
     "Records can be sorted": "Records can be sorted",
     "Records per page": "Records per page",
+    "Enter items per page": "Enter items per page",
+    "Reset to default page sizes": "Reset to default page sizes",
     "Red": "Red",
     "Redirect to": "Redirect to",
     "Reference template": "Reference template",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -856,6 +856,8 @@
     "Record unique key": "记录唯一标识符",
     "Records can be sorted": "可以对行记录进行排序",
     "Records per page": "每页显示数量",
+    "Enter items per page": "输入每页显示数量",
+    "Reset to default page sizes": "重置为默认每页数量",
     "Red": "薄暮",
     "Redirect to": "跳转到",
     "Reference template": "引用模板",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Enable users to set a custom page size for a single table, scoped to the current browser session, without changing server-side configuration or global defaults. This improves table usability when presets are insufficient.

### Description 
Key changes:
- Add a custom page-size input (`InputNumber`) and a reset button to the size changer dropdown.
- Validate custom size against dynamic bounds derived from `defaultPageSizeOptions`:
  - Default options: `[5, 10, 20, 50, 100, 200]`
  - Accept values strictly within `(min, max)`; merge into options and apply.

Touched files:
- packages/core/client/src/schema-component/antd/table-v2/Table.tsx
- locales/en-US.json
- locales/zh-CN.json

Potential risks:
- Low, changes are scoped to client pagination UI and do not alter server behavior.

Testing suggestions:
1. Open a paginated table and confirm default size options show correctly.
2. Enter a custom size (e.g., `33`) and press Enter:
   - `33` appears in options, table resets to page 1 with `pageSize=33`.
   - `localStorage` updates:
     - `nb.pagination.customSizes.<tableId>` includes `33`
     - `nb.pagination.selectedSize.<tableId>` = `33`
3. Bounds: values ≤ min or ≥ max from `defaultPageSizeOptions` are rejected (input clears).
4. Click reset:
   - Options revert to `[5, 10, 20, 50, 100, 200]`
   - Selected size clears, pending applies the schema default; dropdown closes.
5. Hover the input: localized tooltip appears.
6. Refresh the page: sizes and selection persist for this table within the current browser.
7. Verify other tables remain unaffected (different `x-uid` → isolated storage).

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table pagination: support per-table custom page size (client-only); reset uses schema default; add tooltip and i18n. |
| 🇨🇳 Chinese | 表格分页：支持每表自定义分页大小（仅客户端）；重置使用 schema 默认值；新增提示与多语言。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  Not needed |
| 🇨🇳 Chinese |  不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary