### PR TITLE
fix(plugin-file-manager): revert getFileURL method for s3 storage

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/s3.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/s3.ts
@@ -151,25 +151,6 @@ export default class extends StorageType {
     };
   }
 
-  getFileURL(file: AttachmentModel, preview?: boolean): string | Promise<string> {
-    if (file.url && isURL(file.url)) {
-      return super.getFileURL(file, preview);
-    }
-
-    const { bucket, endpoint } = this.storage.options;
-    const baseUrlHasBucket = endpoint && this.storage.baseUrl && new RegExp(`/${bucket}/?$`).test(this.storage.baseUrl);
-
-    const keys = [
-      this.storage.baseUrl,
-      endpoint && !baseUrlHasBucket ? bucket : undefined,
-      file.path && encodeURI(file.path),
-      ensureUrlEncoded(file.filename),
-      preview && this.storage.options.thumbnailRule,
-    ].filter(Boolean);
-
-    return urlJoin(keys);
-  }
-
   async deleteS3Objects(bucketName: string, objects: string[]) {
     const Deleted = [];
     for (const Key of objects) {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where file URL generated incorrectly for files uploaded to S3 storage.

### Description 

Involved by #8231.

### Related issues

Fix #8385.

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where file URL generated incorrectly for files uploaded to S3 storage |
| 🇨🇳 Chinese | 修复上传至 S3 存储引擎的文件 URL 生成错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
