### PR TITLE
feat(workflow-cc): support FlowModel UI and task cards

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-cc/package.json
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/package.json
@@ -15,6 +15,8 @@
   "peerDependencies": {
     "@nocobase/actions": "2.x",
     "@nocobase/client": "2.x",
+    "@nocobase/flow-engine": "2.x",
+    "@nocobase/plugin-flow-engine": "2.x",
     "@nocobase/plugin-ui-schema-storage": "2.x",
     "@nocobase/plugin-users": "2.x",
     "@nocobase/plugin-workflow": "2.x",

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client/flow/RemoteFlowModelRenderer.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client/flow/RemoteFlowModelRenderer.tsx
@@ -1,0 +1,52 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowModel, FlowModelRenderer, useFlowEngine, useFlowViewContext } from '@nocobase/flow-engine';
+import _ from 'lodash';
+import React, { useEffect, useState } from 'react';
+
+export function RemoteFlowModelRenderer({
+  uid,
+  onModelLoaded,
+  enableUIConfiguration = false,
+  mapModel = _.identity,
+  useCache = false,
+}: {
+  uid: string;
+  onModelLoaded?: (model: FlowModel) => void;
+  enableUIConfiguration?: boolean;
+  mapModel?: (model: FlowModel) => FlowModel;
+  useCache?: boolean;
+}) {
+  const [model, setModel] = useState<FlowModel>(null);
+  const flowEngine = useFlowEngine();
+  const viewCtx = useFlowViewContext();
+
+  useEffect(() => {
+    const run = async () => {
+      let loadedModel = await flowEngine.loadModel({ uid });
+      if (loadedModel) {
+        loadedModel = mapModel(loadedModel);
+        if (viewCtx) {
+          loadedModel.context.addDelegate(viewCtx);
+        }
+        loadedModel.context.defineProperty('flowSettingsEnabled', {
+          value: enableUIConfiguration,
+        });
+        setModel(loadedModel);
+        if (onModelLoaded) {
+          onModelLoaded(loadedModel);
+        }
+      }
+    };
+    run();
+  }, [flowEngine, uid, viewCtx, onModelLoaded, enableUIConfiguration, mapModel]);
+
+  return <FlowModelRenderer model={model} hideRemoveInSettings showFlowSettings={false} useCache={useCache} />;
+}

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client/flow/models/CcChildPageModel.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client/flow/models/CcChildPageModel.tsx
@@ -1,0 +1,30 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ChildPageModel } from '@nocobase/client';
+
+export class CcChildPageModel extends ChildPageModel {
+  onInit(options) {
+    super.onInit(options);
+    this.context.defineMethod('aclCheck', () => true);
+  }
+}
+
+CcChildPageModel.registerFlow({
+  key: 'CcChildPageSettings',
+  steps: {
+    init: {
+      handler(ctx, params) {
+        ctx.model.context.defineProperty('collection', {
+          get: () => ctx.engine.dataSourceManager.getCollection(params.dataSourceKey, params.collectionName),
+        });
+      },
+    },
+  },
+});

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client/flow/models/CcTaskCardDetailsModel.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client/flow/models/CcTaskCardDetailsModel.tsx
@@ -1,0 +1,107 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import { FlowModelRenderer, SingleRecordResource, tExpr } from '@nocobase/flow-engine';
+import { DetailsBlockModel, FormComponent } from '@nocobase/client';
+
+/**
+ * CC task card detail model: lightweight, read-only detail block for task cards.
+ */
+export class CcTaskCardDetailsModel extends DetailsBlockModel {
+  // always visible in builder/runtime
+  // @ts-ignore
+  get hidden() {
+    return false;
+  }
+
+  set hidden(value) {}
+
+  onInit(options: any): void {
+    super.onInit(options);
+    this.setDecoratorProps({ size: 'small' });
+    this.context.defineMethod('aclCheck', () => true);
+  }
+
+  createResource(ctx, params) {
+    const resource = this.context.createResource(SingleRecordResource);
+    resource.isNewRecord = false;
+    // @ts-ignore
+    resource.refresh = _.noop;
+    return resource;
+  }
+
+  async refresh() {}
+
+  renderComponent() {
+    const { colon, labelAlign, labelWidth, labelWrap, layout } = this.props;
+    return (
+      <FormComponent model={this} layoutProps={{ colon, labelAlign, labelWidth, labelWrap, layout }}>
+        <FlowModelRenderer model={this.subModels.grid} showFlowSettings={false} />
+      </FormComponent>
+    );
+  }
+}
+
+CcTaskCardDetailsModel.define({
+  hide: true,
+});
+
+CcTaskCardDetailsModel.registerFlow({
+  key: 'cardSettings',
+  title: tExpr('Card settings'),
+  steps: {
+    titleDescription: {
+      title: tExpr('Title & description'),
+      uiSchema: {
+        title: {
+          'x-component': 'Input',
+          'x-decorator': 'FormItem',
+          title: tExpr('Title'),
+        },
+        description: {
+          'x-component': 'Input.TextArea',
+          'x-decorator': 'FormItem',
+          title: tExpr('Description'),
+        },
+      },
+      defaultParams(ctx) {
+        return {
+          title: ctx.model.context.workflow?.title,
+        };
+      },
+      handler(ctx, params) {
+        const title = ctx.t(params.title);
+        const description = ctx.t(params.description);
+        ctx.model.setDecoratorProps({ title, description });
+      },
+    },
+  },
+});
+
+CcTaskCardDetailsModel.registerFlow({
+  key: 'detailsSettings',
+  title: tExpr('Details settings'),
+  sort: 150,
+  steps: {
+    refresh: {
+      async handler(ctx) {
+        if (!ctx.resource) {
+          throw new Error('Resource is not initialized');
+        }
+        await ctx.model.applySubModelsBeforeRenderFlows('grid');
+      },
+    },
+    layout: {
+      use: 'layout',
+      title: tExpr('Layout'),
+    },
+  },
+});

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client/index.tsx
@@ -17,6 +17,8 @@ import {
   useSchemaToolbar,
 } from '@nocobase/client';
 import PluginWorkflowClient from '@nocobase/plugin-workflow/client';
+import { CcChildPageModel } from './flow/models/CcChildPageModel';
+import { CcTaskCardDetailsModel } from './flow/models/CcTaskCardDetailsModel';
 import CCInstruction from './instruction';
 import { addBlockButton } from './instruction/SchemaConfig';
 import ccCollection from '../common/collections/workflowCcTasks';
@@ -30,6 +32,11 @@ function WorkflowCCProvider(props) {
 export class PluginWorkflowCCClient extends Plugin {
   // You can get and modify the app instance here
   async load() {
+    this.flowEngine?.registerModels({
+      CcChildPageModel,
+      CcTaskCardDetailsModel,
+    });
+
     this.app.addProvider(WorkflowCCProvider);
 
     const workflow = this.app.pm.get(PluginWorkflowClient);

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client/instruction/SchemaConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client/instruction/SchemaConfig.tsx
@@ -10,7 +10,7 @@
 import React, { useState } from 'react';
 import { uid } from '@formily/shared';
 import { ISchema, observer, useForm } from '@formily/react';
-import { Button, Spin, Typography } from 'antd';
+import { Button, Dropdown, Modal, Spin, Typography } from 'antd';
 
 import {
   ActionContextProvider,
@@ -20,6 +20,7 @@ import {
   SchemaComponentProvider,
   SchemaInitializer,
   SchemaInitializerItemType,
+  parseCollectionName,
   useActionContext,
   useAPIClient,
   usePlugin,
@@ -34,8 +35,18 @@ import PluginWorkflowClient, {
   useTrigger,
   useWorkflowExecuted,
 } from '@nocobase/plugin-workflow/client';
+import {
+  FlowModel,
+  FlowModelRenderer,
+  useFlowEngine,
+  useFlowEngineContext,
+  useFlowViewContext,
+} from '@nocobase/flow-engine';
+import { DeleteOutlined, DownOutlined, SettingOutlined } from '@ant-design/icons';
 import { NAMESPACE } from '../../common/constants';
 import { lang, usePluginTranslation } from '../locale';
+
+const ConfigChangedContext = React.createContext<any>({});
 
 function useTriggerInitializers(): SchemaInitializerItemType | null {
   const { workflow } = useFlowContext();
@@ -209,7 +220,270 @@ export function SchemaConfig({ value, onChange }) {
   );
 }
 
-const ConfigChangedContext = React.createContext<any>({});
+function CcFlowModelConfigContent({ form, valueKey, modelUse, stepParams }) {
+  const flowEngine = useFlowEngine();
+  const viewCtx = useFlowViewContext();
+  const { data: model, loading } = useRequest(
+    async () => {
+      const model: FlowModel = await flowEngine.loadOrCreateModel({
+        async: true,
+        uid: form.values[valueKey],
+        subType: 'object',
+        use: modelUse,
+        stepParams,
+      });
+
+      if (model?.uid) {
+        model.context.addDelegate(viewCtx);
+        model.context.defineProperty('flowSettingsEnabled', {
+          get: () => !form.disabled,
+        });
+        form.setValuesIn(valueKey, model.uid);
+      }
+
+      return model;
+    },
+    {
+      refreshDeps: [form.values[valueKey], form.disabled],
+    },
+  );
+
+  if (loading) {
+    return <Spin />;
+  }
+
+  return <FlowModelRenderer model={model as FlowModel} hideRemoveInSettings showFlowSettings={false} />;
+}
+
+function CcFlowModelConfigButton({ valueKey, modelUse, title, stepParams }) {
+  const { setFormValueChanged } = useActionContext();
+  const ctx = useFlowEngineContext();
+  const { t, viewer, themeToken } = ctx;
+  const form = useForm();
+  const flowContext = useFlowContext();
+  const [dataSourceName, collectionName] = flowContext?.workflow?.config?.collection
+    ? parseCollectionName(flowContext.workflow.config.collection)
+    : [null, null];
+
+  const open = () => {
+    viewer.open({
+      type: 'dialog',
+      width: 800,
+      closable: true,
+      title: t(title, { ns: NAMESPACE }),
+      inputArgs: {
+        flowContext,
+      },
+      styles: {
+        body: {
+          padding: 0,
+          backgroundColor: 'var(--nb-box-bg)',
+        },
+        content: {
+          padding: 0,
+        },
+        header: {
+          padding: `${themeToken.padding}px ${themeToken.paddingLG}px`,
+          marginBottom: 0,
+        },
+      },
+      content: (
+        <CcFlowModelConfigContent
+          form={form}
+          valueKey={valueKey}
+          modelUse={modelUse}
+          stepParams={
+            stepParams || {
+              CcChildPageSettings: {
+                init: {
+                  dataSourceKey: dataSourceName,
+                  collectionName,
+                },
+              },
+            }
+          }
+        />
+      ),
+    });
+    if (!form.values[valueKey]) {
+      setFormValueChanged?.(true);
+    }
+  };
+
+  return (
+    <Button type="primary" onClick={open} disabled={false} icon={<SettingOutlined />}>
+      {t(title, { ns: NAMESPACE })}
+    </Button>
+  );
+}
+
+export function CcTaskCardConfigButton() {
+  const flowContext = useFlowContext();
+  const [dataSourceName, collectionName] = flowContext?.workflow?.config?.collection
+    ? parseCollectionName(flowContext.workflow.config.collection)
+    : [null, null];
+  return (
+    <CcFlowModelConfigButton
+      valueKey="taskCardUid"
+      modelUse="CcTaskCardDetailsModel"
+      title="Task card"
+      stepParams={{
+        cardSettings: {
+          titleDescription: {
+            title: flowContext.workflow?.title,
+          },
+        },
+        detailsSettings: {
+          refresh: {},
+          layout: {},
+        },
+        CcChildPageSettings: {
+          init: {
+            dataSourceKey: dataSourceName,
+            collectionName,
+          },
+        },
+      }}
+    />
+  );
+}
+
+export function CcInterfaceConfig() {
+  const form = useForm();
+  const ctx = useFlowEngineContext();
+  const flowContext = useFlowContext();
+  const { setFormValueChanged } = useActionContext();
+  const [v1Visible, setV1Visible] = useState(false);
+  const { t, viewer, themeToken } = ctx;
+  const api = useAPIClient();
+  const [dataSourceName, collectionName] = parseCollectionName(flowContext.workflow.config.collection);
+
+  const openV2 = ({ needConfirm } = {} as any) => {
+    const doOpen = () => {
+      viewer.open({
+        type: 'dialog',
+        width: 800,
+        closable: true,
+        title: t('User interface', { ns: NAMESPACE }),
+        inputArgs: {
+          flowContext,
+        },
+        styles: {
+          body: {
+            padding: 0,
+            backgroundColor: 'var(--nb-box-bg)',
+          },
+          content: {
+            padding: 0,
+          },
+          header: {
+            padding: `${themeToken.padding}px ${themeToken.paddingLG}px`,
+            marginBottom: 0,
+          },
+        },
+        content: (
+          <CcFlowModelConfigContent
+            form={form}
+            valueKey="ccUid"
+            modelUse="CcChildPageModel"
+            stepParams={{
+              CcChildPageSettings: {
+                init: {
+                  dataSourceKey: dataSourceName,
+                  collectionName,
+                },
+              },
+            }}
+          />
+        ),
+      });
+      if (!form.values.ccUid) {
+        setFormValueChanged?.(true);
+      }
+    };
+
+    if (form.values.ccDetail && needConfirm) {
+      Modal.confirm({
+        title: t('Configure v2 UI', { ns: NAMESPACE }),
+        content: t(
+          'Before using the v2 UI, you must delete the existing v1 UI. Are you sure you want to delete the v1 UI?',
+          { ns: NAMESPACE },
+        ),
+        onOk: async () => {
+          await deleteV1();
+          doOpen();
+        },
+      });
+      return;
+    }
+
+    doOpen();
+  };
+
+  const deleteV1 = async () => {
+    try {
+      if (form.values.ccDetail) {
+        await api.request({ url: `uiSchemas:remove/${form.values.ccDetail}`, method: 'POST' });
+      }
+      form.setValuesIn('ccDetail', null);
+      setFormValueChanged?.(true);
+    } catch (err) {
+      console.error('Failed to delete v1 configuration:', err);
+    }
+  };
+
+  const items = [
+    {
+      key: 'v1',
+      label: (
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', minWidth: 120 }}>
+          <span style={{ flex: 1 }}>{lang('v1 (Legacy)')}</span>
+          {form.values.ccDetail && (
+            <DeleteOutlined
+              onClick={(e) => {
+                e.stopPropagation();
+                Modal.confirm({
+                  title: t('Delete v1 configuration', { ns: NAMESPACE }),
+                  onOk: deleteV1,
+                });
+              }}
+              style={{ color: '#999', marginLeft: 8 }}
+            />
+          )}
+        </div>
+      ),
+      onClick: () => setV1Visible(true),
+    },
+    {
+      key: 'v2',
+      label: lang('v2'),
+      onClick: () => openV2({ needConfirm: true }),
+    },
+  ];
+
+  if (form.values.ccDetail) {
+    return (
+      <ConfigChangedContext.Provider value={{ setFormValueChanged }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Dropdown menu={{ items }} trigger={['hover']}>
+            <Button type="primary" icon={<SettingOutlined />}>
+              {lang('Go to configure')} <DownOutlined />
+            </Button>
+          </Dropdown>
+        </div>
+        <ActionContextProvider value={{ visible: v1Visible, setVisible: setV1Visible, formValueChanged: false }}>
+          <SchemaConfig />
+        </ActionContextProvider>
+      </ConfigChangedContext.Provider>
+    );
+  }
+
+  return (
+    <Button icon={<SettingOutlined />} type="primary" onClick={() => openV2({ needConfirm: false })} disabled={false}>
+      {lang('Go to configure')}
+    </Button>
+  );
+}
 
 const ForceReadHint = observer(() => {
   const { initialValues, values } = useForm();

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client/instruction/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client/instruction/index.tsx
@@ -35,7 +35,7 @@ import {
 import { NAMESPACE } from '../../common/constants';
 // import NotificationFieldset from '../NotificationFieldset';
 // import { SchemaConfig, SchemaConfigButton } from './SchemaConfig';
-import { SchemaConfig, SchemaConfigButton } from './SchemaConfig';
+import { SchemaConfig, SchemaConfigButton, CcInterfaceConfig, CcTaskCardConfigButton } from './SchemaConfig';
 
 export default class extends Instruction {
   title = `{{t("CC", { ns: "${NAMESPACE}" })}}`;
@@ -112,7 +112,37 @@ export default class extends Instruction {
           'x-component': 'SchemaConfig',
         },
       },
-      required: true,
+      'x-reactions': [
+        {
+          fulfill: {
+            state: {
+              visible: `{{!$form.values.ccUid}}`,
+              required: `{{!$form.values.ccUid}}`,
+            },
+          },
+        },
+      ],
+    },
+    ccUid: {
+      type: 'void',
+      title: `{{t("User interface", { ns: "${NAMESPACE}" })}}`,
+      'x-decorator': 'FormItem',
+      'x-component': 'CcInterfaceConfig',
+      'x-reactions': [
+        {
+          fulfill: {
+            state: {
+              visible: `{{!!$form.values.ccDetail || !$form.disabled}}`,
+            },
+          },
+        },
+      ],
+    },
+    taskCardUid: {
+      type: 'string',
+      title: `{{t("Task card", { ns: "${NAMESPACE}" })}}`,
+      'x-decorator': 'FormItem',
+      'x-component': 'CcTaskCardConfigButton',
     },
     title: {
       type: 'string',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
重构抄送（CC）插件，支持基于 FlowModel 的界面（v2），使工作流界面与配置可以作为可复用的 FlowModel 构建；同时保持对旧版 v1 UI 的兼容，并新增任务卡片功能以增强任务列表的展示体验。

### Description 
主要变更：
- 新增 FlowModel 渲染器与封装（`RemoteFlowModelRenderer`），并注册两个模型：`CcChildPageModel` 与 `CcTaskCardDetailsModel`。
- 指令配置：新增 `CcInterfaceConfig`（用于 v2 UI 的切换与 FlowModel 配置）和 `CcTaskCardConfigButton`（任务卡片配置）；保留 legacy 的 `ccDetail` schema UI，并通过可见性反应进行兼容。
- 任务界面：支持基于 FlowModel 的详情页（`ccUid`）与任务卡片（`taskCardUid`），若未配置则回退为 legacy 的 schema 实现。
- 服务端：在复制工作流配置时会复制 FlowModel（`ccUid` / `taskCardUid`）的 uid，同时保留对 `ccDetail`（ui schema）的复制行为。
- 在插件的 peerDependencies 中声明 `@nocobase/flow-engine` 与 `@nocobase/plugin-flow-engine`。

风险：
- 依赖运行时提供 `@nocobase/flow-engine`；切换到 v2 后用户可能需要重新配置界面，但 v1 将继续保持兼容。

测试建议：
- 新建带 v1 界面的 CC 节点，验证行为与之前一致。
- 通过 FlowModel 配置器创建 v2 界面，验证详情对话框与任务卡片能正常渲染且关闭/刷新功能正常。
- 复制工作流并验证 FlowModel 的 uid 已被正确复制。
- 在本地运行 lint 与相关测试以确认无语法/逻辑错误。

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support flow model-based UI for CC and add task cards |
| 🇨🇳 Chinese | 为抄送插件增加基于 FlowModel 的界面支持并添加任务卡片 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
