### PR TITLE
fix: title field setting disappearing after setting attachmentURL and…

### DIFF
--- a/packages/core/client/src/flow/actions/titleField.tsx
+++ b/packages/core/client/src/flow/actions/titleField.tsx
@@ -38,11 +38,7 @@ export const titleField = defineAction({
     };
   },
   hideInSettings: async (ctx: FlowModelContext) => {
-    return (
-      !ctx.collectionField ||
-      !ctx.collectionField.isAssociationField() ||
-      (ctx.model.subModels.field as any).disableTitleField
-    );
+    return !ctx.collectionField || !ctx.collectionField.isAssociationField();
   },
   beforeParamsSave: async (ctx: any, params, previousParams) => {
     const target = ctx.model.collectionField.target;


### PR DESCRIPTION
… then changing to another field

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix title field setting disappearing after setting attachment URL and then changing to another field in form item        |
| 🇨🇳 Chinese |   修复表单关系字段标题设置附件URL后，再设置为其他字段时，标题设置项消失问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
