### PR TITLE
perf(client): optimize customVariables with useMemo

### DIFF
--- a/packages/core/client/src/variables/hooks/useLocalVariables.tsx
+++ b/packages/core/client/src/variables/hooks/useLocalVariables.tsx
@@ -70,13 +70,16 @@ const useLocalVariables = (props?: Props) => {
   }
 
   const app = useApp();
-  const customVariables =
-    app.getVariables?.().map((variable) => {
-      return {
-        name: variable.name,
-        ctx: variable.useCtx(),
-      };
-    }) || [];
+  const customVariables = useMemo(
+    () =>
+      app.getVariables?.().map((variable) => {
+        return {
+          name: variable.name,
+          ctx: variable.useCtx(),
+        };
+      }) || [],
+    [],
+  );
 
   return useMemo(() => {
     return (


### PR DESCRIPTION

  <!--
  First of all, thank you for your contribution!
  For bug fixes or other non-feature modifications, please base your branch on the main branch.
  For new features or API modifications, please make sure your branch is based on the next branch.
  Thank you!
  -->

  ### This is a ...
  - [ ] New feature
  - [x] Improvement
  - [ ] Bug fix
  - [ ] Others

  ### Motivation
  <!-- Please explain the reason of the changes made in this PR. -->
  当前 `customVariables` 没有使用 `useMemo` 缓存，导致组件每次渲染都会重新调用 `app.getVariables()?.map()`，造成不必要的性能开销。特别是在使用自定义变量（通过 `app.registerVariable` 注册）的场景下，每次渲 染都会执行不必要的变量计算。

  ### Description
  <!--
  Please describe the key changes made in this PR clearly and concisely,
  mention any potential risks,
  and provide some testing suggestions.
  -->
  将 `customVariables` 的计算包裹在 `useMemo` 中，仅在 `app.getVariables` 引用变化时才重新计算。

  **Changes:**
  - `packages/core/client/src/variables/hooks/useLocalVariables.tsx`: 使用 `useMemo` 包裹 `customVariables` 计算

  **Testing:**
  - 确认自定义变量（如通过 `registerVariable` 注册的）功能正常
  - 验证变量在组件更新时正确保持引用稳定
  - 检查依赖数组 `[app.getVariables]` 能正确触发重新计算

  ### Related issues
  N/A

  ### Showcase
  <!-- Including any screenshots of the changes. -->
  N/A

  ### Changelog

  | Language   | Changelog |
  | ---------- | --------- |
  | 🇺🇸 English | Perf: Optimize `customVariables` calculation with `useMemo` to prevent unnecessary re-computation |
  | 🇨🇳 Chinese | 性能优化：使用 `useMemo` 优化 `customVariables` 计算，避免不必要的重复计算 |

  ### Docs

  | Language   | Link |
  | ---------- | --------- |
  | 🇺🇸 English |  N/A    |
  | 🇨🇳 Chinese |  N/A  |

  ### Checklists
  - [x] All changes have been self-tested and work as expected
  - [ ] Test cases are updated/provided or not needed
  - [ ] Doc is updated/provided or not needed
  - [ ] Component demo is updated/provided or not needed
  - [x] Changelog is provided or not needed
  - [x] Request a code review if it is necessary