### PR TITLE
fix(action): update disabled state handling in InternalAction

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.tsx
@@ -314,7 +314,7 @@ const InternalAction: React.FC<InternalActionProps> = observer(function Com(prop
     disabled: disableAction,
     loading: loadingOfUseAction,
   } = useAction?.(actionCallback) || ({} as any);
-  const disabled = form.disabled || field.disabled || field.data?.disabled || propsDisabled || disableAction;
+  const disabled = form.disabled || field.data?.disabled || propsDisabled || disableAction;
   const buttonStyle = useMemo(() => {
     return {
       ...style,

--- a/packages/core/client/src/schema-component/antd/action/utils.ts
+++ b/packages/core/client/src/schema-component/antd/action/utils.ts
@@ -148,7 +148,8 @@ export const linkageAction = async (
         ...field.stateOfLinkageRules,
         disabled: disableResult,
       };
-      field.disabled = last(disableResult);
+      field.data = field.data || {};
+      field.data.disabled = last(disableResult);
       field.componentProps['disabled'] = last(disableResult);
       break;
     case ActionType.Active:
@@ -166,7 +167,8 @@ export const linkageAction = async (
         ...field.stateOfLinkageRules,
         disabled: disableResult,
       };
-      field.disabled = last(disableResult);
+      field.data = field.data || {};
+      field.data.disabled = last(disableResult);
       field.componentProps['disabled'] = last(disableResult);
       break;
     default:
@@ -177,7 +179,7 @@ export const linkageAction = async (
 export const setInitialActionState = (field) => {
   field.data = field.data || {};
   field.display = 'visible';
-  field.disabled = false;
   field.data.hidden = false;
+  field.data.disabled = false;
   field.componentProps['disabled'] = false;
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Fix the issue where table row button linkage rules affect the state of buttons within popup forms   |
| 🇨🇳 Chinese |      修复表格行按钮的联动规则会影响弹窗表单按钮状态的问题     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
