### PR TITLE
fix(quick-edit): improve dropdown visibility handling and max height

### DIFF
--- a/packages/core/client/src/schema-component/antd/quick-edit/QuickEdit.tsx
+++ b/packages/core/client/src/schema-component/antd/quick-edit/QuickEdit.tsx
@@ -12,10 +12,11 @@ import { css } from '@emotion/css';
 import { IFormItemProps } from '@formily/antd-v5';
 import { Field, createForm } from '@formily/core';
 import { FormContext, RecursionField, observer, useField, useFieldSchema } from '@formily/react';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { useCollectionManager_deprecated } from '../../../collection-manager';
 import { useCollection } from '../../../data-source/collection/CollectionProvider';
 import { useToken } from '../../../style';
+import { useNiceDropdownMaxHeight } from '../../../common/useNiceDropdownHeight';
 import { FormItem } from '../form-item';
 import { StablePopover } from '../popover';
 
@@ -48,6 +49,8 @@ export const Editable = observer(
         }),
       [field.value, fieldSchema['x-component-props']],
     );
+    const [visible, setVisible] = useState(false);
+    const popupMaxHeight = useNiceDropdownMaxHeight([visible]);
     const getContainer = () => {
       return containerRef.current;
     };
@@ -64,7 +67,14 @@ export const Editable = observer(
       <FormItem {...props} labelStyle={{ display: 'none' }}>
         <StablePopover
           content={
-            <div style={{ width: '100%', height: '100%', minWidth: 500 }}>
+            <div
+              style={{
+                width: '100%',
+                minWidth: 500,
+                maxHeight: popupMaxHeight,
+                overflow: 'auto',
+              }}
+            >
               <div ref={containerRef}>{modifiedChildren}</div>
             </div>
           }
@@ -77,6 +87,7 @@ export const Editable = observer(
             }
           `}
           onOpenChange={(open) => {
+            setVisible(open);
             if (open) {
               field.validate();
             }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where the shortcut modal height exceeds the viewport height    |
| 🇨🇳 Chinese |     修复快捷便捷弹窗高度超出页面高度的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
