### PR TITLE
fix(RichTextField): add bounds prop for Quill editor

### DIFF
--- a/packages/core/client/src/flow/models/fields/RichTextFieldModel/index.tsx
+++ b/packages/core/client/src/flow/models/fields/RichTextFieldModel/index.tsx
@@ -28,6 +28,7 @@ const ReactQuill = lazy(async () => {
 
 export const RichTextField = (props) => {
   const richTextClass = useRichTextStyles();
+  const boundsClass = React.useMemo(() => `quill-bounds-${Math.random().toString(36).slice(2, 9)}`, []);
   const modules = {
     toolbar: [
       [
@@ -85,7 +86,7 @@ export const RichTextField = (props) => {
 
   return (
     <ReactQuill
-      className={richTextClass}
+      className={`${richTextClass} ${boundsClass}`}
       modules={propsModules || modules}
       formats={propsFormats || formats}
       value={value}
@@ -97,7 +98,7 @@ export const RichTextField = (props) => {
         }
       }}
       readOnly={disabled}
-      bounds={'.quill'}
+      bounds={`.${boundsClass}`}
     />
   );
 };

--- a/packages/core/client/src/schema-component/antd/rich-text/RichText.tsx
+++ b/packages/core/client/src/schema-component/antd/rich-text/RichText.tsx
@@ -21,6 +21,7 @@ const ReactQuill = lazy(() => import('react-quill'));
 export const RichText = connect(
   (props) => {
     const { wrapSSR, hashId, componentCls } = useStyles();
+    const boundsClass = React.useMemo(() => `quill-bounds-${Math.random().toString(36).slice(2, 9)}`, []);
     const modules = {
       toolbar: [['bold', 'italic', 'underline', 'link'], [{ list: 'ordered' }, { list: 'bullet' }], ['clean']],
     };
@@ -53,7 +54,7 @@ export const RichText = connect(
 
     return wrapSSR(
       <ReactQuill
-        className={classNames(componentCls, hashId, quillDisabled, {
+        className={classNames(componentCls, hashId, quillDisabled, boundsClass, {
           'is-disabled': disabled,
         })}
         modules={propsModules || modules}
@@ -67,7 +68,7 @@ export const RichText = connect(
           }
         }}
         readOnly={disabled}
-        bounds={'.quill'}
+        bounds={`.${boundsClass}`}
       />,
     );
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix the issue where the rich text editor's popovers are obscured    |
| 🇨🇳 Chinese |     修复富文本编辑器的弹出层被遮挡的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
