### PR TITLE
fix: close menu after opening popup

### DIFF
--- a/packages/core/flow-engine/src/components/settings/wrappers/component/SwitchWithTitle.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/component/SwitchWithTitle.tsx
@@ -52,7 +52,8 @@ export const SwitchWithTitle: FC = observer(
     };
 
     // 点击整个容器时触发
-    const handleWrapperClick = () => {
+    const handleWrapperClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
       if (disabled) return;
       handleChange(!checked);
     };

--- a/packages/core/flow-engine/src/components/settings/wrappers/component/__tests__/InlineControls.test.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/component/__tests__/InlineControls.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@nocobase/test/client';
+import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
+
+import { SwitchWithTitle } from '../SwitchWithTitle';
+import { SelectWithTitle } from '../SelectWithTitle';
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    Select: ({
+      popupMatchSelectWidth,
+      bordered,
+      popupClassName,
+      fieldNames,
+      labelRender,
+      optionRender,
+      dropdownRender,
+      options,
+      ...props
+    }: any) => React.createElement('select', props),
+    Switch: ({ checkedChildren, unCheckedChildren, size, ...props }: any) =>
+      React.createElement('input', { ...props, type: 'checkbox', readOnly: true }),
+  };
+});
+
+describe('Inline controls - stopPropagation', () => {
+  it('SwitchWithTitle click does not bubble to parent', async () => {
+    const engine = new FlowEngine();
+    const parentClick = vi.fn();
+    const onChange = vi.fn();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <div onClick={parentClick}>
+          <SwitchWithTitle title="Enabled" itemKey="enabled" onChange={onChange} />
+        </div>
+      </FlowEngineProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Enabled'));
+
+    expect(parentClick).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it('SelectWithTitle click does not bubble to parent', async () => {
+    const engine = new FlowEngine();
+    const parentClick = vi.fn();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <div onClick={parentClick}>
+          <SelectWithTitle title="Mode" itemKey="mode" options={[{ label: 'A', value: 'a' }]} />
+        </div>
+      </FlowEngineProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Mode'));
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/flow-engine/src/components/settings/wrappers/contextual/DefaultSettingsIcon.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/contextual/DefaultSettingsIcon.tsx
@@ -184,6 +184,9 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
   // 当模型发生子模型替换/增删等变化时，强制刷新菜单数据
   const [refreshTick, setRefreshTick] = useState(0);
   const [extraMenuItems, setExtraMenuItems] = useState<FlowModelExtraMenuItem[]>([]);
+  const closeDropdown = useCallback(() => {
+    setVisible(false);
+  }, []);
   const handleOpenChange: DropdownProps['onOpenChange'] = useCallback((nextOpen: boolean, info) => {
     if (info.source === 'trigger' || nextOpen) {
       // 当鼠标快速滑过时，终止菜单的渲染，防止卡顿
@@ -292,6 +295,7 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
   );
 
   const handleDelete = useCallback(() => {
+    closeDropdown();
     Modal.confirm({
       title: t('Confirm delete'),
       icon: <ExclamationCircleOutlined />,
@@ -312,7 +316,7 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
         }
       },
     });
-  }, [model]);
+  }, [closeDropdown, model, t]);
 
   const handleStepConfiguration = useCallback(
     (key: string) => {
@@ -345,6 +349,7 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
       }
 
       try {
+        closeDropdown();
         targetModel.openFlowSettings({
           flowKey,
           stepKey,
@@ -353,7 +358,7 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
         console.log(t('Configuration popup cancelled or error'), ':', error);
       }
     },
-    [model],
+    [closeDropdown, model, t],
   );
 
   const handleMenuClick = useCallback(
@@ -363,18 +368,21 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
       const cleanKey = key.includes('-') && /^(.+)-\d+$/.test(key) ? key.replace(/-\d+$/, '') : key;
 
       if (cleanKey.startsWith('copy-pop-uid:')) {
+        closeDropdown();
         handleCopyPopupUid(cleanKey);
         return;
       }
 
       const extra = extraMenuItems.find((it) => it?.key === originalKey || it?.key === cleanKey);
       if (extra?.onClick) {
+        closeDropdown();
         extra.onClick();
         return;
       }
 
       switch (cleanKey) {
         case 'copy-uid':
+          closeDropdown();
           handleCopyUid();
           break;
         case 'delete':
@@ -385,7 +393,7 @@ export const DefaultSettingsIcon: React.FC<DefaultSettingsIconProps> = ({
           break;
       }
     },
-    [handleCopyUid, handleDelete, handleStepConfiguration, handleCopyPopupUid, extraMenuItems],
+    [closeDropdown, handleCopyUid, handleDelete, handleStepConfiguration, handleCopyPopupUid, extraMenuItems],
   );
 
   // 获取单个模型的可配置flows和steps


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where repeatedly clicking the configuration menu could open multiple configuration popups. |
| 🇨🇳 Chinese | 修复能够重复点击配置菜单打开多个配置弹窗的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
