### PR TITLE
fix:issue where sub-detail data in read-only mode could not be displayed correctly in the edit form

### DIFF
--- a/packages/core/client/src/flow/models/blocks/details/DetailsItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/details/DetailsItemModel.tsx
@@ -147,12 +147,12 @@ export class DetailsItemModel extends DisplayItemModel<{
         : fieldModel;
     const mergedProps = this.context.pattern
       ? {
-          ...this.parent.parent.props,
+          ...this.context.blockModel.props,
           ...this.props,
           pattern: this.context.pattern,
           disabled: this.context.pattern === 'readPretty',
         }
-      : { ...this.parent.parent.props, ...this.props };
+      : { ...this.context.blockModel.props, ...this.props };
     const value = getValueWithIndex(record, this.fieldPath, idx);
     return (
       <FormItem {...mergedProps} value={value}>

--- a/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListBlockModel.tsx
@@ -50,7 +50,7 @@ export class ListBlockModel extends CollectionBlockModel<ListBlockModelStructure
   createResource(ctx, params) {
     return this.context.createResource(MultiRecordResource);
   }
-  renderConfiguireActions() {
+  renderConfigureActions() {
     return (
       <AddSubModelButton
         key={'table-column-add-actions'}
@@ -176,7 +176,7 @@ export class ListBlockModel extends CollectionBlockModel<ListBlockModelStructure
 
               return null;
             })}
-            {this.renderConfiguireActions()}
+            {this.renderConfigureActions()}
           </Space>
         </div>
       </DndProvider>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix issue where sub-detail data in read-only mode could not be displayed correctly in the edit form          |
| 🇨🇳 Chinese |     修复编辑表单中配置阅读态子详情数据不能正常显示问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
