### PR TITLE
fix: can't set data scope through ref template event flow

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/ReferenceBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/ReferenceBlockModel.tsx
@@ -117,15 +117,15 @@ export class ReferenceBlockModel extends BlockModel {
     // 事件流/过滤器等配置 UI（如 setTargetDataScope 的 VariableFilterItem）依赖 model.context.collection/resource 等
     // 来构建可选字段列表。但 ReferenceBlockModel 只是一个壳：真正的 collection/resource 在目标区块模型上。
     // 这里桥接相关上下文属性到目标模型，避免“能找到模型实例但字段下拉为空”。
-    const getTargetContext = () => (this._targetModel as any)?.context as any;
-    const bridgeContextProp = (key: string) => {
+    const contextKeys = ['collection', 'dataSource', 'resource', 'association', 'resourceName'] as const;
+    type ContextKey = (typeof contextKeys)[number];
+    const getTargetContext = () => this._targetModel?.context;
+    contextKeys.forEach((key: ContextKey) => {
       this.context.defineProperty(key, {
         cache: false,
         get: () => getTargetContext()?.[key],
       });
-    };
-
-    ['collection', 'dataSource', 'resource', 'association', 'resourceName'].forEach(bridgeContextProp);
+    });
   }
 
   private _getTargetUidFromParams(): string | undefined {

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/ReferenceBlockModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/ReferenceBlockModel.test.tsx
@@ -269,7 +269,7 @@ describe('ReferenceBlockModel', () => {
 
         await referenceBlockModel.dispatchEvent('beforeRender');
 
-        expect((referenceBlockModel as any)?.context?.collection?.name).toBe('mock-collection');
+        expect(referenceBlockModel.context.collection.name).toBe('mock-collection');
       },
       TEST_TIMEOUT,
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where reference template blocks could not set data scopes via event flow settings. |
| 🇨🇳 Chinese | 修复引用模板区块无法通过事件流设置数据范围的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
