### PR TITLE
fix(filter): avoid duplicated time in DateTime filter value

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/DateTimeNoTzFilterFieldModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/fields/date-time/DateTimeNoTzFilterFieldModel.tsx
@@ -13,7 +13,10 @@ import { DateFilterDynamicComponent } from './components/DateFilterDynamicCompon
 
 const DateTimeNoTzPicker = (props) => {
   const { value, format = 'YYYY-MM-DD HH:mm:ss', showTime, picker = 'date', ...rest } = props;
-  return <DateFilterDynamicComponent {...rest} value={value} format={format} picker={picker} showTime={showTime} />;
+  // When showTime is true, use date-only format to avoid duplication
+  // because getDateTimeFormat will append time format automatically
+  const dateFormat = showTime && picker === 'date' ? 'YYYY-MM-DD' : format;
+  return <DateFilterDynamicComponent {...rest} value={value} format={dateFormat} picker={picker} showTime={showTime} />;
 };
 
 export class DateTimeNoTzFilterFieldModel extends DateTimeFilterFieldModel {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
修复在筛选组件中，当 `showTime=true` 时，日期值的字符串格式出现重复时间的错误（例如：`2026-01-15 00:00:00 00:00:00`），导致后端接收到格式不正确的日期时间字符串。

### Description 
- 问题原因：`DateTimeNoTzFilterFieldModel` 传入了包含时间（`YYYY-MM-DD HH:mm:ss`）的 `format`，而 `FilterDatePicker` 会调用 `getDateTimeFormat()` 在 `format` 后再次拼接时间格式，导致格式重复。
- 解决方案：当 `showTime=true` 且 `picker === 'date'` 时，`DateTimeNoTzFilterFieldModel` 只传入日期部分的 `format`（`YYYY-MM-DD`），由 `getDateTimeFormat` 负责拼接时间格式，从根本避免重复。
- 风险：低；仅修改默认传入 format 的逻辑，兼容性良好。

### Related issues
- 无

### Showcase
- 无界面变化，仅修复筛选参数序列化的错误。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicated time in filter DateTime value |
| 🇨🇳 Chinese | 修复筛选区块日期带时间时时间格式重复的问题 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
