### PR TITLE
feat(plugin-text-copy): add copy feature for JSON field type

### DIFF
--- a/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/input/ReadPretty.tsx
@@ -268,6 +268,8 @@ export interface JSONTextAreaReadPrettyProps {
   space?: number;
   prefixCls?: string;
   ellipsis?: boolean;
+  addonBefore?: React.ReactNode;
+  addonAfter?: React.ReactNode;
 }
 
 const JSONClassName = css`
@@ -280,6 +282,8 @@ ReadPretty.JSON = (props: JSONTextAreaReadPrettyProps) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const prefixCls = usePrefixCls('json', props);
   // eslint-disable-next-line react-hooks/rules-of-hooks
+  const compile = useCompile();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const content = useMemo(
     () => (props.value != null ? JSON.stringify(props.value, null, props.space ?? 2) : ''),
     [props.space, props.value],
@@ -290,15 +294,28 @@ ReadPretty.JSON = (props: JSONTextAreaReadPrettyProps) => {
     </pre>
   );
 
-  if (props.ellipsis) {
-    return (
-      <EllipsisWithTooltip ellipsis={props.ellipsis} popoverContent={JSONContent}>
-        {content}
-      </EllipsisWithTooltip>
-    );
-  }
-
-  return JSONContent;
+  return (
+    <div
+      className={cls(prefixCls, props.className)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        overflowWrap: 'break-word',
+        whiteSpace: 'normal',
+        ...props.style,
+      }}
+    >
+      {compile(props.addonBefore)}
+      {props.ellipsis ? (
+        <EllipsisWithTooltip ellipsis={props.ellipsis} popoverContent={JSONContent}>
+          {content}
+        </EllipsisWithTooltip>
+      ) : (
+        JSONContent
+      )}
+      {compile(props.addonAfter)}
+    </div>
+  );
 };
 
 ReadPretty.Input = withPopupWrapper(ReadPretty.Input);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Add a convenient way for users to quickly copy the content of JSON fields in read-only mode.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
- Added a copy-to-clipboard button/feature to the JSON field type in read-only (ReadPretty) mode.
- The copy button appears next to the JSON content, allowing users to easily copy the formatted JSON string.
- No breaking changes; the feature is optional and non-intrusive.
- Suggest testing with various JSON values, including large and deeply nested objects.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->
<!--
![json-copy-demo](link-to-screenshot)
-->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support copy feature for JSON field type in read-only mode. |
| 🇨🇳 Chinese | JSON 类型字段在只读模式下支持一键复制功能。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary