### PR TITLE
fix:  nanoid field not regenerated after form submit

### DIFF
--- a/packages/core/client/src/schema-component/antd/nanoid-input/NanoIDInput.tsx
+++ b/packages/core/client/src/schema-component/antd/nanoid-input/NanoIDInput.tsx
@@ -8,9 +8,10 @@
  */
 
 import { LoadingOutlined } from '@ant-design/icons';
-import { connect, mapProps, mapReadPretty, useForm } from '@formily/react';
+import { connect, mapProps, mapReadPretty, useForm, useFormEffects } from '@formily/react';
 import { Input as AntdInput } from 'antd';
 import { customAlphabet as Alphabet } from 'nanoid';
+import { onFormReset } from '@formily/core';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCollectionField } from '../../../data-source/collection-field/CollectionFieldProvider';
@@ -21,7 +22,7 @@ export const NanoIDInput = Object.assign(
   connect(
     AntdInput,
     mapProps((props: any, field: any) => {
-      const { size, customAlphabet } = useCollectionField() || { size: 21 };
+      const { size, customAlphabet, autoFill } = useCollectionField() || { size: 21 };
       const { t } = useTranslation();
       const form = useForm();
       const { isInFilterFormBlock } = useFlag();
@@ -45,6 +46,17 @@ export const NanoIDInput = Object.assign(
           state.validator = isValidNanoid;
         });
       }, [isInFilterFormBlock]);
+
+      // 监听表单 reset
+      useFormEffects(() => {
+        onFormReset(() => {
+          if (!customAlphabet || isInFilterFormBlock || autoFill === false) return;
+          const value = Alphabet(customAlphabet, size)();
+          field.setInitialValue(value);
+          field.setValue(value);
+        });
+      });
+
       return {
         ...props,
         suffix: <span>{field?.['loading'] || field?.['validating'] ? <LoadingOutlined /> : props.suffix}</span>,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix nanoid field not regenerated after form submit        |
| 🇨🇳 Chinese |    修复 nanoid 字段在表单提交后不重新生成数据的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
