### PR TITLE
fix(calendar): correct locale handling for ru-RU

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calendar.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/Calendar.tsx
@@ -296,7 +296,7 @@ export const Calendar: any = withDynamicSchemaProps(
       const locales = {
         'zh-CN': zhCN,
         'en-US': enUS,
-        ru: ru,
+        'ru-RU': ru,
       };
       const locale = apiClient.auth.locale || 'en-US';
       const formats = useMemo(() => {
@@ -304,44 +304,40 @@ export const Calendar: any = withDynamicSchemaProps(
           monthHeaderFormat: (date, culture, local) =>
             local.format(
               date,
-              locale === 'zh-CN' ? 'yyyy年M月' : locale === 'ru' ? 'LLLL yyyy' : 'MMM yyyy',
-              locales[locale],
+              culture === 'zh-CN' ? 'yyyy年M月' : culture === 'ru-RU' ? 'LLLL yyyy' : 'MMM yyyy',
+              culture,
             ),
           dayHeaderFormat: (date, culture, local) => {
             return local.format(
               date,
-              props.locale === 'zh-CN' ? 'eee, M/d' : props.locale === 'ru' ? 'EEE, d MMM' : 'EEE, MMM d',
-              locales[locale],
+              culture === 'zh-CN' ? 'eee, M/d' : culture === 'ru-RU' ? 'EEE, d MMM' : 'EEE, MMM d',
+              culture,
             );
           },
           agendaDateFormat: (date, culture, local) => {
-            return local.format(
-              date,
-              props.locale === 'zh-CN' ? 'M月d日' : props.locale === 'ru' ? 'd MMM' : 'M-dd',
-              locales[locale],
-            );
+            return local.format(date, culture === 'zh-CN' ? 'M月d日' : culture === 'ru-RU' ? 'd MMM' : 'M-dd', culture);
           },
 
           dayRangeHeaderFormat: ({ start, end }, culture, local) => {
             if (start.getMonth() === end.getMonth()) {
               return local.format(
                 start,
-                locale === 'zh-CN' ? 'yyyy年M月' : locale === 'ru' ? 'LLLL yyyy' : 'MMM yyyy',
-                locale,
+                culture === 'zh-CN' ? 'yyyy年M月' : culture === 'ru-RU' ? 'LLLL yyyy' : 'MMM yyyy',
+                culture,
               );
             }
             return `${local.format(
               start,
-              locale === 'zh-CN' ? 'yyyy年M月' : locale === 'ru' ? 'LLLL yyyy' : 'MMM yyyy',
-              locale,
+              culture === 'zh-CN' ? 'yyyy年M月' : culture === 'ru-RU' ? 'LLLL yyyy' : 'MMM yyyy',
+              culture,
             )} - ${local.format(
               end,
-              locale === 'zh-CN' ? 'yyyy年M月' : locale === 'ru' ? 'LLLL yyyy' : 'MMM yyyy',
-              locale,
+              culture === 'zh-CN' ? 'yyyy年M月' : culture === 'ru-RU' ? 'LLLL yyyy' : 'MMM yyyy',
+              culture,
             )}`;
           },
           weekdayFormat: (date, culture, local) => {
-            return local.format(date, 'eee', locale);
+            return local.format(date, 'EEE', culture);
           },
         };
       }, [locale, view]);
@@ -525,6 +521,7 @@ export const Calendar: any = withDynamicSchemaProps(
               //   },
               // }}
               components={components}
+              culture={locale}
               localizer={localizer}
               tooltipAccessor={(val) => {
                 return val.rawTitle ? val.rawTitle : '';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Calendar localization was partially broken:  
date headers were displayed in English even when the application locale was set to `ru-RU`.

This was caused by inconsistent usage of locale sources between NocoBase, `react-big-calendar`, and `date-fns`.

### Description
This PR fixes calendar localization issues by aligning all locale-related logic and using a single source of truth.

**Key changes:**
- Use `apiClient.auth.locale` as the single source of truth
- Properly map NocoBase locale values to `date-fns` locale objects
- Pass the same locale value consistently to:
  - `culture` (react-big-calendar)
  - `dateFnsLocalizer`
  - calendar format callbacks

**Potential risks:**
- Low risk
- Changes are limited to localization logic
- No behavior changes for `en-US`

**Testing:**
- Tested with: `en-US`, `ru-RU`, `zh-CN`
- Verified:
  - calendar date headers
  - date formatting in month / week / day views

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix calendar localization and date formatting issues |
| 🇨🇳 Chinese | N/A |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary