### PR TITLE
fix(database): error occurs when filtering with `empty` operator after reloading the collection

### DIFF
--- a/packages/core/database/src/operators/empty.ts
+++ b/packages/core/database/src/operators/empty.ts
@@ -38,7 +38,7 @@ const findFilterFieldType = (ctx) => {
     model = modelAssociation.target;
   }
 
-  const collection = db.modelCollection.get(model);
+  const collection = db.getCollection(model.name);
 
   return collection.getField(fieldName);
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix errors when filtering with the `empty` operator after reloading a collection         |
| 🇨🇳 Chinese | 修复数据表重载后使用 `empty` 操作符筛选报错的问题          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
