### PR TITLE
fix(plugin-file-previewer-office): add more file types for previewing

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-previewer-office/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-previewer-office/src/client/index.tsx
@@ -102,6 +102,10 @@ export class PluginFilePreviewerOfficeClient extends Plugin {
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            'application/msword',
+            'application/vnd.ms-excel',
+            'application/vnd.ms-powerpoint',
+            'application/vnd.oasis.opendocument.text',
           ].includes(file.mimetype)
         ) {
           return true;
@@ -115,7 +119,7 @@ export class PluginFilePreviewerOfficeClient extends Plugin {
           const parts = url.pathname.split('.');
           if (parts.length > 1) {
             const ext = parts[parts.length - 1].toLowerCase();
-            return ['docx', 'xlsx', 'pptx', 'odt'].includes(ext);
+            return ['docx', 'xlsx', 'pptx', 'odt', 'doc', 'xls', 'ppt'].includes(ext);
           }
           return false;
         }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Add more file types for previewing on Microsoft.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add more file types for previewing on Microsoft |
| 🇨🇳 Chinese | 支持更多文件类型在微软在线预览工具中预览 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
