### PR TITLE
fix(plugin-ai): after build plugin-ai missing dependency langsmith

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/build.config.ts
+++ b/packages/plugins/@nocobase/plugin-ai/build.config.ts
@@ -131,7 +131,7 @@ export default defineConfig({
       'decamelize',
       'zod',
       // 'zod-to-json-schema',
-      // 'langsmith',
+      'langsmith',
       'p-retry',
       'p-queue',
       'p-timeout',
@@ -142,6 +142,10 @@ export default defineConfig({
     ];
     for (const dep of deps) {
       const depPath = path.resolve(process.cwd(), 'node_modules', dep);
+      if (!fs.existsSync(depPath)) {
+        console.warn(`depPath not existed skip: ${depPath}`);
+        continue;
+      }
       await fs.promises.cp(depPath, path.resolve(__dirname, 'dist/node_modules/@langchain/core/node_modules', dep), {
         recursive: true,
         force: true,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fix: plugin-ai throw missing dependency langsmith error when run in docker
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the system cannot start after building |
| 🇨🇳 Chinese | 修复构建后系统无法启动问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
