### PR TITLE
feat(client): support disabling redundant default appends params for `ResourceActionProvider`

### DIFF
--- a/packages/core/client/src/collection-manager/ResourceActionProvider.tsx
+++ b/packages/core/client/src/collection-manager/ResourceActionProvider.tsx
@@ -39,7 +39,10 @@ const CollectionResourceActionProvider = (props) => {
   if (actionName === 'get') {
     others['filterByTk'] = record[collection.targetKey || collection.filterTargetKey || 'id'];
   }
-  const appends = request?.params?.appends || [];
+  const { appends: requestAppends, disableDefaultAppends, ...restParams } = request?.params || {};
+  const defaultAppends = collection?.fields?.filter?.((field) => field.target).map((field) => field.name) || [];
+  const mergedAppends = disableDefaultAppends ? requestAppends || [] : [...defaultAppends, ...(requestAppends || [])];
+  const shouldAppend = mergedAppends.length > 0;
   const service = useRequest<{
     data: any;
   }>(
@@ -47,11 +50,8 @@ const CollectionResourceActionProvider = (props) => {
       ...request,
       params: {
         ...others,
-        ...request?.params,
-        appends: [
-          ...(collection?.fields?.filter?.((field) => field.target).map((field) => field.name) || []),
-          ...appends,
-        ],
+        ...restParams,
+        ...(shouldAppend ? { appends: mergedAppends } : {}),
         sort: dragSort ? [collection.sortable === true ? 'sort' : collection.sortable] : request?.params?.sort,
       },
     },
@@ -78,17 +78,17 @@ const AssociationResourceActionProvider = (props) => {
   const api = useAPIClient();
   const record = useRecord();
   const resourceOf = record[association.sourceKey];
-  const appends = request?.params?.appends || [];
+  const { appends: requestAppends, disableDefaultAppends, ...restParams } = request?.params || {};
+  const defaultAppends = collection?.fields?.filter?.((field) => field.target).map((field) => field.name) || [];
+  const mergedAppends = disableDefaultAppends ? requestAppends || [] : [...defaultAppends, ...(requestAppends || [])];
+  const shouldAppend = mergedAppends.length > 0;
   const service = useRequest(
     {
       resourceOf,
       ...request,
       params: {
-        ...request?.params,
-        appends: [
-          ...(collection?.fields?.filter?.((field) => field.target).map((field) => field.name) || []),
-          ...appends,
-        ],
+        ...restParams,
+        ...(shouldAppend ? { appends: mergedAppends } : {}),
       },
     },
     { uid },

--- a/packages/plugins/@nocobase/plugin-departments/src/client/departments/DepartmentOwnersField.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/departments/DepartmentOwnersField.tsx
@@ -76,6 +76,7 @@ const EditableDepartmentOwnersField: React.FC = () => {
         resource: `departments/${department.id}/members`,
         action: 'list',
         params: {
+          disableDefaultAppends: true,
           filter: field.value?.length
             ? {
                 id: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Support disabling redundant default appends params for `ResourceActionProvider`         |
| 🇨🇳 Chinese |   `ResourceActionProvider` 支持禁用多余的默认 `appends` 参数        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
