### PR TITLE
fix: nanoid field not regenerating default value after create submission

### DIFF
--- a/packages/core/client/src/flow/models/fields/InputFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/InputFieldModel.tsx
@@ -14,24 +14,27 @@ import { customAlphabet as Alphabet } from 'nanoid';
 import { FieldModel } from '../base';
 
 export class InputFieldModel extends FieldModel {
-  onInit(options: any): void {
-    super.onInit(options);
-
-    // 监听表单reset
-    this.context.blockModel.emitter.on('onFieldReset', () => {
-      if (
-        this.context.collectionField.interface === 'nanoid' &&
-        this.context.collectionField.options.autoFill !== false
-      ) {
-        const { size, customAlphabet } = this.context.collectionField.options || { size: 21 };
-        this.props.onChange(Alphabet(customAlphabet, size)());
-      }
-    });
-  }
   render() {
     return <Input {...this.props} />;
   }
 }
+
+InputFieldModel.registerFlow({
+  key: 'defaultValueForNanoid',
+  steps: {
+    generateNanoid: {
+      handler(ctx, params) {
+        // 监听表单reset
+        ctx.blockModel.emitter.on('onFieldReset', () => {
+          if (ctx.collectionField.interface === 'nanoid' && ctx.collectionField.options.autoFill !== false) {
+            const { size, customAlphabet } = ctx.collectionField.options || { size: 21 };
+            ctx.model.props.onChange(Alphabet(customAlphabet, size)());
+          }
+        });
+      },
+    },
+  },
+});
 
 InputFieldModel.define({
   label: tExpr('Input'),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix nanoid field not regenerating default value after create submission         |
| 🇨🇳 Chinese |     修复 nanoid 字段新增表单提交后未重新生成默认值的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
