### PR TITLE
fix: not able to refresh target block accross popup

### DIFF
--- a/packages/core/client/src/flow/actions/refreshTargetBlocks.tsx
+++ b/packages/core/client/src/flow/actions/refreshTargetBlocks.tsx
@@ -28,7 +28,7 @@ export const refreshTargetBlocks = defineAction({
   async handler(ctx, params) {
     const { targets = [] } = params;
     targets.forEach((target) => {
-      const modelInstance = ctx.engine.getModel(target);
+      const modelInstance = ctx.engine.getModel(target, true);
       if (!modelInstance) {
         console.warn(`Not found model: ${target}`);
         return;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where event flow failed to apply when refreshing target blocks across popup. |
| 🇨🇳 Chinese | 修复事件流刷新跨弹窗目标区块时不生效的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
