### PR TITLE
fix: incorrect refresh after open and close popup

### DIFF
--- a/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
+++ b/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
@@ -417,7 +417,19 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
         // resource.setAPIClient(this.context.api);
         resource.setDataSourceKey(params.dataSourceKey);
         resource.setResourceName(params.associationName || params.collectionName);
+
+        const syncDirtyVersion = () => {
+          const engine = this.context.engine as FlowEngine | undefined;
+          if (!engine?.getDataSourceDirtyVersion) return;
+          const dataSourceKey = resource.getDataSourceKey?.() || params.dataSourceKey || 'main';
+          const resourceName = resource.getResourceName?.() || params.associationName || params.collectionName;
+          if (!resourceName) return;
+          this.lastSeenDirtyVersion = engine.getDataSourceDirtyVersion(dataSourceKey, resourceName);
+        };
+
+        syncDirtyVersion();
         resource.on('refresh', () => {
+          syncDirtyVersion();
           this.invalidateFlowCache('beforeRender');
         });
         return resource;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix issue where page data is incorrectly refreshed after opening and closing the popup for the first time. |
| 🇨🇳 Chinese | 修复首次打开弹窗后关闭弹窗导致页面数据错误刷新问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
