### PR TITLE
fix:  column delete action not working in popup sub-table edit when createModelOptions is configured

### DIFF
--- a/packages/core/flow-engine/src/models/flowModel.tsx
+++ b/packages/core/flow-engine/src/models/flowModel.tsx
@@ -424,7 +424,19 @@ export class FlowModel<Structure extends DefaultStructure = DefaultStructure> {
       const meta = Cls.meta as any;
       const metaCreate = meta?.createModelOptions;
       if (metaCreate && typeof metaCreate === 'object' && metaCreate.subModels) {
-        mergedSubModels = _.merge({}, _.cloneDeep(metaCreate.subModels || {}), _.cloneDeep(subModels || {}));
+        const replaceArrays = (objValue: unknown, srcValue: unknown) => {
+          if (Array.isArray(objValue) && Array.isArray(srcValue)) {
+            // Arrays should be replaced, not merged by index.
+            return srcValue;
+          }
+          return undefined;
+        };
+        mergedSubModels = _.mergeWith(
+          {},
+          _.cloneDeep(metaCreate.subModels || {}),
+          _.cloneDeep(subModels || {}),
+          replaceArrays,
+        );
       }
     } catch (e) {
       // Fallback silently if meta defaults resolution fails


### PR DESCRIPTION
    _createSubModels to avoid default
    actions reappearing

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix column delete action not working in popup sub-table edit when createModelOptions is configured      |
| 🇨🇳 Chinese |   修复子表格（弹窗编辑）中配置 createModelOptions 后列操作删除失效的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
