### PR TITLE
fix: incorrect association create form menu for create new action

### DIFF
--- a/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
+++ b/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
@@ -109,7 +109,7 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
     const genKey = (key) => {
       return this.name + key;
     };
-    const { dataSourceKey, collectionName, associationName } = ctx.view.inputArgs;
+    const { dataSourceKey, collectionName, associationName, filterByTk } = ctx.view.inputArgs;
     const dataSources = ctx.dataSourceManager
       .getDataSources()
       .map((dataSource) => {
@@ -199,7 +199,7 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
         initOptions['associationName'] = associationName;
         initOptions['sourceId'] = '{{ctx.view.inputArgs.sourceId}}';
       }
-      return [
+      const items: any[] = [
         {
           key: genKey('current-collection'),
           label: 'Current collection',
@@ -212,7 +212,12 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
             },
           }),
         },
-        {
+      ];
+
+      // 新建记录的弹窗（如 Add new）没有 record 锚点（filterByTk），此时不应允许添加「关联记录」区块。
+      // 仅当弹窗携带 filterByTk（例如 View/Details 等记录态弹窗）时，才开放关联记录入口。
+      if (typeof filterByTk !== 'undefined' && filterByTk !== null) {
+        items.push({
           key: genKey('associated'),
           label: 'Associated records',
           children: () => {
@@ -251,13 +256,16 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
               })
               .filter(Boolean);
           },
-        },
-        {
-          key: genKey('others-collections'),
-          label: 'Other collections',
-          children: children(ctx),
-        },
-      ];
+        });
+      }
+
+      items.push({
+        key: genKey('others-collections'),
+        label: 'Other collections',
+        children: children(ctx),
+      });
+
+      return items;
     }
     const items = [
       {

--- a/packages/core/client/src/flow/models/base/__tests__/CollectionBlockModel.newScene.associatedRecordsVisibility.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/CollectionBlockModel.newScene.associatedRecordsVisibility.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { FlowEngine } from '@nocobase/flow-engine';
+import { BlockSceneEnum, CollectionBlockModel } from '@nocobase/client';
+
+class NewSceneCollectionBlockModel extends CollectionBlockModel {
+  static scene = BlockSceneEnum.new;
+}
+
+describe('CollectionBlockModel defineChildren - new scene associated records visibility', () => {
+  it('hides "Associated records" when filterByTk is missing', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ NewSceneCollectionBlockModel });
+
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds.addCollection({
+      name: 'orders',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'user_id', type: 'integer', interface: 'number' },
+      ],
+    });
+    ds.addCollection({
+      name: 'users',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        {
+          name: 'orders',
+          title: 'Orders',
+          type: 'hasMany',
+          target: 'orders',
+          interface: 'o2m',
+          foreignKey: 'user_id',
+        },
+      ],
+    });
+
+    const designerCtx = {
+      dataSourceManager: engine.dataSourceManager,
+      view: { inputArgs: { dataSourceKey: 'main', collectionName: 'users' } },
+    } as any;
+
+    const children = (await NewSceneCollectionBlockModel.defineChildren(designerCtx)) as any[];
+    const hasAssociated = children.some((item) => String(item?.key).includes('associated'));
+    expect(hasAssociated).toBe(false);
+  });
+
+  it('shows "Associated records" when filterByTk exists', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ NewSceneCollectionBlockModel });
+
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds.addCollection({
+      name: 'orders',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'user_id', type: 'integer', interface: 'number' },
+      ],
+    });
+    ds.addCollection({
+      name: 'users',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        {
+          name: 'orders',
+          title: 'Orders',
+          type: 'hasMany',
+          target: 'orders',
+          interface: 'o2m',
+          foreignKey: 'user_id',
+        },
+      ],
+    });
+
+    const designerCtx = {
+      dataSourceManager: engine.dataSourceManager,
+      view: { inputArgs: { dataSourceKey: 'main', collectionName: 'users', filterByTk: 1 } },
+    } as any;
+
+    const children = (await NewSceneCollectionBlockModel.defineChildren(designerCtx)) as any[];
+    const hasAssociated = children.some((item) => String(item?.key).includes('associated'));
+    expect(hasAssociated).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where the “Form (Add new)” menu was incorrectly shown in the "Create new" action popup. |
| 🇨🇳 Chinese | 修复添加操作弹窗不应该出现表格（添加）菜单的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
