### PR TITLE
fix: create new association field failing after save popup as template

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/__tests__/openViewActionExtensions.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/__tests__/openViewActionExtensions.test.ts
@@ -444,14 +444,14 @@ describe('openViewActionExtensions (popup template)', () => {
     expect(ctx.inputArgs.filterByTk).toBe('role-1');
 
     // shadow ctx should clear filterByTk (avoid leaking record context into "add" template)
-    // 模板不需要 sourceId 时，也应该清除 sourceId，避免传递到不需要它的弹窗
+    // 关系资源弹窗需要保留 sourceId，否则无法生成正确的关联资源 URL
     expect(capturedCtx).not.toBe(ctx);
     expect(capturedCtx?.inputArgs?.collectionName).toBe('roles');
     expect(capturedCtx?.inputArgs?.associationName).toBe('users.roles');
     expect(capturedCtx?.inputArgs?.filterByTk).toBe(null);
-    expect(capturedCtx?.inputArgs?.sourceId).toBe(null);
+    expect(capturedCtx?.inputArgs?.sourceId).toBe('user-1');
     expect(capturedCtx?.inputArgs?.defaultInputKeys || []).not.toContain('filterByTk');
-    expect(capturedCtx?.inputArgs?.defaultInputKeys || []).not.toContain('sourceId');
+    expect(capturedCtx?.inputArgs?.defaultInputKeys || []).toContain('sourceId');
   });
 
   it('injects placeholder filterByTk when template expects record context but record is unavailable', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix error when reopening and submitting a saved popup template for the association field “Add new” form. |
| 🇨🇳 Chinese | 修复将关系字段新增记录表单弹窗保存为模板后再次打开并提交表单时报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
