### PR TITLE
fix: hide "Enable tree table" and "Expand all rows by default" for no…

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -609,7 +609,7 @@ TableBlockModel.registerFlow({
       title: tExpr('Enable tree table'),
       uiMode: { type: 'switch', key: 'treeTable' },
       hideInSettings(ctx) {
-        if ((ctx.model.collection.template !== 'tree' || ctx.model, ctx.view?.inputArgs?.scene === 'select')) {
+        if (ctx.model.collection.template !== 'tree' || ctx.view?.inputArgs?.scene === 'select') {
           return true;
         }
       },
@@ -627,7 +627,7 @@ TableBlockModel.registerFlow({
       title: tExpr('Expand all rows by default'),
       uiMode: { type: 'switch', key: 'defaultExpandAllRows' },
       hideInSettings(ctx) {
-        if ((ctx.model.collection.template !== 'tree' || ctx.model, ctx.view?.inputArgs?.scene === 'select')) {
+        if (ctx.model.collection.template !== 'tree' || ctx.view?.inputArgs?.scene === 'select') {
           return true;
         }
       },


### PR DESCRIPTION
…n-tree collections

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix: hide "Enable tree table" and "Expand all rows by default" for non-tree collections         |
| 🇨🇳 Chinese |    非树结构表隐藏表格区块 属性里的「启用树表格」和「默认展开所有行」       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
