### PR TITLE
fix: quick create record action will override edit form data

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/EditFormModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/EditFormModel.tsx
@@ -19,7 +19,7 @@ import {
   SingleRecordResource,
 } from '@nocobase/flow-engine';
 import { Pagination, Space } from 'antd';
-import { omitBy, isUndefined } from 'lodash';
+import { isEqual } from 'lodash';
 import React from 'react';
 import { BlockSceneEnum } from '../../base';
 import { FormBlockModel, FormComponent } from './FormBlockModel';
@@ -145,6 +145,8 @@ EditFormModel.registerFlow({
           //   await ctx.form.resetFields();
           // }
 
+          const prevFilterByTk = ctx.resource.getMeta('currentFilterByTk');
+
           const currentRecord = {
             ...ctx.model.getCurrentRecord(),
           };
@@ -162,7 +164,50 @@ EditFormModel.registerFlow({
               currentFilterByTk: ctx.collection.getFilterByTK(currentRecord),
             });
           }
-          ctx.form && ctx.form.setFieldsValue(currentRecord);
+
+          if (!ctx.form) {
+            return;
+          }
+
+          const nextFilterByTk = ctx.resource.getMeta('currentFilterByTk');
+          const recordChanged = !isEqual(prevFilterByTk, nextFilterByTk);
+          const userModified = ctx.model.getUserModifiedFields?.() as Set<string> | undefined;
+          const hasUserModified = !!userModified?.size;
+          const pruneUserModified = () => {
+            if (!userModified?.size) return;
+            const isObject = (val) => val !== null && typeof val === 'object';
+            // 只要当前表单值与服务端记录一致，就认为不再是“未保存修改”
+            for (const fieldName of Array.from(userModified)) {
+              const formValue = ctx.form.getFieldValue(fieldName);
+              const recordValue = currentRecord?.[fieldName];
+              if (
+                Object.is(formValue, recordValue) ||
+                (isObject(formValue) && isObject(recordValue) && isEqual(formValue, recordValue))
+              ) {
+                userModified.delete(fieldName);
+              }
+            }
+          };
+
+          // 当编辑表单存在未保存修改时，避免刷新覆盖用户输入（如：关系字段 Quick Create 导致的脏刷新）
+          if (!recordChanged && hasUserModified) {
+            const mergedRecord = { ...currentRecord };
+            for (const fieldName of userModified) {
+              mergedRecord[fieldName] = ctx.form.getFieldValue(fieldName);
+            }
+
+            ctx.form.setFieldsValue(mergedRecord);
+            pruneUserModified();
+            return;
+          }
+
+          // 切换记录（翻页等）时，清理“用户改动标记”，避免把上一条记录的编辑状态带到下一条
+          if (recordChanged) {
+            ctx.model.resetUserModifiedFields?.();
+          }
+
+          ctx.form.setFieldsValue(currentRecord);
+          pruneUserModified();
         });
       },
     },

--- a/packages/core/client/src/flow/models/blocks/form/submitHandler.ts
+++ b/packages/core/client/src/flow/models/blocks/form/submitHandler.ts
@@ -29,9 +29,12 @@ export async function submitHandler(ctx, params) {
     const data: any = await resource.save(values, params.requestConfig);
     if (blockModel instanceof EditFormModel) {
       resource.isNewRecord = false;
+      // 编辑表单保存成功后，表单应回到“已同步”状态：下一次刷新应允许覆盖为服务端值
+      blockModel.resetUserModifiedFields?.();
       await resource.refresh();
     } else {
       blockModel.form.resetFields();
+      blockModel.resetUserModifiedFields?.();
       blockModel.emitter.emit('onFieldReset');
       if (ctx.view.inputArgs.collectionName === blockModel.collection.name && ctx.view.inputArgs.onChange) {
         ctx.view.inputArgs.onChange(data?.data);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an issue where using the association record picker’s “Quick Create” in the edit form overwrote existing form data. |
| 🇨🇳 Chinese | 修复编辑表单中通过关系字段选择器的快速新增按钮添加数据时会将表单中的数据覆盖的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
