### PR TITLE
fix(kanban): yarn build @nocobase/plugin-kanban

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/board/Column.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/board/Column.tsx
@@ -46,6 +46,13 @@ function Column({
 }) {
   const { fixedBlock } = useKanbanBlockContext();
   const [headerHeight, setHeaderHeight] = useState(0);
+  const columnStyle: React.CSSProperties & { ['--column-height']?: string } = {
+    height: '100%',
+    minHeight: '28px',
+    display: 'inline-block',
+    verticalAlign: 'top',
+    '--column-height': fixedBlock ? `calc(100% - ${headerHeight}px)` : 'inherit',
+  };
   return (
     <Draggable draggableId={`column-draggable-${children.id}`} index={columnIndex} isDragDisabled={disableColumnDrag}>
       {(columnProvided) => {
@@ -56,12 +63,8 @@ function Column({
             ref={columnProvided.innerRef}
             {...draggablePropsWithoutStyle}
             style={{
-              height: '100%',
-              minHeight: '28px',
-              display: 'inline-block',
-              verticalAlign: 'top',
+              ...columnStyle,
               ...columnProvided.draggableProps.style,
-              '--column-height': fixedBlock ? `calc(100% - ${headerHeight}px)` : 'inherit',
             }}
             className="react-kanban-column"
             data-testid={`column-${children.id}`}

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/board/withDroppable.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/board/withDroppable.tsx
@@ -9,13 +9,42 @@
 
 import React from 'react';
 import { Droppable } from 'react-beautiful-dnd';
+import type { DroppableProps } from 'react-beautiful-dnd';
 
-function withDroppable(Component) {
-  const res = function WrapperComponent({ children, ...droppableProps }) {
+type WithDroppableProps = Omit<DroppableProps, 'children'> & {
+  children: React.ReactNode;
+};
+
+function withDroppable(Component: React.ComponentType<any>) {
+  const res = function WrapperComponent({
+    children,
+    ...restProps
+  }: WithDroppableProps & React.HTMLAttributes<HTMLElement>) {
+    const {
+      droppableId,
+      direction,
+      type,
+      isDropDisabled,
+      isCombineEnabled,
+      ignoreContainerClipping,
+      renderClone,
+      getContainerForClone,
+      ...componentProps
+    } = restProps;
+    const droppableProps: Omit<DroppableProps, 'children'> = {
+      droppableId,
+      direction,
+      type,
+      isDropDisabled,
+      isCombineEnabled,
+      ignoreContainerClipping,
+      renderClone,
+      getContainerForClone,
+    };
     return (
       <Droppable {...droppableProps}>
         {(provided) => (
-          <Component ref={provided.innerRef} {...provided.droppableProps}>
+          <Component ref={provided.innerRef} {...componentProps} {...provided.droppableProps}>
             {children}
             {provided.placeholder}
           </Component>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] Bug fix

### Motivation
Fixes TypeScript compilation errors in the Kanban plugin that prevented successful build. The errors were caused by:
1. Custom CSS variables in style objects not being recognized by TypeScript's CSSProperties type
2. Missing required `droppableId` prop in Droppable component wrapper and improper prop passing

### Description 
**Key Changes:**
1. **Column.tsx**: Fixed CSS variable type issue by creating a proper type intersection that includes custom CSS properties while maintaining React.CSSProperties compatibility
2. **withDroppable.tsx**: 
   - Added missing required `droppableId` prop
   - Separated DroppableProps from component props to allow proper prop passing
   - Ensured style and other HTML attributes are passed to the wrapper div instead of the Droppable component

**Testing Suggestions:**
1. Run `yarn build` to verify no TypeScript errors
2. Test Kanban board functionality to ensure drag-and-drop still works correctly
3. Verify column styling and animations work as expected

### logs：
`yarn build`
or
`yarn build @nocobase/plugin-kanban`


@nocobase/plugin-kanban: write external version
@nocobase/plugin-kanban: build declaration
packages\plugins\@nocobase\plugin-kanban\src\client\board\Column.tsx(64,15): error TS2322: Type '{ '--column-height': string; position: "fixed"; top: number; left: number; boxSizing: "border-box"; width: number; height: number; transition: string; transform: string; zIndex: number; opacity: number; pointerEvents: "none"; minHeight: string; display: "inline-block"; verticalAlign: string; } | { ...; }' is not assignable to type 'CSSProperties'.
  Type '{ '--column-height': string; position: "fixed"; top: number; left: number; boxSizing: "border-box"; width: number; height: number; transition: string; transform: string; zIndex: number; opacity: number; pointerEvents: "none"; minHeight: string; display: "inline-block"; verticalAlign: string; }' is not assignable to type 'Properties<string | number, string & {}>'.
    Object literal may only specify known properties, and ''--column-height'' does not exist in type 'Properties<string | number, string & {}>'.
packages\plugins\@nocobase\plugin-kanban\src\client\board\withDroppable.tsx(16,8): error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: DroppableProps): Droppable', gave the following error.
    Property 'droppableId' is missing in type '{ children: (provided: DroppableProvided) => Element; }' but required in type 'Readonly<DroppableProps & { children?: (provided: DroppableProvided, snapshot: DroppableStateSnapshot) => ReactElement<HTMLElement, string | JSXElementConstructor<...>>; }>'.
  Overload 2 of 2, '(props: DroppableProps, context: any): Droppable', gave the following error.
    Property 'droppableId' is missing in type '{ children: (provided: DroppableProvided) => Element; }' but required in type 'Readonly<DroppableProps & { children?: (provided: DroppableProvided, snapshot: DroppableStateSnapshot) => ReactElement<HTMLElement, string | JSXElementConstructor<...>>; }>'.
TypeScript: 2 semantic errors
TypeScript: emit succeeded (with errors)
E:\code\taichuCode\taichuy_nocobase\node_modules\gulp-typescript\release\output.js:131
            this.streamFull.emit('error', new Error("TypeScript: Compilation failed"));
                                          ^

Error: TypeScript: Compilation failed
    at Output.mightFinish (E:\code\taichuCode\taichuy_nocobase\node_modules\gulp-typescript\release\output.js:131:43)
    at E:\code\taichuCode\taichuy_nocobase\node_modules\gulp-typescript\release\output.js:66:22
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
Emitted 'error' event on CompileStream instance at:
    at E:\code\taichuCode\taichuy_nocobase\node_modules\gulp-typescript\release\output.js:117:29
    at processTicksAndRejections (node:internal/process/task_queues:105:5)

Node.js v22.12.0
E:\code\taichuCode\taichuy_nocobase\node_modules\execa\lib\error.js:60
                error = new Error(message);
                        ^

Error: Command failed with exit code 1: nocobase-build
    at makeError (E:\code\taichuCode\taichuy_nocobase\node_modules\execa\lib\error.js:60:11)
    at handlePromise (E:\code\taichuCode\taichuy_nocobase\node_modules\execa\index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Command.<anonymous> (E:\code\taichuCode\taichuy_nocobase\packages\core\cli\src\commands\build.js:40:7) {
  shortMessage: 'Command failed with exit code 1: nocobase-build    ',
  command: 'nocobase-build    ',
  escapedCommand: 'nocobase-build "" "" "" ""',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: undefined,
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}

Node.js v22.12.0
error Command failed with exit code 1.
info Visit `https://yarnpkg.com/en/docs/cli/run` for documentation about this command.


### Related issues



### Showcase
<!-- No visual changes, only TypeScript compilation fixes -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed TypeScript compilation errors in Kanban plugin by resolving CSS variable type issues and missing Droppable props |
| 🇨🇳 Chinese | 修复了看板插件中的 TypeScript 编译错误，解决了 CSS 变量类型问题和缺失的 Droppable 属性 |

### Docs
No documentation changes needed as this is a TypeScript/internal build fix.

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary