### PR TITLE
fix: sub-table still shows edit-mode columns after switching to read-…

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
@@ -141,7 +141,12 @@ export class TableColumnModel extends DisplayItemModel {
           key: fieldPath,
           label: field.title,
           refreshTargets: ['TableCustomColumnModel/TableJSFieldItemModel'],
-          toggleable: (subModel) => subModel.getStepParams('fieldSettings', 'init')?.fieldPath === fieldPath,
+          toggleable: (subModel) => {
+            return (
+              subModel.getStepParams('fieldSettings', 'init')?.fieldPath === fieldPath &&
+              subModel.use === 'TableColumnModel'
+            );
+          },
           useModel: this.name,
           createModelOptions: () => ({
             use: this.name,

--- a/packages/core/client/src/flow/models/fields/DisplayAssociationField/DisplaySubTableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/DisplayAssociationField/DisplaySubTableFieldModel.tsx
@@ -210,8 +210,11 @@ export class DisplaySubTableFieldModel extends FieldModel {
   }
 
   getBaseColumns() {
-    const baseColumns = this.mapSubModels('columns', (column: any) => column.getColumnProps()).filter((v) => {
-      return !v?.hidden;
+    const baseColumns = this.mapSubModels(
+      'columns',
+      (column: any) => column.use === 'TableColumnModel' && column.getColumnProps(),
+    ).filter((v) => {
+      return v && !v?.hidden;
     });
 
     return baseColumns;


### PR DESCRIPTION
…only view in edit form

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix sub-table(inline edit) still shows edit-mode columns after switching to read-only view in edit form      |
| 🇨🇳 Chinese |    修复编辑表单中子表格(行内编辑)设为只读后切换阅读态子表格时仍保留编辑态列字段的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
