### PR TITLE
fix: ctx.sql incorrect context

### DIFF
--- a/packages/core/flow-engine/src/__tests__/flowContext.test.ts
+++ b/packages/core/flow-engine/src/__tests__/flowContext.test.ts
@@ -759,6 +759,84 @@ describe('FlowEngine context', () => {
     expect(engine.context.appName).toBe('NocoBase');
   });
 
+  it('ctx.sql should resolve template variables from caller context in delegate chain', async () => {
+    const engine = new FlowEngine();
+    const request = vi.fn(async () => ({ data: { data: [] } }));
+    engine.context.defineProperty('api', {
+      value: { request },
+    });
+    engine.context.defineProperty('minId', {
+      get: () => 999,
+      cache: false,
+    });
+
+    const callerCtx = new FlowContext();
+    callerCtx.addDelegate(engine.context);
+    callerCtx.defineProperty('minId', {
+      get: () => 1,
+      cache: false,
+    });
+
+    await callerCtx.sql.run('SELECT * FROM users WHERE id > {{ctx.minId}}', { type: 'selectRows' });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const config = request.mock.calls[0]?.[0];
+    expect(config?.url).toBe('flowSql:run');
+    expect(config?.data.bind.__var1).toBe(1);
+  });
+
+  it('ctx.sql should not share repository instance between different caller contexts', async () => {
+    const engine = new FlowEngine();
+    const request = vi.fn(async () => ({ data: { data: [] } }));
+    engine.context.defineProperty('api', {
+      value: { request },
+    });
+
+    const caller1 = new FlowContext();
+    caller1.addDelegate(engine.context);
+    caller1.defineProperty('minId', {
+      get: () => 1,
+      cache: false,
+    });
+
+    const caller2 = new FlowContext();
+    caller2.addDelegate(engine.context);
+    caller2.defineProperty('minId', {
+      get: () => 2,
+      cache: false,
+    });
+
+    expect(caller1.sql).not.toBe(caller2.sql);
+
+    await caller1.sql.run('SELECT * FROM users WHERE id > {{ctx.minId}}', { type: 'selectRows' });
+    await caller2.sql.run('SELECT * FROM users WHERE id > {{ctx.minId}}', { type: 'selectRows' });
+
+    expect(request).toHaveBeenCalledTimes(2);
+    const config1 = request.mock.calls[0]?.[0];
+    const config2 = request.mock.calls[1]?.[0];
+    expect(config1?.data.bind.__var1).toBe(1);
+    expect(config2?.data.bind.__var1).toBe(2);
+  });
+
+  it('engine.context.sql should keep working when accessed directly', async () => {
+    const engine = new FlowEngine();
+    const request = vi.fn(async () => ({ data: { data: [] } }));
+    engine.context.defineProperty('api', {
+      value: { request },
+    });
+    engine.context.defineProperty('minId', {
+      get: () => 3,
+      cache: false,
+    });
+
+    await engine.context.sql.run('SELECT * FROM users WHERE id > {{ctx.minId}}', { type: 'selectRows' });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const config = request.mock.calls[0]?.[0];
+    expect(config?.url).toBe('flowSql:run');
+    expect(config?.data.bind.__var1).toBe(3);
+  });
+
   it('engine.context.getVar should resolve variable by path', async () => {
     const engine = new FlowEngine();
     engine.context.defineProperty('foo', { value: { bar: 1 } });

--- a/packages/core/flow-engine/src/flowContext.ts
+++ b/packages/core/flow-engine/src/flowContext.ts
@@ -1144,7 +1144,8 @@ export class FlowEngineContext extends BaseFlowEngineContext {
       value: this.engine,
     });
     this.defineProperty('sql', {
-      get: () => new FlowSQLRepository(this),
+      get: (ctx) => new FlowSQLRepository(ctx),
+      cache: false,
     });
     this.defineProperty('dataSourceManager', {
       value: dataSourceManager,

--- a/packages/core/flow-engine/src/resources/sqlResource.ts
+++ b/packages/core/flow-engine/src/resources/sqlResource.ts
@@ -27,10 +27,10 @@ type SQLSaveOptions = {
 };
 
 export class FlowSQLRepository {
-  protected ctx: FlowEngineContext;
+  protected ctx: FlowContext;
 
-  constructor(ctx: FlowEngineContext) {
-    this.ctx = new FlowContext() as FlowEngineContext;
+  constructor(ctx: FlowContext) {
+    this.ctx = new FlowContext();
     this.ctx.addDelegate(ctx);
     this.ctx.defineProperty('offset', {
       get: () => 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect execution context for "ctx.sql" in JS Models. |
| 🇨🇳 Chinese | 修复 JS Models 里面的 "ctx.sql" 执行时上下文不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
