### PR TITLE
fix:  issue where file field component can still open selector dialog…

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/UploadFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/UploadFieldModel.tsx
@@ -186,6 +186,9 @@ export const CardUpload = (props) => {
                   justifyContent: 'center',
                 }}
                 onClick={(e) => {
+                  if (disabled) {
+                    return;
+                  }
                   e.stopPropagation();
                   e.preventDefault();
                   onSelectExitRecordClick();


### PR DESCRIPTION
… when disabled

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix issue where file field component can still open selector dialog when disabled       |
| 🇨🇳 Chinese |    修复表单中文件类型字段禁用后仍可打开选择弹窗的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
