### PR TITLE
fix: incorrect filtered data in association dropdown when title field…

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -462,6 +462,9 @@ const paginationState = {
   hasMore: true,
 };
 
+const getSearchGroupKey = (labelFieldName: string) => `__search__${labelFieldName}`;
+const getAssociationGroupKey = (foreignKey: string) => `__assoc__${foreignKey}`;
+
 // 事件绑定
 RecordSelectFieldModel.registerFlow({
   key: 'eventSettings',
@@ -470,6 +473,7 @@ RecordSelectFieldModel.registerFlow({
     bindEvent: {
       handler(ctx, params) {
         const labelFieldName = ctx.model.props.fieldNames.label;
+        const searchGroupKey = getSearchGroupKey(labelFieldName);
 
         ctx.model.onDropdownVisibleChange = (open) => {
           if (open) {
@@ -478,7 +482,7 @@ RecordSelectFieldModel.registerFlow({
               form: ctx.model.context.form,
             });
           } else {
-            ctx.model.resource.removeFilterGroup(labelFieldName);
+            ctx.model.resource.removeFilterGroup(searchGroupKey);
             paginationState.page = 1;
           }
         };
@@ -589,10 +593,10 @@ async function originalHandler(ctx, params) {
     const resource = ctx.model.resource;
     const key = `${labelFieldName}.${operator}`;
     if (searchText === '') {
-      resource.removeFilterGroup(labelFieldName);
+      resource.removeFilterGroup(getSearchGroupKey(labelFieldName));
     } else {
       resource.setPage(1);
-      resource.addFilterGroup(labelFieldName, {
+      resource.addFilterGroup(getSearchGroupKey(labelFieldName), {
         [key]: searchText,
       });
     }
@@ -656,7 +660,7 @@ RecordSelectFieldModel.registerFlow({
         }
 
         if (orFilters.length > 0) {
-          resource.addFilterGroup(foreignKey, { $or: orFilters });
+          resource.addFilterGroup(getAssociationGroupKey(foreignKey), { $or: orFilters });
         }
         ctx.model.resource = resource;
       },


### PR DESCRIPTION
… is a foreign key

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix incorrect filtered data in association dropdown when title field is a foreign key        |
| 🇨🇳 Chinese |    修复表单关系字段组件中标题字段使用外键字段时下拉列表数据展示异常的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
