### PR TITLE
fix(client): fix Action.Modal not close

### DIFF
--- a/packages/core/client/src/schema-component/antd/action/Action.Modal.tsx
+++ b/packages/core/client/src/schema-component/antd/action/Action.Modal.tsx
@@ -110,8 +110,6 @@ export const InternalActionModal: React.FC<ActionDrawerProps<ModalProps>> = obse
 
     const zIndex = getZIndex('modal', _zIndex || parentZIndex, props.level || 0);
     const ready = useDelayedVisible(visible, delay); // 200ms 与 Modal 动画时间一致
-    const closedRef = React.useRef(false);
-
     return (
       <ActionContextNoRerender>
         <zIndexContext.Provider value={zIndex}>
@@ -130,10 +128,7 @@ export const InternalActionModal: React.FC<ActionDrawerProps<ModalProps>> = obse
               destroyOnClose
               open={visible}
               onCancel={() => {
-                if (!closedRef.current) {
-                  setVisible(false, true);
-                  closedRef.current = true;
-                }
+                setVisible(false, true);
               }}
               className={classNames(
                 others.className,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where Action.Modal could not be closed after some interaction.

### Description 

Scenario 1: Test run a node in workflow, the "Test run" popup (modal) can not be closed.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where `Action.Modal` could not be closed after some interaction |
| 🇨🇳 Chinese | 修复 `Action.Modal`（操作弹窗）在某些交互后无法关闭的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
