### PR TITLE
fix(ui-templates): share approval templates

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/SubModelTemplateImporterModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/SubModelTemplateImporterModel.tsx
@@ -132,10 +132,14 @@ function isModelInsideReferenceBlock(model: FlowModel | undefined): boolean {
   return model.parent?.use === 'ReferenceBlockModel';
 }
 
-function resolveExpectedRootUse(blockModel: FlowModel | undefined): string | string[] {
+export function resolveExpectedRootUse(blockModel: FlowModel | undefined): string | string[] {
   // Create/Edit：允许互通
   if (blockModel?.use === 'CreateFormModel' || blockModel?.use === 'EditFormModel') {
     return ['CreateFormModel', 'EditFormModel'];
+  }
+  // 审批发起/处理表单：允许互通（最小改动方案）
+  if (blockModel?.use === 'ApplyFormModel' || blockModel?.use === 'ProcessFormModel') {
+    return ['ApplyFormModel', 'ProcessFormModel'];
   }
   return blockModel?.use || '';
 }

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/SubModelTemplateImporterModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/SubModelTemplateImporterModel.test.ts
@@ -9,7 +9,28 @@
 
 import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
 import { describe, it, expect, vi } from 'vitest';
-import { SubModelTemplateImporterModel } from '../SubModelTemplateImporterModel';
+import { SubModelTemplateImporterModel, resolveExpectedRootUse } from '../SubModelTemplateImporterModel';
+
+describe('resolveExpectedRootUse', () => {
+  it('allows ApplyFormModel and ProcessFormModel to share templates', () => {
+    expect(resolveExpectedRootUse({ use: 'ApplyFormModel' } as FlowModel)).toEqual([
+      'ApplyFormModel',
+      'ProcessFormModel',
+    ]);
+    expect(resolveExpectedRootUse({ use: 'ProcessFormModel' } as FlowModel)).toEqual([
+      'ApplyFormModel',
+      'ProcessFormModel',
+    ]);
+  });
+
+  it('keeps CreateFormModel and EditFormModel sharing behavior', () => {
+    expect(resolveExpectedRootUse({ use: 'CreateFormModel' } as FlowModel)).toEqual([
+      'CreateFormModel',
+      'EditFormModel',
+    ]);
+    expect(resolveExpectedRootUse({ use: 'EditFormModel' } as FlowModel)).toEqual(['CreateFormModel', 'EditFormModel']);
+  });
+});
 
 describe('SubModelTemplateImporterModel', () => {
   it('stores derived targetUid into stepParams in beforeParamsSave', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
审批发起表单（`ApplyFormModel`）和审批处理表单（`ProcessFormModel`）的字段模板无法互相复用。
当前字段模板列表按 `useModel` 严格过滤，两个模型名称不同导致模板在下拉中被过滤掉。

### Description 
在 `SubModelTemplateImporterModel` 的 `resolveExpectedRootUse` 中增加最小互通映射：
- `ApplyFormModel` 与 `ProcessFormModel` 共享同一模板可见范围
- 保留原有 `CreateFormModel` 与 `EditFormModel` 的互通行为
- 新增单元测试覆盖上述两组互通规则，防止后续回归

风险与影响：
- 改动仅在前端模板筛选逻辑，未涉及数据库结构与后端接口
- 仅放宽审批两种表单模型的模板可见范围，其他模型行为不变

测试建议：
- 在审批配置中分别保存发起表单/处理表单字段模板
- 交叉进入另一个表单的字段模板选择器，验证模板可见并可使用

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Enable field template reuse between ApplyFormModel and ProcessFormModel |
| 🇨🇳 Chinese | 支持审批发起与处理表单之间复用字段模板 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
