### PR TITLE
ci: adapt e2e + build-pro-image for v1 branch

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -27,11 +27,16 @@ on:
 jobs:
   get-plugins:
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
+    with:
+      # For v1 builds, only include repos that have the v1 branch.
+      require_branch: ${{ (github.head_ref || github.ref_name) == 'v1' && 'v1' || '' }}
     secrets: inherit
   build-and-push:
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     needs: get-plugins
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
     services:
       verdaccio:
         image: verdaccio/verdaccio:5
@@ -64,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nocobase/pro-plugins
-          ref: main
+          ref: ${{ env.BASE_REF }}
           path: packages/pro-plugins
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -84,7 +89,7 @@ jobs:
         run: |
           for repo in ${{ join(fromJSON(steps.get-pro-plugins.outputs.proRepos), ' ') }}
           do
-          git clone -b main https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
+          git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
       - run: |
           for repo in ${{ join(fromJSON(steps.get-pro-plugins.outputs.proRepos), ' ') }}
@@ -96,7 +101,7 @@ jobs:
               if git show-ref --quiet refs/remotes/origin/${{ github.event.pull_request.base.ref }}; then
                 git checkout ${{ github.event.pull_request.base.ref }}
               else
-                git checkout next
+                git checkout ${{ env.BASE_REF }}
               fi
             fi
             cd ../../../../

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ on:
       - 'main'
       - 'develop'
       - 'next'
+      - 'v1'
     paths:
       - '.github/workflows/e2e.yml'
       - 'packages/**'
@@ -26,6 +27,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      # Use the PR base branch when available (e.g. v1), otherwise use current ref name.
+      BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
     steps:
       - uses: actions/create-github-app-token@v1
         continue-on-error: true # 外部开发者提交 PR 的时候因为没有权限这里会报错，为了能够继续执行后续步骤，所以这里设置为 continue-on-error: true
@@ -41,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: nocobase/pro-plugins
-          ref: main
+          ref: ${{ env.BASE_REF }}
           path: packages/pro-plugins
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -50,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: nocobase/plugin-workflow-approval
-          ref: main
+          ref: ${{ env.BASE_REF }}
           path: packages/pro-plugins/@nocobase/plugin-workflow-approval
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Support v1 maintenance branch CI by avoiding hard-coded 'main' refs in workflows.

### Description
Key changes:
- e2e.yml
  - Include v1 in push triggers.
  - Checkout pro-plugins and plugin-workflow-approval using `${{ github.event.pull_request.base.ref || github.ref_name }}` instead of hard-coding `main`.
- build-pro-image.yml
  - When running on v1, call get-plugins with `require_branch: v1`.
  - Checkout/clone pro-plugins and pro repos using BASE_REF (PR base ref or current ref) instead of `main`.

Potential risks:
- If BASE_REF points to a ref that does not exist in pro-plugins / some pro repos, checkout/clone may still fallback/continue-on-error depending on the step, but the behavior should be no worse than before and is correct for v1 alignment.

Testing suggestions:
- Open a PR targeting v1 and confirm the e2e Build job checks out pro-plugins/plugin-workflow-approval from v1.
- Run build-pro-image via workflow_dispatch on ref=v1 and verify pro repos are cloned from v1 and repo list is filtered by require_branch.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | CI: improve v1 branch compatibility for e2e and pro image workflows |
| 🇨🇳 Chinese | CI：提升 e2e 与 pro 镜像构建流程对 v1 分支的兼容性 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
