### PR TITLE
chore(ci): support v1.x maintenance releases

### DIFF
--- a/.github/workflows/get-plugins.yml
+++ b/.github/workflows/get-plugins.yml
@@ -2,6 +2,15 @@ name: Get plugins
 
 on:
   workflow_call:
+    inputs:
+      require_tag:
+        description: 'If set, only include repos that have this git tag (e.g. v1.9.47 or v2.0.1)'
+        required: false
+        type: string
+      require_branch:
+        description: 'If set, only include repos that have this branch (e.g. v1)'
+        required: false
+        type: string
     secrets:
       NOCOBASE_APP_PRIVATE_KEY:
         required: true
@@ -52,32 +61,67 @@ jobs:
             done
             echo $plugins
           }
-          allPlugins=$(retry custom,rc,beta,alpha,unreleased)
+
+          function filterByBranch() {
+            local branch="$1"
+            local reposJson="$2"
+
+            if [[ -z "$branch" || "$reposJson" == "[]" ]]; then
+              echo "$reposJson"
+              return 0
+            fi
+
+            local repos
+            repos=$(echo "$reposJson" | jq -r '.[]')
+
+            local kept="[]"
+            for repo in $repos; do
+              if gh api -H "Accept: application/vnd.github+json" \
+                "/repos/nocobase/$repo/git/ref/heads/$branch" >/dev/null 2>&1; then
+                kept=$(echo "$kept" | jq --arg r "$repo" '. + [$r]')
+              fi
+            done
+
+            echo "$kept" | jq -c '.'
+          }
+
+          function filterByTag() {
+            local tag="$1"
+            local reposJson="$2"
+
+            if [[ -z "$tag" || "$reposJson" == "[]" ]]; then
+              echo "$reposJson"
+              return 0
+            fi
+
+            local repos
+            repos=$(echo "$reposJson" | jq -r '.[]')
+
+            local kept="[]"
+            for repo in $repos; do
+              if gh api -H "Accept: application/vnd.github+json" \
+                "/repos/nocobase/$repo/git/ref/tags/$tag" >/dev/null 2>&1; then
+                kept=$(echo "$kept" | jq --arg r "$repo" '. + [$r]')
+              fi
+            done
+
+            echo "$kept" | jq -c '.'
+          }
+
+          REQUIRE_TAG='${{ inputs.require_tag }}'
+
+          REQUIRE_BRANCH='${{ inputs.require_branch }}'
+
+          allPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry custom,rc,beta,alpha,unreleased)")")
           if [[ "$allPlugins" == "[]" ]]; then
             echo "Get all plugins empty"
             exit 1
           fi
-          customPlugins=$(retry custom)
-          if [[ "$customPlugins" == "[]" ]]; then
-            echo "Get custom plugins empty"
-            exit 1
-          fi
-          rcPlugins=$(retry rc)
-          if [[ "$rcPlugins" == "[]" ]]; then
-            echo "Get rc plugins empty"
-            exit 1
-          fi
-          betaPlugins=$(retry beta,rc)
-          if [[ "$betaPlugins" == "[]" ]]; then
-            echo "Get beta plugins empty"
-            exit 1
-          fi
-          alphaPlugins=$(retry alpha,beta,rc)
-          if [[ "$alphaPlugins" == "[]" ]]; then
-            echo "Get alpha plugins empty"
-            exit 1
-          fi
-          unreleasedPlugins=$(retry unreleased)
+          customPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry custom)")")
+          rcPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry rc)")")
+          betaPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry beta,rc)")")
+          alphaPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry alpha,beta,rc)")")
+          unreleasedPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry unreleased)")")
           echo "all-plugins=$allPlugins" >> "$GITHUB_OUTPUT"
           echo "custom-plugins=$customPlugins" >> "$GITHUB_OUTPUT"
           echo "rc-plugins=$rcPlugins" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -1,0 +1,196 @@
+name: Manual release v1.x
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'specify a version (e.g. 1.9.48)'
+        type: string
+        required: false
+      is_feat:
+        description: 'is feat (minor bump behavior, see release.sh)'
+        type: boolean
+        required: false
+      dry_run:
+        description: 'If true, do not build, commit, tag, or push. Only compute version + validate tag conflicts and print a plan.'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  get-plugins:
+    uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
+    with:
+      require_branch: v1
+    secrets: inherit
+
+  update-version:
+    needs:
+      - get-plugins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.NOCOBASE_APP_ID }}
+          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
+          repositories: nocobase,pro-plugins,${{ join(fromJSON(needs.get-plugins.outputs.rc-plugins), ',') }},${{ join(fromJSON(needs.get-plugins.outputs.custom-plugins), ',') }}
+          skip-token-revoke: true
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api \"/users/${{ steps.app-token.outputs.app-slug }}[bot]\" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout (v1)
+        uses: actions/checkout@v4
+        with:
+          repository: nocobase/nocobase
+          ref: v1
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Checkout pro-plugins (v1)
+        uses: actions/checkout@v4
+        with:
+          repository: nocobase/pro-plugins
+          ref: v1
+          path: packages/pro-plugins
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Clone pro repos (v1)
+        shell: bash
+        run: |
+          for repo in ${{ join(fromJSON(needs.get-plugins.outputs.rc-plugins), ' ') }} ${{ join(fromJSON(needs.get-plugins.outputs.custom-plugins), ' ') }}
+          do
+            git clone -b v1 https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
+          done
+
+      - name: Set Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Prepare git excludes + identity
+        shell: bash
+        run: |
+          cd ./packages/pro-plugins
+          git checkout v1
+          for repo in ${{ join(fromJSON(needs.get-plugins.outputs.rc-plugins), ' ') }} ${{ join(fromJSON(needs.get-plugins.outputs.custom-plugins), ' ') }}
+          do
+            echo "@nocobase/$repo" >> .git/info/exclude
+          done
+          cd ./../..
+
+          git checkout v1
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          echo "packages/pro-plugins" >> .git/info/exclude
+
+      - name: Compute version (v1.x)
+        id: compute-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.version }}" ]]; then
+            v=$(bash release.sh --only-version --version "${{ inputs.version }}")
+          else
+            v=$(bash release.sh --only-version $IS_FEAT)
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Computed version: $v"
+        env:
+          IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
+
+      - name: Validate tag conflicts (v1.x)
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.compute-version.outputs.version }}"
+          echo "Validating tag does not already exist: $TAG"
+
+          missing_ok=true
+          conflict=()
+
+          repos=("nocobase" "pro-plugins")
+          for r in $(echo '${{ needs.get-plugins.outputs.rc-plugins }}' | jq -r '.[]'); do repos+=("$r"); done
+          for r in $(echo '${{ needs.get-plugins.outputs.custom-plugins }}' | jq -r '.[]'); do repos+=("$r"); done
+
+          for repo in "${repos[@]}"; do
+            if gh api -H "Accept: application/vnd.github+json" "/repos/nocobase/$repo/git/ref/tags/$TAG" >/dev/null 2>&1; then
+              conflict+=("$repo")
+            fi
+          done
+
+          if [[ ${#conflict[@]} -gt 0 ]]; then
+            echo "Tag conflict: $TAG already exists in repos:" >&2
+            printf '%s\n' "${conflict[@]}" >&2
+            exit 1
+          fi
+
+          echo "OK: no conflicts for $TAG"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Dry run plan (v1.x)
+        if: ${{ inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.version }}" ]]; then
+            bash release.sh --dry-run --version "${{ inputs.version }}"
+          else
+            bash release.sh --dry-run $IS_FEAT
+          fi
+        env:
+          PRO_PLUGIN_REPOS: ${{ needs.get-plugins.outputs.rc-plugins }}
+          CUSTOM_PRO_PLUGIN_REPOS: ${{ needs.get-plugins.outputs.custom-plugins }}
+          IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
+
+      - name: yarn install and build
+        if: ${{ !inputs.dry_run }}
+        run: |
+          yarn config set registry https://registry.npmjs.org/
+          yarn install
+          yarn build
+
+      - name: Install Lerna
+        if: ${{ !inputs.dry_run }}
+        run: npm install -g lerna@4
+
+      - name: Run release.sh (v1.x)
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            bash release.sh --version "${{ inputs.version }}"
+          else
+            bash release.sh $IS_FEAT
+          fi
+        env:
+          PRO_PLUGIN_REPOS: ${{ needs.get-plugins.outputs.rc-plugins }}
+          CUSTOM_PRO_PLUGIN_REPOS: ${{ needs.get-plugins.outputs.custom-plugins }}
+          IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
+
+      - name: Push tags/commits (v1)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          for repo in ${{ join(fromJSON(needs.get-plugins.outputs.rc-plugins), ' ') }} ${{ join(fromJSON(needs.get-plugins.outputs.custom-plugins), ' ') }}
+          do
+            cd ./packages/pro-plugins/@nocobase/$repo
+            git push origin v1 --atomic --tags
+            cd ../../../../
+          done
+
+          cd ./packages/pro-plugins
+          git push origin v1 --atomic --tags
+          cd ../../
+          git push origin v1 --atomic --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   get-plugins:
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
+    with:
+      # For v1.x maintenance releases, only include repos that have the v1 branch.
+      # For v2+ we keep the original behavior (no filtering at this stage).
+      require_branch: ${{ startsWith(github.ref_name, 'v1.') && 'v1' || '' }}
     secrets: inherit
   publish-npm:
     needs: get-plugins
@@ -37,6 +41,34 @@ jobs:
             echo "defaultTag=$(echo 'latest')" >> $GITHUB_OUTPUT
             echo "proRepos=$(echo '${{ needs.get-plugins.outputs.rc-plugins }}')" >> $GITHUB_OUTPUT
           fi
+      - name: Validate v1 tag exists in all selected repos
+        if: ${{ startsWith(github.ref_name, 'v1.') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG='${{ github.ref_name }}'
+          missing=()
+
+          for repo in $(echo '${{ steps.get-info.outputs.proRepos }}' | jq -r '.[]'); do
+            if ! gh api -H "Accept: application/vnd.github+json" "/repos/nocobase/$repo/git/ref/tags/$TAG" >/dev/null 2>&1; then
+              missing+=("$repo")
+            fi
+          done
+
+          for repo in $(echo '${{ needs.get-plugins.outputs.custom-plugins }}' | jq -r '.[]'); do
+            if ! gh api -H "Accept: application/vnd.github+json" "/repos/nocobase/$repo/git/ref/tags/$TAG" >/dev/null 2>&1; then
+              missing+=("$repo")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "Missing tag $TAG in repos:" >&2
+            printf '%s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:

--- a/release.sh
+++ b/release.sh
@@ -1,51 +1,110 @@
+set -e
+
 branch=$(git branch --show-current)
 current_version=$(jq -r '.version' lerna.json)
 IFS='.-' read -r major minor patch label pre <<< "$current_version"
 
-if [ "$1" == '--version' ];then
-  new_version="$2"
-  echo $new_version;
-else
-  if [ "$branch" == "main" ]; then
-    # rc
-    if [ "$1" == '--is-feat' ]; then
-      new_version="$major.$minor.0"
-      echo $new_version;
-    else
-      new_patch=$((patch + 1))
-      new_version="$major.$minor.$new_patch"
-      echo $new_version;
-    fi
-  elif [ "$branch" == "next" ]; then
-    # beta
-    if [ "$1" == '--is-feat' ]; then
-      if [ "$2" == '--add-minor' ]; then
-        minor=$((minor + 1))
+DRY_RUN=false
+ONLY_VERSION=false
+EXPLICIT_VERSION=""
+IS_FEAT=""
+ADD_MINOR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --only-version)
+      ONLY_VERSION=true
+      shift
+      ;;
+    --version)
+      EXPLICIT_VERSION="$2"
+      shift 2
+      ;;
+    --is-feat)
+      IS_FEAT="--is-feat"
+      shift
+      ;;
+    --add-minor)
+      ADD_MINOR="--add-minor"
+      shift
+      ;;
+    *)
+      # backward compatible: allow passing flags positionally
+      if [[ "$1" == "--is-feat" ]]; then
+        IS_FEAT="--is-feat"
+        shift
+      else
+        shift
       fi
-      new_version="$major.$minor.0-beta.1"
-      echo $new_version;
-    else
-      new_pre=$((pre + 1))
-      new_version="$major.$minor.$patch-beta.$new_pre"
-      echo $new_version;
-    fi
-  elif [ "$branch" == "develop" ]; then
-    # alpha
-    if [ "$1" == '--is-feat' ]; then
-      new_minor=$((minor + 1))
-      new_version="$major.$new_minor.0-alpha.1"
-      echo $new_version;
-    else
-      new_pre=$((pre + 1))
-      new_version="$major.$minor.$patch-alpha.$new_pre"
-      echo $new_version;
-    fi
+      ;;
+  esac
+done
+
+if [[ -n "$EXPLICIT_VERSION" ]]; then
+  new_version="$EXPLICIT_VERSION"
+elif [[ "$branch" == "main" || "$branch" == "v1" ]]; then
+  # rc/latest-style bump
+  if [[ "$IS_FEAT" == "--is-feat" ]]; then
+    new_version="$major.$minor.0"
   else
-    exit 1
+    new_patch=$((patch + 1))
+    new_version="$major.$minor.$new_patch"
   fi
+elif [[ "$branch" == "next" ]]; then
+  # beta
+  if [[ "$IS_FEAT" == "--is-feat" ]]; then
+    if [[ "$ADD_MINOR" == "--add-minor" ]]; then
+      minor=$((minor + 1))
+    fi
+    new_version="$major.$minor.0-beta.1"
+  else
+    new_pre=$((pre + 1))
+    new_version="$major.$minor.$patch-beta.$new_pre"
+  fi
+elif [[ "$branch" == "develop" ]]; then
+  # alpha
+  if [[ "$IS_FEAT" == "--is-feat" ]]; then
+    new_minor=$((minor + 1))
+    new_version="$major.$new_minor.0-alpha.1"
+  else
+    new_pre=$((pre + 1))
+    new_version="$major.$minor.$patch-alpha.$new_pre"
+  fi
+else
+  echo "Unsupported branch: $branch" >&2
+  exit 1
 fi
 
-lerna version $new_version --preid alpha --force-publish=* --no-git-tag-version -y
+if [[ "$ONLY_VERSION" == "true" ]]; then
+  echo "$new_version"
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "DRY_RUN: computed version = $new_version"
+  echo "DRY_RUN: would tag v$new_version in:"
+  echo "- nocobase/nocobase"
+  echo "- nocobase/pro-plugins"
+  if [[ -n "${PRO_PLUGIN_REPOS:-}" ]]; then
+    echo "$PRO_PLUGIN_REPOS" | jq -r '.[]' | while read -r i; do
+      echo "- nocobase/$i"
+    done
+  fi
+  if [[ -n "${CUSTOM_PRO_PLUGIN_REPOS:-}" ]]; then
+    echo "$CUSTOM_PRO_PLUGIN_REPOS" | jq -r '.[]' | while read -r i; do
+      echo "- nocobase/$i"
+    done
+  fi
+  exit 0
+fi
+
+echo "Releasing version: $new_version"
+
+lerna version "$new_version" --preid alpha --force-publish=* --no-git-tag-version -y
 
 echo $PRO_PLUGIN_REPOS | jq -r '.[]' | while read i; do
   cd ./packages/pro-plugins/@nocobase/$i


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
v1 分支需要支持 maintenance releases 的 CI 流程（与 main 已合入的 #8670 保持一致），用于在 v1.x 上进行发版/打 tag/相关自动化。

### Description
- Backport main 上的 #8670（CI: support v1.x maintenance releases）到 v1 分支
- 主要变更包括：
  - 更新 `get-plugins.yml`
  - 新增 `manual-release-v1.yml`
  - 更新 `release.yml`
  - 调整 `release.sh`

**Potential risks**
- 影响发版相关 workflow；如果仓库 secrets/vars 配置不全可能导致 workflow 失败。

**Testing suggestions**
- 在 v1 分支触发 `manual-release-v1.yml` 的 dry-run（如有），或执行一次 release workflow 的演练，确认能正常生成 tag / release 产物（按现有流程要求）。

### Related issues
- Replaces #8675 (closed due to polluted branch history)
- Backport of #8670

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve CI: backport support for v1.x maintenance releases to v1 branch. |
| 🇨🇳 Chinese | 优化 CI：将 v1.x maintenance releases 的支持回迁到 v1 分支。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
