### PR TITLE
ci(v1): increase frontend test timeout

### DIFF
--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -48,4 +48,4 @@ jobs:
 
       - run: yarn install
       - run: yarn test:client
-    timeout-minutes: 30
+    timeout-minutes: 40


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The frontend test workflow may finish `yarn test:client` close to the 30m job timeout, then get cancelled during the `actions/setup-node` post step (cache save), causing flaky "Post Use Node.js" cancellation.

### Description
- Increase `timeout-minutes` from 30 to 40 in `nocobase-test-frontend.yml` (v1).

Testing suggestions:
- Re-run the frontend test workflow on a PR and confirm it completes without being cancelled in post-job cleanup.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | CI: increase frontend test timeout to avoid post-step cancellation |
| 🇨🇳 Chinese | CI：提高前端测试超时，避免在缓存收尾步骤被取消 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
