### PR TITLE
chore(ci): allow v1 manual release to resume when tags partially exist

### DIFF
--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -110,33 +110,55 @@ jobs:
         env:
           IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
 
-      - name: Validate tag conflicts (v1.x)
+      - name: Check tag status (v1.x)
         shell: bash
         run: |
           set -euo pipefail
           TAG="v${{ steps.compute-version.outputs.version }}"
-          echo "Validating tag does not already exist: $TAG"
+          echo "Checking tag across repos (supports resume): $TAG"
 
-          missing_ok=true
-          conflict=()
+          exist=()
+          missing=()
+          shas=()
 
           repos=("nocobase" "pro-plugins")
           for r in $(echo '${{ needs.get-plugins.outputs.rc-plugins }}' | jq -r '.[]'); do repos+=("$r"); done
           for r in $(echo '${{ needs.get-plugins.outputs.custom-plugins }}' | jq -r '.[]'); do repos+=("$r"); done
 
           for repo in "${repos[@]}"; do
-            if gh api -H "Accept: application/vnd.github+json" "/repos/nocobase/$repo/git/ref/tags/$TAG" >/dev/null 2>&1; then
-              conflict+=("$repo")
+            if sha=$(gh api -H "Accept: application/vnd.github+json" "/repos/nocobase/$repo/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null); then
+              exist+=("$repo")
+              shas+=("$sha")
+            else
+              missing+=("$repo")
             fi
           done
 
-          if [[ ${#conflict[@]} -gt 0 ]]; then
-            echo "Tag conflict: $TAG already exists in repos:" >&2
-            printf '%s\n' "${conflict[@]}" >&2
-            exit 1
+          # If the tag exists, ensure it points to the same object everywhere it exists.
+          if [[ ${#shas[@]} -gt 0 ]]; then
+            uniq_shas=$(printf '%s\n' "${shas[@]}" | sort -u)
+            uniq_count=$(printf '%s\n' "$uniq_shas" | sed '/^$/d' | wc -l | tr -d ' ')
+            if [[ "$uniq_count" -gt 1 ]]; then
+              echo "ERROR: Tag $TAG exists but points to different objects across repos (unsafe to continue)." >&2
+              echo "Distinct tag object SHAs:" >&2
+              printf '%s\n' "$uniq_shas" >&2
+              echo "Repos where tag exists:" >&2
+              printf '%s\n' "${exist[@]}" >&2
+              exit 1
+            fi
           fi
 
-          echo "OK: no conflicts for $TAG"
+          if [[ ${#exist[@]} -gt 0 && ${#missing[@]} -gt 0 ]]; then
+            echo "WARNING: Tag $TAG already exists in some repos. Treating as resume and continuing." >&2
+            echo "  exists:" >&2
+            printf '  - %s\n' "${exist[@]}" >&2
+            echo "  missing:" >&2
+            printf '  - %s\n' "${missing[@]}" >&2
+          elif [[ ${#exist[@]} -gt 0 && ${#missing[@]} -eq 0 ]]; then
+            echo "INFO: Tag $TAG already exists in all repos. Continuing (idempotent)."
+          else
+            echo "OK: Tag $TAG does not exist in any repo."
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The v1 manual release workflow currently hard-fails if the computed tag already exists in any target repo. This blocks the natural "resume" path when a previous run pushed tags to some repos but failed later.

### Description
- Change the tag pre-check in `.github/workflows/manual-release-v1.yml` to support resume/idempotent reruns.
- If the tag exists in some repos, the workflow logs "exists/missing" lists and continues.
- The workflow only fails when the same tag exists but points to different objects across repos (unsafe).

Potential risks:
- The workflow will now proceed when tags partially exist; the final `git push --tags` remains the source of truth.
- Inconsistent tags across repos are detected explicitly and will fail.

Testing suggestions:
- Run the workflow with `dry_run=true` to verify computed version + tag status output.
- Simulate a partial release (create the tag in a subset of repos) and rerun to confirm it continues.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve v1 manual release workflow to allow resuming when tags partially exist across repos. |
| 🇨🇳 Chinese | 优化 v1 手动发版流程：当部分仓库已存在 tag 时支持恢复继续执行。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
