### PR TITLE
chore(ci): fix v1 tag validation for private plugin repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,16 @@ jobs:
             echo "defaultTag=$(echo 'latest')" >> $GITHUB_OUTPUT
             echo "proRepos=$(echo '${{ needs.get-plugins.outputs.rc-plugins }}')" >> $GITHUB_OUTPUT
           fi
+      - uses: actions/create-github-app-token@v1
+        id: validate-token
+        if: ${{ startsWith(github.ref_name, 'v1.') }}
+        with:
+          app-id: ${{ vars.NOCOBASE_APP_ID }}
+          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
+          # Use owner-wide installation token so validation can read tags from other (possibly private) repos.
+          owner: nocobase
+          skip-token-revoke: true
+
       - name: Validate v1 tag exists in all selected repos
         if: ${{ startsWith(github.ref_name, 'v1.') }}
         shell: bash
@@ -67,7 +77,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.validate-token.outputs.token }}
 
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The Release workflow validates that the v1 tag exists in all selected plugin repos before publishing. The validation step currently uses `github.token`, which cannot reliably read refs from other (possibly private) repos, causing false "Missing tag" failures.

### Description
- Create a GitHub App installation token (owner-wide) before the validation step.
- Use that token for the "Validate v1 tag exists in all selected repos" step so it can query tags across nocobase org repos.

Testing suggestions:
- Re-run the Release workflow on an existing v1 tag and confirm the validation step can see tags in plugin repos.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve Release workflow v1 tag validation for plugin repos. |
| 🇨🇳 Chinese | 优化 Release 工作流：修复 v1 tag 在插件仓库中的校验逻辑。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
