### PR TITLE
ci(release): skip changelog+github release for v1 tags

### DIFF
--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -21,9 +21,11 @@ on:
 
 jobs:
   get-plugins:
+    if: ${{ !startsWith(github.ref_name, 'v1.') }}
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
     secrets: inherit
   write-changelog-and-release:
+    if: ${{ !startsWith(github.ref_name, 'v1.') }}
     needs: get-plugins
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
GitHub Releases created for v1 maintenance tags (e.g. v1.9.48) currently become the "Latest" release, which is not desired. For now we want to stop generating changelog + GitHub Release for v1 tags.

### Description
- Skip `Write changelog and create release` workflow when the tag starts with `v1.`.
- This prevents v1 maintenance releases from being marked as GitHub "Latest".

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
