### PR TITLE
fix(flow): unify mobile pagination

### DIFF
--- a/packages/core/client/src/flow/utils/__tests__/pagination.test.ts
+++ b/packages/core/client/src/flow/utils/__tests__/pagination.test.ts
@@ -1,0 +1,64 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyMobilePaginationProps,
+  createCompactSimpleItemRender,
+  getSimpleModePaginationClassName,
+  getUnknownCountPaginationTotal,
+} from '../pagination';
+
+describe('flow pagination utils', () => {
+  it('未知总数场景应按 hasNext 估算 total', () => {
+    expect(
+      getUnknownCountPaginationTotal({
+        dataLength: 12,
+        pageSize: 12,
+        current: 1,
+        hasNext: true,
+      }),
+    ).toBe(13);
+
+    expect(
+      getUnknownCountPaginationTotal({
+        dataLength: 9,
+        pageSize: 12,
+        current: 2,
+        hasNext: true,
+      }),
+    ).toBe(24);
+  });
+
+  it('移动端分页应隐藏 total 与 size changer', () => {
+    const result = applyMobilePaginationProps(
+      {
+        total: 43,
+        current: 1,
+        pageSize: 20,
+        showTotal: () => 'Total 43 items',
+        showSizeChanger: true,
+      },
+      true,
+    ) as any;
+
+    expect(result.showTotal).toBe(false);
+    expect(result.showSizeChanger).toBe(false);
+    expect(result.showLessItems).toBe(true);
+    expect(typeof result.className).toBe('string');
+  });
+
+  it('simple 模式工具应提供 className 与 itemRender', () => {
+    const className = getSimpleModePaginationClassName(true);
+    const itemRender = createCompactSimpleItemRender({ current: 2, controlHeight: 32 });
+
+    expect(typeof className).toBe('string');
+    expect(typeof itemRender).toBe('function');
+  });
+});

--- a/packages/core/client/src/flow/utils/index.ts
+++ b/packages/core/client/src/flow/utils/index.ts
@@ -9,3 +9,4 @@
 
 export * from './blockUtils';
 export * from './dispatchEventDeep';
+export * from './pagination';

--- a/packages/core/client/src/flow/utils/pagination.ts
+++ b/packages/core/client/src/flow/utils/pagination.ts
@@ -1,0 +1,110 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { css, cx } from '@emotion/css';
+import type { PaginationProps } from 'antd';
+import React from 'react';
+
+/**
+ * 计算未知总数场景下的 Pagination total：
+ * - 本页不足 pageSize 或 hasNext=false，说明到末页
+ * - 否则用 +1 触发“还有下一页”
+ */
+export const getUnknownCountPaginationTotal = (options: {
+  dataLength?: number;
+  pageSize?: number;
+  current?: number;
+  hasNext?: boolean;
+}) => {
+  const dataLength = options.dataLength || 0;
+  const pageSize = options.pageSize || 10;
+  const current = options.current || 1;
+  if (dataLength < pageSize || !options.hasNext) {
+    return pageSize * current;
+  }
+  return pageSize * current + 1;
+};
+
+export const getSimpleModePaginationClassName = (withLineHeight = false) => {
+  return css`
+    .ant-pagination-simple-pager {
+      display: none !important;
+    }
+    ${withLineHeight
+      ? `
+      li {
+        line-height: 32px !important;
+      }
+    `
+      : ''}
+  `;
+};
+
+const mobileCompactPaginationClassName = css`
+  justify-content: flex-end !important;
+  .ant-pagination-total-text,
+  .ant-pagination-options,
+  .ant-pagination-jump-prev,
+  .ant-pagination-jump-next {
+    display: none !important;
+  }
+`;
+
+export const getMobileCompactPaginationClassName = () => mobileCompactPaginationClassName;
+
+export const mergePaginationClassName = (...classNames: Array<string | undefined | false>) => {
+  return cx(...classNames.filter(Boolean));
+};
+
+export const createCompactSimpleItemRender = (options: {
+  current?: number;
+  controlHeight?: number;
+  currentTextMarginLeft?: number;
+}): PaginationProps['itemRender'] => {
+  const current = options.current || 1;
+  const controlHeight = options.controlHeight || 32;
+  const currentTextStyle = options.currentTextMarginLeft
+    ? { marginLeft: `${options.currentTextMarginLeft}px` }
+    : undefined;
+
+  return (_, type, originalElement) => {
+    if (type === 'prev') {
+      return React.createElement(
+        'div',
+        {
+          style: { display: 'flex' },
+          className: css`
+            .ant-pagination-item-link {
+              min-width: ${controlHeight}px;
+            }
+          `,
+        },
+        originalElement,
+        React.createElement('div', { style: currentTextStyle }, current),
+      );
+    }
+    return originalElement;
+  };
+};
+
+export const applyMobilePaginationProps = <T extends PaginationProps>(
+  pagination: T,
+  isMobileLayout: boolean,
+): PaginationProps => {
+  if (!isMobileLayout) {
+    return pagination;
+  }
+  return {
+    ...pagination,
+    showTotal: false,
+    showSizeChanger: false,
+    showLessItems: true,
+    className: mergePaginationClassName(pagination.className, getMobileCompactPaginationClassName()),
+  };
+};

--- a/packages/plugins/@nocobase/plugin-block-grid-card/src/client/models/__tests__/GridCardBlockModel.pagination.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-grid-card/src/client/models/__tests__/GridCardBlockModel.pagination.test.ts
@@ -1,0 +1,104 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { GridCardBlockModel } from '../GridCardBlockModel';
+
+function createGridCardModel(options: {
+  count?: number;
+  page?: number;
+  pageSize?: number;
+  hasNext?: boolean;
+  dataLength?: number;
+  isMobileLayout?: boolean;
+}) {
+  const count = options.count ?? 0;
+  const page = options.page ?? 1;
+  const pageSize = options.pageSize ?? 12;
+  const hasNext = options.hasNext ?? false;
+  const dataLength = options.dataLength ?? pageSize;
+  const data = Array.from({ length: dataLength }, (_, i) => ({ id: i + 1 }));
+  const setPage = vi.fn();
+  const setPageSize = vi.fn();
+  const refresh = vi.fn();
+
+  const model = Object.create(GridCardBlockModel.prototype) as GridCardBlockModel;
+  Object.defineProperty(model, 'resource', {
+    configurable: true,
+    value: {
+      getMeta: (key: string) => (key === 'count' ? count : key === 'hasNext' ? hasNext : undefined),
+      getPageSize: () => pageSize,
+      getPage: () => page,
+      getData: () => data,
+      setPage,
+      setPageSize,
+      refresh,
+      loading: false,
+    },
+  });
+  Object.defineProperty(model, 'context', {
+    configurable: true,
+    value: {
+      isMobileLayout: !!options.isMobileLayout,
+      themeToken: { controlHeight: 32 },
+    },
+  });
+  (model as any).props = {
+    columnCount: { xs: 1, md: 2, lg: 3, xxl: 4 },
+    rowCount: 3,
+  };
+  (model as any)._screens = 'lg';
+  Object.defineProperty(model, 'translate', {
+    configurable: true,
+    value: (key: string, vars?: any) => {
+      if (key === 'Total {{count}} items') {
+        return `Total ${vars?.count ?? ''} items`;
+      }
+      return key;
+    },
+  });
+  return { model, setPage, setPageSize, refresh };
+}
+
+describe('GridCardBlockModel pagination', () => {
+  it('移动端已知总数时隐藏 total 与 size changer', () => {
+    const { model } = createGridCardModel({
+      count: 43,
+      page: 2,
+      pageSize: 12,
+      isMobileLayout: true,
+      dataLength: 12,
+    });
+
+    const pagination = model.pagination() as any;
+    expect(pagination.current).toBe(2);
+    expect(pagination.total).toBe(43);
+    expect(pagination.showTotal).toBe(false);
+    expect(pagination.showSizeChanger).toBe(false);
+    expect(pagination.showLessItems).toBe(true);
+  });
+
+  it('移动端未知总数时保持 simple 并隐藏 size changer', () => {
+    const { model } = createGridCardModel({
+      count: 0,
+      page: 1,
+      pageSize: 12,
+      hasNext: true,
+      isMobileLayout: true,
+      dataLength: 12,
+    });
+
+    const pagination = model.pagination() as any;
+    expect(pagination.simple).toBe(true);
+    expect(pagination.showSizeChanger).toBe(false);
+    expect(pagination.showTotal).toBe(false);
+    expect(pagination.total).toBe(13);
+    expect(typeof pagination.itemRender).toBe('function');
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v2 网格卡片与表格分页器在移动端样式不一致，出现总数文案、分页大小切换与分页按钮挤压的问题，影响可读性与可操作性

### Description 
本 PR 在 flow 链路统一了表格与网格卡片分页逻辑：
- 新增 `flow/utils/pagination.ts` 作为共享分页工具，统一 unknown-count total 计算、simple 模式渲染与移动端收敛策略
- `TableBlockModel` 与 `GridCardBlockModel` 共用上述工具，移动端均基于 `ctx.isMobileLayout` 隐藏 total 与 size changer，并启用紧凑分页展示
- 新增回归测试覆盖网格卡片分页模型和共享分页工具，防止移动端分页样式回归

潜在风险：
- 分页逻辑收敛后，表格与网格卡片在移动端行为会保持一致，若历史有依赖差异化展示的场景需要同步确认

测试建议：
- 在移动端布局下验证表格和网格卡片分页器均不显示总数与分页大小切换
- 在未知总数场景验证 simple 模式分页仍可正常翻页

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Unify mobile pagination behavior for table and grid card |
| 🇨🇳 Chinese | 统一表格与网格卡片的移动端分页行为 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
