### PR TITLE
chore(ci): publish v1 maintenance tags under dist-tag v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,8 +220,11 @@ jobs:
 
           TAGS=()
 
-          TAGS+=("nocobase/nocobase:$DEFAULT_TAG")
-          TAGS+=("$ALI_REG/nocobase/nocobase:$DEFAULT_TAG")
+          # For v1 maintenance tags, do not push a floating default tag (e.g. `latest`).
+          if [[ "${{ github.ref_name }}" != v1.* ]]; then
+            TAGS+=("nocobase/nocobase:$DEFAULT_TAG")
+            TAGS+=("$ALI_REG/nocobase/nocobase:$DEFAULT_TAG")
+          fi
 
           IFS=',' read -ra TAG_ARRAY <<< "$META_TAGS"
           for TAG in "${TAG_ARRAY[@]}"; do
@@ -240,8 +243,11 @@ jobs:
 
           TAGS=()
 
-          TAGS+=("nocobase/nocobase:$DEFAULT_TAG-full")
-          TAGS+=("$ALI_REG/nocobase/nocobase:$DEFAULT_TAG-full")
+          # For v1 maintenance tags, do not push a floating default tag (e.g. `latest-full`).
+          if [[ "${{ github.ref_name }}" != v1.* ]]; then
+            TAGS+=("nocobase/nocobase:$DEFAULT_TAG-full")
+            TAGS+=("$ALI_REG/nocobase/nocobase:$DEFAULT_TAG-full")
+          fi
 
           IFS=',' read -ra TAG_ARRAY <<< "$META_TAGS"
           for TAG in "${TAG_ARRAY[@]}"; do


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v1 maintenance releases must not update npm dist-tag `latest` (which should stay on mainline v2.x). Not specifying a dist-tag defaults to `latest`, so v1 releases must publish under a dedicated dist-tag.

### Description
- For tags starting with `v1.`, set `defaultTag` to `v1` in `.github/workflows/release.yml`.
- Publish steps use `--dist-tag` so v1 releases publish under dist-tag `v1`.
- For v1 maintenance tags, do not push floating Docker tags (e.g. `latest` / `latest-full`); only push semver tags.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | CI: publish v1 maintenance releases under dist-tag `v1` and avoid pushing floating Docker tags. |
| 🇨🇳 Chinese | CI：v1 维护版本发布使用 dist-tag `v1`，并避免推送 `latest/latest-full` 等浮动 Docker tag。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
