### PR TITLE
fix(flow): reduce v2 title-tab gap

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -28,7 +28,6 @@ import {
   VIEW_ACTIVATED_EVENT,
 } from '@nocobase/flow-engine';
 import { Tabs } from 'antd';
-import _ from 'lodash';
 import React, { ReactNode } from 'react';
 import { TextAreaWithContextSelector } from '../../../components/TextAreaWithContextSelector';
 import { BasePageTabModel } from './PageTabModel';
@@ -335,9 +334,18 @@ export class PageModel extends FlowModel<PageModelStructure> {
   }
 
   render() {
+    const token = this.context.themeToken;
+    const headerStyle = { ...this.props.headerStyle } as Record<string, any>;
+    if (token) {
+      headerStyle.paddingBlock = token.paddingSM;
+      headerStyle.paddingInline = token.paddingLG;
+    }
+    if (this.props.enableTabs) {
+      headerStyle.paddingBottom = 0;
+    }
     return (
       <>
-        {this.props.displayTitle && <PageHeader title={this.props.title} style={this.props.headerStyle} />}
+        {this.props.displayTitle && <PageHeader title={this.props.title} style={headerStyle} />}
         {this.props.enableTabs ? this.renderTabs() : this.renderFirstTab()}
       </>
     );
@@ -398,6 +406,8 @@ PageModel.registerFlow({
         };
       },
       async handler(ctx, params) {
+        const token = ctx.themeToken;
+        const tabPaddingInline = token?.paddingLG ?? 16;
         ctx.model.setProps('displayTitle', params.displayTitle);
         if (ctx.model.context.closable) {
           ctx.model.setProps('title', ctx.t(params.title, { ns: 'lm-desktop-routes' }));
@@ -413,7 +423,7 @@ PageModel.registerFlow({
           });
           ctx.model.setProps('tabBarStyle', {
             backgroundColor: 'var(--colorBgContainer)',
-            paddingInline: 16,
+            paddingInline: tabPaddingInline,
             marginBottom: 0,
           });
         } else {
@@ -422,7 +432,7 @@ PageModel.registerFlow({
           });
           ctx.model.setProps('tabBarStyle', {
             backgroundColor: 'var(--colorBgLayout)',
-            paddingInline: 16,
+            paddingInline: tabPaddingInline,
             marginBottom: 0,
           });
         }

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
@@ -182,6 +182,41 @@ describe('PageModel', () => {
     });
   });
 
+  describe('render header spacing with tabs', () => {
+    it('should compact page header bottom spacing when tabs are enabled', () => {
+      pageModel.props = {
+        displayTitle: true,
+        enableTabs: true,
+        title: 'Title',
+        headerStyle: { backgroundColor: 'var(--colorBgLayout)' },
+      } as any;
+      pageModel.renderTabs = vi.fn(() => null);
+
+      const result = pageModel.render() as any;
+      const header = result.props.children[0];
+
+      expect(header.props.style).toMatchObject({
+        backgroundColor: 'var(--colorBgLayout)',
+        paddingBottom: 0,
+      });
+    });
+
+    it('should keep original header style when tabs are disabled', () => {
+      pageModel.props = {
+        displayTitle: true,
+        enableTabs: false,
+        title: 'Title',
+        headerStyle: { backgroundColor: 'var(--colorBgLayout)' },
+      } as any;
+      pageModel.renderFirstTab = vi.fn(() => null);
+
+      const result = pageModel.render() as any;
+      const header = result.props.children[0];
+
+      expect(header.props.style).toEqual({ backgroundColor: 'var(--colorBgLayout)' });
+    });
+  });
+
   describe('dirty refresh signal', () => {
     it('should invoke current tab onActive when dataSource:dirty is emitted and page is active', async () => {
       const listeners: Record<string, any> = {};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v2 页面在启用标签页时，页面标题与标签页之间的垂直间距明显大于 v1，影响视觉一致性；同时在部分上下文中 `themeToken` 为空会导致 `PageModel` 渲染报错。

### Description 
- 在 `PageModel` 渲染逻辑中压缩启用 tabs 场景的标题底部间距（`paddingBottom: 0`），对齐 v1 视觉表现
- 为 `themeToken` 读取增加空值兜底，避免访问 `paddingSM/paddingLG` 时崩溃
- 补充并通过 `PageModel` 单测，覆盖 tabs 启用/禁用场景下的标题样式行为

潜在风险：页面标题区域依赖主题 token 的布局在不同主题下可能存在细微差异。  
测试建议：在带/不带 tabs 的页面分别验证标题与标签页间距，并回归页面渲染无报错。

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix excessive spacing between page title and tabs in v2 and prevent theme token null crash |
| 🇨🇳 Chinese | 修复 v2 页面标题与标签页间距过大并避免 theme token 为空时报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
