### PR TITLE
fix(ci): include all v1-branch plugin repos for v1 maintenance releases

### DIFF
--- a/.github/workflows/get-plugins.yml
+++ b/.github/workflows/get-plugins.yml
@@ -122,6 +122,17 @@ jobs:
           betaPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry beta,rc)")")
           alphaPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry alpha,beta,rc)")")
           unreleasedPlugins=$(filterByTag "$REQUIRE_TAG" "$(filterByBranch "$REQUIRE_BRANCH" "$(retry unreleased)")")
+
+          # For v1.x maintenance releases, we should include all plugin repos that have the v1 branch,
+          # regardless of their props.plugin-type (e.g. repos marked as "unreleased").
+          if [[ "$REQUIRE_BRANCH" == "v1" ]]; then
+            rcPlugins=$allPlugins
+            customPlugins='[]'
+            betaPlugins='[]'
+            alphaPlugins='[]'
+            unreleasedPlugins='[]'
+          fi
+
           echo "all-plugins=$allPlugins" >> "$GITHUB_OUTPUT"
           echo "custom-plugins=$customPlugins" >> "$GITHUB_OUTPUT"
           echo "rc-plugins=$rcPlugins" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Some plugin repos were marked as "unreleased" via custom properties, so they were filtered out from v1 maintenance release plugin lists even though they have the `v1` branch. This caused missing tags and missing npm packages in v1 releases.

### Description
- In `.github/workflows/get-plugins.yml`, when `require_branch=v1`, output `rc-plugins` as `all-plugins` (all repos that have the v1 branch), regardless of `props.plugin-type`.
- Clear other buckets to avoid accidental partial lists.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | CI: include all plugin repos with v1 branch in v1 maintenance releases. |
| 🇨🇳 Chinese | CI：v1 维护发版包含所有带 v1 分支的插件仓库（不受 plugin-type 影响）。 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
