### PR TITLE
fix(ai): unify file input for chatGPT APIs using ContentBlock

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -1079,28 +1079,35 @@ If information is missing, clearly state it in the summary.</Important>`;
             content = workContextStr + '\n' + content;
           }
         }
-        const contents = [];
+        const contentBlocks = [];
         if (attachments?.length) {
           for (const attachment of attachments) {
             const parsed = await provider.parseAttachment(this.ctx, attachment);
-            contents.push(parsed);
+            contentBlocks.push(parsed);
           }
           if (content) {
-            contents.push({
+            contentBlocks.push({
               type: 'text',
               text: content,
             });
           }
         }
-        formattedMessages.push({
-          role: 'user',
-          content: contents.length ? contents : content,
-          additional_kwargs: {
-            userContent,
-            attachments,
-            workContext,
-          },
-        });
+        const role = 'user';
+        const additional_kwargs = { userContent, attachments, workContext };
+        if (contentBlocks.length) {
+          formattedMessages.push({
+            role,
+            additional_kwargs,
+            contentBlocks,
+          });
+        } else {
+          formattedMessages.push({
+            role,
+            additional_kwargs,
+            content,
+          });
+        }
+
         continue;
       }
       if (msg.role === 'tool') {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
@@ -22,7 +22,7 @@ export class OpenAICompletionsProvider extends LLMProvider {
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
     const responseFormatOptions = {
-      type: responseFormat,
+      type: responseFormat ?? 'text',
     };
     if (responseFormat === 'json_schema' && schema) {
       responseFormatOptions['json_schema'] = schema;

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -21,6 +21,7 @@ import { tool } from 'langchain';
 import '@langchain/core/utils/stream';
 import { ToolsEntry } from '@nocobase/ai';
 import { LLMResult } from '@langchain/core/outputs';
+import { ContentBlock } from '@langchain/core/messages';
 
 export interface LLMProviderOptions {
   app: Application;
@@ -142,10 +143,13 @@ export abstract class LLMProvider {
       };
     } else {
       return {
-        type: 'input_file',
-        filename: attachment.filename,
-        file_data: data,
-      };
+        type: 'file',
+        mimeType: attachment.mimetype,
+        metadata: {
+          filename: attachment.filename,
+        },
+        data,
+      } as ContentBlock.Multimodal.File;
     }
   }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
The file input parameters are named differently between the completions API and the responses API. Previously, the parameter names were hard-coded for the completions API. Now, the differences are bridged using LangChain's ContentBlock object.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Unify file input for chatGPT APIs using ContentBlock  |
| 🇨🇳 Chinese | 使用 ContentBlock 对象统一 chatGPT API 文件输入 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
