### PR TITLE
fix(flow): keep mobile horizontal form

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/FormBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormBlockModel.tsx
@@ -8,6 +8,7 @@
  */
 
 import { SettingOutlined } from '@ant-design/icons';
+import { css } from '@emotion/css';
 import type { PropertyMetaFactory } from '@nocobase/flow-engine';
 import {
   AddSubModelButton,
@@ -44,6 +45,29 @@ const GRID_DELEGATED_STEP_KEYS: Record<string, Set<string>> = {
   formModelSettings: new Set(['layout', 'assignRules']),
   eventSettings: new Set(['linkageRules']),
 };
+
+const FLOW_KEEP_MOBILE_HORIZONTAL_CLASS = 'nb-flow-keep-mobile-horizontal';
+
+const flowKeepMobileHorizontalClassName = css`
+  &.${FLOW_KEEP_MOBILE_HORIZONTAL_CLASS} {
+    @media (max-width: 575px) {
+      .ant-form-item {
+        flex-wrap: nowrap !important;
+      }
+
+      .ant-form-item .ant-form-item-label {
+        flex: 0 0 auto !important;
+        max-width: none !important;
+      }
+
+      .ant-form-item .ant-form-item-control {
+        flex: 1 1 0 !important;
+        max-width: none !important;
+        min-width: 0;
+      }
+    }
+  }
+`;
 
 function isGridDelegatedStep(flowKey: string, stepKey: string): boolean {
   return !!GRID_DELEGATED_STEP_KEYS[flowKey]?.has(stepKey);
@@ -417,6 +441,15 @@ export function FormComponent({
   onFinish?: (values: any) => void;
   [key: string]: any;
 }) {
+  const keepMobileHorizontalLayout = !!(model?.context?.isMobileLayout && layoutProps?.layout === 'horizontal');
+  const className = [
+    rest.className,
+    keepMobileHorizontalLayout ? FLOW_KEEP_MOBILE_HORIZONTAL_CLASS : '',
+    keepMobileHorizontalLayout ? flowKeepMobileHorizontalClassName : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <Form
       form={model.form}
@@ -441,6 +474,7 @@ export function FormComponent({
         model.emitter.emit('formValuesChange', { changedValues, allValues });
       }}
       {...rest}
+      className={className || undefined}
     >
       {children}
     </Form>

--- a/packages/core/client/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
@@ -12,7 +12,7 @@ import { render, waitFor } from '@testing-library/react';
 import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import { FlowEngine, FlowModel, SingleRecordResource } from '@nocobase/flow-engine';
 // 直接从 models 聚合导入，避免局部文件相互引用顺序导致的循环依赖
-import { FormBlockContent, FormBlockModel } from '../../../..';
+import { FormBlockContent, FormBlockModel, FormComponent } from '../../../..';
 import { Application } from '../../../../../application/Application';
 import {
   InputFieldInterface,
@@ -721,5 +721,54 @@ describe('FormBlockModel block height', () => {
     await waitFor(() => {
       expect(gridModel.setProps).toHaveBeenCalledWith({ height: undefined });
     });
+  });
+});
+
+describe('FormComponent mobile horizontal layout class', () => {
+  const createModel = (isMobileLayout: boolean) => {
+    return {
+      form: undefined,
+      context: {
+        isMobileLayout,
+        view: { inputArgs: {} },
+        record: {},
+      },
+      markUserModifiedFields: vi.fn(),
+      dispatchEvent: vi.fn(),
+      emitter: { emit: vi.fn() },
+    } as any;
+  };
+
+  it('adds mobile horizontal keep class when mobile + horizontal', () => {
+    const model = createModel(true);
+    const { container } = render(
+      <FormComponent model={model} layoutProps={{ layout: 'horizontal' }}>
+        <div data-testid="content">content</div>
+      </FormComponent>,
+    );
+    const formEl = container.querySelector('form.ant-form');
+    expect(formEl?.className).toContain('nb-flow-keep-mobile-horizontal');
+  });
+
+  it('does not add keep class when layout is vertical', () => {
+    const model = createModel(true);
+    const { container } = render(
+      <FormComponent model={model} layoutProps={{ layout: 'vertical' }}>
+        <div data-testid="content">content</div>
+      </FormComponent>,
+    );
+    const formEl = container.querySelector('form.ant-form');
+    expect(formEl?.className || '').not.toContain('nb-flow-keep-mobile-horizontal');
+  });
+
+  it('does not add keep class when desktop + horizontal', () => {
+    const model = createModel(false);
+    const { container } = render(
+      <FormComponent model={model} layoutProps={{ layout: 'horizontal' }}>
+        <div data-testid="content">content</div>
+      </FormComponent>,
+    );
+    const formEl = container.querySelector('form.ant-form');
+    expect(formEl?.className || '').not.toContain('nb-flow-keep-mobile-horizontal');
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v2 详情区块在桌面端设置为 Horizontal 后展示正常，但在移动端（小屏）会被 antd 的默认响应式规则自动折叠为纵向展示，导致配置与最终展示不一致。

### Description 
- 在 flow 的 `FormComponent` 中新增仅针对“移动端 + horizontal”场景的局部 class
- 通过局部样式覆盖小屏下 antd 表单项的自动换行行为，保持 label/control 同行展示
- 新增回归测试，覆盖 3 种分支：`mobile+horizontal`、`mobile+vertical`、`desktop+horizontal`

风险与测试建议：
- 风险范围限定在 flow 表单组件，且仅在移动端 horizontal 时生效
- 建议在 v2 详情区块与表单区块分别验证移动端与桌面端布局表现

### Related issues
- N/A

### Showcase
- N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix mobile fallback to vertical layout in v2 details horizontal mode |
| 🇨🇳 Chinese | 修复 v2 详情区块在移动端水平布局回退为垂直布局的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
