### PR TITLE
fix(admin-layout): close menu before nav

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/mobileMenuNavigation.test.ts
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/mobileMenuNavigation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MOBILE_MENU_CLOSE_DELAY_MS, runAfterMobileMenuClosed } from '../mobileMenuNavigation';
+
+describe('runAfterMobileMenuClosed', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should run callback immediately when not in mobile mode', () => {
+    const closeMobileMenu = vi.fn();
+    const callback = vi.fn();
+
+    runAfterMobileMenuClosed({
+      isMobile: false,
+      closeMobileMenu,
+      callback,
+    });
+
+    expect(closeMobileMenu).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close menu first and run callback after default delay in mobile mode', () => {
+    vi.useFakeTimers();
+    const closeMobileMenu = vi.fn();
+    const callback = vi.fn();
+
+    runAfterMobileMenuClosed({
+      isMobile: true,
+      closeMobileMenu,
+      callback,
+    });
+
+    expect(closeMobileMenu).toHaveBeenCalledTimes(1);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(MOBILE_MENU_CLOSE_DELAY_MS - 1);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support custom delay value in mobile mode', () => {
+    vi.useFakeTimers();
+    const closeMobileMenu = vi.fn();
+    const callback = vi.fn();
+
+    runAfterMobileMenuClosed({
+      isMobile: true,
+      closeMobileMenu,
+      callback,
+      delayMs: 80,
+    });
+
+    vi.advanceTimersByTime(79);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -59,6 +59,7 @@ import { VariableScope } from '../../../variables/VariableScope';
 import { KeepAlive, useKeepAlive } from './KeepAlive';
 import { NocoBaseDesktopRoute, NocoBaseDesktopRouteType } from './convertRoutesToSchema';
 import { MenuSchemaToolbar, ResetThemeTokenAndKeepAlgorithm } from './menuItemSettings';
+import { runAfterMobileMenuClosed } from './mobileMenuNavigation';
 import { userCenterSettings } from './userCenterSettings';
 import { useApplications } from './useApplications';
 import { useFlowEngineContext } from '@nocobase/flow-engine';
@@ -318,6 +319,11 @@ const MenuSchemaToolbarWithContainer = () => {
 };
 
 const menuItemStyle = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' };
+const MobileMenuControlContext = React.createContext<{
+  closeMobileMenu: () => void;
+}>({
+  closeMobileMenu: () => {},
+});
 
 const GroupItem: FC<{ item: any }> = (props) => {
   const { item } = props;
@@ -375,6 +381,10 @@ const MenuItem: FC<{ item: any; options: { isMobile: boolean; collapsed: boolean
   const badgeCount = useEvaluatedExpression(item._route.options?.badge?.count);
   const navigate = useNavigateNoUpdate();
   const basenameOfCurrentRouter = useRouterBasename();
+  const { closeMobileMenu } = useContext(MobileMenuControlContext);
+  // 如果点击的是一个 group，直接跳转到第一个子页面
+  const path = item.redirect || item.path;
+  const badgeProps = { ...item._route.options?.badge, count: badgeCount };
 
   useEffect(() => {
     if (divRef.current) {
@@ -399,16 +409,50 @@ const MenuItem: FC<{ item: any; options: { isMobile: boolean; collapsed: boolean
         const url = await parseURLAndParams(href, params || []);
 
         if (openInNewWindow !== false) {
+          if (props.options?.isMobile) {
+            closeMobileMenu();
+          }
           window.open(url, '_blank');
         } else {
-          navigateWithinSelf(href, navigate, window.location.origin + basenameOfCurrentRouter);
+          runAfterMobileMenuClosed({
+            isMobile: !!props.options?.isMobile,
+            closeMobileMenu,
+            callback: () => {
+              navigateWithinSelf(href, navigate, window.location.origin + basenameOfCurrentRouter);
+            },
+          });
         }
       } catch (err) {
         console.error(err);
+        if (props.options?.isMobile) {
+          closeMobileMenu();
+        }
         window.open(href, '_blank');
       }
     },
-    [parseURLAndParams, item],
+    [parseURLAndParams, item, props.options?.isMobile, closeMobileMenu, navigate, basenameOfCurrentRouter],
+  );
+
+  const handleClickMenuItem = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!props.options?.isMobile) {
+        navigate(path);
+        return;
+      }
+
+      // 移动端先收起菜单，再跳转，避免返回时菜单残留在打开态。
+      runAfterMobileMenuClosed({
+        isMobile: !!props.options?.isMobile,
+        closeMobileMenu,
+        callback: () => {
+          navigate(path);
+        },
+      });
+    },
+    [props.options?.isMobile, closeMobileMenu, navigate, path],
   );
 
   if (item._hidden) {
@@ -457,10 +501,6 @@ const MenuItem: FC<{ item: any; options: { isMobile: boolean; collapsed: boolean
     );
   }
 
-  // 如果点击的是一个 group，直接跳转到第一个子页面
-  const path = item.redirect || item.path;
-  const badgeProps = { ...item._route.options?.badge, count: badgeCount };
-
   return (
     <ParentRouteContext.Provider value={item._parentRoute}>
       <NocoBaseRouteContext.Provider value={item._route}>
@@ -470,7 +510,7 @@ const MenuItem: FC<{ item: any; options: { isMobile: boolean; collapsed: boolean
             hidden={item._route.type === NocoBaseDesktopRouteType.group || item._depth > 0}
             badgeProps={badgeProps}
           >
-            <Link to={path} aria-label={item.name}>
+            <Link to={path} aria-label={item.name} onClick={handleClickMenuItem}>
               {props.children}
             </Link>
           </WithTooltip>
@@ -786,57 +826,66 @@ export const InternalAdminLayout = (props) => {
     };
   }, [styles.headerPopup]);
 
+  const closeMobileMenu = useCallback(() => {
+    if (!isMobileLayout) {
+      return;
+    }
+    setCollapsed(true);
+  }, [isMobileLayout]);
+
   return (
     <div style={rootStyle}>
       <div id="nocobase-app-container" style={appContainerStyle}>
-        <DndContext onDragEnd={onDragEnd}>
-          <ProLayout
-            {...props}
-            contentStyle={contentStyle}
-            siderWidth={token.siderWidth || 200}
-            className={resetStyle}
-            location={location}
-            route={route}
-            actionsRender={actionsRender}
-            logo={
-              <div style={{ display: 'flex', alignItems: 'center' }}>
-                {AppsComponent && <AppsComponent />}
-                <NocoBaseLogo />
-              </div>
-            }
-            title={''}
-            layout="mix"
-            splitMenus
-            token={layoutToken}
-            headerRender={headerRender}
-            menuItemRender={menuItemRender}
-            subMenuItemRender={subMenuItemRender}
-            collapsedButtonRender={collapsedButtonRender}
-            onCollapse={onCollapse}
-            collapsed={collapsed}
-            onPageChange={onPageChange}
-            menu={{
-              // 1.x 暂默认禁用菜单手风琴效果，2.x 支持配置
-              autoClose: false,
-            }}
-            menuProps={menuProps}
-          >
-            <RouteContext.Consumer>
-              {(value: RouteContextType) => {
-                const { isMobile } = value;
-
-                return (
-                  <SetIsMobileLayout isMobile={isMobile}>
-                    <ConfigProvider theme={isMobile ? mobileTheme : theme}>
-                      <GlobalStyle />
-                      <LayoutContent />
-                    </ConfigProvider>
-                  </SetIsMobileLayout>
-                );
+        <MobileMenuControlContext.Provider value={{ closeMobileMenu }}>
+          <DndContext onDragEnd={onDragEnd}>
+            <ProLayout
+              {...props}
+              contentStyle={contentStyle}
+              siderWidth={token.siderWidth || 200}
+              className={resetStyle}
+              location={location}
+              route={route}
+              actionsRender={actionsRender}
+              logo={
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  {AppsComponent && <AppsComponent />}
+                  <NocoBaseLogo />
+                </div>
+              }
+              title={''}
+              layout="mix"
+              splitMenus
+              token={layoutToken}
+              headerRender={headerRender}
+              menuItemRender={menuItemRender}
+              subMenuItemRender={subMenuItemRender}
+              collapsedButtonRender={collapsedButtonRender}
+              onCollapse={onCollapse}
+              collapsed={collapsed}
+              onPageChange={onPageChange}
+              menu={{
+                // 1.x 暂默认禁用菜单手风琴效果，2.x 支持配置
+                autoClose: false,
               }}
-            </RouteContext.Consumer>
-          </ProLayout>
-        </DndContext>
+              menuProps={menuProps}
+            >
+              <RouteContext.Consumer>
+                {(value: RouteContextType) => {
+                  const { isMobile } = value;
+
+                  return (
+                    <SetIsMobileLayout isMobile={isMobile}>
+                      <ConfigProvider theme={isMobile ? mobileTheme : theme}>
+                        <GlobalStyle />
+                        <LayoutContent />
+                      </ConfigProvider>
+                    </SetIsMobileLayout>
+                  );
+                }}
+              </RouteContext.Consumer>
+            </ProLayout>
+          </DndContext>
+        </MobileMenuControlContext.Provider>
       </div>
       <div id="nocobase-embed-container" style={embedContainerStyle}></div>
     </div>

--- a/packages/core/client/src/route-switch/antd/admin-layout/mobileMenuNavigation.ts
+++ b/packages/core/client/src/route-switch/antd/admin-layout/mobileMenuNavigation.ts
@@ -1,0 +1,30 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export const MOBILE_MENU_CLOSE_DELAY_MS = 220;
+
+export const runAfterMobileMenuClosed = ({
+  isMobile,
+  closeMobileMenu,
+  callback,
+  delayMs = MOBILE_MENU_CLOSE_DELAY_MS,
+}: {
+  isMobile: boolean;
+  closeMobileMenu: () => void;
+  callback: () => void;
+  delayMs?: number;
+}) => {
+  if (!isMobile) {
+    callback();
+    return;
+  }
+
+  closeMobileMenu();
+  window.setTimeout(callback, delayMs);
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

在移动端访问管理端页面时，菜单打开状态下点击菜单项跳转后，iOS 左滑返回会出现菜单残留带来的视觉卡顿与体验不一致。

### Description 

本 PR 将“先关闭移动端菜单，再执行路由跳转”沉淀为可复用函数，并接入 admin-layout 菜单项点击链路：
- 新增 `runAfterMobileMenuClosed` 工具，统一处理移动端菜单关闭后的延迟导航
- 菜单普通路由与链接路由都改为先收起菜单，再执行跳转
- 补充 `mobileMenuNavigation` 单元测试，覆盖桌面立即执行、移动端延迟执行、自定义延迟三种场景

风险与建议：
- 风险较低，仅影响移动端菜单点击后的导航时序
- 建议回归验证移动端菜单跳转与 iOS 左滑返回体验

### Related issues

-

### Showcase

-

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | In mobile, close the menu first and then perform the page jump |
| 🇨🇳 Chinese | 移动端中，先关闭菜单再执行页面跳转 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
