### PR TITLE
fix(filter-form): preserve SQL filter titles

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormItemModel.defineChildren.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormItemModel.defineChildren.test.ts
@@ -277,4 +277,53 @@ describe('FilterFormItemModel defineChildren association fields', () => {
 
     expect(filterItem.props.label).toBe('id');
   });
+
+  it('applies getComponentProps from fallback sql field metadata', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      FilterFormItemModel,
+      NumberFieldModel,
+    });
+
+    const filterItem = engine.createModel<FilterFormItemModel>({
+      uid: 'sql-filter-item-component-props',
+      use: 'FilterFormItemModel',
+      stepParams: {
+        fieldSettings: {
+          init: {
+            fieldPath: 'id',
+          },
+        },
+        filterFormItemSettings: {
+          init: {
+            filterField: {
+              name: 'id',
+              interface: 'number',
+              type: 'integer',
+              getComponentProps: () => ({
+                placeholder: 'sql-id',
+                allowMultiple: true,
+                multiple: true,
+                required: true,
+                rules: [{ required: true }],
+              }),
+            },
+          },
+        },
+      },
+      subModels: {
+        field: {
+          use: 'NumberFieldModel',
+        },
+      },
+    } as any);
+
+    await filterItem.dispatchEvent('beforeRender');
+
+    expect(filterItem.props.placeholder).toBe('sql-id');
+    expect(filterItem.props.allowMultiple).toBe(true);
+    expect(filterItem.props.multiple).toBe(true);
+    expect(filterItem.props.required).toBeUndefined();
+    expect(filterItem.props.rules).toBeUndefined();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

在图表区块使用 SQL 查询时，筛选表单新增字段会出现两类问题：
1. 字段会被误判为“已删除”；
2. 新增字段在标题缺失时不显示名称，仅显示冒号。

这会直接影响筛选表单可用性和配置体验，需要统一修复 SQL 字段元数据回退逻辑。

### Description 

本 PR 主要包含以下改动：

- 在 `FilterFormItemModel` 中为 SQL 场景补充虚拟 `collectionField` 回退，避免在无集合上下文时误报“字段已删除”；
- 统一补齐 `filterField`/虚拟字段的 `title`（`title || name`），保证元数据完整性；
- 在 `onInit` 提前注入 `filterField`，避免 `label` 步骤先执行时拿不到字段标题；
- 调整筛选项 `label` 默认值与“原始字段标题”展示逻辑，增加 `name` 兜底；
- 增加回归测试，覆盖：
  - SQL 无集合上下文时 fallback 生效；
  - 有集合上下文时真实删除字段检测不受影响；
  - SQL 字段无 title 时 label 回退到字段名。

潜在风险：
- 变更集中在 `FilterFormItemModel` 初始化链路，可能影响筛选字段标题初始化；
- 已通过相关单测覆盖核心路径，风险可控。

测试建议：
- 手动验证 SQL 图表筛选新增字段显示；
- 手动验证真实删除字段仍提示“字段已删除”；
- 关注普通 collection 筛选表单字段标题是否正常。

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix false deletion warning and missing titles for SQL chart filter fields |
| 🇨🇳 Chinese | 修复 SQL 图表筛选字段误报删除且标题不显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
