### PR TITLE
fix(ai): datasource preview can`t include m2m-array field

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/admin/datasource/components/form-steps/Preview.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/admin/datasource/components/form-steps/Preview.tsx
@@ -124,7 +124,7 @@ const PreviewTable: React.FC<{
         dataIndex: field.name,
         width: 'auto',
         render: (value) => {
-          if (['hasOne', 'hasMany', 'belongsTo', 'belongsToMany'].includes(field.type)) {
+          if (['hasOne', 'hasMany', 'belongsTo', 'belongsToMany', 'belongsToArray'].includes(field.type)) {
             return (
               <Text style={{ minWidth: 100, maxWidth: 300 }} ellipsis={true}>
                 {value ? JSON.stringify(value) : ''}
@@ -141,9 +141,9 @@ const PreviewTable: React.FC<{
             return (
               <Text
                 style={{ minWidth: 100, maxWidth: 300 }}
-                ellipsis={{ tooltip: typeof value === 'string' ? compile(value) : value }}
+                ellipsis={{ tooltip: typeof value === 'string' ? compile(value) : JSON.stringify(value) }}
               >
-                {typeof value === 'string' ? compile(value) : value}
+                {typeof value === 'string' ? compile(value) : JSON.stringify(value)}
               </Text>
             );
           }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
if collection include m2m-array field add to ai datasource will occure render error

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed AI data source configuration rendering issue.  |
| 🇨🇳 Chinese | 修复AI数据源配置渲染异常 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
