### PR TITLE
Alioth-提供的Postgresql Upsert操作

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@commitlint/prompt-cli": "^16.1.0",
+    "@langchain/classic": "^1.0.20",
     "@types/react": "18.3.18",
     "@types/react-dom": "^18.0.0",
     "ali-oss": "^6.1.0",

--- a/packages/core/actions/src/actions/index.ts
+++ b/packages/core/actions/src/actions/index.ts
@@ -18,3 +18,4 @@ export * from './remove';
 export * from './toggle';
 export * from './first-or-create';
 export * from './update-or-create';
+export * from './upsert';

--- a/packages/core/actions/src/actions/upsert.ts
+++ b/packages/core/actions/src/actions/upsert.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Context } from '../index';
+import { getRepositoryFromParams } from '../utils';
+
+export async function upsert(ctx: Context, next: () => Promise<any>) {
+  const repository = getRepositoryFromParams(ctx);
+
+  // 从 params.values 中获取 filterKeys 和 values
+  // 请求体结构: { filterKeys: [...], values: {...} }
+  const paramsValues = ctx.action.params.values || {};
+  const { filterKeys, values, ...rest } = paramsValues;
+
+  const [instance, created] = await repository.upsert({
+    filterKeys,
+    values,
+    context: ctx,
+    ...rest,
+  });
+
+  ctx.body = {
+    data: instance,
+    meta: {
+      created,
+    },
+  };
+
+  ctx.status = 200;
+  await next();
+}

--- a/packages/core/actions/src/index.ts
+++ b/packages/core/actions/src/index.ts
@@ -48,6 +48,7 @@ export function registerActions(api: any) {
       'move',
       'firstOrCreate',
       'updateOrCreate',
+      'upsert',
     ]),
   );
 }

--- a/packages/core/database/src/__tests__/repository/create.test.ts
+++ b/packages/core/database/src/__tests__/repository/create.test.ts
@@ -285,6 +285,125 @@ describe('create', () => {
     expect(u1.age).toEqual(20);
   });
 
+  describe('upsert', () => {
+    test('should create new record when not exists', async () => {
+      const [u1, created] = await User.repository.upsert({
+        filterKeys: ['name'],
+        values: {
+          name: 'upsert_user1',
+          age: 25,
+        },
+      });
+
+      expect(created).toBe(true);
+      expect(u1.name).toEqual('upsert_user1');
+      expect(u1.age).toEqual(25);
+    });
+
+    test('should update existing record when exists', async () => {
+      // 先创建记录
+      await User.repository.create({
+        values: {
+          name: 'upsert_user2',
+          age: 30,
+        },
+      });
+
+      // upsert 应该更新
+      const [u2, created] = await User.repository.upsert({
+        filterKeys: ['name'],
+        values: {
+          name: 'upsert_user2',
+          age: 35,
+        },
+      });
+
+      expect(created).toBe(false);
+      expect(u2.name).toEqual('upsert_user2');
+      expect(u2.age).toEqual(35);
+
+      // 验证数据库中确实更新了
+      const count = await User.repository.count({
+        filter: { name: 'upsert_user2' },
+      });
+      expect(count).toEqual(1);
+    });
+
+    test('should work with multiple filterKeys', async () => {
+      await User.repository.create({
+        values: {
+          name: 'multi_key_user',
+          age: 20,
+        },
+      });
+
+      const [u3, created] = await User.repository.upsert({
+        filterKeys: ['name', 'age'],
+        values: {
+          name: 'multi_key_user',
+          age: 20,
+          email: 'test@example.com',
+        },
+      });
+
+      expect(created).toBe(false);
+      expect(u3.email).toEqual('test@example.com');
+    });
+
+    test('should fallback to updateOrCreate when useNativeUpsert is false', async () => {
+      const [u4, created] = await User.repository.upsert({
+        filterKeys: ['name'],
+        values: {
+          name: 'fallback_user',
+          age: 40,
+        },
+        useNativeUpsert: false,
+      });
+
+      expect(u4.name).toEqual('fallback_user');
+      expect(u4.age).toEqual(40);
+    });
+
+    test('should update updated_at when only conflict fields are provided (postgres DO NOTHING fix)', async () => {
+      // 先创建记录
+      const [u5Created, created1] = await User.repository.upsert({
+        filterKeys: ['name'],
+        values: {
+          name: 'only_conflict_fields_user',
+          age: 50,
+        },
+      });
+      expect(created1).toBe(true);
+
+      // 获取创建时的 updatedAt
+      const originalUpdatedAt = u5Created.updatedAt;
+
+      // 等待一小段时间确保时间戳会变化
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // 再次 upsert，只提供冲突字段（没有其他字段需要更新）
+      // 修复前：使用 DO NOTHING，RETURNING 不会返回数据，需要额外查询
+      // 修复后：使用 DO UPDATE SET updated_at = CURRENT_TIMESTAMP，RETURNING 正常返回
+      const [u5Updated, created2] = await User.repository.upsert({
+        filterKeys: ['name'],
+        values: {
+          name: 'only_conflict_fields_user',
+          // 注意：没有提供 age 或其他非冲突字段
+        },
+      });
+
+      // 应该返回已存在的记录，而不是创建新记录
+      expect(created2).toBe(false);
+      expect(u5Updated).toBeDefined();
+      expect(u5Updated.name).toEqual('only_conflict_fields_user');
+      // 记录的 age 应该保持不变
+      expect(u5Updated.age).toEqual(50);
+
+      // updatedAt 应该被更新（因为我们使用了 DO UPDATE SET updated_at）
+      expect(new Date(u5Updated.updatedAt).getTime()).toBeGreaterThanOrEqual(new Date(originalUpdatedAt).getTime());
+    });
+  });
+
   test('create with association', async () => {
     const u1 = await User.repository.create({
       values: {

--- a/packages/core/database/src/relation-repository/relation-repository.ts
+++ b/packages/core/database/src/relation-repository/relation-repository.ts
@@ -19,7 +19,15 @@ import { OptionsParser } from '../options-parser';
 import { updateAssociations } from '../update-associations';
 import { UpdateGuard } from '../update-guard';
 import { valuesToFilter } from '../utils/filter-utils';
-import { CreateOptions, Filter, FindOptions, FirstOrCreateOptions, TargetKey, UpdateOptions } from './types';
+import {
+  CreateOptions,
+  Filter,
+  FindOptions,
+  FirstOrCreateOptions,
+  TargetKey,
+  UpdateOptions,
+  UpsertOptions,
+} from './types';
 
 export const transaction = transactionWrapperBuilder(function () {
   return this.sourceCollection.model.sequelize.transaction();
@@ -157,8 +165,22 @@ export abstract class RelationRepository {
   }
 
   @transaction()
-  async updateOrCreate(options: FirstOrCreateOptions) {
-    const { filterKeys, values, transaction, hooks, context } = options;
+  async updateOrCreate(options: FirstOrCreateOptions & { useNativeUpsert?: boolean }) {
+    const { filterKeys, values, transaction, hooks, context, useNativeUpsert } = options;
+
+    // 对于支持的数据库，使用原生 upsert
+    if (useNativeUpsert !== false && this.db.inDialect('postgres', 'mysql', 'mariadb', 'sqlite')) {
+      const [instance] = await this.upsert({
+        filterKeys,
+        values,
+        transaction,
+        hooks,
+        context,
+        useNativeUpsert: true,
+      });
+      return instance;
+    }
+
     const filter = valuesToFilter(values, filterKeys);
 
     const instance = await this.findOne({ filter, transaction, context });
@@ -176,6 +198,39 @@ export abstract class RelationRepository {
     }
 
     return this.create({ values, transaction, hooks, context });
+  }
+
+  /**
+   * Upsert - 使用数据库原生 upsert 能力
+   * 对于关联仓库，使用目标仓库的 upsert 方法
+   */
+  @transaction()
+  async upsert(options: UpsertOptions): Promise<[Model, boolean]> {
+    const { filterKeys, values, transaction, context, ...rest } = options;
+
+    // 获取目标仓库
+    const targetRepo = this.targetCollection.repository;
+
+    // 先尝试查找现有记录
+    const filter = valuesToFilter(values, filterKeys);
+    const existingInstance = await this.findOne({ filter, transaction, context });
+
+    if (existingInstance) {
+      // 更新现有记录
+      await this.update({
+        filterByTk: existingInstance.get(
+          this.targetCollection.filterTargetKey || this.targetCollection.model.primaryKeyAttribute,
+        ),
+        values,
+        transaction,
+        ...rest,
+      });
+      return [existingInstance, false];
+    }
+
+    // 创建新记录
+    const newInstance = await this.create({ values, transaction, context, ...rest });
+    return [newInstance, true];
   }
 
   @transaction()

--- a/packages/core/database/src/relation-repository/types.ts
+++ b/packages/core/database/src/relation-repository/types.ts
@@ -83,6 +83,20 @@ export interface FirstOrCreateOptions extends CommonOptions {
   context?: any;
 }
 
+export interface UpsertOptions extends CommonOptions {
+  filterKeys: string[];
+  values?: Values;
+  hooks?: boolean;
+  context?: any;
+  updateAssociationValues?: AssociationKeysToBeUpdate;
+  /**
+   * 是否使用数据库原生的 upsert 能力（如 PostgreSQL 的 ON CONFLICT）
+   * 默认为 true，在支持的数据库上会使用原生 upsert
+   * 设为 false 则回退到先查询后更新/创建的方式
+   */
+  useNativeUpsert?: boolean;
+}
+
 export interface ThroughValues {
   [key: string]: any;
 }

--- a/packages/core/database/src/repository.ts
+++ b/packages/core/database/src/repository.ts
@@ -247,6 +247,20 @@ export interface FirstOrCreateOptions extends Transactionable {
   updateAssociationValues?: AssociationKeysToBeUpdate;
 }
 
+export interface UpsertOptions extends Transactionable {
+  filterKeys: string[];
+  values?: Values;
+  hooks?: boolean;
+  context?: any;
+  updateAssociationValues?: AssociationKeysToBeUpdate;
+  /**
+   * 是否使用数据库原生的 upsert 能力（如 PostgreSQL 的 ON CONFLICT）
+   * 默认为 true，在支持的数据库上会使用原生 upsert
+   * 设为 false 则回退到先查询后更新/创建的方式
+   */
+  useNativeUpsert?: boolean;
+}
+
 export class Repository<TModelAttributes extends {} = any, TCreationAttributes extends {} = TModelAttributes> {
   database: Database;
   collection: Collection;
@@ -622,9 +636,23 @@ export class Repository<TModelAttributes extends {} = any, TCreationAttributes e
     return this.create({ values, transaction, context, ...rest });
   }
 
-  async updateOrCreate(options: FirstOrCreateOptions) {
-    const { filterKeys, values, transaction, context, ...rest } = options;
+  async updateOrCreate(options: FirstOrCreateOptions & { useNativeUpsert?: boolean }) {
+    const { filterKeys, values, transaction, context, useNativeUpsert, ...rest } = options;
 
+    // 对于支持的数据库，默认使用原生 upsert（原子操作，性能更好）
+    if (useNativeUpsert !== false && this.database.inDialect('postgres', 'mysql', 'mariadb', 'sqlite')) {
+      const [instance] = await this.upsert({
+        filterKeys,
+        values,
+        transaction,
+        context,
+        useNativeUpsert: true,
+        ...rest,
+      });
+      return instance;
+    }
+
+    // 回退到先查询后更新的方式（非原子操作）
     const filter = Repository.valuesToFilter(values, filterKeys);
 
     const instance = await this.findOne({ filter, transaction, context });
@@ -640,6 +668,191 @@ export class Repository<TModelAttributes extends {} = any, TCreationAttributes e
     }
 
     return this.create({ values, transaction, context, ...rest });
+  }
+
+  /**
+   * Upsert - 使用数据库原生 upsert 能力（如 PostgreSQL ON CONFLICT）
+   * 在支持的数据库上（PostgreSQL 9.5+, MySQL 5.7+, SQLite 3.24+, MariaDB 10.3+）使用原生 upsert
+   * 在不支持的数据库上回退到 updateOrCreate
+   *
+   * @param options
+   * @returns [instance, created] - created 为 true 表示是新创建的记录
+   */
+  async upsert(options: UpsertOptions): Promise<[Model, boolean]> {
+    const { filterKeys, values, transaction, context, useNativeUpsert = true, ...rest } = options;
+
+    // 如果不使用原生 upsert 或者数据库不支持，则回退到 updateOrCreate
+    if (!useNativeUpsert || !this.database.inDialect('postgres', 'mysql', 'mariadb', 'sqlite')) {
+      const result = await this.updateOrCreate({ filterKeys, values, transaction, context, ...rest });
+      // updateOrCreate 不返回是否创建，这里需要查询判断，但为了不破坏接口，假设是更新
+      return [result as Model, false];
+    }
+
+    const tx = transaction || (await this.database.sequelize.transaction());
+    const useExternalTransaction = !!transaction;
+
+    try {
+      // 1. 准备数据：应用 setter 和 UpdateGuard
+      const guard = UpdateGuard.fromOptions(this.model, {
+        ...rest,
+        action: 'create',
+        underscored: this.collection.options.underscored,
+      });
+      const sanitizedValues = guard.sanitize(values || {});
+
+      // 2. 构建 conflict 字段
+      const conflictFields = filterKeys.map((key) => {
+        // 处理关联字段，如 'roles.name' -> 暂时只支持简单字段
+        if (key.includes('.')) {
+          throw new Error(`upsert does not support nested filterKeys like '${key}' yet`);
+        }
+        return key;
+      });
+
+      // 3. 对于 PostgreSQL，使用原生 ON CONFLICT
+      if (this.database.isPostgresCompatibleDialect()) {
+        const result = await this.upsertPostgres(sanitizedValues, conflictFields, tx, context, rest);
+        if (!useExternalTransaction) {
+          await tx.commit();
+        }
+        return result;
+      }
+
+      // 4. 对于 MySQL/MariaDB/SQLite，使用 Sequelize 的内置 upsert
+      // Sequelize 的 upsert 返回 [instance, created]
+      const [instance, created] = await this.model.upsert(sanitizedValues, {
+        transaction: tx,
+        fields: Object.keys(sanitizedValues),
+      });
+
+      // 5. 触发钩子
+      if (options.hooks !== false) {
+        const eventName = created
+          ? `${this.collection.name}.afterCreateWithAssociations`
+          : `${this.collection.name}.afterUpdateWithAssociations`;
+        await this.database.emitAsync(eventName, instance, { transaction: tx, context });
+        await this.database.emitAsync(`${this.collection.name}.afterSaveWithAssociations`, instance, {
+          transaction: tx,
+          context,
+        });
+        instance.clearChangedWithAssociations();
+      }
+
+      if (!useExternalTransaction) {
+        await tx.commit();
+      }
+
+      return [instance, created];
+    } catch (error) {
+      if (!useExternalTransaction) {
+        await tx.rollback();
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * PostgreSQL 原生 ON CONFLICT 实现
+   */
+  private async upsertPostgres(
+    values: Values,
+    conflictFields: string[],
+    transaction: any,
+    context: any,
+    rest: any,
+  ): Promise<[Model, boolean]> {
+    const tableName = this.collection.tableName();
+    const schema = this.collection.collectionSchema();
+    const fullTableName = schema ? `"${schema}"."${tableName}"` : `"${tableName}"`;
+
+    // 获取所有字段和值
+    const fields = Object.keys(values);
+    const fieldColumns = fields.map((f) => `"${f}"`).join(', ');
+    const placeholders = fields.map((_, i) => `$${i + 1}`).join(', ');
+
+    // 构建 update set 部分（排除 conflict 字段）
+    const updateFields = fields.filter((f) => !conflictFields.includes(f));
+    let updateSet = updateFields.length > 0 ? updateFields.map((f) => `"${f}" = EXCLUDED."${f}"`).join(', ') : null;
+
+    // 如果没有需要更新的字段，至少更新 updated_at 字段
+    // PostgreSQL ON CONFLICT DO NOTHING 会导致 RETURNING 在冲突时不返回数据
+    // 所以必须始终使用 DO UPDATE SET
+    if (!updateSet) {
+      // @ts-ignore
+      const updatedAtField = this.model._timestampAttributes?.updatedAt || 'updatedAt';
+      updateSet = `"${updatedAtField}" = CURRENT_TIMESTAMP`;
+    }
+
+    // 构建 ON CONFLICT 子句
+    const conflictColumns = conflictFields.map((f) => `"${f}"`).join(', ');
+
+    const sql = `
+      INSERT INTO ${fullTableName} (${fieldColumns})
+      VALUES (${placeholders})
+      ON CONFLICT (${conflictColumns})
+      DO UPDATE SET ${updateSet}
+      RETURNING *,
+        (xmax = 0) AS "_upsert_created"
+    `;
+
+    // 执行查询
+    const [rows, affectedCount] = await this.database.sequelize.query(sql, {
+      bind: fields.map((f) => values[f]),
+      transaction,
+      type: QueryTypes.INSERT,
+      model: this.model,
+      mapToModel: true,
+    });
+
+    // 由于始终使用 DO UPDATE SET，RETURNING 总是会返回数据
+    const rawInstance = rows[0];
+    // affectedCount 可能是 Model（Sequelize 类型定义问题），需要判断
+    let created = typeof affectedCount === 'number' ? affectedCount === 1 : true;
+
+    // 使用 xmax 判断是否是新记录（PostgreSQL 特性）
+    // 注意：rawInstance 可能是普通对象或 Model 实例
+    const upsertCreated = rawInstance && rawInstance._upsert_created !== false;
+    created = upsertCreated;
+
+    // 移除内部字段
+    if (rawInstance) {
+      delete rawInstance._upsert_created;
+    }
+
+    // 将原始数据转换为 Model 实例
+    let instance: Model;
+    if (rawInstance instanceof Model) {
+      instance = rawInstance;
+    } else {
+      // 构建 Model 实例
+      instance = this.model.build(rawInstance, { isNewRecord: created });
+      // 如果是已存在的记录，需要标记为已存在
+      if (!created) {
+        instance.isNewRecord = false;
+        // 设置主键
+        const pk = this.collection.model.primaryKeyAttribute;
+        if (pk && rawInstance[pk]) {
+          instance.setDataValue(pk, rawInstance[pk]);
+        }
+      }
+    }
+
+    // 触发钩子
+    if (rest.hooks !== false && instance) {
+      const eventName = created
+        ? `${this.collection.name}.afterCreateWithAssociations`
+        : `${this.collection.name}.afterUpdateWithAssociations`;
+      await this.database.emitAsync(eventName, instance, { transaction, context });
+      await this.database.emitAsync(`${this.collection.name}.afterSaveWithAssociations`, instance, {
+        transaction,
+        context,
+      });
+      if (typeof instance.clearChangedWithAssociations === 'function') {
+        instance.clearChangedWithAssociations();
+      }
+    }
+
+    return [instance, created];
   }
 
   private validate(options: { values: Record<string, any>[]; operation: 'create' | 'update' }) {

--- a/packages/core/flow-engine/src/resources/baseRecordResource.ts
+++ b/packages/core/flow-engine/src/resources/baseRecordResource.ts
@@ -106,7 +106,7 @@ export abstract class BaseRecordResource<TData = any> extends APIResource<TData>
       this.runActionOptions?.[action],
       rest,
     );
-    if (['create', 'update', 'firstOrCreate', 'updateOrCreate'].includes(action)) {
+    if (['create', 'update', 'firstOrCreate', 'updateOrCreate', 'upsert'].includes(action)) {
       config.params = config.params || {};
       config.params.updateAssociationValues = this.getUpdateAssociationValues();
     }

--- a/packages/core/flow-engine/src/resources/multiRecordResource.ts
+++ b/packages/core/flow-engine/src/resources/multiRecordResource.ts
@@ -152,6 +152,36 @@ export class MultiRecordResource<TDataItem = any> extends BaseRecordResource<TDa
     await this.refresh();
   }
 
+  /**
+   * Upsert - 使用数据库原生 upsert 能力（如 PostgreSQL ON CONFLICT）
+   * @param filterKeys 用于判断记录是否存在的字段列表
+   * @param data 要插入或更新的数据
+   * @param options 额外配置
+   * @returns Promise<{ data: TDataItem; meta: { created: boolean } }>
+   */
+  async upsert(
+    filterKeys: string[],
+    data: Partial<TDataItem>,
+    options?: AxiosRequestConfig & { refresh?: boolean },
+  ): Promise<{ data: TDataItem; meta: { created: boolean } }> {
+    const config = this.mergeRequestConfig(
+      {
+        data: {
+          filterKeys,
+          values: data,
+        },
+      },
+      options,
+    );
+    const res = await this.runAction<{ data: TDataItem; meta: { created: boolean } }, any>('upsert', config);
+    this.markDataSourceDirty();
+    this.emit('saved', data);
+    if (options?.refresh !== false) {
+      await this.refresh();
+    }
+    return res;
+  }
+
   async destroySelectedRows(): Promise<void> {
     const selectedRows = this.getSelectedRows();
     if (selectedRows.length === 0) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [*] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
原有的updateOrCreate, firstOrCreate不能通过Postgresql的原生upsert操作进行操作.
在JS 层操作,缺乏原子性支持,且由于缓存等问题,易出现读滞后等边际问题.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
通过判断DB连接器指向约定为Postgresql时启用DB的原生upsert支持,否则退化为原有的updateOrCreate;
且应用时,调整为即时updateSet未配置,依然默认更新updatedAt,从而获取RETURNING *的结果,Postgresql
在ON CONFLICT {} 且存在冲突, DO NOTHING 将导致 RETURNING 不返回任何数据.
### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
