### PR TITLE
fix(ai): anthropic provider default max_tokens is too small for Kimi Code

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/anthropic.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/anthropic.ts
@@ -17,6 +17,12 @@ import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
 import { Context } from '@nocobase/actions';
 import { AIMessageChunk } from '@langchain/core/messages';
 
+// Kimi code API only accept anthropic client
+// And anthropic default max_tokens is 2k that is too small for Kimi code
+const MAX_TOKENS_PRESET = {
+  'kimi-for-coding': 128 * 1024,
+};
+
 export class AnthropicProvider extends LLMProvider {
   declare chatModel: ChatAnthropic;
 
@@ -55,6 +61,8 @@ export class AnthropicProvider extends LLMProvider {
         delete sanitizedModelOptions[key];
       }
     }
+
+    this.setMaxTokens(sanitizedModelOptions);
 
     return new ChatAnthropic({
       apiKey,
@@ -204,6 +212,13 @@ export class AnthropicProvider extends LLMProvider {
         },
       };
     }
+  }
+
+  private setMaxTokens(options: Record<string, any> = {}) {
+    if (!options.model || options.maxTokens) {
+      return;
+    }
+    options.maxTokens = Object.entries(MAX_TOKENS_PRESET).find(([key]) => options.model.startsWith(key))?.[1];
   }
 }
 


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [X] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Kimi Code API now is only accept anthropic client.
anthropic provider default max_tokens is 2K that is too small for Kimi Code.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adapted Anthropic for Kimi Code API calls. |
| 🇨🇳 Chinese | Anthropic 适配 Kimi Code 接口调用 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
