### PR TITLE
fix(client): keep link navigation result in popup details

### DIFF
--- a/packages/core/client/src/flow/models/actions/LinkActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/LinkActionModel.tsx
@@ -13,7 +13,7 @@ import { css } from '@emotion/css';
 import type { ButtonProps } from 'antd/es/button';
 import { TextAreaWithContextSelector } from '../../components/TextAreaWithContextSelector';
 import { ActionModel, ActionSceneEnum } from '../base';
-import { handleLinkNavigation } from './LinkActionUtils';
+import { handleLinkNavigation, shouldDestroyViewAfterLinkNavigation } from './LinkActionUtils';
 
 export function joinUrlSearch(url: string, params: { name: string; value: any }[] = []): string {
   if (!params?.length) return url;
@@ -87,8 +87,15 @@ LinkActionModel.registerFlow({
             router: ctx.router,
             isExternalLink,
           });
-          // 仅在站内同窗口导航后销毁弹窗，避免外链/新窗口场景出现行为回归。
-          if (ctx.view && !openInNewWindow && !isExternalLink) {
+          // embed 是页面容器，不应销毁；仅弹窗视图在站内同窗口跳转后销毁。
+          if (
+            ctx.view &&
+            shouldDestroyViewAfterLinkNavigation({
+              openInNewWindow,
+              isExternalLink,
+              viewType: ctx.view.type,
+            })
+          ) {
             ctx.view.destroy();
           }
         } else {

--- a/packages/core/client/src/flow/models/actions/LinkActionUtils.ts
+++ b/packages/core/client/src/flow/models/actions/LinkActionUtils.ts
@@ -46,3 +46,20 @@ export function handleLinkNavigation(options: {
   // 在弹窗上下文中，错误的关闭时机会把新路由回滚为原页面。
   router.navigate(link, { replace: true });
 }
+
+/**
+ * 判断 Link 导航后是否需要销毁当前视图
+ * @param options 判定参数
+ * @param options.openInNewWindow 是否新窗口打开
+ * @param options.isExternalLink 是否外部链接
+ * @param options.viewType 当前视图类型
+ * @returns 是否应销毁当前视图
+ */
+export function shouldDestroyViewAfterLinkNavigation(options: {
+  openInNewWindow?: boolean;
+  isExternalLink: boolean;
+  viewType?: string;
+}) {
+  const { openInNewWindow, isExternalLink, viewType } = options;
+  return !openInNewWindow && !isExternalLink && viewType !== 'embed';
+}

--- a/packages/core/client/src/flow/models/actions/__tests__/LinkActionModel.test.ts
+++ b/packages/core/client/src/flow/models/actions/__tests__/LinkActionModel.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { handleLinkNavigation } from '../LinkActionUtils';
+import { handleLinkNavigation, shouldDestroyViewAfterLinkNavigation } from '../LinkActionUtils';
 
 describe('handleLinkNavigation', () => {
   it('should navigate relative link without closing popup view implicitly', () => {
@@ -57,5 +57,27 @@ describe('handleLinkNavigation', () => {
     expect(openWindow).toHaveBeenCalledWith(`${window.location.origin}/target-page`, '_blank');
     expect(navigate).not.toHaveBeenCalled();
     expect(setLocationHref).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldDestroyViewAfterLinkNavigation', () => {
+  it('should not destroy embed view for internal same-window link', () => {
+    expect(
+      shouldDestroyViewAfterLinkNavigation({
+        openInNewWindow: false,
+        isExternalLink: false,
+        viewType: 'embed',
+      }),
+    ).toBe(false);
+  });
+
+  it('should destroy popup view for internal same-window link', () => {
+    expect(
+      shouldDestroyViewAfterLinkNavigation({
+        openInNewWindow: false,
+        isExternalLink: false,
+        viewType: 'drawer',
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在弹窗详情中点击 Link 按钮时，原逻辑会先执行路由跳转，再立即执行 `ctx.view.close()`。在相对链接场景下，这会导致刚完成的内部导航被关闭弹窗行为回滚，最终表现为页面未按预期跳转，影响弹窗内 Link 动作的可用性。

### Description
本 PR 的关键改动如下：
- 将 Link 导航相关逻辑抽离到 `LinkActionUtils.ts`，统一处理不同类型链接。
- 对相对链接仅执行 `router.navigate(link, { replace: true })`，不再强制执行 `ctx.view.close()`，而是改为执行 `ctx.view.destroy()`，避免导航结果被覆盖。
- 保留外链与新窗口打开行为，确保原有能力不回退。
- 补充单元测试，覆盖内部导航与外部跳转路径。

潜在风险：
- 主要影响弹窗上下文中的 Link 行为；若其他场景复用了旧关闭策略，需关注行为是否与预期一致。

测试建议：
- 在弹窗详情中点击相对链接，确认跳转后页面保持在目标路由。
- 点击外部链接，确认仍按预期使用 `location.href` 或新窗口行为。

### Related issues
- N/A

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix popup link navigation being reverted after view close |
| 🇨🇳 Chinese | 修复弹窗详情中 Link 跳转结果被关闭视图回滚的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary