### PR TITLE
fix(client): avoid array filterByTk in desktop routes bulk updates

### DIFF
--- a/packages/core/client/src/schema-component/antd/menu/Menu.tsx
+++ b/packages/core/client/src/schema-component/antd/menu/Menu.tsx
@@ -244,10 +244,21 @@ export const useNocoBaseRoutes = (collectionName = 'desktopRoutes') => {
 
   const updateRoute = useCallback(
     async (filterByTk: any, values: NocoBaseDesktopRoute, refreshAfterUpdate = true) => {
-      const res = await resource.update({
-        filterByTk,
-        values,
-      });
+      const res = await resource.update(
+        Array.isArray(filterByTk)
+          ? {
+              filter: {
+                id: {
+                  $in: filterByTk,
+                },
+              },
+              values,
+            }
+          : {
+              filterByTk,
+              values,
+            },
+      );
       refreshAfterUpdate && refreshRoutes();
       return res;
     },

--- a/packages/plugins/@nocobase/plugin-client/src/client/routesTableSchema.tsx
+++ b/packages/plugins/@nocobase/plugin-client/src/client/routesTableSchema.tsx
@@ -133,22 +133,32 @@ export const createRoutesTableSchema = (collectionName: string, basename: string
               const { service } = useBlockRequestContext();
               const { refresh: refreshMenu } = useAllAccessDesktopRoutes();
               const { updateRoute } = useNocoBaseRoutes(collectionName);
+              const [isBatchUpdating, setIsBatchUpdating] = useState(false);
               return {
+                loading: isBatchUpdating,
                 async onClick() {
+                  if (isBatchUpdating) {
+                    return;
+                  }
                   const filterByTk = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
                   if (!filterByTk?.length) {
                     return;
                   }
-                  await updateRoutesInBatch(
-                    filterByTk,
-                    {
-                      hideInMenu: true,
-                    },
-                    updateRoute,
-                  );
-                  tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
-                  service?.refresh?.();
-                  refreshMenu();
+                  setIsBatchUpdating(true);
+                  try {
+                    await updateRoutesInBatch(
+                      filterByTk,
+                      {
+                        hideInMenu: true,
+                      },
+                      updateRoute,
+                    );
+                    tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
+                    service?.refresh?.();
+                    refreshMenu();
+                  } finally {
+                    setIsBatchUpdating(false);
+                  }
                 },
               };
             },
@@ -167,22 +177,34 @@ export const createRoutesTableSchema = (collectionName: string, basename: string
             'x-use-component-props': () => {
               const tableBlockContextBasicValue = useTableBlockContextBasicValue();
               const { service } = useBlockRequestContext();
+              const { refresh: refreshMenu } = useAllAccessDesktopRoutes();
               const { updateRoute } = useNocoBaseRoutes(collectionName);
+              const [isBatchUpdating, setIsBatchUpdating] = useState(false);
               return {
+                loading: isBatchUpdating,
                 async onClick() {
+                  if (isBatchUpdating) {
+                    return;
+                  }
                   const filterByTk = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
                   if (!filterByTk?.length) {
                     return;
                   }
-                  await updateRoutesInBatch(
-                    filterByTk,
-                    {
-                      hideInMenu: false,
-                    },
-                    updateRoute,
-                  );
-                  tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
-                  service?.refresh?.();
+                  setIsBatchUpdating(true);
+                  try {
+                    await updateRoutesInBatch(
+                      filterByTk,
+                      {
+                        hideInMenu: false,
+                      },
+                      updateRoute,
+                    );
+                    tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
+                    service?.refresh?.();
+                    refreshMenu();
+                  } finally {
+                    setIsBatchUpdating(false);
+                  }
                 },
               };
             },

--- a/packages/plugins/@nocobase/plugin-client/src/client/utils/__tests__/updateRoutesInBatch.test.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/client/utils/__tests__/updateRoutesInBatch.test.ts
@@ -11,15 +11,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { updateRoutesInBatch } from '../updateRoutesInBatch';
 
 describe('updateRoutesInBatch', () => {
-  it('should split selected row keys and update one by one', async () => {
+  it('should split selected row keys and update by batch', async () => {
     const updateRoute = vi.fn().mockResolvedValue(undefined);
 
     await updateRoutesInBatch([1, 2, 3], { hideInMenu: true }, updateRoute);
 
-    expect(updateRoute).toHaveBeenCalledTimes(3);
-    expect(updateRoute).toHaveBeenNthCalledWith(1, 1, { hideInMenu: true }, false);
-    expect(updateRoute).toHaveBeenNthCalledWith(2, 2, { hideInMenu: true }, false);
-    expect(updateRoute).toHaveBeenNthCalledWith(3, 3, { hideInMenu: true }, false);
+    expect(updateRoute).toHaveBeenCalledTimes(1);
+    expect(updateRoute).toHaveBeenNthCalledWith(1, [1, 2, 3], { hideInMenu: true }, false);
   });
 
   it('should ignore empty ids', async () => {
@@ -27,8 +25,39 @@ describe('updateRoutesInBatch', () => {
 
     await updateRoutesInBatch([1, null, '', 2, undefined], { hideInMenu: false }, updateRoute);
 
+    expect(updateRoute).toHaveBeenCalledTimes(1);
+    expect(updateRoute).toHaveBeenNthCalledWith(1, [1, 2], { hideInMenu: false }, false);
+  });
+
+  it('should trigger all batches concurrently', async () => {
+    let resolveFirstBatch!: () => void;
+    const updateRoute = vi.fn((routeIds: number[]) => {
+      if (routeIds[0] === 1) {
+        return new Promise<void>((resolve) => {
+          resolveFirstBatch = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+
+    const promise = updateRoutesInBatch(
+      Array.from({ length: 25 }, (_, index) => index + 1),
+      { hideInMenu: true },
+      updateRoute,
+    );
+
+    await Promise.resolve();
+
     expect(updateRoute).toHaveBeenCalledTimes(2);
-    expect(updateRoute).toHaveBeenNthCalledWith(1, 1, { hideInMenu: false }, false);
-    expect(updateRoute).toHaveBeenNthCalledWith(2, 2, { hideInMenu: false }, false);
+    expect(updateRoute).toHaveBeenNthCalledWith(
+      1,
+      Array.from({ length: 20 }, (_, index) => index + 1),
+      { hideInMenu: true },
+      false,
+    );
+    expect(updateRoute).toHaveBeenNthCalledWith(2, [21, 22, 23, 24, 25], { hideInMenu: true }, false);
+
+    resolveFirstBatch();
+    await promise;
   });
 });

--- a/packages/plugins/@nocobase/plugin-client/src/client/utils/updateRoutesInBatch.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/client/utils/updateRoutesInBatch.ts
@@ -9,10 +9,13 @@
 
 type UpdateRoute = (filterByTk: any, values: Record<string, any>, refreshAfterUpdate?: boolean) => Promise<any>;
 
+const BATCH_SIZE = 20;
+
 /**
  * 批量更新路由：
  * - selectedRowKeys 在表格批量操作里通常是数组；
- * - desktopRoutes:update 的 filterByTk 只能是单个主键，不能直接传数组。
+ * - desktopRoutes:update 的 filterByTk 只能是单个主键，不能直接传数组；
+ * - 为降低大批量时的总耗时，按固定批次并发更新。
  */
 export const updateRoutesInBatch = async (
   selectedRowKeys: any,
@@ -21,8 +24,12 @@ export const updateRoutesInBatch = async (
 ) => {
   const routeIds = Array.isArray(selectedRowKeys) ? selectedRowKeys : [selectedRowKeys];
   const validRouteIds = routeIds.filter((id) => id !== undefined && id !== null && id !== '');
+  const batchTasks: Promise<any>[] = [];
 
-  for (const routeId of validRouteIds) {
-    await updateRoute(routeId, values, false);
+  for (let index = 0; index < validRouteIds.length; index += BATCH_SIZE) {
+    const batchRouteIds = validRouteIds.slice(index, index + BATCH_SIZE);
+    batchTasks.push(updateRoute(batchRouteIds, values, false));
   }
+
+  await Promise.all(batchTasks);
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 Routes 页面执行批量操作（Select all -> Hide in menu / Show in menu）时存在三类问题：
1. 早期实现将 `selectedRowKeys` 数组传给 `desktopRoutes:update` 的 `filterByTk`，会导致 400。
2. 逐条更新在大量路由下请求数过多、耗时较长。
3. `Show in menu` 后顶部菜单未实时刷新，且批量更新期间缺少 loading 反馈。

### Description
本 PR 的关键改动如下：
- `updateRoute` 支持数组 id：当传入数组时改为 `filter[id][$in]` 调用 `desktopRoutes:update`，避免数组进入 `filterByTk`。
- `updateRoutesInBatch` 改为按 20 条切批，并发发起批次请求，显著降低请求数量与等待时间。
- `Hide in menu` / `Show in menu` 批量入口统一复用 `updateRoutesInBatch`。
- 修复 `Show in menu` 漏掉 `refreshMenu()` 的问题，保证顶部菜单实时刷新。
- 为 `Hide in menu` / `Show in menu` 增加按钮级 loading 状态，批量更新期间给出明确反馈。
- 补充并更新单元测试，覆盖：按批调用、空 id 过滤、批次并发触发。

潜在风险：
- 批量更新改为并发批次后，后端会短时间接收多次 `update` 请求；若后端未来引入更严格的限流策略，可能需要调整批次大小或并发度。

测试建议：
- 在 Routes 页面执行 Select all 后分别触发 Hide in menu / Show in menu。
- 观察网络请求应为 `desktopRoutes:update?filter[id][$in]`（每批最多 20 条 id），不再逐条单 id 请求。
- 验证 Show in menu 后顶部菜单实时恢复显示。
- 验证批量更新期间按钮 loading 生效，并在完成后恢复。

### Related issues
- N/A

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize desktop routes bulk hide/show with batched concurrent updates, realtime menu refresh, and loading state |
| 🇨🇳 Chinese | 优化桌面路由批量隐藏/显示：按批并发更新、实时刷新顶部菜单，并增加加载态反馈 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary