### PR TITLE
fix(table): fix delayed update after toggling hidden column

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
+++ b/packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx
@@ -26,6 +26,31 @@ import { useColumnSchema } from '../../../../schema-component/antd/table-v2/Tabl
 import { SchemaSettingsLinkageRules } from '../../../../schema-settings';
 import { SchemaSettingsDefaultValue } from '../../../../schema-settings/SchemaSettingsDefaultValue';
 import { isPatternDisabled } from '../../../../schema-settings/isPatternDisabled';
+
+/**
+ * 按 x-uid 在本地 schema 树中就地同步 x-component-props。
+ * 设计器里同一个列可能存在多个 schema 实例，服务端 patch 之前需要先把当前渲染树也同步。
+ */
+function patchSchemaComponentPropsByUid(
+  schema: ISchema | undefined,
+  uid: string,
+  componentProps: Record<string, any>,
+): boolean {
+  if (!schema) {
+    return false;
+  }
+  if (schema['x-uid'] === uid) {
+    schema['x-component-props'] = componentProps;
+    return true;
+  }
+  for (const child of Object.values(schema.properties || {})) {
+    if (patchSchemaComponentPropsByUid(child as ISchema, uid, componentProps)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export const tableColumnSettings = new SchemaSettings({
   name: 'fieldSettings:TableColumn',
   items: [
@@ -434,6 +459,7 @@ export const tableColumnSettings = new SchemaSettings({
             const { t } = useTranslation();
             const columnSchema = useFieldSchema();
             const { columnSchema: tableColumnSchema } = useColumnSchema();
+            const { fieldSchema: associationFieldSchema } = useAssociationFieldContext<any>() || {};
             const { dn } = useDesignable();
             const targetColumnSchema = tableColumnSchema || columnSchema;
 
@@ -455,16 +481,28 @@ export const tableColumnSettings = new SchemaSettings({
                 const schema: ISchema = {
                   ['x-uid']: targetColumnSchema['x-uid'],
                 };
-                targetColumnSchema['x-component-props'] = {
+                const nextComponentProps = {
                   ...targetColumnSchema['x-component-props'],
                   columnHidden: v,
                 };
-                schema['x-component-props'] = targetColumnSchema['x-component-props'];
+                // 子表格场景里菜单项所在 schema 与真实列 schema 可能不是同一个对象，二者都要同步更新。
+                targetColumnSchema['x-component-props'] = nextComponentProps;
+                columnSchema['x-component-props'] = {
+                  ...columnSchema['x-component-props'],
+                  columnHidden: v,
+                };
+                patchSchemaComponentPropsByUid(
+                  associationFieldSchema as unknown as ISchema,
+                  targetColumnSchema['x-uid'],
+                  nextComponentProps,
+                );
+                schema['x-component-props'] = nextComponentProps;
                 field.componentProps.columnHidden = v;
                 dn.emit('patch', {
                   schema,
                 });
-                dn.refresh();
+                // 子表格列由父级表格 schema 统一渲染，需要连同父级一起刷新才能立即生效。
+                dn.refresh({ refreshParentSchema: true });
               },
             };
           },

--- a/packages/core/client/src/schema-component/antd/association-field/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/Table.tsx
@@ -17,7 +17,7 @@ import { RecursionField, Schema, SchemaOptionsContext, observer, useField, useFi
 import { action } from '@formily/reactive';
 import { uid } from '@formily/shared';
 import { isPortalInBody } from '@nocobase/utils/client';
-import { useCreation, useDeepCompareEffect, useMemoizedFn } from 'ahooks';
+import { useDeepCompareEffect, useMemoizedFn } from 'ahooks';
 import { Table as AntdTable, Spin, TableColumnProps } from 'antd';
 import { default as classNames, default as cls } from 'classnames';
 import _, { omit } from 'lodash';
@@ -55,9 +55,6 @@ const useArrayField = (props) => {
   return (props.field || field) as ArrayField;
 };
 
-function getSchemaArrJSON(schemaArr: Schema[]) {
-  return schemaArr.map((item) => (item.name === 'actions' ? omit(item.toJSON(), 'properties') : item.toJSON()));
-}
 function adjustColumnOrder(columns) {
   const leftFixedColumns = [];
   const normalColumns = [];
@@ -75,17 +72,6 @@ function adjustColumnOrder(columns) {
 
   return [...leftFixedColumns, ...normalColumns, ...rightFixedColumns];
 }
-
-export const useColumnsDeepMemoized = (columns: any[]) => {
-  const columnsJSON = getSchemaArrJSON(columns);
-  const oldObj = useCreation(() => ({ value: _.cloneDeep(columnsJSON) }), []);
-
-  if (!_.isEqual(columnsJSON, oldObj.value)) {
-    oldObj.value = _.cloneDeep(columnsJSON);
-  }
-
-  return oldObj.value;
-};
 
 const TableColumnTitle = withTooltipComponent(RecursionField);
 
@@ -105,8 +91,6 @@ const useTableColumns = (props: { showDel?: any; isSubTable?: boolean }, paginat
     return buf;
   }, []);
   const { current, pageSize } = paginationProps;
-  const hasChangedColumns = useColumnsDeepMemoized(columnsSchema);
-
   const schemaToolbarBigger = useMemo(() => {
     return css`
       .nb-action-link {
@@ -180,9 +164,9 @@ const useTableColumns = (props: { showDel?: any; isSubTable?: boolean }, paginat
         } as TableColumnProps<any>;
       }),
 
-    // 这里不能把 columnsSchema 作为依赖，因为其每次都会变化，这里使用 hasChangedColumns 作为依赖
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hasChangedColumns, field.value, field.address, collection, parentRecordData, schemaToolbarBigger, designable],
+    // 子表格列配置（隐藏/删除）在设计器中会原地修改 schema，
+    // 这里要直接依赖 columnsSchema，确保每次修改都能触发列重算。
+    [columnsSchema, field.value, field.address, collection, parentRecordData, schemaToolbarBigger, designable, t],
   );
 
   const tableColumns = useMemo(() => {

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -179,14 +179,14 @@ const useTableColumns = (
   const { designable } = useDesignable();
   const { exists, render } = useSchemaInitializerRender(schema['x-initializer'], schema['x-initializer-props']);
 
-  const columnsSchemas = useMemo(() => {
-    return schema.reduceProperties((buf, s) => {
-      if (isColumnComponent(s) && schemaInWhitelist(Object.values(s.properties || {}).pop())) {
-        return buf.concat([s]);
-      }
-      return buf;
-    }, []);
-  }, [schema, schemaInWhitelist]);
+  // 列配置（隐藏/删除/顺序）在设计器中会对同一个 schema 对象做原地变更，
+  // 这里不能仅依赖引用级 memo，否则会出现配置已保存但界面不立即更新。
+  const columnsSchemas = schema.reduceProperties((buf, s) => {
+    if (isColumnComponent(s) && schemaInWhitelist(Object.values(s.properties || {}).pop())) {
+      return buf.concat([s]);
+    }
+    return buf;
+  }, []);
   const { current, pageSize } = paginationProps;
   const { isPopupVisibleControlledByURL } = usePopupSettings();
   const { refresh } = useRefreshTableColumns();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
此前修复后，子表格列配置仍有两个问题：
1. 开启 `Hide column` 后当前页面不立即生效，需要刷新后才生效。
2. 子表格连续删除列时，第 2 次删除后的列在当前页面不立即消失，需要刷新后才生效。

### Description
本次补充修复聚焦“设计器内 schema 原地变更后未触发即时重渲染”的问题，改动如下：

1. `packages/core/client/src/modules/blocks/data-blocks/table/tableColumnSettings.tsx`
- 在 `hidden` 开关的 `onChange` 中，除了 patch 目标列 schema，还同步当前渲染树中同 `x-uid` 的节点（按 uid 递归定位）。
- 同时同步菜单所在 `columnSchema` 的 `x-component-props.columnHidden`，避免不同 schema 实例状态不一致。
- `dn.refresh()` 调整为 `dn.refresh({ refreshParentSchema: true })`，确保子表格列由父级 schema 渲染时也能立即刷新。

2. `packages/core/client/src/schema-component/antd/association-field/Table.tsx`
- 移除对子表格列 schema 的深比较缓存（`useColumnsDeepMemoized`），避免“schema 内容变化但缓存命中”导致列不重算。
- 列计算依赖改为直接依赖 `columnsSchema`（及 `t`），保证隐藏/删除列后立即重算列定义。

3. `packages/core/client/src/schema-component/antd/table-v2/Table.tsx`
- 移除 `columnsSchemas` 的引用级 `useMemo`，改为每次渲染实时从 `schema.reduceProperties` 读取列。
- 解决设计器对同一 schema 对象原地变更时，引用未变导致 UI 不更新的问题。


### Showcase
- N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix delayed UI updates for subtable column hide toggle and consecutive column deletion |
| 🇨🇳 Chinese | 修复子表格列隐藏切换与连续删除列后界面延迟生效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
