### PR TITLE
fix(routes): normalize tree selection for batch hide/show

### DIFF
--- a/packages/plugins/@nocobase/plugin-client/src/client/routesTableSchema.tsx
+++ b/packages/plugins/@nocobase/plugin-client/src/client/routesTableSchema.tsx
@@ -41,6 +41,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTableBlockProps } from './useTableBlockProps';
 import { getSchemaUidByRouteId } from './utils';
+import { normalizeRouteIds, updateRoutesInBatch } from './utils/updateRoutesInBatch';
 
 const VariableTextArea = getVariableComponentWithScope(Variable.TextArea);
 
@@ -96,18 +97,19 @@ export const createRoutesTableSchema = (collectionName: string, basename: string
 
               return {
                 async onClick() {
-                  const filterByTk = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
-                  if (!filterByTk?.length) {
+                  const selectedRowKeys = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
+                  const routeIds = normalizeRouteIds(selectedRowKeys);
+                  if (!routeIds.length) {
                     return;
                   }
 
-                  for (const id of filterByTk) {
+                  for (const id of routeIds) {
                     const schemaUid = getSchemaUidByRouteId(id, data?.data, isMobile);
                     await deleteRouteSchema(schemaUid);
                   }
 
                   await resource.destroy({
-                    filterByTk,
+                    filterByTk: routeIds,
                   });
                   tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
                   service?.refresh?.();
@@ -134,13 +136,18 @@ export const createRoutesTableSchema = (collectionName: string, basename: string
               const { updateRoute } = useNocoBaseRoutes(collectionName);
               return {
                 async onClick() {
-                  const filterByTk = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
-                  if (!filterByTk?.length) {
+                  const selectedRowKeys = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
+                  const routeIds = normalizeRouteIds(selectedRowKeys);
+                  if (!routeIds.length) {
                     return;
                   }
-                  await updateRoute(filterByTk, {
-                    hideInMenu: true,
-                  });
+                  await updateRoutesInBatch(
+                    routeIds,
+                    {
+                      hideInMenu: true,
+                    },
+                    updateRoute,
+                  );
                   tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
                   service?.refresh?.();
                   refreshMenu();
@@ -165,13 +172,18 @@ export const createRoutesTableSchema = (collectionName: string, basename: string
               const { updateRoute } = useNocoBaseRoutes(collectionName);
               return {
                 async onClick() {
-                  const filterByTk = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
-                  if (!filterByTk?.length) {
+                  const selectedRowKeys = tableBlockContextBasicValue.field?.data?.selectedRowKeys;
+                  const routeIds = normalizeRouteIds(selectedRowKeys);
+                  if (!routeIds.length) {
                     return;
                   }
-                  await updateRoute(filterByTk, {
-                    hideInMenu: false,
-                  });
+                  await updateRoutesInBatch(
+                    routeIds,
+                    {
+                      hideInMenu: false,
+                    },
+                    updateRoute,
+                  );
                   tableBlockContextBasicValue.field.data.clearSelectedRowKeys?.();
                   service?.refresh?.();
                 },

--- a/packages/plugins/@nocobase/plugin-client/src/client/utils/__tests__/updateRoutesInBatch.test.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/client/utils/__tests__/updateRoutesInBatch.test.ts
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { normalizeRouteIds, updateRoutesInBatch } from '../updateRoutesInBatch';
+
+describe('normalizeRouteIds', () => {
+  it('should return checked keys for tree selection object', () => {
+    expect(normalizeRouteIds({ checked: [1, 2], halfChecked: [3] })).toEqual([1, 2]);
+  });
+
+  it('should fallback to selectedRowKeys in object format', () => {
+    expect(normalizeRouteIds({ selectedRowKeys: [4, 5] })).toEqual([4, 5]);
+  });
+});
+
+describe('updateRoutesInBatch', () => {
+  it('should split selected row keys and update one by one', async () => {
+    const updateRoute = vi.fn().mockResolvedValue(undefined);
+
+    await updateRoutesInBatch([1, 2, 3], { hideInMenu: true }, updateRoute);
+
+    expect(updateRoute).toHaveBeenCalledTimes(3);
+    expect(updateRoute).toHaveBeenNthCalledWith(1, 1, { hideInMenu: true }, false);
+    expect(updateRoute).toHaveBeenNthCalledWith(2, 2, { hideInMenu: true }, false);
+    expect(updateRoute).toHaveBeenNthCalledWith(3, 3, { hideInMenu: true }, false);
+  });
+
+  it('should ignore empty ids', async () => {
+    const updateRoute = vi.fn().mockResolvedValue(undefined);
+
+    await updateRoutesInBatch([1, null, '', 2, undefined], { hideInMenu: false }, updateRoute);
+
+    expect(updateRoute).toHaveBeenCalledTimes(2);
+    expect(updateRoute).toHaveBeenNthCalledWith(1, 1, { hideInMenu: false }, false);
+    expect(updateRoute).toHaveBeenNthCalledWith(2, 2, { hideInMenu: false }, false);
+  });
+
+  it('should handle tree selection object', async () => {
+    const updateRoute = vi.fn().mockResolvedValue(undefined);
+
+    await updateRoutesInBatch({ checked: [11, 12], halfChecked: [13] }, { hideInMenu: true }, updateRoute);
+
+    expect(updateRoute).toHaveBeenCalledTimes(2);
+    expect(updateRoute).toHaveBeenNthCalledWith(1, 11, { hideInMenu: true }, false);
+    expect(updateRoute).toHaveBeenNthCalledWith(2, 12, { hideInMenu: true }, false);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-client/src/client/utils/updateRoutesInBatch.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/client/utils/updateRoutesInBatch.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+type UpdateRoute = (filterByTk: any, values: Record<string, any>, refreshAfterUpdate?: boolean) => Promise<any>;
+
+export const normalizeRouteIds = (selectedRowKeys: any): any[] => {
+  if (Array.isArray(selectedRowKeys)) {
+    return selectedRowKeys;
+  }
+
+  if (selectedRowKeys && typeof selectedRowKeys === 'object') {
+    if (Array.isArray(selectedRowKeys.checked)) {
+      return selectedRowKeys.checked;
+    }
+    if (Array.isArray(selectedRowKeys.selectedRowKeys)) {
+      return selectedRowKeys.selectedRowKeys;
+    }
+  }
+
+  return [selectedRowKeys];
+};
+
+/**
+ * 批量更新路由：
+ * - selectedRowKeys 在表格批量操作里通常是数组；
+ * - tree 勾选时 selectedRowKeys 可能是 { checked, halfChecked }；
+ * - desktopRoutes:update 的 filterByTk 只能是单个主键，不能直接传数组。
+ */
+export const updateRoutesInBatch = async (
+  selectedRowKeys: any,
+  values: Record<string, any>,
+  updateRoute: UpdateRoute,
+) => {
+  const routeIds = normalizeRouteIds(selectedRowKeys);
+  const validRouteIds = routeIds.filter((id) => id !== undefined && id !== null && id !== '');
+
+  for (const routeId of validRouteIds) {
+    await updateRoute(routeId, values, false);
+  }
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 Routes 页面执行批量操作（Select all -> Hide in menu / Show in menu）时，树表格选择数据可能以 `checked` 或 `selectedRowKeys` 形式返回。此前逻辑未统一归一化 id，导致批量更新场景可能把不符合预期的数据结构传入更新流程，触发服务端 `filterByTk` 解析异常并返回 400，影响批量配置路由可见性的稳定性。

### Description
本 PR 的关键改动如下：
- 对树表格选择结果进行统一归一化，兼容 `checked` / `selectedRowKeys` 两种载荷，稳定提取路由 id。
- 在路由批量删除、批量隐藏、批量显示操作中复用归一化后的 id，避免批处理阶段出现错误 id 结构。
- 补充单元测试，覆盖树选择归一化与批量更新行为，确保回归稳定。

潜在风险：
- 影响范围集中在 Routes 页面批量操作路径，若第三方扩展依赖了旧的选择载荷结构，可能需要同步适配。

测试建议：
- 在 Routes 页面执行 Select all 后分别触发 Hide in menu / Show in menu / Delete，确认不再出现 400。
- 验证树形结构中父子节点混合选择场景，确认 id 解析与实际操作对象一致。

### Related issues
- N/A

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix route batch actions by normalizing tree selection ids |
| 🇨🇳 Chinese | 修复路由树批量操作因选择 id 未归一化导致的异常 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary