### PR TITLE
fix: reference block set props not working

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/ReferenceBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/ReferenceBlockModel.tsx
@@ -48,6 +48,26 @@ export class ReferenceBlockModel extends BlockModel {
     // - 支持写入：未知属性写入目标模型（若存在对应键）；否则写回自身。
     const proxy = new Proxy(this as any, {
       get(target, prop: string | symbol, receiver) {
+        // 显式转发：当引用区块已解析出目标模型时，props / setProps / getProps 必须指向目标模型
+        // 否则在引用壳子上设置 props 不会影响真正渲染的目标区块。
+        const t = target._targetModel as any;
+        if (t) {
+          if (prop === 'props') return t.props;
+          if (prop === 'setProps' && typeof t.setProps === 'function') {
+            return (...args: any[]) => {
+              const res = t.setProps(...args);
+              // 当目标模型 setProps 以 object 形式替换 props 对象时，保持引用壳子的 props 指针同步
+              // 以支持 ctx.model.props.xxx 的写法在后续继续指向目标 props
+              try {
+                target.props = t.props;
+              } catch (_) {
+                // ignore
+              }
+              return res;
+            };
+          }
+          if (prop === 'getProps' && typeof t.getProps === 'function') return t.getProps.bind(t);
+        }
         if (prop in target) {
           // 自身已有（含原型链）则直接返回；若为函数需绑定到 target，避免 private field 访问报错
           const val = Reflect.get(target, prop, target);
@@ -56,7 +76,6 @@ export class ReferenceBlockModel extends BlockModel {
           }
           return val;
         }
-        const t = target._targetModel as any;
         if (t) {
           const val = Reflect.get(t, prop, t);
           if (typeof val === 'function' && prop !== 'constructor') {
@@ -67,10 +86,21 @@ export class ReferenceBlockModel extends BlockModel {
         return undefined;
       },
       set(target, prop: string | symbol, value, receiver) {
+        // 显式转发：允许直接替换 props（少见但能避免写到壳子导致不生效）
+        const t = target._targetModel as any;
+        if (t && prop === 'props') {
+          const ok = Reflect.set(t, prop, value, t);
+          // 同步壳子 props 指针，避免后续 ctx.model.props 仍指向旧对象
+          try {
+            target.props = t.props;
+          } catch (_) {
+            // ignore
+          }
+          return ok;
+        }
         if (prop in target) {
           return Reflect.set(target, prop, value, target);
         }
-        const t = target._targetModel as any;
         if (t && prop in t) {
           return Reflect.set(t, prop, value, t);
         }
@@ -102,6 +132,7 @@ export class ReferenceBlockModel extends BlockModel {
   public settingsMenuLevel = 2;
   private _scopedEngine?: FlowEngine;
   private _targetModel?: FlowModel;
+  private _localProps?: Record<string, any>;
   private _resolvedTargetUid?: string;
   private _invalidTargetUid?: string;
 
@@ -128,6 +159,8 @@ export class ReferenceBlockModel extends BlockModel {
 
   onInit(option) {
     super.onInit(option);
+    // 保存本地 props，用于在目标未解析/被清空时回退到引用壳子自身
+    this._localProps = this.props as any;
     this.context.defineProperty('refModel', {
       get: () => this._targetModel,
       cache: false,
@@ -145,6 +178,28 @@ export class ReferenceBlockModel extends BlockModel {
         get: () => getTargetContext()?.[key],
       });
     });
+  }
+
+  // 让 `ctx.model.setProps/getProps` 在引用区块场景下也作用到目标模型
+  setProps(props: any, value?: any): void {
+    const t = this._targetModel as any;
+    if (t && typeof t.setProps === 'function') {
+      t.setProps(props, value);
+      // 保持 ctx.model.props.xxx 写法指向目标 props
+      this.props = t.props;
+      return;
+    }
+    // 目标未解析：修改本地 props，并同步 _localProps 指针（处理 object form setProps 会替换对象的情况）
+    super.setProps(props as any, value as any);
+    this._localProps = this.props as any;
+  }
+
+  getProps(): any {
+    const t = this._targetModel as any;
+    if (t && typeof t.getProps === 'function') {
+      return t.getProps();
+    }
+    return super.getProps() as any;
   }
 
   private _getTargetUidFromParams(): string | undefined {
@@ -221,12 +276,18 @@ export class ReferenceBlockModel extends BlockModel {
       this._resolvedTargetUid = undefined;
       this._invalidTargetUid = undefined;
       (this.subModels as any)['target'] = undefined;
+      // 目标为空：回退到引用壳子本地 props
+      if (this._localProps) {
+        this.props = this._localProps as any;
+      }
       return;
     }
 
     this._syncExtraTitle(true);
     if (this._resolvedTargetUid === targetUid && this._targetModel) {
       this._invalidTargetUid = undefined;
+      // 目标未变化：确保 props 仍指向目标模型（避免 target.setProps 替换对象后指针失效）
+      this.props = this._targetModel.props;
       return;
     }
     // 进入解析流程：先清理 invalid 标记，避免渲染层误判为 invalid
@@ -252,6 +313,10 @@ export class ReferenceBlockModel extends BlockModel {
       this._resolvedTargetUid = undefined;
       this._invalidTargetUid = targetUid;
       (this.subModels as any)['target'] = undefined;
+      // 目标非法：回退到引用壳子本地 props
+      if (this._localProps) {
+        this.props = this._localProps as any;
+      }
       this.rerender();
       return;
     }
@@ -273,6 +338,9 @@ export class ReferenceBlockModel extends BlockModel {
     this._targetModel = target;
     this._resolvedTargetUid = targetUid;
     this._invalidTargetUid = undefined;
+    // 关键：让 ctx.model.props.xxx 的写法在引用区块中也能作用到目标区块
+    // - beforeRender 的 flows 会在 onDispatchEventStart 之后执行，因此这里同步可以保证事件流拿到的是目标 props
+    this.props = target.props;
     this.rerender();
   }
 

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/ReferenceBlockModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/ReferenceBlockModel.test.tsx
@@ -544,4 +544,72 @@ describe('ReferenceBlockModel', () => {
       TEST_TIMEOUT,
     );
   });
+
+  describe('Props forwarding', () => {
+    it(
+      'should forward props mutations to target model after beforeRender',
+      async () => {
+        referenceBlockModel = engine.createModel({
+          uid: 'reference-block-uid',
+          use: 'ReferenceBlockModel',
+          parentId: 'grid-uid',
+          subKey: 'items',
+          subType: 'array',
+          stepParams: {
+            referenceSettings: {
+              target: {
+                targetUid: 'target-block-uid',
+                mode: 'reference',
+              },
+            },
+          },
+        }) as ReferenceBlockModel;
+
+        gridModel.addSubModel('items', referenceBlockModel);
+
+        await referenceBlockModel.dispatchEvent('beforeRender');
+
+        const target = (referenceBlockModel as any)._targetModel as FlowModel | undefined;
+        expect(target).toBeTruthy();
+        expect(referenceBlockModel.props).toBe(target!.props);
+
+        (referenceBlockModel.props as any).summary = 'x';
+        expect((target!.props as any).summary).toBe('x');
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      'should forward setProps/getProps to target model',
+      async () => {
+        referenceBlockModel = engine.createModel({
+          uid: 'reference-block-uid',
+          use: 'ReferenceBlockModel',
+          parentId: 'grid-uid',
+          subKey: 'items',
+          subType: 'array',
+          stepParams: {
+            referenceSettings: {
+              target: {
+                targetUid: 'target-block-uid',
+                mode: 'reference',
+              },
+            },
+          },
+        }) as ReferenceBlockModel;
+
+        gridModel.addSubModel('items', referenceBlockModel);
+
+        await referenceBlockModel.dispatchEvent('beforeRender');
+
+        const target = (referenceBlockModel as any)._targetModel as FlowModel | undefined;
+        expect(target).toBeTruthy();
+
+        referenceBlockModel.setProps({ summary: 'y' as any });
+        expect((target!.props as any).summary).toBe('y');
+        expect((referenceBlockModel.getProps() as any).summary).toBe('y');
+      },
+      TEST_TIMEOUT,
+    );
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where changes to props made in a template block’s event flow did not take effect. |
| 🇨🇳 Chinese | 修复模板区块事件流修改props时不生效的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
