### PR TITLE
fix(database): updating the default value of a JSON field does not take effect

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/field-options/default-value.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/field-options/default-value.test.ts
@@ -90,4 +90,50 @@ describe('field defaultValue', () => {
     const item = await app.agent().resource('test1').get();
     expect(item.body.data.field1).toBeNull();
   });
+
+  it('should replace object defaultValue instead of merge', async () => {
+    await app
+      .agent()
+      .resource('collections.fields', 'test1')
+      .create({
+        values: {
+          name: 'field2',
+          type: 'json',
+          defaultValue: {
+            keep: true,
+            nested: {
+              a: 1,
+            },
+          },
+        },
+      });
+
+    await app
+      .agent()
+      .resource('collections.fields', 'test1')
+      .update({
+        filterByTk: 'field2',
+        values: {
+          type: 'json',
+          defaultValue: {
+            nested: {
+              b: 2,
+            },
+          },
+        },
+      });
+
+    const field = await app.db.getRepository('fields').findOne({
+      filter: {
+        collectionName: 'test1',
+        name: 'field2',
+      },
+    });
+
+    expect(field.get('defaultValue')).toEqual({
+      nested: {
+        b: 2,
+      },
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/models/field.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/models/field.ts
@@ -24,6 +24,28 @@ export class FieldModel extends MagicAttributeModel {
     return (<any>this.constructor).database;
   }
 
+  set(key: any, value?: any, options?: any) {
+    if (typeof key === 'string') {
+      if (key === 'defaultValue') {
+        // `defaultValue` should replace as a whole value, not deep-merge.
+        return this.setV1(`${this.magicAttribute}.defaultValue`, value, options);
+      }
+      return super.set(key, value, options);
+    }
+
+    if (_.isPlainObject(key) && Object.prototype.hasOwnProperty.call(key, 'defaultValue')) {
+      const { defaultValue, ...rest } = key;
+      const setOptions = value;
+      if (Object.keys(rest).length) {
+        super.set(rest, setOptions);
+      }
+      this.setV1(`${this.magicAttribute}.defaultValue`, defaultValue, setOptions);
+      return this;
+    }
+
+    return super.set(key, value, options);
+  }
+
   isAssociationField() {
     return ['belongsTo', 'hasOne', 'hasMany', 'belongsToMany'].includes(this.get('type'));
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Updating the default value of a JSON field does not take effect          |
| 🇨🇳 Chinese |  更新 JSON 字段默认值不生效         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
