### PR TITLE
fix(flow): skip hidden field validation

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/FormActionModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormActionModel.tsx
@@ -12,6 +12,7 @@ import { ButtonProps } from 'antd';
 import { AxiosRequestConfig } from 'axios';
 import { ActionModel } from '../../base';
 import { submitHandler } from './submitHandler';
+import { getValidationNamePathsExcludingHiddenModels } from './submitValues';
 
 export class FormActionModel extends ActionModel {}
 
@@ -52,7 +53,16 @@ FormSubmitActionModel.registerFlow({
       async handler(ctx, params) {
         if (params.enable) {
           try {
-            await ctx.form.validateFields();
+            const validateNamePaths = ctx?.flowSettingsEnabled
+              ? getValidationNamePathsExcludingHiddenModels(ctx.blockModel)
+              : null;
+            if (Array.isArray(validateNamePaths)) {
+              if (validateNamePaths.length) {
+                await ctx.form.validateFields(validateNamePaths as any);
+              }
+            } else {
+              await ctx.form.validateFields();
+            }
             const confirmed = await ctx.modal.confirm({
               title: ctx.t(params.title, { ns: 'lm-flow-engine' }),
               content: ctx.t(params.content, { ns: 'lm-flow-engine' }),

--- a/packages/core/client/src/flow/models/blocks/form/__tests__/submitValues.test.ts
+++ b/packages/core/client/src/flow/models/blocks/form/__tests__/submitValues.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { FlowEngine, FlowModel, SingleRecordResource } from '@nocobase/flow-engine';
 // 直接从 models 聚合导入，避免局部文件相互引用顺序导致的循环依赖
 import { FormBlockModel } from '../../../..';
-import { omitHiddenModelValuesFromSubmit } from '../submitValues';
+import { getValidationNamePathsExcludingHiddenModels, omitHiddenModelValuesFromSubmit } from '../submitValues';
 
 class TestFormModel extends FormBlockModel {
   createResource(ctx: any, _params: any) {
@@ -121,5 +121,45 @@ describe('omitHiddenModelValuesFromSubmit', () => {
     createFieldModel(engine, 'field-ab', blockModel, { hidden: true, stepFieldPath: 'a.b' });
 
     expect(omitHiddenModelValuesFromSubmit({ a: { b: 1 } }, blockModel)).toEqual({});
+  });
+});
+
+describe('getValidationNamePathsExcludingHiddenModels', () => {
+  it('excludes hidden field paths from validation name list', () => {
+    const engine = createEngine();
+    const blockModel = createFormBlock(engine, 'block-1');
+    createFieldModel(engine, 'field-b', blockModel, { hidden: true, fieldPathArray: ['b'] });
+    (blockModel.context as any).defineProperty('form', {
+      value: {
+        getFieldsError: () => [{ name: ['a'] }, { name: ['b'] }],
+      },
+    });
+
+    expect(getValidationNamePathsExcludingHiddenModels(blockModel)).toEqual([['a']]);
+  });
+
+  it('keeps validation names when field uses hidden reserved value semantics', () => {
+    const engine = createEngine();
+    const blockModel = createFormBlock(engine, 'block-1');
+    createFieldModel(engine, 'field-b', blockModel, { hidden: false, fieldPathArray: ['b'], props: { hidden: true } });
+    (blockModel.context as any).defineProperty('form', {
+      value: {
+        getFieldsError: () => [{ name: ['a'] }, { name: ['b'] }],
+      },
+    });
+
+    expect(getValidationNamePathsExcludingHiddenModels(blockModel)).toEqual([['a'], ['b']]);
+  });
+
+  it('returns null when no registered field names are available', () => {
+    const engine = createEngine();
+    const blockModel = createFormBlock(engine, 'block-1');
+    (blockModel.context as any).defineProperty('form', {
+      value: {
+        getFieldsError: () => [],
+      },
+    });
+
+    expect(getValidationNamePathsExcludingHiddenModels(blockModel)).toBeNull();
   });
 });

--- a/packages/core/client/src/flow/models/blocks/form/submitHandler.ts
+++ b/packages/core/client/src/flow/models/blocks/form/submitHandler.ts
@@ -10,13 +10,20 @@
 import { MultiRecordResource, SingleRecordResource } from '@nocobase/flow-engine';
 import { EditFormModel } from './EditFormModel';
 import type { FormBlockModel } from './FormBlockModel';
-import { omitHiddenModelValuesFromSubmit } from './submitValues';
+import { getValidationNamePathsExcludingHiddenModels, omitHiddenModelValuesFromSubmit } from './submitValues';
 
 export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?: any) => void) {
   const resource = ctx.resource;
   const blockModel = ctx.blockModel as FormBlockModel;
 
-  await blockModel.form.validateFields();
+  const validateNamePaths = ctx?.flowSettingsEnabled ? getValidationNamePathsExcludingHiddenModels(blockModel) : null;
+  if (Array.isArray(validateNamePaths)) {
+    if (validateNamePaths.length) {
+      await blockModel.form.validateFields(validateNamePaths as any);
+    }
+  } else {
+    await blockModel.form.validateFields();
+  }
   const rawValues = blockModel.form.getFieldsValue(true);
   const values = omitHiddenModelValuesFromSubmit(rawValues, blockModel);
   if (resource instanceof SingleRecordResource) {

--- a/packages/core/client/src/flow/models/blocks/form/submitValues.ts
+++ b/packages/core/client/src/flow/models/blocks/form/submitValues.ts
@@ -89,19 +89,9 @@ function forEachModelIncludingForks(engine: any, visitor: (model: any) => void) 
   });
 }
 
-/**
- * 提交前过滤：移除当前表单 block 中被「联动规则隐藏」的字段值（`model.hidden === true`）。
- *
- * 说明：
- * - 仅对 “隐藏 / Hidden” 生效（对应 `model.hidden=true`）。
- * - “隐藏并保留值 / Hidden (reserved value)” 在实现上是 `props.hidden=true` 但 `model.hidden=false`，
- *   因此仍会提交（保持现有语义）。
- * - 不会清空 antd Form 的内部 store，只影响本次提交 payload。
- */
-export function omitHiddenModelValuesFromSubmit<T = any>(values: T, blockModel: FormBlockModel): T {
-  if (!values || typeof values !== 'object') return values;
+function collectHiddenModelNamePaths(blockModel: FormBlockModel): NamePath[] {
   const engine = blockModel?.flowEngine;
-  if (!engine?.forEachModel) return values;
+  if (!engine?.forEachModel) return [];
 
   const paths: NamePath[] = [];
   const seen = new Set<string>();
@@ -119,6 +109,74 @@ export function omitHiddenModelValuesFromSubmit<T = any>(values: T, blockModel: 
     seen.add(key);
     paths.push(namePath);
   });
+
+  return paths;
+}
+
+function normalizeFormNamePath(name: any): NamePath | null {
+  if (typeof name === 'string') {
+    return name ? [name] : null;
+  }
+  if (Array.isArray(name)) {
+    return normalizeResolvedNamePath(name as NamePath);
+  }
+  return null;
+}
+
+function isNamePathPrefix(prefix: NamePath, target: NamePath): boolean {
+  if (!Array.isArray(prefix) || !Array.isArray(target)) return false;
+  if (prefix.length > target.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (prefix[i] !== target[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * 生成提交前的校验字段列表：
+ * - 在配置态下可用于绕开“联动隐藏字段”的必填校验；
+ * - 仅排除 `model.hidden=true` 的字段路径；
+ * - 返回 null 表示无法安全推断，调用方应回退到 `validateFields()` 全量校验。
+ */
+export function getValidationNamePathsExcludingHiddenModels(blockModel: FormBlockModel): NamePath[] | null {
+  const form = blockModel?.form as any;
+  if (!form || typeof form.getFieldsError !== 'function') return null;
+
+  const fieldErrors = form.getFieldsError();
+  if (!Array.isArray(fieldErrors)) return null;
+
+  const names: NamePath[] = [];
+  const seen = new Set<string>();
+  for (const item of fieldErrors) {
+    const namePath = normalizeFormNamePath(item?.name);
+    if (!namePath) continue;
+    const key = JSON.stringify(namePath);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    names.push(namePath);
+  }
+
+  // 无法可靠获取已注册字段时，回退到调用方全量校验，避免误跳过可见字段。
+  if (!names.length) return null;
+
+  const hiddenPaths = collectHiddenModelNamePaths(blockModel);
+  if (!hiddenPaths.length) return names;
+
+  return names.filter((namePath) => !hiddenPaths.some((hiddenPath) => isNamePathPrefix(hiddenPath, namePath)));
+}
+
+/**
+ * 提交前过滤：移除当前表单 block 中被「联动规则隐藏」的字段值（`model.hidden === true`）。
+ *
+ * 说明：
+ * - 仅对 “隐藏 / Hidden” 生效（对应 `model.hidden=true`）。
+ * - “隐藏并保留值 / Hidden (reserved value)” 在实现上是 `props.hidden=true` 但 `model.hidden=false`，
+ *   因此仍会提交（保持现有语义）。
+ * - 不会清空 antd Form 的内部 store，只影响本次提交 payload。
+ */
+export function omitHiddenModelValuesFromSubmit<T = any>(values: T, blockModel: FormBlockModel): T {
+  if (!values || typeof values !== 'object') return values;
+  const paths = collectHiddenModelNamePaths(blockModel);
 
   if (!paths.length) return values;
 

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/actions/PopupSubTableFormSubmitActionModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/actions/PopupSubTableFormSubmitActionModel.tsx
@@ -10,7 +10,10 @@
 import { tExpr } from '@nocobase/flow-engine';
 import { ButtonProps } from 'antd';
 import { ActionGroupModel, ActionModel } from '../../../../base';
-import { omitHiddenModelValuesFromSubmit } from '../../../../blocks/form/submitValues';
+import {
+  getValidationNamePathsExcludingHiddenModels,
+  omitHiddenModelValuesFromSubmit,
+} from '../../../../blocks/form/submitValues';
 
 function matchPath(paths: string[], key: string) {
   return paths.find((p) => p === key || p.endsWith(`.${key}`)) ?? key;
@@ -42,7 +45,16 @@ PopupSubTableFormSubmitActionModel.registerFlow({
       async handler(ctx, params) {
         if (params.enable) {
           try {
-            await ctx.form.validateFields();
+            const validateNamePaths = ctx?.flowSettingsEnabled
+              ? getValidationNamePathsExcludingHiddenModels(ctx.blockModel)
+              : null;
+            if (Array.isArray(validateNamePaths)) {
+              if (validateNamePaths.length) {
+                await ctx.form.validateFields(validateNamePaths as any);
+              }
+            } else {
+              await ctx.form.validateFields();
+            }
             const confirmed = await ctx.modal.confirm({
               title: ctx.t(params.title, { ns: 'lm-flow-engine' }),
               content: ctx.t(params.content, { ns: 'lm-flow-engine' }),
@@ -70,7 +82,16 @@ PopupSubTableFormSubmitActionModel.registerFlow({
         const parentUpdateAssociations = parentResource.getUpdateAssociationValues();
         const prefixPath = matchPath(parentUpdateAssociations, associationName);
         try {
-          await blockModel.form.validateFields();
+          const validateNamePaths = ctx?.flowSettingsEnabled
+            ? getValidationNamePathsExcludingHiddenModels(blockModel)
+            : null;
+          if (Array.isArray(validateNamePaths)) {
+            if (validateNamePaths.length) {
+              await blockModel.form.validateFields(validateNamePaths as any);
+            }
+          } else {
+            await blockModel.form.validateFields();
+          }
           const rawValues = blockModel.form.getFieldsValue(true);
           const values = omitHiddenModelValuesFromSubmit(rawValues, blockModel);
           subTableModel.dispatchEvent('updateRow', {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在配置模式下，联动规则将字段设为 Hidden 后，该字段仍会参与提交前必填校验，导致提交时出现不符合预期的必填报错；而非配置模式下不会出现该问题。需要统一行为，确保被联动隐藏的字段不参与校验。

### Description 
- 新增 `getValidationNamePathsExcludingHiddenModels`，基于当前表单已注册字段，过滤掉 `model.hidden=true` 的字段路径
- 在主表单提交流程与提交前确认流程中，配置模式改为按过滤后的字段列表执行 `validateFields`
- 在 Popup 子表单提交与确认流程中同步使用同一过滤逻辑，保持行为一致
- 保留 `Hidden (reserved value)` 语义：仅 `props.hidden=true` 且 `model.hidden=false` 的字段仍参与校验与提交
- 补充单测覆盖隐藏字段过滤与回退分支

潜在风险：
- 该逻辑依赖 `getFieldsError()` 返回的已注册字段名；当无法可靠获取字段名时会回退到全量校验，以避免漏校验可见字段

测试建议：
- 在配置模式下复测联动 `Hidden` + `required` 字段，提交不应出现该字段必填错误
- 在非配置模式下复测同页面，行为保持不变
- 复测 `Hidden (reserved value)` 场景，确认仍按既有语义校验/提交


### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix validation for linkage-hidden required fields in config mode |
| 🇨🇳 Chinese | 修复配置模式下联动隐藏必填字段仍被校验的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
