### PR TITLE
fix(core/server): parseFilter with not db type datasource shoul not occur error

### DIFF
--- a/packages/core/server/src/__tests__/middlewares/parse-variables.test.ts
+++ b/packages/core/server/src/__tests__/middlewares/parse-variables.test.ts
@@ -1,0 +1,60 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { parseVariables } from '../../middlewares/parse-variables';
+
+describe('parse variables middleware', () => {
+  it('should resolve field from rest-api collection manager when ctx.database is missing', async () => {
+    const getField = vi.fn(() => undefined);
+    const getCollection = vi.fn(() => ({
+      getField,
+    }));
+
+    const ctx: any = {
+      action: {
+        resourceName: 'tasks',
+        params: {
+          filter: {
+            start_date: {
+              $dateOn: {
+                type: 'today',
+              },
+            },
+          },
+        },
+      },
+      state: {},
+      get: (key: string) => (key === 'x-timezone' ? '+08:00' : ''),
+      dataSource: {
+        collectionManager: {
+          getCollection,
+        },
+      },
+      db: {
+        getFieldByPath: vi.fn(() => {
+          throw new Error('should not fallback to ctx.db for rest-api data source');
+        }),
+      },
+    };
+
+    const next = vi.fn(async () => {});
+    await parseVariables(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(getCollection).toHaveBeenCalledWith('tasks');
+    expect(getField).toHaveBeenCalledWith('start_date');
+    const parsed = ctx.action.params.filter.start_date.$dateOn;
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(4);
+    expect(typeof parsed[0]).toBe('string');
+    expect(typeof parsed[1]).toBe('string');
+    expect(['[]', '[)']).toContain(parsed[2]);
+    expect(parsed[3]).toBe('+08:00');
+  });
+});

--- a/packages/core/server/src/helper.ts
+++ b/packages/core/server/src/helper.ts
@@ -223,17 +223,57 @@ function isNumeric(str: any) {
   return !isNaN(str as any) && !isNaN(parseFloat(str));
 }
 
+function getFieldFromCollectionManager(ctx, resourceName: string, fieldPath: string) {
+  const collectionManager = ctx.dataSource?.collectionManager;
+  if (!collectionManager?.getCollection) {
+    return;
+  }
+
+  const collection = collectionManager.getCollection(resourceName);
+  if (!collection?.getField) {
+    return;
+  }
+
+  const [firstName, ...others] = fieldPath.split('.');
+  let field = collection.getField(firstName);
+  if (!field || !others.length) {
+    return field;
+  }
+
+  let currentCollection =
+    typeof field.targetCollection === 'function' ? field.targetCollection() : field.targetCollection;
+
+  for (const name of others) {
+    if (!currentCollection?.getField) {
+      return;
+    }
+    field = currentCollection.getField(name);
+    if (!field) {
+      return;
+    }
+    currentCollection =
+      typeof field.targetCollection === 'function' ? field.targetCollection() : field.targetCollection;
+  }
+
+  return field;
+}
+
 export function createContextVariablesScope(ctx) {
   const state = JSON.parse(JSON.stringify(ctx.state));
   return {
     timezone: ctx.get('x-timezone'),
     now: new Date().toISOString(),
     getField: (path) => {
+      const { resourceName } = ctx.action;
       const fieldPath = path
         .split('.')
         .filter((p) => !p.startsWith('$') && !isNumeric(p))
         .join('.');
-      const { resourceName } = ctx.action;
+
+      if (!ctx.database) {
+        return getFieldFromCollectionManager(ctx, resourceName, fieldPath);
+      }
+
       return ctx.database.getFieldByPath(`${resourceName}.${fieldPath}`);
     },
     vars: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
if datasouce not a database datasource error will occur in parseFilter

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the error issue in data queries of non-database data sources |
| 🇨🇳 Chinese | 修复非数据库类数据源表格查询报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
