### PR TITLE
fix(core/client): view template missing field `simplePaginate`

### DIFF
--- a/packages/core/client/src/collection-manager/templates/view.tsx
+++ b/packages/core/client/src/collection-manager/templates/view.tsx
@@ -149,6 +149,7 @@ export class ViewCollectionTemplate extends CollectionTemplate {
         },
       },
     },
+    ...getConfigurableProperties('category', 'description', 'simplePaginate'),
     filterTargetKey: {
       title: `{{ t("Record unique key")}}`,
       type: 'single',
@@ -160,6 +161,5 @@ export class ViewCollectionTemplate extends CollectionTemplate {
       },
       'x-reactions': ['{{useAsyncDataSource(loadFilterTargetKeys)}}'],
     },
-    ...getConfigurableProperties('category', 'description'),
   };
 }

--- a/packages/core/database/src/__tests__/view/view-repository.test.ts
+++ b/packages/core/database/src/__tests__/view/view-repository.test.ts
@@ -72,5 +72,10 @@ describe('view repository', () => {
 
     expect(results[0].length).toBe(1);
     expect(results[1]).toBe(4);
+
+    const rows = await viewCollection.repository.find({ limit: 4, order: [['aaa', 'ASC']] });
+    expect(rows.length).toBe(4);
+    expect(rows[0].toJSON().aaa).toBe(1);
+    expect(rows[3].toJSON().aaa).toBe(4);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
view template missing field `simplePaginate`

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed missing 'Simple Pagination' option in collection`s view template. |
| 🇨🇳 Chinese | 修复数据表的视图模板缺少`简单分页`选项问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
