### PR TITLE
fix: forbid adding m2m_array associated records block

### DIFF
--- a/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
+++ b/packages/core/client/src/flow/models/base/CollectionBlockModel.tsx
@@ -248,6 +248,9 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
                 if (!field.targetCollection) {
                   return null;
                 }
+                if (field.type === 'belongsToArray') {
+                  return null;
+                }
                 if (!this.filterCollection(field.targetCollection)) {
                   return null;
                 }
@@ -297,6 +300,9 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
             .getAssociationFields(this._getScene())
             .map((field) => {
               if (!field.targetCollection) {
+                return null;
+              }
+              if (field.type === 'belongsToArray') {
                 return null;
               }
               if (!this.filterCollection(field.targetCollection)) {

--- a/packages/core/client/src/flow/models/base/__tests__/CollectionBlockModel.newScene.associatedRecordsVisibility.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/CollectionBlockModel.newScene.associatedRecordsVisibility.test.ts
@@ -93,4 +93,67 @@ describe('CollectionBlockModel defineChildren - new scene associated records vis
     const hasAssociated = children.some((item) => String(item?.key).includes('associated'));
     expect(hasAssociated).toBe(true);
   });
+
+  it('filters out belongsToArray fields in "Associated records" children', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ NewSceneCollectionBlockModel });
+
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds.addCollection({
+      name: 'orders',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'user_id', type: 'integer', interface: 'number' },
+      ],
+    });
+    ds.addCollection({
+      name: 'orgs',
+      filterTargetKey: 'id',
+      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+    });
+    ds.addCollection({
+      name: 'users',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        {
+          name: 'orders',
+          title: 'Orders',
+          type: 'hasMany',
+          target: 'orders',
+          interface: 'o2m',
+          foreignKey: 'user_id',
+        },
+        {
+          name: 'orgs',
+          title: 'Orgs',
+          type: 'belongsToMany',
+          target: 'orgs',
+          interface: 'm2m',
+        },
+        {
+          name: 'org_m2marray',
+          title: 'Org M2M Array',
+          type: 'belongsToArray',
+          target: 'orgs',
+          interface: 'm2mArray',
+        },
+      ],
+    });
+
+    const designerCtx = {
+      dataSourceManager: engine.dataSourceManager,
+      view: { inputArgs: { dataSourceKey: 'main', collectionName: 'users', filterByTk: 1 } },
+    } as any;
+
+    const children = (await NewSceneCollectionBlockModel.defineChildren(designerCtx)) as any[];
+    const associated = children.find((item) => String(item?.key).includes('associated'));
+    expect(associated).toBeTruthy();
+
+    const associatedChildren = (associated.children?.() || []) as any[];
+    expect(associatedChildren.some((item) => String(item?.key).includes('associated-orders'))).toBe(true);
+    expect(associatedChildren.some((item) => String(item?.key).includes('associated-orgs'))).toBe(true);
+    expect(associatedChildren.some((item) => String(item?.key).includes('associated-org_m2marray'))).toBe(false);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Disabled adding blocks for many-to-many (array) associatied records to prevent errors. |
| 🇨🇳 Chinese | 隐藏多对多（数组）关系记录区块添加，防止报错。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
