### PR TITLE
fix: list block missing current record context

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListItemModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListItemModel.tsx
@@ -57,6 +57,19 @@ export class ListItemModel extends FlowModel<ListItemModelStructure> {
     const grid = this.subModels.grid.createFork({}, `grid-${index}`) as any;
 
     grid.gridContainerRef = React.createRef<HTMLDivElement>();
+    const gridRecordMeta: PropertyMetaFactory = createRecordMetaFactory(
+      () => grid.context.collection,
+      grid.context.t('Current record'),
+      (ctx) => {
+        const coll = ctx.collection;
+        const rec = ctx.record;
+        const name = coll?.name;
+        const dataSourceKey = coll?.dataSourceKey;
+        const filterByTk = coll?.getFilterByTK?.(rec);
+        if (!name || typeof filterByTk === 'undefined' || filterByTk === null) return undefined;
+        return { collection: name, dataSourceKey, filterByTk };
+      },
+    );
     grid.context.defineProperty('fieldIndex', {
       get: () => index,
       cache: false,
@@ -64,6 +77,8 @@ export class ListItemModel extends FlowModel<ListItemModelStructure> {
     grid.context.defineProperty('record', {
       get: () => record,
       cache: false,
+      resolveOnServer: true,
+      meta: gridRecordMeta,
     });
     grid.context.defineProperty('fieldKey', {
       get: () => index,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where list block fields could not use the current record variable. |
| 🇨🇳 Chinese | 修复列表区块字段无法使用当前记录变量的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
