### PR TITLE
fix(client): resolve parent object linkage

### DIFF
--- a/packages/core/client/src/schema-settings/VariableInput/hooks/__tests__/useParentIterationVariable.test.tsx
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/__tests__/useParentIterationVariable.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseSubFormValue = vi.fn();
+const mockUseCollectionParentRecordData = vi.fn();
+const mockUseParentCollection = vi.fn();
+const mockUseFlag = vi.fn();
+
+vi.mock('../../../../schema-component/antd/association-field/hooks', () => {
+  return {
+    useSubFormValue: () => mockUseSubFormValue(),
+  };
+});
+
+vi.mock('../../../../data-source/collection-record/CollectionRecordProvider', () => {
+  return {
+    useCollectionParentRecordData: () => mockUseCollectionParentRecordData(),
+  };
+});
+
+vi.mock('../../../../data-source/collection/AssociationProvider', () => {
+  return {
+    useParentCollection: () => mockUseParentCollection(),
+  };
+});
+
+vi.mock('../../../../flag-provider', () => {
+  return {
+    useFlag: () => mockUseFlag(),
+  };
+});
+
+import { useParentObjectContext } from '../useParentIterationVariable';
+
+describe('useParentObjectContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFlag.mockReturnValue({
+      isInSubForm: false,
+      isInSubTable: true,
+    });
+    mockUseParentCollection.mockReturnValue({
+      name: 't1_org',
+      dataSource: 'main',
+    });
+  });
+
+  it('falls back to parent record data when subform parent object is empty', () => {
+    mockUseSubFormValue.mockReturnValue({
+      parent: {
+        value: {},
+      },
+    });
+    mockUseCollectionParentRecordData.mockReturnValue({
+      orgname: '上级公司A',
+    });
+
+    const { result } = renderHook(() => useParentObjectContext());
+
+    expect(result.current).toEqual({
+      shouldDisplayParentObject: true,
+      parentObjectCtx: {
+        orgname: '上级公司A',
+      },
+      collectionName: 't1_org',
+      dataSource: 'main',
+    });
+  });
+
+  it('prefers the explicit subform parent object when it already has data', () => {
+    mockUseSubFormValue.mockReturnValue({
+      parent: {
+        value: {
+          orgname: '来自子表单上下文',
+        },
+        collection: {
+          name: 't1_org',
+          dataSource: 'main',
+        },
+      },
+    });
+    mockUseCollectionParentRecordData.mockReturnValue({
+      orgname: '来自父记录',
+    });
+
+    const { result } = renderHook(() => useParentObjectContext());
+
+    expect(result.current).toEqual({
+      shouldDisplayParentObject: true,
+      parentObjectCtx: {
+        orgname: '来自子表单上下文',
+      },
+      collectionName: 't1_org',
+      dataSource: 'main',
+    });
+  });
+
+  it('skips duplicated parent wrappers that point to the current subtable row', () => {
+    const currentRow = {
+      staffname: '456',
+      address: null,
+    };
+    mockUseSubFormValue.mockReturnValue({
+      formValue: currentRow,
+      parent: {
+        value: currentRow,
+        collection: {
+          name: 't1_staff',
+          dataSource: 'main',
+        },
+        parent: {
+          value: {
+            orgname: '上级公司A',
+          },
+          collection: {
+            name: 't1_org',
+            dataSource: 'main',
+          },
+        },
+      },
+    });
+    mockUseCollectionParentRecordData.mockReturnValue({});
+
+    const { result } = renderHook(() => useParentObjectContext());
+
+    expect(result.current).toEqual({
+      shouldDisplayParentObject: true,
+      parentObjectCtx: {
+        orgname: '上级公司A',
+      },
+      collectionName: 't1_org',
+      dataSource: 'main',
+    });
+  });
+});

--- a/packages/core/client/src/schema-settings/VariableInput/hooks/useParentIterationVariable.ts
+++ b/packages/core/client/src/schema-settings/VariableInput/hooks/useParentIterationVariable.ts
@@ -8,15 +8,35 @@
  */
 
 import { Schema } from '@formily/json-schema';
+import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { CollectionFieldOptions } from '../../../data-source/collection/Collection';
+import { useCollectionParentRecordData } from '../../../data-source/collection-record/CollectionRecordProvider';
+import { useParentCollection } from '../../../data-source/collection/AssociationProvider';
 import { useFlag } from '../../../flag-provider';
 import { useSubFormValue } from '../../../schema-component/antd/association-field/hooks';
 import { useBaseVariable } from './useBaseVariable';
 
+const getResolvedParent = (parent, currentObjectCtx) => {
+  let resolvedParent = parent;
+
+  // 子表格单元格内部会重复包裹同一行数据的 SubFormProvider，这里需要跳过这层“当前对象”的镜像父级。
+  while (resolvedParent?.parent && resolvedParent.value === currentObjectCtx) {
+    resolvedParent = resolvedParent.parent;
+  }
+
+  return resolvedParent;
+};
+
 export const useParentObjectContext = () => {
-  const { parent } = useSubFormValue();
-  const { value: parentObjectCtx, collection: collectionOfParentObject } = parent || {};
+  const { parent, formValue } = useSubFormValue();
+  const parentRecordData = useCollectionParentRecordData();
+  const parentCollection = useParentCollection();
+  const resolvedParent = getResolvedParent(parent, formValue);
+  const subFormParentObjectCtx = resolvedParent?.value;
+  const parentObjectCtx =
+    _.isEmpty(subFormParentObjectCtx) && !_.isEmpty(parentRecordData) ? parentRecordData : subFormParentObjectCtx;
+  const collectionOfParentObject = resolvedParent?.collection || parentCollection;
   const { isInSubForm, isInSubTable } = useFlag() || {};
 
   return {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
修复对多子表格联动规则使用“上级对象”变量时，子表格新增行无法获取上层子表单字段值的问题。

### Description 
- 修复 `useParentObjectContext` 在子表格单元格内误取到“当前行镜像父级”的问题，改为跳过重复包裹同一行数据的 `SubFormProvider`，继续解析真正的上级对象。
- 保留原有的父记录兜底逻辑，避免在上级对象为空的场景下回退能力丢失。
- 新增回归测试，覆盖重复父级 wrapper 存在时仍能正确解析上层 `org` 行的场景。
- 已用远程 API 驱动本地前端回归验证 `http://localhost:12001/apps/jhb20/admin/7ife5jdj11h`：填写 `公司名称=上级公司A`、`联系电话=456` 后点击 `staff_o2m` 的 `Add new`，新增行现在能正确显示 `姓名=456`、`联系地址=上级公司A`。

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix parent object linkage value in nested subtable |
| 🇨🇳 Chinese | 修复嵌套子表格上级对象联动赋值错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
