### PR TITLE
fix(client): sync new tab route id

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageTabModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageTabModel.tsx
@@ -11,6 +11,7 @@ import { FlowModel, FlowModelRenderer, observable, tExpr } from '@nocobase/flow-
 import { useRequest } from 'ahooks';
 import React from 'react';
 import { Icon } from '../../../../icon';
+import type { NocoBaseDesktopRoute } from '../../../../route-switch/antd/admin-layout/convertRoutesToSchema';
 import { SkeletonFallback } from '../../../components/SkeletonFallback';
 import { TextAreaWithContextSelector } from '../../../components/TextAreaWithContextSelector';
 import { RemoteFlowModelRenderer } from '../../../FlowPage';
@@ -32,6 +33,25 @@ function PageTabChildrenRenderer({ ctx, options }) {
     return <SkeletonFallback style={{ margin }} />;
   }
   return <FlowModelRenderer model={data} fallback={<SkeletonFallback style={{ margin }} />} />;
+}
+
+/**
+ * 统一归一化 `desktopRoutes:updateOrCreate` 的返回值。
+ *
+ * 该接口在 create/update 场景下可能分别返回对象或数组，
+ * 这里始终抽出第一条 route 记录，便于把持久化 id 回填到前端模型。
+ *
+ * @param payload - 接口返回的 data 节点
+ * @returns 可用于回填的 route 记录
+ */
+function normalizePersistedRoute(payload: unknown): Partial<NocoBaseDesktopRoute> | undefined {
+  if (Array.isArray(payload)) {
+    return payload.find((item): item is Partial<NocoBaseDesktopRoute> => !!item && typeof item === 'object');
+  }
+  if (payload && typeof payload === 'object') {
+    return payload as Partial<NocoBaseDesktopRoute>;
+  }
+  return undefined;
 }
 
 export class BasePageTabModel extends FlowModel<{
@@ -150,7 +170,7 @@ export class RootPageTabModel extends BasePageTabModel {
   async save() {
     const json = this.serialize();
     const documentTitle = this.stepParams?.pageTabSettings?.tab?.documentTitle;
-    await this.context.api.request({
+    const response = await this.context.api.request({
       method: 'post',
       url: 'desktopRoutes:updateOrCreate',
       params: {
@@ -166,6 +186,19 @@ export class RootPageTabModel extends BasePageTabModel {
         },
       },
     });
+    const persistedRoute = normalizePersistedRoute(response?.data?.data);
+
+    // 新建 tab 首次保存后需要立即拿到持久化 route id，拖拽排序会直接依赖它。
+    if (persistedRoute) {
+      this.setProps('route', {
+        ...this.props.route,
+        ...persistedRoute,
+        options: {
+          ...this.props.route?.options,
+          ...persistedRoute.options,
+        },
+      });
+    }
   }
 
   async destroy() {

--- a/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
@@ -9,12 +9,33 @@
 
 import { DragEndEvent } from '@dnd-kit/core';
 import { reaction } from '@nocobase/flow-engine';
+import type { FlowModel } from '@nocobase/flow-engine';
 import _ from 'lodash';
-import { NocoBaseDesktopRoute } from '../../../../route-switch/antd/admin-layout/convertRoutesToSchema';
+import type { NocoBaseDesktopRoute } from '../../../../route-switch/antd/admin-layout/convertRoutesToSchema';
 import { PageModel } from './PageModel';
 
 export class RootPageModel extends PageModel {
   mounted = false;
+
+  /**
+   * 新建 tab 在首次保存完成前，前端 route 里可能还没有数据库 id。
+   * 拖拽前兜底触发一次保存，确保 move 接口拿到真实主键。
+   *
+   * @param model - 当前参与拖拽的 tab model
+   * @returns 可用于排序接口的 route id
+   */
+  private async ensurePersistedRouteId(model?: FlowModel): Promise<string | number | undefined> {
+    const routeId = model?.props?.route?.id;
+    if (routeId != null) {
+      return routeId;
+    }
+
+    if (typeof model?.save === 'function') {
+      await model.save();
+    }
+
+    return model?.props?.route?.id;
+  }
 
   onMount() {
     super.onMount();
@@ -67,12 +88,21 @@ export class RootPageModel extends PageModel {
       return;
     }
 
+    const [sourceId, targetId] = await Promise.all([
+      this.ensurePersistedRouteId(activeModel),
+      this.ensurePersistedRouteId(overModel),
+    ]);
+
+    if (sourceId == null || targetId == null) {
+      return;
+    }
+
     await this.context.api.request({
       url: `desktopRoutes:move`,
       method: 'post',
       params: {
-        sourceId: activeModel.props.route.id,
-        targetId: overModel.props.route.id,
+        sourceId,
+        targetId,
         sortField: 'sort',
       },
     });

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/PageTabModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/PageTabModel.test.ts
@@ -140,4 +140,86 @@ describe('PageTabModel', () => {
     expect(call.url).toBe('desktopRoutes:updateOrCreate');
     expect(call.data.options.documentTitle).toBe('Tab doc title');
   });
+
+  it('should sync persisted route id after save', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const request = vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          id: 123,
+          schemaUid: 'tab-1',
+          sort: 9,
+        },
+      },
+    });
+    const model = new RootPageTabModel({
+      props: {
+        route: {
+          schemaUid: 'tab-1',
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Tab title',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        t: (value: string) => value,
+      },
+    } as any);
+
+    await model.save();
+
+    expect(model.props.route.id).toBe(123);
+    expect(model.props.route.sort).toBe(9);
+  });
+
+  it('should sync persisted route when updateOrCreate returns array', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const request = vi.fn().mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: 456,
+            schemaUid: 'tab-1',
+            options: {
+              documentTitle: 'Server doc title',
+            },
+          },
+        ],
+      },
+    });
+    const model = new RootPageTabModel({
+      props: {
+        route: {
+          schemaUid: 'tab-1',
+          options: {
+            flowRegistry: {},
+          },
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Tab title',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        t: (value: string) => value,
+      },
+    } as any);
+
+    await model.save();
+
+    expect(model.props.route.id).toBe(456);
+    expect(model.props.route.options).toMatchObject({
+      flowRegistry: {},
+      documentTitle: 'Server doc title',
+    });
+  });
 });

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/RootPageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/RootPageModel.test.ts
@@ -128,6 +128,42 @@ describe('RootPageModel', () => {
       expect(mockFlowEngine.moveModel).toHaveBeenCalledWith('active-uid', 'over-uid', { persist: false });
     });
 
+    it('should save new tab before moving when route id is missing', async () => {
+      const mockActiveModel = {
+        uid: 'active-uid',
+        props: { route: { schemaUid: 'active-schema-uid' } },
+        save: vi.fn(async () => {
+          mockActiveModel.props.route.id = 'active-route-id';
+        }),
+      };
+      const mockOverModel = {
+        uid: 'over-uid',
+        props: { route: { id: 'over-route-id' } },
+        save: vi.fn(),
+      };
+
+      const mockDragEndEvent = {
+        active: { id: 'active-model-id' },
+        over: { id: 'over-model-id' },
+      };
+
+      mockFlowEngine.getModel.mockReturnValueOnce(mockActiveModel).mockReturnValueOnce(mockOverModel);
+
+      await rootPageModel.handleDragEnd(mockDragEndEvent as any);
+
+      expect(mockActiveModel.save).toHaveBeenCalledTimes(1);
+      expect(mockApi.request).toHaveBeenCalledWith({
+        url: 'desktopRoutes:move',
+        method: 'post',
+        params: {
+          sourceId: 'active-route-id',
+          targetId: 'over-route-id',
+          sortField: 'sort',
+        },
+      });
+      expect(mockFlowEngine.moveModel).toHaveBeenCalledWith('active-uid', 'over-uid', { persist: false });
+    });
+
     it('should handle case when activeModel is not found', async () => {
       const mockDragEndEvent = {
         active: { id: 'active-model-id' },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

新创建的 page v2 tab 在第一次拖拽排序时，请求参数缺少 `sourceId`，导致排序结果无法持久化，刷新页面后 tab 会回到原位置。

### Description

本次修复分两部分：

1. `RootPageTabModel.save()` 在调用 `desktopRoutes:updateOrCreate` 后，立即把后端返回的 route 记录回填到前端模型，确保新建 tab 在首次保存后就拿到持久化 `id`
2. `RootPageModel.handleDragEnd()` 在拖拽前兜底检查参与拖拽的 tab 是否已有 route `id`，如果缺失则先触发保存，再发起 `desktopRoutes:move`

同时补充了回归测试，覆盖 route `id` 回填和“缺少 route id 时先保存再拖拽”的场景。

风险较低，改动范围仅限 page v2 tab 的保存与拖拽排序链路。

### Related issues

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing sourceId when dragging a newly created tab |
| 🇨🇳 Chinese | 修复新建 tab 首次拖拽时缺少 sourceId 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary

