### PR TITLE
fix: missing reference block events

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/ReferenceBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/ReferenceBlockModel.tsx
@@ -30,6 +30,7 @@ import {
 } from './referenceShared';
 
 const TARGET_CONTEXT_BRIDGE_MARKER = Symbol.for('nocobase.referenceBlockTargetContextBridge');
+const TARGET_EVENT_BRIDGE_ORIGINAL_DISPATCH = Symbol.for('nocobase.referenceBlockTargetEventBridge.originalDispatch');
 const TEMPLATE_FALLBACK_PATCH_ORIGINAL_GET_STEP_PARAMS = Symbol.for(
   'nocobase.referenceBlockTemplateFallback.originalGetStepParams',
 );
@@ -154,6 +155,97 @@ export class ReferenceBlockModel extends BlockModel {
     }
   }
 
+  private _restoreTargetEventBridge(target?: FlowModel) {
+    if (!target) return;
+    const original = (target as any)[TARGET_EVENT_BRIDGE_ORIGINAL_DISPATCH] as FlowModel['dispatchEvent'] | undefined;
+    if (!original) return;
+    (target as any).dispatchEvent = original;
+    delete (target as any)[TARGET_EVENT_BRIDGE_ORIGINAL_DISPATCH];
+  }
+
+  private _getForwardedTargetEventFlows(eventName: string) {
+    if (!eventName || super.getEvent(eventName)) {
+      return new Map();
+    }
+
+    return new Map(
+      Array.from(this.getFlows().entries()).filter(([, flow]) => {
+        const on = flow?.on;
+        if (!on) return false;
+        if (typeof on === 'string') return on === eventName;
+        if (typeof on === 'object') return on.eventName === eventName;
+        return false;
+      }),
+    );
+  }
+
+  private _shouldForwardTargetEvent(eventName: string, target?: FlowModel) {
+    if (!target || !eventName) return false;
+    if (super.getEvent(eventName)) return false;
+    return !!target.getEvent(eventName);
+  }
+
+  private _applyTargetEventBridge(target?: FlowModel) {
+    if (!target) return;
+    if ((target as any)[TARGET_EVENT_BRIDGE_ORIGINAL_DISPATCH]) return;
+
+    const originalDispatchEvent = (target as any).dispatchEvent as FlowModel['dispatchEvent'];
+    if (typeof originalDispatchEvent !== 'function') return;
+
+    (target as any)[TARGET_EVENT_BRIDGE_ORIGINAL_DISPATCH] = originalDispatchEvent;
+    const reference = this;
+
+    (target as any).dispatchEvent = async function (eventName: string, inputArgs?: Record<string, any>, options?: any) {
+      if (!reference._shouldForwardTargetEvent(eventName, target)) {
+        return originalDispatchEvent.call(this, eventName, inputArgs, options);
+      }
+
+      const forwardedFlows = reference._getForwardedTargetEventFlows(eventName);
+      if (!forwardedFlows.size) {
+        return originalDispatchEvent.call(this, eventName, inputArgs, options);
+      }
+
+      const originalGetFlows = this.getFlows?.bind(this);
+      const originalGetFlow = this.getFlow?.bind(this);
+      const originalGetStepParams = this.getStepParams?.bind(this);
+
+      this.getFlows = function () {
+        const merged = originalGetFlows ? originalGetFlows() : new Map();
+        for (const [flowKey, flow] of forwardedFlows.entries()) {
+          if (!merged.has(flowKey)) {
+            merged.set(flowKey, flow);
+          }
+        }
+        return merged;
+      };
+
+      this.getFlow = function (flowKey: string) {
+        if (forwardedFlows.has(flowKey)) {
+          return forwardedFlows.get(flowKey);
+        }
+        return originalGetFlow?.(flowKey);
+      };
+
+      this.getStepParams = function (flowKey: string, stepKey?: string) {
+        if (forwardedFlows.has(flowKey)) {
+          const params = reference.getStepParams(flowKey, stepKey as any);
+          if (params !== undefined) {
+            return params;
+          }
+        }
+        return originalGetStepParams?.(flowKey, stepKey as any);
+      };
+
+      try {
+        return await originalDispatchEvent.call(this, eventName, inputArgs, options);
+      } finally {
+        this.getFlows = originalGetFlows;
+        this.getFlow = originalGetFlow;
+        this.getStepParams = originalGetStepParams;
+      }
+    };
+  }
+
   private _shouldTemplateFallbackToList(init: Record<string, any>): boolean {
     const viewArgs = (this as any)?.context?.view?.inputArgs || {};
     const filterByTk = viewArgs?.filterByTk;
@@ -235,6 +327,26 @@ export class ReferenceBlockModel extends BlockModel {
 
   get title() {
     return this._targetModel?.title || super.title;
+  }
+
+  public getEvents<TModel extends FlowModel = this>() {
+    const events = super.getEvents<TModel>();
+    const targetEvents = this._targetModel?.getEvents?.();
+    if (!targetEvents) {
+      return events;
+    }
+
+    for (const [name, event] of targetEvents.entries()) {
+      if (!events.has(name)) {
+        events.set(name, event as any);
+      }
+    }
+
+    return events;
+  }
+
+  public getEvent<TModel extends FlowModel = this>(name: string) {
+    return super.getEvent<TModel>(name) || (this._targetModel?.getEvent?.(name) as any);
   }
 
   onInit(option) {
@@ -349,6 +461,7 @@ export class ReferenceBlockModel extends BlockModel {
       this._syncExtraTitle(false);
       const oldTarget: FlowModel | undefined = (this.subModels as any)['target'];
       if (oldTarget) {
+        this._restoreTargetEventBridge(oldTarget);
         this._restoreTemplateFallbackPatch(oldTarget);
         (this as any).emitter?.emit?.('onSubModelRemoved', oldTarget);
         this._scopedEngine?.removeModel(oldTarget.uid);
@@ -367,6 +480,7 @@ export class ReferenceBlockModel extends BlockModel {
     this._syncExtraTitle(true);
     if (this._resolvedTargetUid === targetUid && this._targetModel) {
       this._invalidTargetUid = undefined;
+      this._applyTargetEventBridge(this._targetModel);
       this._applyTemplateFallbackPatchState(this._targetModel);
       // 目标未变化：确保 props 仍指向目标模型（避免 target.setProps 替换对象后指针失效）
       this.props = this._targetModel.props;
@@ -388,6 +502,7 @@ export class ReferenceBlockModel extends BlockModel {
     if (!target) {
       const oldTarget: FlowModel | undefined = (this.subModels as any)['target'];
       if (oldTarget) {
+        this._restoreTargetEventBridge(oldTarget);
         this._restoreTemplateFallbackPatch(oldTarget);
         (this as any).emitter?.emit?.('onSubModelRemoved', oldTarget);
         this._scopedEngine?.removeModel(oldTarget.uid);
@@ -407,9 +522,11 @@ export class ReferenceBlockModel extends BlockModel {
     const scopedEngine = this._ensureScopedEngine();
     target.setParent(this);
     this._bridgeTargetContext(target, scopedEngine);
+    this._applyTargetEventBridge(target);
     const oldTarget: FlowModel | undefined = (this.subModels as any)['target'];
     if (oldTarget?.uid !== target.uid) {
       if (oldTarget) {
+        this._restoreTargetEventBridge(oldTarget);
         this._restoreTemplateFallbackPatch(oldTarget);
       }
       this._applyTemplateFallbackPatchState(target);
@@ -434,6 +551,7 @@ export class ReferenceBlockModel extends BlockModel {
 
   async destroy(): Promise<boolean> {
     try {
+      this._restoreTargetEventBridge(this._targetModel);
       this._restoreTemplateFallbackPatch(this._targetModel);
       unlinkScopedEngine(this._scopedEngine);
     } finally {

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/ReferenceBlockModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client/models/__tests__/ReferenceBlockModel.test.tsx
@@ -30,6 +30,43 @@ class MockFormBlockModel extends FlowModel {
   }
 }
 
+class MockInteractiveBlockModel extends FlowModel {
+  onInit(options: any) {
+    super.onInit(options);
+    this.context.defineProperty('collection', {
+      value: { filterTargetKey: 'id' },
+    });
+  }
+
+  get collection() {
+    return this.context.collection;
+  }
+
+  highlightRow(record: any) {
+    this.setProps('highlightedRowKey', record?.[this.collection?.filterTargetKey]);
+  }
+
+  clearHighlight() {
+    this.setProps('highlightedRowKey', undefined);
+  }
+}
+
+MockInteractiveBlockModel.registerEvents({
+  rowClick: {
+    title: 'Row click',
+    name: 'rowClick',
+    handler: vi.fn(async (ctx) => {
+      const model = ctx.model as MockInteractiveBlockModel;
+      const rowKey = ctx.inputArgs.record?.[model.collection?.filterTargetKey];
+      if (model.props.highlightedRowKey !== rowKey) {
+        model.highlightRow(ctx.inputArgs.record);
+      } else {
+        model.clearHighlight();
+      }
+    }),
+  },
+});
+
 class DetailsBlockModel extends FlowModel {}
 class EditFormModel extends FlowModel {}
 
@@ -64,6 +101,13 @@ describe('ReferenceBlockModel', () => {
         subKey: 'items',
         subType: 'array',
         props: { title: 'Test Form Block' },
+      },
+      'interactive-target-uid': {
+        uid: 'interactive-target-uid',
+        use: 'InteractiveBlockModel',
+        parentId: 'grid-uid',
+        subKey: 'items',
+        subType: 'array',
       },
     };
 
@@ -132,6 +176,7 @@ describe('ReferenceBlockModel', () => {
     engine.registerModels({
       GridModel: MockGridModel,
       FormBlockModel: MockFormBlockModel,
+      InteractiveBlockModel: MockInteractiveBlockModel,
       DetailsBlockModel,
       EditFormModel,
       ReferenceBlockModel,
@@ -139,6 +184,7 @@ describe('ReferenceBlockModel', () => {
     scopedEngine.registerModels({
       GridModel: MockGridModel,
       FormBlockModel: MockFormBlockModel,
+      InteractiveBlockModel: MockInteractiveBlockModel,
       DetailsBlockModel,
       EditFormModel,
       ReferenceBlockModel,
@@ -777,6 +823,105 @@ describe('ReferenceBlockModel', () => {
         referenceBlockModel.setProps({ summary: 'y' as any });
         expect((target!.props as any).summary).toBe('y');
         expect((referenceBlockModel.getProps() as any).summary).toBe('y');
+      },
+      TEST_TIMEOUT,
+    );
+  });
+
+  describe('Event forwarding', () => {
+    it(
+      'should expose target events on reference block',
+      async () => {
+        const interactiveTarget = engine.createModel({
+          uid: 'interactive-target-uid',
+          use: 'InteractiveBlockModel',
+          parentId: 'grid-uid',
+          subKey: 'items',
+          subType: 'array',
+        });
+
+        gridModel.addSubModel('items', interactiveTarget);
+
+        referenceBlockModel = engine.createModel({
+          uid: 'reference-block-uid',
+          use: 'ReferenceBlockModel',
+          parentId: 'grid-uid',
+          subKey: 'items',
+          subType: 'array',
+          stepParams: {
+            referenceSettings: {
+              target: {
+                targetUid: 'interactive-target-uid',
+                mode: 'reference',
+              },
+            },
+          },
+        }) as ReferenceBlockModel;
+
+        gridModel.addSubModel('items', referenceBlockModel);
+
+        await referenceBlockModel.dispatchEvent('beforeRender');
+
+        expect(referenceBlockModel.getEvents().has('beforeRender')).toBe(true);
+        expect(referenceBlockModel.getEvents().has('rowClick')).toBe(true);
+        expect(referenceBlockModel.getEvent('rowClick')?.name).toBe('rowClick');
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      'should forward target rowClick dispatch to reference flows',
+      async () => {
+        const interactiveTarget = engine.createModel({
+          uid: 'interactive-target-uid',
+          use: 'InteractiveBlockModel',
+          parentId: 'grid-uid',
+          subKey: 'items',
+          subType: 'array',
+        });
+
+        gridModel.addSubModel('items', interactiveTarget);
+
+        referenceBlockModel = engine.createModel({
+          uid: 'reference-block-uid',
+          use: 'ReferenceBlockModel',
+          parentId: 'grid-uid',
+          subKey: 'items',
+          subType: 'array',
+          stepParams: {
+            referenceSettings: {
+              target: {
+                targetUid: 'interactive-target-uid',
+                mode: 'reference',
+              },
+            },
+          },
+        }) as ReferenceBlockModel;
+
+        gridModel.addSubModel('items', referenceBlockModel);
+
+        await referenceBlockModel.dispatchEvent('beforeRender');
+
+        const flowSpy = vi.fn(async () => undefined);
+        referenceBlockModel.registerFlow({
+          key: 'row-click-flow',
+          on: {
+            eventName: 'rowClick',
+          },
+          steps: {
+            test: {
+              handler: flowSpy,
+            },
+          },
+        });
+
+        const target = (referenceBlockModel as any)._targetModel as FlowModel | undefined;
+        expect(target).toBeTruthy();
+
+        await target!.dispatchEvent('rowClick', { record: { id: 1 } });
+
+        expect((target!.props as any).highlightedRowKey).toBe(1);
+        expect(flowSpy).toHaveBeenCalledTimes(1);
       },
       TEST_TIMEOUT,
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the reference block event flow in the table block could not be configured with a row click event flow. |
| 🇨🇳 Chinese | 修复表格区块的引用模板事件流无法配置行点击事件流的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
