### PR TITLE
fix(filter-form): use filterTargetKey

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -46,6 +46,16 @@ export class FilterFormGridModel extends GridModel {
   private hiddenRows: any = {};
   readonly loading = observable.ref(false);
 
+  private getAssociationFilterTargetKey(field: any) {
+    const filterTargetKey = field?.targetCollection?.filterTargetKey;
+
+    if (Array.isArray(filterTargetKey)) {
+      return filterTargetKey[0] || 'id';
+    }
+
+    return filterTargetKey || 'id';
+  }
+
   toggleFormFieldsCollapse(collapse: boolean, visibleRows: number) {
     const gridRows = this.props.rows || {};
 
@@ -116,7 +126,7 @@ export class FilterFormGridModel extends GridModel {
           if (field?.target) {
             return {
               targetId: model.uid,
-              filterPaths: [`${fieldPath}.${field.targetCollection?.filterTargetKey || 'id'}`],
+              filterPaths: [`${fieldPath}.${this.getAssociationFilterTargetKey(field)}`],
             };
           }
         }

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.onModelCreated.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.onModelCreated.test.ts
@@ -33,17 +33,81 @@ class DummyCollectionBlockModel extends CollectionBlockModel {
   }
 }
 
+function createEngine() {
+  const engine = new FlowEngine();
+  engine.registerModels({
+    FilterFormGridModel,
+    FilterFormItemModel,
+    DummyCollectionBlockModel,
+    InputFieldModel,
+    NumberFieldModel,
+    RecordSelectFieldModel,
+  });
+
+  return engine;
+}
+
+function createDataBlockModel(engine: FlowEngine) {
+  return engine.createModel<DummyCollectionBlockModel>({
+    uid: 'users-block',
+    use: 'DummyCollectionBlockModel',
+    stepParams: {
+      resourceSettings: {
+        init: {
+          dataSourceKey: 'main',
+          collectionName: 'users',
+        },
+      },
+    },
+  });
+}
+
+function createGridModel(engine: FlowEngine) {
+  const gridModel = engine.createModel<FilterFormGridModel>({
+    uid: 'filter-grid',
+    use: 'FilterFormGridModel',
+  });
+  const saveConnectFieldsConfig = vi.fn(async () => {});
+
+  gridModel.context.defineProperty('filterManager', {
+    value: { saveConnectFieldsConfig },
+  });
+
+  return { gridModel, saveConnectFieldsConfig };
+}
+
+function createFilterItemModel(engine: FlowEngine, dataBlockModel: DummyCollectionBlockModel, fieldPath: string) {
+  const subModel = engine.createModel<FilterFormItemModel>({
+    uid: `filter-item-${fieldPath}`,
+    use: 'FilterFormItemModel',
+    stepParams: {
+      fieldSettings: {
+        init: {
+          dataSourceKey: 'main',
+          collectionName: 'users',
+          fieldPath,
+        },
+      },
+      filterFormItemSettings: {
+        init: {
+          defaultTargetUid: dataBlockModel.uid,
+        },
+      },
+    },
+  });
+
+  subModel.context.defineProperty('blockGridModel', {
+    value: {
+      filterSubModels: (_key: string, predicate: (item: any) => boolean) => [dataBlockModel].filter(predicate),
+    },
+  });
+
+  return subModel;
+}
+
 describe('FilterFormGridModel onModelCreated', () => {
   it('auto connects association target field path to target block', async () => {
-    const engine = new FlowEngine();
-    engine.registerModels({
-      FilterFormGridModel,
-      FilterFormItemModel,
-      DummyCollectionBlockModel,
-      InputFieldModel,
-      NumberFieldModel,
-      RecordSelectFieldModel,
-    });
+    const engine = createEngine();
 
     const ds = engine.dataSourceManager.getDataSource('main');
     ds.addCollection({
@@ -69,53 +133,9 @@ describe('FilterFormGridModel onModelCreated', () => {
       ],
     });
 
-    const dataBlockModel = engine.createModel<DummyCollectionBlockModel>({
-      uid: 'users-block',
-      use: 'DummyCollectionBlockModel',
-      stepParams: {
-        resourceSettings: {
-          init: {
-            dataSourceKey: 'main',
-            collectionName: 'users',
-          },
-        },
-      },
-    });
-
-    const gridModel = engine.createModel<FilterFormGridModel>({
-      uid: 'filter-grid',
-      use: 'FilterFormGridModel',
-    });
-
-    const saveConnectFieldsConfig = vi.fn(async () => {});
-    gridModel.context.defineProperty('filterManager', {
-      value: { saveConnectFieldsConfig },
-    });
-
-    const subModel = engine.createModel<FilterFormItemModel>({
-      uid: 'filter-item',
-      use: 'FilterFormItemModel',
-      stepParams: {
-        fieldSettings: {
-          init: {
-            dataSourceKey: 'main',
-            collectionName: 'users',
-            fieldPath: 'department.name',
-          },
-        },
-        filterFormItemSettings: {
-          init: {
-            defaultTargetUid: dataBlockModel.uid,
-          },
-        },
-      },
-    });
-
-    subModel.context.defineProperty('blockGridModel', {
-      value: {
-        filterSubModels: (_key: string, predicate: (item: any) => boolean) => [dataBlockModel].filter(predicate),
-      },
-    });
+    const dataBlockModel = createDataBlockModel(engine);
+    const { gridModel, saveConnectFieldsConfig } = createGridModel(engine);
+    const subModel = createFilterItemModel(engine, dataBlockModel, 'department.name');
 
     await gridModel.onModelCreated(subModel);
 
@@ -126,6 +146,100 @@ describe('FilterFormGridModel onModelCreated', () => {
         {
           targetId: dataBlockModel.uid,
           filterPaths: ['department.name'],
+        },
+      ],
+    });
+  });
+
+  it('uses target collection filterTargetKey for association fields', async () => {
+    const engine = createEngine();
+    const ds = engine.dataSourceManager.getDataSource('main');
+
+    ds.addCollection({
+      name: 'departments',
+      filterTargetKey: 'slug',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number', filterable: { operators: [] } },
+        { name: 'slug', type: 'string', interface: 'input', filterable: { operators: [] } },
+        { name: 'name', type: 'string', interface: 'input', filterable: { operators: [] } },
+      ],
+    });
+    ds.addCollection({
+      name: 'users',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number', filterable: { operators: [] } },
+        {
+          name: 'department',
+          type: 'belongsTo',
+          interface: 'm2o',
+          target: 'departments',
+          targetKey: 'id',
+          filterable: { operators: [] },
+        },
+      ],
+    });
+
+    const dataBlockModel = createDataBlockModel(engine);
+    const { gridModel, saveConnectFieldsConfig } = createGridModel(engine);
+    const subModel = createFilterItemModel(engine, dataBlockModel, 'department');
+
+    await gridModel.onModelCreated(subModel);
+
+    expect(saveConnectFieldsConfig).toHaveBeenCalledTimes(1);
+    const [, payload] = saveConnectFieldsConfig.mock.calls[0];
+    expect(payload).toEqual({
+      targets: [
+        {
+          targetId: dataBlockModel.uid,
+          filterPaths: ['department.slug'],
+        },
+      ],
+    });
+  });
+
+  it('uses the first filterTargetKey when target collection has composite keys', async () => {
+    const engine = createEngine();
+    const ds = engine.dataSourceManager.getDataSource('main');
+
+    ds.addCollection({
+      name: 'departments',
+      filterTargetKey: ['slug', 'locale'],
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number', filterable: { operators: [] } },
+        { name: 'slug', type: 'string', interface: 'input', filterable: { operators: [] } },
+        { name: 'locale', type: 'string', interface: 'input', filterable: { operators: [] } },
+      ],
+    });
+    ds.addCollection({
+      name: 'users',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number', filterable: { operators: [] } },
+        {
+          name: 'department',
+          type: 'belongsTo',
+          interface: 'm2o',
+          target: 'departments',
+          targetKey: 'id',
+          filterable: { operators: [] },
+        },
+      ],
+    });
+
+    const dataBlockModel = createDataBlockModel(engine);
+    const { gridModel, saveConnectFieldsConfig } = createGridModel(engine);
+    const subModel = createFilterItemModel(engine, dataBlockModel, 'department');
+
+    await gridModel.onModelCreated(subModel);
+
+    expect(saveConnectFieldsConfig).toHaveBeenCalledTimes(1);
+    const [, payload] = saveConnectFieldsConfig.mock.calls[0];
+    expect(payload).toEqual({
+      targets: [
+        {
+          targetId: dataBlockModel.uid,
+          filterPaths: ['department.slug'],
         },
       ],
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
筛选表单在为关联字段生成过滤路径时固定使用 `targetKey`，当目标集合实际过滤键不是该值时，会导致关联字段过滤行为异常。

### Description 
调整 `FilterFormGridModel` 生成关联字段 `filterPaths` 的逻辑，优先使用目标集合定义的 `filterTargetKey`，未配置时回退到 `id`。

风险较小，影响范围限定在 v2 筛选表单的关联字段路径生成。

测试建议：在筛选表单中选择关联字段，并验证非默认主键场景下的过滤条件是否正常生效。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where filter forms use the wrong key for association fields |
| 🇨🇳 Chinese | 修复筛选表单关联字段使用错误过滤键的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
