### PR TITLE
fix: can't load sql record's detail block

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/openView.closeDestroy.test.tsx
+++ b/packages/core/client/src/flow/actions/__tests__/openView.closeDestroy.test.tsx
@@ -72,4 +72,14 @@ describe('openView action - close/destroy logic', () => {
     expect(callArgs.inputArgs).not.toHaveProperty('triggerByRouter');
     expect(callArgs.inputArgs).toHaveProperty('otherArg', 'value');
   });
+
+  it('wraps scalar filterByTk for single-key array collections', async () => {
+    const ctx = createMockCtx();
+    ctx.collection = { filterTargetKey: ['id'] };
+
+    await openView.handler(ctx, { filterByTk: 1 });
+
+    const callArgs = (ctx.viewer.open as any).mock.calls[0][0];
+    expect(callArgs.inputArgs.filterByTk).toEqual({ id: 1 });
+  });
 });

--- a/packages/core/client/src/flow/actions/openView.tsx
+++ b/packages/core/client/src/flow/actions/openView.tsx
@@ -137,7 +137,15 @@ export const openView = defineAction({
       if (hasInput) return inputArgs[key];
       return actionDefaults?.[key];
     };
-    const mergedFilterByTk = pickWithDefault('filterByTk');
+    const mergedFilterByTk = (() => {
+      const value = pickWithDefault('filterByTk');
+      return Array.isArray(ctx.collection?.filterTargetKey) &&
+        ctx.collection.filterTargetKey.length === 1 &&
+        value != null &&
+        typeof value !== 'object'
+        ? { [ctx.collection.filterTargetKey[0]]: value }
+        : value;
+    })();
     const mergedSourceId = pickWithDefault('sourceId');
 
     const runtimeDataSourceKey =

--- a/packages/core/flow-engine/src/utils/__tests__/parsePathnameToViewParams.test.ts
+++ b/packages/core/flow-engine/src/utils/__tests__/parsePathnameToViewParams.test.ts
@@ -109,6 +109,13 @@ describe('parsePathnameToViewParams', () => {
     expect(result).toEqual([{ viewUid: 'xxx', filterByTk: { id: '1', tenant: 'ac' } }]);
   });
 
+  test('should parse filterByTk from single key-value encoded segment into object', () => {
+    const kv = encodeURIComponent('id=1');
+    const path = `/admin/xxx/filterbytk/${kv}`;
+    const result = parsePathnameToViewParams(path);
+    expect(result).toEqual([{ viewUid: 'xxx', filterByTk: { id: '1' } }]);
+  });
+
   test('should parse filterByTk from JSON object segment', () => {
     const json = encodeURIComponent('{"id":"1","tenant":"ac"}');
     const path = `/admin/xxx/filterbytk/${json}`;

--- a/packages/core/flow-engine/src/utils/parsePathnameToViewParams.ts
+++ b/packages/core/flow-engine/src/utils/parsePathnameToViewParams.ts
@@ -116,8 +116,8 @@ export const parsePathnameToViewParams = (pathname: string): ViewParam[] => {
               // 解析失败，按字符串保留
               parsed = decoded;
             }
-          } else if (decoded && decoded.includes('=') && decoded.includes('&')) {
-            // 形如 a=b&c=d 的整体段
+          } else if (decoded && /^[^=&]+=[^=&]*(?:&[^=&]+=[^=&]*)*$/.test(decoded)) {
+            // 形如 a=b 或 a=b&c=d 的整体段
             parsed = parseKeyValuePairs(decoded);
           }
           currentView.filterByTk = parsed;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the details block of an SQL collection encountered an error when loading data. |
| 🇨🇳 Chinese | 修复 SQL 数据表的详情区块数据加载报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
