### PR TITLE
fix(flow): keep subpage back without tabs

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/ChildPageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/ChildPageModel.tsx
@@ -12,13 +12,31 @@ import { PageModel } from './PageModel';
 import { DragEndEvent } from '@dnd-kit/core';
 import { Button } from 'antd';
 import { ArrowLeftOutlined } from '@ant-design/icons';
-import React, { useMemo } from 'react';
+import React, { CSSProperties, useMemo } from 'react';
 import { PageHeader } from '@ant-design/pro-layout';
 
 export class ChildPageModel extends PageModel {
   tabBarExtraContent = {
     left: <BackButtonUsedInSubPage />,
   };
+
+  renderBackButtonWhenTabsDisabled() {
+    if (this.context?.view?.type !== 'embed') {
+      return null;
+    }
+
+    const token = this.context?.themeToken;
+    const style: CSSProperties = {
+      ...this.props.tabBarStyle,
+      paddingBlock: token?.paddingXS ?? 8,
+    };
+
+    return (
+      <div style={style}>
+        <BackButtonUsedInSubPage renderSpacerWhenNoBack={false} />
+      </div>
+    );
+  }
 
   createPageTabModelOptions = (): CreateModelOptions => {
     return {
@@ -40,7 +58,14 @@ export class ChildPageModel extends PageModel {
         {this.props.displayTitle && this.props.title && (
           <PageHeader title={this.props.title} style={this.props.headerStyle} />
         )}
-        {this.props.enableTabs ? this.renderTabs() : this.renderFirstTab()}
+        {this.props.enableTabs ? (
+          this.renderTabs()
+        ) : (
+          <>
+            {this.renderBackButtonWhenTabsDisabled()}
+            {this.renderFirstTab()}
+          </>
+        )}
       </>
     );
   }
@@ -51,7 +76,7 @@ export class ChildPageModel extends PageModel {
  * - embed 场景渲染返回按钮
  * - drawer/modal 等场景渲染占位元素以保持首个 tab 的左侧留白
  */
-const BackButtonUsedInSubPage = () => {
+const BackButtonUsedInSubPage = ({ renderSpacerWhenNoBack = true }: { renderSpacerWhenNoBack?: boolean }) => {
   const ctx = useFlowContext<any>();
   const token = ctx.themeToken;
   // tab item gutter, this is fixed value in antd
@@ -71,6 +96,9 @@ const BackButtonUsedInSubPage = () => {
 
   // 抽屉/弹窗没有返回按钮，但仍需保留首个 tab 的左侧留白。
   if (ctx.view.type !== 'embed') {
+    if (!renderSpacerWhenNoBack) {
+      return null;
+    }
     return <span aria-hidden="true" style={{ display: 'inline-block', width: tabNavPaddingInlineStart, height: 1 }} />;
   }
 

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/ChildPageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/ChildPageModel.test.ts
@@ -146,4 +146,51 @@ describe('ChildPageModel', () => {
       expect(screen.getByRole('button', { name: 'back-button' })).toBeTruthy();
     });
   });
+
+  describe('render', () => {
+    it('should render back button when tabs are disabled in embed mode', () => {
+      mockUseFlowContext.mockReturnValue({
+        themeToken: { paddingLG: 16, paddingXS: 8 },
+        view: { type: 'embed', close: vi.fn() },
+      });
+
+      (childPageModel as any).props = {
+        displayTitle: false,
+        enableTabs: false,
+        tabBarStyle: { backgroundColor: 'var(--colorBgContainer)' },
+      };
+      (childPageModel as any).context = {
+        view: { type: 'embed' },
+        themeToken: { paddingXS: 8 },
+      };
+      (childPageModel as any).renderFirstTab = vi.fn(() => React.createElement('div', { 'data-testid': 'first-tab' }));
+
+      render(childPageModel.render());
+
+      expect(screen.getByRole('button', { name: 'back-button' })).toBeTruthy();
+      expect(screen.getByTestId('first-tab')).toBeTruthy();
+    });
+
+    it('should not render back button when tabs are disabled in non-embed mode', () => {
+      mockUseFlowContext.mockReturnValue({
+        themeToken: { paddingLG: 16, paddingXS: 8 },
+        view: { type: 'drawer', close: vi.fn() },
+      });
+
+      (childPageModel as any).props = {
+        displayTitle: false,
+        enableTabs: false,
+      };
+      (childPageModel as any).context = {
+        view: { type: 'drawer' },
+        themeToken: { paddingXS: 8 },
+      };
+      (childPageModel as any).renderFirstTab = vi.fn(() => React.createElement('div', { 'data-testid': 'first-tab' }));
+
+      render(childPageModel.render());
+
+      expect(screen.queryByRole('button', { name: 'back-button' })).toBeNull();
+      expect(screen.getByTestId('first-tab')).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
子页面把“返回按钮”放在 tabBar 的 left extra content 里，导致当页面配置 `Enable tabs = false` 时，tabBar 不渲染，返回按钮也被一起隐藏，用户无法从子页面返回。

### Description 
- 在 `ChildPageModel` 中新增无 tabs 场景的返回按钮渲染逻辑：当 `enableTabs=false` 且视图类型为 `embed` 时，单独渲染返回按钮。
- 保持 tabs 开启时现有行为不变，继续通过 `tabBarExtraContent.left` 渲染。
- 为返回按钮组件增加参数控制：在无 tabs 场景下，非 embed 视图不再渲染占位。
- 新增回归测试，覆盖 `enableTabs=false` 的 embed/non-embed 两种场景，防止回归。

测试建议：
- 在子页面中关闭 `Enable tabs`，确认左上角返回按钮仍可见并可点击返回。
- 在抽屉/弹窗场景回归确认未引入额外按钮。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Keep the subpage back button visible when tabs are disabled |
| 🇨🇳 Chinese | 修复子页面关闭选项卡后返回按钮被隐藏的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
