### PR TITLE
fix(map): avoid iOS map block crash

### DIFF
--- a/packages/plugins/@nocobase/plugin-map/src/client/components/AMap/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/components/AMap/Map.tsx
@@ -19,6 +19,7 @@ import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, us
 import { useMapConfiguration, useMapConfig } from '../../hooks';
 import { useMapTranslation } from '../../locale';
 import { MapEditorType } from '../../types';
+import { normalizeErrorMessage, runIdleTask } from '../../utils';
 import { Search } from './Search';
 export interface AMapComponentProps {
   value?: any;
@@ -68,32 +69,6 @@ const methodMapping = {
   },
 };
 
-const runIdleTask = (callback: () => void) => {
-  if (window.requestIdleCallback) {
-    window.requestIdleCallback(() => {
-      callback();
-    });
-    return;
-  }
-  window.setTimeout(callback, 1);
-};
-
-const normalizeErrorMessage = (error: unknown, fallbackMessage: string) => {
-  if (typeof error === 'string') {
-    return error;
-  }
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  if (error && typeof error === 'object' && 'message' in error) {
-    const { message } = error as { message?: unknown };
-    if (typeof message === 'string' && message) {
-      return message;
-    }
-  }
-  return fallbackMessage;
-};
-
 export interface AMapForwardedRefProps {
   setOverlay: (t: MapEditorType, v: any, o?: AMap.PolylineOptions & AMap.PolygonOptions & AMap.MarkerOptions) => any;
   getOverlay: (t: MapEditorType, v: any, o?: AMap.PolylineOptions & AMap.PolygonOptions & AMap.MarkerOptions) => any;
@@ -127,6 +102,7 @@ export const AMapComponent = React.forwardRef<AMapForwardedRefProps, AMapCompone
   const mouseTool = useRef<any>();
   const [needUpdateFlag, forceUpdate] = useState([]);
   const [errMessage, setErrMessage] = useState('');
+  const defaultErrorMessage = 'Something went wrong, please refresh the page and try again';
   const { getField } = useCollection_deprecated();
   const type = useMemo<MapEditorType>(() => {
     if (props.type) return props.type;
@@ -364,8 +340,8 @@ export const AMapComponent = React.forwardRef<AMapForwardedRefProps, AMapCompone
     (window as any).define = undefined;
 
     if (window.AMap) {
-      try {
-        runIdleTask(() => {
+      runIdleTask(() => {
+        try {
           map.current = new AMap.Map(id.current, {
             resizeEnable: true,
             zoom,
@@ -373,11 +349,13 @@ export const AMapComponent = React.forwardRef<AMapForwardedRefProps, AMapCompone
           aMap.current = AMap;
           setErrMessage('');
           forceUpdate([]);
-        });
-        return;
-      } catch (err) {
-        setErrMessage(normalizeErrorMessage(err, 'Something went wrong, please refresh the page and try again'));
-      }
+        } catch (err) {
+          setErrMessage(normalizeErrorMessage(err, defaultErrorMessage));
+        } finally {
+          (window as any).define = _define;
+        }
+      });
+      return;
     }
 
     AMapLoader.load({
@@ -388,23 +366,28 @@ export const AMapComponent = React.forwardRef<AMapForwardedRefProps, AMapCompone
       .then((amap) => {
         (window as any).define = _define;
         return runIdleTask(() => {
-          map.current = new amap.Map(id.current, {
-            resizeEnable: true,
-            zoom,
-          } as AMap.MapOptions);
-          aMap.current = amap;
-          setErrMessage('');
-          forceUpdate([]);
+          try {
+            map.current = new amap.Map(id.current, {
+              resizeEnable: true,
+              zoom,
+            } as AMap.MapOptions);
+            aMap.current = amap;
+            setErrMessage('');
+            forceUpdate([]);
+          } catch (err) {
+            setErrMessage(normalizeErrorMessage(err, defaultErrorMessage));
+          }
         });
       })
       .catch((err) => {
-        const errorMessage = normalizeErrorMessage(err, 'Something went wrong, please refresh the page and try again');
+        (window as any).define = _define;
+        const errorMessage = normalizeErrorMessage(err, defaultErrorMessage);
         if (errorMessage.includes('多个不一致的 key')) {
           setErrMessage(t('The AccessKey is incorrect, please check it'));
           return;
         }
         if (err && typeof err === 'object' && 'type' in err && err.type === 'error') {
-          setErrMessage('Something went wrong, please refresh the page and try again');
+          setErrMessage(defaultErrorMessage);
         } else {
           setErrMessage(errorMessage);
         }

--- a/packages/plugins/@nocobase/plugin-map/src/client/models/components/AMap/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/models/components/AMap/Map.tsx
@@ -18,6 +18,7 @@ import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, us
 import { useMapConfig } from '../../../hooks';
 import { useMapTranslation } from '../../../locale';
 import { MapEditorType } from '../../../types';
+import { normalizeErrorMessage, runIdleTask } from '../../../utils';
 import { Search } from './Search';
 export interface AMapComponentProps {
   value?: any;
@@ -67,32 +68,6 @@ const methodMapping = {
   },
 };
 
-const runIdleTask = (callback: () => void) => {
-  if (window.requestIdleCallback) {
-    window.requestIdleCallback(() => {
-      callback();
-    });
-    return;
-  }
-  window.setTimeout(callback, 1);
-};
-
-const normalizeErrorMessage = (error: unknown, fallbackMessage: string) => {
-  if (typeof error === 'string') {
-    return error;
-  }
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  if (error && typeof error === 'object' && 'message' in error) {
-    const { message } = error as { message?: unknown };
-    if (typeof message === 'string' && message) {
-      return message;
-    }
-  }
-  return fallbackMessage;
-};
-
 export interface AMapForwardedRefProps {
   setOverlay: (t: MapEditorType, v: any, o?: AMap.PolylineOptions & AMap.PolygonOptions & AMap.MarkerOptions) => any;
   getOverlay: (t: MapEditorType, v: any, o?: AMap.PolylineOptions & AMap.PolygonOptions & AMap.MarkerOptions) => any;
@@ -134,6 +109,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
   const mouseTool = useRef<any>();
   const [needUpdateFlag, forceUpdate] = useState([]);
   const [errMessage, setErrMessage] = useState('');
+  const defaultErrorMessage = 'Something went wrong, please refresh the page and try again';
   const ctx = useFlowContext();
 
   const overlay = useRef<AMap.Polygon>();
@@ -371,8 +347,8 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     (window as any).define = undefined;
 
     if (window.AMap) {
-      try {
-        runIdleTask(() => {
+      runIdleTask(() => {
+        try {
           map.current = new window.AMap.Map(id.current, {
             resizeEnable: true,
             zoom,
@@ -380,11 +356,13 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
           aMap.current = AMap;
           setErrMessage('');
           forceUpdate([]);
-        });
-        return;
-      } catch (err) {
-        setErrMessage(normalizeErrorMessage(err, 'Something went wrong, please refresh the page and try again'));
-      }
+        } catch (err) {
+          setErrMessage(normalizeErrorMessage(err, defaultErrorMessage));
+        } finally {
+          (window as any).define = _define;
+        }
+      });
+      return;
     }
 
     AMapLoader.load({
@@ -398,23 +376,28 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
         }
         (window as any).define = _define;
         return runIdleTask(() => {
-          map.current = new amap.Map(id.current, {
-            resizeEnable: true,
-            zoom,
-          } as AMap.MapOptions);
-          aMap.current = amap;
-          setErrMessage('');
-          forceUpdate([]);
+          try {
+            map.current = new amap.Map(id.current, {
+              resizeEnable: true,
+              zoom,
+            } as AMap.MapOptions);
+            aMap.current = amap;
+            setErrMessage('');
+            forceUpdate([]);
+          } catch (err) {
+            setErrMessage(normalizeErrorMessage(err, defaultErrorMessage));
+          }
         });
       })
       .catch((err) => {
-        const errorMessage = normalizeErrorMessage(err, 'Something went wrong, please refresh the page and try again');
+        (window as any).define = _define;
+        const errorMessage = normalizeErrorMessage(err, defaultErrorMessage);
         if (errorMessage.includes('多个不一致的 key')) {
           setErrMessage(t('The AccessKey is incorrect, please check it'));
           return;
         }
         if (err && typeof err === 'object' && 'type' in err && err.type === 'error') {
-          setErrMessage('Something went wrong, please refresh the page and try again');
+          setErrMessage(defaultErrorMessage);
         } else {
           setErrMessage(errorMessage);
         }

--- a/packages/plugins/@nocobase/plugin-map/src/client/utils.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client/utils.ts
@@ -16,3 +16,29 @@ export const getSource = (data: Record<string, any>, fields?: string[], type?: s
   }, data);
   return type === 'o2m' || type === 'm2m' ? res : [res];
 };
+
+export const runIdleTask = (callback: () => void) => {
+  if (window.requestIdleCallback) {
+    window.requestIdleCallback(() => {
+      callback();
+    });
+    return;
+  }
+  window.setTimeout(callback, 1);
+};
+
+export const normalizeErrorMessage = (error: unknown, fallbackMessage: string) => {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const { message } = error as { message?: unknown };
+    if (typeof message === 'string' && message) {
+      return message;
+    }
+  }
+  return fallbackMessage;
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 iOS 移动端访问 v1 地图区块时会触发页面报错，地图无法正常显示；桌面端正常。问题影响移动端可用性，需要补齐浏览器兼容处理并避免错误信息渲染再次崩溃。

### Description 
- 为 AMap 初始化增加空闲回调兼容封装：优先使用 `requestIdleCallback`，不支持时降级到 `setTimeout`。
- 统一 AMap 初始化异常的错误信息归一化，确保传给 `Alert` 的始终是字符串，避免将错误对象直接渲染导致二次崩溃。
- 同步修复 `client/components` 与 `client/models/components` 两套 AMap 实现，避免同类问题在不同入口重复出现。
- 验证：`yarn test --client packages/plugins/@nocobase/plugin-map/src/client/__tests__/block/createMapBlockSchema.test.ts` 通过。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix map blocks failing to load on iOS devices |
| 🇨🇳 Chinese | 修复 iOS 设备上地图区块无法正常加载的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
