### PR TITLE
fix: missing filter and refresh button in reference block template v1 page

### DIFF
--- a/packages/core/client/src/schema-templates/BlockTemplatePage.tsx
+++ b/packages/core/client/src/schema-templates/BlockTemplatePage.tsx
@@ -10,7 +10,7 @@
 import { PageHeader as AntdPageHeader } from '@ant-design/pro-layout';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SchemaComponent } from '../schema-component';
+import { SchemaComponent, SchemaComponentContext, useSchemaComponentContext } from '../schema-component';
 import { uiSchemaTemplatesSchema } from './schemas/uiSchemaTemplates';
 
 export const BlockTemplatePage = () => {
@@ -26,5 +26,10 @@ export const BlockTemplatePage = () => {
 };
 
 export const BlockTemplatesPane = () => {
-  return <SchemaComponent schema={uiSchemaTemplatesSchema} />;
+  const scCtx = useSchemaComponentContext();
+  return (
+    <SchemaComponentContext.Provider value={{ ...scCtx, designable: false }}>
+      <SchemaComponent schema={uiSchemaTemplatesSchema} />
+    </SchemaComponentContext.Provider>
+  );
 };

--- a/packages/core/client/src/schema-templates/schemas/uiSchemaTemplates.ts
+++ b/packages/core/client/src/schema-templates/schemas/uiSchemaTemplates.ts
@@ -9,8 +9,10 @@
 
 import { ISchema } from '@formily/react';
 import { uid } from '@formily/shared';
+import { string as stringOperators } from '../../collection-manager/interfaces/properties/operators';
 import { useBlockRequestContext } from '../../block-provider';
 import { useBulkDestroyActionProps, useDestroyActionProps, useUpdateActionProps } from '../../block-provider/hooks';
+import { useFilterFieldProps } from '../../schema-component';
 import { uiSchemaTemplatesCollection } from '../collections/uiSchemaTemplates';
 import { useSchemaTemplateManager } from '../SchemaTemplateManagerProvider';
 import { CollectionTitle } from './CollectionTitle';
@@ -53,6 +55,36 @@ const useDestroyTemplateProps = () => {
   };
 };
 
+const filterOptions = [
+  {
+    name: 'name',
+    title: '{{ t("Title") }}',
+    schema: {
+      type: 'string',
+      'x-component': 'Input',
+    },
+    operators: stringOperators,
+  },
+  {
+    name: 'collectionName',
+    title: '{{ t("Collection display name") }}',
+    schema: {
+      type: 'string',
+      'x-component': 'Input',
+    },
+    operators: stringOperators,
+  },
+];
+
+const useUiSchemaTemplatesFilterActionProps = () => {
+  const { service } = useBlockRequestContext();
+  return useFilterFieldProps({
+    options: filterOptions,
+    params: service?.state?.params?.[0] || service?.params,
+    service,
+  });
+};
+
 export const uiSchemaTemplatesSchema: ISchema = {
   type: 'object',
   properties: {
@@ -83,6 +115,30 @@ export const uiSchemaTemplatesSchema: ISchema = {
             },
           },
           properties: {
+            filter: {
+              type: 'void',
+              title: '{{ t("Filter") }}',
+              default: {
+                $and: [{ name: { $includes: '' } }],
+              },
+              'x-action': 'filter',
+              'x-component': 'Filter.Action',
+              'x-use-component-props': useUiSchemaTemplatesFilterActionProps,
+              'x-component-props': {
+                icon: 'FilterOutlined',
+              },
+              'x-align': 'left',
+            },
+            refresh: {
+              type: 'void',
+              title: '{{ t("Refresh") }}',
+              'x-component': 'Action',
+              'x-use-component-props': 'useRefreshActionProps',
+              'x-component-props': {
+                icon: 'ReloadOutlined',
+              },
+              'x-align': 'right',
+            },
             destroy: {
               title: '{{ t("Delete") }}',
               'x-action': 'destroy',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the reference template (v1) management page was missing filter and refresh action. |
| 🇨🇳 Chinese | 修复引用模板（v1）管理页面缺少筛选和刷新按钮的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
