### PR TITLE
fix(plugin-file-manager-previewer-office): fix modal height

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-previewer-office/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-previewer-office/src/client/index.tsx
@@ -106,23 +106,18 @@ function OfficeModalPreviewer({ index, list, onSwitchIndex }) {
     >
       <div
         style={{
-          maxWidth: '100%',
-          maxHeight: 'calc(100vh - 256px)',
-          height: '100%',
           width: '100%',
+          height: 'calc(85vh - 120px)',
           background: 'white',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-          overflowY: 'auto',
         }}
       >
         <iframe
           src={url}
           style={{
             width: '100%',
-            maxHeight: '100%',
+            height: '100%',
             flex: '1 1 auto',
             border: 'none',
           }}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Change modal height to a proper value to show more content of file.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Change modal height to a proper value to show more content of file |
| 🇨🇳 Chinese | 将弹窗高度调整为更合适的值以展示更多文件内容 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
