### PR TITLE
fix: table block height being invalid

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -979,8 +979,16 @@ const HighPerformanceTable = React.memo(
             `
           : undefined;
 
-      return classNames(baseClass, selectionPaddingClass);
-    }, [model.props.dragSort, model.props.dragSortBy]);
+      const tableBodyMinHeightClass = tableScroll?.y
+        ? css`
+            .ant-table-body {
+              min-height: ${tableScroll.y}px;
+            }
+          `
+        : undefined;
+
+      return classNames(baseClass, selectionPaddingClass, tableBodyMinHeightClass);
+    }, [model.props.dragSort, model.props.dragSortBy, tableScroll?.y]);
 
     return (
       <MemoizedTable


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
enforce min-height on table body when scroll.y is set

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fixed table block height being invalid     |
| 🇨🇳 Chinese |    修复表格区块高度无效       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
