### PR TITLE
fix: markdown editor full-screen editing exception

### DIFF
--- a/packages/core/client/src/flow/common/Markdown/Edit.tsx
+++ b/packages/core/client/src/flow/common/Markdown/Edit.tsx
@@ -261,28 +261,28 @@ const Edit = (props) => {
     };
   }, [zIndex]);
 
-  useLayoutEffect(() => {
-    if (!containerRef.current) return;
+  // useLayoutEffect(() => {
+  //   if (!containerRef.current) return;
 
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const target = entry.target;
-        if (target.className.includes('vditor--fullscreen')) {
-          document.body.appendChild(target);
-          vdFullscreen.current = true;
-        } else if (vdFullscreen.current) {
-          containerParentRef.current?.appendChild(target);
-          vdFullscreen.current = false;
-        }
-      }
-    });
+  //   const observer = new ResizeObserver((entries) => {
+  //     for (const entry of entries) {
+  //       const target = entry.target;
+  //       if (target.className.includes('vditor--fullscreen')) {
+  //         document.body.appendChild(target);
+  //         vdFullscreen.current = true;
+  //       } else if (vdFullscreen.current) {
+  //         containerParentRef.current?.appendChild(target);
+  //         vdFullscreen.current = false;
+  //       }
+  //     }
+  //   });
 
-    observer.observe(containerRef.current);
+  //   observer.observe(containerRef.current);
 
-    return () => {
-      observer.unobserve(containerRef.current);
-    };
-  }, []);
+  //   return () => {
+  //     observer.unobserve(containerRef.current);
+  //   };
+  // }, []);
 
   return wrapSSR(
     <div ref={containerParentRef} className={`${hashId} ${containerClassName}`}>


### PR DESCRIPTION
…ving overlay

Disable the move-to-body logic that relocated the Vditor container to document.body on fullscreen. That caused Ant Design Popover (rc-trigger) to treat clicks inside the fullscreen editor as outside-clicks and close the popup, and left a dangling overlay when the popup unmounted while the editor was still in fullscreen mode.

Vditor's fullscreen CSS (position:fixed + 100vw/100vh + z-index) works correctly inside Ant Design portals since those are already rendered directly under document.body with no CSS-transform ancestors.

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix markdown editor full-screen editing exception      |
| 🇨🇳 Chinese |       修复富文本编辑器全屏编辑异常     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
