### PR TITLE
fix(client): show o2m in block link

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettingsConnectDataBlocks.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsConnectDataBlocks.tsx
@@ -94,7 +94,10 @@ export function SchemaSettingsConnectDataBlocks(props) {
         title={title}
         value={target?.field || ''}
         options={[
-          ...getSupportFieldsByAssociation(getAllCollectionsInheritChain(collection.name), block).map((field) => {
+          ...getSupportFieldsByAssociation(
+            getAllCollectionsInheritChain(collection.name, collection.dataSource),
+            block,
+          ).map((field) => {
             return {
               label: compile(field.uiSchema.title) || field.name,
               value: `${field.name}.${getTargetKey(field)}`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
外部 MySQL 数据源场景下，v1 页面表格在“连接数据区块”时不会显示可用的 `o2m` 关联字段，导致无法按预期配置区块联动。

### Description
本次修复仅调整 v1 的区块联动字段筛选逻辑：在生成关联字段下拉选项时，补充传入当前 collection 的 `dataSource`，确保继承链查询在正确的数据源上下文中执行。

影响范围：仅涉及 `Connect data blocks` 的关联字段可见性判断，不改变已有联动协议或筛选执行逻辑。

测试建议：
- 在外部 MySQL 数据源页面，使用右侧表格连接左侧表格，确认可看到 `o2m` 字段。
- 在主数据源页面复测同配置，确认原有行为不变。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix connectable fields not displaying when linking data blocks under external data sources |
| 🇨🇳 Chinese | 修复外部数据源下连接数据区块时不显示可连接字段的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
