### PR TITLE
fix: double refresh for data blocks

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/dataLoadingMode.test.tsx
+++ b/packages/core/client/src/flow/actions/__tests__/dataLoadingMode.test.tsx
@@ -37,10 +37,8 @@ describe('dataLoadingMode action (v2)', () => {
 
   it('applies manual mode only for list resources', () => {
     const resource = new MultiRecordResource(new FlowContext());
-    const setStepParams = vi.fn();
     const blockModel = {
       resource,
-      setStepParams,
       hasActiveFilters: vi.fn().mockReturnValue(false),
     } as any;
     const setDataSpy = vi.spyOn(resource, 'setData');
@@ -50,7 +48,6 @@ describe('dataLoadingMode action (v2)', () => {
 
     dataLoadingMode.handler?.({ blockModel } as any, { mode: 'manual' });
 
-    expect(setStepParams).toHaveBeenCalledWith('dataLoadingModeSettings', { mode: 'manual' });
     expect(setDataSpy).toHaveBeenCalledWith([]);
     expect(setMetaSpy).toHaveBeenCalledWith({ count: 0, hasNext: false });
     expect(setPageSpy).toHaveBeenCalledWith(1);
@@ -59,17 +56,14 @@ describe('dataLoadingMode action (v2)', () => {
 
   it('refreshes data when switching to auto mode for list resources', () => {
     const resource = new MultiRecordResource(new FlowContext());
-    const setStepParams = vi.fn();
     const blockModel = {
       resource,
-      setStepParams,
       hasActiveFilters: vi.fn().mockReturnValue(true),
     } as any;
     const refreshSpy = vi.spyOn(resource, 'refresh').mockResolvedValue();
 
     dataLoadingMode.handler?.({ blockModel } as any, { mode: 'auto' });
 
-    expect(setStepParams).toHaveBeenCalledWith('dataLoadingModeSettings', { mode: 'auto' });
     expect(refreshSpy).toHaveBeenCalled();
   });
 });

--- a/packages/core/client/src/flow/actions/dataLoadingMode.tsx
+++ b/packages/core/client/src/flow/actions/dataLoadingMode.tsx
@@ -45,9 +45,6 @@ export const dataLoadingMode = defineAction({
       return;
     }
 
-    // 保存配置到 stepParams
-    blockModel.setStepParams('dataLoadingModeSettings', { mode: params.mode });
-
     // 如果切换到 manual 模式且当前没有活跃的筛选条件，清空数据
     if (params.mode === 'manual' && !blockModel.hasActiveFilters()) {
       resource.setData([]);

--- a/packages/core/client/src/flow/models/base/BlockModel.tsx
+++ b/packages/core/client/src/flow/models/base/BlockModel.tsx
@@ -93,7 +93,8 @@ export class BlockModel<T = DefaultStructure> extends FlowModel<T> {
    * @returns 'auto' | 'manual'
    */
   getDataLoadingMode(): 'auto' | 'manual' {
-    return this.getStepParams('dataLoadingModeSettings')?.mode || 'auto';
+    const flowParams = this.getStepParams('dataLoadingModeSettings');
+    return flowParams?.dataLoadingMode?.mode || 'auto';
   }
 
   static _getScene() {

--- a/packages/core/client/src/flow/models/base/__tests__/CollectionBlockModel.initialBeforeRenderRefresh.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/CollectionBlockModel.initialBeforeRenderRefresh.test.ts
@@ -1,0 +1,130 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FlowEngine, MultiRecordResource } from '@nocobase/flow-engine';
+import { CollectionBlockModel } from '@nocobase/client';
+import { dataLoadingMode } from '../../../actions/dataLoadingMode';
+
+class InitialBeforeRenderTestBlockModel extends CollectionBlockModel {
+  createResource(ctx: any, _params: any) {
+    return ctx.createResource(MultiRecordResource);
+  }
+}
+
+function setupModel() {
+  const engine = new FlowEngine();
+  engine.context.defineProperty('location', { value: { search: '' } as any });
+  engine.registerActions({ dataLoadingMode });
+  engine.registerModels({ InitialBeforeRenderTestBlockModel });
+
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'users',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'name', type: 'string', interface: 'input' },
+    ],
+  });
+
+  const model = engine.createModel<InitialBeforeRenderTestBlockModel>({
+    uid: 'initial-before-render-block',
+    use: 'InitialBeforeRenderTestBlockModel',
+    stepParams: {
+      resourceSettings: {
+        init: {
+          dataSourceKey: 'main',
+          collectionName: 'users',
+        },
+      },
+    },
+  });
+
+  return { model, resource: model.resource as MultiRecordResource };
+}
+
+function setupModelWithManualMode() {
+  const engine = new FlowEngine();
+  engine.context.defineProperty('location', { value: { search: '' } as any });
+  engine.registerActions({ dataLoadingMode });
+  engine.registerModels({ InitialBeforeRenderTestBlockModel });
+
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'users',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'name', type: 'string', interface: 'input' },
+    ],
+  });
+
+  const model = engine.createModel<InitialBeforeRenderTestBlockModel>({
+    uid: 'manual-before-render-block',
+    use: 'InitialBeforeRenderTestBlockModel',
+    stepParams: {
+      resourceSettings: {
+        init: {
+          dataSourceKey: 'main',
+          collectionName: 'users',
+        },
+      },
+      dataLoadingModeSettings: {
+        dataLoadingMode: {
+          mode: 'manual',
+        },
+      },
+    },
+  });
+
+  return { model, resource: model.resource as MultiRecordResource };
+}
+
+describe('CollectionBlockModel initial beforeRender refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('only performs one actual data request on first beforeRender', async () => {
+    const { model, resource } = setupModel();
+    const runActionSpy = vi.spyOn(resource, 'runAction').mockResolvedValue({
+      data: [{ id: 1, name: 'Alice' }],
+      meta: { count: 1, hasNext: false, page: 1, pageSize: 20 },
+    });
+
+    const renderPromise = model.dispatchEvent('beforeRender', undefined, { useCache: false });
+    await vi.runAllTimersAsync();
+    await renderPromise;
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(runActionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects saved manual mode and skips initial request when filters are empty', async () => {
+    const { model, resource } = setupModelWithManualMode();
+    const runActionSpy = vi.spyOn(resource, 'runAction').mockResolvedValue({
+      data: [{ id: 1, name: 'Alice' }],
+      meta: { count: 1, hasNext: false, page: 1, pageSize: 20 },
+    });
+
+    const renderPromise = model.dispatchEvent('beforeRender', undefined, { useCache: false });
+    await vi.runAllTimersAsync();
+    await renderPromise;
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(runActionSpy).not.toHaveBeenCalled();
+    expect(resource.getData()).toEqual([]);
+    expect(resource.getMeta('count')).toBe(0);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where adding a data block or refreshing the page would trigger double refreshes. |
| 🇨🇳 Chinese | 修复添加数据区块及刷新页面时会触发两次刷新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
