### PR TITLE
fix(filter): apply date display format

### DIFF
--- a/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/DatePicker.tsx
@@ -25,7 +25,7 @@ interface IDatePickerProps {
 }
 
 const stripTimeFromFormat = (format?: string) =>
-  format ? format.replace(/\s*HH?:mm(?::ss)?(?:\.SSS)?/g, '').trim() : format;
+  format ? format.replace(/\s*[Hh]{1,2}:mm(?::ss)?(?:\.SSS)?(?:\s*[aA])?/g, '').trim() : format;
 
 /**
  * 解析筛选日期组件的展示格式。

--- a/packages/core/client/src/schema-component/antd/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/core/client/src/schema-component/antd/date-picker/__tests__/date-picker.test.tsx
@@ -119,6 +119,18 @@ describe('resolveFilterPickerFormat', () => {
     ).toBe('MM/DD/YY HH:mm:ss');
   });
 
+  it('应在 12 小时制日期时间格式中避免重复拼接时间部分', () => {
+    expect(
+      resolveFilterPickerFormat({
+        targetPicker: 'date',
+        picker: 'date',
+        format: 'MM/DD/YY hh:mm:ss a',
+        showTime: true,
+        timeFormat: 'hh:mm:ss a',
+      }),
+    ).toBe('MM/DD/YY hh:mm:ss a');
+  });
+
   it('切换 picker 时应回退到对应 picker 的默认格式', () => {
     expect(
       resolveFilterPickerFormat({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

v1 页面筛选表单中的日期字段在配置日期显示格式后，输入框仍然使用默认格式显示，修改后不会立即生效，刷新页面后也没有恢复正确格式，导致筛选配置与页面表现不一致。

### Description

本次修复统一了筛选日期组件的格式解析逻辑，优先读取 schema 中配置的 `dateFormat` 和 `format`，避免被 picker 默认格式覆盖。
同时移除了筛选日期组件内部对旧格式的缓存，确保修改配置后页面立即使用最新格式，并在切换 picker 时同步更新对应的格式配置。
补充了日期格式解析的回归测试，覆盖自定义日期格式、日期时间格式和切换 picker 后的默认格式行为。

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where custom date formats do not take effect in v1 filter forms |
| 🇨🇳 Chinese | 修复 v1 筛选表单中自定义日期格式不生效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
