### PR TITLE
fix: select record popup can't be opened second time

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
@@ -136,7 +136,15 @@ function RemoteModelRenderer({ options, fieldModel }) {
     if (fieldModel) {
       fieldModel.selectBlockModel = data;
     }
-  }, [data]);
+    return () => {
+      if (data?.uid) {
+        ctx?.engine?.removeModelWithSubModels?.(data.uid);
+      }
+      if (fieldModel?.selectBlockModel === data) {
+        fieldModel.selectBlockModel = undefined;
+      }
+    };
+  }, [ctx?.engine, data, fieldModel]);
   if (loading || !data?.uid) {
     return <SkeletonFallback style={{ margin: 16 }} />;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the “Select record” popup in the subtable failed to load correctly when opened the second time. |
| 🇨🇳 Chinese | 修复子表格中的“选择数据”弹窗第二次打开时无法正确加载的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
