### PR TITLE
fix(variable-initializer): set zIndex for aggregate drawer

### DIFF
--- a/packages/plugins/@nocobase/plugin-custom-variables/src/client/variableInitializer.tsx
+++ b/packages/plugins/@nocobase/plugin-custom-variables/src/client/variableInitializer.tsx
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import {
   ActionContextProvider,
   css,
@@ -30,6 +39,19 @@ function FilterDynamicComponent({ value, onChange, renderSchemaComponent }) {
 
 function defaultFilter() {
   return true;
+}
+
+/**
+ * 返回 body 容器，避免挂到带 transform 的应用容器后被外层配置弹窗遮挡。
+ *
+ * @returns 聚合变量抽屉的挂载节点
+ * @example
+ * ```typescript
+ * getDocumentBody();
+ * ```
+ */
+function getDocumentBody() {
+  return document.body;
 }
 
 const FieldsSelect = observer(
@@ -69,6 +91,7 @@ const getAggregateVariableSchema = (initialValues: any, action: string) => {
         'x-component': 'Action.Drawer',
         'x-component-props': {
           zIndex: 9999,
+          getContainer: getDocumentBody,
         },
         type: 'void',
         title: titleMap[action],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

修复菜单项 `Edit badge` 配置弹窗内打开聚合变量抽屉时，抽屉被外层弹窗遮挡的问题。

### Description

- 在聚合变量抽屉配置中显式将挂载容器设置为 `document.body`
- 避免抽屉继续挂载到带有 `transform: translateZ(0)` 的 `#nocobase-app-container`，从而落入错误的堆叠上下文
- 保持改动范围只在 `plugin-custom-variables` 内，降低对其他弹层行为的影响
- 已执行 `yarn eslint packages/plugins/@nocobase/plugin-custom-variables/src/client/variableInitializer.tsx`

建议评审时按以下方式验证：
- 打开页面设计模式中的菜单项设置
- 进入 `Edit badge`
- 从变量面板打开 `Add aggregate variable`
- 确认聚合变量抽屉显示在最上层，不再被 `Edit badge` 弹窗遮挡

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the aggregate variable drawer is obscured |
| 🇨🇳 Chinese | 修复聚合变量抽屉被遮挡的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
