### PR TITLE
docs: improve language section formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-English | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)| [Français](./README.fr.md)
+🌐 Languages: English | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)| [Français](./README.fr.md)
 
 https://github.com/user-attachments/assets/4d11a87b-00e2-48f3-9bf7-389d21072d13
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Improve the readability of the language selector at the top of the README by clearly indicating that the links correspond to available README translations.

### Description
This PR updates the language links section at the top of `README.md` by adding a `🌐 Languages:` prefix.

Before:
English | 中文 | 日本語 | Français

After:
🌐 Languages: English | 中文 | 日本語 | Français

This is a small documentation improvement that enhances clarity without affecting functionality.

Potential risks: None  
Testing: Verified that the README renders correctly on GitHub.

### Related issues
None

### Showcase
Not applicable (documentation formatting change)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve README language section formatting |
| 🇨🇳 Chinese | 优化 README 语言链接部分的格式 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary