### PR TITLE
docs: add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ https://github.com/user-attachments/assets/4d11a87b-00e2-48f3-9bf7-389d21072d13
 <a href="https://www.producthunt.com/posts/nocobase?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_souce=badge-nocobase" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-topic-badge.svg?post_id=456520&theme=light&period=weekly&topic_id=267" alt="NocoBase - Scalability&#0045;first&#0044;&#0032;open&#0045;source&#0032;no&#0045;code&#0032;platform | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 </p>
 
+## Table of Contents
+
+- [What is NocoBase](#what-is-nocobase)
+- [Release Notes](#release-notes)
+- [Distinctive features](#distinctive-features)
+- [Installation](#installation)
+- [How NocoBase works](#how-nocobase-works)
+
 ## What is NocoBase
 
 NocoBase is the most extensible AI-powered no-code platform.   


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Improve navigation within the README by adding a table of contents.

### Description

This PR adds a table of contents near the top of the README to make it easier for readers to navigate through the different sections.

The README is quite long, so this helps users quickly jump to sections such as installation, features, and release notes.

Potential risks: None

Testing: Verified that all anchor links work correctly on GitHub.

### Related issues

None

### Showcase

Not applicable (documentation improvement)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add table of contents to README |
| 🇨🇳 Chinese | 为 README 添加目录 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary