### PR TITLE
fix(schema-settings): restore choice defaults

### DIFF
--- a/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
+++ b/packages/core/client/src/schema-settings/SchemaSettingsDefaultValue.tsx
@@ -50,13 +50,13 @@ const getActionContext = (context: { fieldSchema?: Schema }) => {
  *
  * @param clonedSchema 当前字段 schema 的克隆副本
  * @param collectionFieldUiSchema 数据表字段上的 uiSchema
- * @returns 合并后的字段 schema
  * @example
  * ```typescript
- * const nextSchema = applyCollectionFieldUiSchemaToDefaultValueSchema(
- *   { 'x-component': 'CollectionField' },
- *   { 'x-component': 'Select', enum: [{ label: 'Option 1', value: 'option1' }] },
- * );
+ * const schema = { 'x-component': 'CollectionField' };
+ * applyCollectionFieldUiSchemaToDefaultValueSchema(schema, {
+ *   'x-component': 'Select',
+ *   enum: [{ label: 'Option 1', value: 'option1' }],
+ * });
  * ```
  */
 export const applyCollectionFieldUiSchemaToDefaultValueSchema = (
@@ -64,7 +64,7 @@ export const applyCollectionFieldUiSchemaToDefaultValueSchema = (
   collectionFieldUiSchema: Record<string, any>,
 ) => {
   if (!collectionFieldUiSchema) {
-    return clonedSchema;
+    return;
   }
 
   clonedSchema['x-component'] = collectionFieldUiSchema['x-component'] || 'Input';
@@ -77,14 +77,12 @@ export const applyCollectionFieldUiSchemaToDefaultValueSchema = (
 
   // 选项字段的选项源挂在 schema.enum 上，默认值弹窗如果不显式继承会导致下拉无内容。
   if (collectionFieldUiSchema.enum) {
-    clonedSchema.enum = _.cloneDeep(collectionFieldUiSchema.enum);
+    clonedSchema.enum = collectionFieldUiSchema.enum;
   }
 
   if (collectionFieldUiSchema.type) {
     clonedSchema.type = collectionFieldUiSchema.type;
   }
-
-  return clonedSchema;
 };
 
 export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: {
@@ -201,15 +199,11 @@ export const SchemaSettingsDefaultValue = function DefaultValueConfigure(props: 
               const defaultValue = getFieldDefaultValue(clonedSchema, collectionField);
 
               if (clonedSchema['x-component'] === 'CollectionField' && collectionField?.uiSchema) {
-                applyCollectionFieldUiSchemaToDefaultValueSchema(clonedSchema, _.cloneDeep(collectionField.uiSchema));
+                applyCollectionFieldUiSchemaToDefaultValueSchema(clonedSchema, collectionField.uiSchema);
               }
 
               if (collectionField.target && clonedSchema['x-component-props']) {
                 clonedSchema['x-component-props'].mode = 'Select';
-              }
-
-              if (collectionField?.uiSchema.type) {
-                clonedSchema.type = collectionField.uiSchema.type;
               }
 
               if (collectionField?.uiSchema['x-component'] === 'Checkbox') {

--- a/packages/core/client/src/schema-settings/__tests__/SchemaSettingsDefaultValue.test.ts
+++ b/packages/core/client/src/schema-settings/__tests__/SchemaSettingsDefaultValue.test.ts
@@ -29,15 +29,14 @@ describe('applyCollectionFieldUiSchemaToDefaultValueSchema', () => {
       ],
     };
 
-    const nextSchema = applyCollectionFieldUiSchemaToDefaultValueSchema(schema, uiSchema);
+    applyCollectionFieldUiSchemaToDefaultValueSchema(schema, uiSchema);
 
-    expect(nextSchema['x-component']).toBe('Select');
-    expect(nextSchema.type).toBe('string');
-    expect(nextSchema['x-component-props']).toMatchObject({
+    expect(schema['x-component']).toBe('Select');
+    expect(schema.type).toBe('string');
+    expect(schema['x-component-props']).toMatchObject({
       allowClear: true,
       placeholder: '请选择',
     });
-    expect(nextSchema.enum).toEqual(uiSchema.enum);
-    expect(nextSchema.enum).not.toBe(uiSchema.enum);
+    expect(schema.enum).toBe(uiSchema.enum);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

v1 页面中的选项字段在配置“设置默认值”时，弹窗内没有任何可选项，导致下拉单选、下拉多选、单选、复选字段都无法正常设置默认值。

### Description 

在默认值弹窗中，`CollectionField` 会被转换成实际表单组件来渲染。原来的转换逻辑没有继承选项字段依赖的 `enum` 配置，导致弹窗中的选项源丢失，最终表现为下拉或选项列表为空。

这次调整补齐了默认值弹窗对 `uiSchema.enum` 的继承逻辑，并补充了对应单测，确保选项字段在默认值配置场景下能正常显示可选项。

已完成自测：
- 运行 `yarn test --client packages/core/client/src/schema-settings/__tests__/SchemaSettingsDefaultValue.test.ts`
- 在浏览器中回归验证 v1 页面 4 个选项字段的“设置默认值”弹窗，选项均可正常展示

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where choice fields show no options when setting default values in v1 |
| 🇨🇳 Chinese | 修复 v1 选项字段在设置默认值时没有可选项的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
