### PR TITLE
fix(ai): the specificed base URL dose not get effect in EmbeddingProvider

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -132,7 +132,7 @@ export class DashscopeEmbeddingProvider extends EmbeddingProvider {
   createEmbedding(): EmbeddingsInterface {
     return new OpenAIEmbeddings({
       configuration: {
-        baseURL: this.baseUrl ?? '',
+        baseURL: this.baseURL ?? '',
         apiKey: this.apiKey,
       },
       model: this.model,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
@@ -193,7 +193,7 @@ export class GoogleGenAIEmbeddingProvider extends EmbeddingProvider {
   createEmbedding(): EmbeddingsInterface {
     return new GoogleGenerativeAIEmbeddings({
       apiKey: this.apiKey,
-      baseUrl: this.baseUrl,
+      baseUrl: this.baseURL,
       model: this.model,
     });
   }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/ollama.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/ollama.ts
@@ -81,7 +81,7 @@ export class OllamaEmbeddingProvider extends EmbeddingProvider {
 
   createEmbedding(): EmbeddingsInterface {
     return new OllamaEmbeddings({
-      baseUrl: this.baseUrl,
+      baseUrl: this.baseURL,
       model: this.model,
     });
   }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/embedding.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/embedding.ts
@@ -19,7 +19,7 @@ export class OpenAiEmbeddingProvider extends EmbeddingProvider {
   createEmbedding(): EmbeddingsInterface {
     return new OpenAIEmbeddings({
       configuration: {
-        baseURL: this.baseUrl ?? '',
+        baseURL: this.baseURL ?? '',
         apiKey: this.apiKey,
       },
       model: this.model,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -268,12 +268,12 @@ export abstract class EmbeddingProvider {
     return apiKey;
   }
 
-  protected get baseUrl() {
-    const baseUrl = this.serviceOptions?.baseUrl ?? this.getDefaultUrl();
-    if (!baseUrl) {
-      throw new Error('baseUrl is required');
+  protected get baseURL() {
+    const baseURL = this.serviceOptions?.baseURL ?? this.getDefaultUrl();
+    if (!baseURL) {
+      throw new Error('baseURL is required');
     }
-    return baseUrl;
+    return baseURL;
   }
 
   protected get model() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
 fixed issues that the specificed base URL dose not get effect in EmbeddingProvider

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix issue with specified URL for LLM service not taking effect in text embedding model calls. |
| 🇨🇳 Chinese | 修复LLM服务指定的URL在调用文本嵌入模型时不生效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
