### PR TITLE
fix(ai): data modeling missing system fields createdBy and updatedBy

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/data-modeling/ui/Table.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/data-modeling/ui/Table.tsx
@@ -211,7 +211,7 @@ const useColumns = (
                 value: 'createdAt',
               },
               {
-                label: t('Last Updated at'),
+                label: t('Last updated at'),
                 value: 'updatedAt',
               },
               {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/tools/defineCollections.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/tools/defineCollections.ts
@@ -59,6 +59,44 @@ const updatedAtField = {
     'x-read-pretty': true,
   },
 };
+const createdByField = {
+  type: 'belongsTo',
+  name: 'createdBy',
+  interface: 'createdBy',
+  target: 'users',
+  foreignKey: 'createdById',
+  uiSchema: {
+    type: 'object',
+    title: '{{t("Created by")}}',
+    'x-component': 'AssociationField',
+    'x-component-props': {
+      fieldNames: {
+        value: 'id',
+        label: 'nickname',
+      },
+    },
+    'x-read-pretty': true,
+  },
+};
+const updatedByField = {
+  type: 'belongsTo',
+  name: 'updatedBy',
+  interface: 'updatedBy',
+  target: 'users',
+  foreignKey: 'updatedById',
+  uiSchema: {
+    type: 'object',
+    title: '{{t("Last updated by")}}',
+    'x-component': 'AssociationField',
+    'x-component-props': {
+      fieldNames: {
+        value: 'id',
+        label: 'nickname',
+      },
+    },
+    'x-read-pretty': true,
+  },
+};
 
 class IntentError extends Error {
   constructor(message: string) {
@@ -147,6 +185,14 @@ export default defineTools({
           if (options.updatedAt !== false) {
             systemFields.push(updatedAtField);
             options.updatedAt = true;
+          }
+          if (options.createdBy) {
+            systemFields.push(createdByField);
+            options.createdBy = true;
+          }
+          if (options.updatedBy) {
+            systemFields.push(updatedByField);
+            options.updatedBy = true;
           }
 
           const baseFields = [...systemFields, ...normalFields];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fixed issue that collection created by AI employee always missing `createBy` and `updateBy` fields

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed issue that collection created by AI employee always missing `createBy` and `updateBy` fields |
| 🇨🇳 Chinese | 修复AI员工创建的数据表总是缺少”创建人“、”修改人“字段的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
