### PR TITLE
fix(server): ignore some app events in worker

### DIFF
--- a/packages/core/server/src/__tests__/app-supervisor/sync-message.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/sync-message.test.ts
@@ -1,0 +1,119 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppSupervisor } from '../../app-supervisor';
+import Application from '../../application';
+
+// Stub out Application.prototype.init to avoid real DB/logger initialization
+vi.spyOn(Application.prototype as any, 'init').mockImplementation(function (this: any) {
+  this.reInitEvents();
+});
+
+describe('AppSupervisor sync messages in worker mode', () => {
+  let supervisor: AppSupervisor;
+  let originalWorkerMode: string | undefined;
+  let sendSyncMessageSpy: ReturnType<typeof vi.spyOn>;
+  const createdApps: Application[] = [];
+
+  beforeEach(() => {
+    originalWorkerMode = process.env.WORKER_MODE;
+    supervisor = AppSupervisor.getInstance();
+    sendSyncMessageSpy = vi.spyOn(supervisor, 'sendSyncMessage').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (originalWorkerMode === undefined) {
+      delete process.env.WORKER_MODE;
+    } else {
+      process.env.WORKER_MODE = originalWorkerMode;
+    }
+    sendSyncMessageSpy.mockRestore();
+    // Clean up registered apps from supervisor
+    for (const app of createdApps) {
+      delete (supervisor as any).processAdapter?.apps?.[app.name];
+    }
+    createdApps.length = 0;
+  });
+
+  function registerTestApp(name: string) {
+    const app = supervisor.registerApp({
+      appModel: {
+        name,
+        options: { name, skipSupervisor: true },
+      },
+    });
+    createdApps.push(app);
+    return app;
+  }
+
+  it('should publish sync messages on sub-app lifecycle events when serving', async () => {
+    delete process.env.WORKER_MODE;
+
+    const app = registerTestApp('test-serving-app');
+
+    await app.emitAsync('afterStart');
+    expect(sendSyncMessageSpy).toHaveBeenCalledWith(undefined, {
+      type: 'app:started',
+      appName: 'test-serving-app',
+    });
+
+    sendSyncMessageSpy.mockClear();
+    await app.emitAsync('afterStop');
+    expect(sendSyncMessageSpy).toHaveBeenCalledWith(undefined, {
+      type: 'app:stopped',
+      appName: 'test-serving-app',
+    });
+
+    sendSyncMessageSpy.mockClear();
+    await app.emitAsync('afterDestroy');
+    expect(sendSyncMessageSpy).toHaveBeenCalledWith(undefined, {
+      type: 'app:removed',
+      appName: 'test-serving-app',
+    });
+  });
+
+  it('should NOT publish sync messages on sub-app lifecycle events when WORKER_MODE is "-"', async () => {
+    process.env.WORKER_MODE = '-';
+
+    const app = registerTestApp('test-worker-app');
+
+    await app.emitAsync('afterStart');
+    await app.emitAsync('afterStop');
+    await app.emitAsync('afterDestroy');
+
+    expect(sendSyncMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it('should NOT clearAppStatus on destroy when WORKER_MODE is "-"', async () => {
+    process.env.WORKER_MODE = '-';
+
+    const clearAppStatusSpy = vi.spyOn(supervisor, 'clearAppStatus').mockResolvedValue(undefined);
+    const app = registerTestApp('test-clear-worker');
+
+    supervisor.addApp(app);
+    await app.emitAsync('afterDestroy');
+
+    expect(clearAppStatusSpy).not.toHaveBeenCalled();
+    clearAppStatusSpy.mockRestore();
+  });
+
+  it('should clearAppStatus on destroy when serving', async () => {
+    delete process.env.WORKER_MODE;
+
+    const clearAppStatusSpy = vi.spyOn(supervisor, 'clearAppStatus').mockResolvedValue(undefined);
+    const app = registerTestApp('test-clear-serving');
+
+    supervisor.addApp(app);
+    await app.emitAsync('afterDestroy');
+
+    expect(clearAppStatusSpy).toHaveBeenCalledWith('test-clear-serving');
+    clearAppStatusSpy.mockRestore();
+  });
+});

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -413,7 +413,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
 
     const app = new Application(options);
 
-    if (hook !== false) {
+    if (hook ?? app.serving()) {
       app.on('afterStart', async () => {
         await this.sendSyncMessage(mainApp, {
           type: 'app:started',
@@ -722,6 +722,10 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   }
 
   private bindAppEvents(app: Application) {
+    if (!app.serving()) {
+      return;
+    }
+
     app.on('afterDestroy', async () => {
       delete this.apps[app.name];
       delete this.appStatus[app.name];


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where `beforeStop` event sent by worker cause serving app stops.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where lifecycle events sent by worker cause serving app stops |
| 🇨🇳 Chinese | 修复工作进程发送应用生命周期事件导致服务实例停止的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
