### PR TITLE
fix(resourcer): prevent filterByTk arrays (> 100) from being converted to objects

### DIFF
--- a/packages/core/resourcer/src/__tests__/utils.test.ts
+++ b/packages/core/resourcer/src/__tests__/utils.test.ts
@@ -29,6 +29,13 @@ describe('utils', () => {
         sort: '-col',
       });
     });
+
+    it('normalizes indexed filterByTk objects to arrays when exceeding arrayLimit', () => {
+      const query = Array.from({ length: 120 }, (_, i) => `filterByTk[${i}]=${i + 1}`).join('&');
+      const result = parseQuery(query);
+
+      expect(result.filterByTk).toEqual(Array.from({ length: 120 }, (_, i) => String(i + 1)));
+    });
   });
 
   describe('parseFields', () => {

--- a/packages/core/resourcer/src/utils.ts
+++ b/packages/core/resourcer/src/utils.ts
@@ -239,6 +239,19 @@ function smartParse(str) {
   }
 }
 
+function normalizeIndexedObjectToArray(value: any) {
+  if (!value || Array.isArray(value) || typeof value !== 'object') {
+    return value;
+  }
+
+  const keys = Object.keys(value);
+  if (!keys.length || !keys.every((key) => /^\d+$/.test(key))) {
+    return value;
+  }
+
+  return keys.sort((a, b) => Number(a) - Number(b)).map((key) => value[key]);
+}
+
 export function parseQuery(input: string): any {
   // 自带 query 处理的不太给力，需要用 qs 转一下
   const query = qs.parse(input, {
@@ -258,6 +271,8 @@ export function parseQuery(input: string): any {
   if (typeof query.filterByTk === 'string') {
     query.filterByTk = smartParse(query.filterByTk);
   }
+
+  query.filterByTk = normalizeIndexedObjectToArray(query.filterByTk);
 
   return query;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Prevent the `filterByTk` parameter array from being automatically converted into an object when it exceeds 100 items         |
| 🇨🇳 Chinese | 避免 `filterByTk` 参数数组超过 100 个时被自动转换成对象          |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
