### PR TITLE
refactor(admin-layout): drop content model

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutModel.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutModel.tsx
@@ -15,11 +15,9 @@ import { AdminLayoutRouteCoordinator, type RoutePageMeta } from '../../../flow/a
 import { AdminLayoutShell } from './AdminLayoutShell';
 import { AdminLayoutMenuTreeModel } from './AdminLayoutMenuModels';
 import React from 'react';
-import { AdminLayoutContentModel } from './AdminLayoutSlotModels';
 
 type AdminLayoutStructure = {
   subModels: {
-    layoutContent?: AdminLayoutContentModel;
     menu?: AdminLayoutMenuTreeModel;
   };
 };
@@ -27,16 +25,13 @@ type AdminLayoutStructure = {
 /**
  * Admin Layout 的根模型。
  *
- * 当前阶段先让它稳定托管 Layout 的核心运行时和关键 slot：
- * - `layoutContent`：页面主体区域
- * - `menu`：菜单树
- *
- * 这样可以在不改页面行为的前提下，把 Layout 渲染逐步收敛到 FlowModel 树中。
+ * 当前阶段先让它稳定托管 Layout 的核心运行时和菜单树，
+ * 让页面主体直接由 shell 渲染，避免为纯渲染容器额外挂一层 slot model。
  *
  * @example
  * ```typescript
  * const model = flowEngine.getModel<AdminLayoutModel>('admin-layout-model');
- * model?.subModels.layoutContent;
+ * model?.subModels.menu;
  * ```
  */
 export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
@@ -58,19 +53,12 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
   }
 
   /**
-   * 确保 root model 的关键 slot 始终存在。
+   * 确保 root model 的菜单子树始终存在。
    *
    * 这里使用固定 uid，保证复用现有模型实例时也能补齐缺失的子模型，
    * 避免 `AdminLayout` 分阶段重构时出现新旧模型树结构不一致。
    */
-  ensureShellSubModels() {
-    if (!this.subModels.layoutContent) {
-      this.setSubModel('layoutContent', {
-        uid: `${this.uid}-layout-content`,
-        use: AdminLayoutContentModel,
-      });
-    }
-
+  ensureMenuSubModel() {
     if (!this.subModels.menu) {
       this.setSubModel('menu', {
         uid: `${this.uid}-menu`,
@@ -81,7 +69,7 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
 
   onInit(options) {
     super.onInit(options);
-    this.ensureShellSubModels();
+    this.ensureMenuSubModel();
   }
 
   registerRoutePage(pageUid: string, meta: RoutePageMeta) {
@@ -118,7 +106,7 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
    * @param {NocoBaseDesktopRoute[]} routes 当前用户可访问的桌面路由
    */
   syncMenuRoutes(routes: NocoBaseDesktopRoute[]) {
-    this.ensureShellSubModels();
+    this.ensureMenuSubModel();
     this.subModels.menu?.syncRoutes(routes);
   }
 
@@ -129,7 +117,7 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
 
   protected onMount(): void {
     super.onMount();
-    this.ensureShellSubModels();
+    this.ensureMenuSubModel();
     if (!this.routeDisposer) {
       this.flowEngine.context.defineProperty('currentRoute', {
         get: () => this.getCurrentRouteByActivePage(),

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutShell.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutShell.tsx
@@ -12,7 +12,7 @@ import { HeaderViewProps } from '@ant-design/pro-layout/es/components/Header';
 import type { DragEndEvent } from '@dnd-kit/core';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
-import { DndProvider, FlowModelRenderer, useFlowEngine } from '@nocobase/flow-engine';
+import { DndProvider, useFlowEngine } from '@nocobase/flow-engine';
 import { theme as antdTheme, ConfigProvider, Grid, Popover } from 'antd';
 import { createStyles, createGlobalStyle } from 'antd-style';
 import React, { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -28,6 +28,7 @@ import {
   MobileMenuControlContext,
   resolveAdminLayoutMenuDragMoveOptionsFromEvent,
 } from './AdminLayoutMenuModels';
+import { AdminLayoutContent } from './AdminLayoutSlotModels';
 import { ADMIN_LAYOUT_MODEL_UID } from './constants';
 
 import {
@@ -205,23 +206,6 @@ const headerRender = (props: HeaderViewProps, defaultDom: React.ReactNode) => {
   return <HeaderWrapper>{defaultDom}</HeaderWrapper>;
 };
 
-/**
- * 渲染 Layout 内容区子模型。
- *
- * 这里仍然由 `AdminLayoutShell` 控制 ProLayout 容器，
- * 但页面主体已经改为从 root model 的 `layoutContent` slot 读取。
- */
-const AdminLayoutContentSlot = () => {
-  const flowEngine = useFlowEngine();
-  const model = flowEngine.getModel<AdminLayoutModel>(ADMIN_LAYOUT_MODEL_UID)?.subModels.layoutContent;
-
-  if (!model) {
-    return null;
-  }
-
-  return <FlowModelRenderer model={model} />;
-};
-
 const actionsRender = (props: HeaderViewProps): React.ReactNode[] => {
   if (props.isMobile) {
     return [<MobileActions key="mobile-actions" />];
@@ -396,6 +380,12 @@ export const AdminLayoutShell = (props) => {
   const { Component: AppsComponent } = useApplications();
   const flowSettingsSyncRef = useRef(0);
   const desiredFlowSettingsEnabledRef = useRef(false);
+  const handleLayoutContentElementChange = useCallback(
+    (element: HTMLDivElement | null) => {
+      adminLayoutModel?.setLayoutContentElement(element);
+    },
+    [adminLayoutModel],
+  );
   const selectedTopGroupRoute = useMemo(
     () => findSelectedTopGroupRoute(allAccessRoutes, location.pathname),
     [allAccessRoutes, location.pathname],
@@ -586,7 +576,7 @@ export const AdminLayoutShell = (props) => {
                     <SetIsMobileLayout isMobile={isMobile}>
                       <ConfigProvider theme={isMobile ? mobileTheme : theme}>
                         <GlobalStyle />
-                        <AdminLayoutContentSlot />
+                        <AdminLayoutContent onContentElementChange={handleLayoutContentElementChange} />
                       </ConfigProvider>
                     </SetIsMobileLayout>
                   );

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutSlotModels.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutSlotModels.tsx
@@ -9,17 +9,16 @@
 
 import { HighlightOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
-import { FlowModel } from '@nocobase/flow-engine';
 import { Result } from 'antd';
-import React, { FC, useCallback, useMemo, useRef } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation } from 'react-router-dom';
 import { useDesignable } from '../../../schema-component/hooks';
 import { useToken } from '../../../style';
 import { useAllAccessDesktopRoutes } from '../../../admin-shell';
 
-type LayoutContentHost = FlowModel & {
-  setLayoutContentElement?: (element: HTMLElement | null) => void;
+type AdminLayoutContentProps = {
+  onContentElementChange?: (element: HTMLDivElement | null) => void;
 };
 
 const layoutContentClass = css`
@@ -84,16 +83,19 @@ const ShowTipWhenNoPages = () => {
   return null;
 };
 
-const AdminLayoutContentView: FC<{ host?: LayoutContentHost | null }> = ({ host }) => {
+/**
+ * AdminLayout 内部使用的内容区容器。
+ *
+ * 内容区不再依赖独立 FlowModel，而是通过回调把挂载目标同步给 root model。
+ */
+export const AdminLayoutContent: FC<AdminLayoutContentProps> = ({ onContentElementChange }) => {
   const style = useMemo(() => (isDvhSupported() ? mobileHeight : undefined), []);
-  const layoutContentRef = useRef<HTMLDivElement>(null);
-
   const bindLayoutContentRef = useCallback(
     (node: HTMLDivElement | null) => {
-      layoutContentRef.current = node;
-      host?.setLayoutContentElement?.(node);
+      // shell 直接渲染内容区时，仍需把挂载目标同步给 root model。
+      onContentElementChange?.(node);
     },
-    [host],
+    [onContentElementChange],
   );
 
   return (
@@ -122,28 +124,5 @@ const AdminLayoutContentView: FC<{ host?: LayoutContentHost | null }> = ({ host 
  * ```
  */
 export const LayoutContent: FC = () => {
-  return <AdminLayoutContentView />;
+  return <AdminLayoutContent />;
 };
-
-/**
- * Layout 内容区子模型。
- *
- * 它负责把页面主体渲染收进 FlowModel，同时把 subpage 的挂载目标同步回 root model，
- * 这样后续可以继续把内容区周边能力往子模型上迁移，而不影响现有路由行为。
- *
- * @example
- * ```typescript
- * rootModel.subModels.layoutContent
- * ```
- */
-export class AdminLayoutContentModel extends FlowModel {
-  protected onUnmount(): void {
-    const host = this.parent as LayoutContentHost | undefined;
-    host?.setLayoutContentElement?.(null);
-    super.onUnmount();
-  }
-
-  render() {
-    return <AdminLayoutContentView host={this.parent as LayoutContentHost | undefined} />;
-  }
-}

--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-model.test.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-model.test.tsx
@@ -39,7 +39,6 @@ import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
 import { AdminLayout } from '..';
 import { AdminLayoutModel } from '../AdminLayoutModel';
 import { AdminLayoutMenuTreeModel } from '../AdminLayoutMenuModels';
-import { AdminLayoutContentModel } from '../AdminLayoutSlotModels';
 
 describe('AdminLayout (phase-1 host)', () => {
   beforeEach(() => {
@@ -63,7 +62,7 @@ describe('AdminLayout (phase-1 host)', () => {
     expect(model).toBeInstanceOf(AdminLayoutModel);
     expect(model.props.testFlag).toBe('first-render');
     expect(model.subModels.menu).toBeInstanceOf(AdminLayoutMenuTreeModel);
-    expect(model.subModels.layoutContent).toBeInstanceOf(AdminLayoutContentModel);
+    expect((model.subModels as any).layoutContent).toBeUndefined();
     expect((model.subModels as any).headerActions).toBeUndefined();
     expect(flowModelRendererSpy).toHaveBeenLastCalledWith(expect.objectContaining({ model }));
   });
@@ -88,7 +87,7 @@ describe('AdminLayout (phase-1 host)', () => {
 
     expect(engine.getModel('admin-layout-model')).toBe(existingModel);
     expect(existingModel.subModels.menu).toBeInstanceOf(AdminLayoutMenuTreeModel);
-    expect(existingModel.subModels.layoutContent).toBeInstanceOf(AdminLayoutContentModel);
+    expect((existingModel.subModels as any).layoutContent).toBeUndefined();
     expect((existingModel.subModels as any).headerActions).toBeUndefined();
     expect(flowModelRendererSpy).toHaveBeenLastCalledWith(expect.objectContaining({ model: existingModel }));
   });
@@ -113,6 +112,33 @@ describe('AdminLayout (phase-1 host)', () => {
     await waitFor(() => {
       expect(model.props.testFlag).toBe('v2');
     });
+  });
+
+  it('should expose live layoutContentElement on engine context', async () => {
+    const engine = new FlowEngine();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <AdminLayout />
+      </FlowEngineProvider>,
+    );
+
+    const model = engine.getModel<AdminLayoutModel>('admin-layout-model');
+    expect(model).toBeTruthy();
+
+    const element = document.createElement('div');
+
+    act(() => {
+      model.setLayoutContentElement(element);
+    });
+
+    expect(engine.context.layoutContentElement).toBe(element);
+
+    act(() => {
+      model.setLayoutContentElement(null);
+    });
+
+    expect(engine.context.layoutContentElement).toBeNull();
   });
 
   it('should expose live engine currentRoute when active page changes', async () => {

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -14,7 +14,6 @@ import { RemoteSchemaTemplateManagerPlugin } from '../../../';
 import { Plugin } from '../../../application/Plugin';
 import { AdminLayoutModel } from './AdminLayoutModel';
 import { AdminLayoutMenuItemModel, AdminLayoutMenuTreeModel } from './AdminLayoutMenuModels';
-import { AdminLayoutContentModel } from './AdminLayoutSlotModels';
 import { ADMIN_LAYOUT_MODEL_UID } from './constants';
 import { userCenterSettings } from './userCenterSettings';
 
@@ -68,7 +67,6 @@ export class AdminLayoutPlugin extends Plugin {
       AdminLayoutModel,
       AdminLayoutMenuTreeModel,
       AdminLayoutMenuItemModel,
-      AdminLayoutContentModel,
     });
     this.app.schemaSettingsManager.add(userCenterSettings);
     this.app.addComponents({ AdminLayout, AdminDynamicPage });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

`AdminLayoutModel` 里保留的 `layoutContent` 子模型只负责渲染内容容器并同步 `layoutContentElement`，没有独立状态编排职责，导致 admin-layout 的模型树比实际需要更复杂，也和最近把纯渲染 slot 收回 shell 的重构方向不一致。

### Description 

- 删除 `AdminLayoutContentModel` 和 `AdminLayoutModel` 上的 `layoutContent` 子模型
- 改为由 `AdminLayoutShell` 直接渲染内容区，并继续把内容容器 DOM 同步回 root model
- 保留 `LayoutContent` 的独立组件导出，避免影响 embed 等旧用法
- 更新 admin-layout root model 测试，补充 `layoutContentElement` 上下文断言

已自测：
- `yarn test --client packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-model.test.tsx`
- `yarn test --client packages/core/client/src/flow/__tests__/FlowRoute.test.tsx`
- `yarn test --client packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-route-coordinator.test.ts`
- `./node_modules/.bin/eslint --ext .ts,.tsx packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutModel.tsx packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutSlotModels.tsx packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutShell.tsx packages/core/client/src/route-switch/antd/admin-layout/index.tsx packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-model.test.tsx`

### Showcase

<!-- No UI change -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Simplify admin layout content rendering |
| 🇨🇳 Chinese | 简化 Admin Layout 内容区渲染 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary