### PR TITLE
refactor(admin-layout): unify menu items

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
@@ -68,7 +68,7 @@ export type AdminLayoutMenuNode = {
   routes?: AdminLayoutMenuNode[];
 };
 
-type AdminLayoutMenuRouteOptions = {
+export type AdminLayoutMenuRouteOptions = {
   designable: boolean;
   isMobile: boolean;
   t: (title: any) => any;
@@ -83,13 +83,7 @@ type AdminLayoutMenuMovePositionOption = {
 
 type AdminLayoutMenuItemStructure = {
   subModels: {
-    items?: AdminLayoutMenuItemModel[];
-  };
-};
-
-type AdminLayoutMenuTreeStructure = {
-  subModels: {
-    items?: AdminLayoutMenuItemModel[];
+    menuItems?: AdminLayoutMenuItemModel[];
   };
 };
 
@@ -317,16 +311,22 @@ function getAdminLayoutMenuItemUid(parentUid: string, route: NocoBaseDesktopRout
  * 它会复用还存在的菜单项模型，并同步删除已经失效的分支，
  * 这样可以让 Layout 菜单逐步切换到 FlowModel 树，同时不引入额外的 UI 行为变化。
  *
- * @param {FlowModel & { subModels: { items?: AdminLayoutMenuItemModel[] } }} parent 父模型
+ * @param {FlowModel & { subModels: { menuItems?: AdminLayoutMenuItemModel[] } }} parent 父模型
  * @param {NocoBaseDesktopRoute[]} routes 当前层菜单路由列表
  * @param {NocoBaseDesktopRoute | undefined} parentRoute 父级路由
  */
-function reconcileMenuItems(
-  parent: FlowModel & { subModels: { items?: AdminLayoutMenuItemModel[] } },
+type AdminLayoutMenuItemsParent = FlowModel & {
+  subModels: {
+    menuItems?: AdminLayoutMenuItemModel[];
+  };
+};
+
+export function reconcileAdminLayoutMenuItems(
+  parent: AdminLayoutMenuItemsParent,
   routes: NocoBaseDesktopRoute[],
   parentRoute?: NocoBaseDesktopRoute,
 ) {
-  const existingItems = [...(parent.subModels.items || [])];
+  const existingItems = [...(parent.subModels.menuItems || [])];
   const existingItemMap = new Map(existingItems.map((item) => [item.uid, item]));
   const nextItems: AdminLayoutMenuItemModel[] = [];
   const nextUidSet = new Set<string>();
@@ -337,7 +337,7 @@ function reconcileMenuItems(
     const isExistingModel = !!itemModel;
 
     if (!itemModel) {
-      itemModel = parent.addSubModel('items', {
+      itemModel = parent.addSubModel('menuItems', {
         uid,
         use: AdminLayoutMenuItemModel,
         props: {
@@ -361,7 +361,7 @@ function reconcileMenuItems(
     }
   });
 
-  parent.subModels.items = nextItems;
+  parent.subModels.menuItems = nextItems;
 }
 
 const MenuDesignerButton: FC<{ testId: string }> = (props) => {
@@ -732,7 +732,10 @@ export const AdminLayoutMenuModelRenderer: FC<{
   );
 };
 
-function getInitializerButton(testId: string, parentRoute?: NocoBaseDesktopRoute): AdminLayoutMenuNode {
+export function getAdminLayoutMenuInitializerButton(
+  testId: string,
+  parentRoute?: NocoBaseDesktopRoute,
+): AdminLayoutMenuNode {
   return {
     key: 'x-designer-button',
     name: <MenuDesignerButton testId={testId} />,
@@ -752,7 +755,7 @@ function getInitializerButton(testId: string, parentRoute?: NocoBaseDesktopRoute
  *
  * @example
  * ```typescript
- * const firstItem = menuTree.subModels.items?.[0];
+ * const firstItem = layoutModel.subModels.menuItems?.[0];
  * ```
  */
 export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStructure> {
@@ -777,14 +780,14 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
     });
 
     if (route?.type === NocoBaseDesktopRouteType.group) {
-      reconcileMenuItems(this, Array.isArray(route.children) ? route.children : [], route);
+      reconcileAdminLayoutMenuItems(this, Array.isArray(route.children) ? route.children : [], route);
       return;
     }
 
-    (this.subModels.items || []).forEach((item) => {
+    (this.subModels.menuItems || []).forEach((item) => {
       this.flowEngine.removeModelWithSubModels(item.uid);
     });
-    delete this.subModels.items;
+    delete this.subModels.menuItems;
   }
 
   getRoute() {
@@ -1100,7 +1103,7 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
     if (route.type === NocoBaseDesktopRouteType.group) {
       const itemChildren = Array.isArray(route.children) ? route.children : [];
       const children =
-        (this.subModels.items || [])
+        (this.subModels.menuItems || [])
           .map((item) =>
             item.toProLayoutMenuItem({
               ...options,
@@ -1111,7 +1114,7 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
 
       // add a designer button
       if (options.designable && depth === 0) {
-        children.push(getInitializerButton('schema-initializer-Menu-side', route));
+        children.push(getAdminLayoutMenuInitializerButton('schema-initializer-Menu-side', route));
       }
 
       const groupRoute: AdminLayoutMenuNode = {
@@ -1341,52 +1344,3 @@ registerAdminLayoutMenuExtraMenuItems?.call(AdminLayoutMenuItemModel, (model, t)
       : []),
   ];
 });
-
-/**
- * Layout 菜单树根模型。
- *
- * 当前阶段先把菜单路由同步为一棵独立的 FlowModel 树，
- * 让 Layout 的菜单状态不再依赖 `convertRoutesToLayout()` 这种一次性函数结果。
- *
- * @example
- * ```typescript
- * menuTree.syncRoutes(routes);
- * ```
- */
-export class AdminLayoutMenuTreeModel extends FlowModel<AdminLayoutMenuTreeStructure> {
-  /**
-   * 使用最新的桌面端 route 列表重建菜单树。
-   *
-   * @param {NocoBaseDesktopRoute[]} routes 当前用户可访问的桌面菜单路由
-   */
-  syncRoutes(routes: NocoBaseDesktopRoute[]) {
-    reconcileMenuItems(this, Array.isArray(routes) ? routes : []);
-  }
-
-  toProLayoutRoute(options: Omit<AdminLayoutMenuRouteOptions, 'depth'>) {
-    const result =
-      (this.subModels.items || [])
-        .map((item) =>
-          item.toProLayoutMenuItem({
-            ...options,
-            depth: 0,
-          }),
-        )
-        .filter(Boolean) || [];
-
-    if (options.designable) {
-      options.isMobile
-        ? result.push(getInitializerButton('schema-initializer-Menu-header'))
-        : result.unshift(getInitializerButton('schema-initializer-Menu-header'));
-    }
-
-    return {
-      path: '/',
-      children: result,
-    };
-  }
-
-  render() {
-    return null;
-  }
-}

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutModel.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutModel.tsx
@@ -13,12 +13,17 @@ import { AdminShellProvider } from '../../../admin-shell';
 import { NocoBaseDesktopRoute } from '../../../admin-shell/route-types';
 import { AdminLayoutRouteCoordinator, type RoutePageMeta } from '../../../flow/admin-shell/AdminLayoutRouteCoordinator';
 import { AdminLayoutShell } from './AdminLayoutShell';
-import { AdminLayoutMenuTreeModel } from './AdminLayoutMenuModels';
 import React from 'react';
+import {
+  AdminLayoutMenuItemModel,
+  type AdminLayoutMenuRouteOptions,
+  getAdminLayoutMenuInitializerButton,
+  reconcileAdminLayoutMenuItems,
+} from './AdminLayoutMenuModels';
 
 type AdminLayoutStructure = {
   subModels: {
-    menu?: AdminLayoutMenuTreeModel;
+    menuItems?: AdminLayoutMenuItemModel[];
   };
 };
 
@@ -31,7 +36,7 @@ type AdminLayoutStructure = {
  * @example
  * ```typescript
  * const model = flowEngine.getModel<AdminLayoutModel>('admin-layout-model');
- * model?.subModels.menu;
+ * model?.subModels.menuItems;
  * ```
  */
 export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
@@ -50,26 +55,6 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
 
   private getCurrentRouteByActivePage() {
     return this.routePageMetaMap.get(this.activePageUid)?.currentRoute || {};
-  }
-
-  /**
-   * 确保 root model 的菜单子树始终存在。
-   *
-   * 这里使用固定 uid，保证复用现有模型实例时也能补齐缺失的子模型，
-   * 避免 `AdminLayout` 分阶段重构时出现新旧模型树结构不一致。
-   */
-  ensureMenuSubModel() {
-    if (!this.subModels.menu) {
-      this.setSubModel('menu', {
-        uid: `${this.uid}-menu`,
-        use: AdminLayoutMenuTreeModel,
-      });
-    }
-  }
-
-  onInit(options) {
-    super.onInit(options);
-    this.ensureMenuSubModel();
   }
 
   registerRoutePage(pageUid: string, meta: RoutePageMeta) {
@@ -106,8 +91,30 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
    * @param {NocoBaseDesktopRoute[]} routes 当前用户可访问的桌面路由
    */
   syncMenuRoutes(routes: NocoBaseDesktopRoute[]) {
-    this.ensureMenuSubModel();
-    this.subModels.menu?.syncRoutes(routes);
+    reconcileAdminLayoutMenuItems(this, Array.isArray(routes) ? routes : []);
+  }
+
+  toProLayoutRoute(options: Omit<AdminLayoutMenuRouteOptions, 'depth'>) {
+    const result =
+      (this.subModels.menuItems || [])
+        .map((item) =>
+          item.toProLayoutMenuItem({
+            ...options,
+            depth: 0,
+          }),
+        )
+        .filter(Boolean) || [];
+
+    if (options.designable) {
+      options.isMobile
+        ? result.push(getAdminLayoutMenuInitializerButton('schema-initializer-Menu-header'))
+        : result.unshift(getAdminLayoutMenuInitializerButton('schema-initializer-Menu-header'));
+    }
+
+    return {
+      path: '/',
+      children: result,
+    };
   }
 
   setLayoutContentElement(element: HTMLElement | null) {
@@ -117,7 +124,6 @@ export class AdminLayoutModel extends FlowModel<AdminLayoutStructure> {
 
   protected onMount(): void {
     super.onMount();
-    this.ensureMenuSubModel();
     if (!this.routeDisposer) {
       this.flowEngine.context.defineProperty('currentRoute', {
         get: () => this.getCurrentRouteByActivePage(),

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutShell.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutShell.tsx
@@ -408,7 +408,7 @@ export const AdminLayoutShell = (props) => {
 
   useLayoutEffect(() => {
     adminLayoutModel?.syncMenuRoutes(allAccessRoutes);
-    const nextRoute = adminLayoutModel?.subModels.menu?.toProLayoutRoute({
+    const nextRoute = adminLayoutModel?.toProLayoutRoute({
       designable,
       isMobile: isMobileSider,
       t,

--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-menu-models.test.ts
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-menu-models.test.ts
@@ -13,15 +13,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FlowEngine } from '@nocobase/flow-engine';
 import { observer } from '@nocobase/flow-engine';
 import { NocoBaseDesktopRouteType } from '../../../../admin-shell/route-types';
+import { AdminLayoutModel } from '../AdminLayoutModel';
 import {
   AdminLayoutMenuItemModel,
-  AdminLayoutMenuTreeModel,
   getAdminLayoutMenuMovePositionOptions,
   resolveAdminLayoutMenuDragMoveOptionsFromEvent,
   resolveAdminLayoutMenuDragMoveOptions,
 } from '../AdminLayoutMenuModels';
 
-describe('AdminLayoutMenuTreeModel', () => {
+describe('AdminLayoutModel menu items', () => {
   let engine: FlowEngine;
 
   beforeEach(() => {
@@ -60,13 +60,13 @@ describe('AdminLayoutMenuTreeModel', () => {
     });
   });
 
-  it('should sync route tree into menu subModels and cleanup stale branches', () => {
-    const menuTree = engine.createModel<AdminLayoutMenuTreeModel>({
-      uid: 'admin-layout-menu',
-      use: AdminLayoutMenuTreeModel,
+  it('should sync route tree into menuItems subModels and cleanup stale branches', () => {
+    const adminLayoutModel = engine.createModel<AdminLayoutModel>({
+      uid: 'admin-layout-model',
+      use: AdminLayoutModel,
     });
 
-    menuTree.syncRoutes([
+    adminLayoutModel.syncMenuRoutes([
       {
         id: 1,
         title: 'Group',
@@ -87,17 +87,17 @@ describe('AdminLayoutMenuTreeModel', () => {
       },
     ]);
 
-    expect(menuTree.subModels.items).toHaveLength(2);
-    expect(menuTree.subModels.items?.[0]).toBeInstanceOf(AdminLayoutMenuItemModel);
-    expect(menuTree.subModels.items?.[0].subModels.items).toHaveLength(1);
-    expect(menuTree.subModels.items?.[0].subModels.items?.[0].props.route).toMatchObject({
+    expect(adminLayoutModel.subModels.menuItems).toHaveLength(2);
+    expect(adminLayoutModel.subModels.menuItems?.[0]).toBeInstanceOf(AdminLayoutMenuItemModel);
+    expect(adminLayoutModel.subModels.menuItems?.[0].subModels.menuItems).toHaveLength(1);
+    expect(adminLayoutModel.subModels.menuItems?.[0].subModels.menuItems?.[0].props.route).toMatchObject({
       title: 'Page 1',
       schemaUid: 'page-1',
     });
 
-    const staleGroupUid = menuTree.subModels.items?.[0].uid;
+    const staleGroupUid = adminLayoutModel.subModels.menuItems?.[0].uid;
 
-    menuTree.syncRoutes([
+    adminLayoutModel.syncMenuRoutes([
       {
         id: 2,
         title: 'Link',
@@ -105,8 +105,8 @@ describe('AdminLayoutMenuTreeModel', () => {
       },
     ]);
 
-    expect(menuTree.subModels.items).toHaveLength(1);
-    expect(menuTree.subModels.items?.[0].props.route).toMatchObject({
+    expect(adminLayoutModel.subModels.menuItems).toHaveLength(1);
+    expect(adminLayoutModel.subModels.menuItems?.[0].props.route).toMatchObject({
       title: 'Link',
       type: NocoBaseDesktopRouteType.link,
     });
@@ -114,12 +114,12 @@ describe('AdminLayoutMenuTreeModel', () => {
   });
 
   it('should generate ProLayout route tree from menu models', () => {
-    const menuTree = engine.createModel<AdminLayoutMenuTreeModel>({
-      uid: 'admin-layout-menu',
-      use: AdminLayoutMenuTreeModel,
+    const adminLayoutModel = engine.createModel<AdminLayoutModel>({
+      uid: 'admin-layout-model',
+      use: AdminLayoutModel,
     });
 
-    menuTree.syncRoutes([
+    adminLayoutModel.syncMenuRoutes([
       {
         id: 1,
         title: 'Group',
@@ -140,7 +140,7 @@ describe('AdminLayoutMenuTreeModel', () => {
       },
     ]);
 
-    const route = menuTree.toProLayoutRoute({
+    const route = adminLayoutModel.toProLayoutRoute({
       designable: false,
       isMobile: false,
       t: (title) => title,
@@ -152,7 +152,7 @@ describe('AdminLayoutMenuTreeModel', () => {
     expect(route.children[0].redirect).toBe('/admin/page-1');
     expect(route.children[0]._depth).toBe(0);
     expect(route.children[0]._route).toMatchObject({ id: 1, type: NocoBaseDesktopRouteType.group });
-    expect(route.children[0]._model).toBe(menuTree.subModels.items?.[0]);
+    expect(route.children[0]._model).toBe(adminLayoutModel.subModels.menuItems?.[0]);
     expect(route.children[0].routes).toHaveLength(1);
     expect(route.children[0].routes?.[0].path).toBe('/admin/page-1');
     expect(route.children[0].routes?.[0].redirect).toBe('/admin/page-1');
@@ -161,20 +161,22 @@ describe('AdminLayoutMenuTreeModel', () => {
       schemaUid: 'page-1',
       type: NocoBaseDesktopRouteType.page,
     });
-    expect(route.children[0].routes?.[0]._model).toBe(menuTree.subModels.items?.[0].subModels.items?.[0]);
+    expect(route.children[0].routes?.[0]._model).toBe(
+      adminLayoutModel.subModels.menuItems?.[0].subModels.menuItems?.[0],
+    );
     expect(route.children[1].path).toBe('/');
     expect(route.children[1]._depth).toBe(0);
     expect(route.children[1]._route).toMatchObject({ id: 2, type: NocoBaseDesktopRouteType.link });
-    expect(route.children[1]._model).toBe(menuTree.subModels.items?.[1]);
+    expect(route.children[1]._model).toBe(adminLayoutModel.subModels.menuItems?.[1]);
   });
 
   it('should insert designer buttons in expected positions', () => {
-    const menuTree = engine.createModel<AdminLayoutMenuTreeModel>({
-      uid: 'admin-layout-menu',
-      use: AdminLayoutMenuTreeModel,
+    const adminLayoutModel = engine.createModel<AdminLayoutModel>({
+      uid: 'admin-layout-model',
+      use: AdminLayoutModel,
     });
 
-    menuTree.syncRoutes([
+    adminLayoutModel.syncMenuRoutes([
       {
         id: 1,
         title: 'Group',
@@ -190,7 +192,7 @@ describe('AdminLayoutMenuTreeModel', () => {
       },
     ]);
 
-    const desktopRoute = menuTree.toProLayoutRoute({
+    const desktopRoute = adminLayoutModel.toProLayoutRoute({
       designable: true,
       isMobile: false,
       t: (title) => title,
@@ -200,7 +202,7 @@ describe('AdminLayoutMenuTreeModel', () => {
     expect(React.isValidElement(desktopRoute.children[0].name)).toBe(true);
     expect(desktopRoute.children[1].routes?.[1].key).toBe('x-designer-button');
 
-    const mobileRoute = menuTree.toProLayoutRoute({
+    const mobileRoute = adminLayoutModel.toProLayoutRoute({
       designable: true,
       isMobile: true,
       t: (title) => title,
@@ -210,14 +212,14 @@ describe('AdminLayoutMenuTreeModel', () => {
     expect(mobileRoute.children[0].routes?.[1].key).toBe('x-designer-button');
   });
 
-  it('should update ProLayout route result after menu tree sync in observer render', async () => {
-    const menuTree = engine.createModel<AdminLayoutMenuTreeModel>({
-      uid: 'admin-layout-menu',
-      use: AdminLayoutMenuTreeModel,
+  it('should update ProLayout route result after menuItems sync in observer render', async () => {
+    const adminLayoutModel = engine.createModel<AdminLayoutModel>({
+      uid: 'admin-layout-model',
+      use: AdminLayoutModel,
     });
 
     const RouteReader = observer(() => {
-      const route = menuTree.toProLayoutRoute({
+      const route = adminLayoutModel.toProLayoutRoute({
         designable: true,
         isMobile: false,
         t: (title) => title,
@@ -231,7 +233,7 @@ describe('AdminLayoutMenuTreeModel', () => {
     expect(screen.getByTestId('route-length').textContent).toBe('1');
 
     act(() => {
-      menuTree.syncRoutes([
+      adminLayoutModel.syncMenuRoutes([
         {
           id: 1,
           title: 'Page 1',

--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-model.test.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-model.test.tsx
@@ -38,7 +38,6 @@ vi.mock('@nocobase/flow-engine', async (importOriginal) => {
 import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
 import { AdminLayout } from '..';
 import { AdminLayoutModel } from '../AdminLayoutModel';
-import { AdminLayoutMenuTreeModel } from '../AdminLayoutMenuModels';
 
 describe('AdminLayout (phase-1 host)', () => {
   beforeEach(() => {
@@ -61,7 +60,7 @@ describe('AdminLayout (phase-1 host)', () => {
     const model = engine.getModel<AdminLayoutModel>('admin-layout-model');
     expect(model).toBeInstanceOf(AdminLayoutModel);
     expect(model.props.testFlag).toBe('first-render');
-    expect(model.subModels.menu).toBeInstanceOf(AdminLayoutMenuTreeModel);
+    expect((model.subModels as any).menu).toBeUndefined();
     expect((model.subModels as any).layoutContent).toBeUndefined();
     expect((model.subModels as any).headerActions).toBeUndefined();
     expect(flowModelRendererSpy).toHaveBeenLastCalledWith(expect.objectContaining({ model }));
@@ -86,7 +85,7 @@ describe('AdminLayout (phase-1 host)', () => {
     });
 
     expect(engine.getModel('admin-layout-model')).toBe(existingModel);
-    expect(existingModel.subModels.menu).toBeInstanceOf(AdminLayoutMenuTreeModel);
+    expect((existingModel.subModels as any).menu).toBeUndefined();
     expect((existingModel.subModels as any).layoutContent).toBeUndefined();
     expect((existingModel.subModels as any).headerActions).toBeUndefined();
     expect(flowModelRendererSpy).toHaveBeenLastCalledWith(expect.objectContaining({ model: existingModel }));

--- a/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/index.tsx
@@ -13,7 +13,7 @@ import { AdminDynamicPage, MobileLayoutProvider } from '../../../admin-shell';
 import { RemoteSchemaTemplateManagerPlugin } from '../../../';
 import { Plugin } from '../../../application/Plugin';
 import { AdminLayoutModel } from './AdminLayoutModel';
-import { AdminLayoutMenuItemModel, AdminLayoutMenuTreeModel } from './AdminLayoutMenuModels';
+import { AdminLayoutMenuItemModel } from './AdminLayoutMenuModels';
 import { ADMIN_LAYOUT_MODEL_UID } from './constants';
 import { userCenterSettings } from './userCenterSettings';
 
@@ -65,7 +65,6 @@ export class AdminLayoutPlugin extends Plugin {
   async load() {
     this.app.flowEngine.registerModels({
       AdminLayoutModel,
-      AdminLayoutMenuTreeModel,
       AdminLayoutMenuItemModel,
     });
     this.app.schemaSettingsManager.add(userCenterSettings);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

继续简化 admin-layout 的 FlowModel 结构，把顶层菜单树从独立的 `AdminLayoutMenuTreeModel` 收回到 `AdminLayoutModel`，并把整棵菜单模型树的子节点键统一为 `menuItems`，减少 root 与子节点两套命名并存带来的理解和维护成本。

### Description 

- 移除 `AdminLayoutMenuTreeModel`，由 `AdminLayoutModel` 直接负责顶层菜单路由同步和 `toProLayoutRoute()` 生成
- 把菜单项模型递归子节点的 `subModels.items` 统一改为 `subModels.menuItems`
- 同步更新 shell、模型注册和 admin-layout 相关测试，保证菜单树行为和现有路由结果不变

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Simplify the admin layout menu model structure |
| 🇨🇳 Chinese | 简化管理后台布局的菜单模型结构 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
