### PR TITLE
fix(plugin-kanban): avoid initial unfiltered query before data scope filter parsing

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/KanbanBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/KanbanBlockProvider.tsx
@@ -68,10 +68,14 @@ const InternalKanbanBlockProvider = (props) => {
 };
 
 export const KanbanBlockProvider = (props) => {
-  const { filter: parsedFilter } = useParsedFilter({
+  const { filter: parsedFilter, parseVariableLoading } = useParsedFilter({
     filterOption: props.params?.filter,
   });
   const params = { ...props.params, filter: parsedFilter };
+
+  if (parseVariableLoading) {
+    return null;
+  }
 
   return (
     <BlockProvider name="kanban" {...props} params={params}>


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
This PR fixes an issue in @nocobase/plugin-kanban where a Kanban block could send an initial list request without any filter even when data scope was configured.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix(plugin-kanban): avoid initial unfiltered list request before data scope filter parsing completes     |
| 🇨🇳 Chinese |      修复 (plugin-kanban)：配置数据范围后，首屏加载不再先发起一次无过滤条件的查询     |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
