### PR TITLE
feat(client): add textAlign support to numeric field interfaces and R…

### DIFF
--- a/packages/core/client/src/collection-manager/interfaces/integer.ts
+++ b/packages/core/client/src/collection-manager/interfaces/integer.ts
@@ -43,6 +43,17 @@ export class IntegerFieldInterface extends CollectionFieldInterface {
   excludeValidationOptions = ['precision'];
   properties = {
     ...defaultProps,
+    'uiSchema.x-component-props.style.textAlign': {
+      type: 'string',
+      title: '{{t("Align")}}',
+      'x-component': 'Radio.Group',
+      'x-decorator': 'FormItem',
+      default: 'left',
+      enum: [
+        { label: '{{t("Left")}}', value: 'left' },
+        { label: '{{t("Right")}}', value: 'right' },
+      ],
+    },
     layout: {
       type: 'void',
       title: '{{t("Index")}}',

--- a/packages/core/client/src/collection-manager/interfaces/number.ts
+++ b/packages/core/client/src/collection-manager/interfaces/number.ts
@@ -49,6 +49,17 @@ export class NumberFieldInterface extends CollectionFieldInterface {
     },
     ...defaultProps,
     unique,
+    'uiSchema.x-component-props.style.textAlign': {
+      type: 'string',
+      title: '{{t("Align")}}',
+      'x-component': 'Radio.Group',
+      'x-decorator': 'FormItem',
+      default: 'left',
+      enum: [
+        { label: '{{t("Left")}}', value: 'left' },
+        { label: '{{t("Right")}}', value: 'right' },
+      ],
+    },
     'uiSchema.x-component-props.step': {
       type: 'string',
       title: '{{t("Precision(UI)")}}',

--- a/packages/core/client/src/collection-manager/interfaces/percent.ts
+++ b/packages/core/client/src/collection-manager/interfaces/percent.ts
@@ -79,7 +79,9 @@ export class PercentFieldInterface extends CollectionFieldInterface {
   };
   schemaInitialize(schema: ISchema, { field, block, readPretty, action }) {
     const props = (schema['x-component-props'] = schema['x-component-props'] || {});
+    const fieldStyle = field?.uiSchema?.['x-component-props']?.style || {};
     schema['x-component-props'].style = {
+      ...fieldStyle,
       ...(props.style || {}),
       width: '100%',
     };
@@ -91,6 +93,17 @@ export class PercentFieldInterface extends CollectionFieldInterface {
   properties = {
     ...defaultProps,
     unique,
+    'uiSchema.x-component-props.style.textAlign': {
+      type: 'string',
+      title: '{{t("Align")}}',
+      'x-component': 'Radio.Group',
+      'x-decorator': 'FormItem',
+      default: 'left',
+      enum: [
+        { label: '{{t("Left")}}', value: 'left' },
+        { label: '{{t("Right")}}', value: 'right' },
+      ],
+    },
     'uiSchema.x-component-props.step': {
       type: 'string',
       title: '{{t("Precision")}}',

--- a/packages/core/client/src/locale/en-US.json
+++ b/packages/core/client/src/locale/en-US.json
@@ -94,6 +94,7 @@
   "After successful submission, the selected data blocks will be automatically refreshed.": "After successful submission, the selected data blocks will be automatically refreshed.",
   "After successful update": "After successful update",
   "Agenda": "Agenda",
+  "Align": "Align",
   "All": "All",
   "All collections": "All collections",
   "All collections use general action permissions by default; permission configured individually will override the default one.": "All collections use general action permissions by default; permission configured individually will override the default one.",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -94,6 +94,7 @@
   "After successful submission, the selected data blocks will be automatically refreshed.": "提交成功后，会自动刷新这里选中的数据区块。",
   "After successful update": "更新成功后",
   "Agenda": "列表",
+  "Align": "对齐方式",
   "All": "所有",
   "All collections": "全部数据表",
   "All collections use general action permissions by default; permission configured individually will override the default one.": "所有数据表都默认使用通用数据操作权限；同时，可以针对每个数据表单独配置权限。",

--- a/packages/core/client/src/schema-component/antd/input-number/ReadPretty.tsx
+++ b/packages/core/client/src/schema-component/antd/input-number/ReadPretty.tsx
@@ -168,10 +168,12 @@ export interface InputNumberReadPrettyProps {
   value?: any;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
+  style?: React.CSSProperties;
 }
 
 export const ReadPretty: React.FC<InputNumberReadPrettyProps> = withPopupWrapper((props) => {
-  const { step, formatStyle, value, addonBefore, addonAfter, unitConversion, unitConversionType, separator } = props;
+  const { step, formatStyle, value, addonBefore, addonAfter, unitConversion, unitConversionType, separator, style } =
+    props;
   const result = useMemo(() => {
     return formatNumber({ step, formatStyle, value, unitConversion, unitConversionType, separator });
   }, [step, formatStyle, value, unitConversion, unitConversionType, separator]);
@@ -180,7 +182,7 @@ export const ReadPretty: React.FC<InputNumberReadPrettyProps> = withPopupWrapper
   }
 
   return (
-    <div>
+    <div style={style}>
       {addonBefore}
       <span dangerouslySetInnerHTML={{ __html: result }} />
       {addonAfter}


### PR DESCRIPTION
# Pull Request Description

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Providing alignment configuration for numeric fields enhances UI flexibility, allowing users to choose between left or right alignment (common for financial or statistical data) to improve readability in lists, cards, and detail views.

### Description 
This PR introduces the `textAlign` property to the UI schema of numeric field interfaces and ensures the display component respects this configuration.

**Key Changes:**
1.  **Field Interfaces**: Updated `Integer`, `Number`, and `Percent` field interfaces to include a `textAlign` configuration in their `uiSchema.x-component-props.style`. This adds a "Align" (左对齐/右对齐) option in the field configuration drawer.
2.  **Display Component**: Enhanced the `InputNumber`'s `ReadPretty` component to accept and apply a `style` prop to its root `div`, enabling the `textAlign` setting to take effect in "Read Pretty" mode.
3.  **Default Value**: Set the default alignment to `left` to maintain backward compatibility.

**Risk Assessment**: Low. The change only adds an optional style property and does not affect the underlying data or validation logic.

**Testing Suggestions**:
1.  Add a numeric field (Number, Integer, or Percent) to a collection.
2.  In the field configuration, find the new "Align" option and set it to "Right".
3.  View the field in a list or detail block (Read Pretty mode) and verify the text is right-aligned.
4.  Change it back to "Left" and verify it returns to the default alignment.

### Related issues
N/A (Derived from feature migration task)

### Showcase
<!-- Including any screenshots of the changes. -->
(Please add screenshots showing the "Align" option in the field configuration and the resulting alignment in the UI.)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `textAlign` support to numeric field interfaces (Integer, Number, Percent) and `ReadPretty` component. |
| 🇨🇳 Chinese | 数值类型字段（整数、数字、百分比）及 ReadPretty 组件支持配置文本对齐方式（左对齐/右对齐）。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary

---