### PR TITLE
docs: improve Docker installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,31 @@ NocoBase supports three installation methods:
 - <a target="_blank" href="https://docs.nocobase.com/welcome/getting-started/installation/docker-compose">Installing With Docker (👍Recommended)</a>
 
   Suitable for no-code scenarios, no code to write. When upgrading, just download the latest image and reboot.
+  Quick start:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   Then access:
+   http://localhost:13000
+
+   📘 Full guide:
+    https://docs.nocobase.com/v1/welcome/getting-started/installation/docker-compose
+
+    Notes:
+    - Default port is `13000`
+    - Make sure Docker is running before starting
+
+    Troubleshooting:
+    - If containers fail to start:
+      ```bash
+      docker-compose logs
+      ```
+    - To stop:
+      ```bash
+      docker-compose down
+      ```	
 
 - <a target="_blank" href="https://docs.nocobase.com/welcome/getting-started/installation/create-nocobase-app">Installing from create-nocobase-app CLI</a>
 


### PR DESCRIPTION
**This is a ...**  
- [ ] New feature  
- [x] Improvement  
- [ ] Bug fix  
- [ ] Others  

---
## Motivation :
Improve the Docker installation section in the README by providing a clearer and faster quick start process.
---

**Description:**
This PR improves the Docker installation instructions by adding a concise **Quick start** section, including the minimal command needed to run NocoBase using Docker Compose.

It also adds:
- Direct access URL after startup
- Link to the full official Docker guide
- Notes about the default port and Docker requirements
- Basic troubleshooting commands (`docker-compose logs`, `docker-compose down`)

These additions help new users quickly launch NocoBase while still providing guidance for troubleshooting when needed.

**Potential risks:** None (documentation-only change)
---
**Testing :**
Verified that the commands run successfully and correctly start the application locally using Docker Compose.
---
 **Related issues** : None
---
## Changelog
| Language | Changelog |
|----------|-----------|
| 🇺🇸 English | Improve Docker installation instructions with quick start and troubleshooting |
| 🇨🇳 Chinese | 优化 README 中的 Docker 安装说明，添加快速开始和故障排除 |
---
## Docs
| Language | Link |
|----------|------|
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |
---
## Checklists
- [x] All changes have been self-tested and work as expected  
- [x] Test cases are updated/provided or not needed  
- [x] Doc is updated/provided or not needed  
- [x] Component demo is updated/provided or not needed  
- [x] Changelog is provided or not needed  
- [ ] Request a code review if it is necessary