### PR TITLE
fix(server): change pubsub close timing to `beforeStop`

### DIFF
--- a/packages/core/server/src/__tests__/pub-sub-manager.test.ts
+++ b/packages/core/server/src/__tests__/pub-sub-manager.test.ts
@@ -55,6 +55,36 @@ describe('connect', () => {
     expect(mockListener).toHaveBeenCalledWith('message1');
   });
 
+  test('closed before db close on app stop', async () => {
+    const mockListener = vi.fn();
+    await app.start();
+    await pubSubManager.subscribe('test1', mockListener);
+    // Verify message works before stop
+    await pubSubManager.publish('test1', 'message1');
+    expect(mockListener).toBeCalledTimes(1);
+    mockListener.mockClear();
+    // Track the order of close and db.close
+    const order: string[] = [];
+    const origClose = pubSubManager.close.bind(pubSubManager);
+    vi.spyOn(pubSubManager, 'close').mockImplementation(async () => {
+      order.push('pubsub.close');
+      return origClose();
+    });
+    const origDbClose = app.db.close.bind(app.db);
+    vi.spyOn(app.db, 'close').mockImplementation(async () => {
+      order.push('db.close');
+      return origDbClose();
+    });
+    await app.stop();
+    // pubSub should be closed before db (may appear more than once due to disposeServices)
+    const pubsubFirst = order.indexOf('pubsub.close');
+    const dbFirst = order.indexOf('db.close');
+    expect(pubsubFirst).toBeLessThan(dbFirst);
+    // After stop, publish should not reach subscriber
+    await pubSubManager.publish('test1', 'message2');
+    expect(mockListener).not.toHaveBeenCalled();
+  });
+
   test('subscribe after connect', async () => {
     await app.start();
     const mockListener = vi.fn();

--- a/packages/core/server/src/__tests__/sync-message-manager.test.ts
+++ b/packages/core/server/src/__tests__/sync-message-manager.test.ts
@@ -64,6 +64,34 @@ describe('sync-message-manager', () => {
     await cluster.destroy();
   });
 
+  test('plugin.handleSyncMessage should not be called after app stopped', async () => {
+    const mockListener = vi.fn();
+    class MyPlugin extends Plugin {
+      get name() {
+        return 'test1';
+      }
+      async handleSyncMessage(message) {
+        mockListener(message);
+      }
+    }
+    const cluster = await createMockCluster({
+      plugins: [MyPlugin],
+    });
+    const [app1, app2] = cluster.nodes;
+    // Verify message works before stop
+    await app1.pm.get(MyPlugin).sendSyncMessage('message_before_stop');
+    await sleep(1100);
+    expect(mockListener).toBeCalledTimes(1);
+    mockListener.mockClear();
+    // Stop app2 — its pubSubManager should be closed during beforeStop, before db.close()
+    await app2.stop();
+    // Publish from app1 — app2's handler should NOT be called since pubSub is already closed
+    await app1.pm.get(MyPlugin).sendSyncMessage('message_after_stop');
+    await sleep(1100);
+    expect(mockListener).not.toHaveBeenCalled();
+    await cluster.destroy();
+  });
+
   test('plugin.handleSyncMessage + transaction', async () => {
     const mockListener = vi.fn();
     class MyPlugin extends Plugin {

--- a/packages/core/server/src/pub-sub-manager/pub-sub-manager.ts
+++ b/packages/core/server/src/pub-sub-manager/pub-sub-manager.ts
@@ -23,7 +23,7 @@ export const createPubSubManager = (app: Application, options: PubSubManagerOpti
   app.on('afterStart', async () => {
     await pubSubManager.connect();
   });
-  app.on('afterStop', async () => {
+  app.on('beforeStop', async () => {
     await pubSubManager.close();
   });
   return pubSubManager;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Change close timing of Pub-Sub to `beforeStop`, to avoid message sent or handled after database closed.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Change close timing of Pub-Sub to `beforeStop`, to avoid message sent or handled after database closed |
| 🇨🇳 Chinese | 将 Pub-Sub 关闭的时机改为 `beforeStop`，以避免数据库关闭后仍进行了消息发送和处理 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
