### PR TITLE
feat(flow): add js variables to event flow

### DIFF
--- a/packages/core/client/src/flow/actions/customVariable.tsx
+++ b/packages/core/client/src/flow/actions/customVariable.tsx
@@ -7,12 +7,22 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { ActionScene, defineAction, tExpr, useFlowContext } from '@nocobase/flow-engine';
+import {
+  ActionScene,
+  defineAction,
+  isRunJSValue,
+  normalizeRunJSValue,
+  runjsWithSafeGlobals,
+  tExpr,
+  type RunJSValue,
+  useFlowContext,
+} from '@nocobase/flow-engine';
 import React from 'react';
 import { Table, Button, Dropdown, Modal, Form, Input, Space, Tag } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { uid } from '@formily/shared';
+import { RunJSValueEditor } from '../components/RunJSValueEditor';
 
 export const customVariable = defineAction({
   name: 'customVariable',
@@ -30,6 +40,26 @@ export const customVariable = defineAction({
     const { variables = [] } = params;
 
     variables.forEach((variable) => {
+      if (variable.type === 'runjs') {
+        const getFunction = async () => {
+          const { code, version } = normalizeRunJSValue(variable.runjs);
+          return runjsWithSafeGlobals(ctx, code, { version });
+        };
+        const metaFunction = () => ({
+          title: variable.title,
+          type: 'any',
+        });
+
+        metaFunction.title = variable.title;
+
+        ctx.model.context.defineProperty(variable.key, {
+          get: getFunction,
+          cache: false,
+          meta: metaFunction,
+        });
+        return;
+      }
+
       const getFunction = () => {
         const modelInstance = ctx.model.flowEngine.getModel(variable.formUid);
         return modelInstance?.form?.getFieldsValue(true);
@@ -67,7 +97,7 @@ export const customVariable = defineAction({
   },
 });
 
-type FlowVariableType = 'formValue';
+type FlowVariableType = 'formValue' | 'runjs';
 
 interface FormValueVariable {
   key: string;
@@ -76,7 +106,14 @@ interface FormValueVariable {
   formUid: string;
 }
 
-type FlowVariable = FormValueVariable;
+interface RunJSVariable {
+  key: string;
+  title: string;
+  type: 'runjs';
+  runjs: RunJSValue;
+}
+
+type FlowVariable = FormValueVariable | RunJSVariable;
 
 interface VariableEditorProps {
   value?: FlowVariable[];
@@ -88,13 +125,16 @@ interface VariableFormValues {
   key: string;
   title: string;
   formUid: string;
+  runjs: RunJSValue;
 }
 
 const VARIABLE_TYPE_LABELS: Record<FlowVariableType, string> = {
   formValue: tExpr('Form variable'),
+  runjs: tExpr('JS variable'),
 };
 
 const generateVariableKey = () => `var_${uid().slice(0, 4)}`;
+const createDefaultRunJSValue = (): RunJSValue => ({ code: '', version: 'v2' });
 
 function VariableEditor(props: VariableEditorProps) {
   const { value = [], onChange, disabled } = props;
@@ -107,7 +147,7 @@ function VariableEditor(props: VariableEditorProps) {
 
   const resetForm = React.useCallback(() => {
     form.resetFields();
-    form.setFieldsValue({ key: generateVariableKey(), title: '', formUid: '' });
+    form.setFieldsValue({ key: generateVariableKey(), title: '', formUid: '', runjs: createDefaultRunJSValue() });
   }, [form]);
 
   const openModal = React.useCallback(
@@ -126,6 +166,7 @@ function VariableEditor(props: VariableEditorProps) {
           key: target.key,
           title: target.title,
           formUid: target.type === 'formValue' ? target.formUid : '',
+          runjs: target.type === 'runjs' ? normalizeRunJSValue(target.runjs) : createDefaultRunJSValue(),
         });
       }
 
@@ -142,12 +183,20 @@ function VariableEditor(props: VariableEditorProps) {
 
   const handleSubmit = React.useCallback(async () => {
     const formValues = await form.validateFields();
-    const nextVariable: FlowVariable = {
-      key: formValues.key,
-      title: formValues.title,
-      type: currentType,
-      formUid: formValues.formUid,
-    };
+    const nextVariable: FlowVariable =
+      currentType === 'runjs'
+        ? {
+            key: formValues.key,
+            title: formValues.title,
+            type: 'runjs',
+            runjs: normalizeRunJSValue(formValues.runjs),
+          }
+        : {
+            key: formValues.key,
+            title: formValues.title,
+            type: 'formValue',
+            formUid: formValues.formUid,
+          };
 
     const nextVariables = [...value];
 
@@ -262,6 +311,10 @@ function VariableEditor(props: VariableEditorProps) {
           key: 'formValue',
           label: t(VARIABLE_TYPE_LABELS.formValue),
         },
+        {
+          key: 'runjs',
+          label: t(VARIABLE_TYPE_LABELS.runjs),
+        },
       ],
       onClick: ({ key }: { key: string }) => handleAdd(key as FlowVariableType),
     }),
@@ -320,6 +373,23 @@ function VariableEditor(props: VariableEditorProps) {
               rules={[{ required: true, message: t('Please enter form uid') }]}
             >
               <Input placeholder={t('Please enter form uid')} />
+            </Form.Item>
+          ) : null}
+          {currentType === 'runjs' ? (
+            <Form.Item
+              label={t('JavaScript')}
+              name="runjs"
+              rules={[
+                {
+                  validator: async (_, value) => {
+                    if (!isRunJSValue(value) || !normalizeRunJSValue(value).code.trim()) {
+                      throw new Error(t('Please enter JavaScript code'));
+                    }
+                  },
+                },
+              ]}
+            >
+              <RunJSValueEditor t={t} scene="eventFlow" height="240px" containerStyle={{ width: '100%' }} />
             </Form.Item>
           ) : null}
         </Form>

--- a/packages/core/client/src/flow/components/RunJSValueEditor.tsx
+++ b/packages/core/client/src/flow/components/RunJSValueEditor.tsx
@@ -13,7 +13,7 @@ import { CodeEditor } from './code-editor';
 
 export interface RunJSValueEditorProps {
   t?: (key: string) => string;
-  value: unknown;
+  value?: unknown;
   onChange?: (value: RunJSValue) => void;
   height?: string;
   scene?: string;

--- a/packages/core/client/src/flow/components/code-editor/core/EditorCore.tsx
+++ b/packages/core/client/src/flow/components/code-editor/core/EditorCore.tsx
@@ -23,6 +23,7 @@ import { javascriptWithHtmlTemplates } from '../javascriptHtmlTemplate';
 import { createHtmlCompletion } from '../htmlCompletion';
 import { createJsxCompletion } from '../jsxCompletion';
 import { createJavaScriptLinter } from '../linter';
+import { resolveTooltipParent } from './tooltipParent';
 
 export const EditorCore: React.FC<{
   value?: string;
@@ -104,12 +105,9 @@ export const EditorCore: React.FC<{
       }),
       ...(placeholder ? [cmPlaceholder(placeholder)] : []),
       ...(enableLinter ? [lintGutter(), createJavaScriptLinter({ knownCtxMemberRoots })] : []),
-      // Force CM tooltips to render under the app container that doesn't clip (closer to Edit event flows behavior)
+      // Prefer the current popup container so completion tooltips stay above Modal/Drawer masks.
       tooltips({
-        parent:
-          (document.getElementById('nocobase-embed-container') as HTMLElement) ||
-          (editorRef.current?.closest('#nocobase-embed-container') as HTMLElement) ||
-          document.body,
+        parent: resolveTooltipParent(editorRef.current),
       }),
       EditorView.updateListener.of((update) => {
         if (update.docChanged && !readonly) {
@@ -122,7 +120,7 @@ export const EditorCore: React.FC<{
         }
       }),
       EditorView.theme({
-        '&': {
+        '&.cm-editor': {
           height: typeof height === 'string' ? height || '100%' : `${height}px`,
         },
         ...gutterTheme,
@@ -171,6 +169,9 @@ export const EditorCore: React.FC<{
           backgroundImage: `url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' width='6' height='3'><path d='m0 3 l2 -2 l1 0 l2 2 l1 0' stroke='%231890ff' fill='none' stroke-width='.7'/></svg>")`,
           backgroundRepeat: 'repeat-x',
           backgroundPosition: 'left bottom',
+        },
+        '.cm-tooltip': {
+          zIndex: 1,
         },
       }),
     ];

--- a/packages/core/client/src/flow/components/code-editor/core/tooltipParent.ts
+++ b/packages/core/client/src/flow/components/code-editor/core/tooltipParent.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+const POPUP_CONTAINER_SELECTORS = [
+  '.ant-modal-content',
+  '.ant-modal',
+  '.ant-drawer-content',
+  '.ant-drawer-content-wrapper',
+];
+
+export const resolveTooltipParent = (element: HTMLElement | null) => {
+  const doc = element?.ownerDocument ?? document;
+
+  for (const selector of POPUP_CONTAINER_SELECTORS) {
+    const popupContainer = element?.closest(selector);
+    if (popupContainer instanceof HTMLElement) {
+      return popupContainer;
+    }
+  }
+
+  return (doc.getElementById('nocobase-embed-container') as HTMLElement | null) || doc.body;
+};

--- a/packages/core/client/src/locale/en-US.json
+++ b/packages/core/client/src/locale/en-US.json
@@ -670,6 +670,7 @@
   "Form values": "Form values",
   "Form values change": "Form values change",
   "Form variable": "Form variable",
+  "JS variable": "JS variable",
   "Format": "Format",
   "Formula": "Formula",
   "Formula description": "Compute a value in each record based on other fields in the same record.",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -669,6 +669,7 @@
   "Form values": "表单值",
   "Form values change": "表单值变更",
   "Form variable": "表单变量",
+  "JS variable": "JS变量",
   "Format": "格式",
   "Formula": "Formula",
   "Formula description": "Compute a value in each record based on other fields in the same record.",


### PR DESCRIPTION
Support JS-backed custom variables in the flow action editor.

Keep CodeMirror completion tooltips inside modal and drawer content. Relax RunJSValueEditor props so Form.Item usage type-checks cleanly.

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
add js variables to event flow

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      add js variables to event flow      |
| 🇨🇳 Chinese |   事件流添加 js 变量       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
