### PR TITLE
fix(flow): guard missing collection field

### DIFF
--- a/packages/core/client/src/flow/actions/pattern.tsx
+++ b/packages/core/client/src/flow/actions/pattern.tsx
@@ -45,12 +45,13 @@ export const pattern = defineAction({
     return ctx.model.collectionField.inputable === false;
   },
   defaultParams: (ctx) => {
+    const collectionField = ctx.model.collectionField;
     return {
       pattern:
-        ctx.model.collectionField.inputable === false ||
+        collectionField?.inputable === false ||
         ctx.model.context.parentDisabled ||
         ctx.model.props.disabled ||
-        ctx.model.collectionField.readonly
+        collectionField?.readonly
           ? 'disabled'
           : 'editable',
     };

--- a/packages/core/client/src/flow/actions/titleField.tsx
+++ b/packages/core/client/src/flow/actions/titleField.tsx
@@ -14,7 +14,7 @@ export const titleField = defineAction({
   name: 'titleField',
   title: tExpr('Title field'),
   uiMode: (ctx) => {
-    const targetCollection = ctx.collectionField.targetCollection;
+    const targetCollection = ctx.collectionField?.targetCollection;
     const dataSourceManager = ctx.app.dataSourceManager;
     const targetFields = targetCollection?.getFields?.() ?? [];
     const options = targetFields
@@ -32,7 +32,7 @@ export const titleField = defineAction({
     };
   },
   defaultParams: (ctx: any) => {
-    const titleField = ctx.model.context.collectionField.targetCollectionTitleFieldName;
+    const titleField = ctx.model.context.collectionField?.targetCollectionTitleFieldName;
     return {
       label: ctx.model.parent?.props?.titleField || ctx.model.props.titleField || titleField,
     };

--- a/packages/core/client/src/flow/models/__tests__/missingCollectionFieldGuards.test.ts
+++ b/packages/core/client/src/flow/models/__tests__/missingCollectionFieldGuards.test.ts
@@ -1,0 +1,91 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { FlowEngine } from '@nocobase/flow-engine';
+import { pattern } from '../../actions/pattern';
+import { titleField } from '../../actions/titleField';
+import { FormItemModel } from '../blocks/form/FormItemModel';
+import { TableColumnModel } from '../blocks/table/TableColumnModel';
+import { RecordSelectFieldModel } from '../fields/AssociationFieldModel/RecordSelectFieldModel';
+import { FilterFormCustomRecordSelectFieldModel } from '../blocks/filter-form/fields/FilterFormCustomRecordSelectFieldModel';
+
+describe('missing collectionField guards', () => {
+  it('pattern and titleField actions tolerate missing collectionField', () => {
+    const ctx: any = {
+      app: { dataSourceManager: {} },
+      collectionField: undefined,
+      model: {
+        props: {},
+        parent: undefined,
+        context: {},
+        subModels: {},
+      },
+      t: (value: string) => value,
+    };
+
+    expect(() => pattern.defaultParams?.(ctx)).not.toThrow();
+    expect(pattern.defaultParams?.(ctx)).toEqual({ pattern: 'editable' });
+    expect(() => titleField.uiMode?.(ctx)).not.toThrow();
+    expect(() => titleField.defaultParams?.(ctx)).not.toThrow();
+    expect(titleField.defaultParams?.(ctx)).toEqual({ label: undefined });
+  });
+
+  it('form and table flows tolerate missing collectionField', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ FormItemModel, TableColumnModel });
+
+    const formItem = engine.createModel<FormItemModel>({
+      uid: 'form-item-missing-field',
+      use: 'FormItemModel',
+    });
+    const formFlow: any = formItem.getFlow('editItemSettings');
+
+    expect(() => formFlow.steps.initialValue.defaultParams({ model: formItem })).not.toThrow();
+    expect(formFlow.steps.initialValue.defaultParams({ model: formItem })).toEqual({ defaultValue: undefined });
+    expect(() => formFlow.steps.titleField.defaultParams({ model: formItem })).not.toThrow();
+    expect(formFlow.steps.titleField.defaultParams({ model: formItem })).toEqual({ titleField: undefined });
+
+    const tableColumn = engine.createModel<TableColumnModel>({
+      uid: 'table-column-missing-field',
+      use: 'TableColumnModel',
+    });
+    const columnFlow: any = tableColumn.getFlow('tableColumnSettings');
+
+    expect(() => columnFlow.steps.quickEdit.defaultParams({ model: tableColumn })).not.toThrow();
+    expect(columnFlow.steps.quickEdit.defaultParams({ model: tableColumn })).toEqual({ editable: false });
+    expect(() => columnFlow.steps.fieldNames.defaultParams({ model: tableColumn })).not.toThrow();
+    expect(columnFlow.steps.fieldNames.defaultParams({ model: tableColumn })).toEqual({ label: undefined });
+  });
+
+  it('record select flows tolerate missing collectionField', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ RecordSelectFieldModel, FilterFormCustomRecordSelectFieldModel });
+
+    const recordSelect = engine.createModel<RecordSelectFieldModel>({
+      uid: 'record-select-missing-field',
+      use: 'RecordSelectFieldModel',
+    });
+    const recordSelectFlow: any = recordSelect.getFlow('selectSettings');
+    expect(() => recordSelectFlow.steps.allowMultiple.defaultParams({ model: recordSelect })).not.toThrow();
+    expect(recordSelectFlow.steps.allowMultiple.defaultParams({ model: recordSelect })).toEqual({
+      allowMultiple: false,
+    });
+
+    const filterRecordSelect = engine.createModel<FilterFormCustomRecordSelectFieldModel>({
+      uid: 'filter-record-select-missing-field',
+      use: 'FilterFormCustomRecordSelectFieldModel',
+    });
+    const filterRecordSelectFlow: any = filterRecordSelect.getFlow('selectSettings');
+    expect(() => filterRecordSelectFlow.steps.allowMultiple.defaultParams({ model: filterRecordSelect })).not.toThrow();
+    expect(filterRecordSelectFlow.steps.allowMultiple.defaultParams({ model: filterRecordSelect })).toEqual({
+      allowMultiple: false,
+    });
+  });
+});

--- a/packages/core/client/src/flow/models/blocks/filter-form/fields/FilterFormCustomRecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/fields/FilterFormCustomRecordSelectFieldModel.tsx
@@ -480,6 +480,7 @@ FilterFormCustomRecordSelectFieldModel.registerFlow({
         );
       },
       defaultParams(ctx) {
+        const collectionField = ctx.collectionField || ctx.model.context.collectionField;
         if (typeof ctx.model.props.allowMultiple === 'boolean') {
           return {
             allowMultiple: ctx.model.props.allowMultiple,
@@ -487,8 +488,7 @@ FilterFormCustomRecordSelectFieldModel.registerFlow({
         }
         return {
           allowMultiple:
-            ctx.collectionField &&
-            ['belongsToMany', 'hasMany', 'belongsToArray'].includes(ctx.model.context.collectionField.type),
+            !!collectionField && ['belongsToMany', 'hasMany', 'belongsToArray'].includes(collectionField.type),
         };
       },
       handler(ctx, params) {

--- a/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
@@ -358,6 +358,11 @@ FormItemModel.registerFlow({
       },
       defaultParams: (ctx) => {
         const collectionField = ctx.model.collectionField;
+        if (!collectionField) {
+          return {
+            defaultValue: undefined,
+          };
+        }
 
         if (collectionField.interface === 'nanoid' && collectionField.options.autoFill !== false) {
           const { size, customAlphabet } = collectionField.options || { size: 21 };
@@ -411,7 +416,7 @@ FormItemModel.registerFlow({
       },
       defaultParams: (ctx: any) => {
         const titleField =
-          ctx.model.props.titleField || ctx.model.context.collectionField.targetCollectionTitleFieldName;
+          ctx.model.props.titleField || ctx.model.context.collectionField?.targetCollectionTitleFieldName;
         return {
           titleField: titleField,
         };

--- a/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
@@ -434,7 +434,7 @@ TableColumnModel.registerFlow({
       title: tExpr('Enable quick edit'),
       uiMode: { type: 'switch', key: 'editable' },
       defaultParams(ctx) {
-        if (ctx.model.collectionField.readonly || ctx.model.associationPathName) {
+        if (ctx.model.collectionField?.readonly || ctx.model.associationPathName || !ctx.model.collectionField) {
           return {
             editable: false,
           };
@@ -517,7 +517,7 @@ TableColumnModel.registerFlow({
         ctx.model.setProps(targetCollectionField.getComponentProps());
       },
       defaultParams: (ctx: any) => {
-        const titleField = ctx.model.context.collectionField.targetCollectionTitleFieldName;
+        const titleField = ctx.model.context.collectionField?.targetCollectionTitleFieldName;
         return {
           label: ctx.model.props.titleField || titleField,
         };

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -769,10 +769,10 @@ RecordSelectFieldModel.registerFlow({
         );
       },
       defaultParams(ctx) {
+        const collectionField = ctx.collectionField || ctx.model.context.collectionField;
         return {
           allowMultiple:
-            ctx.collectionField &&
-            ['belongsToMany', 'hasMany', 'belongsToArray'].includes(ctx.model.context.collectionField.type),
+            !!collectionField && ['belongsToMany', 'hasMany', 'belongsToArray'].includes(collectionField.type),
         };
       },
       handler(ctx, params) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在部分 v2 页面中，字段模型初始化时可能暂时拿不到 `collectionField`。这时多个共享 flow step 的 `defaultParams` 仍直接读取字段属性，导致页面配置项解析阶段抛出运行时错误，并影响筛选表单、关联选择字段以及表单/表格字段设置的正常渲染。

### Description 
- 为 `pattern`、`titleField`、表单字段默认值、表格列快捷编辑、关联字段多选设置等共享 flow step 补充 `collectionField` 缺失时的空值兜底，避免页面初始化阶段空指针报错。
- 补充针对性单测，覆盖 `collectionField` 缺失时这些 `defaultParams` 不应抛错的场景。
- 风险较低，改动只影响设置项默认值计算分支；建议回归关联字段、新增表单、筛选表单和表格列设置面板的打开流程。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix page errors caused by missing field metadata in v2 |
| 🇨🇳 Chinese | 修复 v2 页面因字段元数据缺失导致的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
