### PR TITLE
fix(plugin-graph-collection-manager): fix ER diagram rendering in Firefox

### DIFF
--- a/packages/plugins/@nocobase/plugin-graph-collection-manager/src/client/GraphDrawPage.tsx
+++ b/packages/plugins/@nocobase/plugin-graph-collection-manager/src/client/GraphDrawPage.tsx
@@ -446,8 +446,21 @@ export const GraphDrawPage = React.memo(() => {
 
   const dataSource = useDataSource();
   const initGraphCollections = () => {
+    const container = document.getElementById('container');
+    if (!container) return;
+
+    // Ensure container has explicit dimensions for Firefox compatibility
+    const parentElement = container.parentElement;
+    if (parentElement) {
+      const rect = parentElement.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        container.style.width = `${rect.width}px`;
+        container.style.height = `${rect.height}px`;
+      }
+    }
+
     targetGraph = new Graph({
-      container: document.getElementById('container')!,
+      container: container,
       moveThreshold: 0,
       virtual: false,
       async: true,
@@ -755,13 +768,22 @@ export const GraphDrawPage = React.memo(() => {
     m2mEdge && lightUp(m2mEdge);
   };
   // 全量渲染
-  const renderInitGraphCollection = (rawData, isSaveLayput = true) => {
+  const renderInitGraphCollection = async (rawData, isSaveLayput = true) => {
     targetGraph.clearCells();
     const { nodesData, edgesData, inheritEdges } = formatData(rawData);
     targetGraph.data = { nodes: nodesData, edges: edgesData };
     targetGraph.fromJSON({ nodes: nodesData });
     targetGraph.addEdges(edgesData);
     targetGraph.addEdges(inheritEdges);
+    
+    // Add a small delay for Firefox to properly render foreignObject content
+    // Firefox has timing issues with SVG foreignObject rendering that can cause
+    // nodes to appear blank if layout is calculated too quickly
+    const isFirefox = typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('firefox');
+    if (isFirefox) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    
     layout(saveGraphPositionAction, isSaveLayput);
   };
 

--- a/packages/plugins/@nocobase/plugin-graph-collection-manager/src/client/style.tsx
+++ b/packages/plugins/@nocobase/plugin-graph-collection-manager/src/client/style.tsx
@@ -268,6 +268,19 @@ const useStyles = createStyles(({ token, css }) => {
         height: calc(100vh) !important;
         width: calc(100vw) !important;
       }
+      /* Firefox-specific fixes for SVG foreignObject rendering */
+      @supports (-moz-appearance: none) {
+        .x6-graph {
+          foreignObject {
+            display: block;
+          }
+          .x6-node {
+            foreignObject {
+              overflow: visible;
+            }
+          }
+        }
+      }
     `,
   };
 });


### PR DESCRIPTION
This PR fixes the ER diagram rendering issue in Firefox where tables were not being displayed (Issue #3772).

Changes:
- Added explicit dimension setting for the graph container before initialization
- Added a small delay for Firefox before layout calculation to allow foreignObject content to render
- Added Firefox-specific CSS fixes for SVG foreignObject display

Fixes #3772