### PR TITLE
fix(database): support belongsTo query by filter target key

### DIFF
--- a/packages/core/database/src/__tests__/relation-repository/belongs-to-repository.test.ts
+++ b/packages/core/database/src/__tests__/relation-repository/belongs-to-repository.test.ts
@@ -141,4 +141,45 @@ describe('belongs to repository', () => {
     await p1.reload();
     expect(p1.userId).toEqual(user3.id);
   });
+
+  test('should find belongsTo target by source filterTargetKey', async () => {
+    const Account = db.collection({
+      name: 'accounts',
+      fields: [
+        { type: 'string', name: 'name' },
+        { type: 'hasMany', name: 'articles' },
+      ],
+    });
+
+    const Article = db.collection({
+      name: 'articles',
+      filterTargetKey: 'slug',
+      fields: [
+        { type: 'string', name: 'slug', unique: true },
+        {
+          type: 'belongsTo',
+          name: 'account',
+        },
+      ],
+    });
+
+    await db.sync();
+
+    await Account.repository.create({
+      values: {
+        name: 'u1',
+        articles: [
+          {
+            slug: 'a-1',
+          },
+        ],
+      },
+    });
+
+    const ArticleAccountRepository = db.getRepository<BelongsToRepository>('articles.account', 'a-1');
+    const account = await ArticleAccountRepository.findOne();
+
+    expect(account).not.toBeNull();
+    expect(account.get('name')).toBe('u1');
+  });
 });

--- a/packages/core/database/src/fields/relation-field.ts
+++ b/packages/core/database/src/fields/relation-field.ts
@@ -29,7 +29,7 @@ export abstract class RelationField extends Field {
   }
 
   get sourceKey() {
-    return this.options.sourceKey || this.collection.model.primaryKeyAttribute;
+    return this.options.sourceKey || this.collection.filterTargetKey;
   }
 
   get targetKey() {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When handling `belongsTo` queries, the source collection could fail to load if its externally used unique identifier was configured via `filterTargetKey` instead of the primary key. In that case, relation repositories still defaulted to the primary key as the source lookup key, which broke `belongsTo` relation queries by target key.

### Description
This PR changes the default relation `sourceKey` fallback from the collection primary key to `collection.filterTargetKey`, so relation repositories resolve source records consistently with the collection's configured unique identifier.

It also adds a regression test covering a `belongsTo` query where the source collection uses a non-primary unique `filterTargetKey`.

Risk is low and limited to default relation key inference. Explicitly configured `sourceKey` relations are unchanged.

Suggested testing:
- Run the relation repository test suite for `belongsTo`
- Verify `belongsTo` queries work when the source collection uses `filterTargetKey` instead of the primary key

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed `belongsTo` queries when the source collection uses a non-primary `filterTargetKey` as its unique identifier |
| 🇨🇳 Chinese | 修复源表使用非主键 `filterTargetKey` 作为唯一标识时 `belongsTo` 查询报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
