### PR TITLE
fix(client): prevent empty display text from crashing field rendering

### DIFF
--- a/packages/core/client/src/flow/models/fields/DisplayTextFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/DisplayTextFieldModel.tsx
@@ -12,9 +12,9 @@ import React from 'react';
 import { ClickableFieldModel } from './ClickableFieldModel';
 
 export class DisplayTextFieldModel extends ClickableFieldModel {
-  t(value: string) {
+  t(value: string | undefined | null) {
     // 如果 value 是 {{ 开头 }} 结尾，则认为是 i18n 表达式，需要翻译
-    if (value.startsWith('{{') && value.endsWith('}}')) {
+    if (value?.startsWith('{{') && value?.endsWith('}}')) {
       return this.translate(value);
     }
     return value;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在流程中的 `DisplayTextFieldModel` 渲染显示文本时，会默认对值执行 `startsWith` / `endsWith` 来判断是否为 i18n 表达式。当字段值为空、`null` 或 `undefined` 时，这段逻辑会直接抛错，导致文本字段渲染失败。

### Description 
- 将 `DisplayTextFieldModel.t()` 的入参类型扩展为 `string | undefined | null`
- 为 i18n 表达式判断增加空值保护，避免空文本值触发运行时异常
- 保持非 i18n 文本与已有翻译逻辑不变

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent display text fields from crashing when their text value is empty. |
| 🇨🇳 Chinese | 修复显示文本字段在文本值为空时的渲染报错问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
