### PR TITLE
fix(association): omit 'style' from resolved options

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/recordSelectShared.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/recordSelectShared.tsx
@@ -208,7 +208,7 @@ export function resolveOptions(
 ) {
   if (options?.length) {
     return options.map((v) => {
-      return omit(v, 'disabled', 'options');
+      return omit(v, 'disabled', 'options', 'style');
     });
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
多对一关系字段在打开下拉时，会把接口返回的整条业务数据直接作为选项对象传给 Select 渲染。当返回记录中包含 `style` 业务字段时，会被误当成组件样式属性，触发运行时报错。

### Description 
在关系选择共享逻辑中，继续沿用现有数据结构和交互方式，只对传入 Select 的选项对象做最小清洗，额外过滤掉 `style` 字段，避免业务数据污染 UI 组件渲染。

这次改动只涉及一处共享逻辑，保持现有值结构和回调行为不变，风险较低。

建议重点验证：
- 普通表单中的多对一字段打开下拉不再报错
- 筛选表单中的关系筛选字段打开下拉不再报错
- 返回数据中包含 `style` 字段时，选项仍能正常显示和选择

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error when relation field options contain style data |
| 🇨🇳 Chinese | 修复关系字段选项包含 style 数据时的报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
