### PR TITLE
fix(plugin-flow-engine): comment legacy uiSchema event out

### DIFF
--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/repository.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/repository.ts
@@ -996,11 +996,11 @@ WHERE TreeTable.depth = 1 AND  TreeTable.ancestor = :ancestor and TreeTable.sort
 
       // move node to new parent
       if (oldParentUid !== null && oldParentUid !== parentUid) {
-        await this.database.emitAsync('uiSchemaMove', savedNode, {
-          transaction,
-          oldParentUid,
-          parentUid,
-        });
+        // await this.database.emitAsync('uiSchemaMove', savedNode, {
+        //   transaction,
+        //   oldParentUid,
+        //   parentUid,
+        // });
 
         if (options.removeParentsIfNoChildren) {
           await this.recursivelyRemoveIfNoChildren({


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Remove legacy event copied from uiSchema repository to avoid incorrectly triggering.

### Description 

```
schemaInstance.getServerHooksByType is not a function extra={"method":"error-handler","err":"TypeError: schemaInstance.getServerHooksByType is not a function
 at ServerHooks.callSchemaInstanceHooksByType (/home/me/nocobase/packages/plugins/@nocobase/plugin-ui-schema-storage/src/serve r/server-hooks/index.ts:2:1869)
 at ServerHooks.onUiSchemaMove (/home/me/nocobase/packages/plugins/@nocobase/plugin-ui-schema-storage/src/s erver/server-hooks/index.ts:2:2112)
 at AsyncEmitter.<anonymous> (/home/me/nocobase/packages/plugins/@nocobase/plugin-ui-schema-storage/src /server/server-hooks/index.ts:2:1618)
 at run (/home/me/nocobase/packages/core/utils/src/mixin/AsyncEmitter.ts:2:1174)
 at AsyncEmitter.e mitAsync (/home/me/nocobase/packages/core/utils/src/mixin/AsyncEmitter.ts:2:1440)
 at _FlowModelRepository.insertSingleNode (/home/mytharch er/nocobase/packages/plugins/@nocobase/plugin-flow-engine/src/server/repository.ts:44:597)
 at process.processTicksAndRejections (node:internal/pro cess/task_queues:95:5)
 at async _FlowModelRepository.duplicate (/home/me/nocobase/packages/plugins/@nocobase/plugin-flow-engine/src/server /repository.ts:15:2301)
```

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove legacy event copied from uiSchema repository to avoid error thrown when triggering |
| 🇨🇳 Chinese | 移除从 uiSchema 表复制的遗留事件，避免触发调用后报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
