### PR TITLE
fix: add set form item and detail item snuppets

### DIFF
--- a/packages/core/flow-engine/src/__tests__/runjsSnippets.test.ts
+++ b/packages/core/flow-engine/src/__tests__/runjsSnippets.test.ts
@@ -125,8 +125,8 @@ describe('RunJS Snippets', () => {
       expect(tableStyle?.scenes).toEqual(['tableFieldEvent']);
 
       const fieldStyle = fieldSnippets.find((s) => s.ref === 'scene/detail/set-field-style');
-      expect(fieldStyle?.name).toBe('表单、详情字段样式设置');
-      expect(fieldStyle?.body).toContain('ctx.model.subModels.field.props.style');
+      expect(fieldStyle?.name).toBe('设置表单项/详情项样式');
+      expect(fieldStyle?.body).toContain('ctx.model.props.style');
       expect(fieldStyle?.scenes).toEqual(expect.arrayContaining(['detailFieldEvent', 'formFieldEvent']));
       expect(fieldStyle?.groups).toEqual(expect.arrayContaining(['scene/detail', 'scene/form']));
 

--- a/packages/core/flow-engine/src/runjs-context/snippets/scene/detail/set-field-style.snippet.ts
+++ b/packages/core/flow-engine/src/runjs-context/snippets/scene/detail/set-field-style.snippet.ts
@@ -11,18 +11,18 @@ import type { SnippetModule } from '../../types';
 const snippet: SnippetModule = {
   contexts: ['*'],
   scenes: ['detailFieldEvent', 'formFieldEvent'],
-  prefix: 'sn-field-style',
-  label: 'Set field style',
-  description: 'Customize form and detail field styles',
+  prefix: 'sn-item-style',
+  label: 'Set form item/details item style',
+  description: 'Customize form item and details item container styles',
   locales: {
     'zh-CN': {
-      label: '表单、详情字段样式设置',
-      description: '自定义表单字段和详情字段的样式',
+      label: '设置表单项/详情项样式',
+      description: '自定义表单项和详情项容器样式',
     },
   },
   content: `
-ctx.model.subModels.field.props.style = {
-  fontWeight: 900,
+ctx.model.props.style = {
+  background: 'red',
 };
 `,
 };

--- a/packages/core/flow-engine/src/runjs-context/snippets/scene/table/set-cell-style.snippet.ts
+++ b/packages/core/flow-engine/src/runjs-context/snippets/scene/table/set-cell-style.snippet.ts
@@ -24,7 +24,7 @@ const snippet: SnippetModule = {
 ctx.model.props.onCell = (record, rowIndex) => {
   return {
     style: {
-      fontWeight: 900,
+      background: 'red',
     },
   };
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
add js snippets for setting form item and details item

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Add js snippets for setting form item and details item     |
| 🇨🇳 Chinese |    添加设置表单控件和详情控件的js片段       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
