### PR TITLE
Filter form support 2-level association field selection and fix duplicate menu key warning

### DIFF
--- a/packages/core/client/src/schema-initializer/utils.ts
+++ b/packages/core/client/src/schema-initializer/utils.ts
@@ -547,7 +547,7 @@ const associationFieldToMenu = (
   processedCollections: string[],
 ) => {
   if (field.target && field.uiSchema) {
-    if (processedCollections.includes(field.target) || processedCollections.length >= 1) return;
+    if (processedCollections.includes(field.target) || processedCollections.length >= 2) return;
 
     const subFields = getCollectionFields(field.target);
 
@@ -587,6 +587,7 @@ const associationFieldToMenu = (
   };
 
   return {
+    key: schemaName,
     name: field.uiSchema?.title || field.name,
     type: 'item',
     title: field.uiSchema?.title || field.name,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

The filter form's "Configure fields" panel currently only supports
selecting 1 level of association fields, while the table's Filter action
already supports 2 levels of association field nesting. This PR aligns
the filter form's association field depth with the table filter action.
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Filter form: Association fields in "Configure fields" support 2 levels of nesting, consistent with the table filter action.     |
| 🇨🇳 Chinese |     筛选表单:「配置字段」中的关联字段现在支持 2 层嵌套，与表格筛选操作保持一致。      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [x] Request a code review if it is necessary
