### PR TITLE
fix(plugin-workflow): fix validation of collection trigger

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -1383,5 +1383,81 @@ describe('workflow > triggers > collection', () => {
       });
       expect(status).toBe(400);
     });
+
+    it('validate mode in update', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      const res1 = await agent.resource('workflows').update({
+        filterByTk: workflow.id,
+        values: {
+          config: {
+            mode: 2,
+            collection: 'posts',
+          },
+        },
+      });
+      expect(res1.status).toBe(200);
+
+      const res2 = await agent.resource('workflows').update({
+        filterByTk: workflow.id,
+        values: {
+          config: {
+            mode: 3,
+            collection: 'posts',
+          },
+        },
+      });
+      expect(res2.status).toBe(200);
+
+      const res3 = await agent.resource('workflows').update({
+        filterByTk: workflow.id,
+        values: {
+          config: {
+            mode: 4,
+            collection: 'posts',
+          },
+        },
+      });
+      expect(res3.status).toBe(200);
+
+      const res4 = await agent.resource('workflows').update({
+        filterByTk: workflow.id,
+        values: {
+          config: {
+            mode: 0,
+            collection: 'posts',
+          },
+        },
+      });
+      expect(res4.status).toBe(400);
+
+      const res5 = await agent.resource('workflows').update({
+        filterByTk: workflow.id,
+        values: {
+          config: {
+            mode: null,
+            collection: 'posts',
+          },
+        },
+      });
+      expect(res5.status).toBe(400);
+
+      const res6 = await agent.resource('workflows').update({
+        filterByTk: workflow.id,
+        values: {
+          config: {
+            collection: 'posts',
+          },
+        },
+      });
+      expect(res6.status).toBe(200);
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -57,7 +57,12 @@ function getFieldRawName(collection: ICollection, name: string) {
 export default class CollectionTrigger extends Trigger {
   configSchema = Joi.object({
     collection: Joi.string().required(),
-    mode: Joi.number().valid(...Object.values(MODE_BITMAP)),
+    mode: Joi.number().valid(
+      MODE_BITMAP.CREATE,
+      MODE_BITMAP.UPDATE,
+      MODE_BITMAP.DESTROY,
+      MODE_BITMAP.CREATE | MODE_BITMAP.UPDATE,
+    ),
     changed: Joi.when('mode', {
       is: (mode) => (mode & MODE_BITMAP.UPDATE) === MODE_BITMAP.UPDATE,
       then: Joi.array().items(Joi.string()).optional(),


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where mode of collection trigger can not be set to create or update.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where mode of collection trigger can not be set to "create or update" |
| 🇨🇳 Chinese | 修复数据表触发器的触发模式不能设置为“新增或更新”的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
