### PR TITLE
fix(mcp-server): avoid auth mismatches in generic CRUD tool

### DIFF
--- a/packages/plugins/@nocobase/plugin-mcp-server/src/server/crud-tool.ts
+++ b/packages/plugins/@nocobase/plugin-mcp-server/src/server/crud-tool.ts
@@ -120,24 +120,31 @@ function buildRequestPayload(args: BusinessTableCrudArgs) {
 }
 
 function buildHeaders(args: BusinessTableCrudArgs, context?: McpToolCallContext) {
-  const headers: Record<string, any> = {
-    ...(context?.headers || {}),
-  };
+  const incomingHeaders = context?.headers || {};
+  const headers: Record<string, any> = {};
 
-  // These transport-level headers belong to the incoming MCP request and must not
-  // be forwarded to the internal injected request.
-  delete headers['content-length'];
-  delete headers['Content-Length'];
-  delete headers['transfer-encoding'];
-  delete headers['Transfer-Encoding'];
-  delete headers.connection;
-  delete headers.Connection;
-  delete headers.host;
-  delete headers.Host;
+  // The generic CRUD tool targets internal business APIs. Reusing arbitrary MCP
+  // transport headers here can pollute the injected request and cause auth
+  // mismatches that do not affect swagger-generated tools.
+  const forwardedRole = normalizeHeaderValue(incomingHeaders['x-role'] || incomingHeaders['X-Role']);
+  if (forwardedRole) {
+    headers['x-role'] = forwardedRole;
+  }
 
-  const authorization = normalizeHeaderValue(headers.authorization || headers.Authorization);
-  if (!authorization && context?.token) {
+  const forwardedAuthenticator = normalizeHeaderValue(
+    incomingHeaders['x-authenticator'] || incomingHeaders['X-Authenticator'],
+  );
+  if (forwardedAuthenticator) {
+    headers['x-authenticator'] = forwardedAuthenticator;
+  }
+
+  if (context?.token) {
     headers.authorization = `Bearer ${context.token}`;
+  } else {
+    const authorization = normalizeHeaderValue(incomingHeaders.authorization || incomingHeaders.Authorization);
+    if (authorization) {
+      headers.authorization = authorization;
+    }
   }
 
   headers['content-type'] = 'application/json';


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The generic MCP CRUD tool was reusing arbitrary headers from the incoming MCP request when building injected internal API requests. That could carry transport-level or unrelated auth headers into business API calls and cause authentication mismatches.

### Description
- Limit forwarded headers in the generic CRUD tool to `x-role`, `x-authenticator`, and an explicit `authorization` value.
- Prefer the MCP context token when present, and only fall back to an incoming authorization header when no token is available.
- This keeps generic CRUD requests aligned with the intended internal auth path and avoids pollution from unrelated MCP transport headers.

Tests:
- `git commit` hooks ran `lint-staged`
- No additional manual tests were run

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed authentication mismatches caused by unrelated forwarded headers in the MCP generic CRUD tool |
| 🇨🇳 Chinese | 修复 MCP 通用 CRUD 工具因透传无关请求头导致的鉴权不匹配问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
