### PR TITLE
fix: suppress verbose unzip output during bootstrap

### DIFF
--- a/docker/nocobase/docker-entrypoint.sh
+++ b/docker/nocobase/docker-entrypoint.sh
@@ -7,12 +7,12 @@ export NOCOBASE_RUNNING_IN_DOCKER=true
 
 if [ -f /opt/libreoffice24.8.zip ] && [ ! -d /opt/libreoffice24.8 ]; then
   echo "Unzipping /opt/libreoffice24.8.zip..."
-  unzip /opt/libreoffice24.8.zip -d /opt/
+  unzip -q /opt/libreoffice24.8.zip -d /opt/
 fi
 
 if [ -f /opt/instantclient_19_25.zip ] && [ ! -d /opt/instantclient_19_25 ]; then
   echo "Unzipping /opt/instantclient_19_25.zip..."
-  unzip /opt/instantclient_19_25.zip -d /opt/
+  unzip -q /opt/instantclient_19_25.zip -d /opt/
   echo "/opt/instantclient_19_25" > /etc/ld.so.conf.d/oracle-instantclient.conf
   ldconfig
 fi


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The bootstrap process includes inflating LibreOffice and other tools (Oracle Instant Client). This generates almost 5,000 log messages every time the server starts. This makes the logs extremely noisy and unnecessarily adds to logging costs. 

### Description 
Reduce log noise by adding the `-q` (quiet) flag to `unzip` commands for LibreOffice and Oracle Instant Client extraction in `docker/nocobase/docker-entrypoint.sh`. 

This eliminates ~5,000 log messages per server start (NocoBase v2.1.0-beta.1), significantly reducing logging costs while maintaining visibility of the extraction process through the existing high-level `echo` status messages.

**Testing Suggestions:**
Start a new container using this modified entrypoint script and verify that the "Unzipping..." echo statements still appear, but the thousands of `inflating: ...` lines are successfully suppressed.

### Related issues
### Showcase
*Before (Noisy Logs):*
*Code Change:*
### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reduced log noise during server startup by silencing unzip commands for LibreOffice and Oracle Instant Client |
| 🇨🇳 Chinese | 通过静默解压 LibreOffice 和 Oracle Instant Client, 减少服务器启动时的冗余日志 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary