### PR TITLE
fix(mcp-server): sanitize MCP tool input schema

### DIFF
--- a/packages/plugins/@nocobase/plugin-mcp-server/src/server/__tests__/mcp-tools.test.ts
+++ b/packages/plugins/@nocobase/plugin-mcp-server/src/server/__tests__/mcp-tools.test.ts
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sanitizeJsonSchemaForOpenAITools } from '../schema-utils';
+
+describe('sanitizeJsonSchemaForOpenAITools', () => {
+  it('should remove null type and nullable markers recursively', () => {
+    const schema = sanitizeJsonSchemaForOpenAITools({
+      type: 'object',
+      properties: {
+        requestBody: {
+          type: null,
+          nullable: true,
+          properties: {
+            actions: {
+              type: 'array',
+              items: {
+                type: null,
+                nullable: true,
+                properties: {
+                  scope: {
+                    type: 'null',
+                    nullable: true,
+                    properties: {
+                      id: {
+                        type: ['integer', 'null'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        requestBody: {
+          type: 'object',
+          properties: {
+            actions: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  scope: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'integer',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-mcp-server/src/server/mcp-tools.ts
+++ b/packages/plugins/@nocobase/plugin-mcp-server/src/server/mcp-tools.ts
@@ -13,6 +13,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import { requireModule } from '@nocobase/utils';
 import { merge as deepmerge } from '@nocobase/utils';
 import inject from 'light-my-request';
+import { sanitizeJsonSchemaForOpenAITools } from './schema-utils';
 
 type OpenAPIDocument = OpenAPIV3.Document;
 type McpToolDefinitionWithBaseUrl = import('openapi-mcp-generator').McpToolDefinition & { baseUrl?: string };
@@ -314,7 +315,7 @@ export async function collectMcpToolsFromSwagger(options: {
     return {
       name: tool.name,
       description: tool.description,
-      inputSchema: tool.inputSchema,
+      inputSchema: sanitizeJsonSchemaForOpenAITools(tool.inputSchema),
       call: async (args: Record<string, any>, context?: McpToolCallContext) => {
         const request = buildRequest(tool, args, context);
         if (request.missingPathParams.length > 0) {

--- a/packages/plugins/@nocobase/plugin-mcp-server/src/server/schema-utils.ts
+++ b/packages/plugins/@nocobase/plugin-mcp-server/src/server/schema-utils.ts
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+function sanitizeSchemaNode(node: any): any {
+  if (Array.isArray(node)) {
+    return node.map((item) => sanitizeSchemaNode(item)).filter((item) => typeof item !== 'undefined');
+  }
+
+  if (!node || typeof node !== 'object') {
+    return node;
+  }
+
+  const sanitizedEntries = Object.entries(node)
+    .filter(([, value]) => value !== null)
+    .map(([key, value]) => [key, sanitizeSchemaNode(value)] as const)
+    .filter(([, value]) => typeof value !== 'undefined');
+
+  const sanitizedNode = Object.fromEntries(sanitizedEntries) as Record<string, any>;
+
+  if (Array.isArray(sanitizedNode.type)) {
+    const nextTypes = sanitizedNode.type.filter((type: unknown) => type !== null && type !== 'null');
+    if (nextTypes.length === 1) {
+      sanitizedNode.type = nextTypes[0];
+    } else if (nextTypes.length > 1) {
+      sanitizedNode.type = nextTypes;
+    } else {
+      delete sanitizedNode.type;
+    }
+  } else if (sanitizedNode.type === null || sanitizedNode.type === 'null') {
+    delete sanitizedNode.type;
+  }
+
+  delete sanitizedNode.nullable;
+
+  if (typeof sanitizedNode.type === 'undefined') {
+    if (
+      sanitizedNode.properties ||
+      sanitizedNode.additionalProperties ||
+      Array.isArray(sanitizedNode.required) ||
+      sanitizedNode.patternProperties
+    ) {
+      sanitizedNode.type = 'object';
+    } else if (sanitizedNode.items) {
+      sanitizedNode.type = 'array';
+    }
+  }
+
+  return sanitizedNode;
+}
+
+export function sanitizeJsonSchemaForOpenAITools<T>(schema: T): T {
+  return sanitizeSchemaNode(schema);
+}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
OpenAPI-generated MCP tool schemas may contain `null` types and `nullable` markers that are rejected by OpenAI tool schema validation, causing MCP tools generated from Swagger to be unavailable.

### Description 
This PR sanitizes MCP tool input schemas before exposing them to OpenAI-compatible tool consumers.
It removes recursive `null` type entries and `nullable` markers, and infers `object` or `array` types when the schema structure already implies them.
The change is covered by a focused server-side test for nested request body schemas.

Potential risk is limited to schema normalization for MCP tool inputs generated from Swagger.

Testing:
- `yarn test:server packages/plugins/@nocobase/plugin-mcp-server/src/server/__tests__/mcp-tools.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed MCP tools generated from Swagger when input schemas include `null` types or `nullable` markers that are invalid for OpenAI tool validation |
| 🇨🇳 Chinese | 修复 Swagger 生成的 MCP 工具在输入 schema 含有 `null` 类型或 `nullable` 标记时无法通过 OpenAI 工具校验的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
