### PR TITLE
chore(repo): sync .gitignore from develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ cache/diskstore-*
 **/.dumi/tmp-production
 packages/core/client/docs/contributing.md
 packages/core/app/client/src/.plugins
+packages/core/app/client-v2/src/.plugins
 tsconfig.paths.json
 /playwright
 .swc
@@ -42,3 +43,4 @@ python/
 git-repos.json
 CLAUDE.md
 AGENTS.md
+openspec/


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The `main` branch `.gitignore` is missing ignore rules that already exist on `develop`, which leaves generated `client-v2` plugin files and local `openspec` workspace files easier to accidentally surface in contributor working trees.

### Description
- Sync `.gitignore` on `main` with the current `develop` entries for `packages/core/app/client-v2/src/.plugins`.
- Add the `openspec/` ignore rule so local spec workspace files stay out of version control.

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Updated `.gitignore` on `main` to ignore generated `client-v2` plugin files and local `openspec` workspace files. |
| 🇨🇳 Chinese | 更新了 `main` 分支的 `.gitignore`，忽略生成的 `client-v2` 插件文件和本地 `openspec` 工作区文件。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
