### PR TITLE
fix(departments): remove legacy action

### DIFF
--- a/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/actions.test.ts
@@ -84,44 +84,6 @@ describe('actions', () => {
     expect(res.body.data.length).toBe(0);
   });
 
-  it('should set main department', async () => {
-    const user = await db.getRepository('users').findOne();
-    const depts = await repo.create({
-      values: [
-        {
-          title: 'Dept1',
-          members: [user.id],
-        },
-        {
-          title: 'Dept2',
-          members: [user.id],
-        },
-      ],
-    });
-
-    const userRepo = db.getRepository('users');
-    await userRepo.update({
-      filterByTk: 1,
-      values: {
-        mainDepartmentId: depts[0].id,
-      },
-    });
-
-    const res = await agent.resource('users').setMainDepartment({
-      values: {
-        userId: user.id,
-        departmentId: depts[1].id,
-      },
-    });
-    expect(res.status).toBe(200);
-
-    const user2 = await userRepo.findOne({
-      filterByTk: 1,
-      fields: ['id', 'mainDepartmentId'],
-    });
-    expect(user2.mainDepartmentId).toBe(depts[1].id);
-  });
-
   it('should allow setting mainDepartmentId when submitting departments together (user had none before)', async () => {
     const userRepo = db.getRepository('users');
     const user = await userRepo.findOne();

--- a/packages/plugins/@nocobase/plugin-departments/src/server/actions/users.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/actions/users.ts
@@ -94,34 +94,3 @@ export const setDepartments = async (ctx: Context, next: Next) => {
   });
   await next();
 };
-
-export const setMainDepartment = async (ctx: Context, next: Next) => {
-  const { userId, departmentId } = ctx.action.params.values || {};
-  const repo = ctx.db.getRepository('users');
-  const throughRepo = ctx.db.getRepository('departmentsUsers');
-
-  await ctx.db.sequelize.transaction(async (t) => {
-    await repo.update({
-      filterByTk: userId,
-      values: { mainDepartmentId: departmentId },
-      transaction: t,
-    });
-
-    const existingAssoc = await throughRepo.findOne({
-      filter: { userId, departmentId },
-      transaction: t,
-    });
-    if (!existingAssoc) {
-      await throughRepo.create({
-        values: {
-          userId,
-          departmentId,
-          isOwner: false,
-        },
-        transaction: t,
-      });
-    }
-  });
-
-  await next();
-};

--- a/packages/plugins/@nocobase/plugin-departments/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/plugin.ts
@@ -19,7 +19,7 @@
 import { Cache } from '@nocobase/cache';
 import { InstallOptions, Plugin } from '@nocobase/server';
 import { aggregateSearch, removeOwner, setOwner } from './actions/departments';
-import { listExcludeDept, setMainDepartment } from './actions/users';
+import { listExcludeDept } from './actions/users';
 import { departmentsField, mainDepartmentField } from './collections/users';
 import {
   destroyDepartmentCheck,
@@ -55,13 +55,12 @@ export class PluginDepartmentsServer extends Plugin {
 
     this.app.resourceManager.registerActionHandlers({
       'users:listExcludeDept': listExcludeDept,
-      'users:setMainDepartment': setMainDepartment,
       'departments:aggregateSearch': aggregateSearch,
       'departments:setOwner': setOwner,
       'departments:removeOwner': removeOwner,
     });
 
-    this.app.acl.allow('users', ['setMainDepartment', 'listExcludeDept'], 'loggedIn');
+    this.app.acl.allow('users', ['listExcludeDept'], 'loggedIn');
     this.app.acl.registerSnippet({
       name: `pm.${this.name}`,
       actions: [
@@ -69,7 +68,6 @@ export class PluginDepartmentsServer extends Plugin {
         'roles:list',
         'users:list',
         'users:listExcludeDept',
-        'users:setMainDepartment',
         'users.departments:*',
         'roles.departments:*',
         'departments.members:*',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The departments plugin exposed a legacy `users:setMainDepartment` action even though the current product path updates a user's main department through `users.update`. Keeping the extra action registered and ACL-addressable unnecessarily expanded the attack surface.

### Description 
This PR removes the legacy `users:setMainDepartment` server action from the departments plugin, drops its ACL exposure, and deletes the obsolete action test coverage tied to that endpoint.

The remaining main-department update path continues to go through `users.update`, which is already used by the current client implementation.

Self-tested by running:
- `pnpm --filter @nocobase/plugin-departments test -- --runInBand packages/plugins/@nocobase/plugin-departments/src/server/__tests__/actions.test.ts packages/plugins/@nocobase/plugin-departments/src/server/__tests__/set-main-department.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
