### PR TITLE
fix(ai): deepseek should give a friendly tips while user upload unsupport file

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
@@ -122,11 +122,14 @@ export class DeepSeekProvider extends LLMProvider {
   }
 
   async parseAttachment(ctx: Context, attachment: any): Promise<any> {
+    const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
     if (!attachment?.mimetype || attachment.mimetype.startsWith('image/')) {
-      return super.parseAttachment(ctx, attachment);
+      return {
+        placement: 'system',
+        content: `The user has uploaded a ${attachment.mimetype} file (filename: ${safeFilename}). Please inform the user directly that you do not support parsing image content.`,
+      };
     }
     const parsed = await this.aiPlugin.documentLoaders.cached.load(attachment);
-    const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
     if (!parsed.supported) {
       return {
         placement: 'system',


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
if user upload image file to deepseek will occrur error show that image_url is not support, add system prompt let deepseek give a friendly tips to handle this situation

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize prompts for deepseek when handling unsupported file types |
| 🇨🇳 Chinese | 优化deepseek处理不支持的文件类型时的提示 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
