### PR TITLE
fix: associated fields in the table was not displayed correctly

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
@@ -116,6 +116,14 @@ export const CustomWidth = ({ setOpen, t, handleChange, defaultValue }) => {
     </div>
   );
 };
+
+function getSavedAssociationTitleField(model: {
+  props?: { titleField?: string };
+  getStepParams?: (flowKey: string, stepKey: string) => { label?: string } | undefined;
+}) {
+  return model.getStepParams?.('tableColumnSettings', 'fieldNames')?.label || model.props?.titleField;
+}
+
 export class TableColumnModel extends DisplayItemModel {
   // 标记：该类的 render 返回函数， 避免错误的reactive封装
   static renderMode: ModelRenderMode = ModelRenderMode.RenderFunction;
@@ -332,12 +340,20 @@ TableColumnModel.registerFlow({
         if (!collectionField) {
           return;
         }
+        const titleField = getSavedAssociationTitleField(ctx.model);
+        const componentProps =
+          collectionField.isAssociationField() && titleField
+            ? {
+                ...collectionField.getComponentProps(),
+                ...collectionField.targetCollection?.getField?.(titleField)?.getComponentProps?.(),
+              }
+            : collectionField.getComponentProps();
         ctx.model.setProps('title', collectionField.title);
         ctx.model.setProps('dataIndex', collectionField.name);
         // for quick edit
         await ctx.model.applySubModelsBeforeRenderFlows('field');
         ctx.model.setProps({
-          ...collectionField.getComponentProps(),
+          ...componentProps,
         });
       },
     },
@@ -519,7 +535,7 @@ TableColumnModel.registerFlow({
       defaultParams: (ctx: any) => {
         const titleField = ctx.model.context.collectionField.targetCollectionTitleFieldName;
         return {
-          label: ctx.model.props.titleField || titleField,
+          label: getSavedAssociationTitleField(ctx.model) || titleField,
         };
       },
       handler(ctx, params) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fixed the issue where the copy of the associated fields in the table was not displayed correctly in the first rendering.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the issue where the copy of the associated fields in the table was not displayed correctly in the first rendering.     |
| 🇨🇳 Chinese |     修复表格中关联字段的文案首次渲染未正确显示      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
