### PR TITLE
refactor(docker): support parallel docs build in pro image pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,6 @@ RUN mkdir -p /app/nocobase/storage/uploads/ && \
   echo "$COMMIT_HASH" > /app/commit_hash.txt
 
 COPY ./docker/nocobase/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh
 
 CMD ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The pro image pipeline needs to build docs after a full NocoBase dependency install, but the previous Dockerfile bundled source build, package release, app packaging, and final runtime assembly into one flow. That structure prevented docs build and app packaging from being handled in parallel by CI.

### Description
- Move the NocoBase source install, build, version, and release steps out of the Dockerfile so CI can finish them before Docker packaging starts.
- Keep the `create-nocobase-app` packaging flow in Docker, and let the runtime image consume prebuilt `nocobase.tar.gz` and `dist.tar.gz` artifacts.

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved the pro image pipeline to support parallel docs build and app packaging. |
| 🇨🇳 Chinese | 优化了 pro 镜像构建流程，支持文档构建和应用打包并行执行。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
