### PR TITLE
fix(ai): qwen enabel_search conflict with tool use

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -33,7 +33,9 @@ export class DashscopeProvider extends LLMProvider {
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
 
-    const modelKwargs: Record<string, any> = {};
+    const modelKwargs: Record<string, any> = {
+      thinking_budget: 40000,
+    };
 
     // Only set response_format when responseFormat is explicitly provided
     // Dashscope API rejects { type: undefined }
@@ -53,11 +55,12 @@ export class DashscopeProvider extends LLMProvider {
       // enable platform's web search ability
       // ref: https://bailian.console.aliyun.com/?tab=doc#/doc/?type=model&url=2867560
       modelKwargs['enable_search'] = true;
-      modelKwargs['search_options'] = { forced_search: true };
     }
 
     return new ReasoningChatOpenAI({
       apiKey,
+      topP: 0.8,
+      temperature: 0.7,
       ...this.modelOptions,
       modelKwargs,
       configuration: {
@@ -65,6 +68,18 @@ export class DashscopeProvider extends LLMProvider {
       },
       verbose: false,
     });
+  }
+
+  isToolConflict(): boolean {
+    return true;
+  }
+
+  resolveTools(toolDefinitions: any[]): any[] {
+    if (this.isToolConflict() && this.modelOptions?.builtIn?.webSearch === true) {
+      return [];
+    } else {
+      return toolDefinitions;
+    }
   }
 
   parseResponseMessage(message: Model) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
When using the Qwen LLM, if both the enable_search=true parameter and the tools parameter are present simultaneously, a conflict will occur, preventing the model from performing web searches properly.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue of abnormal web search behavior when using the Qwen  LLM |
| 🇨🇳 Chinese | 修复使用千问大模型时联网搜索行为异常的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
