### PR TITLE
fix(ai): should ignore skills list when getSkill tool not exist

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/ai/ai-employees/vera.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/ai/ai-employees/vera.ts
@@ -25,7 +25,7 @@ Provide accurate, timely, and well-sourced answers to user questions by searchin
 // --- CORE OPERATING PROCESS (The "How") ---
 You have a default, step-by-step process for handling every user request.
 1.  **Deconstruct & Plan:** First, analyze the user's question to identify the core entities, keywords, and the specific information needed. Formulate multiple, precise search queries to cover different angles of the topic.
-2.  **Search & Aggregate:** Execute the search queries using the provided internet search tool. You must gather information from at least 3-5 different, high-quality sources to build a comprehensive and balanced view.
+2.  **Search & Aggregate:** Execute the search queries on public internet. You must gather information from at least 3-5 different, high-quality sources to build a comprehensive and balanced view.
 3.  **Synthesize & Verify:** Critically evaluate the search results. Cross-reference key facts between different sources. Prioritize information from reputable news outlets, official documentation, academic papers, and established expert organizations. Discard or explicitly flag unsubstantiated or clearly outdated claims.
 4.  **Structure & Report:** **Based on your findings, structure your response according to the following priorities:**
     * **Priority 1: Direct Answer.** Your primary goal is to directly answer the user's question. Synthesize the verified findings into a clear, concise summary. It is mandatory that every sentence containing a factual claim MUST end with a citation marker in the format \`\`.

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -1258,6 +1258,11 @@ If information is missing, clearly state it in the summary.</Important>`;
 
   private async getAvailableSkills(): Promise<SkillsEntry[]> {
     const { skillsManager } = this.plugin.ai;
+    const aIEmployeeTools = await this.getAIEmployeeTools();
+    const getSkills = aIEmployeeTools.find((it) => it.definition.name === 'getSkills');
+    if (!getSkills) {
+      return [];
+    }
     const generalSkills = await skillsManager.listSkills({ scope: 'GENERAL' });
     const specifiedSkillNames = this.employee.skillSettings?.skills ?? [];
     const specifiedSkills = specifiedSkillNames.length ? await skillsManager.getSkills(specifiedSkillNames) : [];

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
@@ -129,7 +129,9 @@ ${task.context ? `<context>\n${task.context}\n</context>` : ''}
 ${
   availableSkills?.length
     ? `<skills>
-You have access to the following skills (tools groups). When a user's request matches a skill's description, use the getSkill tool to load that skill's detailed content and available tools:
+You have access to the following skills (tools groups). When a user's request matches a skill's description, use the **getSkill** tool to load that skill's detailed content and available tools
+
+But if there is no tool named **getSkill** don't try to use **getSkill** tool to load skills
 
 ${availableSkills.map((skill) => `- **${skill.name}**: ${skill.description || 'No description'}`).join('\n')}
 </skills>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
The LLM should not be instructed to use skills when the getSkill tool is not available.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the LLM still attempts to load skills after the getSkill tool is disabled |
| 🇨🇳 Chinese | 修复禁用getSkill工具后大模型仍然尝试加载技能的问题  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
