### PR TITLE
fix(docker): ensure docs llms text files use UTF-8 charset

### DIFF
--- a/docker/nocobase/nocobase-docs.conf
+++ b/docker/nocobase/nocobase-docs.conf
@@ -20,6 +20,8 @@ server {
   client_max_body_size 0;
   access_log /var/log/nginx/nocobase-docs.log apm2;
 
+  charset utf-8;
+
   error_page 404 /404.html;
 
   absolute_redirect off;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The docs site's Nginx config does not explicitly declare UTF-8 for responses. That can cause non-ASCII text in `llms.txt` and `llms-full.txt` to be decoded incorrectly and appear garbled when consumed by browsers or LLM tooling.

### Description
- add `charset utf-8;` to the docs Nginx server block so `llms.txt` and `llms-full.txt` are served with an explicit UTF-8 charset
- keep the existing docs routing, caching, and error-page behavior unchanged

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where non-ASCII text in the docs site's `llms.txt` and `llms-full.txt` files could appear garbled because responses were missing the UTF-8 charset. |
| 🇨🇳 Chinese | 修复了文档站点 `llms.txt` 和 `llms-full.txt` 响应未声明 UTF-8 编码，导致非 ASCII 文本可能乱码的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
