### PR TITLE
fix(docker): ensure docs llms text files use UTF-8 charset

### DIFF
--- a/docker/nocobase/nocobase-docs.conf
+++ b/docker/nocobase/nocobase-docs.conf
@@ -51,6 +51,22 @@ server {
     etag off;
   }
 
+  # 专门针对 txt 文件的路由
+  location ~ \.txt$ {
+    root /app/nocobase/docs;
+    
+    # 清空默认的 types 映射，强制指定带有 charset 的 Content-Type
+    types { }
+    default_type "text/plain; charset=utf-8";
+
+    # 保持原有的头部控制逻辑
+    add_header Last-Modified $date_gmt;
+    add_header Cache-Control 'no-store, no-cache';
+    if_modified_since off;
+    expires off;
+    etag off;
+  }
+
   location / {
     root /app/nocobase/docs;
     try_files $uri $uri.html $uri/index.html /index.html;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The docs site's Nginx config does not explicitly declare UTF-8 for responses. That can cause non-ASCII text in `llms.txt` and `llms-full.txt` to be decoded incorrectly and appear garbled when consumed by browsers or LLM tooling.

### Description
- add a dedicated `.txt` location to the docs Nginx config that clears the default type mapping and forces `text/plain; charset=utf-8` for `llms.txt` and `llms-full.txt`
- keep the existing docs routing, caching, and error-page behavior unchanged

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where non-ASCII text in the docs site's `llms.txt` and `llms-full.txt` files could appear garbled because responses were missing the UTF-8 charset. |
| 🇨🇳 Chinese | 修复了文档站点 `llms.txt` 和 `llms-full.txt` 响应未声明 UTF-8 编码，导致非 ASCII 文本可能乱码的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
