### PR TITLE
fix(ai): request deespseek with thinking_budget in dashsope occur error

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -33,9 +33,7 @@ export class DashscopeProvider extends LLMProvider {
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
 
-    const modelKwargs: Record<string, any> = {
-      thinking_budget: 40000,
-    };
+    const modelKwargs: Record<string, any> = {};
 
     // Only set response_format when responseFormat is explicitly provided
     // Dashscope API rejects { type: undefined }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
thinking_budget parameter will make request fail when use deepseek or minmax in dashscope

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue when using deepseek or minmax models on dashscope |
| 🇨🇳 Chinese | 修复在Dashscope上使用用deepseek或minmax模型报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
