### PR TITLE
fix(ai): if set APP_PUBLIC_PATH, upload file to ai employee will occur error

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/utils.ts
@@ -56,7 +56,11 @@ export function parseResponseMessage(row: Model) {
 }
 
 export async function encodeLocalFile(url: string) {
+  if (process.env.APP_PUBLIC_PATH && url.startsWith(process.env.APP_PUBLIC_PATH)) {
+    url = url.slice(process.env.APP_PUBLIC_PATH.length);
+  }
   url = path.join(process.cwd(), url);
+
   const data = await fs.promises.readFile(url);
   return Buffer.from(data).toString('base64');
 }


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
The local file resolution logic for AI employees does not consider the APP_PUBLIC_PATH env.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix AI employee document upload failure under subpath access with APP_PUBLIC_PATH configured. |
| 🇨🇳 Chinese | 修复配置 APP_PUBLIC_PATH 后，子路径访问下 AI 员工上传文档失败的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
