### PR TITLE
fix: incorrect secondary confirm

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/submitHandler.ts
+++ b/packages/core/client/src/flow/models/blocks/form/submitHandler.ts
@@ -43,8 +43,8 @@ export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?
       await resource.refresh();
     } else {
       blockModel.form.resetFields();
-      blockModel.resetUserModifiedFields?.();
       blockModel.emitter.emit('onFieldReset');
+      blockModel.resetUserModifiedFields?.();
       if (ctx.view.inputArgs.collectionName === blockModel.collection.name && ctx.view.inputArgs.onChange) {
         ctx.view.inputArgs.onChange(data?.data);
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where an incorrect secondary confirmation popup would appear when submitting the form after creating a record via a popup subtable. |
| 🇨🇳 Chinese | 修复通过弹窗子表格添加记录后提交表单时会出现错误的二次确认弹窗的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
