### PR TITLE
docs: add table of contents to README.fr.md

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -6,6 +6,13 @@ https://github.com/user-attachments/assets/4d11a87b-00e2-48f3-9bf7-389d21072d13
 <a href="https://trendshift.io/repositories/4112" target="_blank"><img src="https://trendshift.io/api/badge/repositories/4112" alt="nocobase%2Fnocobase | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 <a href="https://www.producthunt.com/posts/nocobase?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_souce=badge-nocobase" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-topic-badge.svg?post_id=456520&theme=light&period=weekly&topic_id=267" alt="NocoBase - Scalability&#0045;first&#0044;&#0032;open&#0045;source&#0032;no&#0045;code&#0032;platform | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 </p>
+## Table des matières
+
+- [Qu'est-ce que NocoBase ?](#quest-ce-que-nocobase-)
+- [Notes de version](#notes-de-version)
+- [Fonctionnalités distinctives](#fonctionnalités-distinctives)
+- [Installation](#installation)
+- [Comment fonctionne NocoBase](#comment-fonctionne-nocobase)
 
 ## Qu'est-ce que NocoBase ?
 


### PR DESCRIPTION

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The French README currently lacks a Table of Contents, making navigation less convenient compared to the English version.

### Description 
This PR adds a Table of Contents to `README.fr.md` to improve readability and navigation.

Key changes:
- Added a structured Table of Contents at the top of the file
- Ensured consistency with the English README structure

Risks:
- Minimal risk (documentation-only change)

Testing suggestions:
- Verify that all links in the Table of Contents correctly navigate to their respective sections

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add Table of Contents to French README |
| 🇨🇳 Chinese | 为法语 README 添加目录 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary