### PR TITLE
docs: add table of contents to README.ja-JP.md

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -8,6 +8,13 @@ https://github.com/user-attachments/assets/4d11a87b-00e2-48f3-9bf7-389d21072d13
 <a href="https://www.producthunt.com/posts/nocobase?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_souce=badge-nocobase" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-topic-badge.svg?post_id=456520&theme=light&period=weekly&topic_id=267" alt="NocoBase - Scalability&#0045;first&#0044;&#0032;open&#0045;source&#0032;no&#0045;code&#0032;platform | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 </p>
 
+## 目次
+
+- [NocoBaseはなに？](#nocobaseはなに)
+- [リリースノート](#リリースノート)
+- [他の製品との違い](#他の製品との違い)
+- [インストール](#インストール)
+- [NocoBaseの仕組み](#nocobaseの仕組み)
 ## NocoBaseはなに？
 
 超拡張可能な AIノーコード開発プラットフォーム。


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The Japanese README currently lacks a Table of Contents, which makes navigation less intuitive compared to the English version.

### Description 
This PR adds a Table of Contents to `README.ja-JP.md` to improve usability and consistency.

Key changes:
- Added a Table of Contents section at the top of the file
- Aligned structure with the English README

Risks:
- No functional impact (documentation-only change)

Testing suggestions:
- Check that all anchor links in the Table of Contents work correctly

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add Table of Contents to Japanese README |
| 🇨🇳 Chinese | 为日语 README 添加目录 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary