### PR TITLE
docs(ar): add Arabic translation for documentation homepage

### DIFF
--- a/docs/docs/ar/index.md
+++ b/docs/docs/ar/index.md
@@ -1,0 +1,54 @@
+---
+pageType: home
+
+pageName: home
+
+hero:
+  name: توثيق NocoBase
+  text: تعلّم NocoBase بسرعة واحترافية
+  actions:
+    - theme: brand
+      text: البدء
+      link: /get-started/how-nocobase-works
+    - theme: alt
+      text: GitHub
+      link: https://github.com/nocobase/nocobase
+
+features:
+  - title: البدء
+    details: تعلّم كيفية استخدام NocoBase وإتمام التثبيت والنشر.
+    items:
+      - title: البدء مع NocoBase
+        details: فهم المفاهيم الأساسية والعمليات الرئيسية في NocoBase.
+        link: /get-started/how-nocobase-works
+      - title: التثبيت، الترقية والنشر
+        details: تثبيت NocoBase من البداية، تنفيذ الترقيات، ونشره في بيئة الإنتاج.
+        link: /get-started/quickstart
+      - title: تثبيت وترقية الإضافات
+        details: تعلّم كيفية إضافة وإدارة وتحديث الإضافات لتوسيع قدرات النظام.
+        link: /get-started/install-upgrade-plugins
+
+  - title: متقدم
+    details: التعمق في مفاهيم NocoBase الأساسية وإتقان الإعدادات وإمكانيات التطوير.
+    items:
+      - title: المزيد...
+        details: استكشاف المزيد من وحدات الميزات.
+        link: /guide
+
+  - title: التطوير
+    details: يوفر NocoBase إمكانيات قوية للتوسيع والتكامل للمطورين.
+    items:
+      - title: المزيد...
+        details: استكشاف المزيد من دروس تطوير الإضافات.
+        link: /development
+
+  - title: الحلول
+    details: قوالب حلول جاهزة مبنية على NocoBase لمختلف المجالات.
+    items:
+      - title: نظام التذاكر
+        details: منصة ذكية لإدارة التذاكر مدعومة بالذكاء الاصطناعي مع دعم قنوات متعددة، إدارة SLA، قاعدة معرفة وغيرها.
+        link: /solution/ticket-system/
+      - title: CRM (معاينة)
+        details: منصة مرنة لإدارة علاقات العملاء بدون كود تشمل العملاء، العملاء المحتملين، الفرص، الطلبات وغيرها.
+        link: /solution/crm/
+---


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Provide Arabic language support for the NocoBase documentation by translating the homepage entry file.

Adding Arabic improves accessibility for Arabic-speaking users and helps expand the international community.

### Description
This PR adds the Arabic translation of the documentation homepage:

`docs/docs/ar/index.md`

The structure, links, and formatting remain identical to the English version.
Only user-facing text has been translated to Arabic.

No functional changes were made.

### Related issues
N/A

### Showcase
N/A (documentation translation only)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add Arabic translation for documentation homepage |
| 🇨🇳 Chinese | 新增阿拉伯语文档首页翻译 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | docs/docs/en/index.md |
| 🇸🇦 Arabic | docs/docs/ar/index.md |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary