### PR TITLE
fix(acl): preserve empty arrays when clearing relations

### DIFF
--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/change-with-association.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/change-with-association.test.ts
@@ -300,6 +300,51 @@ describe('Change with association', async () => {
     });
   });
 
+  test('associate only, update, should keep empty array for clearing relations', async () => {
+    await adminAgent.resource('roles.resources', 'test-role').create({
+      values: {
+        usingActionsConfig: true,
+        name: 'test',
+        actions: [
+          {
+            name: 'update',
+            fields: ['name', 'assoc1'],
+          },
+        ],
+      },
+    });
+
+    const user = await db.getRepository('users').create({
+      values: {
+        roles: ['test-role'],
+      },
+    });
+
+    const ctx = app.context;
+    ctx.app = app;
+    ctx.log = app.log;
+    ctx.database = db;
+    ctx.state = {
+      currentUser: user,
+      currentRoles: ['test-role'],
+    };
+    ctx.action = {
+      resourceName: 'test',
+      actionName: 'update',
+      params: {
+        values: {
+          name: 'test-1',
+          assoc1: [],
+        },
+      },
+    };
+    await compose([app.acl.middleware(), checkChangesWithAssociation])(ctx, async () => {});
+    expect(ctx.action.params.values).toMatchObject({
+      name: 'test-1',
+      assoc1: [],
+    });
+  });
+
   test('allow associate one exist record key', async () => {
     await adminAgent.resource('roles.resources', 'test-role').create({
       values: {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/check-change-with-association.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/check-change-with-association.ts
@@ -327,7 +327,7 @@ function normalizeAssociationValue(
     const result = value
       .map((v) => (typeof v === 'number' || typeof v === 'string' ? v : v[recordKey]))
       .filter((v) => v !== null && v !== undefined);
-    return result.length > 0 ? result : undefined;
+    return result;
   }
   return typeof value === 'number' || typeof value === 'string' ? value : value[recordKey];
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The ACL association sanitizing logic treated an explicit empty array as an omitted field, so clearing relation values in update requests did not take effect.

### Description 
- Preserve explicit empty arrays for association fields during ACL sanitization
- Add a regression test covering update requests that clear relation values with []
- Risk is low and limited to association value normalization in ACL middleware
- Testing suggestion: update a relation field with an empty array and confirm the relation is cleared

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where clearing relation values with an empty array could fail under ACL |
| 🇨🇳 Chinese | 修复 ACL 下使用空数组清空关联值可能不生效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
