### PR TITLE
fix(flow-engine): stabilize observer scheduler

### DIFF
--- a/packages/core/flow-engine/src/reactive/__tests__/observer.test.tsx
+++ b/packages/core/flow-engine/src/reactive/__tests__/observer.test.tsx
@@ -208,4 +208,82 @@ describe('observer', () => {
     expect(screen.getByText('Count: 0')).toBeInTheDocument();
     expect(screen.queryByText('Count: 1')).not.toBeInTheDocument();
   });
+
+  it('should flush pending update without TDZ error when context becomes active before timer callback runs', async () => {
+    vi.useFakeTimers();
+
+    const model = observable({ count: 0 });
+    const pageActive = observable.ref(false);
+    const tabActive = observable.ref(true);
+
+    const context = {
+      pageActive,
+      tabActive,
+    };
+
+    (useFlowContext as any).mockReturnValue(context);
+
+    const Component = observer(() => <div>Count: {model.count}</div>);
+
+    render(<Component />);
+
+    expect(screen.getByText('Count: 0')).toBeInTheDocument();
+
+    act(() => {
+      model.count++;
+      pageActive.value = true;
+    });
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(screen.getByText('Count: 1')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('should cleanup pending timer and listener on unmount', async () => {
+    vi.useFakeTimers();
+
+    const model = observable({ count: 0 });
+    const pageActive = observable.ref(false);
+    const tabActive = observable.ref(true);
+    const renderSpy = vi.fn();
+
+    const context = {
+      pageActive,
+      tabActive,
+    };
+
+    (useFlowContext as any).mockReturnValue(context);
+
+    const Component = observer(() => {
+      renderSpy(model.count);
+      return <div>Count: {model.count}</div>;
+    });
+
+    const { unmount } = render(<Component />);
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Count: 0')).toBeInTheDocument();
+
+    act(() => {
+      model.count++;
+    });
+
+    unmount();
+
+    act(() => {
+      pageActive.value = true;
+    });
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
 });

--- a/packages/core/flow-engine/src/reactive/__tests__/observer.test.tsx
+++ b/packages/core/flow-engine/src/reactive/__tests__/observer.test.tsx
@@ -212,78 +212,82 @@ describe('observer', () => {
   it('should flush pending update without TDZ error when context becomes active before timer callback runs', async () => {
     vi.useFakeTimers();
 
-    const model = observable({ count: 0 });
-    const pageActive = observable.ref(false);
-    const tabActive = observable.ref(true);
+    try {
+      const model = observable({ count: 0 });
+      const pageActive = observable.ref(false);
+      const tabActive = observable.ref(true);
 
-    const context = {
-      pageActive,
-      tabActive,
-    };
+      const context = {
+        pageActive,
+        tabActive,
+      };
 
-    (useFlowContext as any).mockReturnValue(context);
+      (useFlowContext as any).mockReturnValue(context);
 
-    const Component = observer(() => <div>Count: {model.count}</div>);
+      const Component = observer(() => <div>Count: {model.count}</div>);
 
-    render(<Component />);
+      render(<Component />);
 
-    expect(screen.getByText('Count: 0')).toBeInTheDocument();
+      expect(screen.getByText('Count: 0')).toBeInTheDocument();
 
-    act(() => {
-      model.count++;
-      pageActive.value = true;
-    });
+      act(() => {
+        model.count++;
+        pageActive.value = true;
+      });
 
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
 
-    expect(screen.getByText('Count: 1')).toBeInTheDocument();
-
-    vi.useRealTimers();
+      expect(screen.getByText('Count: 1')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('should cleanup pending timer and listener on unmount', async () => {
     vi.useFakeTimers();
 
-    const model = observable({ count: 0 });
-    const pageActive = observable.ref(false);
-    const tabActive = observable.ref(true);
-    const renderSpy = vi.fn();
+    try {
+      const model = observable({ count: 0 });
+      const pageActive = observable.ref(false);
+      const tabActive = observable.ref(true);
+      const renderSpy = vi.fn();
 
-    const context = {
-      pageActive,
-      tabActive,
-    };
+      const context = {
+        pageActive,
+        tabActive,
+      };
 
-    (useFlowContext as any).mockReturnValue(context);
+      (useFlowContext as any).mockReturnValue(context);
 
-    const Component = observer(() => {
-      renderSpy(model.count);
-      return <div>Count: {model.count}</div>;
-    });
+      const Component = observer(() => {
+        renderSpy(model.count);
+        return <div>Count: {model.count}</div>;
+      });
 
-    const { unmount } = render(<Component />);
+      const { unmount } = render(<Component />);
 
-    expect(renderSpy).toHaveBeenCalledTimes(1);
-    expect(screen.getByText('Count: 0')).toBeInTheDocument();
+      expect(renderSpy).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Count: 0')).toBeInTheDocument();
 
-    act(() => {
-      model.count++;
-    });
+      act(() => {
+        model.count++;
+      });
 
-    unmount();
+      unmount();
 
-    act(() => {
-      pageActive.value = true;
-    });
+      act(() => {
+        pageActive.value = true;
+      });
 
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
 
-    expect(renderSpy).toHaveBeenCalledTimes(1);
-
-    vi.useRealTimers();
+      expect(renderSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/flow-engine/src/reactive/observer.tsx
+++ b/packages/core/flow-engine/src/reactive/observer.tsx
@@ -86,8 +86,15 @@ export const observer = <P, Options extends IObserverOptions = IObserverOptions>
     // 组件卸载时统一清理所有挂起任务，避免异步回调在卸载后继续运行。
     useEffect(() => {
       return () => {
-        clearPendingTimer();
-        clearPendingDisposer();
+        if (pendingTimerRef.current) {
+          clearTimeout(pendingTimerRef.current);
+          pendingTimerRef.current = null;
+        }
+
+        if (pendingDisposerRef.current) {
+          pendingDisposerRef.current();
+          pendingDisposerRef.current = null;
+        }
       };
     }, []);
 

--- a/packages/core/flow-engine/src/reactive/observer.tsx
+++ b/packages/core/flow-engine/src/reactive/observer.tsx
@@ -10,7 +10,7 @@
 import { observer as originalObserver, IObserverOptions, ReactFC } from '@formily/reactive-react';
 import React, { useMemo, useEffect, useRef } from 'react';
 import { useFlowContext } from '../FlowContextProvider';
-import { autorun } from '@formily/reactive';
+import { reaction } from '@formily/reactive';
 import { FlowEngineContext } from '..';
 
 type ObserverComponentProps<P, Options extends IObserverOptions> = Options extends {
@@ -30,16 +30,64 @@ export const observer = <P, Options extends IObserverOptions = IObserverOptions>
     const ctxRef = useRef(ctx);
     ctxRef.current = ctx;
 
-    // Store the pending disposer to avoid creating multiple listeners
+    // 保存延迟更新的监听器，避免重复创建监听。
     const pendingDisposerRef = useRef<(() => void) | null>(null);
+    // 保存延迟创建监听器的定时器，避免组件卸载后仍继续调度。
+    const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Cleanup on unmount
+    /**
+     * 清理挂起的可见性监听器。
+     *
+     * @example
+     * ```typescript
+     * clearPendingDisposer();
+     * ```
+     */
+    const clearPendingDisposer = () => {
+      if (pendingDisposerRef.current) {
+        pendingDisposerRef.current();
+        pendingDisposerRef.current = null;
+      }
+    };
+
+    /**
+     * 清理挂起的定时器。
+     *
+     * @example
+     * ```typescript
+     * clearPendingTimer();
+     * ```
+     */
+    const clearPendingTimer = () => {
+      if (pendingTimerRef.current) {
+        clearTimeout(pendingTimerRef.current);
+        pendingTimerRef.current = null;
+      }
+    };
+
+    /**
+     * 判断当前页面与标签页是否允许立即更新。
+     *
+     * @returns 当前上下文是否处于可更新状态。
+     * @example
+     * ```typescript
+     * if (isContextActive()) {
+     *   updater();
+     * }
+     * ```
+     */
+    const isContextActive = () => {
+      const pageActive = getPageActive(ctxRef.current);
+      const tabActive = ctxRef.current?.tabActive?.value;
+
+      return pageActive !== false && tabActive !== false;
+    };
+
+    // 组件卸载时统一清理所有挂起任务，避免异步回调在卸载后继续运行。
     useEffect(() => {
       return () => {
-        if (pendingDisposerRef.current) {
-          pendingDisposerRef.current();
-          pendingDisposerRef.current = null;
-        }
+        clearPendingTimer();
+        clearPendingDisposer();
       };
     }, []);
 
@@ -47,38 +95,45 @@ export const observer = <P, Options extends IObserverOptions = IObserverOptions>
       () =>
         originalObserver(Component, {
           scheduler(updater) {
-            const pageActive = getPageActive(ctxRef.current);
-            const tabActive = ctxRef.current?.tabActive?.value;
+            if (!isContextActive()) {
+              if (pendingTimerRef.current || pendingDisposerRef.current) {
+                return;
+              }
 
-            if (pageActive === false || tabActive === false) {
-              // Avoid stack overflow
-              setTimeout(() => {
-                // If there is already a pending updater, do nothing
+              // 通过异步任务打断同步调度，避免连续触发时形成递归更新。
+              pendingTimerRef.current = setTimeout(() => {
+                pendingTimerRef.current = null;
+
                 if (pendingDisposerRef.current) {
                   return;
                 }
 
-                // Delay the update until the page and tab become active
-                const disposer = autorun(() => {
-                  if (
-                    ctxRef.current?.pageActive?.value &&
-                    (ctxRef.current?.tabActive?.value === true || ctxRef.current?.tabActive?.value === undefined)
-                  ) {
+                if (isContextActive()) {
+                  updater();
+                  return;
+                }
+
+                // 只监听组合后的“是否可更新”状态，条件恢复后执行一次并立即销毁。
+                pendingDisposerRef.current = reaction(
+                  () => isContextActive(),
+                  (active) => {
+                    if (!active) {
+                      return;
+                    }
+
+                    clearPendingDisposer();
                     updater();
-                    disposer?.();
-                    pendingDisposerRef.current = null;
-                  }
-                });
-                pendingDisposerRef.current = disposer;
+                  },
+                  {
+                    name: 'FlowObserverPendingUpdate',
+                  },
+                );
               });
               return;
             }
 
-            // If we are updating immediately, clear any pending disposer
-            if (pendingDisposerRef.current) {
-              pendingDisposerRef.current();
-              pendingDisposerRef.current = null;
-            }
+            clearPendingTimer();
+            clearPendingDisposer();
 
             updater();
           },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

修复 flow-engine 的 observer 在页面或标签页不可见时延迟更新的随机运行时错误。原实现依赖 `autorun` 同步首轮执行后的自销毁逻辑，在特定时序下会触发初始化前访问 disposer 的错误。

### Description 

将延迟更新逻辑改为显式的 pending timer 与 `reaction` 监听：
- 页面或标签页不可更新时，仅保留一个挂起任务，等待恢复可更新后执行一次更新
- 组件卸载时统一清理挂起的 timer 与监听器，避免卸载后继续触发更新
- 补充回归测试，覆盖原随机报错时序与卸载清理场景

风险主要在 observer 调度时序，但本次改动保持了“不可见时延迟、恢复后执行一次”的原有语义，并已通过相关单测验证。

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the random observer error when page visibility changes |
| 🇨🇳 Chinese | 修复页面可见性切换时 observer 随机报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
