### PR TITLE
fix(client): fix default values and formula updates in v2 association subforms

### DIFF
--- a/.github/workflows/deploy-client-docs.yml
+++ b/.github/workflows/deploy-client-docs.yml
@@ -44,6 +44,7 @@ jobs:
             echo "::set-output name=tags::pr-${{ github.event.pull_request.number }}"
           fi
       - name: copy files via ssh - ${{ steps.set-tags.outputs.tags }}
+        if: github.event.pull_request.head.repo.fork != true
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.CN_CLIENT_HOST }}

--- a/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
@@ -24,21 +24,11 @@ import { EditFormModel } from './EditFormModel';
 import _ from 'lodash';
 import { coerceForToOneField } from '../../../internal/utils/associationValueCoercion';
 import { buildDynamicNamePath } from './dynamicNamePath';
-
-const interfacesOfUnsupportedDefaultValue = [
-  'o2o',
-  'oho',
-  'obo',
-  'o2m',
-  'attachment',
-  'expression',
-  'point',
-  'lineString',
-  'circle',
-  'polygon',
-  'sequence',
-  'formula',
-];
+import {
+  hasOwnInitialValueConfig,
+  interfacesOfUnsupportedDefaultValue,
+  resolveCollectionFieldInitialValue,
+} from './defaultValue';
 
 export class FormItemModel<T extends DefaultStructure = DefaultStructure> extends EditableItemModel<T> {
   static defineChildren(ctx: FlowModelContext) {
@@ -120,6 +110,10 @@ export class FormItemModel<T extends DefaultStructure = DefaultStructure> extend
                 get: () => this.context.currentObject,
               });
             }
+            fork.context.defineProperty('fieldPathArray', {
+              get: () => this.context.fieldPathArray,
+              cache: false,
+            });
             const itemOptions = this.context.getPropertyOptions('item');
             if (this.context.item) {
               const { value: _value, ...rest } = (itemOptions || {}) as any;
@@ -296,9 +290,18 @@ FormItemModel.registerFlow({
       async handler(ctx) {
         const fieldPath = ctx.model.fieldPath;
         const fullName = fieldPath.includes('.') ? fieldPath.split('.') : fieldPath;
-        ctx.model.setProps({
+        const nextProps: Record<string, any> = {
           name: fullName,
-        });
+        };
+
+        if (!hasOwnInitialValueConfig(ctx.model)) {
+          const initialValue = resolveCollectionFieldInitialValue(ctx.model.collectionField);
+          if (typeof initialValue !== 'undefined') {
+            nextProps.initialValue = initialValue;
+          }
+        }
+
+        ctx.model.setProps(nextProps);
       },
     },
 

--- a/packages/core/client/src/flow/models/blocks/form/__tests__/defaultValue.test.ts
+++ b/packages/core/client/src/flow/models/blocks/form/__tests__/defaultValue.test.ts
@@ -1,0 +1,76 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { hasOwnInitialValueConfig, resolveCollectionFieldInitialValue } from '../defaultValue';
+
+describe('form default value helpers', () => {
+  it('resolves collection field default value for supported interfaces', () => {
+    expect(
+      resolveCollectionFieldInitialValue({
+        interface: 'input',
+        defaultValue: '1123',
+      }),
+    ).toBe('1123');
+  });
+
+  it('coerces to-one association defaults before applying them', () => {
+    expect(
+      resolveCollectionFieldInitialValue({
+        interface: 'm2o',
+        isAssociationField: () => true,
+        type: 'belongsTo',
+        defaultValue: [1, 2],
+      }),
+    ).toBe(1);
+  });
+
+  it('skips unsupported interfaces such as formula', () => {
+    expect(
+      resolveCollectionFieldInitialValue({
+        interface: 'formula',
+        defaultValue: '1123',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('treats props.initialValue as explicit config even when the value is undefined', () => {
+    expect(
+      hasOwnInitialValueConfig({
+        props: {
+          initialValue: undefined,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('detects legacy step-based default config', () => {
+    expect(
+      hasOwnInitialValueConfig({
+        getStepParams(flowKey: string, stepKey: string) {
+          if (flowKey === 'editItemSettings' && stepKey === 'initialValue') {
+            return { defaultValue: 'A' };
+          }
+          return undefined;
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the form item has no explicit default config', () => {
+    expect(
+      hasOwnInitialValueConfig({
+        props: {},
+        getStepParams() {
+          return undefined;
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/client/src/flow/models/blocks/form/defaultValue.ts
+++ b/packages/core/client/src/flow/models/blocks/form/defaultValue.ts
@@ -1,0 +1,66 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { coerceForToOneField } from '../../../internal/utils/associationValueCoercion';
+
+export const interfacesOfUnsupportedDefaultValue = [
+  'o2o',
+  'oho',
+  'obo',
+  'o2m',
+  'attachment',
+  'expression',
+  'point',
+  'lineString',
+  'circle',
+  'polygon',
+  'sequence',
+  'formula',
+];
+
+export function hasOwnInitialValueConfig(model: {
+  getProps?: () => Record<string, any>;
+  props?: Record<string, any>;
+  getStepParams?: (flowKey: string, stepKey: string) => any;
+}) {
+  const props = typeof model?.getProps === 'function' ? model.getProps() : model?.props;
+  if (props && Object.prototype.hasOwnProperty.call(props, 'initialValue')) {
+    return true;
+  }
+
+  try {
+    const fromEdit = model?.getStepParams?.('editItemSettings', 'initialValue');
+    if (fromEdit && Object.prototype.hasOwnProperty.call(fromEdit, 'defaultValue')) {
+      return true;
+    }
+
+    const fromLegacy = model?.getStepParams?.('formItemSettings', 'initialValue');
+    if (fromLegacy && Object.prototype.hasOwnProperty.call(fromLegacy, 'defaultValue')) {
+      return true;
+    }
+  } catch {
+    // ignore legacy step access failures
+  }
+
+  return false;
+}
+
+export function resolveCollectionFieldInitialValue(collectionField: any) {
+  const iface = collectionField?.interface;
+  if (!collectionField || interfacesOfUnsupportedDefaultValue?.includes?.(iface)) {
+    return undefined;
+  }
+
+  const defaultValue = collectionField.defaultValue;
+  if (typeof defaultValue === 'undefined') {
+    return undefined;
+  }
+
+  return coerceForToOneField(collectionField, defaultValue);
+}

--- a/packages/core/client/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
+++ b/packages/core/client/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
@@ -246,6 +246,120 @@ describe('FormValueRuntime (default rules)', () => {
     await runtime.setFormValues(fieldCtx, [{ path: ['y'], value: 30 }], { source: 'user' });
     await waitFor(() => expect(formStub.getFieldValue(['a'])).toBe(30));
   });
+
+  it('applies subform row initialValue to the absolute fieldPathArray instead of the relative row name', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const formStub = createFormStub({ users: [{ __is_new__: true, name: '' }] });
+
+    const blockModel: any = {
+      uid: 'form-subform-default-row',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'update',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    blockModel.context = blockCtx;
+
+    const fieldCtx = createFieldContext(runtime);
+    fieldCtx.defineProperty('blockModel', { value: blockModel });
+    fieldCtx.defineProperty('fieldPathArray', { value: ['users', 0, 'name'] });
+    fieldCtx.defineProperty('item', {
+      get: () => ({
+        index: 0,
+        length: 1,
+        __is_new__: true,
+        __is_stored__: false,
+        value: formStub.getFieldValue(['users', 0]),
+      }),
+      cache: false,
+    });
+
+    const fieldModel: any = {
+      uid: 'users.name',
+      context: fieldCtx,
+      props: observable({
+        name: [0, 'name'],
+        initialValue: 'ABC',
+      }),
+      getProps() {
+        return this.props;
+      },
+    };
+    fieldCtx.defineProperty('model', { value: fieldModel });
+
+    engineEmitter.emit('model:mounted', { model: fieldModel });
+
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'name'])).toBe('ABC'));
+    expect(formStub.getFieldValue([0, 'name'])).toBeUndefined();
+  });
+
+  it('reads subform row initialValue from the mounted fork props when master props have no initialValue', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const formStub = createFormStub({ users: [{ __is_new__: true, name: '' }] });
+
+    const blockModel: any = {
+      uid: 'form-subform-default-row-fork-props',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'update',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    blockModel.context = blockCtx;
+
+    const fieldCtx = createFieldContext(runtime);
+    fieldCtx.defineProperty('blockModel', { value: blockModel });
+    fieldCtx.defineProperty('fieldPathArray', { value: ['users', 0, 'name'] });
+    fieldCtx.defineProperty('item', {
+      get: () => ({
+        index: 0,
+        length: 1,
+        __is_new__: true,
+        __is_stored__: false,
+        value: formStub.getFieldValue(['users', 0]),
+      }),
+      cache: false,
+    });
+
+    const masterModel: any = {
+      uid: 'users.name.master',
+      props: observable({
+        name: ['name'],
+      }),
+      getProps() {
+        return this.props;
+      },
+    };
+
+    const fieldModel: any = {
+      uid: 'users.name',
+      master: masterModel,
+      context: fieldCtx,
+      props: observable({
+        name: [0, 'name'],
+        initialValue: 'ROW_ONLY',
+      }),
+      getProps() {
+        return this.props;
+      },
+    };
+    fieldCtx.defineProperty('model', { value: fieldModel });
+
+    engineEmitter.emit('model:mounted', { model: fieldModel });
+
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'name'])).toBe('ROW_ONLY'));
+  });
 });
 
 describe('FormValueRuntime (form assign rules)', () => {

--- a/packages/core/client/src/flow/models/blocks/form/value-runtime/rules.ts
+++ b/packages/core/client/src/flow/models/blocks/form/value-runtime/rules.ts
@@ -691,7 +691,7 @@ export class RuleEngine {
     this.bindMasterInitialValue(master, id);
 
     const getRawPropsInitialValue = () => {
-      const p = (master as any)?.getProps?.() ?? (master as any)?.props;
+      const p = (model as any)?.getProps?.() ?? (model as any)?.props;
       return p?.initialValue;
     };
 

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubFormFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubFormFieldModel.tsx
@@ -268,6 +268,10 @@ const ArrayNester = ({
                   get: () => fieldIndex,
                   cache: false,
                 });
+                currentFork.context.defineProperty('fieldPathArray', {
+                  get: () => model?.parent?.context?.fieldPathArray ?? [],
+                  cache: false,
+                });
 
                 const getRowItem = createItemChainGetter({
                   valueAccessor: () => currentFork.context.form.getFieldValue([name, fieldName]),

--- a/packages/core/client/src/formily/NocoBaseField.tsx
+++ b/packages/core/client/src/formily/NocoBaseField.tsx
@@ -13,13 +13,26 @@ import { useCompile } from '../schema-component/hooks/useCompile';
 import { NocoBaseReactiveField } from './NocoBaseReactiveField';
 import { createNocoBaseField } from './createNocoBaseField';
 
+export function resolveLightweightFieldValue(options: { value: any; schemaDefault: any; record?: any }) {
+  const { value, schemaDefault, record } = options;
+  if (typeof value !== 'undefined') {
+    return value;
+  }
+
+  if (record?.__is_new__ !== true) {
+    return value;
+  }
+
+  return schemaDefault;
+}
+
 /**
  * To maintain high performance of Table, this component removes Formily-related components
  * @param props component props
  * @returns
  */
 export const NocoBaseField = <D extends JSXComponent, C extends JSXComponent>(
-  props: IFieldProps<D, C> & { schema: Schema },
+  props: IFieldProps<D, C> & { schema: Schema; form?: any; record?: any },
 ) => {
   const compile = useCompile();
   const fieldSchema = useFieldSchema();
@@ -28,7 +41,10 @@ export const NocoBaseField = <D extends JSXComponent, C extends JSXComponent>(
 
   // update componentProps to rerender field component
   Object.assign(field.componentProps, fieldSchema['x-component-props']);
-  field.value = props.value;
+  field.form = props.form ?? field.form;
+
+  const schemaDefault = compile(fieldSchema?.default) ?? compile(props.schema?.default);
+  field.value = resolveLightweightFieldValue({ value: props.value, schemaDefault, record: props.record });
 
   return (
     <FieldContext.Provider value={field as any}>

--- a/packages/core/client/src/formily/NocoBaseRecursionField.tsx
+++ b/packages/core/client/src/formily/NocoBaseRecursionField.tsx
@@ -31,6 +31,7 @@ import { useCollection } from '../data-source/collection/CollectionProvider';
 import { SchemaComponentOnChangeContext } from '../schema-component/core/SchemaComponent';
 import { EMPTY_OBJECT } from '../variables';
 import { NocoBaseField } from './NocoBaseField';
+import { setLightweightFormValue } from './createNocoBaseField';
 
 interface INocoBaseRecursionFieldProps extends IRecursionFieldProps {
   /**
@@ -49,6 +50,11 @@ interface INocoBaseRecursionFieldProps extends IRecursionFieldProps {
    */
   isUseFormilyField?: boolean;
   parentSchema?: Schema;
+  /**
+   * The full record object (row data), used to construct reactive form for formula fields
+   * in table-v2 cell rendering context.
+   */
+  record?: any;
 }
 
 const CollectionFieldUISchemaContext = React.createContext<CollectionFieldOptions>({});
@@ -170,6 +176,7 @@ const propertiesToReactElement = ({
   propsRecursion,
   values,
   isUseFormilyField,
+  record,
 }: {
   schema: Schema;
   field: any;
@@ -179,6 +186,7 @@ const propertiesToReactElement = ({
   propsRecursion?: any;
   values?: Record<string, any>;
   isUseFormilyField?: boolean;
+  record?: any;
 }) => {
   const properties = Schema.getOrderProperties(schema);
   if (!properties.length) return null;
@@ -210,6 +218,7 @@ const propertiesToReactElement = ({
               basePath={base}
               values={_.get(values, name)}
               isUseFormilyField={isUseFormilyField}
+              record={record}
             />
           ) : (
             <NocoBaseRecursionField
@@ -218,6 +227,7 @@ const propertiesToReactElement = ({
               basePath={base}
               values={_.get(values, name)}
               isUseFormilyField={isUseFormilyField}
+              record={record}
             />
           );
 
@@ -268,6 +278,7 @@ export const NocoBaseRecursionField: ReactFC<INocoBaseRecursionFieldProps> = Rea
     isUseFormilyField = true,
     uiSchema,
     parentSchema,
+    record: recordProp,
   } = props;
   const basePath = useBasePath(props);
   const newFieldSchemaRef = useRef(null);
@@ -332,6 +343,7 @@ export const NocoBaseRecursionField: ReactFC<INocoBaseRecursionFieldProps> = Rea
       propsRecursion,
       values,
       isUseFormilyField,
+      record: recordProp ?? values,
     });
   };
 
@@ -358,7 +370,27 @@ export const NocoBaseRecursionField: ReactFC<INocoBaseRecursionFieldProps> = Rea
     return isUseFormilyField ? (
       <Field {...fieldProps} name={name} basePath={basePath} />
     ) : (
-      <NocoBaseField name={name} value={values} initialValue={values} basePath={basePath} schema={mergedFieldSchema} />
+      (() => {
+        const record = recordProp ?? values;
+        const form = {
+          values: record,
+          getFieldsValue: () => form.values,
+          setFieldValue: (path, val) => {
+            setLightweightFormValue(form.values, path, val);
+          },
+        };
+        return (
+          <NocoBaseField
+            name={name}
+            value={values}
+            initialValue={values}
+            form={form}
+            record={record}
+            basePath={basePath}
+            schema={mergedFieldSchema}
+          />
+        ) as any;
+      })()
     );
   };
 

--- a/packages/core/client/src/formily/__tests__/NocoBaseField.test.tsx
+++ b/packages/core/client/src/formily/__tests__/NocoBaseField.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Schema, SchemaContext } from '@formily/react';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { NocoBaseField, resolveLightweightFieldValue } from '../NocoBaseField';
+import { setLightweightFormValue } from '../createNocoBaseField';
+
+const ValueViewer = (props: any) => <span data-testid="value">{String(props.value)}</span>;
+
+const schema = new Schema({
+  type: 'string',
+  default: 'DEFAULT',
+  'x-component': ValueViewer,
+});
+
+function renderField(props: Record<string, any>) {
+  return render(
+    <SchemaContext.Provider value={schema}>
+      <NocoBaseField schema={schema} {...props} />
+    </SchemaContext.Provider>,
+  );
+}
+
+describe('NocoBaseField', () => {
+  it('updates rendered value when props.value changes', () => {
+    const { rerender } = renderField({ value: 'A', record: { id: 1 } });
+
+    expect(screen.getByTestId('value').textContent).toBe('A');
+
+    rerender(
+      <SchemaContext.Provider value={schema}>
+        <NocoBaseField schema={schema} value="B" record={{ id: 1 }} />
+      </SchemaContext.Provider>,
+    );
+
+    expect(screen.getByTestId('value').textContent).toBe('B');
+  });
+
+  it('only uses schema default for new rows with undefined values', () => {
+    const { rerender } = renderField({ value: undefined, record: { __is_new__: true } });
+
+    expect(screen.getByTestId('value').textContent).toBe('DEFAULT');
+
+    rerender(
+      <SchemaContext.Provider value={schema}>
+        <NocoBaseField schema={schema} value={undefined} record={{ id: 1 }} />
+      </SchemaContext.Provider>,
+    );
+
+    expect(screen.getByTestId('value').textContent).toBe('undefined');
+
+    rerender(
+      <SchemaContext.Provider value={schema}>
+        <NocoBaseField schema={schema} value={null} record={{ __is_new__: true }} />
+      </SchemaContext.Provider>,
+    );
+
+    expect(screen.getByTestId('value').textContent).toBe('null');
+  });
+});
+
+describe('lightweight field helpers', () => {
+  it('keeps explicit null values instead of falling back to schema default', () => {
+    expect(resolveLightweightFieldValue({ value: null, schemaDefault: 'DEFAULT', record: { __is_new__: true } })).toBe(
+      null,
+    );
+  });
+
+  it('writes array name paths into nested objects', () => {
+    const values = {
+      items: [{ total: null }],
+    };
+
+    setLightweightFormValue(values, ['items', 0, 'total'], 5);
+
+    expect(values.items[0].total).toBe(5);
+    expect((values as any)['items,0,total']).toBeUndefined();
+  });
+});

--- a/packages/core/client/src/formily/createNocoBaseField.ts
+++ b/packages/core/client/src/formily/createNocoBaseField.ts
@@ -10,10 +10,15 @@
 import { IFieldProps } from '@formily/core';
 import { JSXComponent, Schema } from '@formily/react';
 import { toArr } from '@formily/shared';
+import { observable } from '@formily/reactive';
 import _ from 'lodash';
 
 export function createNocoBaseField<Decorator extends JSXComponent, Component extends JSXComponent>(props: any) {
   return new NocoBaseField(props);
+}
+
+export function setLightweightFormValue(values: any, path: any, value: any) {
+  _.set(values, path as any, value);
 }
 
 /**
@@ -28,6 +33,8 @@ class NocoBaseField<
   props: IFieldProps<Decorator, Component, TextType, ValueType> & {
     schema: Schema;
     compile: (source: any) => any;
+    form?: any;
+    record?: any;
   };
   initialized: boolean;
   loading: boolean;
@@ -119,7 +126,20 @@ class NocoBaseField<
     this.componentType = this.props.schema?.['x-component'];
 
     this.path = {};
-    this.form = {};
+    const externalForm = this.props.form;
+    if (externalForm) {
+      this.form = externalForm;
+    } else {
+      const record = this.props.record || {};
+      const reactiveValues = observable(record);
+      this.form = {
+        values: reactiveValues,
+        getFieldsValue: () => this.form.values,
+        setFieldValue: (path, val) => {
+          setLightweightFormValue(this.form.values, path, val);
+        },
+      };
+    }
     this.address = {
       concat: _.noop,
     };

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.tsx
@@ -140,6 +140,7 @@ const TableCellRender: FC<{
         propsRecursion
         filterProperties={filterProperties}
         isUseFormilyField={false}
+        record={record}
       />
     </span>
   );

--- a/packages/plugins/@nocobase/plugin-field-formula/src/client/FormulaFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client/FormulaFieldModel.tsx
@@ -7,7 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { useTranslation } from 'react-i18next';
 import { toJS } from '@formily/reactive';
 import { EditableItemModel, DisplayItemModel, FilterableItemModel, tExpr } from '@nocobase/flow-engine';
 import { Form } from 'antd';
@@ -15,7 +14,7 @@ import { Checkbox, DatePicker, FieldModel, InputNumber, Input as InputString } f
 import { Evaluator, evaluators } from '@nocobase/evaluators/client';
 import { Registry, toFixedByStep } from '@nocobase/utils/client';
 import _ from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { toDbType } from '../utils';
 
@@ -41,31 +40,84 @@ const EditableComponents = {
   string: InputString,
 };
 
-function getValuesByPath(values, key, index?) {
-  const targetValue = values?.[key];
-  if (Array.isArray(targetValue)) {
-    return targetValue[index];
-  }
-  if (targetValue && typeof targetValue === 'object') {
-    return targetValue;
-  } else {
-    return values;
-  }
+type FormulaNamePath = Array<string | number>;
+
+function normalizeFormulaNamePath(path: unknown): FormulaNamePath | null {
+  const normalized: FormulaNamePath = [];
+
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+
+    if (typeof value === 'number') {
+      normalized.push(value);
+      return;
+    }
+
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    value
+      .split('.')
+      .filter(Boolean)
+      .forEach((segment) => {
+        normalized.push(/^\d+$/.test(segment) ? Number(segment) : segment);
+      });
+  };
+
+  visit(path);
+  return normalized.length ? normalized : null;
 }
 
-function getValuesByFullPath(values, fieldPath) {
-  const fieldPaths = fieldPath.split('.');
-  let currentKeyIndex = 0;
-  let value = values || {};
-  //loop to get the last field
-  while (currentKeyIndex < fieldPaths.length) {
-    const fieldName = fieldPaths[currentKeyIndex];
-    const index = parseInt(fieldPaths?.[currentKeyIndex + 1]);
-    value = getValuesByPath(value, fieldName, index);
-    //have index means an array, then jump 2; else 1
-    currentKeyIndex = currentKeyIndex + (index >= 0 ? 2 : 1);
+export function resolveFormulaTargetNamePath(options: {
+  context?: any;
+  name?: unknown;
+  id?: unknown;
+  collectionField?: { name?: string };
+}): FormulaNamePath | null {
+  const contextPath = normalizeFormulaNamePath(options?.context?.fieldPathArray);
+  if (contextPath?.length) {
+    return contextPath;
   }
-  return value;
+
+  const namePath = normalizeFormulaNamePath(options?.name);
+  if (namePath?.length) {
+    return namePath;
+  }
+
+  const idPath = normalizeFormulaNamePath(options?.id);
+  if (!idPath?.length) {
+    return null;
+  }
+
+  const fieldName = options?.collectionField?.name;
+  if (!fieldName || idPath[idPath.length - 1] === fieldName) {
+    return idPath;
+  }
+
+  const lastSegment = idPath[idPath.length - 1];
+  const prevSegment = idPath[idPath.length - 2];
+  if (typeof lastSegment === 'number' && prevSegment === fieldName) {
+    return [...idPath.slice(0, -2), lastSegment, fieldName];
+  }
+
+  return [...idPath, fieldName];
+}
+
+export function getFormulaScopeValues(values: any, fieldPath: FormulaNamePath | null) {
+  if (!fieldPath?.length) {
+    return values || {};
+  }
+
+  const parentPath = fieldPath.slice(0, -1);
+  if (!parentPath.length) {
+    return values || {};
+  }
+
+  return _.get(values, parentPath) || {};
 }
 
 function areValuesEqual(value1, value2) {
@@ -93,14 +145,17 @@ const resolveFormulaUsageFlags = (form: any, ctx?: any) => {
 };
 
 export function FormulaResult(props) {
-  const { value, collectionField, form, id, context, ...others } = props;
+  const { value, collectionField, form, id, name, context, ...others } = props;
   const { dataType, expression, engine = 'math.js' } = collectionField?.options || {};
   const [editingValue, setEditingValue] = useState(value);
   const { evaluate } = (evaluators as Registry<Evaluator>).get(engine);
   const antdForm = typeof form?.getFieldsValue === 'function' ? form : undefined;
   const watchedValues = Form.useWatch([], antdForm);
-  const fieldPath = Array.isArray(id) ? id?.join('.') : id;
-  const { t } = useTranslation();
+  const targetNamePath = useMemo(
+    () => resolveFormulaTargetNamePath({ context, name, id, collectionField }),
+    [context?.fieldPathArray, name, id, collectionField?.name],
+  );
+  const targetNamePathKey = targetNamePath?.map((segment) => String(segment)).join('.') || '';
 
   const { flags, isFilterContext, isDefaultValueDialog } = resolveFormulaUsageFlags(form, context);
 
@@ -115,8 +170,11 @@ export function FormulaResult(props) {
     if (form?.readPretty || isFilterContext || isDefaultValueDialog || constantOrNull) {
       return;
     }
+    if (!targetNamePath?.length) {
+      return;
+    }
     const formValues = typeof form?.getFieldsValue === 'function' ? form.getFieldsValue() : form?.values || {};
-    const scope = toJS(getValuesByFullPath(formValues, fieldPath));
+    const scope = toJS(getFormulaScopeValues(formValues, targetNamePath));
     let v;
     try {
       v = evaluate(expression, scope);
@@ -133,12 +191,12 @@ export function FormulaResult(props) {
   useEffect(() => {
     if (!areValuesEqual(value, editingValue) && !isFilterContext && !isDefaultValueDialog) {
       setTimeout(() => {
-        if (typeof form?.setFieldValue === 'function') {
-          form.setFieldValue(fieldPath, editingValue);
+        if (typeof form?.setFieldValue === 'function' && targetNamePath?.length) {
+          form.setFieldValue(targetNamePath as any, editingValue);
         }
       });
     }
-  }, [editingValue, isFilterContext, isDefaultValueDialog]);
+  }, [editingValue, isFilterContext, isDefaultValueDialog, targetNamePathKey]);
 
   // 筛选/默认值等场景下需要可编辑组件
   if (isFilterContext || isDefaultValueDialog) {

--- a/packages/plugins/@nocobase/plugin-field-formula/src/client/__tests__/FormulaFieldModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-formula/src/client/__tests__/FormulaFieldModel.test.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getFormulaScopeValues, resolveFormulaTargetNamePath } from '../FormulaFieldModel';
+
+describe('FormulaFieldModel helpers', () => {
+  it('prefers absolute subform fieldPathArray over relative row name', () => {
+    expect(
+      resolveFormulaTargetNamePath({
+        context: { fieldPathArray: ['items', 0, 'amount'] },
+        name: [0, 'amount'],
+        collectionField: { name: 'amount' },
+      }),
+    ).toEqual(['items', 0, 'amount']);
+  });
+
+  it('reconstructs the full target path from subtable row id', () => {
+    expect(
+      resolveFormulaTargetNamePath({
+        id: ['items.amount', 3],
+        collectionField: { name: 'amount' },
+      }),
+    ).toEqual(['items', 3, 'amount']);
+  });
+
+  it('uses the current row object as formula scope for nested fields', () => {
+    expect(
+      getFormulaScopeValues(
+        {
+          items: [
+            { amount: 3, count: 2, total: 6 },
+            { amount: 5, count: 4, total: 20 },
+          ],
+        },
+        ['items', 1, 'total'],
+      ),
+    ).toEqual({ amount: 5, count: 4, total: 20 });
+  });
+});


### PR DESCRIPTION
… subforms

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
On v2 pages, when an association field is edited as a subform/subform list inside a parent form, child field default values do not apply and formula fields do not update correctly for newly created child records.

### Description 
- propagate row and field path context in v2 subform forks
- fix formula field resolution and updates for row-scoped values
- make default-value runtime read initialValue from mounted fork props
- fix default value display and formula updates in association subforms
- add regression tests for default values and formula behavior

### Related issues
NocoBase 2.x association subform fields do not apply defaults and formula fields do not auto-calculate

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix default values and formula updates in v2 association subforms      |
| 🇨🇳 Chinese |     修复 v2 页面关联子表单中默认值不生效、公式字段不自动更新的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
