### PR TITLE
fix(graph-collection-manager): fix Auto Layout 500 error when updating graphPositions during Auto Layout

### DIFF
--- a/packages/plugins/@nocobase/plugin-graph-collection-manager/src/client/GraphDrawPage.tsx
+++ b/packages/plugins/@nocobase/plugin-graph-collection-manager/src/client/GraphDrawPage.tsx
@@ -403,15 +403,37 @@ export const GraphDrawPage = React.memo(() => {
   const updatePositionAction = async (data, isbatch = false) => {
     if (!selectedCollections) {
       if (isbatch) {
-        await api.resource('graphPositions').update({
-          values: data,
-        });
+        const items = Array.isArray(data) ? data : [data];
+
+        for (const item of items) {
+          if (!item || typeof item !== 'object' || !item.collectionName) {
+            continue;
+          }
+
+          await api.resource('graphPositions').update({
+            filter: {
+              collectionName: item.collectionName,
+            },
+            values: {
+              x: item.x,
+              y: item.y,
+            },
+          });
+        }
       } else {
+        if (!data?.collectionName) return;
+
         await api.resource('graphPositions').update({
-          filter: { collectionName: data.collectionName },
-          values: { ...data },
+          filter: {
+            collectionName: data.collectionName,
+          },
+          values: {
+            x: data.x,
+            y: data.y,
+          },
         });
       }
+
       await refreshPositions();
     }
   };


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Auto Layout in the Graphical Interface plugin throws a 500 error when updating graphPositions after deleting unused collections. The issue occurs because the update request may be sent without a valid filter, which is required by the backend.

### Description
This PR fixes the Auto Layout 500 error by ensuring each graphPositions update call always includes a valid filter based on collectionName.

Key changes:
- ensures batch updates iterate safely over items
- skips invalid entries missing collectionName
- removes duplicate values assignment
- guarantees backend update requirements are respected
- preserves existing layout behavior

Potential risks:
- minimal, change is isolated to GraphDrawPage update handler
- only affects Auto Layout position persistence logic

Testing suggestions:
1. Open Graphical Interface plugin
2. Click **Auto Layout**
3. Verify:
   - no 500 error occurs
   - layout positions are saved correctly
   - behavior remains unchanged

### Related issues
Fixes #8925

### Showcase
N/A (behavioral fix, no UI changes)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(graph-collection-manager): prevent 500 error when updating graphPositions during Auto Layout |
| 🇨🇳 Chinese | 修复 Auto Layout 时 graphPositions 更新导致的 500 错误 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary