### PR TITLE
fix: details block with pagination uses get action for non-DB datasources (REST API)

### DIFF
--- a/packages/core/client/src/modules/blocks/data-blocks/details-multi/hooks/useDetailsWithPaginationDecoratorProps.ts
+++ b/packages/core/client/src/modules/blocks/data-blocks/details-multi/hooks/useDetailsWithPaginationDecoratorProps.ts
@@ -6,19 +6,33 @@
  * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
-
 import { useParentRecordCommon } from '../../../useParentRecordCommon';
 import { useDetailsWithPaginationBlockParams } from './useDetailsWithPaginationBlockParams';
+import { useDataSource } from '../../../../../data-source/data-source/DataSourceProvider';
+import { useFilterByTk } from '../../../../../block-provider/BlockProvider';
 
 export function useDetailsWithPaginationDecoratorProps(props) {
   let parentRecord;
-
   const { params, parseVariableLoading } = useDetailsWithPaginationBlockParams(props);
+  const dataSource = useDataSource();
+  const filterByTk = useFilterByTk(props);
+  const isDBInstance = dataSource?.getOption('isDBInstance') ?? true;
 
   // association 的值是固定不变的，所以可以在条件中使用 hooks
   if (props.association) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     parentRecord = useParentRecordCommon(props.association);
+  }
+
+  // For non-DB datasources (e.g. REST API), use 'get' action with filterByTk
+  // because their list and get endpoints return different data structures
+  if (!isDBInstance && filterByTk) {
+    return {
+      parentRecord,
+      action: 'get',
+      params: { filterByTk },
+      parseVariableLoading,
+    };
   }
 
   return {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When using a REST API datasource, the Details block calls the `list` action instead of `get`. REST API `list` and `get` endpoints return different data structures, so the Details block was missing data that only the `get` endpoint provides.

### Description
In `useDetailsWithPaginationDecoratorProps`, detect if the datasource is a non-DB instance using `isDBInstance`. If so, switch to `action: 'get'` with `filterByTk` instead of `list` with a filter.

- DB datasources (main, external DB): unchanged, still uses `list` ✅
- Non-DB datasources (REST API): now uses `get` with `filterByTk` ✅

### Related issues
#8549

### Showcase
N/A

### Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed details block calling `list` instead of `get` for REST API datasources |
| 🇨🇳 Chinese | 修复详情区块在 REST API 数据源中调用 `list` 而非 `get` 的问题 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary