### PR TITLE
fix(database): avoid unnecessary distinct in count

### DIFF
--- a/packages/core/database/src/__tests__/repository/count.test.ts
+++ b/packages/core/database/src/__tests__/repository/count.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { Collection, HasManyRepository, createMockDatabase } from '@nocobase/database';
+import { vi } from 'vitest';
 
 describe('count', () => {
   let db;
@@ -155,6 +156,22 @@ describe('count', () => {
     expect(await User.repository.count()).toEqual(3);
   });
 
+  test('without association should not enable distinct', async () => {
+    await User.repository.createMany({
+      records: [{ name: 'u1' }, { name: 'u2' }],
+    });
+
+    const countSpy = vi.spyOn(User.model, 'count');
+
+    expect(await User.repository.count()).toEqual(2);
+    expect(countSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction: null,
+      }),
+    );
+    expect(countSpy.mock.calls[0][0]).not.toHaveProperty('distinct');
+  });
+
   test('with filter params', async () => {
     const repository = User.repository;
 
@@ -185,5 +202,49 @@ describe('count', () => {
         },
       }),
     ).toEqual(1);
+  });
+
+  test('with association filter should enable distinct', async () => {
+    const user1 = await User.repository.create({
+      values: {
+        name: 'u1',
+      },
+    });
+
+    const t1 = await Tag.repository.create({
+      values: {
+        name: 't1',
+      },
+    });
+
+    const t2 = await Tag.repository.create({
+      values: {
+        name: 't2',
+      },
+    });
+
+    const userPostRepository = User.repository.relation<HasManyRepository>('posts');
+
+    await userPostRepository.of(user1['id']).create({
+      values: {
+        title: 'u1p1',
+        tags: [t1, t2],
+      },
+    });
+
+    const countSpy = vi.spyOn(Post.model, 'count');
+
+    expect(
+      await Post.repository.count({
+        filter: {
+          'tags.name': 't1',
+        },
+      }),
+    ).toEqual(1);
+    expect(countSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinct: true,
+      }),
+    );
   });
 });

--- a/packages/core/database/src/repository.ts
+++ b/packages/core/database/src/repository.ts
@@ -289,15 +289,18 @@ export class Repository<TModelAttributes extends {} = any, TCreationAttributes e
       };
     }
 
+    const hasInclude = Array.isArray(options['include']) && options['include'].length > 0;
     const queryOptions: any = {
       ...options,
-      distinct: Boolean(this.collection.model.primaryKeyAttribute) && !this.collection.isMultiFilterTargetKey(),
     };
 
-    if (Array.isArray(queryOptions.include) && queryOptions.include.length > 0) {
+    if (hasInclude) {
       queryOptions.include = processIncludes(queryOptions.include, this.collection.model);
+      queryOptions.distinct =
+        Boolean(this.collection.model.primaryKeyAttribute) && !this.collection.isMultiFilterTargetKey();
     } else {
       delete queryOptions.include;
+      delete queryOptions.distinct;
     }
 
     // @ts-ignore

--- a/packages/core/database/src/repository.ts
+++ b/packages/core/database/src/repository.ts
@@ -300,7 +300,6 @@ export class Repository<TModelAttributes extends {} = any, TCreationAttributes e
         Boolean(this.collection.model.primaryKeyAttribute) && !this.collection.isMultiFilterTargetKey();
     } else {
       delete queryOptions.include;
-      delete queryOptions.distinct;
     }
 
     // @ts-ignore


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

`Repository.count()` always enabled `distinct` when a primary key existed. This is unnecessary for single-table count queries and can introduce avoidable overhead on the database side.

### Description

This PR limits `distinct` in `Repository.count()` to cases where the query contains `include` clauses, which are the cases that may duplicate root rows during joins. For plain single-table counts, the query now avoids `COUNT(DISTINCT pk)`.

Key changes:
- Only set `distinct` when `count()` has includes
- Keep `distinct` for association-filter counts to preserve correct results
- Add regression tests to verify both branches

Potential risk:
- Queries that rely on row de-duplication without includes would no longer use `distinct`. Based on current implementation, duplication comes from joined associations, so this change keeps the intended correctness boundary.

Testing suggestions:
- Run the database repository count tests
- Verify count results for plain filters and association filters

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize repository count queries by only enabling distinct when includes are present. |
| 🇨🇳 Chinese | 优化 repository count 查询，仅在存在 include 关联时启用 distinct。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
