### PR TITLE
fix(plugin-block-custom-resource): fix render error when resource does not exist

### DIFF
--- a/packages/plugins/@nocobase-example/plugin-block-custom-resource/src/client/models/CustomResourceTableBlockModel.tsx
+++ b/packages/plugins/@nocobase-example/plugin-block-custom-resource/src/client/models/CustomResourceTableBlockModel.tsx
@@ -36,9 +36,9 @@ export class CustomBlockWithResourceModel extends BlockModel {
       <div>
         <h1>Hello, NocoBase!</h1>
         <p>
-          This is a simple block rendered by <strong>CustomResourceTableBlockModel</strong>.
+          This is a simple block rendered by <strong>CustomResourceBlockModel</strong>.
         </p>
-        <pre>{JSON.stringify(this.resource.getData(), null, 2)}</pre>
+        <pre>{JSON.stringify(this.resource?.getData(), null, 2)}</pre>
       </div>
     );
   }
@@ -56,8 +56,12 @@ CustomBlockWithResourceModel.registerFlow({
     },
     refresh: {
       handler: async (ctx) => {
-        const resource = ctx.resource as SingleRecordResource;
-        await resource.refresh();
+        try {
+          const resource = ctx.resource as SingleRecordResource;
+          await resource.refresh();
+        } catch (error) {
+          console.log(error);
+        }
       },
     },
   },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
`CustomBlockWithResourceModel` accesses `this.resource.getData()` and calls `resource.refresh()` without guarding against a missing resource, causing a render crash when the resource does not exist.

### Description
- Add optional chaining to `this.resource?.getData()` to prevent crash when resource does not exist
- Wrap `resource.refresh()` in try-catch to avoid unhandled errors breaking the page
- Fix component name text from `CustomResourceTableBlockModel` to `CustomResourceBlockModel`

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix render error in custom resource block when resource does not exist |
| 🇨🇳 Chinese | 修复自定义资源区块在资源不存在时的渲染报错问题 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary