### PR TITLE
fix(ai): align query ordering and date filters

### DIFF
--- a/packages/core/database/src/__tests__/query/formatter.test.ts
+++ b/packages/core/database/src/__tests__/query/formatter.test.ts
@@ -227,4 +227,34 @@ describe('query formatter', () => {
       { orderDate: '2024-05-14', orderCount: 1 },
     ]);
   });
+
+  it('should support ordering aggregate queries by measure alias', async () => {
+    const repo = db.getRepository('query_format_test');
+
+    const rows = [
+      { dateOnly: '2024-05-14' },
+      { dateOnly: '2024-05-14' },
+      { dateOnly: '2024-05-14' },
+      { dateOnly: '2024-05-13' },
+      { dateOnly: '2024-05-13' },
+      { dateOnly: '2024-05-12' },
+    ];
+
+    for (const values of rows) {
+      await repo.create({ values });
+    }
+
+    expect(
+      await repo.query({
+        measures: [{ field: ['id'], aggregation: 'count', alias: 'count' }],
+        dimensions: [{ field: ['dateOnly'], alias: 'dateOnly' }],
+        orders: [{ field: 'count', order: 'desc' }],
+        timezone: '+00:00',
+      }),
+    ).toMatchObject([
+      { dateOnly: '2024-05-14', count: 3 },
+      { dateOnly: '2024-05-13', count: 2 },
+      { dateOnly: '2024-05-12', count: 1 },
+    ]);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/query-permission.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/query-permission.test.ts
@@ -237,6 +237,40 @@ describe('query permission', () => {
     });
   });
 
+  it('should keep aggregate alias orders when the measure is allowed', async () => {
+    const role = app.acl.define({ role: 'aggregate-order-viewer' });
+    role.grantAction('orders:view', {
+      fields: ['id', 'user'],
+    });
+    role.grantAction('users:view', {
+      fields: ['nickname'],
+    });
+
+    const result = await applyQueryPermission({
+      acl: app.acl,
+      db,
+      resourceName: 'orders',
+      currentRole: 'aggregate-order-viewer',
+      currentRoles: ['aggregate-order-viewer'],
+      query: {
+        collection: 'orders',
+        measures: [{ field: ['id'], aggregation: 'count', alias: 'count' }],
+        dimensions: [{ field: ['user', 'nickname'], alias: 'nickname' }],
+        orders: [
+          { field: 'count', order: 'desc' },
+          { field: 'nickname', order: 'asc' },
+        ],
+      },
+    });
+
+    expect(result.query.measures).toEqual([{ field: ['id'], aggregation: 'count', alias: 'count' }]);
+    expect(result.query.dimensions).toEqual([{ field: ['user', 'nickname'], alias: 'nickname' }]);
+    expect(result.query.orders).toEqual([
+      { field: 'count', order: 'desc' },
+      { field: 'nickname', order: 'asc' },
+    ]);
+  });
+
   it('should prune association selections when target resource permission is missing', async () => {
     const role = app.acl.define({ role: 'root-only-viewer' });
     role.grantAction('orders:view', {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/query/apply-query-permission.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/query/apply-query-permission.ts
@@ -146,13 +146,12 @@ function pruneSelections<T extends QuerySelection>(
   return pruneEmptyArray((items || []).filter((item) => isAllowedFieldPath(acl, db, roles, resourceName, item.field)));
 }
 
-function getAvailableHavingKeys(resourceName: string, query: QueryPermissionQuery) {
+function getAvailableSelectionKeys(resourceName: string, query: QueryPermissionQuery) {
   const keys = new Set<string>();
 
   for (const item of [...(query.measures || []), ...(query.dimensions || [])]) {
     if (item.alias) {
       keys.add(item.alias);
-      continue;
     }
 
     const fieldPathKey = stringifyFieldPath(item.field);
@@ -167,6 +166,26 @@ function getAvailableHavingKeys(resourceName: string, query: QueryPermissionQuer
   }
 
   return keys;
+}
+
+function pruneOrders(
+  items: QueryOrder[] | undefined,
+  acl: ACL,
+  db: Database,
+  roles: string[],
+  resourceName: string,
+  availableSelectionKeys: Set<string>,
+) {
+  return pruneEmptyArray(
+    (items || []).filter((item) => {
+      if (isAllowedFieldPath(acl, db, roles, resourceName, item.field)) {
+        return true;
+      }
+
+      const fieldKey = stringifyFieldPath(item.field);
+      return !!fieldKey && availableSelectionKeys.has(fieldKey);
+    }),
+  );
 }
 
 function pruneHavingNode(node: any, availableKeys: Set<string>): any {
@@ -233,11 +252,11 @@ export async function applyQueryPermission(options: ApplyQueryPermissionOptions)
     ...sourceQuery,
     measures: pruneSelections(sourceQuery.measures, acl, db, roles, resourceName),
     dimensions: pruneSelections(sourceQuery.dimensions, acl, db, roles, resourceName),
-    orders: pruneSelections(sourceQuery.orders, acl, db, roles, resourceName),
   };
 
-  const availableHavingKeys = getAvailableHavingKeys(resourceName, query);
-  query.having = pruneHavingNode(query.having, availableHavingKeys);
+  const availableSelectionKeys = getAvailableSelectionKeys(resourceName, query);
+  query.orders = pruneOrders(sourceQuery.orders, acl, db, roles, resourceName, availableSelectionKeys);
+  query.having = pruneHavingNode(query.having, availableSelectionKeys);
 
   const aclFilter = await getParsedPermissionFilter(
     {

--- a/packages/plugins/@nocobase/plugin-ai/src/ai/skills/business-analysis-report/SKILLS.md
+++ b/packages/plugins/@nocobase/plugin-ai/src/ai/skills/business-analysis-report/SKILLS.md
@@ -34,9 +34,23 @@ Your job is to understand the business question, use the data-query workflow to 
 - If multiple available data sources could plausibly contain relevant business data, inspect each candidate data source before deciding the analysis scope.
 - Do not silently analyze only one data source when multiple relevant data sources are available.
 - In the final report, state which data sources were included and explicitly mention any relevant data sources that were excluded, with the reason.
-- When you must generate explicit datetime filter values yourself, generate them in UTC using ISO 8601 timestamps with a trailing `Z`.
-- Do not generate local offsets such as `+09:00` or `-05:00`, and do not provide timezone values yourself.
-- If timezone affects whether a boundary record belongs to one period or another, verify the boundary with raw records and state that the generated filter values use UTC.
+- For common business calendar queries, you can generate frontend-compatible date filters directly without checking field type first.
+- Prefer calendar-style date filters that match the frontend:
+  - relative periods such as `{ "type": "today" }`, `{ "type": "thisMonth" }`, or `{ "type": "past", "number": 7, "unit": "day" }`
+  - explicit single dates such as `YYYY-MM-DD`
+  - explicit date ranges such as `["YYYY-MM-DD", "YYYY-MM-DD"]`
+  - explicit months or years such as `YYYY-MM` or `YYYY`
+- When a query can be expressed either as a calendar filter or as a UTC instant range, prefer the calendar filter form used by the frontend.
+- Do not default to UTC ISO timestamps with a trailing `Z` for business-day, week, month, quarter, or year boundaries.
+- Only inspect field type when:
+  - the query requires exact timestamps rather than calendar periods
+  - timezone boundary correctness matters
+  - or the first result suggests a boundary mismatch
+- If exact timestamps are required, use a format that matches the field semantics:
+  - for timezone-aware datetime fields, use full ISO 8601 timestamps such as `2026-04-10T12:00:00.000Z`
+  - for `datetimeNoTz` fields, use timezone-free local datetime strings such as `2026-04-10 12:00:00`
+  - for `dateOnly` fields, use `YYYY-MM-DD`
+- If the user explicitly asks for timezone-based boundary analysis, state the timezone assumption and verify boundary-sensitive cases with raw records when necessary.
 - Inspect the schema with `getCollectionNames`, `getCollectionMetadata`, or `searchFieldMetadata`.
 - Use `dataQuery` for grouped metrics, trends, comparisons, rankings, and post-aggregation filtering.
 - Use `dataSourceQuery` for raw-row inspection and anomaly checks.

--- a/packages/plugins/@nocobase/plugin-ai/src/ai/skills/business-analysis-report/SKILLS.md
+++ b/packages/plugins/@nocobase/plugin-ai/src/ai/skills/business-analysis-report/SKILLS.md
@@ -6,13 +6,7 @@ introduction:
   title: '{{t("ai.skills.businessAnalysisReport.title", { ns: "@nocobase/plugin-ai" })}}'
   about: '{{t("ai.skills.businessAnalysisReport.about", { ns: "@nocobase/plugin-ai" })}}'
 tools:
-  - getDataSources
-  - getCollectionNames
-  - getCollectionMetadata
-  - searchFieldMetadata
-  - dataQuery
-  - dataSourceQuery
-  - dataSourceCounting
+  - getSkill
   - businessReportGenerator
 ---
 
@@ -30,31 +24,19 @@ Your job is to understand the business question, use the data-query workflow to 
 
 ## 2. Use the data-query workflow before reporting
 
-- If the user did not explicitly name a data source, call `getDataSources` first.
+- For every request that needs business data, your first tool call must be `getSkill` with `skillName="data-query"`.
+- Do not inspect schema, write SQL, describe query results, or call `businessReportGenerator` before `data-query` has been loaded.
+- After loading `data-query`, follow that skill's workflow and use the tools it activates.
+- The loaded `data-query` workflow is responsible for loading `data-metadata` when schema or field discovery is needed. Do not bypass that dependency chain by inventing schema details yourself.
+- If the user did not explicitly name a data source, follow the loaded `data-query` workflow to discover the correct data source first.
 - If multiple available data sources could plausibly contain relevant business data, inspect each candidate data source before deciding the analysis scope.
 - Do not silently analyze only one data source when multiple relevant data sources are available.
 - In the final report, state which data sources were included and explicitly mention any relevant data sources that were excluded, with the reason.
-- For common business calendar queries, you can generate frontend-compatible date filters directly without checking field type first.
-- Prefer calendar-style date filters that match the frontend:
-  - relative periods such as `{ "type": "today" }`, `{ "type": "thisMonth" }`, or `{ "type": "past", "number": 7, "unit": "day" }`
-  - explicit single dates such as `YYYY-MM-DD`
-  - explicit date ranges such as `["YYYY-MM-DD", "YYYY-MM-DD"]`
-  - explicit months or years such as `YYYY-MM` or `YYYY`
-- When a query can be expressed either as a calendar filter or as a UTC instant range, prefer the calendar filter form used by the frontend.
-- Do not default to UTC ISO timestamps with a trailing `Z` for business-day, week, month, quarter, or year boundaries.
-- Only inspect field type when:
-  - the query requires exact timestamps rather than calendar periods
-  - timezone boundary correctness matters
-  - or the first result suggests a boundary mismatch
-- If exact timestamps are required, use a format that matches the field semantics:
-  - for timezone-aware datetime fields, use full ISO 8601 timestamps such as `2026-04-10T12:00:00.000Z`
-  - for `datetimeNoTz` fields, use timezone-free local datetime strings such as `2026-04-10 12:00:00`
-  - for `dateOnly` fields, use `YYYY-MM-DD`
-- If the user explicitly asks for timezone-based boundary analysis, state the timezone assumption and verify boundary-sensitive cases with raw records when necessary.
-- Inspect the schema with `getCollectionNames`, `getCollectionMetadata`, or `searchFieldMetadata`.
-- Use `dataQuery` for grouped metrics, trends, comparisons, rankings, and post-aggregation filtering.
-- Use `dataSourceQuery` for raw-row inspection and anomaly checks.
-- Use `dataSourceCounting` only for the simplest count scenario.
+- For all date filtering, follow the `data-query` workflow's frontend date filter contract instead of inventing a report-specific format.
+- For business calendar queries, prefer the frontend date operators and value shapes defined by the `data-query` skill and its query tools.
+- Do not expand month, week, or day calendar requests into UTC boundary timestamps unless the user explicitly asks for exact timestamp comparison.
+- If the user explicitly asks for timezone-based boundary analysis, state the timezone assumption and verify boundary-sensitive cases with raw records when necessary, while still following the same frontend date filter contract.
+- Use the tools activated by the loaded `data-query` skill for schema inspection and data retrieval.
 
 Do not guess collection names, relation paths, or aliases.
 
@@ -69,6 +51,7 @@ When the report needs mixed text-and-chart layout, place charts inline by adding
 Call `businessReportGenerator` at most once for the same user request unless the user explicitly asks you to regenerate the whole report.
 If the report tool succeeds, stop and return the result instead of making follow-up retry calls to add charts.
 If you cannot produce valid charts in that single call, omit `charts` and complete the report as markdown-only.
+Never call `businessReportGenerator` with guessed numbers, guessed SQL, or guessed query results. Query first, then report.
 
 The report should usually include:
 
@@ -101,11 +84,5 @@ Prefer this structure:
 
 # Available Tools
 
-- `getDataSources`
-- `getCollectionNames`
-- `getCollectionMetadata`
-- `searchFieldMetadata`
-- `dataQuery`
-- `dataSourceQuery`
-- `dataSourceCounting`
+- `getSkill`: Load the `data-query` skill before any schema inspection or query work so its workflow and tools become available in the current conversation.
 - `businessReportGenerator`

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-employee-skill-binding.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-employee-skill-binding.test.ts
@@ -1,0 +1,97 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { AIEmployee } from '../ai-employees/ai-employee';
+
+describe('AIEmployee skill tool binding', () => {
+  it('should include tools from dynamically loaded skills even if they are filtered out of available skills', async () => {
+    const employee = Object.create(AIEmployee.prototype) as AIEmployee & {
+      plugin: any;
+      getLoadedSkillNames: () => Promise<string[]>;
+      getAvailableSkills: () => Promise<any[]>;
+    };
+
+    employee.plugin = {
+      ai: {
+        skillsManager: {
+          getSkills: vi.fn().mockResolvedValue([
+            {
+              name: 'data-query',
+              tools: ['getSkill', 'dataQuery', 'dataSourceQuery', 'dataSourceCounting'],
+            },
+            {
+              name: 'data-metadata',
+              tools: ['getDataSources', 'getCollectionNames', 'getCollectionMetadata', 'searchFieldMetadata'],
+            },
+          ]),
+        },
+      },
+    };
+    employee.getLoadedSkillNames = vi.fn().mockResolvedValue(['data-query', 'data-metadata']);
+    employee.getAvailableSkills = vi.fn().mockResolvedValue([
+      {
+        name: 'business-analysis-report',
+        tools: ['getSkill', 'businessReportGenerator'],
+      },
+    ]);
+
+    const result = await employee.getActivatedSkillToolNames();
+
+    expect(result).toEqual(
+      new Set([
+        'getSkill',
+        'dataQuery',
+        'dataSourceQuery',
+        'dataSourceCounting',
+        'getDataSources',
+        'getCollectionNames',
+        'getCollectionMetadata',
+        'searchFieldMetadata',
+      ]),
+    );
+    expect(employee.plugin.ai.skillsManager.getSkills).toHaveBeenCalledWith(['data-query', 'data-metadata']);
+  });
+
+  it('should keep skill-owned tools unavailable until the skill is loaded', async () => {
+    const employee = Object.create(AIEmployee.prototype) as AIEmployee & {
+      getAIEmployeeTools: () => Promise<any[]>;
+      getToolsMap: () => Promise<Map<string, any>>;
+      getAvailableSkills: () => Promise<any[]>;
+    };
+
+    const getSkillTool = { definition: { name: 'getSkill' } };
+    const businessReportGeneratorTool = { definition: { name: 'businessReportGenerator' } };
+    const getCollectionMetadataTool = { definition: { name: 'getCollectionMetadata' } };
+
+    employee.getAIEmployeeTools = vi.fn().mockResolvedValue([getSkillTool, businessReportGeneratorTool]);
+    employee.getToolsMap = vi.fn().mockResolvedValue(
+      new Map([
+        ['getSkill', getSkillTool],
+        ['businessReportGenerator', businessReportGeneratorTool],
+        ['getCollectionMetadata', getCollectionMetadataTool],
+      ]),
+    );
+    employee.getAvailableSkills = vi.fn().mockResolvedValue([
+      {
+        name: 'business-analysis-report',
+        tools: ['getSkill', 'businessReportGenerator'],
+      },
+    ]);
+
+    const result = await (employee as any).getAgentTools();
+
+    expect(result.baseToolNames).toEqual(new Set(['getSkill']));
+    expect(result.tools.map((tool) => tool.definition.name)).toEqual([
+      'getSkill',
+      'businessReportGenerator',
+      'getCollectionMetadata',
+    ]);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts
@@ -11,21 +11,20 @@ import { describe, expect, it, vi } from 'vitest';
 import { skillToolBindingMiddleware } from '../ai-employees/middleware/skill-tools';
 
 describe('skillToolBindingMiddleware', () => {
-  it('should append tools from dynamically loaded skills to model requests', async () => {
+  it('should keep only tools allowed by loaded skills in model requests', async () => {
     const middleware = skillToolBindingMiddleware(
       {
         getActivatedSkillToolNames: vi.fn().mockResolvedValue(new Set(['getSkill', 'dataQuery', 'getCollectionNames'])),
       } as any,
       {
         baseToolNames: ['getSkill'],
-        toolCatalog: [{ name: 'getSkill' }, { name: 'dataQuery' }, { name: 'getCollectionNames' }] as any,
       },
     );
 
     const handler = vi.fn(async (request) => request);
     const result = await middleware.wrapModelCall(
       {
-        tools: [{ name: 'getSkill' }],
+        tools: [{ name: 'getSkill' }, { name: 'dataQuery' }, { name: 'getCollectionNames' }, { name: 'hiddenTool' }],
       } as any,
       handler,
     );

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts
@@ -32,4 +32,28 @@ describe('skillToolBindingMiddleware', () => {
     expect(handler).toHaveBeenCalledOnce();
     expect(result.tools.map((tool) => tool.name)).toEqual(['getSkill', 'dataQuery', 'getCollectionNames']);
   });
+
+  it('should preserve provider built-in tools without names', async () => {
+    const middleware = skillToolBindingMiddleware(
+      {
+        getActivatedSkillToolNames: vi.fn().mockResolvedValue(new Set(['getSkill'])),
+      } as any,
+      {
+        baseToolNames: ['getSkill'],
+      },
+    );
+
+    const handler = vi.fn(async (request) => request);
+    const webSearchTool = { type: 'web_search_preview' };
+    const googleSearchTool = { googleSearch: {} };
+    const result = await middleware.wrapModelCall(
+      {
+        tools: [{ name: 'getSkill' }, webSearchTool, googleSearchTool, { name: 'hiddenTool' }],
+      } as any,
+      handler,
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(result.tools).toEqual([{ name: 'getSkill' }, webSearchTool, googleSearchTool]);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { skillToolBindingMiddleware } from '../ai-employees/middleware/skill-tools';
+
+describe('skillToolBindingMiddleware', () => {
+  it('should append tools from dynamically loaded skills to model requests', async () => {
+    const middleware = skillToolBindingMiddleware(
+      {
+        getActivatedSkillToolNames: vi.fn().mockResolvedValue(new Set(['getSkill', 'dataQuery', 'getCollectionNames'])),
+      } as any,
+      {
+        baseToolNames: ['getSkill'],
+        toolCatalog: [{ name: 'getSkill' }, { name: 'dataQuery' }, { name: 'getCollectionNames' }] as any,
+      },
+    );
+
+    const handler = vi.fn(async (request) => request);
+    const result = await middleware.wrapModelCall(
+      {
+        tools: [{ name: 'getSkill' }],
+      } as any,
+      handler,
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(result.tools.map((tool) => tool.name)).toEqual(['getSkill', 'dataQuery', 'getCollectionNames']);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -125,14 +125,14 @@ export class AIEmployee {
   }
 
   private async initSession({ messageId, provider, model, providerName }) {
-    const { tools, baseToolNames, toolCatalog } = await this.getAgentTools();
+    const { tools, baseToolNames } = await this.getAgentTools();
     const resolvedTools = provider.resolveTools(tools.map(buildTool));
     if (!messageId && this.legacy !== true) {
       return {
         historyMessages: [],
         tools,
         resolvedTools,
-        middleware: this.getMiddleware({ tools, baseToolNames, toolCatalog: resolvedTools, model, providerName }),
+        middleware: this.getMiddleware({ tools, baseToolNames, model, providerName }),
         config: undefined,
         state: undefined,
       };
@@ -151,7 +151,6 @@ export class AIEmployee {
       middleware: this.getMiddleware({
         tools,
         baseToolNames,
-        toolCatalog: resolvedTools,
         model,
         providerName,
         messageId,
@@ -1381,7 +1380,6 @@ If information is missing, clearly state it in the summary.</Important>`;
   private async getAgentTools(): Promise<{
     tools: ToolsEntry[];
     baseToolNames: Set<string>;
-    toolCatalog: ToolsEntry[];
   }> {
     const baseTools = await this.getAIEmployeeTools();
     const toolMap = await this.getToolsMap();
@@ -1390,28 +1388,10 @@ If information is missing, clearly state it in the summary.</Important>`;
     const baseToolNames = new Set(
       baseTools.map((it) => it.definition.name).filter((name) => name === 'getSkill' || !skillOwnedToolNames.has(name)),
     );
-    const skillTools = _.uniq(
-      availableSkills
-        .flatMap((it) => it.tools ?? [])
-        .map((toolName) => toolMap.get(toolName))
-        .filter((it) => !!it)
-        .map((it) => it.definition.name),
-    )
-      .map((toolName) => toolMap.get(toolName))
-      .filter((it) => !!it);
-
-    const toolsMap = new Map<string, ToolsEntry>(toolMap);
-    for (const tool of baseTools) {
-      toolsMap.set(tool.definition.name, tool);
-    }
-    for (const tool of skillTools) {
-      toolsMap.set(tool.definition.name, tool);
-    }
 
     return {
-      tools: Array.from(toolsMap.values()),
+      tools: Array.from(toolMap.values()),
       baseToolNames,
-      toolCatalog: Array.from(toolMap.values()),
     };
   }
 
@@ -1478,15 +1458,13 @@ If information is missing, clearly state it in the summary.</Important>`;
     model: string;
     tools: any[];
     baseToolNames: Set<string>;
-    toolCatalog: any[];
     messageId?: string;
     agentThread?: AgentThread;
   }) {
-    const { providerName, model, tools, baseToolNames, toolCatalog, messageId, agentThread } = options;
+    const { providerName, model, tools, baseToolNames, messageId, agentThread } = options;
     return [
       skillToolBindingMiddleware(this, {
         baseToolNames: Array.from(baseToolNames.values()),
-        toolCatalog,
       }),
       toolInteractionMiddleware(this, tools),
       toolCallStatusMiddleware(this),

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -125,12 +125,14 @@ export class AIEmployee {
   }
 
   private async initSession({ messageId, provider, model, providerName }) {
-    const { tools, baseToolNames } = await this.getAgentTools();
+    const { tools, baseToolNames, toolCatalog } = await this.getAgentTools();
+    const resolvedTools = provider.resolveTools(tools.map(buildTool));
     if (!messageId && this.legacy !== true) {
       return {
         historyMessages: [],
         tools,
-        middleware: this.getMiddleware({ tools, baseToolNames, model, providerName }),
+        resolvedTools,
+        middleware: this.getMiddleware({ tools, baseToolNames, toolCatalog: resolvedTools, model, providerName }),
         config: undefined,
         state: undefined,
       };
@@ -145,9 +147,11 @@ export class AIEmployee {
     return {
       historyMessages,
       tools,
+      resolvedTools,
       middleware: this.getMiddleware({
         tools,
         baseToolNames,
+        toolCatalog: resolvedTools,
         model,
         providerName,
         messageId,
@@ -177,7 +181,7 @@ export class AIEmployee {
     const { provider, model, service } = await this.plugin.aiManager.getLLMService({
       ...this.model,
     });
-    const { historyMessages, tools, middleware, config, state } = await this.initSession({
+    const { historyMessages, tools, resolvedTools, middleware, config, state } = await this.initSession({
       messageId,
       provider,
       model,
@@ -187,7 +191,7 @@ export class AIEmployee {
     const chatContext = await this.aiChatConversation.getChatContext({
       userMessages: [...historyMessages, ...(userMessages ?? [])],
       userDecisions,
-      tools,
+      tools: resolvedTools,
       middleware,
       getSystemPrompt: (userMessages) => this.getSystemPrompt(userMessages),
       formatMessages: (messages) => this.formatMessages({ messages, provider }),
@@ -298,7 +302,7 @@ export class AIEmployee {
     middleware?: any[];
   }) {
     const model = provider.createModel();
-    const allTools = provider.resolveTools(tools?.map(buildTool) ?? []);
+    const allTools = tools ?? [];
     if (this.from === 'main-agent') {
       const checkpointer = new SequelizeCollectionSaver(() => this.ctx.app.mainDataSource);
       return createLangChainAgent({ model, tools: allTools, middleware, systemPrompt, checkpointer });
@@ -1374,11 +1378,18 @@ If information is missing, clearly state it in the summary.</Important>`;
     );
   }
 
-  private async getAgentTools(): Promise<{ tools: ToolsEntry[]; baseToolNames: Set<string> }> {
+  private async getAgentTools(): Promise<{
+    tools: ToolsEntry[];
+    baseToolNames: Set<string>;
+    toolCatalog: ToolsEntry[];
+  }> {
     const baseTools = await this.getAIEmployeeTools();
-    const baseToolNames = new Set(baseTools.map((it) => it.definition.name));
     const toolMap = await this.getToolsMap();
     const availableSkills = await this.getAvailableSkills();
+    const skillOwnedToolNames = new Set(availableSkills.flatMap((it) => it.tools ?? []));
+    const baseToolNames = new Set(
+      baseTools.map((it) => it.definition.name).filter((name) => name === 'getSkill' || !skillOwnedToolNames.has(name)),
+    );
     const skillTools = _.uniq(
       availableSkills
         .flatMap((it) => it.tools ?? [])
@@ -1389,7 +1400,10 @@ If information is missing, clearly state it in the summary.</Important>`;
       .map((toolName) => toolMap.get(toolName))
       .filter((it) => !!it);
 
-    const toolsMap = new Map<string, ToolsEntry>(baseTools.map((it) => [it.definition.name, it]));
+    const toolsMap = new Map<string, ToolsEntry>(toolMap);
+    for (const tool of baseTools) {
+      toolsMap.set(tool.definition.name, tool);
+    }
     for (const tool of skillTools) {
       toolsMap.set(tool.definition.name, tool);
     }
@@ -1397,6 +1411,7 @@ If information is missing, clearly state it in the summary.</Important>`;
     return {
       tools: Array.from(toolsMap.values()),
       baseToolNames,
+      toolCatalog: Array.from(toolMap.values()),
     };
   }
 
@@ -1436,7 +1451,11 @@ If information is missing, clearly state it in the summary.</Important>`;
       return new Set<string>();
     }
     const availableSkills = await this.getAvailableSkills();
-    const skillsMap = new Map(availableSkills.map((it) => [it.name, it]));
+    const loadedSkills = await this.plugin.ai.skillsManager.getSkills(loadedSkillNames);
+    const normalizedLoadedSkills = Array.isArray(loadedSkills) ? loadedSkills : [loadedSkills];
+    const skillsMap = new Map(
+      [...availableSkills, ...normalizedLoadedSkills.filter(Boolean)].map((it) => [it.name, it]),
+    );
     const result = new Set<string>();
     for (const skillName of loadedSkillNames) {
       const target = skillsMap.get(skillName);
@@ -1457,15 +1476,17 @@ If information is missing, clearly state it in the summary.</Important>`;
   private getMiddleware(options: {
     providerName: string;
     model: string;
-    tools: ToolsEntry[];
+    tools: any[];
     baseToolNames: Set<string>;
+    toolCatalog: any[];
     messageId?: string;
     agentThread?: AgentThread;
   }) {
-    const { providerName, model, tools, baseToolNames, messageId, agentThread } = options;
+    const { providerName, model, tools, baseToolNames, toolCatalog, messageId, agentThread } = options;
     return [
       skillToolBindingMiddleware(this, {
         baseToolNames: Array.from(baseToolNames.values()),
+        toolCatalog,
       }),
       toolInteractionMiddleware(this, tools),
       toolCallStatusMiddleware(this),

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/skill-tools.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/skill-tools.ts
@@ -40,6 +40,9 @@ export const skillToolBindingMiddleware = (
     const allowedToolNames = await getAllowedToolNames();
     return tools.filter((tool) => {
       const name = getToolName(tool);
+      if (name == null) {
+        return true;
+      }
       return name && allowedToolNames.has(name);
     });
   };

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/skill-tools.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/skill-tools.ts
@@ -14,11 +14,9 @@ export const skillToolBindingMiddleware = (
   aiEmployee: AIEmployee,
   options: {
     baseToolNames: string[];
-    toolCatalog: any[];
   },
 ) => {
   const baseToolNames = new Set(options.baseToolNames ?? []);
-  const toolCatalog = options.toolCatalog ?? [];
 
   const getAllowedToolNames = async () => {
     const activatedSkillToolNames = await aiEmployee.getActivatedSkillToolNames();
@@ -40,26 +38,10 @@ export const skillToolBindingMiddleware = (
 
   const filterRequestTools = async (tools: any[] = []) => {
     const allowedToolNames = await getAllowedToolNames();
-    const result = new Map<string, any>();
-
-    for (const tool of tools) {
+    return tools.filter((tool) => {
       const name = getToolName(tool);
-      if (!name) {
-        continue;
-      }
-      if (allowedToolNames.has(name)) {
-        result.set(name, tool);
-      }
-    }
-
-    for (const tool of toolCatalog) {
-      const name = getToolName(tool);
-      if (name && allowedToolNames.has(name) && !result.has(name)) {
-        result.set(name, tool);
-      }
-    }
-
-    return Array.from(result.values());
+      return name && allowedToolNames.has(name);
+    });
   };
 
   return createMiddleware({

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/skill-tools.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/middleware/skill-tools.ts
@@ -14,23 +14,52 @@ export const skillToolBindingMiddleware = (
   aiEmployee: AIEmployee,
   options: {
     baseToolNames: string[];
+    toolCatalog: any[];
   },
 ) => {
   const baseToolNames = new Set(options.baseToolNames ?? []);
+  const toolCatalog = options.toolCatalog ?? [];
 
   const getAllowedToolNames = async () => {
     const activatedSkillToolNames = await aiEmployee.getActivatedSkillToolNames();
     return new Set([...baseToolNames, ...activatedSkillToolNames]);
   };
 
+  const getToolName = (tool: any) => {
+    if (!tool || typeof tool !== 'object') {
+      return null;
+    }
+    if (typeof tool.name === 'string') {
+      return tool.name;
+    }
+    if (typeof tool.function?.name === 'string') {
+      return tool.function.name;
+    }
+    return null;
+  };
+
   const filterRequestTools = async (tools: any[] = []) => {
     const allowedToolNames = await getAllowedToolNames();
-    return tools.filter((tool: any) => {
-      if (!tool || typeof tool !== 'object' || typeof tool.name !== 'string') {
-        return true;
+    const result = new Map<string, any>();
+
+    for (const tool of tools) {
+      const name = getToolName(tool);
+      if (!name) {
+        continue;
       }
-      return allowedToolNames.has(tool.name);
-    });
+      if (allowedToolNames.has(name)) {
+        result.set(name, tool);
+      }
+    }
+
+    for (const tool of toolCatalog) {
+      const name = getToolName(tool);
+      if (name && allowedToolNames.has(name) && !result.has(name)) {
+        result.set(name, tool);
+      }
+    }
+
+    return Array.from(result.values());
   };
 
   return createMiddleware({

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
@@ -112,6 +112,7 @@ This prompt uses a structured tag system to organize your operational framework:
 4. **Communication Standards**
    - Use language specified in \`<locale>\`: ${environment.locale}, unless the user requests otherwise
    - When the task depends on "now", "today", reporting timestamps, or time ranges, use \`<current_datetime>\` and \`<timezone>\` as the authoritative time context instead of guessing
+   - For common business calendar queries, prefer frontend-compatible date filters such as relative date objects, \`YYYY-MM-DD\`, \`YYYY-MM\`, \`YYYY\`, or \`["start","end"]\` ranges instead of defaulting to UTC timestamp boundaries
    - Be professional, concise, and helpful
 
 5. **Tool Integration**

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
@@ -112,7 +112,7 @@ This prompt uses a structured tag system to organize your operational framework:
 4. **Communication Standards**
    - Use language specified in \`<locale>\`: ${environment.locale}, unless the user requests otherwise
    - When the task depends on "now", "today", reporting timestamps, or time ranges, use \`<current_datetime>\` and \`<timezone>\` as the authoritative time context instead of guessing
-   - For common business calendar queries, prefer frontend-compatible date filters such as relative date objects, \`YYYY-MM-DD\`, \`YYYY-MM\`, \`YYYY\`, or \`["start","end"]\` ranges instead of defaulting to UTC timestamp boundaries
+   - Always follow the frontend date filter contract: valid date operators are only \`$dateOn\`, \`$dateNotOn\`, \`$dateBefore\`, \`$dateAfter\`, \`$dateNotBefore\`, \`$dateNotAfter\`, \`$dateBetween\`, \`$empty\`, and \`$notEmpty\`; valid relative \`type\` values are only \`today\`, \`yesterday\`, \`tomorrow\`, \`thisWeek\`, \`lastWeek\`, \`nextWeek\`, \`thisMonth\`, \`lastMonth\`, \`nextMonth\`, \`thisQuarter\`, \`lastQuarter\`, \`nextQuarter\`, \`thisYear\`, \`lastYear\`, \`nextYear\`, \`past\`, and \`next\`; do not default to UTC timestamp boundaries for calendar queries
    - Be professional, concise, and helpful
 
 5. **Tool Integration**

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/common/common.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/common/common.ts
@@ -19,34 +19,34 @@ export const ArgSchema = z.object({
   filter: z.object({}).catchall(z.any()).describe(`# Parameters definition
 \`\`\`
 export type QueryCondition = {
-  [field: string]: { // \`field\` key is Field name
-    [operator: string]: any; // \`operator\` key is Query condition operator.
+  [field: string]: {
+    [operator: string]: any;
   };
 };
 
 
 export type QueryObject =
   | {
-      [logic: string]: (QueryCondition | QueryObject)[]; // \`logic\` key is the relationship between query conditions, should be one of '$and', '$or', the value is recursion object array, item in array can be QueryCondition or QueryObject
+      [logic: string]: (QueryCondition | QueryObject)[];
     }
-  | QueryCondition // QueryCondition definition above;
+  | QueryCondition
 \`\`\`
 
-
-// QueryCondition examples
+Field names are collection field names.
+Operator names are query operators such as \`$eq\`, \`$in\`, or \`$dateOn\`.
+Logical keys in \`QueryObject\` should be \`$and\` or \`$or\`.
 
 \`\`\`
 const example1: QueryCondition = {
-  age: { $gt: 18 },          // age great than 18
-  name: { $like: '%John%' }, // name include John
+  age: { $gt: 18 },
+  name: { $like: '%John%' },
 };
 
 const example2: QueryCondition = {
-  status: { $in: ['active', 'pending'] }, // status is active or pending
+  status: { $in: ['active', 'pending'] },
 };
 \`\`\`
 
-// QueryObject example
 \`\`\`
 const example1: QueryObject = {
   $and: [
@@ -70,9 +70,57 @@ const example2: QueryObject = {
 const example3: QueryObject = { age: { $lt: 50 } };
 \`\`\`
 
-// Datetime rule
-// If you must provide explicit datetime literals in filters, use UTC ISO 8601 strings with a trailing \`Z\`.
-// Example: \`2026-04-01T00:00:00.000Z\`
+Supported scalar operators include:
+\`$eq\`, \`$ne\`, \`$gt\`, \`$gte\`, \`$lt\`, \`$lte\`, \`$like\`, \`$notLike\`, \`$includes\`, \`$notIncludes\`, \`$in\`, \`$notIn\`, \`$dateOn\`, \`$dateNotOn\`, \`$dateBefore\`, \`$dateAfter\`, \`$dateNotBefore\`, \`$dateNotAfter\`, \`$dateBetween\`, \`$empty\`, \`$notEmpty\`
+
+Frontend date filter contract:
+- Always follow the same frontend-compatible date filter contract used by NocoBase filters.
+- \`filter\` itself must be a structured object. Do not pass a JSON-encoded string such as \`"{\\"createdAt\\":{\\"$dateOn\\":\\"2025-11\\"}}"\`.
+- For calendar-style date filtering, supported operators are exactly:
+  - \`$dateOn\`
+  - \`$dateNotOn\`
+  - \`$dateBefore\`
+  - \`$dateAfter\`
+  - \`$dateNotBefore\`
+  - \`$dateNotAfter\`
+  - \`$dateBetween\`
+  - \`$empty\`
+  - \`$notEmpty\`
+- Do not generate \`$gte\`, \`$gt\`, \`$lte\`, \`$lt\`, or custom operator names for calendar date ranges.
+- Allowed values:
+  - for \`$dateOn\`, \`$dateNotOn\`, \`$dateBefore\`, \`$dateAfter\`, \`$dateNotBefore\`, \`$dateNotAfter\`: \`YYYY-MM-DD\`, \`YYYY-MM\`, \`YYYY\`, a relative period object, or an exact datetime string only when the user explicitly wants timestamp comparison
+  - for \`$dateBetween\`: \`["YYYY-MM-DD", "YYYY-MM-DD"]\` or a relative period object
+  - for \`$empty\` and \`$notEmpty\`: no value
+- Relative period object \`type\` values are exactly:
+  - \`today\`
+  - \`yesterday\`
+  - \`tomorrow\`
+  - \`thisWeek\`
+  - \`lastWeek\`
+  - \`nextWeek\`
+  - \`thisMonth\`
+  - \`lastMonth\`
+  - \`nextMonth\`
+  - \`thisQuarter\`
+  - \`lastQuarter\`
+  - \`nextQuarter\`
+  - \`thisYear\`
+  - \`lastYear\`
+  - \`nextYear\`
+  - \`past\`
+  - \`next\`
+- If \`type\` is \`past\` or \`next\`, also provide:
+  - \`number\`: positive integer
+  - \`unit\`: one of \`day\`, \`week\`, \`month\`, \`quarter\`, \`year\`
+- Prefer frontend-style calendar filters such as:
+  - \`{ createdAt: { $dateOn: "2026-04" } }\`
+  - \`{ createdAt: { $dateOn: { type: "thisMonth" } } }\`
+  - \`{ createdAt: { $dateBetween: ["2026-04-01", "2026-04-30"] } }\`
+- Do not expand calendar queries into UTC month-start or day-start boundary expressions.
+- If the user explicitly asks for exact timestamp comparison instead of a calendar period:
+  - timezone-aware datetime fields: use ISO 8601 strings such as \`2026-04-10T12:00:00.000Z\`
+  - \`datetimeNoTz\` fields: use local datetime strings such as \`2026-04-10 12:00:00\`
+  - \`dateOnly\` fields: use date-only strings without time components
 `),
   sort: z.array(z.string()).describe(`{{t("ai.tools.dataQuery.args.sort", { ns: "${pkg.name}" })}}`),
   offset: z.number().optional().describe(`{{t("ai.tools.dataQuery.args.offset", { ns: "${pkg.name}" })}}`),

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/common/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/common/utils.ts
@@ -81,7 +81,8 @@ export function getStructuredQueryArgError(name: string, value: unknown): string
   }
 
   if (typeof value === 'string') {
-    return `"${name}" must be an object, not a JSON string. Pass structured JSON like { "createdAt": { "$dateOn": "2025-11" } }.`;
+    const example = name === 'having' ? '{ "count": { "$gt": 10 } }' : '{ "createdAt": { "$dateOn": "2025-11" } }';
+    return `"${name}" must be an object, not a JSON string. Pass structured JSON like ${example}.`;
   }
 
   if (value === null || Array.isArray(value) || typeof value !== 'object') {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/common/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/common/utils.ts
@@ -74,3 +74,19 @@ export function truncateLongStrings(obj: any, maxLen = MAX_STRING_LENGTH): any {
   }
   return obj;
 }
+
+export function getStructuredQueryArgError(name: string, value: unknown): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return `"${name}" must be an object, not a JSON string. Pass structured JSON like { "createdAt": { "$dateOn": "2025-11" } }.`;
+  }
+
+  if (value === null || Array.isArray(value) || typeof value !== 'object') {
+    return `"${name}" must be an object.`;
+  }
+
+  return null;
+}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-metadata/SKILLS.md
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-metadata/SKILLS.md
@@ -2,6 +2,11 @@
 scope: GENERAL
 name: data-metadata
 description: helps get collection metadata (data model, like database table definition, RESTful API definition), like collection definition, field metadata
+tools:
+  - getDataSources
+  - getCollectionNames
+  - getCollectionMetadata
+  - searchFieldMetadata
 introduction:
   title: '{{t("ai.skills.dataMetadata.title", { ns: "@nocobase/plugin-data-source-manager" })}}'
   about: '{{t("ai.skills.dataMetadata.about", { ns: "@nocobase/plugin-data-source-manager" })}}'

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/SKILLS.md
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/SKILLS.md
@@ -3,10 +3,10 @@ scope: GENERAL
 name: data-query
 description: Inspect schemas, retrieve records, and run aggregate queries on specified datasources
 tools:
-  - getDataSources
-  - getCollectionNames
-  - getCollectionMetadata
-  - searchFieldMetadata
+  - getSkill
+  - dataQuery
+  - dataSourceQuery
+  - dataSourceCounting
 introduction:
   title: '{{t("ai.skills.dataQuery.title", { ns: "@nocobase/plugin-data-source-manager" })}}'
   about: '{{t("ai.skills.dataQuery.about", { ns: "@nocobase/plugin-data-source-manager" })}}'
@@ -21,15 +21,18 @@ This skill focuses on safe read-only data access.
 
 ## Schema-first Querying
 
-When the user does not provide an exact collection or field name:
+When the user does not provide an exact collection or field name, or when this is the first query against a collection in the current conversation:
 
-1. Call `getDataSources` if the target data source is unclear.
-2. If multiple data sources may contain relevant data, inspect each candidate before choosing the query scope.
-3. Do not silently default to `main` when other relevant data sources are available.
-4. If you intentionally limit the query to one data source, explain why that data source was chosen and why others were not used.
-5. Call `getCollectionNames` to find the right collection.
-6. Call `getCollectionMetadata` or `searchFieldMetadata` to confirm field names, relation paths, and data types.
-7. Only then run a data tool.
+1. If schema, field, relation path, or datasource choice is not already explicit and reliable, your first tool call must be `getSkill` with `skillName="data-metadata"`.
+2. Do not guess collection names, field names, relation paths, or data types before `data-metadata` has been loaded.
+3. Call `getDataSources` from the loaded `data-metadata` workflow if the target data source is unclear.
+4. If multiple data sources may contain relevant data, inspect each candidate before choosing the query scope.
+5. Do not silently default to `main` when other relevant data sources are available.
+6. If you intentionally limit the query to one data source, explain why that data source was chosen and why others were not used.
+7. Call `getCollectionNames` from the loaded `data-metadata` workflow to find the right collection.
+8. Call `getCollectionMetadata` or `searchFieldMetadata` from the loaded `data-metadata` workflow to confirm field names, relation paths, and data types.
+9. Only then run a data tool.
+10. Even if the user already mentions a collection name such as `date_boundary_cases` or a common field such as `createdAt`, verify them with the loaded `data-metadata` workflow before the first real query when the collection has not yet been confirmed in the current conversation.
 
 Do not guess collection names, measure aliases, or dotted relation paths.
 
@@ -69,17 +72,29 @@ Use `dataSourceCounting` only for a simple total when grouped output is unnecess
 5. Use aliases when the user clearly needs stable output keys.
 6. For dotted relation fields, prefer the exact field path confirmed from metadata, such as `createdBy.nickname`.
 7. Default row limit is 50 and the tool caps the limit at 100.
-8. When you must generate explicit datetime filter values yourself, generate them in UTC using ISO 8601 timestamps with a trailing `Z`.
-9. Do not generate local offsets such as `+09:00` or `-05:00` in AI-authored datetime filter values.
-10. Do not provide a timezone parameter yourself.
-11. If a report depends on calendar boundaries such as "this month" or "April", state explicitly that the generated filter values are in UTC when it matters.
+8. Always follow the same frontend date filter contract used by NocoBase filters.
+8.1. `filter` and `having` must be structured objects, not JSON-encoded strings.
+9. Supported date operators are exactly `$dateOn`, `$dateNotOn`, `$dateBefore`, `$dateAfter`, `$dateNotBefore`, `$dateNotAfter`, `$dateBetween`, `$empty`, and `$notEmpty`.
+10. For calendar-style date filtering, do not generate `$gte`, `$gt`, `$lte`, `$lt`, or custom operator names.
+11. Allowed value shapes are:
+    - for `$dateOn`, `$dateNotOn`, `$dateBefore`, `$dateAfter`, `$dateNotBefore`, `$dateNotAfter`: `YYYY-MM-DD`, `YYYY-MM`, `YYYY`, a relative period object, or an exact datetime string only when the user explicitly wants timestamp comparison
+    - for `$dateBetween`: `["YYYY-MM-DD", "YYYY-MM-DD"]` or a relative period object
+    - for `$empty` and `$notEmpty`: no value
+12. Relative period objects must use exactly these `type` values: `today`, `yesterday`, `tomorrow`, `thisWeek`, `lastWeek`, `nextWeek`, `thisMonth`, `lastMonth`, `nextMonth`, `thisQuarter`, `lastQuarter`, `nextQuarter`, `thisYear`, `lastYear`, `nextYear`, `past`, `next`.
+13. If `type` is `past` or `next`, the object must also include `number` as a positive integer and `unit` as one of `day`, `week`, `month`, `quarter`, `year`.
+14. For day, week, month, quarter, year, and common relative-period queries, prefer frontend date filters such as `{ createdAt: { $dateOn: "2026-04" } }`, `{ createdAt: { $dateOn: { type: "thisMonth" } } }`, or `{ createdAt: { $dateBetween: ["2026-04-01", "2026-04-30"] } }`.
+15. Do not expand calendar queries into UTC boundary expressions such as `createdAt >= 2026-04-01T00:00:00.000Z` and `< 2026-05-01T00:00:00.000Z`.
+16. For fields such as `createdAt` and `updatedAt`, still prefer the frontend date operators above for calendar queries instead of UTC boundary expansion.
+17. Only inspect field type when the user explicitly asks for an exact timestamp comparison rather than a calendar period.
+18. If an exact timestamp comparison is required, keep the operator frontend-compatible and choose the value format that matches the field semantics:
+    - timezone-aware datetime fields: ISO 8601 timestamp strings such as `2026-04-10T12:00:00.000Z`
+    - `datetimeNoTz` fields: timezone-free local datetime strings such as `2026-04-10 12:00:00`
+    - `dateOnly` fields: date-only strings without time components
+19. Do not provide a timezone parameter yourself. The runtime request timezone is already supplied by the system.
 
 # Available Tools
 
-- `getDataSources`: Lists all available data sources.
-- `getCollectionNames`: Lists all collections in a data source.
-- `getCollectionMetadata`: Returns field metadata for collections.
-- `searchFieldMetadata`: Searches fields by keyword.
+- `getSkill`: Load the `data-metadata` skill before metadata inspection so its schema exploration tools become available in the current conversation.
 - `dataSourceQuery`: Query data from a specified collection in a data source. Supports filtering, sorting, field selection, and pagination. Returns paged results with total count.
 - `dataQuery`: Run aggregate repository queries with measures, dimensions, orders, filter, and having.
 - `dataSourceCounting`: Get the total count of records matching the specified filter conditions in a collection.
@@ -192,9 +207,10 @@ Action: Call dataSourceCounting with collectionName="users", filter={ status: { 
 ```
 User: "Show monthly revenue by salesperson"
 Action:
-1. Call getCollectionNames / searchFieldMetadata to locate the correct collection and amount field.
-2. Call getCollectionMetadata if date or relation paths are unclear.
-3. Call dataQuery with the confirmed fields.
+1. Call getSkill with skillName="data-metadata".
+2. Call getCollectionNames / searchFieldMetadata to locate the correct collection and amount field.
+3. Call getCollectionMetadata if date or relation paths are unclear.
+4. Call dataQuery with the confirmed fields.
 ```
 
 # Notes

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/tools/dataQuery.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/tools/dataQuery.ts
@@ -11,7 +11,12 @@ import { Context } from '@nocobase/actions';
 import { NoPermissionError } from '@nocobase/acl';
 import { defineTools } from '@nocobase/ai';
 import { applyQueryPermission, QueryPermissionQuery as DataQueryPermissionQuery } from '@nocobase/plugin-acl';
-import { MAX_QUERY_LIMIT, normalizeLimitOffset, truncateLongStrings } from '../../../common/utils';
+import {
+  MAX_QUERY_LIMIT,
+  getStructuredQueryArgError,
+  normalizeLimitOffset,
+  truncateLongStrings,
+} from '../../../common/utils';
 // @ts-ignore
 import pkg from '../../../../../package.json';
 
@@ -135,12 +140,13 @@ const AggregateQuerySchema = {
     filter: {
       type: 'object',
       description:
-        'Filter object applied before aggregation. If you must provide explicit datetime literals, use UTC ISO 8601 strings with a trailing Z.',
+        'Filter object applied before aggregation. Pass a structured object, not a JSON string. Follow the frontend NocoBase date filter contract: use only $dateOn, $dateNotOn, $dateBefore, $dateAfter, $dateNotBefore, $dateNotAfter, $dateBetween, $empty, and $notEmpty for calendar-style date filtering; prefer YYYY-MM-DD, YYYY-MM, YYYY, relative period objects, or ["start","end"] date ranges; do not expand month/day queries into UTC boundary timestamps.',
       additionalProperties: true,
     },
     having: {
       type: 'object',
-      description: 'Having object applied after grouping.',
+      description:
+        'Having object applied after grouping. Pass a structured object, not a JSON string. Reference selected measure aliases or selected field paths here, for example { count: { $gt: 10 } }.',
       additionalProperties: true,
     },
     offset: {
@@ -195,6 +201,22 @@ export default defineTools({
     schema: AggregateQuerySchema,
   },
   invoke: async (ctx: Context, args: AggregateQueryArgs) => {
+    const filterError = getStructuredQueryArgError('filter', args.filter);
+    if (filterError) {
+      return {
+        status: 'error',
+        content: filterError,
+      };
+    }
+
+    const havingError = getStructuredQueryArgError('having', args.having);
+    if (havingError) {
+      return {
+        status: 'error',
+        content: havingError,
+      };
+    }
+
     const dataSourceKey = getDataSourceKey(args);
     const ds = ctx.app.dataSourceManager.get(dataSourceKey);
 

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/tools/dataSourceCounting.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/tools/dataSourceCounting.ts
@@ -10,6 +10,7 @@
 import { defineTools } from '@nocobase/ai';
 import { ArgSchema, ArgType } from '../../../common/common';
 import { Context } from '@nocobase/actions';
+import { getStructuredQueryArgError } from '../../../common/utils';
 // @ts-ignore
 import pkg from '../../../../../package.json';
 
@@ -23,10 +24,18 @@ export default defineTools({
   definition: {
     name: 'dataSourceCounting',
     description:
-      'Use dataSource, collectionName, and collection fields to query data from the database, get total count of records',
+      'Use dataSource, collectionName, and collection fields to query data from the database, get total count of records. The filter argument must be a structured object, not a JSON string.',
     schema: ArgSchema,
   },
   invoke: async (ctx: Context, args: ArgType) => {
+    const filterError = getStructuredQueryArgError('filter', args.filter);
+    if (filterError) {
+      return {
+        status: 'error',
+        content: filterError,
+      };
+    }
+
     const plugin = ctx.app.pm.get('ai');
     const content = await plugin.aiContextDatasourceManager.query(ctx, { ...args, offset: 0, limit: 1 } as any);
     return {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/tools/dataSourceQuery.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/tools/dataSourceQuery.ts
@@ -12,6 +12,7 @@ import { ArgSchema, ArgType } from '../../../common/common';
 import { Context } from '@nocobase/actions';
 import {
   buildPagedToolResult,
+  getStructuredQueryArgError,
   normalizeLimitOffset,
   truncateLongStrings,
   MAX_QUERY_LIMIT,
@@ -28,10 +29,19 @@ export default defineTools({
   },
   definition: {
     name: 'dataSourceQuery',
-    description: 'Use dataSource, collectionName, and collection fields to query data from the database',
+    description:
+      'Use dataSource, collectionName, and collection fields to query data from the database. The filter argument must be a structured object, not a JSON string.',
     schema: ArgSchema,
   },
   invoke: async (ctx: Context, args: ArgType) => {
+    const filterError = getStructuredQueryArgError('filter', args.filter);
+    if (filterError) {
+      return {
+        status: 'error',
+        content: filterError,
+      };
+    }
+
     const plugin = ctx.app.pm.get('ai');
 
     // 限制单次查询数量

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/ai-data-query-tool.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/ai-data-query-tool.test.ts
@@ -197,8 +197,7 @@ describe('dataQuery tool', () => {
 
     expect(result).toEqual({
       status: 'error',
-      content:
-        '"having" must be an object, not a JSON string. Pass structured JSON like { "createdAt": { "$dateOn": "2025-11" } }.',
+      content: '"having" must be an object, not a JSON string. Pass structured JSON like { "count": { "$gt": 10 } }.',
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/ai-data-query-tool.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/ai-data-query-tool.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { NoPermissionError } from '@nocobase/acl';
 import { applyQueryPermission } from '@nocobase/plugin-acl';
 import dataQueryTool from '../../ai/skills/data-query/tools/dataQuery';
+import { ArgSchema } from '../../ai/common/common';
 
 vi.mock('@nocobase/plugin-acl', () => ({
   applyQueryPermission: vi.fn(),
@@ -142,26 +143,62 @@ describe('dataQuery tool', () => {
     );
   });
 
-  it('should not inherit request timezone unless explicitly provided', async () => {
-    await invokeTool(
+  it('should describe frontend-compatible calendar filter rules in aggregate query schema', () => {
+    const sharedFilterDescription = ArgSchema.shape.filter.description;
+    const schema: any = dataQueryTool.definition.schema;
+    const filterDescription = schema.properties.filter.description;
+    const havingDescription = schema.properties.having.description;
+
+    expect(sharedFilterDescription).toContain('$dateOn');
+    expect(sharedFilterDescription).toContain('$dateBetween');
+    expect(sharedFilterDescription).toContain('must be a structured object');
+    expect(sharedFilterDescription).toContain(
+      'Do not expand calendar queries into UTC month-start or day-start boundary expressions.',
+    );
+    expect(sharedFilterDescription).toContain('datetimeNoTz');
+
+    expect(filterDescription).toContain('$dateOn');
+    expect(filterDescription).toContain('$dateBetween');
+    expect(filterDescription).toContain('not a JSON string');
+    expect(filterDescription).toContain('do not expand month/day queries into UTC boundary timestamps');
+    expect(havingDescription).toContain('selected measure aliases');
+  });
+
+  it('should reject stringified filter objects', async () => {
+    const result = await invokeTool(
       ctx,
       {
         dataSource: 'main',
         collectionName: 'orders',
         measures: [{ field: ['id'], aggregation: 'count', alias: 'count' }],
+        filter: '{"status":{"$eq":"paid"}}' as any,
       },
-      { toolCallId: 'tool-call-4', writer: vi.fn() },
+      { toolCallId: 'tool-call-5', writer: vi.fn() },
     );
 
-    expect(applyQueryPermission).toHaveBeenCalledWith(
-      expect.objectContaining({
-        timezone: 'Asia/Shanghai',
-      }),
+    expect(result).toEqual({
+      status: 'error',
+      content:
+        '"filter" must be an object, not a JSON string. Pass structured JSON like { "createdAt": { "$dateOn": "2025-11" } }.',
+    });
+  });
+
+  it('should reject stringified having objects', async () => {
+    const result = await invokeTool(
+      ctx,
+      {
+        dataSource: 'main',
+        collectionName: 'orders',
+        measures: [{ field: ['id'], aggregation: 'count', alias: 'count' }],
+        having: '{"count":{"$gt":10}}' as any,
+      },
+      { toolCallId: 'tool-call-6', writer: vi.fn() },
     );
-    expect(repositoryQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        timezone: 'Asia/Shanghai',
-      }),
-    );
+
+    expect(result).toEqual({
+      status: 'error',
+      content:
+        '"having" must be an object, not a JSON string. Pass structured JSON like { "createdAt": { "$dateOn": "2025-11" } }.',
+    });
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The AI business analysis flow could generate date filters that did not match the frontend query format, and aggregate query sorting by aliases could be dropped during ACL query sanitization.

### Description
- Keep aggregate measure and dimension aliases available for query ordering after ACL sanitization
- Add regression tests for aggregate alias ordering in both the database query layer and the ACL query permission layer
- Update AI business analysis prompts to prefer frontend-compatible calendar date filters for common business queries

Potential risk:
- Alias-based ordering is now preserved only for measures and dimensions that remain allowed after ACL pruning

Testing suggestions:
- Verify grouped `dataQuery` requests can sort by aggregate aliases such as `count desc`
- Verify AI-generated business date filters use frontend-compatible calendar formats for day, month, and range queries

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed aggregate query sorting dropped by ACL |
| 🇨🇳 Chinese | 修复 ACL 导致聚合查询排序丢失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
