### PR TITLE
fix(file-manager): improve preview download error handling

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
@@ -118,7 +118,7 @@ const Preview = (props) => {
     }
   }, [list.length, previewOpen]);
   const onDownload = React.useCallback(
-    (fileOverride?: any) => {
+    async (fileOverride?: any) => {
       const file = fileOverride || list[current];
       if (!file) {
         return;
@@ -133,19 +133,31 @@ const Preview = (props) => {
         filename = `${filename}.${ext}`;
       }
       const downloadName = `${Date.now()}_${filename || 'file'}`;
-      // eslint-disable-next-line promise/catch-or-return
-      fetch(url)
-        .then((response) => response.blob())
-        .then((blob) => {
-          const blobUrl = URL.createObjectURL(new Blob([blob]));
-          const link = document.createElement('a');
-          link.href = blobUrl;
-          link.download = downloadName;
-          document.body.appendChild(link);
-          link.click();
+
+      try {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`Download failed with status ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        const blobUrl = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+
+        link.href = blobUrl;
+        link.download = downloadName;
+
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+
+        setTimeout(() => {
           URL.revokeObjectURL(blobUrl);
-          link.remove();
-        });
+        }, 1000);
+      } catch (error) {
+        console.error('File download failed:', error);
+      }
     },
     [current, list],
   );

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
@@ -9,7 +9,7 @@
 
 import { DetailsItemModel, FieldModel, TableColumnModel, css } from '@nocobase/client';
 import { tExpr, DisplayItemModel } from '@nocobase/flow-engine';
-import { Image, Space, Tooltip } from 'antd';
+import { Image, Space, Tooltip, message } from 'antd';
 import { castArray } from 'lodash';
 import React from 'react';
 import {
@@ -117,22 +117,31 @@ const Preview = (props) => {
       setPreviewOpen(false);
     }
   }, [list.length, previewOpen]);
+  const DOWNLOAD_REVOKE_DELAY = 1000; // delay to avoid revoking URL too early during download
+
   const onDownload = React.useCallback(
     async (fileOverride?: any) => {
       const file = fileOverride || list[current];
       if (!file) {
         return;
       }
+
       const url = file.url || file.preview;
       if (!url) {
         return;
       }
+
       let filename = getFileName(file, url);
       const ext = getFileExt(file, url);
+
       if (filename && ext && !filename.toLowerCase().endsWith(`.${ext}`)) {
         filename = `${filename}.${ext}`;
       }
+
       const downloadName = `${Date.now()}_${filename || 'file'}`;
+
+      let blobUrl: string | undefined;
+      let link: HTMLAnchorElement | undefined;
 
       try {
         const response = await fetch(url);
@@ -142,21 +151,27 @@ const Preview = (props) => {
         }
 
         const blob = await response.blob();
-        const blobUrl = URL.createObjectURL(blob);
-        const link = document.createElement('a');
+        blobUrl = URL.createObjectURL(blob);
 
+        link = document.createElement('a');
         link.href = blobUrl;
         link.download = downloadName;
 
         document.body.appendChild(link);
         link.click();
-        link.remove();
-
-        setTimeout(() => {
-          URL.revokeObjectURL(blobUrl);
-        }, 1000);
       } catch (error) {
         console.error('File download failed:', error);
+        message.error('File download failed');
+      } finally {
+        if (link) {
+          link.remove();
+        }
+
+        if (blobUrl) {
+          setTimeout(() => {
+            URL.revokeObjectURL(blobUrl!);
+          }, DOWNLOAD_REVOKE_DELAY);
+        }
       }
     },
     [current, list],

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
@@ -12,6 +12,7 @@ import { tExpr, DisplayItemModel } from '@nocobase/flow-engine';
 import { Image, Space, Tooltip, message } from 'antd';
 import { castArray } from 'lodash';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   FilePreviewRenderer,
   getFallbackIcon,
@@ -97,6 +98,7 @@ const FilePreview = ({
 
 const Preview = (props) => {
   const { value = [], size = 28, showFileName } = props;
+  const { t } = useTranslation(); //  i18n added
   const [current, setCurrent] = React.useState(0);
   const [previewOpen, setPreviewOpen] = React.useState(false);
   const list = React.useMemo(
@@ -161,7 +163,9 @@ const Preview = (props) => {
         link.click();
       } catch (error) {
         console.error('File download failed:', error);
-        message.error('File download failed');
+
+        // FIXED (i18n)
+        message.error(t('file-manager:File download failed'));
       } finally {
         if (link) {
           link.remove();
@@ -174,7 +178,7 @@ const Preview = (props) => {
         }
       }
     },
-    [current, list],
+    [current, list, t], // added t dependency
   );
   const onOpenAtIndex = React.useCallback((index: number) => {
     setCurrent(index);

--- a/packages/plugins/@nocobase/plugin-file-manager/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/locale/en-US.json
@@ -25,6 +25,7 @@
   "File size limit": "File size limit",
   "File storage": "File storage",
   "File type allowed (in MIME type format)": "File type allowed (in MIME type format)",
+  "File download failed": "File download failed",
   "Filename": "Filename",
   "Files are only removed when their corresponding records in the file collection are deleted. If a record from another collection includes an associating field referencing the file collection, the file will not be deleted unless cascade deletion is enabled for that association.": "Files are only removed when their corresponding records in the file collection are deleted. If a record from another collection includes an associating field referencing the file collection, the file will not be deleted unless cascade deletion is enabled for that association.",
   "Keep file in storage when destroy record": "Keep file in storage when destroy record",

--- a/packages/plugins/@nocobase/plugin-file-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/locale/zh-CN.json
@@ -20,6 +20,7 @@
   "File name": "文件名",
   "File pre-process parameters": "文件预处理参数",
   "File size limit": "文件大小限制",
+  "File download failed": "文件下载失败",
   "File storage": "文件存储器",
   "File type allowed (in MIME type format)": "允许的文件类型（MIME 格式）",
   "File type is not supported for previewing, please <1>download it to preview</1>": "文件类型不支持预览，请<1>下载后查看</1>",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Improve reliability of file downloads from the preview modal.

### Description

This PR improves the robustness of preview file downloads by:

- checking `response.ok` before creating the blob
- adding error handling around the download flow
- removing unnecessary `new Blob([blob])`
- delaying `URL.revokeObjectURL` slightly to avoid revoking the object URL too early

These changes help prevent silent failures when downloading files, especially when files are served from external storage providers or CDNs.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language | Changelog |
|----------|----------|
| 🇺🇸 English | Improved preview file download error handling |
| 🇨🇳 Chinese | 改进了预览文件下载时的错误处理 |

### Docs

| Language | Link |
|----------|------|
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are not needed
- [x] Doc update is not needed
- [x] Component demo is not needed
- [x] Changelog is provided
- [ ] Request a code review if it is necessary