### PR TITLE
fix(file-manager): return null when preview url is missing

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
@@ -36,7 +36,7 @@ const FilePreview = ({
   const previewFile = normalizePreviewFile(file);
   const src = getPreviewFileUrl(previewFile);
   if (!src) {
-    return;
+    return null;
   }
   const fileName = getFileName(previewFile, src);
   const fallback = getFallbackIcon(previewFile, src);


### PR DESCRIPTION
### This is a 
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Avoid returning undefined from a React component when no preview URL is available.

### Description

This PR updates FilePreview to return null instead of undefined when no preview URL exists.

This is more consistent with React component expectations and helps avoid potential warnings such as:

Nothing was returned from render

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language | Changelog |
|----------|----------|
| 🇺🇸 English | Return null when preview URL is missing |
| 🇨🇳 Chinese | 当预览 URL 缺失时返回 null |

### Docs

| Language | Link |
|----------|------|
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are not needed
- [x] Doc update is not needed
- [x] Component demo is not needed
- [x] Changelog is provided
- [x] Request a code review if it is necessary