### PR TITLE
fix(ai): baseURL settings not effect in GoogleGenAIProvider

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
@@ -19,7 +19,7 @@ import { Context } from '@nocobase/actions';
 import { AIChatContext } from '../types/ai-chat-conversation.type';
 import { ChatGenerationChunk, LLMResult } from '@langchain/core/outputs';
 
-const GOOGLE_GEN_AI_URL = 'https://generativelanguage.googleapis.com/v1beta/';
+const GOOGLE_GEN_AI_URL = 'https://generativelanguage.googleapis.com';
 
 export class GoogleGenAIProvider extends LLMProvider {
   declare chatModel: ChatGoogleGenerativeAI;
@@ -29,7 +29,7 @@ export class GoogleGenAIProvider extends LLMProvider {
   }
 
   createModel() {
-    const { apiKey } = this.serviceOptions || {};
+    const { apiKey, baseURL } = this.serviceOptions || {};
     const { model, responseFormat } = this.modelOptions || {};
 
     return new ChatGoogleGenerativeAI({
@@ -37,7 +37,7 @@ export class GoogleGenAIProvider extends LLMProvider {
       ...this.modelOptions,
       model,
       json: responseFormat === 'json',
-      verbose: true,
+      baseUrl: baseURL ?? this.baseURL,
     });
   }
 
@@ -59,7 +59,7 @@ export class GoogleGenAIProvider extends LLMProvider {
       baseURL = baseURL.slice(0, -1);
     }
     try {
-      const res = await axios.get(`${baseURL}/models?key=${apiKey}`);
+      const res = await axios.get(`${baseURL}/v1beta/models?key=${apiKey}`);
       return {
         models: res?.data?.models.map((model) => ({
           id: model.name,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
fixed issue that baseURL settings not effect in GoogleGenAIProvider
### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the baseURL settings of google-gen-ai's LLM service does not take effect  |
| 🇨🇳 Chinese | 修复 google-gen-ai 的 LLM 服务 baseURL 配置不生效问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
