### PR TITLE
fix: the optional options of single-select fields in field rule configuration are empty

### DIFF
--- a/packages/core/client/src/flow/components/filter/LinkageFilterItem.tsx
+++ b/packages/core/client/src/flow/components/filter/LinkageFilterItem.tsx
@@ -21,7 +21,7 @@ import {
   observer,
 } from '@nocobase/flow-engine';
 import { NumberPicker } from '@formily/antd-v5';
-import { enumToOptions, translateOptions } from '../../internal/utils/enumOptionsUtils';
+import { enumToOptions, translateOptions, UiSchemaEnumItem } from '../../internal/utils/enumOptionsUtils';
 import { lazy } from '../../../lazy-helper';
 import { mergeItemMetaTreeForAssignValue } from '../FieldAssignValueInput';
 import { resolveOperatorComponent } from '../../internal/utils/operatorSchemaHelper';
@@ -321,6 +321,11 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
     [mergedSchema, leftFieldMeta, stableT],
   );
 
+  const enumOptions = useMemo(
+    () => enumToOptions(mergedSchema?.enum as UiSchemaEnumItem[], stableT) || [],
+    [mergedSchema, stableT],
+  );
+
   const constantInputRenderer = useMemo(() => {
     const resolved = resolveOperatorComponent(model.context.app, selectedOperator, operatorMetadataList);
     const shouldUseKeywordComponent = KEYWORD_OPERATOR_VALUES.has(selectedOperator);
@@ -331,6 +336,10 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
     const { Comp, props: componentProps } = resolved;
     return (inputProps: { value?: any; onChange?: (v: any) => void } & Record<string, any>) => {
       const { value: inputValue, onChange, ...rest } = inputProps || {};
+      const nextProps = { ...componentProps };
+      if ((!nextProps?.options || nextProps?.options.length === 0) && enumOptions.length > 0) {
+        nextProps.options = enumOptions;
+      }
       const normalizedValue = Array.isArray(inputValue)
         ? inputValue
         : typeof inputValue === 'string'
@@ -342,11 +351,11 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
 
       return (
         <Comp
-          {...componentProps}
+          {...nextProps}
           {...rest}
           value={normalizedValue}
           onChange={onChange}
-          style={{ width: 200, ...(componentProps?.style || {}), ...(rest?.style || {}) }}
+          style={{ width: 200, ...(nextProps?.style || {}), ...(rest?.style || {}) }}
         />
       );
 
@@ -356,7 +365,7 @@ export const LinkageFilterItem: React.FC<LinkageFilterItemProps> = observer((pro
         onChange,
       });
     };
-  }, [model.context.app, operatorMetadataList, selectedOperator, staticInputRenderer]);
+  }, [enumOptions, model.context.app, operatorMetadataList, selectedOperator, staticInputRenderer]);
 
   const NullComponent = useMemo(() => {
     return function NullValue() {

--- a/packages/core/client/src/flow/components/filter/__tests__/LinkageFilterItem.test.tsx
+++ b/packages/core/client/src/flow/components/filter/__tests__/LinkageFilterItem.test.tsx
@@ -168,6 +168,69 @@ describe('LinkageFilterItem', () => {
     });
   });
 
+  it('passes enum options to single select multi-value operators', async () => {
+    const value = observable({ path: '', operator: '', value: ['draft'] }) as any;
+    const { model, app } = createModel();
+
+    const MultipleKeywordsInput = ({
+      value: inputValue,
+      options,
+    }: {
+      value?: string[];
+      options?: Array<{ label: string; value: string }>;
+    }) => {
+      return (
+        <button
+          type="button"
+          data-testid="keyword-select-input"
+          data-value={JSON.stringify(inputValue || [])}
+          data-options={JSON.stringify(options || [])}
+        >
+          keyword-select-input
+        </button>
+      );
+    };
+    app.addComponents({ MultipleKeywordsInput });
+
+    (globalThis as any).__TEST_META__ = {
+      interface: 'select',
+      uiSchema: {
+        'x-component': 'Select',
+        enum: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+        'x-filter-operators': [
+          {
+            value: '$in',
+            label: 'is any of',
+            selected: true,
+            schema: {
+              'x-component': 'MultipleKeywordsInput',
+              'x-component-props': { mode: 'tags' },
+            },
+          },
+        ],
+      },
+      paths: ['collection', 'status'],
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+    };
+
+    render(<LinkageFilterItem value={value} model={model} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+
+    const keywordInput = await screen.findByTestId('keyword-select-input');
+    expect(keywordInput.getAttribute('data-value')).toBe(JSON.stringify(['draft']));
+    expect(keywordInput.getAttribute('data-options')).toBe(
+      JSON.stringify([
+        { label: 'Draft', value: 'draft' },
+        { label: 'Published', value: 'published' },
+      ]),
+    );
+  });
+
   it('normalizes keyword arrays when switching back to a scalar operator', async () => {
     const value = observable({ path: '', operator: '', value: 'foo\nbar' }) as any;
     const { model, app } = createModel();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed the optional options of single-select fields in field rule configuration are empty     |
| 🇨🇳 Chinese |     修复单选字段在字段规则配置中可选项为空      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
