### PR TITLE
fix(idp-oauth): support OAuth access for API resources

### DIFF
--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/plugin.ts
@@ -17,6 +17,17 @@ import { resolveCurrentUser } from './utils';
 export class PluginIdpOauthServer extends Plugin {
   service: IdpOauthService;
 
+  private registerDefaultApiResource() {
+    this.service.registerResourceServer('api', {
+      path: '/',
+      scope: 'api',
+      accessTokenFormat: 'jwt',
+      jwt: {
+        sign: { alg: 'RS256' },
+      },
+    });
+  }
+
   async load() {
     const bridgeTokenCache = await this.app.cacheManager.createCache({
       name: 'idp-oauth-token',
@@ -24,6 +35,7 @@ export class PluginIdpOauthServer extends Plugin {
       store: 'memory',
     });
     this.service = new IdpOauthService(this.app, bridgeTokenCache);
+    this.registerDefaultApiResource();
     const paths = createIdpOauthPaths();
 
     this.app.use(
@@ -87,7 +99,9 @@ export class PluginIdpOauthServer extends Plugin {
     );
   }
 
-  async remove() {}
+  async remove() {
+    this.service?.unregisterResourceServer?.('api');
+  }
 }
 
 export default PluginIdpOauthServer;

--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/service.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/service.ts
@@ -58,6 +58,7 @@ type ProviderContext = {
 
 const defaultSupportedScopes = ['openid', 'offline_access', 'profile', 'email'] as const;
 const envJwksKeys = ['IDP_OAUTH_JWKS', 'OAUTH_JWKS'] as const;
+const MAX_CACHE_TTL_MS = 2_147_483_647;
 type JsonWebKeySet = Awaited<ReturnType<JoseModule['exportJWK']>> extends infer T
   ? { keys: Array<T & { kid?: string; use?: string; alg?: string }> }
   : { keys: Array<Record<string, any>> };
@@ -254,9 +255,22 @@ export class IdpOauthService {
   }
 
   private getRequestResourceConfig(ctx: any) {
+    const requestPath = normalizeBasePath(ctx.path || this.getRequestPath(ctx) || '/');
+
     for (const config of this.resourceServers.values()) {
-      const requestPath = this.getResourcePath(config);
-      if (requestPath && ctx.path === requestPath) {
+      const resourcePath = this.getResourcePath(config);
+      if (!resourcePath) {
+        continue;
+      }
+
+      const normalizedResourcePath = normalizeBasePath(resourcePath);
+      const isRootResource = normalizedResourcePath === normalizeBasePath(`${this.getApiBasePath()}/`);
+      const matches =
+        requestPath === normalizedResourcePath ||
+        requestPath.startsWith(`${normalizedResourcePath}/`) ||
+        (isRootResource && requestPath.startsWith(`${this.getApiBasePath()}/`));
+
+      if (matches) {
         return config;
       }
     }
@@ -505,7 +519,7 @@ export class IdpOauthService {
     const cachedInternalToken = await this.bridgeTokenCache.get<string>(bridgeTokenCacheKey);
     const internalToken = cachedInternalToken || (await this.issueInternalToken(user.id, oauthExpiresInMs));
     if (!cachedInternalToken && typeof oauthExpiresInMs === 'number' && oauthExpiresInMs > 0) {
-      await this.bridgeTokenCache.set(bridgeTokenCacheKey, internalToken, oauthExpiresInMs);
+      await this.bridgeTokenCache.set(bridgeTokenCacheKey, internalToken, Math.min(oauthExpiresInMs, MAX_CACHE_TTL_MS));
     }
     const authorizationHeader = `Bearer ${internalToken}`;
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Enable `nocobase-ctl` OAuth access for regular API requests and avoid bridge-token cache timer overflow warnings.

### Description 
- registered the regular API as an OAuth protected resource so OAuth access tokens can reach standard `/api/*` requests
- matched protected resources by path prefix so generated API routes and `swagger:get` can use OAuth tokens
- clamped the bridge token cache TTL to Node's timer limit to avoid `TimeoutOverflowWarning`

Tests were not run in this repository during this change.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed OAuth access for regular API requests |
| 🇨🇳 Chinese | 修复普通 API 请求的 OAuth 访问 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
