### PR TITLE
refactor(ai): add document load ability for openai, anthropic, gemini

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -590,6 +590,10 @@ export class AIEmployee {
     if (workContextBackground?.length) {
       background = `${background}\n${workContextBackground.join('\n')}`;
     }
+    const addSystemPrompt = userMessages?.filter((it) => it.role == 'system');
+    if (addSystemPrompt.length) {
+      background = `${background}\n${addSystemPrompt.map((it) => it.content).join('\n')}`;
+    }
 
     let knowledgeBase;
     if (this.isEnabledKnowledgeBase() && this.employee.knowledgeBasePrompt && userMessages?.length) {
@@ -1050,7 +1054,7 @@ If information is missing, clearly state it in the summary.</Important>`;
         const contentBlocks = [];
         if (attachments?.length) {
           for (const attachment of attachments) {
-            const parsed = await provider.parseAttachment(this.ctx, attachment);
+            const parsed = await provider.parseAttachment(this.ctx, attachment as any);
             if (parsed.placement === 'system') {
               formattedMessages.push({
                 role: 'system',

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/anthropic.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/anthropic.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { LLMProvider } from './provider';
+import { LLMProvider, ParsedAttachmentResult } from './provider';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { PluginFileManagerServer } from '@nocobase/plugin-file-manager';
 import axios from 'axios';
@@ -191,7 +191,7 @@ export class AnthropicProvider extends LLMProvider {
       }));
   }
 
-  async parseAttachment(ctx: Context, attachment: any): Promise<any> {
+  protected async convertToContent(ctx: Context, attachment: any): Promise<ParsedAttachmentResult> {
     const fileManager = this.app.pm.get('file-manager') as PluginFileManagerServer;
     const url = await fileManager.getFileURL(attachment);
     const data = await encodeFile(ctx, decodeURIComponent(url));

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -18,6 +18,7 @@ import _ from 'lodash';
 import PluginAIServer from '../plugin';
 import path from 'node:path';
 import { ReasoningChatOpenAI } from './common/reasoning';
+import { AttachmentModel } from '@nocobase/plugin-file-manager';
 
 const DASHSCOPE_URL = 'https://dashscope.aliyuncs.com/compatible-mode/v1';
 
@@ -108,32 +109,8 @@ export class DashscopeProvider extends LLMProvider {
     return null;
   }
 
-  async parseAttachment(ctx: Context, attachment: any): Promise<any> {
-    if (!attachment?.mimetype || attachment.mimetype.startsWith('image/')) {
-      return super.parseAttachment(ctx, attachment);
-    }
-    const parsed = await this.aiPlugin.documentLoaders.cached.load(attachment);
-    const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
-    if (!parsed.supported) {
-      return {
-        placement: 'system',
-        content: `File ${safeFilename} is not a supported document type for text parsing.`,
-      };
-    }
-    if (parsed.text.length === 0) {
-      return {
-        placement: 'system',
-        content: `The file provided by the user is an empty file, file name is "${safeFilename}"`,
-      };
-    }
-    return {
-      placement: 'system',
-      content: `<parsed_document filename="${safeFilename}">\n${parsed.text}\n</parsed_document>`,
-    };
-  }
-
-  private get aiPlugin(): PluginAIServer {
-    return this.app.pm.get('ai');
+  protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
+    return attachment.mimetype?.startsWith('image/') ?? false;
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
@@ -9,7 +9,7 @@
 
 import { ChatDeepSeek } from '@langchain/deepseek';
 import { AIMessageChunk, BaseMessage } from '@langchain/core/messages';
-import { LLMProvider } from './provider';
+import { LLMProvider, ParsedAttachmentResult } from './provider';
 import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
 import { Model } from '@nocobase/database';
 import _ from 'lodash';
@@ -18,6 +18,7 @@ import { collectReasoningMap, patchRequestMessagesReasoning, REASONING_MAP_KEY }
 import { Context } from '@nocobase/actions';
 import PluginAIServer from '../plugin';
 import path from 'node:path';
+import { AttachmentModel } from '@nocobase/plugin-file-manager';
 
 class ReasoningDeepSeek extends ChatDeepSeek {
   async _generate(messages: BaseMessage[], options: any, runManager?: any) {
@@ -121,35 +122,8 @@ export class DeepSeekProvider extends LLMProvider {
     return null;
   }
 
-  async parseAttachment(ctx: Context, attachment: any): Promise<any> {
-    const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
-    if (!attachment?.mimetype || attachment.mimetype.startsWith('image/')) {
-      return {
-        placement: 'system',
-        content: `The user has uploaded a ${attachment.mimetype} file (filename: ${safeFilename}). Please inform the user directly that you do not support parsing image content.`,
-      };
-    }
-    const parsed = await this.aiPlugin.documentLoaders.cached.load(attachment);
-    if (!parsed.supported) {
-      return {
-        placement: 'system',
-        content: `File ${safeFilename} is not a supported document type for text parsing.`,
-      };
-    }
-    if (parsed.text.length === 0) {
-      return {
-        placement: 'system',
-        content: `The file provided by the user is an empty file, file name is "${safeFilename}"`,
-      };
-    }
-    return {
-      placement: 'system',
-      content: `<parsed_document filename="${safeFilename}">\n${parsed.text}\n</parsed_document>`,
-    };
-  }
-
-  private get aiPlugin(): PluginAIServer {
-    return this.app.pm.get('ai');
+  protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
+    return false;
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
@@ -8,11 +8,11 @@
  */
 
 import { ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings } from '@langchain/google-genai';
-import { EmbeddingProvider, LLMProvider } from './provider';
+import { EmbeddingProvider, LLMProvider, ParsedAttachmentResult } from './provider';
 import axios from 'axios';
 import { Model } from '@nocobase/database';
 import { encodeFile } from '../utils';
-import { PluginFileManagerServer } from '@nocobase/plugin-file-manager';
+import { AttachmentModel, PluginFileManagerServer } from '@nocobase/plugin-file-manager';
 import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
 import { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { Context } from '@nocobase/actions';
@@ -108,11 +108,11 @@ export class GoogleGenAIProvider extends LLMProvider {
     };
   }
 
-  async parseAttachment(ctx: Context, attachment: any) {
+  protected async convertToContent(ctx: Context, attachment: AttachmentModel): Promise<ParsedAttachmentResult> {
     const fileManager = this.app.pm.get('file-manager') as PluginFileManagerServer;
     const url = await fileManager.getFileURL(attachment);
-    const data = await encodeFile(ctx, decodeURIComponent(url));
-    if (attachment.mimetype.startsWith('image/')) {
+    if (attachment.mimetype?.startsWith('image/')) {
+      const data = await encodeFile(ctx, decodeURIComponent(url));
       return {
         placement: 'contentBlocks',
         content: {
@@ -123,6 +123,7 @@ export class GoogleGenAIProvider extends LLMProvider {
         },
       };
     } else {
+      const data = await encodeFile(ctx, decodeURIComponent(url));
       return {
         placement: 'contentBlocks',
         content: {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
@@ -18,6 +18,7 @@ import { LLMProviderMeta, SupportedModel } from '../../manager/ai-manager';
 import { CachedDocumentLoader } from '../../document-loader';
 import { KimiDocumentLoader } from './document-loader';
 import { ReasoningChatOpenAI } from '../common/reasoning';
+import { AttachmentModel } from '@nocobase/plugin-file-manager';
 
 export class KimiProvider extends LLMProvider {
   declare chatModel: ReasoningChatOpenAI;
@@ -77,35 +78,15 @@ export class KimiProvider extends LLMProvider {
     return null;
   }
 
-  async parseAttachment(ctx: Context, attachment: any): Promise<any> {
-    if (!attachment?.mimetype || attachment.mimetype.startsWith('image/')) {
-      return super.parseAttachment(ctx, attachment);
-    }
-    const parsed = await this.documentLoader.load(attachment);
-    const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
-    if (!parsed.supported) {
-      return {
-        placement: 'system',
-        content: `File ${safeFilename} is not a supported document type for text parsing.`,
-      };
-    }
-    if (parsed.text.length === 0) {
-      return {
-        placement: 'system',
-        content: `The file provided by the user is an empty file, file name is "${safeFilename}"`,
-      };
-    }
-    return {
-      placement: 'system',
-      content: `<parsed_document filename="${safeFilename}">\n${parsed.text}\n</parsed_document>`,
-    };
+  protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
+    return attachment.mimetype?.startsWith('image/') ?? false;
   }
 
   private get aiPlugin(): PluginAIServer {
     return this.app.pm.get('ai');
   }
 
-  private get documentLoader() {
+  protected get documentLoader(): CachedDocumentLoader {
     if (!this._documentLoader) {
       const loader = new KimiDocumentLoader(this.aiPlugin.fileManager, {
         apiKey: this.serviceOptions?.apiKey,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -9,7 +9,7 @@
 
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { Model } from '@nocobase/database';
-import { PluginFileManagerServer } from '@nocobase/plugin-file-manager';
+import { AttachmentModel, PluginFileManagerServer } from '@nocobase/plugin-file-manager';
 import { Application } from '@nocobase/server';
 import axios from 'axios';
 import { AIChatContext } from '../types/ai-chat-conversation.type';
@@ -22,6 +22,9 @@ import '@langchain/core/utils/stream';
 import { ToolsEntry } from '@nocobase/ai';
 import { LLMResult } from '@langchain/core/outputs';
 import { ContentBlock } from '@langchain/core/messages';
+import { CachedDocumentLoader, SUPPORTED_DOCUMENT_EXTNAMES, SupportedDocumentExtname } from '../document-loader';
+import path from 'node:path';
+import PluginAIServer from '../plugin';
 
 export type ParsedAttachmentResult = {
   placement: string;
@@ -135,7 +138,34 @@ export abstract class LLMProvider {
     return stripToolCallTags(chunk);
   }
 
-  async parseAttachment(ctx: Context, attachment: any): Promise<ParsedAttachmentResult> {
+  async parseAttachment(ctx: Context, attachment: AttachmentModel): Promise<ParsedAttachmentResult> {
+    if (this.isApiSupportedAttachment(attachment)) {
+      return await this.convertToContent(ctx, attachment);
+    } else if (this.isDocumentLoaderSupportedAttachment(attachment)) {
+      return await this.loadDocument(ctx, attachment);
+    } else {
+      const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
+      return {
+        placement: 'system',
+        content: `The user has uploaded a ${attachment.mimetype} file (filename: ${safeFilename}). Please inform the user directly that you do not support parsing image content.`,
+      };
+    }
+  }
+
+  protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
+    const media = ['image/'];
+    const pdf = ['application/pdf'];
+    const supportedMedia = media.some((it) => attachment?.mimetype?.startsWith(it));
+    const supportedPdf = pdf.some((it) => attachment?.mimetype?.includes(it));
+    return supportedMedia || supportedPdf;
+  }
+
+  protected isDocumentLoaderSupportedAttachment(attachment: AttachmentModel): boolean {
+    const ext = path.extname(attachment?.filename ?? '').toLocaleLowerCase();
+    return SUPPORTED_DOCUMENT_EXTNAMES.includes(ext as SupportedDocumentExtname);
+  }
+
+  protected async convertToContent(ctx: Context, attachment: any): Promise<ParsedAttachmentResult> {
     const fileManager = this.app.pm.get('file-manager') as PluginFileManagerServer;
     const url = await fileManager.getFileURL(attachment);
     const data = await encodeFile(ctx, decodeURIComponent(url));
@@ -162,6 +192,27 @@ export abstract class LLMProvider {
         } as ContentBlock.Multimodal.File,
       } as ParsedAttachmentResult;
     }
+  }
+
+  protected async loadDocument(_ctx: Context, attachment: any): Promise<any> {
+    const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
+    const parsed = await this.documentLoader.load(attachment);
+    if (!parsed.supported) {
+      return {
+        placement: 'system',
+        content: `File ${safeFilename} is not a supported document type for text parsing.`,
+      };
+    }
+    if (parsed.text.length === 0) {
+      return {
+        placement: 'system',
+        content: `The file provided by the user is an empty file, file name is "${safeFilename}"`,
+      };
+    }
+    return {
+      placement: 'system',
+      content: `<parsed_document filename="${safeFilename}">\n${parsed.text}\n</parsed_document>`,
+    };
   }
 
   getStructuredOutputOptions(structuredOutput: AIChatContext['structuredOutput']): any {
@@ -238,6 +289,14 @@ export abstract class LLMProvider {
 
   parseResponseError(err) {
     return err?.message ?? 'Unexpected LLM service error';
+  }
+
+  protected get documentLoader(): CachedDocumentLoader {
+    return this.aiPlugin.documentLoaders.cached;
+  }
+
+  protected get aiPlugin(): PluginAIServer {
+    return this.app.pm.get('ai');
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-chat-conversation.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-chat-conversation.ts
@@ -125,8 +125,13 @@ class AIChatConversationImpl implements AIChatConversation {
       getSystemPrompt,
       formatMessages,
     } = options ?? {};
-    const messages = userMessages ? (await formatMessages?.(userMessages)) ?? [] : undefined;
-    const systemPrompt = (await getSystemPrompt?.(userMessages)) ?? '';
+    let messages = userMessages ? (await formatMessages?.(userMessages)) ?? [] : undefined;
+    const additionSystemPrompt = messages
+      ?.filter((it) => it.role === 'system')
+      .map((it) => it.content)
+      .join('\n');
+    messages = messages?.filter((it) => it.role !== 'system');
+    const systemPrompt = `${(await getSystemPrompt?.(userMessages ?? [])) ?? ''}\n\n${additionSystemPrompt}`;
     const chatContext: AIChatContext = {
       systemPrompt,
       messages,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->
make openai, anthropic, gemini support document parsing

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve AI employees' ability to parse uploaded documents |
| 🇨🇳 Chinese | 完善 AI 员工对上传文档解析能力 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
