### PR TITLE
fix(data-source-manager): preserve alias fields during sync merge

### DIFF
--- a/packages/core/data-source-manager/src/__tests__/database-data-source.test.ts
+++ b/packages/core/data-source-manager/src/__tests__/database-data-source.test.ts
@@ -1,0 +1,115 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { DatabaseDataSource } from '@nocobase/data-source-manager';
+
+describe('database data source', () => {
+  it('should preserve mapped fields regardless of loaded field order', () => {
+    const dataSource = Object.create(DatabaseDataSource.prototype) as DatabaseDataSource<any>;
+
+    const [mergedCollection] = dataSource.mergeWithLoadedCollections(
+      [
+        {
+          name: 'files',
+          fields: [
+            { name: 'url', type: 'text', interface: 'url' },
+            { name: 'title', type: 'string', interface: 'input' },
+          ],
+        },
+      ] as any,
+      {
+        files: {
+          name: 'files',
+          fields: [
+            { name: 'preview', type: 'text', interface: 'url', field: 'url' },
+            { name: 'title', type: 'string', interface: 'input' },
+            { name: 'url', type: 'text', interface: 'url' },
+          ],
+        },
+      } as any,
+    );
+
+    expect(mergedCollection.fields.map((field) => field.name)).toEqual(['url', 'title', 'preview']);
+    expect(mergedCollection.fields.find((field) => field.name === 'preview')).toMatchObject({
+      name: 'preview',
+      field: 'url',
+      interface: 'url',
+    });
+  });
+
+  it('should not preserve same-name physical mappings as logical alias fields', () => {
+    const dataSource = Object.create(DatabaseDataSource.prototype) as DatabaseDataSource<any>;
+
+    const [mergedCollection] = dataSource.mergeWithLoadedCollections(
+      [
+        {
+          name: 'events',
+          fields: [{ name: 'createdAt', type: 'date', interface: 'datetime' }],
+        },
+      ] as any,
+      {
+        events: {
+          name: 'events',
+          fields: [{ name: 'created_at', type: 'datetimeTz', interface: 'datetime', field: 'created_at' }],
+        },
+      } as any,
+    );
+
+    expect(mergedCollection.fields.map((field) => field.name)).toEqual(['createdAt']);
+  });
+
+  it('should preserve loaded metadata when incoming field matches by physical column', () => {
+    const dataSource = Object.create(DatabaseDataSource.prototype) as DatabaseDataSource<any>;
+
+    const [mergedCollection] = dataSource.mergeWithLoadedCollections(
+      [
+        {
+          name: 'events',
+          fields: [
+            {
+              name: 'created_at',
+              type: 'date',
+              interface: 'datetime',
+              uiSchema: {
+                title: 'created_at',
+              },
+            },
+          ],
+        },
+      ] as any,
+      {
+        events: {
+          name: 'events',
+          fields: [
+            {
+              name: 'createdAt',
+              type: 'datetimeTz',
+              interface: 'datetime',
+              field: 'created_at',
+              uiSchema: {
+                title: 'Created time',
+              },
+            },
+          ],
+        },
+      } as any,
+    );
+
+    expect(mergedCollection.fields).toHaveLength(1);
+    expect(mergedCollection.fields[0]).toMatchObject({
+      name: 'createdAt',
+      field: 'created_at',
+      type: 'datetimeTz',
+      interface: 'datetime',
+      uiSchema: {
+        title: 'Created time',
+      },
+    });
+  });
+});

--- a/packages/core/data-source-manager/src/database-data-source.ts
+++ b/packages/core/data-source-manager/src/database-data-source.ts
@@ -51,13 +51,26 @@ export abstract class DatabaseDataSource<T extends DatabaseIntrospector = Databa
       if (!loadedCollection) return collection;
 
       const collectionFields = collection.fields || [];
-      const loadedFieldsObj = Object.fromEntries(
-        (loadedCollection.fields || []).map((f) => [f.columnName || f.field || f.name, f]),
+      const loadedFieldsByName = Object.fromEntries((loadedCollection.fields || []).map((f) => [f.name, f]));
+      const loadedFieldsByColumn = (loadedCollection.fields || []).reduce<Record<string, FieldOptions[]>>(
+        (result, field) => {
+          const key = field.columnName || field.field || field.name;
+          result[key] = result[key] || [];
+          result[key].push(field);
+          return result;
+        },
+        {},
       );
+      const isAliasField = (field?: FieldOptions) => Boolean(field?.field && field.name !== field.field);
 
       // Merge existing fields
       const newFields = collectionFields.map((field) => {
-        const loadedField = loadedFieldsObj[field.name];
+        const loadedField =
+          loadedFieldsByName[field.name] ||
+          loadedFieldsByColumn[field.columnName || field.field || field.name]?.find(
+            (candidate) => !isAliasField(candidate),
+          ) ||
+          loadedFieldsByColumn[field.columnName || field.field || field.name]?.[0];
         if (!loadedField) return field;
         if (loadedField.possibleTypes) {
           loadedField.possibleTypes = field.possibleTypes;
@@ -65,9 +78,20 @@ export abstract class DatabaseDataSource<T extends DatabaseIntrospector = Databa
         return this.mergeFieldOptions(field, loadedField);
       });
 
+      // Preserve logical fields that reuse another physical column, such as
+      // file collection `preview` -> `url`, because introspection cannot
+      // reconstruct them from the physical table definition alone.
+      const loadedMappedFields = (loadedCollection.fields || []).filter(
+        (field) => isAliasField(field) && !newFields.find((newField) => newField.name === field.name),
+      );
+
+      newFields.push(...loadedMappedFields);
+
       // Add association fields from loaded data
-      const loadedAssociationFields = (loadedCollection.fields || []).filter((field) =>
-        ['belongsTo', 'belongsToMany', 'hasMany', 'hasOne', 'belongsToArray'].includes(field.type),
+      const loadedAssociationFields = (loadedCollection.fields || []).filter(
+        (field) =>
+          ['belongsTo', 'belongsToMany', 'hasMany', 'hasOne', 'belongsToArray'].includes(field.type) &&
+          !newFields.find((newField) => newField.name === field.name),
       );
 
       newFields.push(...loadedAssociationFields);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Field synchronization for file collections could behave differently depending on field ordering in loaded metadata, causing alias fields like `preview` to be removed or other saved field metadata to be overwritten by database introspection results.

### Description
This PR fixes the collection field merge logic used during field synchronization. It now prefers exact field-name matches first, falls back to physical-column matches for persisted metadata, and preserves true alias fields like `preview -> url` without treating same-name physical mappings as aliases. Unit tests were added to cover alias preservation, same-name mapping exclusion, and physical-column metadata preservation.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed file collection field sync removing `preview` field |
| 🇨🇳 Chinese | 修复文件表字段同步时误删 `preview` 字段的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
