### PR TITLE
fix(departments): expose parent foreign key field

### DIFF
--- a/packages/plugins/@nocobase/plugin-departments/src/client/collections/departments.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/collections/departments.ts
@@ -42,6 +42,18 @@ export const departmentCollection = {
       },
     },
     {
+      name: 'parentId',
+      type: 'bigInt',
+      interface: 'integer',
+      isForeignKey: true,
+      uiSchema: {
+        type: 'number',
+        title: 'parentId',
+        'x-component': 'InputNumber',
+        'x-read-pretty': true,
+      },
+    },
+    {
       name: 'parent',
       type: 'belongsTo',
       interface: 'm2o',

--- a/packages/plugins/@nocobase/plugin-departments/src/client/collections/users.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/collections/users.ts
@@ -137,7 +137,7 @@ export const userCollection = {
       },
     },
     {
-      interface: 'inputNumber',
+      interface: 'integer',
       type: 'bigInt',
       name: 'mainDepartmentId',
       uiSchema: {

--- a/packages/plugins/@nocobase/plugin-departments/src/server/collections/departments.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/collections/departments.ts
@@ -83,6 +83,18 @@ export default defineCollection({
       },
     },
     {
+      type: 'bigInt',
+      name: 'parentId',
+      interface: 'integer',
+      isForeignKey: true,
+      uiSchema: {
+        type: 'number',
+        title: 'parentId',
+        'x-component': 'InputNumber',
+        'x-read-pretty': true,
+      },
+    },
+    {
       type: 'boolean',
       name: 'isLeaf',
     },

--- a/packages/plugins/@nocobase/plugin-departments/src/server/collections/departments.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/collections/departments.ts
@@ -46,6 +46,19 @@ export const ownersField = {
   },
 };
 
+export const parentIdField = {
+  type: 'bigInt',
+  name: 'parentId',
+  interface: 'integer',
+  isForeignKey: true,
+  uiSchema: {
+    type: 'number',
+    title: 'parentId',
+    'x-component': 'InputNumber',
+    'x-read-pretty': true,
+  },
+};
+
 export default defineCollection({
   name: 'departments',
   migrationRules: ['overwrite'],
@@ -82,18 +95,7 @@ export default defineCollection({
         'x-component': 'Input',
       },
     },
-    {
-      type: 'bigInt',
-      name: 'parentId',
-      interface: 'integer',
-      isForeignKey: true,
-      uiSchema: {
-        type: 'number',
-        title: 'parentId',
-        'x-component': 'InputNumber',
-        'x-read-pretty': true,
-      },
-    },
+    parentIdField,
     {
       type: 'boolean',
       name: 'isLeaf',

--- a/packages/plugins/@nocobase/plugin-departments/src/server/collections/users.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/collections/users.ts
@@ -70,7 +70,7 @@ export const mainDepartmentField = {
 
 export const mainDepartmentIdField = {
   collectionName: 'users',
-  interface: 'inputNumber',
+  interface: 'integer',
   type: 'bigInt',
   name: 'mainDepartmentId',
   uiSchema: {

--- a/packages/plugins/@nocobase/plugin-departments/src/server/migrations/20260417120000-add-parent-id-field.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/migrations/20260417120000-add-parent-id-field.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Migration } from '@nocobase/server';
+import { parentIdField } from '../collections/departments';
+
+export default class extends Migration {
+  on = 'afterLoad';
+
+  async up() {
+    const fieldRepo = this.db.getRepository('fields');
+    if (!fieldRepo) {
+      return;
+    }
+
+    const field = await fieldRepo.findOne({
+      filter: {
+        collectionName: 'departments',
+        name: 'parentId',
+      },
+    });
+
+    if (field) {
+      return;
+    }
+
+    await fieldRepo.create({
+      values: {
+        collectionName: 'departments',
+        ...parentIdField,
+      },
+    });
+  }
+}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
- Department collection metadata did not expose the `parentId` foreign key field in the UI
- `mainDepartmentId` in the departments plugin was also using a non-standard field interface value

### Description 
- Added the `parentId` foreign key field to the departments collection metadata on both client and server sides so it can be displayed and configured in the UI
- Standardized `parentId` and `mainDepartmentId` to use the `integer` field interface while keeping `InputNumber` as the UI component
- Risk is low because the change only affects field metadata exposure and does not change relation behavior
- Suggested testing: open the departments collection field list in the UI and confirm `parentId` is available and displays correctly

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Display the `parentId` foreign key field of department collection in the UI |
| 🇨🇳 Chinese | 在界面中显示部门表的 `parentId` 外键字段 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
