### PR TITLE
fix(data-visualization): use aliases in chart sort fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/chart-resource.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/chart-resource.test.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ChartResource } from '../flow/resources/ChartResource';
+import { FlowContext } from '@nocobase/flow-engine';
+
+describe('ChartResource', () => {
+  test('should fill aggregated order alias from selected query fields', () => {
+    const resource = new ChartResource(new FlowContext());
+
+    expect(
+      resource.parseQuery({
+        mode: 'builder',
+        collectionPath: ['main', 'orders'],
+        measures: [{ field: ['price'], aggregation: 'sum', alias: 'Revenue' }],
+        dimensions: [{ field: ['createdAt'], format: 'YYYY-MM', alias: 'Month' }],
+        orders: [{ field: 'Revenue', order: 'DESC' }, { field: ['createdAt'], order: 'ASC' }],
+      }),
+    ).toMatchObject({
+      orders: [
+        { field: 'Revenue', alias: 'Revenue', order: 'DESC' },
+        { field: ['createdAt'], alias: 'Month', order: 'ASC' },
+      ],
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/query-builder.service.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/query-builder.service.test.ts
@@ -1,0 +1,58 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { buildOrderFieldOptions, validateQuery } from '../flow/models/QueryBuilder.service';
+
+describe('query builder service', () => {
+  test('should use aliases in aggregated order field options', () => {
+    const fieldOptions = [
+      {
+        name: 'price',
+        title: 'Price',
+      },
+      {
+        name: 'createdAt',
+        title: 'Created at',
+      },
+    ];
+
+    expect(
+      buildOrderFieldOptions(
+        fieldOptions,
+        [{ field: ['createdAt'], alias: 'Month' }],
+        [{ field: ['price'], aggregation: 'sum', alias: 'Revenue' }],
+      ),
+    ).toMatchObject([
+      {
+        name: 'Month',
+        title: 'Month',
+        key: 'Month',
+        value: 'Month',
+      },
+      {
+        name: 'Revenue',
+        title: 'Revenue',
+        key: 'Revenue',
+        value: 'Revenue',
+      },
+    ]);
+  });
+
+  test('should accept aliases as aggregated order fields during validation', () => {
+    expect(
+      validateQuery({
+        mode: 'builder',
+        collectionPath: ['main', 'orders'],
+        measures: [{ field: ['price'], aggregation: 'sum', alias: 'Revenue' }],
+        dimensions: [{ field: ['createdAt'], format: 'YYYY-MM', alias: 'Month' }],
+        orders: [{ field: 'Revenue', order: 'DESC' }, { field: 'Month', order: 'ASC' }],
+      }),
+    ).toEqual({ success: true, message: '' });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/QueryBuilder.service.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/QueryBuilder.service.ts
@@ -61,6 +61,25 @@ export function aliasOf(val: any): string {
   return Array.isArray(val) ? val.filter(Boolean).join('.') : val || '';
 }
 
+function orderKeyOf(item: any): string {
+  return item?.alias || aliasOf(item?.field);
+}
+
+function findOptionByPath(options: any[] = [], path: string[]): any {
+  if (!path.length) return null;
+
+  let currentOptions = options;
+  let currentOption = null;
+
+  for (const segment of path) {
+    currentOption = (currentOptions || []).find((opt) => opt?.name === segment);
+    if (!currentOption) return null;
+    currentOptions = currentOption?.children || [];
+  }
+
+  return currentOption;
+}
+
 export function buildOrderFieldOptions(
   fieldOptions: any[] = [],
   dimensionsValue: any[] = [],
@@ -69,56 +88,34 @@ export function buildOrderFieldOptions(
   const hasAgg = (measuresValue || []).some((m: any) => !!m?.aggregation);
   if (!hasAgg) return fieldOptions;
 
-  const pickedPaths: string[][] = [];
-
   const toPath = (val: any): string[] => {
     if (!val) return [];
     if (Array.isArray(val)) return val.filter(Boolean).map(String);
     return [String(val)];
   };
 
-  (dimensionsValue || []).forEach((d: any) => {
-    const p = toPath(d?.field);
-    if (p.length) pickedPaths.push(p);
-  });
-  (measuresValue || []).forEach((m: any) => {
-    const p = toPath(m?.field);
-    if (p.length) pickedPaths.push(p);
-  });
+  const selectedFields = [...(dimensionsValue || []), ...(measuresValue || [])];
+  const uniqueOptions = new Map<string, any>();
 
-  if (!pickedPaths.length) return fieldOptions;
+  selectedFields.forEach((item: any) => {
+    const path = toPath(item?.field);
+    const key = orderKeyOf(item);
+    if (!path.length || !key || uniqueOptions.has(key)) {
+      return;
+    }
 
-  const filterTree = (options: any[], paths: string[][]): any[] => {
-    const map = new Map<string, string[][]>();
-    paths.forEach((p) => {
-      const [head, ...tail] = p;
-      if (!head) return;
-      const list = map.get(head) || [];
-      list.push(tail);
-      map.set(head, list);
+    const matched = findOptionByPath(fieldOptions, path);
+    uniqueOptions.set(key, {
+      ...(matched || {}),
+      name: key,
+      key,
+      value: key,
+      title: item?.alias || matched?.title || aliasOf(item?.field),
+      children: undefined,
     });
+  });
 
-    return (options || [])
-      .map((opt) => {
-        const name = opt?.name;
-        const tails = map.get(name);
-        if (!tails) return null;
-
-        const hasNext = tails.some((t) => (t || []).length > 0);
-        if (!hasNext) {
-          return opt;
-        }
-
-        const nextPaths = tails.filter((t) => (t || []).length > 0) as string[][];
-        const children = opt?.children ? filterTree(opt.children, nextPaths) : [];
-        if (!children.length) return null;
-
-        return { ...opt, children };
-      })
-      .filter(Boolean);
-  };
-
-  return filterTree(fieldOptions, pickedPaths);
+  return Array.from(uniqueOptions.values());
 }
 
 // 纯函数：根据维度“字段值”返回格式化选项
@@ -198,17 +195,17 @@ export function validateQuery(query: Record<string, any>): { success: boolean; m
     if (hasAgg) {
       const allowedOrderFields = new Set<string>();
       (query.dimensions || []).forEach((d: any) => {
-        const alias = aliasOf(d?.field);
+        const alias = orderKeyOf(d);
         if (alias) allowedOrderFields.add(alias);
       });
       (query.measures || []).forEach((m: any) => {
-        const alias = aliasOf(m?.field);
+        const alias = orderKeyOf(m);
         if (alias) allowedOrderFields.add(alias);
       });
 
       if (Array.isArray(query.orders) && query.orders.length) {
         for (const order of query.orders) {
-          const alias = aliasOf(order?.field);
+          const alias = orderKeyOf(order);
           if (!alias || !allowedOrderFields.has(alias)) {
             return { success: false, message: 'please select valid sort field' };
           }

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/resources/ChartResource.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/resources/ChartResource.ts
@@ -88,32 +88,48 @@ export class ChartResource<TData = any> extends BaseRecordResource<TData> {
   // 解析 queryBuider 表单值为请求参数
   parseQuery(query: Record<string, any>) {
     const [dataSource, collection] = query.collectionPath || [];
+    const measures = (query.measures || []).map((item: any) => {
+      const measure = { ...item };
+      if (item.aggregation && !item.alias) {
+        const { alias } = parseField(item.field);
+        measure.alias = alias;
+      }
+      return measure;
+    });
+    const dimensions = (query.dimensions || []).map((item: any) => {
+      const dimension = { ...item };
+      if (item.format && !item.alias) {
+        const { alias } = parseField(item.field);
+        dimension.alias = alias;
+      }
+      return dimension;
+    });
+    const selectedFieldAliasMap = new Map<string, string>();
+    [...dimensions, ...measures].forEach((item: any) => {
+      const fieldKey = Array.isArray(item?.field) ? item.field.filter(Boolean).join('.') : item?.field;
+      const alias = item?.alias || fieldKey;
+      if (!fieldKey || !alias) return;
+      selectedFieldAliasMap.set(fieldKey, alias);
+      selectedFieldAliasMap.set(alias, alias);
+    });
+
     const data = {
       mode: query.mode, // 模式：builder | sql
       sql: query.sql, // 仅当 mode === 'sql' 时有效
       dataSource, // 数据源
       collection, // db 表名
       // 度量 yAxis
-      measures: (query.measures || []).map((item: any) => {
-        const measure = { ...item };
-        if (item.aggregation && !item.alias) {
-          const { alias } = parseField(item.field);
-          measure.alias = alias;
-        }
-        return measure;
-      }),
+      measures,
       // 维度 xAxis
-      dimensions: (query.dimensions || []).map((item: any) => {
-        const dimension = { ...item };
-        if (item.format && !item.alias) {
-          const { alias } = parseField(item.field);
-          dimension.alias = alias;
-        }
-        return dimension;
-      }),
+      dimensions,
       // 过滤条件
       filter: query.filter ? removeUnparsableFilter(transformFilter(query.filter)) : undefined,
-      orders: query.orders,
+      orders: (query.orders || []).map((item: any) => {
+        const order = { ...item };
+        const fieldKey = Array.isArray(item?.field) ? item.field.filter(Boolean).join('.') : item?.field;
+        order.alias = item?.alias || selectedFieldAliasMap.get(fieldKey) || fieldKey;
+        return order;
+      }),
       limit: query.limit,
       offset: query.offset,
       contextParams: query.contextParams,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Chart blocks could use measure aliases in query results, but the sort field picker and builder payload still relied on raw field paths. In aggregated queries this could cause sort options to ignore aliases and trigger `Invalid SQL column or table reference` when sorting by aliased measures.

### Description 
- Use selected aliases as sort field options in aggregated chart queries
- Validate aggregated sort fields against aliases instead of raw field paths
- Fill sort aliases in the chart query payload before sending requests
- Add client tests for alias-based sort options, validation, and payload generation

Potential risk:
- Aggregated sort options now become a flat alias list instead of the original nested field tree, which matches the actual sortable query outputs

Testing suggestions:
- In a chart block, set an alias for an aggregated measure and confirm the alias appears in Sort
- Run the query and verify sorting by the aliased measure no longer raises SQL column reference errors

### Related issues
- task-3481

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed chart block sorting to use aliased measures and dimensions in aggregated queries |
| 🇨🇳 Chinese | 修复图表区块在聚合查询中排序未使用度量和维度别名的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
