### PR TITLE
fix(collection-sql): validate sql on update

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
@@ -186,6 +186,67 @@ describe('sql collection', () => {
     expect(loadedFields2.size).toBe(1);
   });
 
+  it('sqlCollection:update: should check sql', async () => {
+    await agent.resource('collections').create({
+      values: {
+        name: 'fakeCollection',
+        fields: [
+          {
+            name: 'testField1',
+            type: 'string',
+            interface: 'input',
+          },
+        ],
+      },
+    });
+    await agent.resource('collections').create({
+      values: {
+        name: 'sqlCollection',
+        sql: 'select * from "fakeCollection"',
+        template: 'sql',
+        fields: [
+          {
+            name: 'testField1',
+            type: 'string',
+            interface: 'input',
+          },
+        ],
+      },
+    });
+
+    const collection = await db.getRepository('collections').findOne({
+      filter: {
+        name: 'sqlCollection',
+      },
+    });
+
+    const updateRes = await agent.resource('sqlCollection').update({
+      filterByTk: 'sqlCollection',
+      values: {
+        key: collection.key,
+        sql: "select pg_read_file('/etc/passwd')",
+        name: 'sqlCollection',
+        fields: [
+          {
+            name: 'testField1',
+            type: 'string',
+            interface: 'input',
+          },
+        ],
+      },
+    });
+
+    expect(updateRes.status).toBe(400);
+    expect(updateRes.body.errors[0].message).toMatch('SQL statements contain dangerous keywords');
+
+    const collectionAfterUpdate = await db.getRepository('collections').findOne({
+      filter: {
+        name: 'sqlCollection',
+      },
+    });
+    expect(collectionAfterUpdate.options.sql).toBe('select * from "fakeCollection"');
+  });
+
   it('sqlCollection:setFields', async () => {
     await agent.resource('collections').create({
       values: {

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/resources/sql.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/resources/sql.ts
@@ -103,6 +103,14 @@ export default {
       await next();
     },
     update: async (ctx: Context, next: Next) => {
+      const { sql } = ctx.action.params.values || {};
+      if (sql) {
+        try {
+          checkSQL(sql);
+        } catch (e) {
+          ctx.throw(400, ctx.t(e.message));
+        }
+      }
       const transaction = await ctx.app.db.sequelize.transaction();
       try {
         const { upRes } = await updateCollection(ctx, transaction);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The sqlCollection:update action accepted arbitrary SQL without running the existing checkSQL validation. A SQL collection could be created with safe SQL and then updated to dangerous SQL that would execute when the collection was queried.

### Description 
- Added checkSQL validation to sqlCollection:update before the update transaction starts
- Added a regression test covering dangerous SQL submitted through sqlCollection:update and verifying the original SQL remains unchanged after rejection
- Risk is low because the change reuses the same validation already enforced by create and execute
- Tested with `yarn test packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts -t "sqlCollection:update: should check sql"`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed missing SQL validation on SQL collection updates |
| 🇨🇳 Chinese | 修复 SQL 数据表更新时缺少 SQL 校验的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
