### PR TITLE
refactor(scripts): generalize feishu notification script and add auto-merge failure alert

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -60,6 +60,7 @@ jobs:
           persist-credentials: true
           fetch-depth: 0
       - name: ${{ steps.get-branch.outputs.baseBranch }} -> ${{ steps.get-branch.outputs.targetBranch }} (${{ inputs.repository || 'nocobase' }})
+        id: auto-merge
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
@@ -68,6 +69,25 @@ jobs:
           git checkout ${{ steps.get-branch.outputs.targetBranch }}
           git merge ${{ steps.get-branch.outputs.baseBranch }}
           git push origin ${{ steps.get-branch.outputs.targetBranch }}
+      - name: Checkout nocobase for notify script
+        if: failure()
+        uses: actions/checkout@v4
+        with:
+          repository: nocobase/nocobase
+          token: ${{ steps.app-token.outputs.token }}
+          sparse-checkout: scripts/feishu-notify.sh
+          path: nocobase-scripts
+      - name: Send Feishu notification on failure
+        if: failure()
+        shell: bash
+        env:
+          WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
+          TITLE: "Auto Merge 失败通知"
+          STATUS: "failure"
+          STATUS_TEXT_FAILURE: "合并失败"
+          CONTENT: "**仓库：**${{ inputs.repository || 'nocobase' }}\n**分支：**${{ steps.get-branch.outputs.baseBranch }} → ${{ steps.get-branch.outputs.targetBranch }}\n**状态：**❌ 合并失败"
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash nocobase-scripts/scripts/feishu-notify.sh
       # - name: push ${{ inputs.repository || 'nocobase' }}(${{ steps.get-branch.outputs.targetBranch }})
       #   uses: ad-m/github-push-action@master
       #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,8 @@ jobs:
         shell: bash
         env:
           WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
-          VERSION: ${{ github.ref_name }}
+          TITLE: "NocoBase 版本 ${{ github.ref_name }} Release 结果通知"
           STATUS: ${{ steps.result.outputs.status }}
+          CONTENT: "**版本：**${{ github.ref_name }}\n**时间：**$(TZ='Asia/Shanghai' date +'%Y-%m-%d %H:%M:%S')\n**状态：**${{ steps.result.outputs.status == 'success' && '✅ 构建成功' || '❌ 构建失败' }}"
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: bash scripts/feishu-release-notify.sh
+        run: bash scripts/feishu-notify.sh

--- a/.github/workflows/test-feishu-notify.yml
+++ b/.github/workflows/test-feishu-notify.yml
@@ -1,12 +1,12 @@
-name: Test Feishu Release Notification
+name: Test Feishu Notification
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version tag (e.g. v2.0.34)'
+      title:
+        description: 'Card title'
         required: true
-        default: 'v0.0.0-test'
+        default: 'NocoBase 版本 v0.0.0-test Release 结果通知'
       status:
         description: 'Build status'
         required: true
@@ -15,6 +15,10 @@ on:
           - success
           - failure
         default: 'success'
+      content:
+        description: 'Card body content in lark_md format (leave empty for default)'
+        required: false
+        default: ''
       build_time:
         description: 'Build time (leave empty for current time)'
         required: false
@@ -34,8 +38,9 @@ jobs:
         shell: bash
         env:
           WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
-          VERSION: ${{ inputs.version }}
+          TITLE: ${{ inputs.title }}
           STATUS: ${{ inputs.status }}
+          CONTENT: ${{ inputs.content }}
           BUILD_TIME: ${{ inputs.build_time }}
           WORKFLOW_URL: ${{ inputs.workflow_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
-        run: bash scripts/feishu-release-notify.sh
+        run: bash scripts/feishu-notify.sh

--- a/scripts/feishu-notify.sh
+++ b/scripts/feishu-notify.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
-# Send a Feishu interactive card notification for release results.
+# Send a Feishu interactive card notification.
 #
 # Required environment variables:
 #   WEBHOOK_URL   - Feishu bot webhook URL
-#   VERSION       - Release version (e.g. v2.0.34)
+#   TITLE         - Card title
 #   STATUS        - "success" or "failure"
 #   WORKFLOW_URL  - Link to the GitHub Actions run
 #
 # Optional environment variables:
+#   STATUS_TEXT_SUCCESS - Custom success text (defaults to "构建成功")
+#   STATUS_TEXT_FAILURE - Custom failure text (defaults to "构建失败")
+#   CONTENT       - Card body content in lark_md format (defaults to status line)
 #   BUILD_TIME    - Build timestamp (defaults to current time in Asia/Shanghai)
 
 set -euo pipefail
 
 : "${WEBHOOK_URL:?WEBHOOK_URL is required}"
-: "${VERSION:?VERSION is required}"
+: "${TITLE:?TITLE is required}"
 : "${STATUS:?STATUS must be 'success' or 'failure'}"
 : "${WORKFLOW_URL:?WORKFLOW_URL is required}"
 
@@ -21,15 +24,15 @@ BUILD_TIME="${BUILD_TIME:-$(TZ="Asia/Shanghai" date +"%Y-%m-%d %H:%M:%S")}"
 
 if [[ "$STATUS" == "success" ]]; then
   HEADER_TEMPLATE="green"
-  STATUS_TEXT="构建成功"
+  STATUS_TEXT="${STATUS_TEXT_SUCCESS:-构建成功}"
   STATUS_EMOJI="✅"
 else
   HEADER_TEMPLATE="red"
-  STATUS_TEXT="构建失败"
+  STATUS_TEXT="${STATUS_TEXT_FAILURE:-构建失败}"
   STATUS_EMOJI="❌"
 fi
 
-TITLE="NocoBase 版本 ${VERSION} Release 结果通知"
+CONTENT="${CONTENT:-"**时间：**${BUILD_TIME}\n**状态：**${STATUS_EMOJI} ${STATUS_TEXT}"}"
 
 PAYLOAD=$(cat <<EOF
 {
@@ -47,7 +50,7 @@ PAYLOAD=$(cat <<EOF
         "tag": "div",
         "text": {
           "tag": "lark_md",
-          "content": "**版本：**${VERSION}\n**时间：**${BUILD_TIME}\n**状态：**${STATUS_EMOJI} ${STATUS_TEXT}"
+          "content": "${CONTENT}"
         }
       },
       {
@@ -57,7 +60,7 @@ PAYLOAD=$(cat <<EOF
             "tag": "button",
             "text": {
               "tag": "plain_text",
-              "content": "查看构建详情"
+              "content": "查看详情"
             },
             "url": "${WORKFLOW_URL}",
             "type": "primary"


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
飞书通知脚本 `feishu-release-notify.sh` 原本只用于 release 通知，标题硬编码在脚本内。将其改为通用通知工具后，可复用于 auto-merge 等其他场景。同时 auto-merge 失败时缺少通知，需要手动检查才能发现问题。

### Description
- Rename `scripts/feishu-release-notify.sh` to `scripts/feishu-notify.sh` and make `TITLE` a required env var
- Add optional `CONTENT`, `STATUS_TEXT_SUCCESS`, `STATUS_TEXT_FAILURE` env vars for customization
- Update `release.yml` and `test-feishu-notify.yml` to use the renamed script with explicit `TITLE`
- Add failure notification step to `auto-merge.yml` that sends a Feishu alert when merge fails

### Showcase
<!-- N/A -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Generalize the Feishu notification script to support custom titles and add auto-merge failure alerts. |
| 🇨🇳 Chinese | 将飞书通知脚本改为通用工具并为 auto-merge 失败添加飞书告警。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- N/A --> |
| 🇨🇳 Chinese | <!-- N/A --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary