### PR TITLE
fix(sequence): preserve sequence field type after database sync

### DIFF
--- a/packages/core/data-source-manager/src/database-data-source.ts
+++ b/packages/core/data-source-manager/src/database-data-source.ts
@@ -14,6 +14,7 @@ import { MariaDBIntrospector } from './database-introspector/mariadb-introspecto
 import { DataSource } from './data-source';
 import { Context } from '@nocobase/actions';
 import { CollectionOptions, FieldOptions } from './types';
+import { SequelizeCollectionManager } from './sequelize-collection-manager';
 
 export abstract class DatabaseDataSource<T extends DatabaseIntrospector = DatabaseIntrospector> extends DataSource {
   declare introspector: T;
@@ -91,12 +92,13 @@ export abstract class DatabaseDataSource<T extends DatabaseIntrospector = Databa
       : fieldOptions.type
         ? [fieldOptions.type]
         : [];
+    const hasCompatibleStorageType = this.hasCompatibleStorageType(fieldOptions.type, modelOptions.type);
 
     const shouldUseIncomingType =
       Boolean(fieldOptions.rawType) &&
       (modelOptions.rawType
-        ? fieldOptions.rawType !== modelOptions.rawType
-        : !incomingPossibleTypes.includes(modelOptions.type));
+        ? fieldOptions.rawType !== modelOptions.rawType && !hasCompatibleStorageType
+        : !incomingPossibleTypes.includes(modelOptions.type) && !hasCompatibleStorageType);
 
     if (shouldUseIncomingType) {
       newOptions.type = fieldOptions.type;
@@ -111,5 +113,66 @@ export abstract class DatabaseDataSource<T extends DatabaseIntrospector = Databa
     }
 
     return newOptions;
+  }
+
+  private hasCompatibleStorageType(incomingType?: string, loadedType?: string) {
+    if (!incomingType || !loadedType || incomingType === loadedType) {
+      return false;
+    }
+
+    const incomingStorageType = this.getFieldStorageType(incomingType);
+    const loadedStorageType = this.getFieldStorageType(loadedType);
+
+    if (!incomingStorageType || !loadedStorageType) {
+      return false;
+    }
+
+    return incomingStorageType === loadedStorageType;
+  }
+
+  private getFieldStorageType(type?: string) {
+    if (!type) {
+      return;
+    }
+
+    const db = (this.collectionManager as SequelizeCollectionManager)?.db;
+    if (!db) {
+      return;
+    }
+
+    try {
+      const fieldClass = db.fieldTypes.get(type);
+      if (!fieldClass) {
+        return;
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(fieldClass.prototype, 'dataType');
+      const collection = {
+        name: '__sync_probe__',
+        options: {
+          underscored: false,
+        },
+        isView() {
+          return false;
+        },
+      };
+      const dataType = descriptor?.get?.call({
+        options: {
+          type,
+        },
+        database: db,
+        collection,
+        context: {
+          database: db,
+          collection,
+        },
+      });
+      if (typeof dataType === 'string') {
+        return dataType;
+      }
+      return dataType?.key || dataType?.constructor?.key || dataType?.constructor?.name;
+    } catch {
+      return;
+    }
   }
 }

--- a/packages/plugins/@nocobase/plugin-field-sequence/src/client/sequence.tsx
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/client/sequence.tsx
@@ -361,7 +361,7 @@ export class SequenceFieldInterface extends CollectionFieldInterface {
       'x-component-props': {},
     },
   };
-  availableTypes = ['string'];
+  availableTypes = ['sequence'];
   hasDefaultValue = false;
   filterable = {
     operators: interfacesProperties.operators.string,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
- Sequence fields created in the UI could still be reset to `string` after syncing fields from the database.
- The sequence field interface also exposed the wrong available type in the client.

### Description 
- Preserve an existing field type during database sync when the synced type and saved type share the same underlying storage type
- Restore the sequence field interface available type to `sequence`
- Risk is limited to the sync fallback path that compares compatible storage types across field classes
- Testing suggestion: create a sequence field, run database field sync, and confirm the field type remains sequence

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where sequence fields could be changed to string after database synchronization |
| 🇨🇳 Chinese | 修复数据库同步后 sequence 字段可能被改成 string 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
