### PR TITLE
fix(client): remove tab style guard

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -10,7 +10,6 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { PageHeader } from '@ant-design/pro-layout';
 import { DragEndEvent } from '@dnd-kit/core';
-import { css } from '@emotion/css';
 import { uid } from '@formily/shared';
 import {
   AddSubModelButton,
@@ -39,22 +38,6 @@ type PageModelStructure = {
     tabs: BasePageTabModel[];
   };
 };
-
-const TABS_DESIGN_MODE_ROOT_CLASS_NAME = css`
-  > .ant-tabs-nav .ant-tabs-tab {
-    min-width: 54px;
-  }
-
-  > .ant-tabs-nav .ant-tabs-tab .ant-tabs-tab-btn {
-    display: block;
-    width: 100%;
-  }
-
-  > .ant-tabs-nav .ant-tabs-tab .ant-tabs-tab-btn > [data-has-float-menu='true'] {
-    display: block;
-    width: 100%;
-  }
-`;
 
 export class PageModel extends FlowModel<PageModelStructure> {
   tabBarExtraContent: { left?: ReactNode; right?: ReactNode } = {};
@@ -309,7 +292,6 @@ export class PageModel extends FlowModel<PageModelStructure> {
 
   renderTabs() {
     const tabNavPaddingInlineStart = this.context.themeToken?.paddingLG ?? 16;
-    const rootClassName = this.context.flowSettingsEnabled ? TABS_DESIGN_MODE_ROOT_CLASS_NAME : undefined;
     const leftExtraContent =
       this.tabBarExtraContent.left !== undefined ? (
         this.tabBarExtraContent.left
@@ -338,7 +320,6 @@ export class PageModel extends FlowModel<PageModelStructure> {
     return (
       <DndProvider onDragEnd={this.handleDragEnd.bind(this)}>
         <Tabs
-          className={rootClassName}
           activeKey={
             this.context.view?.navigation?.viewParams
               ? this.context.view.navigation.viewParams.tabUid || this.getFirstTab()?.uid

--- a/packages/core/client/src/flow/models/base/PageModel/PageTabModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageTabModel.tsx
@@ -86,7 +86,7 @@ export class BasePageTabModel extends FlowModel<{
 
   renderHiddenInConfig() {
     return (
-      <span style={{ display: 'inline-block', paddingTop: this.context.flowSettingsEnabled ? 10 : 0, opacity: 0.5 }}>
+      <span style={{ display: 'inline-block', opacity: 0.5 }}>
         <Icon style={{ marginRight: 8 }} type={this.getTabIcon()} />
         {this.getTabTitle()}
       </span>
@@ -95,7 +95,7 @@ export class BasePageTabModel extends FlowModel<{
 
   render() {
     return (
-      <span style={{ display: 'inline-block', paddingTop: this.context.flowSettingsEnabled ? 10 : 0 }}>
+      <span style={{ display: 'inline-block' }}>
         <Icon style={{ marginRight: 8 }} type={this.getTabIcon()} />
         {this.getTabTitle()}
       </span>

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
@@ -316,7 +316,7 @@ describe('PageModel', () => {
       expect(tabsElement.props.activeKey).toBe('tab-from-props');
     });
 
-    it('should apply tabs root className in flow settings mode', () => {
+    it('should not apply tabs root className in flow settings mode anymore', () => {
       // @ts-ignore
       pageModel.context = {
         t: (str: string) => str,
@@ -327,8 +327,7 @@ describe('PageModel', () => {
       const result = pageModel.renderTabs() as any;
       const tabsElement = result.props.children;
 
-      expect(typeof tabsElement.props.className).toBe('string');
-      expect(tabsElement.props.className.length).toBeGreaterThan(0);
+      expect(tabsElement.props.className).toBeUndefined();
     });
 
     it('should not apply tabs root className in normal mode', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Page v2 的配置模式里，tab 区域还保留着一组早期为避免配置 toolbar 遮挡而加的样式补偿。现在 toolbar 已经不会遮挡，这组补偿会反过来导致 tab 高度变大、最小宽度被强制限制，影响实际展示效果。

### Description

- 移除配置模式下 tab 的最小宽度限制
- 移除配置模式下 tab 标题额外的顶部偏移
- 同步更新对应单测预期，确保新的渲染行为被覆盖

风险较低，影响范围限定在 `PageModel` 配置模式下的 tab 头部展示。建议在 page v2 配置模式下验证短标题 tab 的宽度和高度表现。

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the oversized height and width of tabs in page configuration mode |
| 🇨🇳 Chinese | 修复页面配置模式下标签页高度和宽度异常的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
