### PR TITLE
fix(departments): sort department lists by sort field

### DIFF
--- a/packages/plugins/@nocobase/plugin-departments/src/client/ResourcesProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/ResourcesProvider.tsx
@@ -72,6 +72,7 @@ export const ResourcesProvider: React.FC = (props) => {
     action: 'list',
     params: {
       paginate: false,
+      sort: ['sort'],
       filter: {
         parentId: null,
       },

--- a/packages/plugins/@nocobase/plugin-departments/src/client/departments/DepartmentTable.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/departments/DepartmentTable.tsx
@@ -187,6 +187,7 @@ const RequestProvider: React.FC<{
   });
   useEffect(() => {
     service.run({
+      sort: ['sort'],
       filter: {
         parentId: null,
       },

--- a/packages/plugins/@nocobase/plugin-departments/src/client/departments/DepartmentsField.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/departments/DepartmentsField.tsx
@@ -32,7 +32,7 @@ const useDataSource = (options?: any) => {
     action: 'list',
     params: {
       appends: ['parent(recursively=true)'],
-      sort: ['createdAt'],
+      sort: ['sort'],
     },
   };
   const service = useRequest(defaultRequest, options);

--- a/packages/plugins/@nocobase/plugin-departments/src/client/departments/UserDepartmentsField.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/departments/UserDepartmentsField.tsx
@@ -44,7 +44,7 @@ const useDataSource = (options?: any) => {
       // filter: {
       //   parentId: null,
       // },
-      sort: ['createdAt'],
+      sort: ['sort'],
     },
   };
   const service = useRequest(defaultRequest, options);

--- a/packages/plugins/@nocobase/plugin-departments/src/client/hooks/departments-manager.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/hooks/departments-manager.ts
@@ -39,6 +39,7 @@ export const useDepartmentManager = (options?: DepartmentManagerOptions) => {
     const { data } = await resourceAPI.list(
       deepmerge(params, {
         paginate: false,
+        sort: ['sort'],
         appends: ['parent(recursively=true)'],
         filter: {
           parentId: key,
@@ -55,6 +56,7 @@ export const useDepartmentManager = (options?: DepartmentManagerOptions) => {
     const { data } = await resourceAPI.list(
       deepmerge(params, {
         paginate: false,
+        sort: ['sort'],
         filter: {
           title: {
             $includes: keyword,

--- a/packages/plugins/@nocobase/plugin-departments/src/client/roles/RoleDepartmentsManager.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client/roles/RoleDepartmentsManager.tsx
@@ -98,7 +98,7 @@ const useDataSource = (options?: any) => {
       //   parentId: null,
       // },
       appends: ['roles', 'parent(recursively=true)'],
-      sort: ['createdAt'],
+      sort: ['sort'],
     },
   };
   const service = useRequest(defaultRequest, options);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Department management did not consistently order department data by the collection `sort` field, so the displayed order could differ from the intended department order.

### Description 
This change updates department-related client requests to consistently use the `sort` field when loading department lists, including the management tree, table-based selectors, lazy-loaded child departments, and role-related department selectors.

Risk is low because the change only adjusts query sort parameters for existing department list requests.

Testing suggestion: verify department order in department management, department selection drawers, and role department selection after changing department sort order.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed department lists in department management not following the `sort` field order |
| 🇨🇳 Chinese | 修复部门管理中的部门列表未按 `sort` 字段顺序显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
