### PR TITLE
fix(cli): improve api help warnings

### DIFF
--- a/packages/core/cli/src/lib/bootstrap.ts
+++ b/packages/core/cli/src/lib/bootstrap.ts
@@ -1,9 +1,18 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { getCurrentEnvName, getEnv, setEnvRuntime, updateEnvConnection } from './auth-store.js';
 import type { CliHomeScope } from './cli-home.js';
 import { resolveAccessToken } from './env-auth.js';
 import { generateRuntime } from './runtime-generator.js';
 import { hasRuntimeSync, saveRuntime } from './runtime-store.js';
-import { confirmAction, printInfo, printVerbose, printWarning, setVerboseMode, stopTask, updateTask } from './ui.js';
+import { confirmAction, printInfo, printVerbose, printWarningBlock, setVerboseMode, stopTask, updateTask } from './ui.js';
 
 const APP_RETRY_INTERVAL = 2000;
 const APP_RETRY_TIMEOUT = 120000;
@@ -82,6 +91,10 @@ function isBuiltinCommand(argv: string[]) {
 
 export function shouldSkipRuntimeBootstrap(argv: string[]) {
   return hasVersionFlag(argv) || isBuiltinCommand(argv);
+}
+
+function shouldIgnoreBootstrapFailure(argv: string[], commandToken?: string) {
+  return !commandToken || hasHelpFlag(argv) || (commandToken === 'api' && argv.length === 1);
 }
 
 async function requestJson(url: string, options: { method?: string; token?: string; role?: string }) {
@@ -281,6 +294,10 @@ function hasInvalidTokenError(data: any) {
   return collectErrorEntries(data).some((entry) => entry?.code === 'INVALID_TOKEN');
 }
 
+function isNetworkFetchFailure(response: { status: number; data: any }) {
+  return response.status === 0;
+}
+
 export function formatSwaggerSchemaError(
   response: { status: number; data: any },
   context: { baseUrl: string; token?: string; role?: string; envName?: string; commandToken?: string },
@@ -307,6 +324,18 @@ export function formatSwaggerSchemaError(
     ].join('\n');
   }
 
+  if (isNetworkFetchFailure(response)) {
+    const rawMessage = response.data?.error?.message || 'fetch failed';
+    return [
+      'Failed to reach the NocoBase server while loading the command runtime from `swagger:get`.',
+      `Base URL: ${context.baseUrl}`,
+      `Network error: ${rawMessage}`,
+      'Check that the NocoBase app is running, the base URL is correct, and the server is reachable from this machine.',
+      'If you recently changed the server address, update it with `nb env add --name <name> --base-url <url>` and retry `nb env update`.',
+      'Use `nb env list` to inspect the current env configuration.',
+    ].join('\n');
+  }
+
   return `Failed to load swagger schema from \`swagger:get\`.\n${JSON.stringify(response.data, null, 2)}`;
 }
 
@@ -330,65 +359,69 @@ export function formatMissingRuntimeEnvError(commandToken?: string) {
 export async function ensureRuntimeFromArgv(argv: string[], options: { configFile: string }) {
   const commandToken = getCommandToken(argv);
   const isRootInvocation = !commandToken;
+  const canContinueWithoutRuntime = shouldIgnoreBootstrapFailure(argv, commandToken);
   setVerboseMode(hasBooleanFlag(argv, 'verbose'));
 
   if (shouldSkipRuntimeBootstrap(argv)) {
     return;
   }
 
-  const envName = readFlag(argv, 'env') ?? (await getCurrentEnvName());
-  const env = await getEnv(envName);
-  const baseUrl = readFlag(argv, 'base-url') ?? env?.baseUrl;
-  const role = readFlag(argv, 'role');
-  const token = await resolveAccessToken({
-    envName,
-    baseUrl,
-    token: readFlag(argv, 'token'),
-  });
-  const runtimeVersion = env?.runtime?.version;
+  try {
+    const envName = readFlag(argv, 'env') ?? (await getCurrentEnvName());
+    const env = await getEnv(envName);
+    const baseUrl = readFlag(argv, 'base-url') ?? env?.baseUrl;
+    const role = readFlag(argv, 'role');
+    const token = await resolveAccessToken({
+      envName,
+      baseUrl,
+      token: readFlag(argv, 'token'),
+    });
+    const runtimeVersion = env?.runtime?.version;
 
-  if (runtimeVersion && hasRuntimeSync(runtimeVersion)) {
-    return;
-  }
-
-  if (!baseUrl) {
-    if (isRootInvocation) {
+    if (runtimeVersion && hasRuntimeSync(runtimeVersion)) {
       return;
     }
-    throw new Error(formatMissingRuntimeEnvError(commandToken));
-  }
 
-  updateTask('Loading command runtime...');
-  try {
-    printVerbose(`Runtime source: ${baseUrl}`);
-    const document = await fetchSwaggerSchema(
-      baseUrl,
-      token,
-      role,
-      { envName, commandToken },
-      isRootInvocation
-        ? {
-            allowEnableApiDoc: false,
-            retryAppAvailability: false,
-          }
-        : undefined,
-    );
-    const runtime = await generateRuntime(document, options.configFile, baseUrl);
-    await saveRuntime(runtime);
-    await setEnvRuntime(envName, {
-      version: runtime.version,
-      schemaHash: runtime.schemaHash,
-      generatedAt: runtime.generatedAt,
-    });
+    if (!baseUrl) {
+      if (isRootInvocation) {
+        return;
+      }
+      throw new Error(formatMissingRuntimeEnvError(commandToken));
+    }
+
+    updateTask('Loading command runtime...');
+    try {
+      printVerbose(`Runtime source: ${baseUrl}`);
+      const document = await fetchSwaggerSchema(
+        baseUrl,
+        token,
+        role,
+        { envName, commandToken },
+        isRootInvocation
+          ? {
+              allowEnableApiDoc: false,
+              retryAppAvailability: false,
+            }
+          : undefined,
+      );
+      const runtime = await generateRuntime(document, options.configFile, baseUrl);
+      await saveRuntime(runtime);
+      await setEnvRuntime(envName, {
+        version: runtime.version,
+        schemaHash: runtime.schemaHash,
+        generatedAt: runtime.generatedAt,
+      });
+    } finally {
+      stopTask();
+    }
   } catch (error) {
-    if (!isRootInvocation) {
+    if (!canContinueWithoutRuntime) {
       throw error;
     }
 
-    const message = error instanceof Error ? error.message : String(error);
-    printWarning(`${message}\nContinuing with built-in help because runtime commands could not be loaded.`);
-  } finally {
     stopTask();
+    const message = error instanceof Error ? error.message : String(error);
+    printWarningBlock(`Unable to load runtime commands. Showing built-in help instead.\n\n${message}`);
   }
 }
 

--- a/packages/core/cli/src/lib/env-auth.ts
+++ b/packages/core/cli/src/lib/env-auth.ts
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import crypto from 'node:crypto';
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
@@ -9,7 +18,7 @@ import {
   type AuthStoreOptions,
   type OauthAuthConfig,
 } from './auth-store.js';
-import { printInfo, printVerbose, printWarning, updateTask } from './ui.js';
+import { printInfo, printVerbose, printWarning, printWarningBlock, updateTask } from './ui.js';
 
 const ACCESS_TOKEN_REFRESH_WINDOW_MS = 60_000;
 const LOOPBACK_HOST = '127.0.0.1';
@@ -99,9 +108,38 @@ function formatOauthError(prefix: string, data: any, fallbackStatus?: number) {
   return prefix;
 }
 
-async function fetchOauthServerMetadata(baseUrl: string) {
+function formatOauthFetchFailure(prefix: string, options: { baseUrl?: string; url: string; rawMessage?: string; envName?: string }) {
+  return [
+    prefix,
+    options.envName ? `Env: ${options.envName}` : undefined,
+    options.baseUrl ? `Base URL: ${options.baseUrl}` : undefined,
+    `Request URL: ${options.url}`,
+    `Network error: ${options.rawMessage || 'fetch failed'}`,
+    'Check that the NocoBase app is running, the base URL is correct, and the server is reachable from this machine.',
+    options.envName
+      ? `If the saved login is stale, run \`nb env auth -e ${options.envName}\` again after connectivity is restored.`
+      : 'If the saved login is stale, run `nb env auth -e <name>` again after connectivity is restored.',
+    'Use `nb env list` to inspect the current env configuration.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function fetchOauthServerMetadata(baseUrl: string, options: { envName?: string } = {}) {
   const metadataUrl = getOauthMetadataUrl(baseUrl);
-  const response = await fetch(metadataUrl);
+  let response: Response;
+  try {
+    response = await fetch(metadataUrl);
+  } catch (error: any) {
+    throw new Error(
+      formatOauthFetchFailure('Failed to load OAuth metadata.', {
+        envName: options.envName,
+        baseUrl,
+        url: metadataUrl,
+        rawMessage: error?.message,
+      }),
+    );
+  }
   const data = await parseJsonResponse(response);
 
   if (!response.ok) {
@@ -335,7 +373,7 @@ async function refreshOauthAccessToken(options: {
     throw new Error(`OAuth session for env "${options.envName}" cannot be refreshed. Run \`nb env auth -e ${options.envName}\`.`);
   }
 
-  const metadata = await fetchOauthServerMetadata(options.baseUrl);
+  const metadata = await fetchOauthServerMetadata(options.baseUrl, { envName: options.envName });
   const resource = options.auth.resource || getOauthResource(metadata.issuer);
   const body = new URLSearchParams({
     grant_type: 'refresh_token',
@@ -351,6 +389,15 @@ async function refreshOauthAccessToken(options: {
       'content-type': 'application/x-www-form-urlencoded',
     },
     body,
+  }).catch((error: any) => {
+    throw new Error(
+      formatOauthFetchFailure(`Failed to refresh OAuth session for env "${options.envName}".`, {
+        envName: options.envName,
+        baseUrl: options.baseUrl,
+        url: metadata.token_endpoint,
+        rawMessage: error?.message,
+      }),
+    );
   });
   const data = await parseJsonResponse(response);
 
@@ -466,7 +513,7 @@ export async function authenticateEnvWithOauth(options: {
   }
 
   updateTask(`Loading OAuth metadata for env "${envName}"...`);
-  const metadata = await fetchOauthServerMetadata(baseUrl);
+  const metadata = await fetchOauthServerMetadata(baseUrl, { envName });
   const state = encodeBase64Url(crypto.randomBytes(16));
   const { codeVerifier, codeChallenge } = buildPkcePair();
   const callback = await createLoopbackServer(state);
@@ -490,7 +537,7 @@ export async function authenticateEnvWithOauth(options: {
     updateTask(`Waiting for OAuth login for env "${envName}"...`);
     const opened = maybeOpenBrowser(authorizationUrl.toString());
     if (!opened) {
-      printWarning('Unable to open the browser automatically. Open this URL manually:');
+      printWarningBlock('Unable to open the browser automatically. Open this URL manually:');
     } else {
       printInfo('Complete the OAuth login in your browser.');
     }

--- a/packages/core/cli/src/lib/ui.ts
+++ b/packages/core/cli/src/lib/ui.ts
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import ora, { type Ora } from 'ora';
@@ -122,20 +131,21 @@ export function printSuccess(message: string) {
   console.log(pc.green(message));
 }
 
-export function printWarning(message: string) {
+function clearActiveSpinner() {
   if (activeSpinner) {
-    if (!isInteractiveTerminal()) {
-      activeSpinner = undefined;
-      console.log(pc.yellow(message));
-      return;
-    }
-
-    activeSpinner.warn(pc.yellow(message));
+    activeSpinner.stop();
     activeSpinner = undefined;
-    return;
   }
+}
 
-  console.log(pc.yellow(message));
+export function printWarning(message: string) {
+  clearActiveSpinner();
+  console.log(pc.yellow(`⚠ Warning: ${message}`));
+}
+
+export function printWarningBlock(message: string) {
+  clearActiveSpinner();
+  console.log(pc.yellow(`⚠ Warning\n${message}\n`));
 }
 
 export function printVerboseWarning(message: string) {
@@ -191,10 +201,7 @@ export function failTask(message: string) {
 }
 
 export function stopTask() {
-  if (activeSpinner) {
-    activeSpinner.stop();
-    activeSpinner = undefined;
-  }
+  clearActiveSpinner();
 }
 
 export function renderTable(headers: string[], rows: string[][]) {

--- a/packages/core/cli/test/bootstrap.test.ts
+++ b/packages/core/cli/test/bootstrap.test.ts
@@ -1,10 +1,16 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { formatMissingRuntimeEnvError, formatSwaggerSchemaError, shouldSkipRuntimeBootstrap } from '../src/lib/bootstrap.js';
+import {
+  formatMissingRuntimeEnvError,
+  formatSwaggerSchemaError,
+  shouldSkipRuntimeBootstrap,
+} from '../src/lib/bootstrap.js';
 
 test('shouldSkipRuntimeBootstrap skips root help and no-arg invocations', () => {
   assert.equal(shouldSkipRuntimeBootstrap([]), false);
   assert.equal(shouldSkipRuntimeBootstrap(['--help']), false);
+  assert.equal(shouldSkipRuntimeBootstrap(['-h']), false);
+  assert.equal(shouldSkipRuntimeBootstrap(['api']), false);
   assert.equal(shouldSkipRuntimeBootstrap(['env', '--help']), true);
   assert.equal(shouldSkipRuntimeBootstrap(['resource', 'list']), true);
 });
@@ -59,6 +65,29 @@ test('formatSwaggerSchemaError falls back to the raw swagger error for non-auth 
 
   assert.match(message, /^Failed to load swagger schema from `swagger:get`\./);
   assert.match(message, /Internal Server Error/);
+});
+
+test('formatSwaggerSchemaError explains network fetch failures clearly', () => {
+  const message = formatSwaggerSchemaError(
+    {
+      status: 0,
+      data: {
+        error: {
+          message: 'fetch failed',
+        },
+      },
+    },
+    {
+      baseUrl: 'http://localhost:13000/api',
+      commandToken: 'api',
+    },
+  );
+
+  assert.match(message, /Failed to reach the NocoBase server while loading the command runtime/);
+  assert.match(message, /Base URL: http:\/\/localhost:13000\/api/);
+  assert.match(message, /Network error: fetch failed/);
+  assert.match(message, /nb env add --name <name> --base-url <url>/);
+  assert.match(message, /nb env list/);
 });
 
 test('formatMissingRuntimeEnvError explains unknown runtime commands without an env', () => {

--- a/packages/core/cli/test/env-auth.test.ts
+++ b/packages/core/cli/test/env-auth.test.ts
@@ -4,7 +4,12 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { saveAuthConfig } from '../src/lib/auth-store.js';
-import { getOauthMetadataUrl, getOauthResource, isOauthAccessTokenExpired, resolveAccessToken } from '../src/lib/env-auth.js';
+import {
+  getOauthMetadataUrl,
+  getOauthResource,
+  isOauthAccessTokenExpired,
+  resolveAccessToken,
+} from '../src/lib/env-auth.js';
 
 async function withTempCliHome(run: () => Promise<void>) {
   const previous = process.env.NOCOBASE_CTL_HOME;
@@ -24,7 +29,10 @@ async function withTempCliHome(run: () => Promise<void>) {
 }
 
 test('OAuth helpers derive metadata and resource URLs from base URL', () => {
-  assert.equal(getOauthMetadataUrl('http://localhost:13000/api/'), 'http://localhost:13000/api/.well-known/oauth-authorization-server');
+  assert.equal(
+    getOauthMetadataUrl('http://localhost:13000/api/'),
+    'http://localhost:13000/api/.well-known/oauth-authorization-server',
+  );
   assert.equal(getOauthResource('http://localhost:13000/api/'), 'http://localhost:13000/api/');
   assert.equal(getOauthResource('https://demo.example.com/custom/api'), 'https://demo.example.com/custom/api/');
 });
@@ -117,6 +125,62 @@ test('resolveAccessToken refreshes expired OAuth sessions', async () => {
         scope: 'global',
       });
       assert.equal(token, 'fresh-token');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+test('resolveAccessToken explains OAuth metadata network failures clearly', async () => {
+  await withTempCliHome(async () => {
+    await saveAuthConfig(
+      {
+        currentEnv: 'test',
+        envs: {
+          test: {
+            baseUrl: 'http://localhost:13000/api',
+            auth: {
+              type: 'oauth',
+              accessToken: 'expired-token',
+              refreshToken: 'refresh-token',
+              expiresAt: '2026-04-14T00:00:00.000Z',
+              issuer: 'http://localhost:13000/api',
+              clientId: 'client-1',
+              resource: 'http://localhost:13000/api/',
+              scope: 'openid api offline_access',
+            },
+          },
+        },
+      },
+      { scope: 'global' },
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed');
+    }) as typeof fetch;
+
+    try {
+      await assert.rejects(
+        () =>
+          resolveAccessToken({
+            envName: 'test',
+            scope: 'global',
+          }),
+        (error: any) => {
+          assert.match(error.message, /Failed to load OAuth metadata\./);
+          assert.match(error.message, /Env: test/);
+          assert.match(error.message, /Base URL: http:\/\/localhost:13000\/api/);
+          assert.match(
+            error.message,
+            /Request URL: http:\/\/localhost:13000\/api\/\.well-known\/oauth-authorization-server/,
+          );
+          assert.match(error.message, /Network error: fetch failed/);
+          assert.match(error.message, /nb env auth -e test/);
+          assert.match(error.message, /nb env list/);
+          return true;
+        },
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
- `nb api` and `nb api -h` could fail early when runtime bootstrap or OAuth refresh hit a network error, which blocked built-in help and only showed a raw `fetch failed` message.
- Warning output was inconsistent across CLI flows and did not separate fallback warnings clearly from the following help text.

### Description 
- Let `nb api` and help-style API entrypoints continue to built-in help when runtime bootstrap fails.
- Replace raw network fetch failures in runtime bootstrap and OAuth refresh with actionable guidance that includes the env/base URL context and follow-up commands.
- Unify CLI warning presentation with a consistent `⚠ Warning` style and blank-line separation before subsequent help output.
- Added tests covering API help fallback and OAuth metadata network failure messaging.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved `nb api` help fallback and unified warning messages for runtime bootstrap failures |
| 🇨🇳 Chinese | 优化 `nb api` 在运行时引导失败时的帮助降级表现，并统一警告信息样式 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
