### PR TITLE
fix(departments): sync main department after saving associations

### DIFF
--- a/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/actions.test.ts
@@ -116,4 +116,30 @@ describe('actions', () => {
     });
     expect(membershipCount).toBe(1);
   });
+
+  it('should auto fill mainDepartmentId when creating a user with departments only', async () => {
+    const userRepo = db.getRepository('users');
+    const dept = await repo.create({
+      values: { title: 'Dept auto main' },
+    });
+
+    const user = await userRepo.create({
+      values: {
+        username: 'user-with-department',
+        password: '123456',
+        departments: [dept.id],
+      },
+    });
+
+    const userReload = await userRepo.findOne({
+      filterByTk: user.id,
+      fields: ['id', 'mainDepartmentId'],
+    });
+    expect(userReload.mainDepartmentId).toBe(dept.id);
+
+    const membershipCount = await db.getRepository('departmentsUsers').count({
+      filter: { userId: user.id, departmentId: dept.id },
+    });
+    expect(membershipCount).toBe(1);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/data-sync.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/data-sync.test.ts
@@ -166,7 +166,7 @@ describe('department data sync', async () => {
     });
     expect(departmentUser).toBeTruthy();
     expect(departmentUser.isOwner).toBe(false);
-    expect(user.mainDepartmentId).toBeNull();
+    expect(user.mainDepartmentId).toBe(department.id);
 
     await resourceManager.updateOrCreate({
       sourceName: 'test',
@@ -236,7 +236,7 @@ describe('department data sync', async () => {
     });
     expect(departmentUser3).toBeTruthy();
     expect(departmentUser3.isOwner).toBe(true);
-    expect(user2.mainDepartmentId).toBeNull();
+    expect(user2.mainDepartmentId).toBe(department.id);
   });
 
   it('should update department custom field', async () => {

--- a/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/set-main-department.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/set-main-department.test.ts
@@ -216,4 +216,18 @@ describe('set main department', () => {
     const user = await db.getRepository('users').findOne({ filterByTk: 1, fields: ['id', 'mainDepartmentId'] });
     expect(user.mainDepartmentId).toBe(depts[1].id);
   });
+
+  it('should clear main department when departments.members.set removes the last department', async () => {
+    const dept = await repo.create({ values: { title: 'OnlyDept' } });
+    await agent.resource('departments.members', dept.id).add({
+      values: [1],
+    });
+
+    await agent.resource('departments.members', dept.id).set({
+      values: [],
+    });
+
+    const user = await db.getRepository('users').findOne({ filterByTk: 1, fields: ['id', 'mainDepartmentId'] });
+    expect(user.mainDepartmentId).toBeNull();
+  });
 });

--- a/packages/plugins/@nocobase/plugin-departments/src/server/middlewares/set-main-department.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/middlewares/set-main-department.ts
@@ -17,85 +17,46 @@
  */
 
 import { Context, Next } from '@nocobase/actions';
+import { syncUserMainDepartment } from '../sync-user-main-department';
+
+const normalizeIds = (values: any[] = []) =>
+  values
+    .map((value) => (typeof value === 'object' && value ? value.id ?? value : value))
+    .filter((value) => value !== null && value !== undefined);
+
+const syncUsersMainDepartment = async (ctx: Context, userIds: any[]) => {
+  const uniqUserIds = [...new Set(normalizeIds(userIds))];
+  for (const userId of uniqUserIds) {
+    await syncUserMainDepartment(ctx.db, userId, ctx.transaction);
+  }
+};
 
 export const setMainDepartment = async (ctx: Context, next: Next) => {
+  const { associatedName, resourceName, associatedIndex, actionName, values, filterByTk } = ctx.action.params;
+  let affectedDepartmentMemberUserIds: any[] = [];
+
+  if (associatedName === 'departments' && resourceName === 'members' && actionName === 'set') {
+    const throughRepo = ctx.db.getRepository('departmentsUsers');
+    const currentMembers = await throughRepo.find({
+      fields: ['userId'],
+      filter: { departmentId: associatedIndex },
+      transaction: ctx.transaction,
+    });
+    affectedDepartmentMemberUserIds = currentMembers.map((member: any) => member.get?.('userId') ?? member.userId);
+  }
+
   await next();
 
-  const { associatedName, resourceName, associatedIndex, actionName, values, filterByTk } = ctx.action.params;
-
   // When operating from department side: departments.members
-  if (associatedName === 'departments' && resourceName === 'members' && values?.length) {
-    const userRepo = ctx.db.getRepository('users');
-    const throughRepo = ctx.db.getRepository('departmentsUsers');
-
-    if (actionName === 'add' || actionName === 'set') {
-      // Set first main if not have one
-      for (const userId of values) {
-        const user = await userRepo.findOne({ filterByTk: userId, fields: ['id', 'mainDepartmentId'] });
-        if (!user?.mainDepartmentId) {
-          await userRepo.update({
-            filterByTk: userId,
-            values: { mainDepartmentId: associatedIndex },
-          });
-        }
-      }
-      return;
-    }
-
-    if (actionName === 'remove') {
-      for (const userId of values) {
-        const user = await userRepo.findOne({ filterByTk: userId, fields: ['id', 'mainDepartmentId'] });
-        if (user?.mainDepartmentId === Number(associatedIndex)) {
-          const firstDept = await throughRepo.findOne({
-            filter: { userId },
-          });
-          await userRepo.update({
-            filterByTk: userId,
-            values: { mainDepartmentId: firstDept ? firstDept.departmentId : null },
-          });
-        }
-      }
-    }
+  if (associatedName === 'departments' && resourceName === 'members' && ['add', 'remove', 'set'].includes(actionName)) {
+    const affectedUserIds =
+      actionName === 'set' ? [...affectedDepartmentMemberUserIds, ...(values || [])] : values || [];
+    await syncUsersMainDepartment(ctx, affectedUserIds);
+    return;
   }
 
   // When operating from user side: users.departments
   if (associatedName === 'users' && resourceName === 'departments' && ['add', 'remove', 'set'].includes(actionName)) {
-    const userRepo = ctx.db.getRepository('users');
-    const throughRepo = ctx.db.getRepository('departmentsUsers');
-    const user = await userRepo.findOne({ filterByTk: associatedIndex, fields: ['id', 'mainDepartmentId'] });
-
-    // If user has no main OR current main department is no longer associated, pick a new one from remaining
-    let hasValidMain = false;
-    if (user?.mainDepartmentId) {
-      const existingAssoc = await throughRepo.findOne({
-        filter: { userId: associatedIndex, departmentId: user.mainDepartmentId },
-      });
-      hasValidMain = !!existingAssoc;
-    }
-
-    if (!hasValidMain) {
-      const firstDept = await throughRepo.findOne({
-        filter: { userId: associatedIndex },
-      });
-      await userRepo.update({
-        filterByTk: associatedIndex,
-        values: { mainDepartmentId: firstDept ? firstDept.departmentId : null },
-      });
-    }
-  }
-
-  // 用户更新：当通过 users.update 修改部门关联后，若仅剩一个部门则设为主属部门
-  if (resourceName === 'users' && actionName === 'update') {
-    const userRepo = ctx.db.getRepository('users');
-    const throughRepo = ctx.db.getRepository('departmentsUsers');
-    const userId = associatedIndex ?? filterByTk ?? ctx.body?.data?.id;
-    if (!userId) return;
-    const deptUsers = await throughRepo.find({ filter: { userId } });
-    if (deptUsers.length === 1) {
-      await userRepo.update({
-        filterByTk: userId,
-        values: { mainDepartmentId: deptUsers[0].departmentId },
-      });
-    }
+    await syncUsersMainDepartment(ctx, [associatedIndex ?? filterByTk]);
   }
 };

--- a/packages/plugins/@nocobase/plugin-departments/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/plugin.ts
@@ -34,6 +34,7 @@ import { DepartmentDataSyncResource } from './department-data-sync-resource';
 import PluginUserDataSyncServer from '@nocobase/plugin-user-data-sync';
 import { DataSource } from '@nocobase/data-source-manager';
 import PluginErrorHandler from '@nocobase/plugin-error-handler';
+import { syncUserMainDepartment } from './sync-user-main-department';
 
 export class PluginDepartmentsServer extends Plugin {
   afterAdd() {}
@@ -94,16 +95,23 @@ export class PluginDepartmentsServer extends Plugin {
     this.app.resourceManager.use(setMainDepartmentMiddleware);
 
     // Delete cache when the departments of a user changed
-    this.app.db.on('departmentsUsers.afterSave', async (model) => {
+    this.app.db.on('departmentsUsers.afterSave', async (model, options) => {
       const cache = this.app.cache as Cache;
+      await syncUserMainDepartment(this.app.db, model.get('userId'), options?.transaction);
       await cache.del(`departments:${model.get('userId')}`);
     });
-    this.app.db.on('departmentsUsers.afterDestroy', async (model) => {
+    this.app.db.on('departmentsUsers.afterDestroy', async (model, options) => {
       const cache = this.app.cache as Cache;
+      await syncUserMainDepartment(this.app.db, model.get('userId'), options?.transaction);
       await cache.del(`departments:${model.get('userId')}`);
     });
 
+    this.app.db.on('users.afterSaveWithAssociations', async (model, options) => {
+      await syncUserMainDepartment(this.app.db, model.get('id'), options?.transaction);
+    });
+
     this.app.db.on('users.beforeSave', async (model, options) => {
+      const submittedDepartments = options?.values?.departments;
       const mainDepartmentId = model.get('mainDepartmentId');
       if (!mainDepartmentId) {
         return;
@@ -122,7 +130,6 @@ export class PluginDepartmentsServer extends Plugin {
           return;
         }
       }
-      const submittedDepartments = options?.values?.departments;
       if (Array.isArray(submittedDepartments)) {
         const included = submittedDepartments.some((d) => {
           const id = typeof d === 'object' ? d && (d.id ?? d) : d;

--- a/packages/plugins/@nocobase/plugin-departments/src/server/sync-user-main-department.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/sync-user-main-department.ts
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This program is offered under a commercial license.
+ * For more information, see <https://www.nocobase.com/agreement>
+ */
+
+import type { Database } from '@nocobase/database';
+import type { Transaction } from 'sequelize';
+
+export const syncUserMainDepartment = async (db: Database, userId: number | string, transaction?: Transaction) => {
+  if (!userId) {
+    return;
+  }
+
+  const userRepo = db.getRepository('users');
+  const throughRepo = db.getRepository('departmentsUsers');
+  const user = await userRepo.findOne({
+    filterByTk: userId,
+    fields: ['id', 'mainDepartmentId'],
+    transaction,
+  });
+
+  if (!user) {
+    return;
+  }
+
+  const currentMainDepartmentId = user.get('mainDepartmentId');
+  const currentMainDepartment =
+    currentMainDepartmentId &&
+    (await throughRepo.findOne({
+      filter: {
+        userId,
+        departmentId: currentMainDepartmentId,
+      },
+      transaction,
+    }));
+
+  if (currentMainDepartment) {
+    return;
+  }
+
+  const firstDepartment = await throughRepo.findOne({
+    filter: { userId },
+    transaction,
+  });
+  const nextMainDepartmentId = firstDepartment ? firstDepartment.get('departmentId') : null;
+
+  if (currentMainDepartmentId === nextMainDepartmentId) {
+    return;
+  }
+
+  await userRepo.update({
+    filterByTk: userId,
+    values: { mainDepartmentId: nextMainDepartmentId },
+    transaction,
+  });
+};


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Creating or updating user-department associations through different save paths could leave `mainDepartmentId` unset or stale because the sync logic was split across multiple places.

### Description 
- Added a shared main-department sync helper and reused it after user saves with associations and relation actions
- Kept relation-action handling for `users.departments` and `departments.members`, while removing duplicate `users.update` middleware logic
- Added regression coverage for creating users with departments only and clearing the last department via `departments.members.set([])`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed missing or stale main department values after saving user departments |
| 🇨🇳 Chinese | 修复保存用户部门后主部门未同步或同步错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
