### PR TITLE
fix(cli): avoid Windows OAuth URL truncation

### DIFF
--- a/packages/core/cli/src/lib/env-auth.ts
+++ b/packages/core/cli/src/lib/env-auth.ts
@@ -11,6 +11,9 @@ import crypto from 'node:crypto';
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
 import { URL } from 'node:url';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import {
   getCurrentEnvName,
   getEnv,
@@ -213,13 +216,76 @@ function buildPkcePair() {
   };
 }
 
-function maybeOpenBrowser(url: string) {
+function escapeHtmlAttribute(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeScriptString(value: string) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+type BrowserOpenTarget = {
+  target: string;
+  cleanup?: () => Promise<void>;
+};
+
+export function buildOauthRedirectHtml(url: string) {
+  const escapedUrl = escapeHtmlAttribute(url);
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=${escapedUrl}">
+  <title>NocoBase OAuth Login</title>
+</head>
+<body>
+  <script>window.location.replace(${escapeScriptString(url)});</script>
+  <p>Redirecting to the OAuth login page. If nothing happens, <a href="${escapedUrl}">continue manually</a>.</p>
+</body>
+</html>
+`;
+}
+
+async function createWindowsBrowserRedirectFile(url: string) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'nocobase-cli-oauth-'));
+  const filePath = path.join(directory, 'authorize.html');
+  await writeFile(filePath, buildOauthRedirectHtml(url), 'utf8');
+
+  const cleanup = setTimeout(() => {
+    void rm(directory, { recursive: true, force: true });
+  }, OAUTH_LOGIN_TIMEOUT_MS);
+  cleanup.unref?.();
+
+  return {
+    target: filePath,
+    cleanup: async () => {
+      clearTimeout(cleanup);
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+async function getBrowserOpenTarget(url: string): Promise<BrowserOpenTarget> {
+  if (process.platform !== 'win32') {
+    return { target: url };
+  }
+
+  return createWindowsBrowserRedirectFile(url);
+}
+
+async function maybeOpenBrowser(url: string): Promise<{ opened: boolean; cleanup?: () => Promise<void> }> {
+  const { target, cleanup } = await getBrowserOpenTarget(url);
   const candidates =
     process.platform === 'darwin'
-      ? [['open', url]]
+      ? [['open', target]]
       : process.platform === 'win32'
-        ? [['cmd', '/c', 'start', '', url]]
-        : [['xdg-open', url]];
+        ? [['cmd', '/c', 'start', '', target]]
+        : [['xdg-open', target]];
 
   for (const [command, ...args] of candidates) {
     try {
@@ -228,13 +294,19 @@ function maybeOpenBrowser(url: string) {
         stdio: 'ignore',
       });
       child.unref();
-      return true;
+      return {
+        opened: true,
+        cleanup,
+      };
     } catch (_error) {
       continue;
     }
   }
 
-  return false;
+  return {
+    opened: false,
+    cleanup,
+  };
 }
 
 async function createLoopbackServer(state: string) {
@@ -518,6 +590,7 @@ export async function authenticateEnvWithOauth(options: {
   const { codeVerifier, codeChallenge } = buildPkcePair();
   const callback = await createLoopbackServer(state);
   const resource = getOauthResource(metadata.issuer);
+  let cleanupBrowserOpenTarget: (() => Promise<void>) | undefined;
 
   try {
     updateTask(`Registering OAuth client for env "${envName}"...`);
@@ -535,8 +608,9 @@ export async function authenticateEnvWithOauth(options: {
     authorizationUrl.searchParams.set('resource', resource);
 
     updateTask(`Waiting for OAuth login for env "${envName}"...`);
-    const opened = maybeOpenBrowser(authorizationUrl.toString());
-    if (!opened) {
+    const browser = await maybeOpenBrowser(authorizationUrl.toString());
+    cleanupBrowserOpenTarget = browser.cleanup;
+    if (!browser.opened) {
       printWarningBlock('Unable to open the browser automatically. Open this URL manually:');
     } else {
       printInfo('Complete the OAuth login in your browser.');
@@ -590,6 +664,7 @@ export async function authenticateEnvWithOauth(options: {
       { scope: options.scope },
     );
   } finally {
+    await cleanupBrowserOpenTarget?.().catch(() => undefined);
     await callback.close().catch(() => undefined);
   }
 }

--- a/packages/core/cli/test/env-auth.test.ts
+++ b/packages/core/cli/test/env-auth.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { saveAuthConfig } from '../src/lib/auth-store.js';
 import {
+  buildOauthRedirectHtml,
   getOauthMetadataUrl,
   getOauthResource,
   isOauthAccessTokenExpired,
@@ -35,6 +36,18 @@ test('OAuth helpers derive metadata and resource URLs from base URL', () => {
   );
   assert.equal(getOauthResource('http://localhost:13000/api/'), 'http://localhost:13000/api/');
   assert.equal(getOauthResource('https://demo.example.com/custom/api'), 'https://demo.example.com/custom/api/');
+});
+
+test('buildOauthRedirectHtml escapes OAuth URLs for HTML and script contexts', () => {
+  const url = 'https://example.com/oauth?scope=openid api&state="abc"&next=<script>alert(1)</script>';
+  const html = buildOauthRedirectHtml(url);
+
+  assert.match(html, /scope=openid api&amp;state=&quot;abc&quot;&amp;next=&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(
+    html,
+    /window\.location\.replace\("https:\/\/example\.com\/oauth\?scope=openid api&state=\\"abc\\"&next=\\u003cscript>alert\(1\)\\u003c\/script>"/,
+  );
+  assert.doesNotMatch(html, /href="[^"]*&state="/);
 });
 
 test('isOauthAccessTokenExpired uses a refresh window', () => {

--- a/packages/core/cli/test/generated-command-body-modes.test.ts
+++ b/packages/core/cli/test/generated-command-body-modes.test.ts
@@ -64,10 +64,7 @@ test('parseBody should still enforce required body fields when flag mode is used
     bodyRequired: true,
   };
 
-  await assert.rejects(
-    () => parseBody({ 'primary-value': 'ok' }, operation),
-    /Missing required body field --items/,
-  );
+  await assert.rejects(() => parseBody({ 'primary-value': 'ok' }, operation), /Missing required body field --items/);
 });
 
 test('parseBody should accept raw body JSON without checking sibling flags', async () => {
@@ -94,7 +91,7 @@ test('parseBody should describe conflicting raw body and body flags clearly', as
 
   await assert.rejects(
     () => parseBody({ body: '{"primaryValue":"ok","items":[]}', 'primary-value': 'ok' }, operation),
-    /Conflicting request body inputs: received --body together with body field flags \(\-\-primary-value\)/,
+    /Conflicting request body inputs: received --body together with body field flags \(--primary-value\)/,
   );
 });
 
@@ -105,8 +102,8 @@ test('buildExamples should not mix required body flags with --body examples', ()
   });
 
   assert.deepEqual(examples, [
-    'nb test api --primary-value <value> --items value1 --items value2',
-    `nb test api --body '{"primaryValue":"value","items":[]}'`,
+    'nb api test api --primary-value <value> --items value1 --items value2',
+    `nb api test api --body '{"primaryValue":"value","items":[]}'`,
   ]);
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
OAuth login from the CLI can fail on Windows when the system browser is opened through the shell with a long authorization URL.

### Description
This change avoids passing the full OAuth authorization URL directly to the Windows shell. The CLI now opens a short temporary local HTML file that redirects the browser to the full authorization URL, then cleans up that file after the OAuth flow completes with a timeout fallback.

The CLI OAuth tests were extended to cover redirect HTML escaping, and an existing generated-command example assertion was updated to match the current `nb api` command namespace.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed CLI OAuth login failures on Windows caused by long authorization URLs |
| 🇨🇳 Chinese | 修复 Windows 上 CLI OAuth 登录可能因授权链接过长而失败的问题 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
