### PR TITLE
fix: incorrect values for sub table after applying field value

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
+++ b/packages/core/client/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
@@ -205,6 +205,30 @@ describe('FormValueRuntime (default rules)', () => {
     await waitFor(() => expect(formStub.getFieldValue(['a'])).toBe('Y'));
   });
 
+  it('patched form.setFieldsValue replaces top-level array fields instead of merging stale rows', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const formStub = createFormStub({ users: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+
+    const blockModel: any = {
+      uid: 'form-set-fields-value-array-replace',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    formStub.setFieldsValue({ users: [] });
+    formStub.setFieldsValue({ users: [{ id: 'A' }, { id: 'B' }] });
+
+    await waitFor(() => {
+      expect(formStub.getFieldValue(['users'])).toEqual([{ id: 'A' }, { id: 'B' }]);
+    });
+  });
+
   it('tracks dynamic deps (formValues[selector]) and updates subscriptions', async () => {
     const engineEmitter = new EventEmitter();
     const blockEmitter = new EventEmitter();

--- a/packages/core/client/src/flow/models/blocks/form/value-runtime/runtime.ts
+++ b/packages/core/client/src/flow/models/blocks/form/value-runtime/runtime.ts
@@ -505,8 +505,17 @@ export class FormValueRuntime {
         }
         this.suppressFormCallbackDepth++;
         try {
-          form.setFieldsValue?.(patchToApply);
-          _.merge(this.valuesMirror, patchToApply);
+          for (const [pathKey, rawValue] of patchEntries) {
+            const value = isObservable(rawValue) ? toJS(rawValue) : rawValue;
+            if (typeof form.setFieldValue === 'function') {
+              form.setFieldValue(pathKey, value);
+            } else if (typeof (form as any).setFields === 'function') {
+              (form as any).setFields([{ name: pathKey, value }]);
+            } else {
+              form.setFieldsValue?.({ [pathKey]: value });
+            }
+            _.set(this.valuesMirror, [pathKey], value);
+          }
           this.bumpChangeTick();
         } finally {
           this.suppressFormCallbackDepth--;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where updating sub-table values through field assignment would result in data contamination. |
| 🇨🇳 Chinese | 修复字段赋值修改子表格里的值后出现数据污染的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
