### PR TITLE
fix(plugin-workflow-javascript): fix error thrown from editor

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/CodeEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/CodeEditor.tsx
@@ -1,10 +1,18 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import React, { useRef, useEffect } from 'react';
 import { basicSetup } from 'codemirror';
 import { EditorView } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
 import { javascript } from '@codemirror/lang-javascript';
-import { linter } from '@codemirror/lint';
-import { JSHINT } from 'jshint';
+// import { linter } from '@codemirror/lint';
 import { useMemoizedFn } from 'ahooks';
 import { createStyles } from 'antd-style';
 
@@ -43,54 +51,54 @@ const enableTheme = EditorView.theme({
   '.cm-scroller': { backgroundColor: '#fff' },
 });
 
-const jshintLinter = linter(async (view) => {
-  const code = view.state.doc.toString();
-  // 运行 JSHint
-  JSHINT(code, {
-    esversion: 11, // 支持现代 JavaScript 特性
-    asi: false, // 强制使用分号
-    browser: true, // 浏览器环境
-    undef: true, // 禁止未定义的变量
-    unused: true, // 警告未使用的变量
-    strict: 'global', // 强制使用严格模式
-    module: true, // 允许 ES 模块语法
-    // 可以根据需要添加更多配置
-  });
-  const errors = JSHINT.errors;
+// const jshintLinter = linter(async (view) => {
+//   const code = view.state.doc.toString();
+//   // 运行 JSHint
+//   JSHINT(code, {
+//     esversion: 11, // 支持现代 JavaScript 特性
+//     asi: false, // 强制使用分号
+//     browser: true, // 浏览器环境
+//     undef: true, // 禁止未定义的变量
+//     unused: true, // 警告未使用的变量
+//     strict: 'global', // 强制使用严格模式
+//     module: true, // 允许 ES 模块语法
+//     // 可以根据需要添加更多配置
+//   });
+//   const errors = JSHINT.errors;
 
-  // 转换 JSHint 错误为 CodeMirror lint 格式
-  return (errors || [])
-    .map((err) => {
-      if (!err) return null;
+//   // 转换 JSHint 错误为 CodeMirror lint 格式
+//   return (errors || [])
+//     .map((err) => {
+//       if (!err) return null;
 
-      try {
-        // 获取错误所在行的位置
-        const line = view.state.doc.line(err.line || 1);
-        const column = Math.min(Math.max(0, err.character - 1), line.length);
+//       try {
+//         // 获取错误所在行的位置
+//         const line = view.state.doc.line(err.line || 1);
+//         const column = Math.min(Math.max(0, err.character - 1), line.length);
 
-        // 计算错误范围
-        let endColumn = column;
-        if (err.evidence) {
-          // 找到错误标记的实际长度
-          const errorToken = err.evidence.slice(column).match(/^\w+|./)?.[0] || '';
-          endColumn = Math.min(column + errorToken.length, line.length);
-        }
+//         // 计算错误范围
+//         let endColumn = column;
+//         if (err.evidence) {
+//           // 找到错误标记的实际长度
+//           const errorToken = err.evidence.slice(column).match(/^\w+|./)?.[0] || '';
+//           endColumn = Math.min(column + errorToken.length, line.length);
+//         }
 
-        return {
-          from: line.from + column,
-          // 确保 to 位置不超过行的长度
-          to: line.from + endColumn,
-          message: err.reason || 'Syntax error',
-          severity: err.code && err.code.startsWith('W') ? 'warning' : 'error',
-          source: 'jshint',
-        };
-      } catch (e) {
-        console.warn('Error processing lint result:', e);
-        return null;
-      }
-    })
-    .filter(Boolean);
-});
+//         return {
+//           from: line.from + column,
+//           // 确保 to 位置不超过行的长度
+//           to: line.from + endColumn,
+//           message: err.reason || 'Syntax error',
+//           severity: err.code && err.code.startsWith('W') ? 'warning' : 'error',
+//           source: 'jshint',
+//         };
+//       } catch (e) {
+//         console.warn('Error processing lint result:', e);
+//         return null;
+//       }
+//     })
+//     .filter(Boolean);
+// });
 
 const CodeEditor: React.FC<Props> = ({ onChange, value, disabled }) => {
   const editorRef = useRef(null);
@@ -107,7 +115,7 @@ const CodeEditor: React.FC<Props> = ({ onChange, value, disabled }) => {
       extensions: [
         basicSetup,
         javascript(),
-        compartment.of(jshintLinter),
+        // compartment.of(jshintLinter),
         EditorView.updateListener.of((v) => {
           if (v.docChanged) {
             const content = v.state.doc.toString();


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where error thrown when configure JavaScript node.

### Description 

```
TypeError: _.each is not a function
    at eval (webpack-internal:///./node_modules/jshint/src/messages.js:261:3)
    at ./node_modules/jshint/src/messages.js (http://192.168.11.30:15001/assets/vendor-misc-611dad61.js:4597:1)
    at __webpack_require__ (http://192.168.11.30:15001/assets/runtime-4c15708c.js:33:29)
    at fn (http://192.168.11.30:15001/assets/runtime-4c15708c.js:245:10)
    at eval (webpack-internal:///./node_modules/jshint/src/jshint.js:36:20)
    at ./node_modules/jshint/src/jshint.js (http://192.168.11.30:15001/assets/vendor-misc-611dad61.js:4587:1)
    at __webpack_require__ (http://192.168.11.30:15001/assets/runtime-4c15708c.js:33:29)
    at fn (http://192.168.11.30:15001/assets/runtime-4c15708c.js:245:10)
    at eval (webpack-internal:///./packages/plugins/@nocobase/plugin-workflow-javascript/src/client/CodeEditor.tsx:13:44)
    at ./packages/plugins/@nocobase/plugin-workflow-javascript/src/client/CodeEditor.tsx (http://192.168.11.30:15001/assets/packages_plugins_nocobase_plugin-workflow-javascript_src_client_CodeEditor_tsx-ae22c486.js:4:1)
```

Just comment JSHint out.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where error thrown when configure JavaScript node |
| 🇨🇳 Chinese | 修复配置 JavaScript 节点时的报错 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
