### PR TITLE
fix(collection-repository): prevent crash when fields is undefined

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/repositories/collection-repository.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/repositories/collection-repository.ts
@@ -90,6 +90,10 @@ export class CollectionRepository extends Repository {
 
         const fields = nameMap[instanceName].get('fields');
 
+        if (!Array.isArray(fields)) {
+          return [];
+        }
+
         return fields
           .filter((field) => field['type'] === 'belongsTo' || field['type'] === 'belongsToMany')
           .map((field) => field.get('name'));
@@ -121,6 +125,10 @@ export class CollectionRepository extends Repository {
 
       const skipField = (() => {
         const fields = nameMap[viewCollectionName].get('fields');
+
+        if (!Array.isArray(fields)) {
+          return [];
+        }
 
         return fields
           .filter((field) => {


### PR DESCRIPTION
This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

## Motivation
Prevent potential runtime errors when loading collections if `fields` is undefined or not an array.

In `CollectionRepository.load`, the code uses `.filter()` and `.map()` directly on `fields`. If `fields` is missing or invalid, it can throw an error like:

> Cannot read properties of undefined (reading 'filter')

## Description
This PR adds defensive checks to ensure `fields` is a valid array before applying `.filter()` and `.map()` operations.

This change:
- adds `Array.isArray(fields)` guards in two places inside `CollectionRepository.load`
- returns an empty array when `fields` is not a valid array
- preserves existing behavior when `fields` is correctly defined

## Related issues
N/A

## Showcase
N/A

## Changelog
| Language | Changelog |
|----------|----------|
| 🇺🇸 English | Prevent crash when fields is undefined during collection loading |
| 🇨🇳 Chinese | 防止在集合加载期间 fields 未定义时发生崩溃 |

## Docs
| Language | Link |
|----------|------|
| 🇺🇸 English | |
| 🇨🇳 Chinese |  |

## Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are not needed
- [x] Doc update is not needed
- [x] Component demo is not needed
- [x] Changelog is provided
- [ ] Request a code review if it is necessary