### PR TITLE
fix(client): add page tab spacing

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -302,19 +302,21 @@ export class PageModel extends FlowModel<PageModelStructure> {
       this.tabBarExtraContent.right !== undefined ? (
         this.tabBarExtraContent.right
       ) : (
-        <AddSubModelButton
-          model={this}
-          subModelKey={'tabs'}
-          items={[
-            {
-              key: 'blank',
-              label: this.context.t('Blank tab'),
-              createModelOptions: this.createPageTabModelOptions,
-            },
-          ]}
-        >
-          <FlowSettingsButton icon={<PlusOutlined />}>{this.context.t('Add tab')}</FlowSettingsButton>
-        </AddSubModelButton>
+        <span style={{ display: 'inline-flex', marginInlineEnd: tabNavPaddingInlineStart }}>
+          <AddSubModelButton
+            model={this}
+            subModelKey={'tabs'}
+            items={[
+              {
+                key: 'blank',
+                label: this.context.t('Blank tab'),
+                createModelOptions: this.createPageTabModelOptions,
+              },
+            ]}
+          >
+            <FlowSettingsButton icon={<PlusOutlined />}>{this.context.t('Add tab')}</FlowSettingsButton>
+          </AddSubModelButton>
+        </span>
       );
 
     return (

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
@@ -387,6 +387,26 @@ describe('PageModel', () => {
 
       expect(tabsElement.props.tabBarExtraContent.right).toBe('custom-right');
     });
+
+    it('should inject default right spacing via tabBarExtraContent', () => {
+      // @ts-ignore
+      pageModel.context = {
+        t: (str: string) => str,
+        view: { navigation: null },
+        flowSettingsEnabled: false,
+        themeToken: { paddingLG: 24 },
+      } as any;
+
+      const result = pageModel.renderTabs() as any;
+      const tabsElement = result.props.children;
+      const rightExtraContent = tabsElement.props.tabBarExtraContent.right;
+
+      expect(rightExtraContent).toBeTruthy();
+      expect(rightExtraContent.props.style).toMatchObject({
+        display: 'inline-flex',
+        marginInlineEnd: 24,
+      });
+    });
   });
 
   describe('render header spacing with tabs', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
修复页面标签栏中“添加标签页”按钮右侧贴边的问题，让普通页面和弹窗中的页面都保留一致的左右留白。

### Description 
- 调整 `PageModel` 默认右侧额外内容的样式，为“添加标签页”按钮补充与左侧一致的右边距
- 保持自定义 `tabBarExtraContent.right` 的行为不变，仅影响默认按钮渲染
- 补充单元测试，覆盖默认右侧留白的样式注入

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the Add tab button is too close to the right edge |
| 🇨🇳 Chinese | 修复添加标签页按钮过于贴近右侧边缘的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
