### PR TITLE
fix: percentage fields being reset to numeric ​​when resynchronizing external data sources

### DIFF
--- a/packages/core/data-source-manager/src/__tests__/database-data-source.test.ts
+++ b/packages/core/data-source-manager/src/__tests__/database-data-source.test.ts
@@ -112,4 +112,54 @@ describe('database data source', () => {
       },
     });
   });
+
+  it('should preserve interface-only overrides during resync', () => {
+    const dataSource = Object.create(DatabaseDataSource.prototype) as DatabaseDataSource<any>;
+
+    const [mergedCollection] = dataSource.mergeWithLoadedCollections(
+      [
+        {
+          name: 'metrics',
+          fields: [
+            {
+              name: 'ratio',
+              type: 'float',
+              rawType: 'DOUBLE PRECISION',
+              interface: 'number',
+              uiSchema: {
+                title: 'ratio',
+              },
+            },
+          ],
+        },
+      ] as any,
+      {
+        metrics: {
+          name: 'metrics',
+          fields: [
+            {
+              name: 'ratio',
+              interface: 'percent',
+              uiSchema: {
+                title: 'Completion ratio',
+                'x-component': 'Percent',
+              },
+            },
+          ],
+        },
+      } as any,
+    );
+
+    expect(mergedCollection.fields).toHaveLength(1);
+    expect(mergedCollection.fields[0]).toMatchObject({
+      name: 'ratio',
+      type: 'float',
+      rawType: 'DOUBLE PRECISION',
+      interface: 'percent',
+      uiSchema: {
+        title: 'Completion ratio',
+        'x-component': 'Percent',
+      },
+    });
+  });
 });

--- a/packages/core/data-source-manager/src/database-data-source.ts
+++ b/packages/core/data-source-manager/src/database-data-source.ts
@@ -120,6 +120,7 @@ export abstract class DatabaseDataSource<T extends DatabaseIntrospector = Databa
 
     const shouldUseIncomingType =
       Boolean(fieldOptions.rawType) &&
+      Boolean(modelOptions.rawType || modelOptions.type) &&
       (modelOptions.rawType
         ? fieldOptions.rawType !== modelOptions.rawType && !hasCompatibleStorageType
         : !incomingPossibleTypes.includes(modelOptions.type) && !hasCompatibleStorageType);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
Fix for percentage fields being reset to numeric ​​when resynchronizing external data sources

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix for percentage fields being reset to numeric ​​when resynchronizing external data sources      |
| 🇨🇳 Chinese |     修复外部数据源重新同步时百分比字段被重置为数值      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
