### PR TITLE
fix(ai): formfiller not effect while form have relation field

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
@@ -43,8 +43,35 @@ const parseFlowModel = async (model: FlowModel) => {
   }
 };
 
+const getRelationFieldPrompt = (collectionField: FormItemModel['collectionField']) => {
+  if (!collectionField.targetCollection) {
+    return undefined;
+  }
+
+  const isToMany = ['hasMany', 'belongsToMany', 'belongsToArray'].includes(collectionField.type);
+  const requiredPropertyNames = _.uniq([collectionField.targetKey]).filter(Boolean);
+  const exampleObject = `{ ${requiredPropertyNames.map((name) => `"${name}": <${name}>`).join(', ')} }`;
+  const exampleValue = isToMany ? `[${exampleObject}]` : exampleObject;
+
+  return `This field must be filled with ${
+    isToMany ? 'an array of related record objects' : 'a related record object'
+  } from collection [${collectionField.targetCollection.name}]. Use [${
+    collectionField.targetKey
+  }] as the identity field. The value for [${collectionField.name}] must be ${
+    isToMany ? 'an array' : 'an object'
+  }. Each item must contain only [${requiredPropertyNames.join(', ')}]. Example: "${
+    collectionField.name
+  }": ${exampleValue}. Never output indexed or path-style keys such as "${collectionField.name}[0]" or "${
+    collectionField.name
+  }[1]", and never return only a primitive id.`;
+};
+
 const toSimplifyForm = (model: FormBlockModel) => {
-  const result = {
+  const result: {
+    uid: string;
+    fields: any[];
+    value: any;
+  } = {
     uid: model.uid,
     fields: [],
     value: undefined,
@@ -61,6 +88,7 @@ const toSimplifyForm = (model: FormBlockModel) => {
         enum: collectionField.enum,
         readonly: collectionField.readonly,
         defaultValue: collectionField.defaultValue,
+        prompt: getRelationFieldPrompt(collectionField),
       });
       duplicateFields.add(collectionField.name);
     }
@@ -69,9 +97,7 @@ const toSimplifyForm = (model: FormBlockModel) => {
     }
   });
   if (model.form) {
-    console.log(excludeFieldValues);
     result['value'] = model.form.getFieldsValue(true, (meta) => {
-      console.log(meta);
       return !excludeFieldValues.has(meta.name[0]);
     });
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix issue where AI employees cannot fill relation field values in forms. |
| 🇨🇳 Chinese | 修复 AI 员工填表单时无法填写关联字段值的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
