### PR TITLE
fix(flow): restrict grid drag slots

### DIFF
--- a/packages/core/client/src/flow/models/base/GridModel.tsx
+++ b/packages/core/client/src/flow/models/base/GridModel.tsx
@@ -397,7 +397,10 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     if (!this.dragState) {
       return;
     }
-    const snapshot = buildLayoutSnapshot({ container: this.getDragContainer() });
+    const snapshot = buildLayoutSnapshot({
+      container: this.getDragContainer(),
+      allowColumnInsertSlots: false,
+    });
     this.dragState.slots = snapshot.slots;
     this.dragState.containerRect = snapshot.containerRect;
   }

--- a/packages/core/client/src/flow/models/base/GridModel.tsx
+++ b/packages/core/client/src/flow/models/base/GridModel.tsx
@@ -482,6 +482,25 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     }
   }
 
+  private getHitTestSlot(slot: LayoutSlot): LayoutSlot {
+    return {
+      ...slot,
+      // 命中区域与实际显示的 overlay 保持一致，避免鼠标仍在蓝框内时命中跳走
+      rect: this.computeOverlayRect(slot),
+    };
+  }
+
+  private resolveDragSlot(point: { x: number; y: number }): LayoutSlot | null {
+    if (!this.dragState?.slots.length) {
+      return null;
+    }
+
+    return resolveDropIntent(
+      point,
+      this.dragState.slots.map((slot) => this.getHitTestSlot(slot)),
+    );
+  }
+
   private applyPreview(slot: LayoutSlot | null) {
     if (!this.dragState) {
       return;
@@ -571,7 +590,7 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
       return;
     }
 
-    const slot = resolveDropIntent(point, this.dragState.slots);
+    const slot = this.resolveDragSlot(point);
     this.applyPreview(slot);
   }
 

--- a/packages/core/client/src/flow/models/base/__tests__/GridModel.dragSnapshotContainer.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/GridModel.dragSnapshotContainer.test.ts
@@ -104,4 +104,47 @@ describe('GridModel drag snapshot container', () => {
 
     expect((model as any).dragState?.slots?.length).toBeGreaterThan(0);
   });
+
+  it('uses overlay-sized hit area when resolving drag slot', () => {
+    const model = engine.createModel<GridModel>({
+      use: 'GridModel',
+      uid: 'grid-drag-hit-area',
+      props: {},
+      structure: {} as any,
+    });
+
+    model.dragOverlayConfig = {
+      columnEdge: {
+        right: { width: 24, offsetLeft: 8 },
+      },
+    } as any;
+
+    (model as any).dragState = {
+      sourceUid: 'item-1',
+      snapshot: { rows: {}, sizes: {} },
+      slots: [
+        {
+          type: 'column-edge',
+          rowId: 'row-1',
+          columnIndex: 0,
+          direction: 'right',
+          rect: { top: 100, left: 200, width: 16, height: 120 },
+        },
+      ],
+      containerEl: null,
+      containerRect: { top: 0, left: 0, width: 0, height: 0 },
+      activeSlotKey: null,
+      previewLayout: undefined,
+      refreshTimer: null,
+    };
+
+    const resolved = (model as any).resolveDragSlot({ x: 225, y: 140 });
+
+    expect(resolved).toMatchObject({
+      type: 'column-edge',
+      rowId: 'row-1',
+      columnIndex: 0,
+      direction: 'right',
+    });
+  });
 });

--- a/packages/core/flow-engine/src/components/__tests__/gridDragPlanner.test.ts
+++ b/packages/core/flow-engine/src/components/__tests__/gridDragPlanner.test.ts
@@ -115,6 +115,71 @@ describe('buildLayoutSnapshot', () => {
     // 不应混入嵌套 grid（其 top >= 360）
     expect(snapshot.slots.every((slot) => slot.rect.top < 300)).toBe(true);
   });
+
+  it('should skip column insert slots when allowColumnInsertSlots is false', () => {
+    const container = document.createElement('div');
+    const row = document.createElement('div');
+    row.setAttribute('data-grid-row-id', 'row-1');
+    container.appendChild(row);
+
+    const column = document.createElement('div');
+    column.setAttribute('data-grid-column-row-id', 'row-1');
+    column.setAttribute('data-grid-column-index', '0');
+    row.appendChild(column);
+
+    const item = document.createElement('div');
+    item.setAttribute('data-grid-item-row-id', 'row-1');
+    item.setAttribute('data-grid-column-index', '0');
+    item.setAttribute('data-grid-item-index', '0');
+    column.appendChild(item);
+
+    mockRect(container, { top: 0, left: 0, width: 600, height: 200 });
+    mockRect(row, { top: 20, left: 20, width: 320, height: 120 });
+    mockRect(column, { top: 20, left: 20, width: 320, height: 120 });
+    mockRect(item, { top: 30, left: 30, width: 300, height: 80 });
+
+    const snapshot = buildLayoutSnapshot({ container, allowColumnInsertSlots: false });
+
+    expect(snapshot.slots.filter((slot) => slot.type === 'column')).toHaveLength(0);
+    expect(snapshot.slots.filter((slot) => slot.type === 'column-edge')).toHaveLength(2);
+    expect(snapshot.slots.filter((slot) => slot.type === 'row-gap')).toHaveLength(2);
+  });
+
+  it('should skip column insert slots for legacy multi-item columns when allowColumnInsertSlots is false', () => {
+    const container = document.createElement('div');
+    const row = document.createElement('div');
+    row.setAttribute('data-grid-row-id', 'row-1');
+    container.appendChild(row);
+
+    const column = document.createElement('div');
+    column.setAttribute('data-grid-column-row-id', 'row-1');
+    column.setAttribute('data-grid-column-index', '0');
+    row.appendChild(column);
+
+    const firstItem = document.createElement('div');
+    firstItem.setAttribute('data-grid-item-row-id', 'row-1');
+    firstItem.setAttribute('data-grid-column-index', '0');
+    firstItem.setAttribute('data-grid-item-index', '0');
+    column.appendChild(firstItem);
+
+    const secondItem = document.createElement('div');
+    secondItem.setAttribute('data-grid-item-row-id', 'row-1');
+    secondItem.setAttribute('data-grid-column-index', '0');
+    secondItem.setAttribute('data-grid-item-index', '1');
+    column.appendChild(secondItem);
+
+    mockRect(container, { top: 0, left: 0, width: 600, height: 240 });
+    mockRect(row, { top: 20, left: 20, width: 320, height: 160 });
+    mockRect(column, { top: 20, left: 20, width: 320, height: 160 });
+    mockRect(firstItem, { top: 30, left: 30, width: 300, height: 60 });
+    mockRect(secondItem, { top: 100, left: 30, width: 300, height: 60 });
+
+    const snapshot = buildLayoutSnapshot({ container, allowColumnInsertSlots: false });
+
+    expect(snapshot.slots.filter((slot) => slot.type === 'column')).toHaveLength(0);
+    expect(snapshot.slots.filter((slot) => slot.type === 'column-edge')).toHaveLength(2);
+    expect(snapshot.slots.filter((slot) => slot.type === 'row-gap')).toHaveLength(2);
+  });
 });
 
 describe('getSlotKey', () => {
@@ -301,6 +366,43 @@ describe('resolveDropIntent', () => {
     const point: Point = { x: 90, y: 90 };
     const result = resolveDropIntent(point, slots);
     expect(result).toEqual(slot1);
+  });
+
+  it('should fall back to row gap or column edge when column insert slots are absent', () => {
+    const slots: LayoutSlot[] = [
+      {
+        type: 'row-gap',
+        targetRowId: 'row1',
+        position: 'above',
+        rect: { top: 0, left: 100, width: 200, height: 20 },
+      },
+      {
+        type: 'column-edge',
+        rowId: 'row1',
+        columnIndex: 0,
+        direction: 'left',
+        rect: { top: 20, left: 100, width: 20, height: 100 },
+      },
+      {
+        type: 'column-edge',
+        rowId: 'row1',
+        columnIndex: 0,
+        direction: 'right',
+        rect: { top: 20, left: 280, width: 20, height: 100 },
+      },
+      {
+        type: 'row-gap',
+        targetRowId: 'row1',
+        position: 'below',
+        rect: { top: 120, left: 100, width: 200, height: 20 },
+      },
+    ];
+
+    const point: Point = { x: 200, y: 70 };
+    const result = resolveDropIntent(point, slots);
+
+    expect(result).not.toBeNull();
+    expect(result?.type === 'row-gap' || result?.type === 'column-edge').toBe(true);
   });
 });
 

--- a/packages/core/flow-engine/src/components/dnd/gridDragPlanner.ts
+++ b/packages/core/flow-engine/src/components/dnd/gridDragPlanner.ts
@@ -188,6 +188,7 @@ const ensureRowOrder = (layout: GridLayoutData) => {
 
 export interface BuildLayoutSnapshotOptions {
   container: HTMLElement | null;
+  allowColumnInsertSlots?: boolean;
 }
 
 const toRect = (domRect: DOMRect): Rect => ({
@@ -274,7 +275,10 @@ const expandColumnRect = (columnRect: Rect): Rect => ({
   height: Math.max(columnRect.height, MIN_SLOT_THICKNESS),
 });
 
-export const buildLayoutSnapshot = ({ container }: BuildLayoutSnapshotOptions): LayoutSnapshot => {
+export const buildLayoutSnapshot = ({
+  container,
+  allowColumnInsertSlots = true,
+}: BuildLayoutSnapshotOptions): LayoutSnapshot => {
   if (!container) {
     return {
       slots: [],
@@ -384,6 +388,10 @@ export const buildLayoutSnapshot = ({ container }: BuildLayoutSnapshotOptions): 
           columnIndex,
           rect: expandColumnRect(columnRect),
         });
+        return;
+      }
+
+      if (!allowColumnInsertSlots) {
         return;
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
当前 Grid 拖拽允许把区块继续插入到某一列内部的上方或下方，这会继续产生“一行允许多列，但一列也允许多项”的布局结构，导致区块和字段拖拽体验不符合预期。

### Description
- 为 `buildLayoutSnapshot` 增加了可选开关，用于按调用场景决定是否暴露列内 before/after 的拖拽 slot。
- 在 `GridModel` 的桌面端拖拽链路中显式关闭非空列的列内插入 slot，不再支持拖到列内上下插入。
- 保留新增列、新增行，以及 resize 过程中空列占位的填充能力，避免影响现有布局编辑体验。
- 保留底层 `column` slot 和旧布局显示兼容，避免自动改写历史上的“一列多项”数据。
- 补充了对应的 planner 单测，覆盖禁用列内插入 slot 后的快照行为和最近 slot 回退行为。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve grid drag and drop so items no longer insert above or below within a column |
| 🇨🇳 Chinese | 优化区块和字段拖拽交互，不再支持拖到列内上下插入 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
