### PR TITLE
fix(client): use filter target key for variable relation lookup

### DIFF
--- a/packages/core/client/src/block-provider/BlockProvider.tsx
+++ b/packages/core/client/src/block-provider/BlockProvider.tsx
@@ -288,6 +288,20 @@ export const useBlockAssociationContext = () => {
   return useContext(BlockAssociationContext) || association;
 };
 
+export const getFilterByTkByCollection = (collection: any, recordData: Record<string, any>) => {
+  const filterTargetKey = collection?.filterTargetKey || collection?.getPrimaryKey?.() || 'id';
+
+  if (isArray(filterTargetKey)) {
+    const filterByTk = {};
+    for (const key of filterTargetKey) {
+      filterByTk[key] = recordData?.[key];
+    }
+    return filterByTk;
+  }
+
+  return recordData?.[filterTargetKey];
+};
+
 export const useFilterByTk = (blockProps?: any) => {
   const { resource, __parent } = useBlockRequestContext();
   const recordIndex = useRecordIndex();
@@ -306,17 +320,13 @@ export const useFilterByTk = (blockProps?: any) => {
 
   if (assoc) {
     const association = cm.getCollectionField(assoc);
+    const filterByTk = getFilterByTkByCollection(collection, recordData);
+    if (filterByTk !== undefined) {
+      return filterByTk;
+    }
     return recordData?.[association.targetKey || association.sourceKey || 'id'];
   }
-  if (isArray(collection.filterTargetKey)) {
-    const filterByTk = {};
-    for (const key of collection.filterTargetKey) {
-      filterByTk[key] = recordData?.[key];
-    }
-    return filterByTk;
-  } else {
-    return recordData?.[collection.filterTargetKey || 'id'];
-  }
+  return getFilterByTkByCollection(collection, recordData);
 };
 
 /**

--- a/packages/core/client/src/block-provider/__tests__/hooks/useFilterByTk.test.ts
+++ b/packages/core/client/src/block-provider/__tests__/hooks/useFilterByTk.test.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getFilterByTkByCollection } from '../../BlockProvider';
+
+describe('getFilterByTkByCollection', () => {
+  it('uses collection filterTargetKey when it differs from id', () => {
+    const filterByTk = getFilterByTkByCollection(
+      {
+        filterTargetKey: 'uuid',
+      },
+      {
+        id: 1,
+        uuid: 'staff-uuid-001',
+      },
+    );
+
+    expect(filterByTk).toBe('staff-uuid-001');
+  });
+
+  it('supports array filterTargetKey', () => {
+    const filterByTk = getFilterByTkByCollection(
+      {
+        filterTargetKey: ['tenant', 'uuid'],
+      },
+      {
+        id: 1,
+        tenant: 't-1',
+        uuid: 'staff-uuid-001',
+      },
+    );
+
+    expect(filterByTk).toEqual({
+      tenant: 't-1',
+      uuid: 'staff-uuid-001',
+    });
+  });
+});

--- a/packages/core/client/src/data-source/__tests__/collection/CollectionManager.test.tsx
+++ b/packages/core/client/src/data-source/__tests__/collection/CollectionManager.test.tsx
@@ -311,6 +311,44 @@ describe('CollectionManager', () => {
         expect(result2).toBe('rolesName');
       });
 
+      it('should use target collection filterTargetKey for associations', () => {
+        const app = new Application({
+          dataSourceManager: {
+            collections: [
+              {
+                name: 'staff',
+                filterTargetKey: 'uuid',
+                fields: [
+                  { name: 'id', type: 'integer', interface: 'number', primaryKey: true },
+                  { name: 'uuid', type: 'string', interface: 'input' },
+                ],
+              },
+              {
+                name: 'orgs',
+                filterTargetKey: 'id',
+                fields: [
+                  { name: 'id', type: 'integer', interface: 'number', primaryKey: true },
+                  {
+                    name: 'staffs',
+                    type: 'belongsToMany',
+                    interface: 'm2m',
+                    target: 'staff',
+                    targetKey: 'id',
+                    sourceKey: 'id',
+                    foreignKey: 'orgId',
+                    otherKey: 'staffId',
+                  },
+                ],
+              },
+            ] as any,
+          },
+        });
+        const cm = app.getCollectionManager();
+
+        const result = cm.getFilterByTK('orgs.staffs', { id: 1, uuid: 'staff-uuid-001' });
+        expect(result).toBe('staff-uuid-001');
+      });
+
       it('should return undefined when collectionOrAssociation is not provided', () => {
         const result = collectionManager.getFilterByTK('', { id: 1 });
         expect(result).toBeUndefined();

--- a/packages/core/client/src/data-source/collection/CollectionManager.ts
+++ b/packages/core/client/src/data-source/collection/CollectionManager.ts
@@ -192,6 +192,10 @@ export class CollectionManager {
         );
         return;
       }
+      const targetCollection = this.getCollection(field.target);
+      if (targetCollection) {
+        return buildFilterByTk(targetCollection.getFilterTargetKey(), collectionRecordOrAssociationRecord);
+      }
       if (field.targetKey) {
         return collectionRecordOrAssociationRecord[field.targetKey];
       }

--- a/packages/core/client/src/variables/VariablesProvider.tsx
+++ b/packages/core/client/src/variables/VariablesProvider.tsx
@@ -49,6 +49,47 @@ const getFieldPath = (variablePath: string, variablesStore: Record<string, Varia
   };
 };
 
+const getAssociationSourceRecordKey = (associationField: CollectionFieldOptions_deprecated, collection) => {
+  if (associationField?.sourceKey) {
+    return associationField.sourceKey;
+  }
+
+  if (Array.isArray(collection?.filterTargetKey)) {
+    if (collection.filterTargetKey.length === 1) {
+      return collection.filterTargetKey[0];
+    }
+    return collection.filterTargetKey;
+  }
+
+  return collection?.filterTargetKey || collection?.getPrimaryKey?.() || 'id';
+};
+
+const getAssociationSourceId = (
+  record: Record<string, any>,
+  associationField: CollectionFieldOptions_deprecated,
+  collection,
+) => {
+  const sourceRecordKey = getAssociationSourceRecordKey(associationField, collection);
+
+  if (Array.isArray(sourceRecordKey)) {
+    const filterByTk = sourceRecordKey.reduce((result, key) => {
+      if (record?.[key] == null) {
+        return result;
+      }
+      result[key] = record[key];
+      return result;
+    }, {});
+
+    if (Object.keys(filterByTk).length !== sourceRecordKey.length) {
+      return;
+    }
+
+    return encodeURIComponent(JSON.stringify(filterByTk));
+  }
+
+  return record?.[sourceRecordKey];
+};
+
 /**
  * @internal
  * Note: There can only be one VariablesProvider in the entire context. It cannot be used in plugins.
@@ -121,18 +162,13 @@ const VariablesProvider = ({ children, filterVariables }: any) => {
         const currentVariablePath = list.slice(0, index + 1).join('.');
         const { fieldPath } = getFieldPath(currentVariablePath, _variableToCollectionName);
         const associationField: CollectionFieldOptions_deprecated = getCollectionJoinField(fieldPath, dataSource);
-        const collectionPrimaryKey = getCollection(collectionName, dataSource)?.getPrimaryKey();
+        const sourceCollection = getCollection(collectionName, dataSource);
         if (Array.isArray(current)) {
           const result = current.map((item) => {
-            if (
-              !options?.doNotRequest &&
-              shouldToRequest(item?.[key], item, currentVariablePath) &&
-              item?.[collectionPrimaryKey] != null
-            ) {
+            const sourceId = getAssociationSourceId(item, associationField, sourceCollection);
+            if (!options?.doNotRequest && shouldToRequest(item?.[key], item, currentVariablePath) && sourceId != null) {
               if (associationField?.target) {
-                const url = `/${collectionName}/${
-                  item[associationField.sourceKey || collectionPrimaryKey]
-                }/${key}:${getAction(associationField.type)}`;
+                const url = `/${collectionName}/${sourceId}/${key}:${getAction(associationField.type)}`;
                 if (hasRequested(url)) {
                   return getRequested(url);
                 }
@@ -159,12 +195,11 @@ const VariablesProvider = ({ children, filterVariables }: any) => {
         } else if (
           !options?.doNotRequest &&
           shouldToRequest(current[key], current, currentVariablePath) &&
-          current[collectionPrimaryKey] != null &&
+          getAssociationSourceId(current, associationField, sourceCollection) != null &&
           associationField?.target
         ) {
-          const url = `/${collectionName}/${
-            current[associationField.sourceKey || collectionPrimaryKey]
-          }/${key}:${getAction(associationField.type)}`;
+          const sourceId = getAssociationSourceId(current, associationField, sourceCollection);
+          const url = `/${collectionName}/${sourceId}/${key}:${getAction(associationField.type)}`;
           let data = null;
           if (hasRequested(url)) {
             data = await getRequested(url);

--- a/packages/core/client/src/variables/__tests__/useVariables.test.tsx
+++ b/packages/core/client/src/variables/__tests__/useVariables.test.tsx
@@ -71,8 +71,20 @@ vi.mock('../../collection-manager', async () => {
               target: 'test',
             };
           }
+          if (path === 'staff.belongsToField') {
+            return {
+              type: 'belongsTo',
+              target: 'test',
+            };
+          }
         },
-        getCollection: () => {
+        getCollection: (collectionName?: string) => {
+          if (collectionName === 'staff') {
+            return {
+              filterTargetKey: ['uuid'],
+              getPrimaryKey: () => 'id',
+            };
+          }
           return {
             getPrimaryKey: () => 'id',
           };
@@ -182,6 +194,18 @@ mockRequest.onGet('/someBelongsToField/0/belongsToField:get').reply(() => {
       data: {
         id: 0,
         name: '$some.belongsToField.belongsToField',
+      },
+    },
+  ];
+});
+
+mockRequest.onGet('/staff/staff-uuid-001/belongsToField:get').reply(() => {
+  return [
+    200,
+    {
+      data: {
+        id: 2,
+        name: '$staff.belongsToField',
       },
     },
   ];
@@ -973,6 +997,29 @@ describe('useVariables', () => {
         type: 'belongsTo',
         target: 'test',
       });
+    });
+  });
+
+  it('uses source collection filterTargetKey when lazy loading belongsTo variables', async () => {
+    const { result } = renderHook(() => useVariables(), {
+      wrapper: Providers,
+    });
+
+    await waitFor(async () => {
+      result.current.registerVariable({
+        name: '$staff',
+        ctx: {
+          id: 1,
+          uuid: 'staff-uuid-001',
+        },
+        collectionName: 'staff',
+      });
+    });
+
+    await waitFor(async () => {
+      expect(await result.current.parseVariable('{{ $staff.belongsToField.name }}').then(({ value }) => value)).toBe(
+        '$staff.belongsToField',
+      );
     });
   });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When popup pages resolve relation requests, the client could fall back to collection primary keys instead of the collection `filterTargetKey`. For collections configured with a non-primary unique key, this caused popup relation requests to send the wrong record identifier and trigger lookup errors such as `invalid input syntax for type uuid`.

### Description 
This PR fixes two v1 popup paths so they both respect the collection `filterTargetKey` before falling back to the primary key:

1. Popup record variables now use the source collection `filterTargetKey` when lazily loading `belongsTo` relations without an explicit `sourceKey`.
2. Popup relation blocks now derive association `filterByTk` from the target collection `filterTargetKey` instead of the association `targetKey`.

Regression tests cover both cases with collections whose primary key is `id` while the actual record identifier exposed to the popup is a non-primary unique key such as `uuid`.

Risk is low because the change only affects popup relation lookup fallback logic and preserves the existing behavior when association keys are explicitly configured.

Testing suggestions:
- Open a v1 popup page that uses popup record variables on a `belongsTo` field from a collection with a non-primary unique key
- Open a v1 popup relation block from a collection with a non-primary unique key and verify the popup URL / requests use the target collection `filterTargetKey`
- Run `yarn vitest packages/core/client/src/variables/__tests__/useVariables.test.tsx --run`
- Run `yarn vitest packages/core/client/src/data-source/__tests__/collection/CollectionManager.test.tsx --run`
- Run `yarn vitest packages/core/client/src/block-provider/__tests__/hooks/useFilterByTk.test.ts --run`

### Related issues


### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed popup relation blocks and popup record variables using the wrong record identifier when collections use a non-primary unique key |
| 🇨🇳 Chinese | 修复集合使用非主键唯一标识时，弹窗关联区块和弹窗记录变量使用了错误记录标识的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary