### PR TITLE
fix(acl): filter nested appends by read permission

### DIFF
--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -18,6 +18,7 @@ import { ACLRole, ResourceActionsOptions, RoleActionParams } from './acl-role';
 import { AllowManager, ConditionFunc } from './allow-manager';
 import { NoPermissionError } from './errors/no-permission-error';
 import FixedParamsManager, { Merger, GeneralMerger } from './fixed-params-manager';
+import { filterAppendsByAssociationReadPermission, isAllowedAppendPath } from './read-append-permissions';
 import SnippetManager, { SnippetOptions } from './snippet-manager';
 import { mergeAclActionParams, removeEmptyParams } from './utils';
 import Database from '@nocobase/database';
@@ -496,7 +497,7 @@ export class ACL extends EventEmitter {
 
             if (parsedParams.appends && resourcerAction.params.fields) {
               for (const queryField of resourcerAction.params.fields) {
-                if (parsedParams.appends.indexOf(queryField) !== -1) {
+                if (isAllowedAppendPath(queryField, parsedParams.appends)) {
                   // move field to appends
                   if (!resourcerAction.params.appends) {
                     resourcerAction.params.appends = [];
@@ -517,12 +518,22 @@ export class ACL extends EventEmitter {
                 if (!y) {
                   return x;
                 }
-                return (x as any[]).filter((i) => y.includes(i.split('.').shift()));
+                return (x as any[]).filter((i) => isAllowedAppendPath(i, y));
               },
             });
 
             if (isEmptyFields) {
               resourcerAction.params.fields = [];
+            }
+
+            if (resourcerAction.params.appends) {
+              resourcerAction.params.appends = filterAppendsByAssociationReadPermission({
+                ctx,
+                db,
+                resourceName,
+                actionName,
+                appends: resourcerAction.params.appends,
+              });
             }
 
             ctx.permission.mergedParams = lodash.cloneDeep(resourcerAction.params);

--- a/packages/core/acl/src/read-append-permissions.ts
+++ b/packages/core/acl/src/read-append-permissions.ts
@@ -1,0 +1,142 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import lodash from 'lodash';
+
+export function getAppendPaths(appends: any): string[] {
+  return lodash
+    .castArray(appends || [])
+    .flatMap((append) => (typeof append === 'string' ? append.split(',') : []))
+    .map((append) => append.trim())
+    .filter(Boolean);
+}
+
+export function isAllowedAppendPath(queryField: string, allowedAppends: any) {
+  if (typeof queryField !== 'string') {
+    return false;
+  }
+  const appendPaths = getAppendPaths(allowedAppends);
+  const queryRoot = queryField.split('.').shift();
+  return appendPaths.some((allowedAppend) => {
+    return allowedAppend === queryField || allowedAppend === queryRoot || queryField.startsWith(`${allowedAppend}.`);
+  });
+}
+
+function isRelationField(field: any) {
+  return field?.isRelationField?.() || field?.targetCollection;
+}
+
+function getPermittedAppendPaths(options: {
+  ctx: any;
+  collection: any;
+  actionName: string;
+  append: string;
+  prefix?: string;
+}) {
+  const { ctx, collection, actionName, append, prefix = '' } = options;
+  const [fieldName, ...rest] = append.split('.').map((segment) => segment.split('(').shift() || segment);
+  const field = collection?.getField?.(fieldName);
+
+  if (!field || !isRelationField(field)) {
+    return [];
+  }
+
+  const targetCollection = field.targetCollection?.();
+  if (!targetCollection) {
+    return [];
+  }
+
+  const fieldPath = prefix ? `${prefix}.${fieldName}` : fieldName;
+
+  // Attachment permissions are configured on the source field. The "attachments" table is a system target table
+  // and should not require standalone read permission for this field append.
+  if (field?.options?.interface === 'attachment' && targetCollection.name === 'attachments') {
+    return [fieldPath];
+  }
+
+  // Normal associations still need read permission on each target collection before nested appends are kept.
+  const permission = ctx.can?.({
+    resource: targetCollection.name,
+    action: actionName,
+  });
+
+  if (!permission) {
+    return [];
+  }
+
+  const targetParams = permission.params;
+  const isUnrestrictedRead =
+    !targetParams || (!lodash.has(targetParams || {}, 'fields') && !lodash.has(targetParams || {}, 'appends'));
+
+  if (!rest.length) {
+    if (isUnrestrictedRead) {
+      return [fieldPath];
+    }
+    return lodash
+      .castArray(targetParams?.fields)
+      .filter((allowedField) => {
+        const targetField = targetCollection?.getField?.(allowedField);
+        return targetField && !isRelationField(targetField);
+      })
+      .map((allowedField) => `${fieldPath}.${allowedField}`);
+  }
+
+  const nextPath = rest.join('.');
+  const nextFieldName = rest[0];
+  const nextField = targetCollection.getField?.(nextFieldName);
+
+  if (!nextField) {
+    return [];
+  }
+
+  if (!isRelationField(nextField)) {
+    return isUnrestrictedRead || lodash.castArray(targetParams?.fields).includes(nextFieldName)
+      ? [`${fieldPath}.${nextPath}`]
+      : [];
+  }
+
+  if (!isUnrestrictedRead && !isAllowedAppendPath(nextPath, targetParams?.appends)) {
+    return [];
+  }
+
+  return getPermittedAppendPaths({
+    ctx,
+    collection: targetCollection,
+    actionName,
+    append: nextPath,
+    prefix: fieldPath,
+  });
+}
+
+export function filterAppendsByAssociationReadPermission(options: {
+  ctx: any;
+  db: any;
+  resourceName: string;
+  actionName: string;
+  appends: any;
+}) {
+  const { ctx, db, resourceName, actionName, appends } = options;
+  const collection = db?.getCollection?.(resourceName);
+
+  if (!collection) {
+    return appends;
+  }
+
+  const appendPaths = getAppendPaths(appends);
+  const permittedAppends = appendPaths.flatMap((append) =>
+    getPermittedAppendPaths({
+      ctx,
+      collection,
+      actionName,
+      append,
+    }),
+  );
+
+  return lodash.uniq(permittedAppends);
+}

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/get-action.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/get-action.test.ts
@@ -14,12 +14,11 @@ describe('get action with acl', () => {
   let app: MockServer;
 
   let Post;
-
   let Comment;
   let userAgent;
 
-  beforeEach(async () => {
-    app = await prepareApp();
+  async function setupApp(options?: Parameters<typeof prepareApp>[0]) {
+    app = await prepareApp(options);
     const UserRepo = app.db.getCollection('users').repository;
     const users = await UserRepo.create({
       values: [{ nickname: 'a', roles: [{ name: 'test' }] }],
@@ -53,9 +52,29 @@ describe('get action with acl', () => {
     });
 
     await app.db.sync();
+  }
+
+  afterEach(async () => {
+    if (app) {
+      await app.destroy();
+    }
   });
 
+  function useCurrentRole(role = 'test') {
+    app.resourceManager.use(
+      (ctx, next) => {
+        ctx.state.currentRole = role;
+        return next();
+      },
+      {
+        before: 'acl',
+      },
+    );
+  }
+
   it('should get with fields', async () => {
+    await setupApp();
+
     const testRole = app.acl.define({
       role: 'test',
     });
@@ -77,15 +96,7 @@ describe('get action with acl', () => {
       ],
     });
 
-    app.resourceManager.use(
-      (ctx, next) => {
-        ctx.state.currentRole = 'test';
-        return next();
-      },
-      {
-        before: 'acl',
-      },
-    );
+    useCurrentRole();
 
     const response = await userAgent.resource('posts').get({
       filterByTk: p1.get('id'),
@@ -94,9 +105,142 @@ describe('get action with acl', () => {
 
     expect(response.status).toBe(200);
 
-    console.log(response.body);
     // expect only has comments
     expect(response.body.data.title).toBeUndefined();
     expect(response.body.data.comments).toBeDefined();
+  });
+
+  it('should keep nested many-to-many file table fields allowed by association target permissions for templates', async () => {
+    await setupApp({
+      plugins: ['file-manager'],
+    });
+
+    app.db.collection({
+      name: 'files',
+      template: 'file',
+      fields: [
+        {
+          type: 'string',
+          name: 'title',
+        },
+        {
+          type: 'text',
+          name: 'url',
+        },
+      ],
+    });
+
+    Comment.setField('files', {
+      type: 'belongsToMany',
+      target: 'files',
+      through: 'comments_files',
+    });
+
+    await app.db.sync();
+
+    const testRole = app.acl.define({
+      role: 'test',
+    });
+
+    testRole.grantAction('posts:view', {
+      fields: ['title', 'comments'],
+    });
+
+    testRole.grantAction('comments:view', {
+      fields: ['content', 'files'],
+    });
+
+    testRole.grantAction('files:view', {
+      fields: ['title'],
+    });
+
+    const [p1] = await Post.repository.create({
+      values: [
+        {
+          title: 'p1',
+          comments: [
+            {
+              content: 'c1',
+              files: [
+                {
+                  title: 'file1',
+                  url: 'https://example.com/file1.png',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    useCurrentRole();
+
+    const response = await userAgent.resource('posts').get({
+      filterByTk: p1.get('id'),
+      fields: ['comments', 'comments.files'],
+      isTemplate: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.comments[0].files[0].title).toBe('file1');
+    expect(response.body.data.comments[0].files[0].url).toBeUndefined();
+  });
+
+  it('should keep nested attachment fields allowed by attachment field permissions for templates', async () => {
+    await setupApp({
+      plugins: ['file-manager'],
+    });
+
+    Comment.setField('attachments', {
+      type: 'belongsToMany',
+      target: 'attachments',
+      through: 'comments_attachments',
+      interface: 'attachment',
+    });
+
+    await app.db.sync();
+
+    const testRole = app.acl.define({
+      role: 'test',
+    });
+
+    testRole.grantAction('posts:view', {
+      fields: ['title', 'comments'],
+    });
+
+    testRole.grantAction('comments:view', {
+      fields: ['content', 'attachments'],
+    });
+
+    const [p1] = await Post.repository.create({
+      values: [
+        {
+          title: 'p1',
+          comments: [
+            {
+              content: 'c1',
+              attachments: [
+                {
+                  title: 'file1',
+                  url: 'https://example.com/file1.png',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    useCurrentRole();
+
+    const response = await userAgent.resource('posts').get({
+      filterByTk: p1.get('id'),
+      fields: ['comments', 'comments.attachments'],
+      isTemplate: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.comments[0].attachments[0].title).toBe('file1');
+    expect(response.body.data.comments[0].attachments[0].url).toBe('https://example.com/file1.png');
   });
 });

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/prepare.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/prepare.ts
@@ -9,22 +9,25 @@
 
 import { createMockServer, MockServer } from '@nocobase/test';
 
-export async function prepareApp(): Promise<MockServer> {
+export async function prepareApp(options?: { plugins?: string[] }): Promise<MockServer> {
+  const plugins = [
+    'acl',
+    'error-handler',
+    'field-sort',
+    'users',
+    'ui-schema-storage',
+    'data-source-main',
+    'auth',
+    'data-source-manager',
+    'collection-tree',
+    ...(options?.plugins || []),
+    'system-settings',
+  ];
+
   const app = await createMockServer({
     registerActions: true,
     acl: true,
-    plugins: [
-      'acl',
-      'error-handler',
-      'field-sort',
-      'users',
-      'ui-schema-storage',
-      'data-source-main',
-      'auth',
-      'data-source-manager',
-      'collection-tree',
-      'system-settings',
-    ],
+    plugins,
     logger: {
       system: {
         level: 'debug',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When template reads request nested association appends, ACL only matched root-level append paths. This could drop nested attachment data and also missed recursive read-permission checks on target collections.

### Description 
- Allow nested append paths to match permitted root association appends during ACL parameter merge
- Recursively filter nested appends by target collection read permissions
- Keep attachment field appends available when permission is granted on the source attachment field instead of requiring standalone `attachments:view`
- Extract the append read-permission logic from `acl.ts` into a dedicated helper for easier review
- Add regression tests for both a normal many-to-many file table and a real attachment field with `file-manager`

Potential risk:
- Read-side append filtering is now stricter for nested associations, so cases that relied on missing target read checks may stop returning nested data

Testing suggestions:
- Verify template get requests with nested association fields still return allowed nested data
- Verify nested associations do not expose fields from target collections without read permission
- Verify attachment fields continue to work when only the source field permission is granted

### Related issues
- task-2858

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed ACL filtering for nested association appends and attachment fields in template reads |
| 🇨🇳 Chinese | 修复模板读取时嵌套关联追加字段和附件字段的 ACL 过滤问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
