### PR TITLE
fix(flow-engine): preserve IME composition in v2 FieldModelRenderer (Korean/CJK input)

### DIFF
--- a/packages/core/flow-engine/src/components/FieldModelRenderer.tsx
+++ b/packages/core/flow-engine/src/components/FieldModelRenderer.tsx
@@ -9,7 +9,7 @@
 
 import { FlowModelRenderer, FlowModelRendererProps } from '@nocobase/flow-engine';
 import _ from 'lodash';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect } from 'react';
 
 const flowModelRendererPropKeys: (keyof FlowModelRendererProps)[] = [
   'model',
@@ -28,8 +28,19 @@ const flowModelRendererPropKeys: (keyof FlowModelRendererProps)[] = [
 
 export function FieldModelRenderer(props: any) {
   const { model, ...rest } = props;
-  const composingRef = useRef(false);
 
+  // IME (Korean / Chinese / Japanese) composition handling:
+  // - Do not branch on composition state. rc-input already tracks its own
+  //   composition ref internally and handles composition-specific concerns
+  //   (e.g. skipping max-length truncation while composing).
+  // - Important: invoke `props.onChange(val)` on every change event, including
+  //   during composition. If form state stays stale while the DOM is composing,
+  //   React's controlled-input updateWrapper overwrites the DOM with the stale
+  //   `props.value` on the next commit (it runs `node.value = props.value`
+  //   whenever `node.value !== props.value`), which cancels the in-progress
+  //   IME composition and turns syllables into separate jamo. Formily v1's
+  //   Input forwards onChange on every keystroke the same way and works with
+  //   Korean / Chinese / Japanese input correctly.
   const handleChange = (e: any) => {
     let val;
     if (e && e.target && typeof e.target.value !== 'undefined') {
@@ -46,24 +57,10 @@ export function FieldModelRenderer(props: any) {
     }
 
     model.setProps({ value: val });
-    if (!composingRef.current) {
-      props.onChange?.(val);
-    }
-  };
-  const handleCompositionStart = () => {
-    composingRef.current = true;
-  };
-
-  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>, flag = true) => {
-    composingRef.current = false;
-    if (flag) {
-      props.onChange(e);
-    }
+    props.onChange?.(val);
   };
 
   const modelProps = {
-    onCompositionStart: handleCompositionStart,
-    onCompositionEnd: handleCompositionEnd,
     ..._.omit(rest, flowModelRendererPropKeys),
     onChange: handleChange,
   };


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Korean IME input (Hangul composition) is broken in Modern Page (v2) single line text fields. When typing Korean characters, the composition gets cancelled mid-syllable and individual jamo are committed as separate characters instead of composed syllables.

Example: typing **김성훈** in a v2 input produces **김ㅅㅓㅇ훈**. The first syllable usually works, but subsequent syllables — especially those following a character with 받침 (final consonant) — fragment.

The same input flow works correctly in Classic Page (v1) because Formily v1's Input always forwards `onChange` on every keystroke, keeping `props.value` in sync with `DOM.value`.

Other CJK IMEs (Chinese / Japanese) are almost certainly affected by the same root cause.

#### Root cause

`FieldModelRenderer.tsx` in `@nocobase/flow-engine` blocks `props.onChange` while `composingRef.current` is true:

```tsx
// before
model.setProps({ value: val });
if (!composingRef.current) {
  props.onChange?.(val);  // ← blocked during composition
}
```

Blocking form `onChange` during composition keeps the form state stale while the DOM advances through composition. On the next React commit, React's controlled-input `updateWrapper` (react-dom) runs:

```js
// react-dom/cjs/react-dom.development.js (L1836)
} else if (node.value !== toString(value)) {
  node.value = toString(value);
}
```

`updateWrapper` is called on **every** input commit, not only when the `value` prop changed (see the input branch in `commitUpdate`). When `props.value` is the stale committed value (e.g. `'김'`) but the DOM is mid-composition (e.g. `'김ㅅ'`), React writes `node.value = '김'`, which cancels the browser's in-progress IME composition. The user's next jamo then starts a brand-new `compositionstart`, and the IME commits the previous jamo as a raw character.

### Description

Match Formily v1's behavior: forward `onChange` on every change event regardless of composition state. `rc-input`'s internal `compositionRef` already handles composition-specific concerns (e.g. skipping max-length truncation during composition), so no explicit `onCompositionStart` / `onCompositionEnd` handling is needed in `FieldModelRenderer`.

The change is minimal:

```tsx
// after
model.setProps({ value: val });
props.onChange?.(val);
```

and the `composingRef`, `handleCompositionStart`, `handleCompositionEnd`, and their entries in `modelProps` are removed.

With this change, `props.value` stays in sync with `DOM.value` on every keystroke. React's `updateWrapper` then sees `node.value === toString(props.value)` and leaves the DOM alone, allowing the browser's IME to complete composition naturally.

**Potential risks / testing notes**

- Form `onChange` now fires on every composition keystroke. This matches Formily v1 behavior and is what every other CJK-safe React input does; we don't expect regressions for non-CJK input or non-text field types. Validation / form-value change listeners that previously fired only at `compositionEnd` will now fire on each keystroke — the same as in v1.
- Non-text field types (number, select, date, checkbox, association, ...) go through the same `FieldModelRenderer` but don't involve text composition, so their behavior is unchanged (they receive primitive values from their components' `onChange`, exactly as before).
- `rc-input`'s internal `compositionRef` and `source: 'compositionEnd'` early-return in `triggerChange` (rc-input `Input.js`) continue to prevent double-commits; our handler is simply a pass-through.

### Related issues

(none filed yet — happy to open one if preferred.)

### Showcase

Diagnostic logs captured while typing `김성훈` with the bug (before fix), confirming composition was cancelled after every jamo because the DOM kept getting reset to the stale form value:

```
compositionStart targetValue='', modelValue='', restValue=''
onChange val='ㄱ', composing=true, nativeIsComposing=true
compositionStart targetValue='', modelValue='', restValue=''   ← DOM reset to '' between keystrokes
onChange val='기', composing=true, ...
compositionStart targetValue='', ...
onChange val='김', composing=true, ...
compositionStart targetValue='', ...
onChange val='ㅅ', ...
...
```

After the fix, typing `김성훈`, `한글`, `인광이에스` in Modern Page (v2) single line text fields all produce the correctly composed Korean text.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: IME composition (Korean / Chinese / Japanese) in Modern Page (v2) single line text fields no longer fragments into separate jamo / characters. |
| 🇨🇳 Chinese | 修复：新版页面 (v2) 单行文本字段中的输入法（中文 / 日语 / 韩语）组合输入不再被中断为单独的字符。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | n/a (internal behavior fix, no user-facing docs change needed) |
| 🇨🇳 Chinese | n/a |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed (reproduction is IME-driven and requires a real browser + OS-level IME; automated test would need IME simulation beyond the scope of unit tests)
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary