### PR TITLE
fix(acl-role): prevent crash when snippet is undefined

### DIFF
--- a/packages/core/acl/src/acl-role.ts
+++ b/packages/core/acl/src/acl-role.ts
@@ -150,7 +150,7 @@ export class ACLRole {
     const effectiveSnippets = this.effectiveSnippets();
 
     const getActions = (snippets) => {
-      return snippets.map((snippetName) => this.acl.snippetManager.snippets.get(snippetName).actions).flat();
+      return snippets.map((snippetName) => this.acl.snippetManager.snippets.get(snippetName)?.actions ?? []).flat();
     };
 
     const allowedActions = getActions(effectiveSnippets.allowed);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Prevent potential runtime errors when a snippet name does not exist in the snippet manager.

In `ACLRole.snippetAllowed`, the code accesses `.actions` directly on the result of:


this.acl.snippetManager.snippets.get(snippetName)


If the snippet is undefined, this leads to a runtime crash.

### Description

* Added optional chaining when accessing `actions` from snippet manager
* Added fallback to an empty array when snippet is not found
* Ensures safe handling of missing or invalid snippet names
* No changes to existing behavior for valid snippets

### Potential risk

* Very low risk, as the change only adds a defensive fallback without modifying existing logic

### Testing suggestions

* Call `snippetAllowed` with valid snippet names → behavior unchanged
* Call `snippetAllowed` with a missing snippet → no crash, safe fallback

### Related issues

* N/A

### Showcase

* N/A (defensive bug fix)

### Changelog

| Language | Changelog |
|----------|-----------|
| 🇺🇸 English | Prevent crash when snippet is undefined in acl-role |
| 🇨🇳 Chinese | 修复 acl-role 中 snippet 未定义导致的崩溃 |

### Docs

| Language | Link |
|----------|------|
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists

* [x] All changes have been self-tested and work as expected
* [x] Test cases are updated/provided or not needed
* [x] Doc is updated/provided or not needed
* [x] Component demo is updated/provided or not needed
* [x] Changelog is provided or not needed
* [ ] Request a code review if it is necessary