### PR TITLE
fix: not show actions to global

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/models/actions/CalendarActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/models/actions/CalendarActionModels.tsx
@@ -155,7 +155,7 @@ CalendarCollectionActionGroupModel.defineChildren = async function defineChildre
 };
 
 export class CalendarTodayActionModel extends ActionModel {
-  static scene = 'collection' as const;
+  // static scene = 'collection' as const;
 
   defaultProps = {
     type: 'default' as const,
@@ -174,7 +174,7 @@ CalendarTodayActionModel.define({
 });
 
 export class CalendarNavActionModel extends ActionModel {
-  static scene = 'collection' as const;
+  // static scene = 'collection' as const;
 
   enableEditTooltip = false;
   enableEditTitle = false;
@@ -194,7 +194,7 @@ CalendarNavActionModel.define({
 });
 
 export class CalendarTitleActionModel extends ActionModel {
-  static scene = 'collection' as const;
+  // static scene = 'collection' as const;
 
   enableEditTooltip = false;
   enableEditTitle = false;
@@ -214,7 +214,7 @@ CalendarTitleActionModel.define({
 });
 
 export class CalendarViewSelectActionModel extends ActionModel {
-  static scene = 'collection' as const;
+  // static scene = 'collection' as const;
 
   enableEditTooltip = false;
   enableEditTitle = false;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->
not register calendar actions to other blocks

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     not register calendar actions to other blocks      |
| 🇨🇳 Chinese |     不将日历操作注册到其他块      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
