### PR TITLE
fix(data-source-manager): allow clearing sort scope key

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/data-sources.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/data-sources.test.ts
@@ -612,6 +612,44 @@ describe('data source', async () => {
       expect(field.options.title).toBe('标题 Field');
     });
 
+    it('should clear scopeKey from external data source sort field', async () => {
+      const createResp = await app
+        .agent()
+        .resource('dataSourcesCollections.fields', 'mockInstance1.posts')
+        .create({
+          values: {
+            type: 'sort',
+            name: 'sort',
+            title: 'Sort field',
+            scopeKey: 'title',
+          },
+        });
+
+      expect(createResp.status).toBe(200);
+
+      const dataSource = app.dataSourceManager.dataSources.get('mockInstance1');
+      const collection = dataSource.collectionManager.getCollection('posts');
+      expect(collection.getField('sort').options.scopeKey).toBe('title');
+
+      const fieldUpdateResp = await app
+        .agent()
+        .resource('dataSourcesCollections.fields', 'mockInstance1.posts')
+        .update({
+          filterByTk: 'sort',
+          values: {
+            type: 'sort',
+            title: null,
+            scopeKey: null,
+          },
+        });
+
+      expect(fieldUpdateResp.status).toBe(200);
+      expect(fieldUpdateResp.body.data.scopeKey).toBeNull();
+      expect(fieldUpdateResp.body.data.title).toBe('Sort field');
+      expect(collection.getField('sort').options.scopeKey).toBeNull();
+      expect(collection.getField('sort').options.title).toBe('Sort field');
+    });
+
     it('should update fields through collection', async () => {
       const dataSource = app.dataSourceManager.dataSources.get('mockInstance1');
       const collection = dataSource.collectionManager.getCollection('posts');

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/server/utils.ts
@@ -11,14 +11,20 @@ import { DataSourceModel } from './models/data-source';
 import { Application } from '@nocobase/server';
 import PluginDataSourceManagerServer from './plugin';
 
+const nullableOverrideConfig: Record<string, string[]> = {
+  sort: ['scopeKey'],
+};
+
 export function mergeOptions(fieldOptions, modelOptions) {
   const newOptions = {
     ...fieldOptions,
     ...modelOptions,
   };
+  const fieldType = modelOptions.type || fieldOptions.type;
+  const nullableOverrideKeys = nullableOverrideConfig[fieldType] || [];
 
   for (const key of Object.keys(modelOptions)) {
-    if (modelOptions[key] === null && fieldOptions[key]) {
+    if (modelOptions[key] === null && fieldOptions[key] && !nullableOverrideKeys.includes(key)) {
       newOptions[key] = fieldOptions[key];
     }
   }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When clearing grouped sorting for sort fields in external data sources, the request already sends `scopeKey: null`, but the server-side merge logic restores the previous value. As a result, the grouped sorting setting cannot actually be cleared.

### Description 
This PR updates external data source field option merging so nullable overrides are controlled by a type-based config map. For sort fields, `scopeKey` is allowed to remain `null`, which makes clearing grouped sorting work as expected while keeping the previous fallback behavior for other nullable field options.

A regression test was added to cover clearing grouped sorting on an external data source sort field and to verify other nullable values still keep their previous values.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where grouped sorting on external data source sort fields could not be cleared |
| 🇨🇳 Chinese | 修复外部数据源排序字段的分组排序无法清空的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
