### PR TITLE
fix(database): validate number string precision

### DIFF
--- a/packages/core/database/src/__tests__/repository/validation.test.ts
+++ b/packages/core/database/src/__tests__/repository/validation.test.ts
@@ -148,6 +148,36 @@ describe('validation', () => {
 
       expect(result.get('amount')).toBeCloseTo(1.23, 10);
     });
+
+    it('should succeed when precision is within limit with string input', async () => {
+      const result = await NumberCollection.repository.create({
+        values: {
+          amount: '1.23',
+        },
+      });
+
+      expect(result.get('amount')).toBeCloseTo(1.23, 10);
+    });
+
+    it('should succeed when zero string input keeps fixed decimal places within precision limit', async () => {
+      const result = await NumberCollection.repository.create({
+        values: {
+          amount: '0.00',
+        },
+      });
+
+      expect(result.get('amount')).toBeCloseTo(0, 10);
+    });
+
+    it('should throw validation error when string input has trailing decimals beyond precision limit', async () => {
+      await expect(
+        NumberCollection.repository.create({
+          values: {
+            amount: '1.230',
+          },
+        }),
+      ).rejects.toThrow();
+    });
   });
 
   describe('date field validation', () => {

--- a/packages/core/database/src/utils/field-validation.ts
+++ b/packages/core/database/src/utils/field-validation.ts
@@ -11,6 +11,22 @@ import Joi, { AnySchema } from 'joi';
 import { ValidationOptions } from '../fields';
 import _ from 'lodash';
 
+function getFractionLength(value: string) {
+  const normalized = value.trim().replace(/,/g, '');
+  if (!normalized || /e/i.test(normalized)) {
+    return 0;
+  }
+
+  const unsignedValue = normalized.startsWith('+') || normalized.startsWith('-') ? normalized.slice(1) : normalized;
+  const dotIndex = unsignedValue.indexOf('.');
+
+  if (dotIndex < 0) {
+    return 0;
+  }
+
+  return unsignedValue.slice(dotIndex + 1).length;
+}
+
 export function buildJoiSchema(validation: ValidationOptions, options: { label?: string; value: string }): AnySchema {
   const { type, rules } = validation;
   const { label, value } = options;
@@ -34,8 +50,24 @@ export function buildJoiSchema(validation: ValidationOptions, options: { label?:
     rules.forEach((rule) => {
       const args = _.cloneDeep(rule.args);
       if (rule.name === 'precision') {
-        // Keep precision validation strict even when convert is enabled at validate-time.
-        schema = schema.strict();
+        const limit = Number(args?.limit);
+        schema = schema.custom((currentValue, helpers) => {
+          if (Number.isNaN(limit)) {
+            return currentValue;
+          }
+
+          const originalValue = helpers.original;
+          if (originalValue === null || originalValue === undefined || originalValue === '') {
+            return currentValue;
+          }
+
+          if (getFractionLength(String(originalValue)) > limit) {
+            return helpers.error('number.precision', { limit });
+          }
+
+          return currentValue;
+        });
+        return;
       }
       if (!_.isEmpty(args)) {
         if (rule.name === 'pattern' && !_.isRegExp(args.regex)) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Decimal and number fields can submit numeric values as strings when using string-mode input components. With precision validation enabled, valid decimal strings such as `1.23` and `0.00` were rejected as not being numbers.

### Description 
This PR updates number precision validation to accept numeric strings while still validating the original decimal places. Values exceeding the configured precision continue to be rejected.

Testing performed:
- `yarn test packages/core/database/src/__tests__/repository/validation.test.ts`

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where decimal fields with validation could reject valid numeric input |
| 🇨🇳 Chinese | 修复 decimal 字段设置验证规则后可能拒绝有效数字输入的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary