### PR TITLE
fix(users): reload edit profile form data for configured fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client/EditProfile.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client/EditProfile.tsx
@@ -74,7 +74,9 @@ const useUpdateProfileActionProps = () => {
 const useEditProfileFormBlockDecoratorProps = () => {
   const { data } = useCurrentUserContext() || {};
   return {
-    record: data?.data,
+    params: {
+      filterByTk: data?.data?.id,
+    },
   };
 };
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When fields are added to the edit profile form through form configuration, the drawer could reuse the cached current user record instead of loading the latest form data.

### Description 
- Reload the edit profile form record by current user id instead of directly using the cached current user record
- This keeps dynamically configured fields consistent with the form schema request, including association fields such as main department
- Risk is low and limited to the edit profile drawer data loading path

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed dynamically configured fields in Edit profile not loading the latest user data |
| 🇨🇳 Chinese | 修复个人资料编辑中动态配置字段未加载最新用户数据的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
