### PR TITLE
fix(flow): keep popup selector filter fields after reopening

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormBlockModel.tsx
@@ -101,15 +101,17 @@ export class FilterFormBlockModel extends FilterBlockModel<{
     // 首次进入页面：等待子模型 beforeRender 完成（例如 name 初始化），再应用表单级默认值并触发筛选
     void this.applyDefaultsAndInitialFilter();
 
-    // 监听页面区块删除，自动清理已失效的筛选字段
+    // 监听页面区块删除，自动清理已失效的筛选字段。
+    // 这里使用 onSubModelDestroyed 而不是 onSubModelRemoved，避免弹窗关闭时
+    // 的临时模型卸载被误判成“用户删除了目标区块”。
     const blockGridModel = this.context.blockGridModel;
     if (blockGridModel?.emitter) {
       const handleTargetRemoved = (model) => {
         if (!model?.uid || model.uid === this.uid) return;
         this.handleTargetBlockRemoved(model.uid);
       };
-      blockGridModel.emitter.on('onSubModelRemoved', handleTargetRemoved);
-      this.removeTargetBlockListener = () => blockGridModel.emitter.off('onSubModelRemoved', handleTargetRemoved);
+      blockGridModel.emitter.on('onSubModelDestroyed', handleTargetRemoved);
+      this.removeTargetBlockListener = () => blockGridModel.emitter.off('onSubModelDestroyed', handleTargetRemoved);
     }
   }
 

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormBlockModel.cleanup.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormBlockModel.cleanup.test.ts
@@ -1,0 +1,135 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import '@nocobase/client';
+import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import { TableBlockModel } from '../../table/TableBlockModel';
+import { FilterFormBlockModel } from '../FilterFormBlockModel';
+import { FilterFormGridModel } from '../FilterFormGridModel';
+import { FilterFormItemModel } from '../FilterFormItemModel';
+
+describe('FilterFormBlockModel cleanup', () => {
+  function createFilterFormSetup() {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      FlowModel,
+      TableBlockModel,
+      FilterFormBlockModel,
+      FilterFormGridModel,
+      FilterFormItemModel,
+    });
+
+    const blockGridModel = engine.createModel<FlowModel>({
+      uid: 'block-grid',
+      use: 'FlowModel',
+      subModels: {
+        items: [],
+      },
+    } as any);
+
+    const tableBlock = blockGridModel.addSubModel('items', {
+      uid: 'target-table',
+      use: 'TableBlockModel',
+    }) as TableBlockModel;
+
+    const filterForm = blockGridModel.addSubModel('items', {
+      uid: 'filter-form',
+      use: 'FilterFormBlockModel',
+      subModels: {
+        grid: {
+          uid: 'filter-grid',
+          use: 'FilterFormGridModel',
+          subModels: {
+            items: [],
+          },
+        },
+      },
+    }) as FilterFormBlockModel;
+
+    const filterItem = filterForm.subModels.grid.addSubModel('items', {
+      uid: 'filter-item',
+      use: 'FilterFormItemModel',
+      stepParams: {
+        filterFormItemSettings: {
+          init: {
+            defaultTargetUid: tableBlock.uid,
+          },
+        },
+      },
+    }) as FilterFormItemModel;
+
+    const removeFilterConfig = vi.fn(async () => {});
+    const saveConnectFieldsConfig = vi.fn(async () => {});
+    const getConnectFieldsConfig = vi.fn(() => ({
+      targets: [
+        {
+          targetId: tableBlock.uid,
+          filterPaths: ['name'],
+        },
+      ],
+    }));
+
+    filterForm.context.defineProperty('blockGridModel', { value: blockGridModel });
+    filterForm.context.defineProperty('filterManager', {
+      value: {
+        removeFilterConfig,
+        saveConnectFieldsConfig,
+        getConnectFieldsConfig,
+      },
+    });
+    filterForm.subModels.grid.context.defineProperty('filterManager', {
+      value: {
+        removeFilterConfig,
+        saveConnectFieldsConfig,
+        getConnectFieldsConfig,
+      },
+    });
+
+    const destroySpy = vi.spyOn(filterItem, 'destroy').mockResolvedValue(true as any);
+    vi.spyOn(filterForm as any, 'applyDefaultsAndInitialFilter').mockResolvedValue(undefined);
+
+    (filterForm as any).onMount();
+
+    return {
+      engine,
+      blockGridModel,
+      tableBlock,
+      filterForm,
+      filterItem,
+      removeFilterConfig,
+      saveConnectFieldsConfig,
+      getConnectFieldsConfig,
+      destroySpy,
+    };
+  }
+
+  it('does not remove filter items when target block is only removed during popup teardown', async () => {
+    const { engine, blockGridModel, tableBlock, filterForm, removeFilterConfig, destroySpy } = createFilterFormSetup();
+
+    await Promise.resolve(engine.removeModelWithSubModels(blockGridModel.uid));
+
+    expect(removeFilterConfig).not.toHaveBeenCalled();
+    expect(destroySpy).not.toHaveBeenCalled();
+
+    (filterForm as any).onUnmount();
+    expect(engine.getModel(tableBlock.uid)).toBeUndefined();
+  });
+
+  it('removes filter items when target block is actually destroyed', async () => {
+    const { tableBlock, filterForm, removeFilterConfig, destroySpy } = createFilterFormSetup();
+
+    await tableBlock.destroy();
+
+    expect(removeFilterConfig).toHaveBeenCalledWith({ filterId: 'filter-item' });
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+
+    (filterForm as any).onUnmount();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
关系字段使用 Popup select 时，`Select record` 弹窗关闭会触发临时模型卸载。筛选表单把这次卸载误判成目标区块被删除，导致已配置的筛选字段被自动清理，重新打开弹窗后字段消失。

### Description 
- 将筛选表单的目标区块监听从 `onSubModelRemoved` 改为 `onSubModelDestroyed`，只在真实删除区块时清理筛选字段配置
- 新增回归测试，覆盖“弹窗关闭的临时卸载不应清理字段”和“真实删除目标区块仍应清理字段”两种场景
- 已执行 `yarn test:client packages/core/client/src/flow/models/blocks/filter-form`，并在连接 `main.v2` API 的本地浏览器环境中回归，关闭并重新打开 `org_m2o` 的 `Select record` 弹窗后，筛选表单字段仍然保留

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where filter form fields disappear after reopening a popup record selector |
| 🇨🇳 Chinese | 修复关系字段弹窗选择页面中筛选表单字段会消失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
