### PR TITLE
fix(client): avoid page popup reopen race

### DIFF
--- a/packages/core/client/src/schema-component/antd/page/PagePopups.tsx
+++ b/packages/core/client/src/schema-component/antd/page/PagePopups.tsx
@@ -29,7 +29,7 @@ import {
   getStoredPopupContext,
   usePopupUtils,
 } from './pagePopupUtils';
-import { removePopupLayerState } from './popupState';
+import { clearPopupLayerCloseTimer, removePopupLayerState, setPopupLayerCloseTimer } from './popupState';
 import {
   PopupContext,
   getPopupContextFromActionOrAssociationFieldSchema,
@@ -86,6 +86,13 @@ PopupVisibleProvider.displayName = 'PopupVisibleProvider';
 const VisibleProvider: FC<{ popupuid: string }> = React.memo(({ children, popupuid }) => {
   const { closePopup } = usePopupUtils();
   const [visible, _setVisible] = useState(true);
+  const { currentLevel = 0, params } = useCurrentPopupContext() || {};
+
+  useEffect(() => {
+    clearPopupLayerCloseTimer(currentLevel);
+    _setVisible(true);
+  }, [currentLevel, params?.collection, params?.filterbytk, params?.puid, params?.sourceid, params?.tab, popupuid]);
+
   const setVisible = useCallback(
     (visible: boolean) => {
       if (!visible) {
@@ -101,14 +108,17 @@ const VisibleProvider: FC<{ popupuid: string }> = React.memo(({ children, popupu
         }
 
         // Leave some time to refresh the block data
-        setTimeout(() => {
+        const timer = setTimeout(() => {
           closePopup();
           // Deleting here ensures that the next time the same popup is opened, it will generate another random key.
           deleteRandomNestedSchemaKey(popupuid);
         }, 300);
+        clearPopupLayerCloseTimer(currentLevel);
+        // 记录当前层级的延迟关闭定时器，便于下一次快速点击时取消旧关闭动作。
+        setPopupLayerCloseTimer(currentLevel, timer);
       }
     },
-    [closePopup, popupuid],
+    [closePopup, currentLevel, popupuid],
   );
 
   return (

--- a/packages/core/client/src/schema-component/antd/page/__tests__/pagePopupUtils.test.ts
+++ b/packages/core/client/src/schema-component/antd/page/__tests__/pagePopupUtils.test.ts
@@ -7,8 +7,16 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { getPopupParamsFromPath, getPopupPathFromParams, removeLastPopupPath } from '../pagePopupUtils';
+import {
+  clearPopupLayerCloseTimer,
+  getPopupLayerState,
+  hasPopupLayerCloseTimer,
+  removePopupLayerState,
+  setPopupLayerCloseTimer,
+  setPopupLayerState,
+} from '../popupState';
 
 describe('getPopupParamsFromPath', () => {
   it('should parse the path and return the popup parameters', () => {
@@ -129,5 +137,47 @@ describe('removeLastPopupPath', () => {
     const result = removeLastPopupPath(path);
 
     expect(result).toBe('');
+  });
+});
+
+describe('popupState close timers', () => {
+  it('should clear pending close timer when removing popup layer state', () => {
+    vi.useFakeTimers();
+
+    const timer = setTimeout(() => undefined, 300);
+    setPopupLayerState(1, true);
+    setPopupLayerCloseTimer(1, timer);
+
+    expect(getPopupLayerState(1)).toBe(true);
+    expect(hasPopupLayerCloseTimer(1)).toBe(true);
+
+    removePopupLayerState(1);
+
+    expect(getPopupLayerState(1)).toBe(false);
+    expect(hasPopupLayerCloseTimer(1)).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it('should replace previous close timer for the same layer', () => {
+    vi.useFakeTimers();
+
+    const firstTimer = setTimeout(() => {
+      throw new Error('first timer should be cleared');
+    }, 300);
+    const secondSpy = vi.fn();
+    const secondTimer = setTimeout(secondSpy, 300);
+
+    setPopupLayerCloseTimer(1, firstTimer);
+    setPopupLayerCloseTimer(1, secondTimer);
+
+    expect(hasPopupLayerCloseTimer(1)).toBe(true);
+
+    vi.advanceTimersByTime(300);
+
+    expect(secondSpy).toHaveBeenCalledTimes(1);
+
+    clearPopupLayerCloseTimer(1);
+    vi.useRealTimers();
   });
 });

--- a/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
+++ b/packages/core/client/src/schema-component/antd/page/pagePopupUtils.tsx
@@ -26,7 +26,14 @@ import {
 import { ActionContext } from '../action/context';
 import { PopupVisibleProviderContext, useCurrentPopupContext } from './PagePopups';
 import { usePopupSettings } from './PopupSettingsProvider';
-import { getPopupLayerState, removePopupLayerState, setPopupLayerState } from './popupState';
+import { deleteRandomNestedSchemaKey } from './nestedSchemaKeyStorage';
+import {
+  clearPopupLayerCloseTimer,
+  getPopupLayerState,
+  hasPopupLayerCloseTimer,
+  removePopupLayerState,
+  setPopupLayerState,
+} from './popupState';
 import { PopupContext, usePopupContextInActionOrAssociationField } from './usePopupContextInActionOrAssociationField';
 export interface PopupParams {
   /** popup uid */
@@ -271,10 +278,23 @@ export const usePopupUtils = (
       if (schema.properties) {
         const nextLevel = currentLevel + 1;
 
+        // 如果上一轮关闭动画仍在延迟阶段，先取消旧关闭任务，避免把新打开的同层弹窗一并关闭。
+        if (hasPopupLayerCloseTimer(nextLevel)) {
+          clearPopupLayerCloseTimer(nextLevel);
+        }
+
         // Prevent route confusion caused by repeated clicks
         if (getPopupLayerState(nextLevel)) {
-          closePopup(); // 已经打开过的弹窗，再次调用 openPopup 时，直接关闭当前弹窗。防止出现点击按钮没反应的问题
+          closePopup(); // 已经打开过的弹窗，再次调用 openPopup 时，先关闭当前弹窗，再立即重开当前点击目标。
           removePopupLayerState(nextLevel);
+          // 同层重开时强制生成新的嵌套 schema key，避免复用上一次已经隐藏的弹窗实例。
+          deleteRandomNestedSchemaKey(currentPopupUidWithoutOpened);
+          let nextBaseUrl = location.pathname;
+          if (_.last(nextBaseUrl) === '/') {
+            nextBaseUrl = nextBaseUrl.slice(0, -1);
+          }
+          navigate(withSearchParams(`${nextBaseUrl}${pathname}`), { replace: true });
+          setPopupLayerState(nextLevel, true);
           return;
         }
         setPopupLayerState(nextLevel, true);
@@ -288,6 +308,7 @@ export const usePopupUtils = (
     [
       association,
       cm,
+      closePopup,
       collection,
       dataSourceKey,
       fieldSchema,
@@ -301,8 +322,10 @@ export const usePopupUtils = (
       getSourceId,
       getNewPopupContext,
       blockData,
+      setVisibleFromAction,
       tableBlockContextBasicValue,
       currentLevel,
+      updatePopupContext,
     ],
   );
 

--- a/packages/core/client/src/schema-component/antd/page/popupState.ts
+++ b/packages/core/client/src/schema-component/antd/page/popupState.ts
@@ -13,6 +13,7 @@
  * level 2 is a popup opened from within the first popup, and so on.
  */
 const popupLayerStates: Record<string | number, boolean> = {};
+const popupLayerCloseTimers: Record<string | number, ReturnType<typeof setTimeout> | undefined> = {};
 
 /**
  * Sets the visibility state of a popup at the specified level
@@ -21,6 +22,26 @@ const popupLayerStates: Record<string | number, boolean> = {};
  */
 export const setPopupLayerState = (layerLevel: number, isOpen: boolean) => {
   popupLayerStates[layerLevel] = isOpen;
+};
+
+export const setPopupLayerCloseTimer = (layerLevel: number, timer: ReturnType<typeof setTimeout>) => {
+  const currentTimer = popupLayerCloseTimers[layerLevel];
+  if (currentTimer) {
+    clearTimeout(currentTimer);
+  }
+  popupLayerCloseTimers[layerLevel] = timer;
+};
+
+export const clearPopupLayerCloseTimer = (layerLevel: number) => {
+  const timer = popupLayerCloseTimers[layerLevel];
+  if (timer) {
+    clearTimeout(timer);
+  }
+  delete popupLayerCloseTimers[layerLevel];
+};
+
+export const hasPopupLayerCloseTimer = (layerLevel: number) => {
+  return !!popupLayerCloseTimers[layerLevel];
 };
 
 /**
@@ -38,5 +59,6 @@ export const getPopupLayerState = (layerLevel: number) => {
  * @param layerLevel - The level of the popup to remove state for
  */
 export const removePopupLayerState = (layerLevel: number) => {
+  clearPopupLayerCloseTimer(layerLevel);
   delete popupLayerStates[layerLevel];
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
修复 v1 表格字段启用链接弹窗后，在快速关闭并立即点击另一条记录时，弹窗路由与可见状态竞争，导致 URL 已进入 `/popups/...` 但弹窗不显示的问题。

### Description
- 为 popup layer 增加延迟关闭定时器管理，在同层弹窗重开前取消旧的关闭任务，避免关闭动画把新弹窗一并关闭
- 在同层重复打开时强制刷新 nested schema key，并在弹窗上下文切换时重置可见状态，避免复用已隐藏的旧弹窗实例
- 补充 popup layer close timer 单测，并通过浏览器手工回归验证快速关闭后立即打开另一条记录的场景

### Showcase
- N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the race condition that sometimes prevents linked record popups from reopening |
| 🇨🇳 Chinese | 修复链接记录弹窗在快速关闭后偶发无法重新打开的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
