### PR TITLE
fix(ai): pick block with AttachmentURLField trigger error

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatMessageActions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatMessageActions.ts
@@ -81,7 +81,11 @@ export const useChatMessageActions = () => {
           continue;
         }
         FlowUtils.walkthrough(model, (subModel) => {
-          if (subModel instanceof UploadFieldModel && subModel.props?.value?.length) {
+          if (
+            subModel instanceof UploadFieldModel &&
+            subModel.props?.value?.length &&
+            typeof subModel.props.value !== 'string'
+          ) {
             addAttachments(subModel.props.value.map((it) => ({ ...it, status: 'done' })));
           }
         });

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
@@ -92,7 +92,7 @@ const toSimplifyForm = (model: FormBlockModel) => {
       });
       duplicateFields.add(collectionField.name);
     }
-    if (model instanceof UploadFieldModel) {
+    if (model instanceof UploadFieldModel && model.props?.value?.length && typeof model.props.value !== 'string') {
       excludeFieldValues.add(model.props.name);
     }
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue of missing URL field values for attachments in AI employee form selections. |
| 🇨🇳 Chinese | 修复 AI 员工选中表单的附件URL字段值丢失问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
