### PR TITLE
fix(data-source-main): validate choice colors and default title field

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/modeling-apply.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/modeling-apply.test.ts
@@ -33,7 +33,10 @@ describe('modeling apply actions', () => {
             name: 'status',
             title: 'Status',
             interface: 'select',
-            enum: ['draft', 'paid'],
+            enum: [
+              { label: 'Draft', value: 'draft', color: 'gold' },
+              { label: 'Paid', value: 'paid', color: 'green' },
+            ],
           },
           {
             name: 'customer',
@@ -51,6 +54,7 @@ describe('modeling apply actions', () => {
 
     const collection = app.db.getCollection('orders');
     expect(collection).toBeDefined();
+    expect(collection.options.titleField).toBe('id');
     expect(collection.hasField('createdAt')).toBe(true);
     expect(collection.hasField('createdBy')).toBe(true);
     expect(collection.hasField('updatedAt')).toBe(true);
@@ -60,8 +64,8 @@ describe('modeling apply actions', () => {
     expect(statusField.options.type).toBe('string');
     expect(statusField.options.uiSchema.title).toBe('Status');
     expect(statusField.options.uiSchema.enum).toEqual([
-      { label: 'draft', value: 'draft' },
-      { label: 'paid', value: 'paid' },
+      { label: 'Draft', value: 'draft', color: 'gold' },
+      { label: 'Paid', value: 'paid', color: 'green' },
     ]);
 
     const customerField = collection.getField('customer');
@@ -120,6 +124,35 @@ describe('modeling apply actions', () => {
     expect(commentsPost.options.uiSchema.title).toBe('Post');
     expect(postsComments.options.foreignKey).toBe(commentsPost.options.foreignKey);
     // expect(postsComments.options.reverseKey).toBeDefined();
+  });
+
+  it('should apply a choice field from fields apply when enum colors are valid', async () => {
+    await agent.resource('collections').create({
+      values: {
+        name: 'orders',
+      },
+    });
+
+    const response = await agent.resource('fields').apply({
+      values: {
+        collectionName: 'orders',
+        name: 'status',
+        title: 'Status',
+        interface: 'select',
+        enum: [
+          { label: 'Draft', value: 'draft', color: 'gold' },
+          { label: 'Paid', value: 'paid', color: 'green' },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const orders = app.db.getCollection('orders');
+    expect(orders.getField('status').options.uiSchema.enum).toEqual([
+      { label: 'Draft', value: 'draft', color: 'gold' },
+      { label: 'Paid', value: 'paid', color: 'green' },
+    ]);
   });
 
   it('should return normalized verification result from collections apply', async () => {
@@ -241,6 +274,45 @@ describe('modeling apply actions', () => {
 
     expect(response.statusCode).toBe(500);
     expect(response.body.errors[0].message).toContain('type json does not match interface markdown');
+  });
+
+  it('should reject collections apply choice fields when enum colors are missing', async () => {
+    const response = await agent.resource('collections').apply({
+      values: {
+        name: 'broken_choice_colors',
+        template: 'general',
+        fields: [
+          {
+            name: 'status',
+            interface: 'select',
+            enum: [{ label: 'Draft', value: 'draft' }],
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body.errors[0].message).toContain('requires color');
+  });
+
+  it('should reject fields apply choice fields when enum color is outside the available palette', async () => {
+    await agent.resource('collections').create({
+      values: {
+        name: 'palette_checks',
+      },
+    });
+
+    const response = await agent.resource('fields').apply({
+      values: {
+        collectionName: 'palette_checks',
+        name: 'status',
+        interface: 'select',
+        enum: [{ label: 'Draft', value: 'draft', color: 'pink' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body.errors[0].message).toContain('Allowed colors');
   });
 
   it('should preserve explicit relation keys from compact field input', async () => {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/collections.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/collections.ts
@@ -208,6 +208,13 @@ export function normalizeCollectionInput(input: PlainObject, options: { mode?: '
     values.fields = values.fields.map((field) => normalizeFieldInput(field, { collectionName: values.name }));
   }
 
+  if ((options.mode || 'create') === 'create' && !values.titleField) {
+    const primaryKeyField = values.fields?.find?.((field) => field?.primaryKey === true);
+    if (primaryKeyField?.name) {
+      values.titleField = primaryKeyField.name;
+    }
+  }
+
   return values;
 }
 

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/constants.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/constants.ts
@@ -42,6 +42,23 @@ export const INTERFACE_ALIASES: Record<string, string> = {
   o2o: 'obo',
 };
 
+export const CHOICE_COLOR_OPTIONS = [
+  'red',
+  'magenta',
+  'volcano',
+  'orange',
+  'gold',
+  'lime',
+  'green',
+  'cyan',
+  'blue',
+  'geekblue',
+  'purple',
+  'default',
+];
+
+const CHOICE_COLOR_OPTION_SET = new Set(CHOICE_COLOR_OPTIONS);
+
 export const PLUGIN_REQUIREMENTS: Record<string, { runtimeName: string; packageName: string; capability: string }> = {
   file: {
     runtimeName: 'file-manager',
@@ -136,6 +153,32 @@ export function normalizeChoiceEnum(enumValues: any[] = []) {
       label: String(item),
       value: item,
     };
+  });
+}
+
+export function validateChoiceEnumColors(enumValues: any[] = [], fieldName = '(unknown)') {
+  const allowedColors = CHOICE_COLOR_OPTIONS.join(', ');
+
+  enumValues.forEach((item, index) => {
+    if (!_.isPlainObject(item)) {
+      throw new Error(
+        `Field ${fieldName} enum item #${
+          index + 1
+        } must be an object with value, label, and color; string shorthand is not allowed`,
+      );
+    }
+
+    const optionName = item.value ?? item.label ?? `#${index + 1}`;
+
+    if (!item.color) {
+      throw new Error(`Field ${fieldName} enum item ${optionName} requires color`);
+    }
+
+    if (!CHOICE_COLOR_OPTION_SET.has(item.color)) {
+      throw new Error(
+        `Field ${fieldName} enum item ${optionName} color ${item.color} is invalid. Allowed colors: ${allowedColors}`,
+      );
+    }
   });
 }
 

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/fields.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/fields.ts
@@ -19,6 +19,7 @@ import {
   normalizeChoiceEnum,
   toDisplayTitle,
   uniqueByName,
+  validateChoiceEnumColors,
 } from './constants';
 
 export function normalizeInterfaceName(value?: string) {
@@ -439,6 +440,33 @@ function buildReverseField(field: PlainObject) {
     },
     { collectionName: field.target },
   );
+}
+
+function getChoiceEnumInput(field: PlainObject) {
+  if (Array.isArray(field?.enum)) {
+    return field.enum;
+  }
+
+  if (Array.isArray(field?.uiSchema?.enum)) {
+    return field.uiSchema.enum;
+  }
+
+  return [];
+}
+
+export function validateChoiceFieldInput(field: PlainObject = {}) {
+  const interfaceName = normalizeInterfaceName(field.interface);
+
+  if (!CHOICE_INTERFACES.has(interfaceName)) {
+    return;
+  }
+
+  const enumValues = getChoiceEnumInput(field);
+  if (!enumValues.length) {
+    return;
+  }
+
+  validateChoiceEnumColors(enumValues, field.name || '(unknown)');
 }
 
 export function normalizeFieldInput(input: PlainObject, context: PlainObject = {}) {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/service.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/service.ts
@@ -10,7 +10,7 @@
 import { assertModelingSupport, verifyCollectionDefinition } from './capabilities';
 import { composeCollectionDefinition, normalizeCollectionInput } from './collections';
 import { PlainObject, RELATION_INTERFACES } from './constants';
-import { normalizeFieldInput, normalizeFieldList } from './fields';
+import { normalizeFieldInput, normalizeFieldList, validateChoiceFieldInput } from './fields';
 
 function mergeSettings(input: PlainObject = {}) {
   const { settings, ...rest } = input;
@@ -18,6 +18,14 @@ function mergeSettings(input: PlainObject = {}) {
     ...(settings || {}),
     ...rest,
   };
+}
+
+function validateApplyFieldInputs(fields?: PlainObject[]) {
+  if (!Array.isArray(fields)) {
+    return;
+  }
+
+  fields.forEach((field) => validateChoiceFieldInput(field));
 }
 
 export async function findCollection(ctx, collectionName: string) {
@@ -49,6 +57,7 @@ export async function upsertFieldDefinition(ctx, rawInput: PlainObject) {
     throw new Error('field apply requires collectionName');
   }
 
+  validateChoiceFieldInput(input);
   const values = normalizeFieldInput(input, { collectionName });
   await assertModelingSupport(ctx.app, { fields: [values] });
 
@@ -106,6 +115,7 @@ export async function applyCollectionDefinition(
     throw new Error('collections:apply requires name');
   }
 
+  validateApplyFieldInputs(input.fields);
   const existing = await findCollection(ctx, collectionName);
 
   if (!existing) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
- Dropdown choice fields could be created without valid color metadata
- Newly created collections could miss an explicit `titleField`, which could affect relation display fallback on the frontend

### Description 
- Validate local choice-field enum items in `collections:apply` and `fields:apply` so every option includes a supported color
- Default collection `titleField` to the primary key when creating a collection without an explicit value
- Add server tests for valid and invalid enum color payloads and for the default `titleField` behavior

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   |
| 🇨🇳 Chinese |  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
