### PR TITLE
feat(cli): add request source to api logs

### DIFF
--- a/packages/core/cli/src/__tests__/api-client.test.ts
+++ b/packages/core/cli/src/__tests__/api-client.test.ts
@@ -1,0 +1,76 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+vi.mock('../lib/env-auth.js', () => ({
+  resolveServerRequestTarget: vi.fn(async () => ({
+    baseUrl: 'http://localhost:13000/api',
+    token: 'test-token',
+  })),
+}));
+
+import { executeApiRequest, executeRawApiRequest } from '../lib/api-client.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test('executeApiRequest sends the CLI request source header', async () => {
+  let requestHeaders: Headers | undefined;
+
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    requestHeaders = init?.headers as Headers;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  await executeApiRequest({
+    flags: {},
+    operation: {
+      method: 'get',
+      pathTemplate: '/users:list',
+      parameters: [],
+    },
+  });
+
+  expect(requestHeaders?.get('x-request-source')).toBe('cli');
+  expect(requestHeaders?.get('authorization')).toBe('Bearer test-token');
+});
+
+test('executeRawApiRequest preserves custom headers and adds the CLI request source header', async () => {
+  let requestHeaders: Headers | undefined;
+
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    requestHeaders = init?.headers as Headers;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  await executeRawApiRequest({
+    method: 'post',
+    path: '/users:create',
+    headers: {
+      'x-data-source': 'test',
+    },
+    body: {
+      nickname: 'Ada',
+    },
+  });
+
+  expect(requestHeaders?.get('x-request-source')).toBe('cli');
+  expect(requestHeaders?.get('x-data-source')).toBe('test');
+  expect(requestHeaders?.get('content-type')).toBe('application/json');
+});

--- a/packages/core/cli/src/__tests__/app-management-commands.test.ts
+++ b/packages/core/cli/src/__tests__/app-management-commands.test.ts
@@ -7,8 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test, vi, expect } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   formatMissingManagedAppEnvMessage: vi.fn((envName?: string) =>
@@ -166,19 +165,16 @@ test('start enables daemon by default for npm/git envs', async () => {
 
   await Start.prototype.run.call(command);
 
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Starting NocoBase for "local" in the background...'],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['NocoBase is starting for "local" at http://127.0.0.1:13000.'],
   ]);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 1);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[0]?.envName, 'local');
-  assert.deepEqual(
-    mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1],
-    ['start', '--quickstart', '--port', '13000', '--daemon', '--instances', '2', '--launch-mode', 'pm2'],
-  );
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2], {
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(1);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[0]?.envName).toBe('local');
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1]).toEqual(['start', '--quickstart', '--port', '13000', '--daemon', '--instances', '2', '--launch-mode', 'pm2']);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2]).toEqual({
     stdio: 'ignore',
   });
 });
@@ -193,10 +189,7 @@ test('start explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Start.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*new NocoBase AI environment.*run `nb init --env local53` first\./s,
-  );
+  await expect((() => Start.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*new NocoBase AI environment.*run `nb init --env local53` first\./s);
 });
 
 test('start reports when the local app is already running', async () => {
@@ -227,10 +220,10 @@ test('start reports when the local app is already running', async () => {
 
   await Start.prototype.run.call(command);
 
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['NocoBase is already running for "local" at http://127.0.0.1:13000.'],
   ]);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 0);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(0);
 });
 
 test('start supports --no-daemon for npm/git envs', async () => {
@@ -256,17 +249,14 @@ test('start supports --no-daemon for npm/git envs', async () => {
 
   await Start.prototype.run.call(command);
 
-  assert.deepEqual(mocks.printInfo.mock.calls, [
+  expect(mocks.printInfo.mock.calls).toEqual([
     ['Starting NocoBase for "local" in the foreground at http://127.0.0.1:13000. Press Ctrl+C to stop.'],
   ]);
-  assert.equal(mocks.startTask.mock.calls.length, 0);
-  assert.equal(mocks.succeedTask.mock.calls.length, 0);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 1);
-  assert.deepEqual(
-    mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1],
-    ['start', '--port', '13000'],
-  );
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2], {
+  expect(mocks.startTask.mock.calls.length).toBe(0);
+  expect(mocks.succeedTask.mock.calls.length).toBe(0);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(1);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1]).toEqual(['start', '--port', '13000']);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2]).toEqual({
     stdio: 'ignore',
   });
 });
@@ -301,10 +291,10 @@ test('start foreground mode explains how to restart when the local app is alread
 
   await Start.prototype.run.call(command);
 
-  assert.deepEqual(mocks.printInfo.mock.calls, [
+  expect(mocks.printInfo.mock.calls).toEqual([
     ['NocoBase is already running for "local" at http://127.0.0.1:13000. Use `nb stop --env local` before starting it again in the foreground.'],
   ]);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 0);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(0);
 });
 
 test('start enables raw startup output when --verbose is set', async () => {
@@ -329,7 +319,7 @@ test('start enables raw startup output when --verbose is set', async () => {
 
   await Start.prototype.run.call(command);
 
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2], {
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2]).toEqual({
     stdio: 'inherit',
   });
 });
@@ -354,14 +344,11 @@ test('start shows product-style local failure guidance instead of raw command er
     },
   });
 
-  await assert.rejects(
-    () => Start.prototype.run.call(command),
-    /Couldn't start NocoBase for "local".*The CLI was not able to start the local npm app successfully\..*Expected app port: 13000\./s,
-  );
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  await expect((() => Start.prototype.run.call(command))()).rejects.toThrow(/Couldn't start NocoBase for "local".*The CLI was not able to start the local npm app successfully\..*Expected app port: 13000\./s);
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Starting NocoBase for "local" in the background...'],
   ]);
-  assert.deepEqual(mocks.failTask.mock.calls, [
+  expect(mocks.failTask.mock.calls).toEqual([
     ['Failed to start NocoBase for "local".'],
   ]);
 });
@@ -387,13 +374,13 @@ test('start accepts docker envs without treating the default daemon flag as expl
 
   await Start.prototype.run.call(command);
 
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Starting NocoBase for "docker-local"...'],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['NocoBase is already running for "docker-local".'],
   ]);
-  assert.deepEqual(mocks.startDockerContainer.mock.calls, [[
+  expect(mocks.startDockerContainer.mock.calls).toEqual([[
     'nb-demo-docker-local-app',
     { stdio: 'ignore' },
   ]]);
@@ -418,10 +405,7 @@ test('start rejects local-only flags for docker envs', async () => {
   });
   command.argv = ['--no-daemon'];
 
-  await assert.rejects(
-    () => Start.prototype.run.call(command),
-    /Can't apply --no-daemon to "docker-local".*only available for local npm\/git installs/s,
-  );
+  await expect((() => Start.prototype.run.call(command))()).rejects.toThrow(/Can't apply --no-daemon to "docker-local".*only available for local npm\/git installs/s);
 });
 
 test('stop routes docker envs to docker stop', async () => {
@@ -444,13 +428,13 @@ test('stop routes docker envs to docker stop', async () => {
 
   await Stop.prototype.run.call(command);
 
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Stopping NocoBase for "docker-local"...'],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['NocoBase is already stopped for "docker-local".'],
   ]);
-  assert.deepEqual(mocks.stopDockerContainer.mock.calls, [[
+  expect(mocks.stopDockerContainer.mock.calls).toEqual([[
     'nb-demo-docker-local-app',
     { stdio: 'ignore' },
   ]]);
@@ -466,10 +450,7 @@ test('stop explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Stop.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*new NocoBase AI environment.*run `nb init --env local53` first\./s,
-  );
+  await expect((() => Stop.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*new NocoBase AI environment.*run `nb init --env local53` first\./s);
 });
 
 test('upgrade explains when the requested env does not exist', async () => {
@@ -482,10 +463,7 @@ test('upgrade explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Upgrade.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s,
-  );
+  await expect((() => Upgrade.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s);
 });
 
 test('pm list explains when the requested env does not exist', async () => {
@@ -498,10 +476,7 @@ test('pm list explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => PmList.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s,
-  );
+  await expect((() => PmList.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s);
 });
 
 test('stop enables raw shutdown output when --verbose is set', async () => {
@@ -525,13 +500,13 @@ test('stop enables raw shutdown output when --verbose is set', async () => {
 
   await Stop.prototype.run.call(command);
 
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Stopping NocoBase for "local"...'],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['NocoBase has stopped for "local".'],
   ]);
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2], {
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[2]).toEqual({
     stdio: 'inherit',
   });
 });
@@ -555,14 +530,11 @@ test('stop shows product-style local failure guidance', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Stop.prototype.run.call(command),
-    /Couldn't stop NocoBase for "local".*still available, then try again\..*Details: nocobase command exited with code 1/s,
-  );
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  await expect((() => Stop.prototype.run.call(command))()).rejects.toThrow(/Couldn't stop NocoBase for "local".*still available, then try again\..*Details: nocobase command exited with code 1/s);
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Stopping NocoBase for "local"...'],
   ]);
-  assert.deepEqual(mocks.failTask.mock.calls, [
+  expect(mocks.failTask.mock.calls).toEqual([
     ['Failed to stop NocoBase for "local".'],
   ]);
 });
@@ -589,11 +561,11 @@ test('logs supports --env and --no-follow for local app logs', async () => {
 
   await Logs.prototype.run.call(command);
 
-  assert.deepEqual(mocks.resolveManagedAppRuntime.mock.calls, [['app1']]);
-  assert.deepEqual(mocks.printInfo.mock.calls, [
+  expect(mocks.resolveManagedAppRuntime.mock.calls).toEqual([['app1']]);
+  expect(mocks.printInfo.mock.calls).toEqual([
     ['Showing recent logs for "app1".'],
   ]);
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1], [
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1]).toEqual([
     'pm2',
     'logs',
     '--lines',
@@ -623,7 +595,7 @@ test('logs reads docker app logs', async () => {
 
   await Logs.prototype.run.call(command);
 
-  assert.deepEqual(mocks.run.mock.calls, [[
+  expect(mocks.run.mock.calls).toEqual([[
     'docker',
     ['logs', '--tail', '100', '--follow', 'nb-demo-docker-local-app'],
     {
@@ -643,10 +615,7 @@ test('logs explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Logs.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s,
-  );
+  await expect((() => Logs.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s);
 });
 
 test('logs explains remote envs do not have local runtime logs', async () => {
@@ -664,10 +633,7 @@ test('logs explains remote envs do not have local runtime logs', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Logs.prototype.run.call(command),
-    /Can't show runtime logs for "remote" from this machine\..*only has an API connection/s,
-  );
+  await expect((() => Logs.prototype.run.call(command))()).rejects.toThrow(/Can't show runtime logs for "remote" from this machine\..*only has an API connection/s);
 });
 
 test('ps lists all configured env runtime statuses', async () => {
@@ -740,16 +706,16 @@ test('ps lists all configured env runtime statuses', async () => {
 
   await Ps.prototype.run.call(command);
 
-  assert.deepEqual(mocks.listEnvs.mock.calls, [[]]);
-  assert.deepEqual(mocks.resolveManagedAppRuntime.mock.calls, [['docker'], ['local'], ['remote']]);
-  assert.deepEqual(mocks.buildDockerDbContainerName.mock.calls[0], ['docker', 'postgres', 'nb-demo']);
-  assert.deepEqual(mocks.renderTable.mock.calls[0]?.[0], ['Env', 'Source', 'App', 'Database', 'URL']);
-  assert.deepEqual(mocks.renderTable.mock.calls[0]?.[1], [
+  expect(mocks.listEnvs.mock.calls).toEqual([[]]);
+  expect(mocks.resolveManagedAppRuntime.mock.calls).toEqual([['docker'], ['local'], ['remote']]);
+  expect(mocks.buildDockerDbContainerName.mock.calls[0]).toEqual(['docker', 'postgres', 'nb-demo']);
+  expect(mocks.renderTable.mock.calls[0]?.[0]).toEqual(['Env', 'Source', 'App', 'Database', 'URL']);
+  expect(mocks.renderTable.mock.calls[0]?.[1]).toEqual([
     ['docker', 'docker', 'running', 'stopped', 'http://127.0.0.1:13000'],
     ['local', 'npm', 'running', '-', 'http://127.0.0.1:13001'],
     ['remote', 'remote', 'remote', 'external', 'https://demo.example.com'],
   ]);
-  assert.match(String(command.log.mock.calls[0]?.[0] ?? ''), /Env\|Source\|App\|Database\|URL/);
+  expect(String(command.log.mock.calls[0]?.[0] ?? '')).toMatch(/Env\|Source\|App\|Database\|URL/);
 });
 
 test('ps supports --env without listing all envs first', async () => {
@@ -778,9 +744,9 @@ test('ps supports --env without listing all envs first', async () => {
 
   await Ps.prototype.run.call(command);
 
-  assert.equal(mocks.listEnvs.mock.calls.length, 0);
-  assert.deepEqual(mocks.resolveManagedAppRuntime.mock.calls, [['app1']]);
-  assert.deepEqual(mocks.renderTable.mock.calls[0]?.[1], [
+  expect(mocks.listEnvs.mock.calls.length).toBe(0);
+  expect(mocks.resolveManagedAppRuntime.mock.calls).toEqual([['app1']]);
+  expect(mocks.renderTable.mock.calls[0]?.[1]).toEqual([
     ['app1', 'docker', 'stopped', '-', 'http://127.0.0.1:13000'],
   ]);
 });
@@ -795,10 +761,7 @@ test('ps explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Ps.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s,
-  );
+  await expect((() => Ps.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s);
 });
 
 test('db ps lists all configured database runtime statuses', async () => {
@@ -867,10 +830,10 @@ test('db ps lists all configured database runtime statuses', async () => {
 
   await DbPs.prototype.run.call(command);
 
-  assert.deepEqual(mocks.resolveManagedAppRuntime.mock.calls, [['docker'], ['local'], ['remote']]);
-  assert.deepEqual(mocks.buildDockerDbContainerName.mock.calls[0], ['docker', 'postgres', 'nb-demo']);
-  assert.deepEqual(mocks.renderTable.mock.calls[0]?.[0], ['Env', 'Type', 'Dialect', 'Status', 'Address']);
-  assert.deepEqual(mocks.renderTable.mock.calls[0]?.[1], [
+  expect(mocks.resolveManagedAppRuntime.mock.calls).toEqual([['docker'], ['local'], ['remote']]);
+  expect(mocks.buildDockerDbContainerName.mock.calls[0]).toEqual(['docker', 'postgres', 'nb-demo']);
+  expect(mocks.renderTable.mock.calls[0]?.[0]).toEqual(['Env', 'Type', 'Dialect', 'Status', 'Address']);
+  expect(mocks.renderTable.mock.calls[0]?.[1]).toEqual([
     ['docker', 'builtin', 'postgres', 'running', 'nb-demo-docker-postgres:5432'],
     ['local', 'external', 'postgres', 'external', '127.0.0.1:5432'],
     ['remote', 'remote', 'mysql', 'remote', ''],
@@ -905,14 +868,14 @@ test('db start routes built-in database envs to docker start', async () => {
 
   await DbStart.prototype.run.call(command);
 
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Starting the built-in database for "app1"...'],
   ]);
-  assert.deepEqual(mocks.startDockerContainer.mock.calls, [[
+  expect(mocks.startDockerContainer.mock.calls).toEqual([[
     'nb-demo-app1-postgres',
     { stdio: 'ignore' },
   ]]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['The built-in database is running for "app1" at 127.0.0.1:5432.'],
   ]);
 });
@@ -946,14 +909,14 @@ test('db stop routes built-in database envs to docker stop', async () => {
 
   await DbStop.prototype.run.call(command);
 
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Stopping the built-in database for "app1"...'],
   ]);
-  assert.deepEqual(mocks.stopDockerContainer.mock.calls, [[
+  expect(mocks.stopDockerContainer.mock.calls).toEqual([[
     'nb-demo-app1-postgres',
     { stdio: 'inherit' },
   ]]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['The built-in database has stopped for "app1".'],
   ]);
 });
@@ -987,10 +950,10 @@ test('db logs routes built-in database envs to docker logs', async () => {
 
   await DbLogs.prototype.run.call(command);
 
-  assert.deepEqual(mocks.printInfo.mock.calls, [
+  expect(mocks.printInfo.mock.calls).toEqual([
     ['Showing recent built-in database logs for "app1".'],
   ]);
-  assert.deepEqual(mocks.run.mock.calls, [[
+  expect(mocks.run.mock.calls).toEqual([[
     'docker',
     ['logs', '--tail', '50', 'nb-demo-app1-postgres'],
     {
@@ -1023,11 +986,8 @@ test('db start explains when the env does not use a built-in database', async ()
     },
   });
 
-  await assert.rejects(
-    () => DbStart.prototype.run.call(command),
-    /does not use a CLI-managed built-in database.*recreate the env with the built-in database option enabled/s,
-  );
-  assert.equal(mocks.startDockerContainer.mock.calls.length, 0);
+  await expect((() => DbStart.prototype.run.call(command))()).rejects.toThrow(/does not use a CLI-managed built-in database.*recreate the env with the built-in database option enabled/s);
+  expect(mocks.startDockerContainer.mock.calls.length).toBe(0);
 });
 
 test('db logs explains when the env does not use a built-in database', async () => {
@@ -1053,11 +1013,8 @@ test('db logs explains when the env does not use a built-in database', async () 
     },
   });
 
-  await assert.rejects(
-    () => DbLogs.prototype.run.call(command),
-    /does not use a CLI-managed built-in database.*read logs from here.*recreate the env with the built-in database option enabled/s,
-  );
-  assert.equal(mocks.run.mock.calls.length, 0);
+  await expect((() => DbLogs.prototype.run.call(command))()).rejects.toThrow(/does not use a CLI-managed built-in database.*read logs from here.*recreate the env with the built-in database option enabled/s);
+  expect(mocks.run.mock.calls.length).toBe(0);
 });
 
 test('down removes docker app and built-in database containers by default', async () => {
@@ -1086,7 +1043,7 @@ test('down removes docker app and built-in database containers by default', asyn
 
   await Down.prototype.run.call(command);
 
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(mocks.run.mock.calls).toEqual([
     [
       'docker',
       ['rm', '-f', 'nb-demo-docker-local-app'],
@@ -1104,8 +1061,8 @@ test('down removes docker app and built-in database containers by default', asyn
       },
     ],
   ]);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 0);
-  assert.equal(mocks.removeEnv.mock.calls.length, 0);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(0);
+  expect(mocks.removeEnv.mock.calls.length).toBe(0);
 });
 
 test('down stops local apps and removes the built-in database container when configured', async () => {
@@ -1137,12 +1094,12 @@ test('down stops local apps and removes the built-in database container when con
 
   await Down.prototype.run.call(command);
 
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls, [[
+  expect(mocks.runLocalNocoBaseCommand.mock.calls).toEqual([[
     runtime,
     ['pm2', 'kill'],
     { stdio: 'inherit' },
   ]]);
-  assert.deepEqual(mocks.run.mock.calls, [[
+  expect(mocks.run.mock.calls).toEqual([[
     'docker',
     ['rm', '-f', 'nb-demo-local-mysql'],
     {
@@ -1179,15 +1136,12 @@ test('down confirms before removing user data', async () => {
 
   await Down.prototype.run.call(command);
 
-  assert.equal(mocks.confirmAction.mock.calls.length, 1);
-  assert.match(String(mocks.confirmAction.mock.calls[0]?.[0] ?? ''), /Delete storage and managed database data/);
-  assert.equal(mocks.run.mock.calls.length, 0);
-  assert.equal(
-    mocks.succeedTask.mock.calls.some((call) =>
+  expect(mocks.confirmAction.mock.calls.length).toBe(1);
+  expect(String(mocks.confirmAction.mock.calls[0]?.[0] ?? '')).toMatch(/Delete storage and managed database data/);
+  expect(mocks.run.mock.calls.length).toBe(0);
+  expect(mocks.succeedTask.mock.calls.some((call) =>
       String(call[0]).includes('Storage and managed database data deleted'),
-    ),
-    true,
-  );
+    )).toBe(true);
 });
 
 test('down can remove CLI env config when requested', async () => {
@@ -1215,7 +1169,7 @@ test('down can remove CLI env config when requested', async () => {
 
   await Down.prototype.run.call(command);
 
-  assert.deepEqual(mocks.removeEnv.mock.calls, [['docker-local']]);
+  expect(mocks.removeEnv.mock.calls).toEqual([['docker-local']]);
 });
 
 test('down refuses to remove data without confirmation in non-interactive mode', async () => {
@@ -1242,11 +1196,8 @@ test('down refuses to remove data without confirmation in non-interactive mode',
     },
   });
 
-  await assert.rejects(
-    () => Down.prototype.run.call(command),
-    /Refusing to remove user data for "docker-local" without confirmation/,
-  );
-  assert.equal(mocks.run.mock.calls.length, 0);
+  await expect((() => Down.prototype.run.call(command))()).rejects.toThrow(/Refusing to remove user data for "docker-local" without confirmation/);
+  expect(mocks.run.mock.calls.length).toBe(0);
 });
 
 test('down explains remote envs do not have local runtime resources', async () => {
@@ -1266,10 +1217,7 @@ test('down explains remote envs do not have local runtime resources', async () =
     },
   });
 
-  await assert.rejects(
-    () => Down.prototype.run.call(command),
-    /Can't bring down "remote" from this machine\..*only has an API connection/s,
-  );
+  await expect((() => Down.prototype.run.call(command))()).rejects.toThrow(/Can't bring down "remote" from this machine\..*only has an API connection/s);
 });
 
 test('upgrade refreshes local npm envs, then restarts them with quickstart', async () => {
@@ -1310,7 +1258,7 @@ test('upgrade refreshes local npm envs, then restarts them with quickstart', asy
 
   await Upgrade.prototype.run.call(command);
 
-  assert.deepEqual(runCommand.mock.calls, [[
+  expect(runCommand.mock.calls).toEqual([[
     'download',
     [
       '-y',
@@ -1328,7 +1276,7 @@ test('upgrade refreshes local npm envs, then restarts them with quickstart', asy
       '--no-build',
     ],
   ]]);
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls, [
+  expect(mocks.runLocalNocoBaseCommand.mock.calls).toEqual([
     [
       {
         kind: 'local',
@@ -1374,7 +1322,7 @@ test('upgrade refreshes local npm envs, then restarts them with quickstart', asy
       { stdio: 'ignore' },
     ],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls.at(-1), [
+  expect(mocks.succeedTask.mock.calls.at(-1)).toEqual([
     'NocoBase has been upgraded for "local" at http://127.0.0.1:13000.',
   ]);
 });
@@ -1413,15 +1361,15 @@ test('upgrade skips download for local app-path envs and still restarts with qui
 
   await Upgrade.prototype.run.call(command);
 
-  assert.equal(runCommand.mock.calls.length, 0);
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[1]?.[1], [
+  expect(runCommand.mock.calls.length).toBe(0);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[1]?.[1]).toEqual([
     'start',
     '--quickstart',
     '--port',
     '14000',
     '--daemon',
   ]);
-  assert.deepEqual(mocks.printInfo.mock.calls, [[
+  expect(mocks.printInfo.mock.calls).toEqual([[
     'Skipping code download for "local-app" because this env is managed from an existing local app path.',
   ]]);
 });
@@ -1471,7 +1419,7 @@ test('upgrade refreshes docker envs by pulling the image and recreating the cont
 
   await Upgrade.prototype.run.call(command);
 
-  assert.deepEqual(runCommand.mock.calls, [[
+  expect(runCommand.mock.calls).toEqual([[
     'download',
     [
       '-y',
@@ -1487,11 +1435,11 @@ test('upgrade refreshes docker envs by pulling the image and recreating the cont
       'linux/arm64',
     ],
   ]]);
-  assert.deepEqual(mocks.stopDockerContainer.mock.calls, [[
+  expect(mocks.stopDockerContainer.mock.calls).toEqual([[
     'nb-demo-docker-local-app',
     { stdio: 'ignore' },
   ]]);
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(mocks.run.mock.calls).toEqual([
     [
       'docker',
       ['rm', '-f', 'nb-demo-docker-local-app'],
@@ -1533,7 +1481,7 @@ test('upgrade refreshes docker envs by pulling the image and recreating the cont
       { errorName: 'docker run', stdio: 'ignore' },
     ],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls.at(-1), [
+  expect(mocks.succeedTask.mock.calls.at(-1)).toEqual([
     'NocoBase has been upgraded for "docker-local" at http://127.0.0.1:13000.',
   ]);
 });
@@ -1584,16 +1532,16 @@ test('upgrade can restart docker envs without pulling a new image', async () => 
 
   await Upgrade.prototype.run.call(command);
 
-  assert.equal(runCommand.mock.calls.length, 0);
-  assert.deepEqual(mocks.stopDockerContainer.mock.calls, [[
+  expect(runCommand.mock.calls.length).toBe(0);
+  expect(mocks.stopDockerContainer.mock.calls).toEqual([[
     'nb-demo-docker-local-app',
     { stdio: 'ignore' },
   ]]);
-  assert.deepEqual(mocks.startDockerContainer.mock.calls, [[
+  expect(mocks.startDockerContainer.mock.calls).toEqual([[
     'nb-demo-docker-local-app',
     { stdio: 'ignore' },
   ]]);
-  assert.equal(mocks.run.mock.calls.length, 0);
+  expect(mocks.run.mock.calls.length).toBe(0);
 });
 
 test('pm enable routes docker envs to docker exec nocobase pm enable', async () => {
@@ -1618,7 +1566,7 @@ test('pm enable routes docker envs to docker exec nocobase pm enable', async () 
 
   await PmEnable.prototype.run.call(command);
 
-  assert.deepEqual(mocks.runDockerNocoBaseCommand.mock.calls, [[
+  expect(mocks.runDockerNocoBaseCommand.mock.calls).toEqual([[
     'nb-demo-docker-local-app',
     ['pm', 'enable', '@nocobase/plugin-sample'],
   ]]);
@@ -1647,12 +1595,9 @@ test('pm disable routes local envs to the local nocobase command', async () => {
 
   await PmDisable.prototype.run.call(command);
 
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 1);
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[0]?.envName, 'dev');
-  assert.deepEqual(
-    mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1],
-    ['pm', 'disable', '@nocobase/plugin-a', '@nocobase/plugin-b'],
-  );
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(1);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[0]?.envName).toBe('dev');
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1]).toEqual(['pm', 'disable', '@nocobase/plugin-a', '@nocobase/plugin-b']);
 });
 
 test('dev runs local npm/git source envs with saved env settings', async () => {
@@ -1682,10 +1627,10 @@ test('dev runs local npm/git source envs with saved env settings', async () => {
 
   await Dev.prototype.run.call(command);
 
-  assert.deepEqual(mocks.printInfo.mock.calls, [
+  expect(mocks.printInfo.mock.calls).toEqual([
     ['Starting NocoBase dev mode for "dev" from /tmp/nocobase. Press Ctrl+C to stop.'],
   ]);
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls, [[
+  expect(mocks.runLocalNocoBaseCommand.mock.calls).toEqual([[
     runtime,
     ['dev', '--rsbuild', '--db-sync', '--port', '13000', '--client', '--inspect', '9229'],
     { stdio: 'inherit' },
@@ -1715,7 +1660,7 @@ test('dev uses an explicit port instead of the saved app port', async () => {
 
   await Dev.prototype.run.call(command);
 
-  assert.deepEqual(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1], [
+  expect(mocks.runLocalNocoBaseCommand.mock.calls[0]?.[1]).toEqual([
     'dev',
     '--rsbuild',
     '--port',
@@ -1750,11 +1695,8 @@ test('dev explains when the app is already running on the target port', async ()
     },
   });
 
-  await assert.rejects(
-    () => Dev.prototype.run.call(command),
-    /NocoBase is already running for "dev" at http:\/\/127\.0\.0\.1:13000\..*nb stop --env dev.*dev port/s,
-  );
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 0);
+  await expect((() => Dev.prototype.run.call(command))()).rejects.toThrow(/NocoBase is already running for "dev" at http:\/\/127\.0\.0\.1:13000\..*nb stop --env dev.*dev port/s);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(0);
 });
 
 test('dev rejects docker envs with source-oriented guidance', async () => {
@@ -1774,11 +1716,8 @@ test('dev rejects docker envs with source-oriented guidance', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Dev.prototype.run.call(command),
-    /Can't run dev mode for "docker-local".*requires a local npm or Git source directory/s,
-  );
-  assert.equal(mocks.runLocalNocoBaseCommand.mock.calls.length, 0);
+  await expect((() => Dev.prototype.run.call(command))()).rejects.toThrow(/Can't run dev mode for "docker-local".*requires a local npm or Git source directory/s);
+  expect(mocks.runLocalNocoBaseCommand.mock.calls.length).toBe(0);
 });
 
 test('dev rejects remote envs because they have no local source directory', async () => {
@@ -1796,10 +1735,7 @@ test('dev rejects remote envs because they have no local source directory', asyn
     },
   });
 
-  await assert.rejects(
-    () => Dev.prototype.run.call(command),
-    /Can't run dev mode for "remote".*only has an API connection/s,
-  );
+  await expect((() => Dev.prototype.run.call(command))()).rejects.toThrow(/Can't run dev mode for "remote".*only has an API connection/s);
 });
 
 test('dev explains when the requested env does not exist', async () => {
@@ -1812,10 +1748,7 @@ test('dev explains when the requested env does not exist', async () => {
     },
   });
 
-  await assert.rejects(
-    () => Dev.prototype.run.call(command),
-    /Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s,
-  );
+  await expect((() => Dev.prototype.run.call(command))()).rejects.toThrow(/Env "local53" is not configured in this workspace\..*run `nb init --env local53` first\./s);
 });
 
 test('pm list keeps API fallback for remote envs', async () => {
@@ -1838,5 +1771,5 @@ test('pm list keeps API fallback for remote envs', async () => {
 
   await PmList.prototype.run.call(command);
 
-  assert.deepEqual(runCommand.mock.calls, [['api:pm:list', ['--mode=summary']]]);
+  expect(runCommand.mock.calls).toEqual([['api:pm:list', ['--mode=summary']]]);
 });

--- a/packages/core/cli/src/__tests__/app-runtime.test.ts
+++ b/packages/core/cli/src/__tests__/app-runtime.test.ts
@@ -7,11 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import { saveAuthConfig } from '../lib/auth-store.js';
 import { buildDockerAppContainerName, resolveManagedAppRuntime } from '../lib/app-runtime.js';
 
@@ -33,10 +32,7 @@ async function withTempCliHome(run: () => Promise<void>) {
 }
 
 test('buildDockerAppContainerName keeps workspace-scoped naming consistent', () => {
-  assert.equal(
-    buildDockerAppContainerName('Local_01', 'NB Demo Workspace'),
-    'nb-demo-workspace-local_01-app',
-  );
+  expect(buildDockerAppContainerName('Local_01', 'NB Demo Workspace')).toBe('nb-demo-workspace-local_01-app');
 });
 
 test('resolveManagedAppRuntime detects local, docker, and remote envs', async () => {
@@ -64,21 +60,21 @@ test('resolveManagedAppRuntime detects local, docker, and remote envs', async ()
     );
 
     const dockerRuntime = await resolveManagedAppRuntime('docker-env');
-    assert.deepEqual(dockerRuntime && { kind: dockerRuntime.kind, source: dockerRuntime.source }, {
+    expect(dockerRuntime && { kind: dockerRuntime.kind, source: dockerRuntime.source }).toEqual({
       kind: 'docker',
       source: 'docker',
     });
-    assert.equal(dockerRuntime?.kind === 'docker' ? dockerRuntime.containerName : '', 'nb-demo-docker-env-app');
+    expect(dockerRuntime?.kind === 'docker' ? dockerRuntime.containerName : '').toBe('nb-demo-docker-env-app');
 
     const localRuntime = await resolveManagedAppRuntime('git-env');
-    assert.deepEqual(localRuntime && { kind: localRuntime.kind, source: localRuntime.source }, {
+    expect(localRuntime && { kind: localRuntime.kind, source: localRuntime.source }).toEqual({
       kind: 'local',
       source: 'git',
     });
-    assert.match(localRuntime?.kind === 'local' ? localRuntime.projectRoot : '', /apps\/git-env$/);
+    expect(localRuntime?.kind === 'local' ? localRuntime.projectRoot : '').toMatch(/apps\/git-env$/);
 
     const remoteRuntime = await resolveManagedAppRuntime('remote');
-    assert.deepEqual(remoteRuntime && { kind: remoteRuntime.kind, source: remoteRuntime.source }, {
+    expect(remoteRuntime && { kind: remoteRuntime.kind, source: remoteRuntime.source }).toEqual({
       kind: 'remote',
       source: undefined,
     });

--- a/packages/core/cli/src/__tests__/auth-store.test.ts
+++ b/packages/core/cli/src/__tests__/auth-store.test.ts
@@ -7,11 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import {
   ensureWorkspaceName,
   getEnv,
@@ -65,8 +64,8 @@ test('upsertEnv clears runtime metadata when base URL or token changes', async (
     await upsertEnv('test', { baseUrl: 'http://localhost:13000/api', accessToken: 'new-token' }, { scope: 'global' });
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.equal(env?.auth?.accessToken, 'new-token');
-    assert.equal(env?.runtime, undefined);
+    expect(env?.auth?.accessToken).toBe('new-token');
+    expect(env?.runtime).toBe(undefined);
   });
 });
 
@@ -76,10 +75,10 @@ test('ensureWorkspaceName stores one workspace-level name outside env entries', 
     const second = await ensureWorkspaceName('nb-other', { scope: 'global' });
     const config = await loadAuthConfig({ scope: 'global' });
 
-    assert.equal(first, 'nb-workspace');
-    assert.equal(second, 'nb-workspace');
-    assert.equal(config.name, 'nb-workspace');
-    assert.deepEqual(config.envs, {});
+    expect(first).toBe('nb-workspace');
+    expect(second).toBe('nb-workspace');
+    expect(config.name).toBe('nb-workspace');
+    expect(config.envs).toEqual({});
   });
 });
 
@@ -95,7 +94,7 @@ test('loadAuthConfig maps the legacy dockerResourcePrefix field to workspace nam
     );
 
     const config = await loadAuthConfig({ scope: 'global' });
-    assert.equal(config.name, 'nb-legacy');
+    expect(config.name).toBe('nb-legacy');
   });
 });
 
@@ -125,7 +124,7 @@ test('upsertEnv preserves runtime metadata when connection settings are unchange
     await upsertEnv('test', { baseUrl: 'http://localhost:13000/api', accessToken: 'same-token' }, { scope: 'global' });
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.deepEqual(env?.runtime, {
+    expect(env?.runtime).toEqual({
       version: 'v1',
       schemaHash: 'hash',
       generatedAt: '2026-04-13T00:00:00.000Z',
@@ -138,8 +137,8 @@ test('upsertEnv allows saving an env without a token', async () => {
     await upsertEnv('test', { baseUrl: 'http://localhost:13000/api' }, { scope: 'global' });
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.equal(env?.baseUrl, 'http://localhost:13000/api');
-    assert.equal(env?.auth, undefined);
+    expect(env?.baseUrl).toBe('http://localhost:13000/api');
+    expect(env?.auth).toBe(undefined);
   });
 });
 
@@ -168,8 +167,8 @@ test('upsertEnv clears an OAuth session when the base URL changes', async () => 
     await upsertEnv('test', { baseUrl: 'http://localhost:14000/api' }, { scope: 'global' });
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.equal(env?.baseUrl, 'http://localhost:14000/api');
-    assert.equal(env?.auth, undefined);
+    expect(env?.baseUrl).toBe('http://localhost:14000/api');
+    expect(env?.auth).toBe(undefined);
   });
 });
 
@@ -199,9 +198,9 @@ test('updateEnvConnection updates only the token and preserves the current base 
     await updateEnvConnection('test', { accessToken: 'new-token' }, { scope: 'global' });
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.equal(env?.baseUrl, 'http://localhost:13000/api');
-    assert.equal(env?.auth?.accessToken, 'new-token');
-    assert.equal(env?.runtime, undefined);
+    expect(env?.baseUrl).toBe('http://localhost:13000/api');
+    expect(env?.auth?.accessToken).toBe('new-token');
+    expect(env?.runtime).toBe(undefined);
   });
 });
 
@@ -231,7 +230,7 @@ test('updateEnvConnection preserves runtime metadata when connection settings ar
     await updateEnvConnection('test', { accessToken: 'same-token' }, { scope: 'global' });
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.deepEqual(env?.runtime, {
+    expect(env?.runtime).toEqual({
       version: 'v1',
       schemaHash: 'hash',
       generatedAt: '2026-04-13T00:00:00.000Z',
@@ -284,9 +283,9 @@ test('setEnvOauthSession can preserve runtime metadata during token refresh', as
     );
 
     const env = await getEnv('test', { scope: 'global' });
-    assert.equal(env?.auth?.type, 'oauth');
-    assert.equal(env?.auth?.accessToken, 'new-access-token');
-    assert.deepEqual(env?.runtime, {
+    expect(env?.auth?.type).toBe('oauth');
+    expect(env?.auth?.accessToken).toBe('new-access-token');
+    expect(env?.runtime).toEqual({
       version: 'v1',
       schemaHash: 'hash',
       generatedAt: '2026-04-13T00:00:00.000Z',

--- a/packages/core/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/core/cli/src/__tests__/bootstrap.test.ts
@@ -1,5 +1,13 @@
-import assert from 'node:assert/strict';
-import { test } from 'vitest';
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { test, expect } from 'vitest';
 import {
   formatMissingRuntimeEnvError,
   formatSwaggerSchemaError,
@@ -7,20 +15,20 @@ import {
 } from '../lib/bootstrap.js';
 
 test('shouldSkipRuntimeBootstrap skips root help and no-arg invocations', () => {
-  assert.equal(shouldSkipRuntimeBootstrap([]), false);
-  assert.equal(shouldSkipRuntimeBootstrap(['--help']), false);
-  assert.equal(shouldSkipRuntimeBootstrap(['-h']), false);
-  assert.equal(shouldSkipRuntimeBootstrap(['api']), false);
-  assert.equal(shouldSkipRuntimeBootstrap(['env', '--help']), true);
-  assert.equal(shouldSkipRuntimeBootstrap(['resource', 'list']), true);
-  assert.equal(shouldSkipRuntimeBootstrap(['api', 'resource', 'list']), true);
-  assert.equal(shouldSkipRuntimeBootstrap(['api', 'resource', 'list', '--help']), true);
+  expect(shouldSkipRuntimeBootstrap([])).toBe(false);
+  expect(shouldSkipRuntimeBootstrap(['--help'])).toBe(false);
+  expect(shouldSkipRuntimeBootstrap(['-h'])).toBe(false);
+  expect(shouldSkipRuntimeBootstrap(['api'])).toBe(false);
+  expect(shouldSkipRuntimeBootstrap(['env', '--help'])).toBe(true);
+  expect(shouldSkipRuntimeBootstrap(['resource', 'list'])).toBe(true);
+  expect(shouldSkipRuntimeBootstrap(['api', 'resource', 'list'])).toBe(true);
+  expect(shouldSkipRuntimeBootstrap(['api', 'resource', 'list', '--help'])).toBe(true);
 });
 
 test('shouldSkipRuntimeBootstrap still loads runtime for non-builtin commands', () => {
-  assert.equal(shouldSkipRuntimeBootstrap(['users', 'list']), false);
-  assert.equal(shouldSkipRuntimeBootstrap(['users', 'list', '--json-output']), false);
-  assert.equal(shouldSkipRuntimeBootstrap(['api', 'users', 'list']), false);
+  expect(shouldSkipRuntimeBootstrap(['users', 'list'])).toBe(false);
+  expect(shouldSkipRuntimeBootstrap(['users', 'list', '--json-output'])).toBe(false);
+  expect(shouldSkipRuntimeBootstrap(['api', 'users', 'list'])).toBe(false);
 });
 
 test('formatSwaggerSchemaError returns actionable guidance for invalid tokens', () => {
@@ -43,12 +51,12 @@ test('formatSwaggerSchemaError returns actionable guidance for invalid tokens', 
     },
   );
 
-  assert.match(message, /Authentication failed while loading the command runtime/);
-  assert.match(message, /env "local"/);
-  assert.match(message, /INVALID_TOKEN/);
-  assert.match(message, /env add <name> --base-url <url> --auth-type token --token <api-key>/);
-  assert.match(message, /nb env update/);
-  assert.match(message, /nb --help/);
+  expect(message).toMatch(/Authentication failed while loading the command runtime/);
+  expect(message).toMatch(/env "local"/);
+  expect(message).toMatch(/INVALID_TOKEN/);
+  expect(message).toMatch(/env add <name> --base-url <url> --auth-type token --token <api-key>/);
+  expect(message).toMatch(/nb env update/);
+  expect(message).toMatch(/nb --help/);
 });
 
 test('formatSwaggerSchemaError falls back to the raw swagger error for non-auth failures', () => {
@@ -66,8 +74,8 @@ test('formatSwaggerSchemaError falls back to the raw swagger error for non-auth 
     },
   );
 
-  assert.match(message, /^Failed to load swagger schema from `swagger:get`\./);
-  assert.match(message, /Internal Server Error/);
+  expect(message).toMatch(/^Failed to load swagger schema from `swagger:get`\./);
+  expect(message).toMatch(/Internal Server Error/);
 });
 
 test('formatSwaggerSchemaError explains network fetch failures clearly', () => {
@@ -86,18 +94,18 @@ test('formatSwaggerSchemaError explains network fetch failures clearly', () => {
     },
   );
 
-  assert.match(message, /Failed to reach the NocoBase server while loading the command runtime/);
-  assert.match(message, /Base URL: http:\/\/localhost:13000\/api/);
-  assert.match(message, /Network error: fetch failed/);
-  assert.match(message, /nb env add <name> --base-url <url>/);
-  assert.match(message, /nb env list/);
+  expect(message).toMatch(/Failed to reach the NocoBase server while loading the command runtime/);
+  expect(message).toMatch(/Base URL: http:\/\/localhost:13000\/api/);
+  expect(message).toMatch(/Network error: fetch failed/);
+  expect(message).toMatch(/nb env add <name> --base-url <url>/);
+  expect(message).toMatch(/nb env list/);
 });
 
 test('formatMissingRuntimeEnvError explains unknown runtime commands without an env', () => {
   const message = formatMissingRuntimeEnvError('not-a-real-command');
 
-  assert.match(message, /Unable to resolve runtime command `not-a-real-command`/);
-  assert.match(message, /No env is configured/);
-  assert.match(message, /nb --help/);
-  assert.match(message, /nb env update/);
+  expect(message).toMatch(/Unable to resolve runtime command `not-a-real-command`/);
+  expect(message).toMatch(/No env is configured/);
+  expect(message).toMatch(/nb --help/);
+  expect(message).toMatch(/nb env update/);
 });

--- a/packages/core/cli/src/__tests__/command-discovery.test.ts
+++ b/packages/core/cli/src/__tests__/command-discovery.test.ts
@@ -1,8 +1,16 @@
-import assert from 'node:assert/strict';
-import { test } from 'vitest';
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { test, expect } from 'vitest';
 import { commandRelativePathToRegistryKey } from '../lib/command-discovery.js';
 
 test('commandRelativePathToRegistryKey maps index modules to parent commands', () => {
-  assert.equal(commandRelativePathToRegistryKey('api/resource/index.ts'), 'api:resource');
-  assert.equal(commandRelativePathToRegistryKey('api/resource/list.ts'), 'api:resource:list');
+  expect(commandRelativePathToRegistryKey('api/resource/index.ts')).toBe('api:resource');
+  expect(commandRelativePathToRegistryKey('api/resource/list.ts')).toBe('api:resource:list');
 });

--- a/packages/core/cli/src/__tests__/download.test.ts
+++ b/packages/core/cli/src/__tests__/download.test.ts
@@ -7,11 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, test, vi } from 'vitest';
+import { afterEach, test, vi, expect } from 'vitest';
 import type { DownloadResolvedFlags } from '../commands/download.js';
 import Download from '../commands/download.js';
 
@@ -95,7 +94,7 @@ test('downloadFromDocker pulls image and saves a sanitized tarball path', async 
     'registry.cn-shanghai.aliyuncs.com-nocobase-nocobase-feature-foo.tar',
   );
 
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(mocks.run.mock.calls).toEqual([
     [
       'docker',
       ['pull', '--platform', 'linux/arm64', imageRef],
@@ -126,8 +125,8 @@ test('downloadFromNpm skips build without dev dependencies and forwards npm regi
 
   const projectRoot = await command.downloadFromNpm(flags);
 
-  assert.equal(projectRoot, path.join(cwd, 'app'));
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(projectRoot).toBe(path.join(cwd, 'app'));
+  expect(mocks.run.mock.calls).toEqual([
     [
       'npx',
       ['-y', 'create-nocobase-app@latest', 'app', '--skip-dev-dependencies'],
@@ -155,7 +154,7 @@ test('downloadFromNpm skips build without dev dependencies and forwards npm regi
       },
     ],
   ]);
-  assert.equal(runCommand.mock.calls.length, 0);
+  expect(runCommand.mock.calls.length).toBe(0);
 });
 
 test('downloadFromGit maps alpha to develop and builds with --no-dts by default', async () => {
@@ -174,8 +173,8 @@ test('downloadFromGit maps alpha to develop and builds with --no-dts by default'
 
   const projectRoot = await command.downloadFromGit(flags);
 
-  assert.equal(projectRoot, path.join(cwd, 'repo'));
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(projectRoot).toBe(path.join(cwd, 'repo'));
+  expect(mocks.run.mock.calls).toEqual([
     [
       'git',
       ['clone', '--branch', 'develop', '--depth', '1', 'https://github.com/nocobase/nocobase.git', './repo'],
@@ -192,7 +191,7 @@ test('downloadFromGit maps alpha to develop and builds with --no-dts by default'
       },
     ],
   ]);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(runCommand.mock.calls).toEqual([
     ['build', ['--cwd', path.join(cwd, 'repo'), '--no-dts']],
   ]);
 });
@@ -214,8 +213,8 @@ test('download forwards raw command output only in verbose mode', async () => {
 
   const projectRoot = await command.downloadFromGit(flags);
 
-  assert.equal(projectRoot, path.join(cwd, 'repo'));
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(projectRoot).toBe(path.join(cwd, 'repo'));
+  expect(mocks.run.mock.calls).toEqual([
     [
       'git',
       ['clone', '--branch', 'develop', '--depth', '1', 'https://github.com/nocobase/nocobase.git', './repo'],
@@ -232,7 +231,7 @@ test('download forwards raw command output only in verbose mode', async () => {
       },
     ],
   ]);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(runCommand.mock.calls).toEqual([
     ['build', ['--cwd', path.join(cwd, 'repo'), '--no-dts', '--verbose']],
   ]);
 });
@@ -263,18 +262,18 @@ test('download shows a delayed loading indicator for long-running commands in no
   const promise = command.downloadFromDocker(flags);
 
   await vi.advanceTimersByTimeAsync(7_999);
-  assert.equal(mocks.startTask.mock.calls.length, 0);
+  expect(mocks.startTask.mock.calls.length).toBe(0);
 
   await vi.advanceTimersByTimeAsync(1);
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Pulling the Docker image. Please wait...'],
   ]);
 
   resolveRun?.();
   await promise;
 
-  assert.equal(mocks.stopTask.mock.calls.length, 1);
-  assert.equal(mocks.updateTask.mock.calls.length, 0);
+  expect(mocks.stopTask.mock.calls.length).toBe(1);
+  expect(mocks.updateTask.mock.calls.length).toBe(0);
 });
 
 test('download shows a preparation loading state before entering the source-specific flow', async () => {
@@ -300,16 +299,16 @@ test('download shows a preparation loading state before entering the source-spec
     vi.fn(async () => resolved) as never;
   (command as Download & { downloadFromNpm: (flags: DownloadResolvedFlags) => Promise<string> }).downloadFromNpm =
     vi.fn(async (flags: DownloadResolvedFlags) => {
-      assert.deepEqual(flags, resolved);
-      assert.deepEqual(mocks.startTask.mock.calls, [
+      expect(flags).toEqual(resolved);
+      expect(mocks.startTask.mock.calls).toEqual([
         ['Preparing download from npm package'],
       ]);
-      assert.equal(mocks.stopTask.mock.calls.length, 0);
+      expect(mocks.stopTask.mock.calls.length).toBe(0);
       return path.join(process.cwd(), 'app');
     }) as never;
 
   const result = await command.download();
 
-  assert.equal(result.projectRoot, path.join(process.cwd(), 'app'));
-  assert.equal(mocks.stopTask.mock.calls.length, 1);
+  expect(result.projectRoot).toBe(path.join(process.cwd(), 'app'));
+  expect(mocks.stopTask.mock.calls.length).toBe(1);
 });

--- a/packages/core/cli/src/__tests__/env-add-command.test.ts
+++ b/packages/core/cli/src/__tests__/env-add-command.test.ts
@@ -7,8 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
-import { test, vi } from 'vitest';
+import { test, vi, expect } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   runPromptCatalog: vi.fn(),
@@ -82,7 +81,7 @@ test('env add saves builtinDb into env config when provided by install', async (
 
   await EnvAdd.prototype.run.call(command);
 
-  assert.deepEqual(mocks.upsertEnv.mock.calls[0], [
+  expect(mocks.upsertEnv.mock.calls[0]).toEqual([
     'local',
     {
       baseUrl: 'http://127.0.0.1:13000/api',
@@ -101,7 +100,7 @@ test('env add saves builtinDb into env config when provided by install', async (
     },
     { scope: 'project' },
   ]);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(runCommand.mock.calls).toEqual([
     ['env:update', ['local']],
   ]);
 });

--- a/packages/core/cli/src/__tests__/env-auth-command.test.ts
+++ b/packages/core/cli/src/__tests__/env-auth-command.test.ts
@@ -7,8 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
-import { test, vi } from 'vitest';
+import { test, vi, expect } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getCurrentEnvName: vi.fn(),
@@ -49,15 +48,15 @@ test('env auth falls back to the current env and uses product-style task message
 
   await EnvAuth.prototype.run.call(command);
 
-  assert.deepEqual(mocks.getCurrentEnvName.mock.calls, [[{ scope: undefined }]]);
-  assert.deepEqual(mocks.authenticateEnvWithOauth.mock.calls, [[{ envName: 'staging', scope: undefined }]]);
-  assert.deepEqual(mocks.startTask.mock.calls, [
+  expect(mocks.getCurrentEnvName.mock.calls).toEqual([[{ scope: undefined }]]);
+  expect(mocks.authenticateEnvWithOauth.mock.calls).toEqual([[{ envName: 'staging', scope: undefined }]]);
+  expect(mocks.startTask.mock.calls).toEqual([
     ['Starting browser sign-in for "staging"...'],
   ]);
-  assert.deepEqual(mocks.succeedTask.mock.calls, [
+  expect(mocks.succeedTask.mock.calls).toEqual([
     ['Signed in to "staging".'],
   ]);
-  assert.equal(mocks.failTask.mock.calls.length, 0);
+  expect(mocks.failTask.mock.calls.length).toBe(0);
 });
 
 test('env auth rejects conflicting environment names from arg and --env', async () => {
@@ -73,8 +72,5 @@ test('env auth rejects conflicting environment names from arg and --env', async 
     },
   });
 
-  await assert.rejects(
-    () => EnvAuth.prototype.run.call(command),
-    /Please use only one/,
-  );
+  await expect((() => EnvAuth.prototype.run.call(command))()).rejects.toThrow(/Please use only one/);
 });

--- a/packages/core/cli/src/__tests__/env-auth.test.ts
+++ b/packages/core/cli/src/__tests__/env-auth.test.ts
@@ -7,11 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import { saveAuthConfig } from '../lib/auth-store.js';
 import {
   buildOauthCompletionHtml,
@@ -56,76 +55,64 @@ async function withOauthRetryDelay(delayMs: string, run: () => Promise<void>) {
 }
 
 test('OAuth helpers derive metadata and resource URLs from base URL', () => {
-  assert.equal(
-    getOauthMetadataUrl('http://localhost:13000/api/'),
-    'http://localhost:13000/api/.well-known/oauth-authorization-server',
-  );
-  assert.equal(getOauthResource('http://localhost:13000/api/'), 'http://localhost:13000/api/');
-  assert.equal(getOauthResource('https://demo.example.com/custom/api'), 'https://demo.example.com/custom/api/');
+  expect(getOauthMetadataUrl('http://localhost:13000/api/')).toBe('http://localhost:13000/api/.well-known/oauth-authorization-server');
+  expect(getOauthResource('http://localhost:13000/api/')).toBe('http://localhost:13000/api/');
+  expect(getOauthResource('https://demo.example.com/custom/api')).toBe('https://demo.example.com/custom/api/');
 });
 
 test('buildOauthRedirectHtml escapes OAuth URLs for HTML and script contexts', () => {
   const url = 'https://example.com/oauth?scope=openid api&state="abc"&next=<script>alert(1)</script>';
   const html = buildOauthRedirectHtml(url);
 
-  assert.match(html, /<title>NocoBase OAuth Login<\/title>/);
-  assert.match(html, /Redirecting to sign-in/);
-  assert.match(html, /Continue to sign-in/);
-  assert.match(html, /Open manually/);
-  assert.match(html, /scope=openid api&amp;state=&quot;abc&quot;&amp;next=&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
-  assert.match(
-    html,
-    /window\.location\.replace\("https:\/\/example\.com\/oauth\?scope=openid api&state=\\"abc\\"&next=\\u003cscript>alert\(1\)\\u003c\/script>"/,
-  );
-  assert.doesNotMatch(html, /href="[^"]*&state="/);
+  expect(html).toMatch(/<title>NocoBase OAuth Login<\/title>/);
+  expect(html).toMatch(/Redirecting to sign-in/);
+  expect(html).toMatch(/Continue to sign-in/);
+  expect(html).toMatch(/Open manually/);
+  expect(html).toMatch(/scope=openid api&amp;state=&quot;abc&quot;&amp;next=&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  expect(html).toMatch(/window\.location\.replace\("https:\/\/example\.com\/oauth\?scope=openid api&state=\\"abc\\"&next=\\u003cscript>alert\(1\)\\u003c\/script>"/);
+  expect(html).not.toMatch(/href="[^"]*&state="/);
 });
 
 test('buildOauthCompletionHtml renders a styled completion page with auto-close guidance', () => {
   const html = buildOauthCompletionHtml();
 
-  assert.match(html, /<title>Authentication complete<\/title>/);
-  assert.match(html, /NocoBase CLI/);
-  assert.match(html, /Authentication complete/);
-  assert.match(html, /This page will close automatically in 10 seconds\./);
-  assert.match(html, /window\.close\(\)/);
-  assert.match(html, /}, 10000\);/);
-  assert.match(html, /If this tab stays open, you can close it manually\./);
+  expect(html).toMatch(/<title>Authentication complete<\/title>/);
+  expect(html).toMatch(/NocoBase CLI/);
+  expect(html).toMatch(/Authentication complete/);
+  expect(html).toMatch(/This page will close automatically in 10 seconds\./);
+  expect(html).toMatch(/window\.close\(\)/);
+  expect(html).toMatch(/}, 10000\);/);
+  expect(html).toMatch(/If this tab stays open, you can close it manually\./);
 });
 
 test('buildOauthErrorHtml renders a styled error page and escapes detail content', () => {
   const html = buildOauthErrorHtml('Invalid state: <script>alert("xss")</script>');
 
-  assert.match(html, /<title>Authentication failed<\/title>/);
-  assert.match(html, /The OAuth sign-in flow could not be completed in this browser tab\./);
-  assert.match(html, /Invalid state: &lt;script&gt;alert\(&quot;xss&quot;\)&lt;\/script&gt;/);
-  assert.doesNotMatch(html, /<script>alert\("xss"\)<\/script>/);
-  assert.match(html, /Return to the terminal to review the error details and try again if needed\./);
+  expect(html).toMatch(/<title>Authentication failed<\/title>/);
+  expect(html).toMatch(/The OAuth sign-in flow could not be completed in this browser tab\./);
+  expect(html).toMatch(/Invalid state: &lt;script&gt;alert\(&quot;xss&quot;\)&lt;\/script&gt;/);
+  expect(html).not.toMatch(/<script>alert\("xss"\)<\/script>/);
+  expect(html).toMatch(/Return to the terminal to review the error details and try again if needed\./);
 });
 
 test('isOauthAccessTokenExpired uses a refresh window', () => {
   const now = Date.parse('2026-04-15T00:00:00.000Z');
-  assert.equal(
-    isOauthAccessTokenExpired(
+  expect(isOauthAccessTokenExpired(
       {
         type: 'oauth',
         accessToken: 'token',
         expiresAt: '2026-04-15T00:00:30.000Z',
       },
       now,
-    ),
-    true,
-  );
-  assert.equal(
-    isOauthAccessTokenExpired(
+    )).toBe(true);
+  expect(isOauthAccessTokenExpired(
       {
         type: 'oauth',
         accessToken: 'token',
         expiresAt: '2026-04-15T00:05:00.000Z',
       },
       now,
-    ),
-    false,
-  );
+    )).toBe(false);
 });
 
 test('resolveAccessToken refreshes expired OAuth sessions', async () => {
@@ -166,12 +153,12 @@ test('resolveAccessToken refreshes expired OAuth sessions', async () => {
         );
       }
 
-      assert.equal(url, 'http://localhost:13000/api/idpOAuth/token');
+      expect(url).toBe('http://localhost:13000/api/idpOAuth/token');
       const body = init?.body instanceof URLSearchParams ? init.body : new URLSearchParams(String(init?.body ?? ''));
-      assert.equal(body.get('grant_type'), 'refresh_token');
-      assert.equal(body.get('client_id'), 'client-1');
-      assert.equal(body.get('refresh_token'), 'refresh-token');
-      assert.equal(body.get('resource'), 'http://localhost:13000/api/');
+      expect(body.get('grant_type')).toBe('refresh_token');
+      expect(body.get('client_id')).toBe('client-1');
+      expect(body.get('refresh_token')).toBe('refresh-token');
+      expect(body.get('resource')).toBe('http://localhost:13000/api/');
 
       return new Response(
         JSON.stringify({
@@ -189,7 +176,7 @@ test('resolveAccessToken refreshes expired OAuth sessions', async () => {
         envName: 'test',
         scope: 'global',
       });
-      assert.equal(token, 'fresh-token');
+      expect(token).toBe('fresh-token');
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -241,8 +228,8 @@ test('resolveAccessToken retries transient OAuth metadata network failures', asy
           );
         }
 
-        assert.equal(url, 'http://localhost:13000/api/idpOAuth/token');
-        assert.equal(init?.method, 'POST');
+        expect(url).toBe('http://localhost:13000/api/idpOAuth/token');
+        expect(init?.method).toBe('POST');
         return new Response(
           JSON.stringify({
             access_token: 'fresh-token-after-retry',
@@ -258,8 +245,8 @@ test('resolveAccessToken retries transient OAuth metadata network failures', asy
           envName: 'test',
           scope: 'global',
         });
-        assert.equal(token, 'fresh-token-after-retry');
-        assert.equal(metadataAttempts, 3);
+        expect(token).toBe('fresh-token-after-retry');
+        expect(metadataAttempts).toBe(3);
       } finally {
         globalThis.fetch = originalFetch;
       }
@@ -298,26 +285,25 @@ test('resolveAccessToken explains OAuth metadata network failures clearly', asyn
       }) as typeof fetch;
 
       try {
-        await assert.rejects(
-          () =>
-            resolveAccessToken({
-              envName: 'test',
-              scope: 'global',
-            }),
-          (error: any) => {
-            assert.match(error.message, /Failed to load OAuth metadata\./);
-            assert.match(error.message, /Env: test/);
-            assert.match(error.message, /Base URL: http:\/\/localhost:13000\/api/);
-            assert.match(
-              error.message,
-              /Request URL: http:\/\/localhost:13000\/api\/\.well-known\/oauth-authorization-server/,
-            );
-            assert.match(error.message, /Network error: fetch failed/);
-            assert.match(error.message, /nb env auth test/);
-            assert.match(error.message, /nb env list/);
-            return true;
-          },
-        );
+        try {
+          await resolveAccessToken({
+            envName: 'test',
+            scope: 'global',
+          });
+        } catch (error: any) {
+          expect(error.message).toMatch(/Failed to load OAuth metadata\./);
+          expect(error.message).toMatch(/Env: test/);
+          expect(error.message).toMatch(/Base URL: http:\/\/localhost:13000\/api/);
+          expect(error.message).toMatch(
+            /Request URL: http:\/\/localhost:13000\/api\/\.well-known\/oauth-authorization-server/,
+          );
+          expect(error.message).toMatch(/Network error: fetch failed/);
+          expect(error.message).toMatch(/nb env auth test/);
+          expect(error.message).toMatch(/nb env list/);
+          return;
+        }
+
+        throw new Error('Expected resolveAccessToken to reject');
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/packages/core/cli/src/__tests__/generated-command-body-modes.test.ts
+++ b/packages/core/cli/src/__tests__/generated-command-body-modes.test.ts
@@ -7,11 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import { Command } from '@oclif/core';
 import { parseBody, type RequestOperation } from '../lib/api-client.js';
 import { createGeneratedFlags, type GeneratedOperation } from '../lib/generated-command.js';
@@ -54,7 +53,7 @@ class ParseOnlyTestApiCommand extends Command {
 
 test('body JSON path should not require body field flags at parse time', async () => {
   const result = await ParseOnlyTestApiCommand.run(['--body', '{"primaryValue":"ok","items":[]}']);
-  assert.deepEqual(result.flags, {
+  expect(result.flags).toEqual({
     body: '{"primaryValue":"ok","items":[]}',
     'json-output': true,
     verbose: false,
@@ -63,8 +62,8 @@ test('body JSON path should not require body field flags at parse time', async (
 
 test('body-file path should not require inline body or body field flags at parse time', async () => {
   const result = await ParseOnlyTestApiCommand.run(['--body-file', '/tmp/test-api.json']);
-  assert.equal(result.flags['body-file'], '/tmp/test-api.json');
-  assert.equal(result.flags.body, undefined);
+  expect(result.flags['body-file']).toBe('/tmp/test-api.json');
+  expect(result.flags.body).toBe(undefined);
 });
 
 test('parseBody should still enforce required body fields when flag mode is used', async () => {
@@ -76,7 +75,7 @@ test('parseBody should still enforce required body fields when flag mode is used
     bodyRequired: true,
   };
 
-  await assert.rejects(() => parseBody({ 'primary-value': 'ok' }, operation), /Missing required body field --items/);
+  await expect((() => parseBody({ 'primary-value': 'ok' }, operation))()).rejects.toThrow(/Missing required body field --items/);
 });
 
 test('parseBody should accept raw body JSON without checking sibling flags', async () => {
@@ -89,7 +88,7 @@ test('parseBody should accept raw body JSON without checking sibling flags', asy
   };
 
   const body = await parseBody({ body: '{"primaryValue":"ok","items":[]}' }, operation);
-  assert.deepEqual(body, { primaryValue: 'ok', items: [] });
+  expect(body).toEqual({ primaryValue: 'ok', items: [] });
 });
 
 test('parseBody should parse --body-file with UTF-8 BOM', async () => {
@@ -106,7 +105,7 @@ test('parseBody should parse --body-file with UTF-8 BOM', async () => {
 
   try {
     const body = await parseBody({ 'body-file': filePath }, operation);
-    assert.deepEqual(body, { primaryValue: 'ok', items: [] });
+    expect(body).toEqual({ primaryValue: 'ok', items: [] });
   } finally {
     await fs.unlink(filePath).catch(() => undefined);
   }
@@ -121,10 +120,7 @@ test('parseBody should reject invalid JSON for json-encoded body fields', async 
     bodyRequired: true,
   };
 
-  await assert.rejects(
-    () => parseBody({ 'primary-value': 'ok', items: '[{name:item}]' }, operation),
-    /Invalid JSON for --items/,
-  );
+  await expect((() => parseBody({ 'primary-value': 'ok', items: '[{name:item}]' }, operation))()).rejects.toThrow(/Invalid JSON for --items/);
 });
 
 test('parseBody should describe conflicting raw body and body flags clearly', async () => {
@@ -136,10 +132,7 @@ test('parseBody should describe conflicting raw body and body flags clearly', as
     bodyRequired: true,
   };
 
-  await assert.rejects(
-    () => parseBody({ body: '{"primaryValue":"ok","items":[]}', 'primary-value': 'ok' }, operation),
-    /Conflicting request body inputs: received --body together with body field flags \(--primary-value\)/,
-  );
+  await expect((() => parseBody({ body: '{"primaryValue":"ok","items":[]}', 'primary-value': 'ok' }, operation))()).rejects.toThrow(/Conflicting request body inputs: received --body together with body field flags \(--primary-value\)/);
 });
 
 test('buildExamples should not mix required body flags with --body examples', () => {
@@ -148,7 +141,7 @@ test('buildExamples should not mix required body flags with --body examples', ()
     hasBody: true,
   });
 
-  assert.deepEqual(examples, [
+  expect(examples).toEqual([
     "nb api test api --primary-value <value> --items '[]'",
     `nb api test api --body '{"primaryValue":"value","items":[]}'`,
   ]);
@@ -157,10 +150,10 @@ test('buildExamples should not mix required body flags with --body examples', ()
 test('createGeneratedFlags should group body, raw JSON body, and global flags separately for help output', () => {
   const flags = createGeneratedFlags(testApiOperation);
 
-  assert.equal(flags['primary-value'].helpGroup, 'Body Field');
-  assert.equal(flags.items.helpGroup, 'Body Field');
-  assert.equal(flags.body.helpGroup, 'Raw JSON Body');
-  assert.equal(flags['body-file'].helpGroup, 'Raw JSON Body');
-  assert.equal(flags.env.helpGroup, 'Global');
-  assert.equal(flags['base-url'].helpGroup, 'Global');
+  expect(flags['primary-value'].helpGroup).toBe('Body Field');
+  expect(flags.items.helpGroup).toBe('Body Field');
+  expect(flags.body.helpGroup).toBe('Raw JSON Body');
+  expect(flags['body-file'].helpGroup).toBe('Raw JSON Body');
+  expect(flags.env.helpGroup).toBe('Global');
+  expect(flags['base-url'].helpGroup).toBe('Global');
 });

--- a/packages/core/cli/src/__tests__/init.test.ts
+++ b/packages/core/cli/src/__tests__/init.test.ts
@@ -7,8 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test, vi, expect } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   runPromptCatalogWebUI: vi.fn(),
@@ -130,9 +129,9 @@ test('nb init continues from the browser UI result and runs env:add for an exist
 
   await Init.prototype.run.call(command);
 
-  assert.equal(mocks.runPromptCatalogWebUI.mock.calls.length, 1);
-  assert.equal(mocks.runPromptCatalog.mock.calls.length, 1);
-  assert.deepEqual(mocks.runPromptCatalog.mock.calls[0]?.[1]?.values, {
+  expect(mocks.runPromptCatalogWebUI.mock.calls.length).toBe(1);
+  expect(mocks.runPromptCatalog.mock.calls.length).toBe(1);
+  expect(mocks.runPromptCatalog.mock.calls[0]?.[1]?.values).toEqual({
     appName: 'staging',
     hasNocobase: 'yes',
     installSkills: false,
@@ -140,9 +139,9 @@ test('nb init continues from the browser UI result and runs env:add for an exist
     authType: 'token',
     accessToken: 'secret-token',
   });
-  assert.equal(mocks.runPromptCatalog.mock.calls[0]?.[1]?.yes, true);
-  assert.equal(mocks.runNpm.mock.calls.length, 0);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(mocks.runPromptCatalog.mock.calls[0]?.[1]?.yes).toBe(true);
+  expect(mocks.runNpm.mock.calls.length).toBe(0);
+  expect(runCommand.mock.calls).toEqual([
     [
       'env:add',
       [
@@ -222,8 +221,8 @@ test('nb init forwards download options to nb install for a new app flow', async
 
   await Init.prototype.run.call(command);
 
-  assert.equal(mocks.runNpm.mock.calls.length, 0);
-  assert.deepEqual(mocks.upsertEnv.mock.calls, [[
+  expect(mocks.runNpm.mock.calls.length).toBe(0);
+  expect(mocks.upsertEnv.mock.calls).toEqual([[
     'demoapp',
     {
       baseUrl: 'http://127.0.0.1:13080/api',
@@ -245,7 +244,7 @@ test('nb init forwards download options to nb install for a new app flow', async
     },
     { scope: 'project' },
   ]]);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(runCommand.mock.calls).toEqual([
     [
       'install',
       [
@@ -356,13 +355,10 @@ test('nb init saves env config before install starts so failures still leave the
     },
   });
 
-  await assert.rejects(
-    () => Init.prototype.run.call(command),
-    /install failed/,
-  );
+  await expect((() => Init.prototype.run.call(command))()).rejects.toThrow(/install failed/);
 
-  assert.equal(mocks.upsertEnv.mock.calls.length, 1);
-  assert.equal(mocks.upsertEnv.mock.invocationCallOrder[0] < runCommand.mock.invocationCallOrder[0], true);
+  expect(mocks.upsertEnv.mock.calls.length).toBe(1);
+  expect(mocks.upsertEnv.mock.invocationCallOrder[0] < runCommand.mock.invocationCallOrder[0]).toBe(true);
 });
 
 test('nb init --resume delegates to nb install --resume for the selected env', async () => {
@@ -391,8 +387,8 @@ test('nb init --resume delegates to nb install --resume for the selected env', a
 
   await Init.prototype.run.call(command);
 
-  assert.equal(mocks.runPromptCatalog.mock.calls.length, 0);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(mocks.runPromptCatalog.mock.calls.length).toBe(0);
+  expect(runCommand.mock.calls).toEqual([
     [
       'install',
       ['--no-intro', '--env', 'app1', '--resume'],
@@ -440,10 +436,10 @@ test('nb init installs skills when --install-skills is provided', async () => {
     process.argv = originalArgv;
   }
 
-  assert.deepEqual(mocks.runNpm.mock.calls, [
+  expect(mocks.runNpm.mock.calls).toEqual([
     ['npx', ['-y', 'skills', 'add', 'nocobase/skills', '-y']],
   ]);
-  assert.deepEqual(runCommand.mock.calls[0], [
+  expect(runCommand.mock.calls[0]).toEqual([
     'env:add',
     ['staging', '--no-intro', '--scope', 'project', '--api-base-url', 'http://localhost:13000/api', '--auth-type', 'oauth'],
   ]);
@@ -477,7 +473,7 @@ test('nb init does not forward the default app port in --yes mode unless it was 
       { yes: true },
     );
 
-    assert.equal(argv.includes('--app-port'), false);
+    expect(argv.includes('--app-port')).toBe(false);
   } finally {
     process.argv = originalArgv;
   }
@@ -510,12 +506,9 @@ test('nb init logs duplicate env validation errors with Clack in --yes mode', as
     },
   });
 
-  await assert.rejects(
-    () => Init.prototype.run.call(command),
-    /exit: 1/,
-  );
-  assert.equal(mocks.promptError.mock.calls.length, 1);
-  assert.match(String(mocks.promptError.mock.calls[0]?.[0] ?? ''), /local3/);
+  await expect((() => Init.prototype.run.call(command))()).rejects.toThrow(/exit: 1/);
+  expect(mocks.promptError.mock.calls.length).toBe(1);
+  expect(String(mocks.promptError.mock.calls[0]?.[0] ?? '')).toMatch(/local3/);
 });
 
 test('nb init explains that --env is required when --yes skips prompts', async () => {
@@ -538,19 +531,13 @@ test('nb init explains that --env is required when --yes skips prompts', async (
     },
   });
 
-  await assert.rejects(
-    () => Init.prototype.run.call(command),
-    /exit: 1/,
-  );
-  assert.equal(mocks.runPromptCatalog.mock.calls.length, 0);
-  assert.equal(mocks.promptInfo.mock.calls.length, 0);
-  assert.equal(mocks.promptWarn.mock.calls.length, 0);
-  assert.equal(runCommand.mock.calls.length, 0);
-  assert.equal(mocks.promptError.mock.calls.length, 1);
-  assert.match(
-    String(mocks.promptError.mock.calls[0]?.[0] ?? ''),
-    /App name is required when prompts are skipped\..*nb init --yes --env <envName>/s,
-  );
+  await expect((() => Init.prototype.run.call(command))()).rejects.toThrow(/exit: 1/);
+  expect(mocks.runPromptCatalog.mock.calls.length).toBe(0);
+  expect(mocks.promptInfo.mock.calls.length).toBe(0);
+  expect(mocks.promptWarn.mock.calls.length).toBe(0);
+  expect(runCommand.mock.calls.length).toBe(0);
+  expect(mocks.promptError.mock.calls.length).toBe(1);
+  expect(String(mocks.promptError.mock.calls[0]?.[0] ?? '')).toMatch(/App name is required when prompts are skipped\..*nb init --yes --env <envName>/s);
 });
 
 test('nb init --locale overrides the environment locale for prompt-side messages', async () => {
@@ -575,13 +562,9 @@ test('nb init --locale overrides the environment locale for prompt-side messages
     },
   });
 
-  await assert.rejects(
-    () => Init.prototype.run.call(command),
-    /exit: 1/,
-  );
-  assert.equal(mocks.promptError.mock.calls.length, 1);
-  assert.match(
-    String(mocks.promptError.mock.calls[0]?.[0] ?? ''),
+  await expect((() => Init.prototype.run.call(command))()).rejects.toThrow(/exit: 1/);
+  expect(mocks.promptError.mock.calls.length).toBe(1);
+  expect(String(mocks.promptError.mock.calls[0]?.[0] ?? '')).toMatch(
     /App name is required when prompts are skipped\..*nb init --yes --env <envName>/s,
   );
 });
@@ -636,18 +619,12 @@ test('nb init --force allows reconfiguring an existing workspace env and warns b
     process.argv = originalArgv;
   }
 
-  assert.deepEqual(runCommand.mock.calls[0], [
+  expect(runCommand.mock.calls[0]).toEqual([
     'install',
     ['-y', '--no-intro', '--env', 'local5', '--lang', 'en-US', '--app-root-path', './nocobase', '--storage-path', './storage/local5', '--force'],
   ]);
-  assert.equal(
-    mocks.promptWarn.mock.calls.some((call) => String(call[0]).includes('Reconfiguring existing env')),
-    true,
-  );
-  assert.equal(
-    mocks.promptWarn.mock.calls.some((call) => String(call[0]).includes('local5')),
-    true,
-  );
+  expect(mocks.promptWarn.mock.calls.some((call) => String(call[0]).includes('Reconfiguring existing env'))).toBe(true);
+  expect(mocks.promptWarn.mock.calls.some((call) => String(call[0]).includes('local5'))).toBe(true);
 });
 
 test('nb init forwards dynamically selected ports in --yes mode', async () => {
@@ -680,14 +657,8 @@ test('nb init forwards dynamically selected ports in --yes mode', async () => {
       { yes: true },
     );
 
-    assert.deepEqual(
-      argv.slice(argv.indexOf('--app-port'), argv.indexOf('--app-port') + 2),
-      ['--app-port', '54180'],
-    );
-    assert.deepEqual(
-      argv.slice(argv.indexOf('--db-port'), argv.indexOf('--db-port') + 2),
-      ['--db-port', '54181'],
-    );
+    expect(argv.slice(argv.indexOf('--app-port'), argv.indexOf('--app-port') + 2)).toEqual(['--app-port', '54180']);
+    expect(argv.slice(argv.indexOf('--db-port'), argv.indexOf('--db-port') + 2)).toEqual(['--db-port', '54181']);
   } finally {
     process.argv = originalArgv;
   }
@@ -722,7 +693,7 @@ test('nb init does not forward a hidden Docker built-in database port in --yes m
       { yes: true },
     );
 
-    assert.equal(argv.includes('--db-port'), false);
+    expect(argv.includes('--db-port')).toBe(false);
   } finally {
     process.argv = originalArgv;
   }
@@ -747,13 +718,10 @@ test('nb init treats the --yes download source as docker when resolving dynamic 
 
     const initialValues = await buildDynamicInitialValuesForInstall({ yes: true }, { appPort: '13000' });
 
-    assert.equal(Object.prototype.hasOwnProperty.call(initialValues, 'appRootPath'), false);
-    assert.equal(Object.prototype.hasOwnProperty.call(initialValues, 'storagePath'), false);
+    expect(Object.prototype.hasOwnProperty.call(initialValues, 'appRootPath')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(initialValues, 'storagePath')).toBe(false);
 
-    assert.equal(
-      buildDbPromptInitialValues.mock.calls[0]?.[0].downloadResults.source,
-      'docker',
-    );
+    expect(buildDbPromptInitialValues.mock.calls[0]?.[0].downloadResults.source).toBe('docker');
   } finally {
     buildDbPromptInitialValues.mockRestore();
   }
@@ -801,12 +769,9 @@ test('nb init preserves argument values that contain spaces when building instal
     );
 
     const nicknameIndex = argv.indexOf('--root-nickname');
-    assert.notEqual(nicknameIndex, -1);
-    assert.equal(argv[nicknameIndex + 1], 'Super Admin');
-    assert.deepEqual(
-      argv.slice(argv.indexOf('--docker-platform'), argv.indexOf('--docker-platform') + 2),
-      ['--docker-platform', 'linux/arm64'],
-    );
+    expect(nicknameIndex).not.toBe(-1);
+    expect(argv[nicknameIndex + 1]).toBe('Super Admin');
+    expect(argv.slice(argv.indexOf('--docker-platform'), argv.indexOf('--docker-platform') + 2)).toEqual(['--docker-platform', 'linux/arm64']);
   } finally {
     process.argv = originalArgv;
   }
@@ -850,13 +815,10 @@ test('nb init disables skills install by default when the current workspace has 
   } finally {
   }
 
-  assert.equal(mocks.runPromptCatalog.mock.calls[0]?.[1]?.values?.installSkills, false);
-  assert.equal(mocks.runNpm.mock.calls.length, 0);
-  assert.equal(
-    mocks.promptInfo.mock.calls.some((call) => String(call[0]).includes('Skipped NocoBase agent skills install.')),
-    true,
-  );
-  assert.deepEqual(runCommand.mock.calls[0], [
+  expect(mocks.runPromptCatalog.mock.calls[0]?.[1]?.values?.installSkills).toBe(false);
+  expect(mocks.runNpm.mock.calls.length).toBe(0);
+  expect(mocks.promptInfo.mock.calls.some((call) => String(call[0]).includes('Skipped NocoBase agent skills install.'))).toBe(true);
+  expect(runCommand.mock.calls[0]).toEqual([
     'env:add',
     ['staging', '--no-intro', '--scope', 'project', '--api-base-url', 'http://localhost:13000/api', '--auth-type', 'oauth'],
   ]);

--- a/packages/core/cli/src/__tests__/install-db.test.ts
+++ b/packages/core/cli/src/__tests__/install-db.test.ts
@@ -7,10 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import net from 'node:net';
 import path from 'node:path';
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import Install from '../commands/install.js';
 import { validateAvailableTcpPort } from '../lib/prompt-validators.js';
 
@@ -95,17 +94,14 @@ test('builtin postgres db plan uses workspace network and env scoped docker cont
 
   const prefix = `nb-${path.basename(process.cwd()).toLowerCase()}`;
   const containerName = `${prefix}-demo-postgres`;
-  assert.equal(plan.networkName, prefix);
-  assert.equal(plan.containerName, containerName);
-  assert.equal(plan.dbHost, '127.0.0.1');
-  assert.equal(plan.dbPort, '5433');
-  assert.equal(plan.image, 'postgres:16');
-  assert.equal(plan.builtinDbImage, 'postgres:16');
-  assert.equal(
-    plan.dataDir,
-    path.resolve('./storage/demo', 'db', 'postgres'),
-  );
-  assert.deepEqual(plan.args, [
+  expect(plan.networkName).toBe(prefix);
+  expect(plan.containerName).toBe(containerName);
+  expect(plan.dbHost).toBe('127.0.0.1');
+  expect(plan.dbPort).toBe('5433');
+  expect(plan.image).toBe('postgres:16');
+  expect(plan.builtinDbImage).toBe('postgres:16');
+  expect(plan.dataDir).toBe(path.resolve('./storage/demo', 'db', 'postgres'));
+  expect(plan.args).toEqual([
     'run',
     '-d',
     '--name',
@@ -141,9 +137,9 @@ test('builtin postgres db plan uses a custom built-in database image when provid
     builtinDbImage: 'registry.example.com/postgres:16',
   });
 
-  assert.equal(plan.image, 'registry.example.com/postgres:16');
-  assert.equal(plan.builtinDbImage, 'registry.example.com/postgres:16');
-  assert.equal(plan.args.includes('registry.example.com/postgres:16'), true);
+  expect(plan.image).toBe('registry.example.com/postgres:16');
+  expect(plan.builtinDbImage).toBe('registry.example.com/postgres:16');
+  expect(plan.args.includes('registry.example.com/postgres:16')).toBe(true);
 });
 
 test('builtin postgres db plan can use the workspace name from config', () => {
@@ -156,8 +152,8 @@ test('builtin postgres db plan can use the workspace name from config', () => {
     dbDialect: 'postgres',
   });
 
-  assert.equal(plan.networkName, 'nb-shared-workspace');
-  assert.equal(plan.containerName, 'nb-shared-workspace-demo-postgres');
+  expect(plan.networkName).toBe('nb-shared-workspace');
+  expect(plan.containerName).toBe('nb-shared-workspace-demo-postgres');
 });
 
 test('builtin db plan does not publish host port for docker source and uses container host', () => {
@@ -174,11 +170,8 @@ test('builtin db plan does not publish host port for docker source and uses cont
     dbPassword: 'nocobase',
   });
 
-  assert.equal(
-    plan.dbHost,
-    `nb-${path.basename(process.cwd()).toLowerCase()}-dockerapp-postgres`,
-  );
-  assert.equal(plan.args.includes('-p'), false);
+  expect(plan.dbHost).toBe(`nb-${path.basename(process.cwd()).toLowerCase()}-dockerapp-postgres`);
+  expect(plan.args.includes('-p')).toBe(false);
 });
 
 test('builtin mysql db plan publishes the selected db port', () => {
@@ -195,12 +188,12 @@ test('builtin mysql db plan publishes the selected db port', () => {
     dbPassword: 'nb_pass',
   });
 
-  assert.equal(plan.image, 'mysql:8');
-  assert.equal(plan.args.includes('-p'), true);
-  assert.equal(plan.args.includes('3307:3306'), true);
-  assert.equal(plan.args.includes('MYSQL_USER=nb_user'), true);
-  assert.equal(plan.args.includes('MYSQL_DATABASE=nb_mysql'), true);
-  assert.equal(plan.args.includes('MYSQL_PASSWORD=nb_pass'), true);
+  expect(plan.image).toBe('mysql:8');
+  expect(plan.args.includes('-p')).toBe(true);
+  expect(plan.args.includes('3307:3306')).toBe(true);
+  expect(plan.args.includes('MYSQL_USER=nb_user')).toBe(true);
+  expect(plan.args.includes('MYSQL_DATABASE=nb_mysql')).toBe(true);
+  expect(plan.args.includes('MYSQL_PASSWORD=nb_pass')).toBe(true);
 });
 
 test('builtin kingbase db plan uses the default kingbase image and runtime options', () => {
@@ -217,22 +210,16 @@ test('builtin kingbase db plan uses the default kingbase image and runtime optio
     dbPassword: 'nocobase',
   });
 
-  assert.equal(
-    plan.image,
-    'registry.cn-shanghai.aliyuncs.com/nocobase/kingbase:v009r001c001b0030_single_x86',
-  );
-  assert.equal(plan.builtinDbImage, plan.image);
-  assert.equal(plan.args.includes('--platform'), true);
-  assert.equal(plan.args.includes('linux/amd64'), true);
-  assert.equal(plan.args.includes('--privileged'), true);
-  assert.equal(plan.args.includes('ENABLE_CI=no'), true);
-  assert.equal(plan.args.includes('DB_MODE=pg'), true);
-  assert.equal(plan.args.includes('NEED_START=yes'), true);
-  assert.equal(plan.args.includes('54321:54321'), true);
-  assert.equal(
-    plan.args.includes(`${path.resolve('./storage/kingapp', 'db', 'kingbase')}:/home/kingbase/userdata`),
-    true,
-  );
+  expect(plan.image).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/kingbase:v009r001c001b0030_single_x86');
+  expect(plan.builtinDbImage).toBe(plan.image);
+  expect(plan.args.includes('--platform')).toBe(true);
+  expect(plan.args.includes('linux/amd64')).toBe(true);
+  expect(plan.args.includes('--privileged')).toBe(true);
+  expect(plan.args.includes('ENABLE_CI=no')).toBe(true);
+  expect(plan.args.includes('DB_MODE=pg')).toBe(true);
+  expect(plan.args.includes('NEED_START=yes')).toBe(true);
+  expect(plan.args.includes('54321:54321')).toBe(true);
+  expect(plan.args.includes(`${path.resolve('./storage/kingapp', 'db', 'kingbase')}:/home/kingbase/userdata`)).toBe(true);
 });
 
 test('docker app plan wires app, db, network, port, and image settings', () => {
@@ -267,33 +254,33 @@ test('docker app plan wires app, db, network, port, and image settings', () => {
     },
   });
 
-  assert.equal(plan.source, 'docker');
-  assert.equal(plan.networkName, prefix);
-  assert.equal(plan.containerName, `${prefix}-demo-app`);
-  assert.equal(plan.imageRef, 'registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:develop');
-  assert.equal(plan.appPort, '13000');
-  assert.equal(plan.storagePath, path.resolve('./storage/demo'));
-  assert.equal(plan.appKey.length, 64);
-  assert.equal(typeof plan.timeZone, 'string');
-  assert.equal(plan.timeZone.length > 0, true);
-  assert.equal(plan.args.includes('--platform'), false);
-  assert.equal(plan.args.includes('--network'), true);
-  assert.equal(plan.args.includes(prefix), true);
-  assert.equal(plan.args.includes('13000:80'), true);
-  assert.equal(plan.args.includes('--port'), false);
-  assert.equal(plan.args.includes('INIT_APP_LANG=zh-CN'), true);
-  assert.equal(plan.args.includes('INIT_ROOT_USERNAME=nocobase'), true);
-  assert.equal(plan.args.includes('INIT_ROOT_EMAIL=admin@nocobase.com'), true);
-  assert.equal(plan.args.includes('INIT_ROOT_PASSWORD=admin123'), true);
-  assert.equal(plan.args.includes('INIT_ROOT_NICKNAME=Super Admin'), true);
-  assert.equal(plan.args.includes(`APP_KEY=${plan.appKey}`), true);
-  assert.equal(plan.args.includes(`TZ=${plan.timeZone}`), true);
-  assert.equal(plan.args.includes('DB_DIALECT=postgres'), true);
-  assert.equal(plan.args.includes(`DB_HOST=${prefix}-demo-postgres`), true);
-  assert.equal(plan.args.includes('DB_PORT=5432'), true);
-  assert.equal(plan.args.includes('DB_DATABASE=nocobase'), true);
-  assert.equal(plan.args.includes('DB_USER=nocobase'), true);
-  assert.equal(plan.args.includes('DB_PASSWORD=nocobase'), true);
+  expect(plan.source).toBe('docker');
+  expect(plan.networkName).toBe(prefix);
+  expect(plan.containerName).toBe(`${prefix}-demo-app`);
+  expect(plan.imageRef).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/nocobase:develop');
+  expect(plan.appPort).toBe('13000');
+  expect(plan.storagePath).toBe(path.resolve('./storage/demo'));
+  expect(plan.appKey.length).toBe(64);
+  expect(typeof plan.timeZone).toBe('string');
+  expect(plan.timeZone.length > 0).toBe(true);
+  expect(plan.args.includes('--platform')).toBe(false);
+  expect(plan.args.includes('--network')).toBe(true);
+  expect(plan.args.includes(prefix)).toBe(true);
+  expect(plan.args.includes('13000:80')).toBe(true);
+  expect(plan.args.includes('--port')).toBe(false);
+  expect(plan.args.includes('INIT_APP_LANG=zh-CN')).toBe(true);
+  expect(plan.args.includes('INIT_ROOT_USERNAME=nocobase')).toBe(true);
+  expect(plan.args.includes('INIT_ROOT_EMAIL=admin@nocobase.com')).toBe(true);
+  expect(plan.args.includes('INIT_ROOT_PASSWORD=admin123')).toBe(true);
+  expect(plan.args.includes('INIT_ROOT_NICKNAME=Super Admin')).toBe(true);
+  expect(plan.args.includes(`APP_KEY=${plan.appKey}`)).toBe(true);
+  expect(plan.args.includes(`TZ=${plan.timeZone}`)).toBe(true);
+  expect(plan.args.includes('DB_DIALECT=postgres')).toBe(true);
+  expect(plan.args.includes(`DB_HOST=${prefix}-demo-postgres`)).toBe(true);
+  expect(plan.args.includes('DB_PORT=5432')).toBe(true);
+  expect(plan.args.includes('DB_DATABASE=nocobase')).toBe(true);
+  expect(plan.args.includes('DB_USER=nocobase')).toBe(true);
+  expect(plan.args.includes('DB_PASSWORD=nocobase')).toBe(true);
 });
 
 test('install env add argv forwards endpoint, auth, app, storage, and db settings', () => {
@@ -332,7 +319,7 @@ test('install env add argv forwards endpoint, auth, app, storage, and db setting
     },
   });
 
-  assert.deepEqual(argv, [
+  expect(argv).toEqual([
     'demo',
     '--no-intro',
     '--scope',
@@ -405,9 +392,9 @@ test('install env add argv records when an env uses an external database', () =>
     },
   });
 
-  assert.equal(argv.includes('--no-builtin-db'), true);
-  assert.equal(argv.includes('--no-intro'), true);
-  assert.equal(argv.includes('--builtin-db'), false);
+  expect(argv.includes('--no-builtin-db')).toBe(true);
+  expect(argv.includes('--no-intro')).toBe(true);
+  expect(argv.includes('--builtin-db')).toBe(false);
 });
 
 test('install env add argv records docker download settings for later upgrades', () => {
@@ -441,14 +428,14 @@ test('install env add argv records docker download settings for later upgrades',
     },
   });
 
-  assert.equal(argv.includes('--source'), true);
-  assert.equal(argv.includes('docker'), true);
-  assert.equal(argv.includes('--download-version'), true);
-  assert.equal(argv.includes('alpha'), true);
-  assert.equal(argv.includes('--docker-registry'), true);
-  assert.equal(argv.includes('nocobase/nocobase'), true);
-  assert.equal(argv.includes('--docker-platform'), true);
-  assert.equal(argv.includes('linux/amd64'), true);
+  expect(argv.includes('--source')).toBe(true);
+  expect(argv.includes('docker')).toBe(true);
+  expect(argv.includes('--download-version')).toBe(true);
+  expect(argv.includes('alpha')).toBe(true);
+  expect(argv.includes('--docker-registry')).toBe(true);
+  expect(argv.includes('nocobase/nocobase')).toBe(true);
+  expect(argv.includes('--docker-platform')).toBe(true);
+  expect(argv.includes('linux/amd64')).toBe(true);
 });
 
 test('install resolves an available app port default when the preferred port is busy', async () => {
@@ -461,14 +448,14 @@ test('install resolves an available app port default when the preferred port is 
   });
 
   const address = server.address();
-  assert.ok(address && typeof address === 'object');
+  expect(address && typeof address === 'object').toBeTruthy();
 
   const busyPort = String(address.port);
 
   try {
     const appPort = await installStatics.resolveAvailableDefaultPort(busyPort);
-    assert.notEqual(appPort, busyPort);
-    assert.equal(await validateAvailableTcpPort(appPort), undefined);
+    expect(appPort).not.toBe(busyPort);
+    expect(await validateAvailableTcpPort(appPort)).toBe(undefined);
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
@@ -489,14 +476,14 @@ test('install seeds app port initial values unless the user provided --app-port'
     envName: 'demo',
     flags: {},
   });
-  assert.equal(initialValues.appRootPath, './demo/source/');
-  assert.equal(initialValues.storagePath, './demo/storage/');
-  assert.equal(typeof initialValues.appPort, 'string');
-  assert.equal(await validateAvailableTcpPort(String(initialValues.appPort)), undefined);
-  assert.deepEqual(await installStatics.buildAppPromptInitialValues({
+  expect(initialValues.appRootPath).toBe('./demo/source/');
+  expect(initialValues.storagePath).toBe('./demo/storage/');
+  expect(typeof initialValues.appPort).toBe('string');
+  expect(await validateAvailableTcpPort(String(initialValues.appPort))).toBe(undefined);
+  expect(await installStatics.buildAppPromptInitialValues({
     envName: 'demo',
     flags: { 'app-port': '14000', 'app-root-path': './custom/source/', 'storage-path': './custom/storage/' },
-  }), {});
+  })).toEqual({});
 });
 
 test('install seeds built-in database host port for npm/git sources when the default port is busy', async () => {
@@ -523,8 +510,8 @@ test('install seeds built-in database host port for npm/git sources when the def
         dbDialect: 'kingbase',
       },
     });
-    assert.notEqual(initialValues.dbPort, '54321');
-    assert.equal(await validateAvailableTcpPort(String(initialValues.dbPort)), undefined);
+    expect(initialValues.dbPort).not.toBe('54321');
+    expect(await validateAvailableTcpPort(String(initialValues.dbPort))).toBe(undefined);
   } finally {
     if (serverStarted) {
       await new Promise<void>((resolve, reject) => {
@@ -543,8 +530,7 @@ test('install seeds built-in database host port for npm/git sources when the def
 test('install does not seed built-in database host port for docker source or explicit --db-port', async () => {
   const installStatics = Install as unknown as InstallStatics;
 
-  assert.deepEqual(
-    await installStatics.buildDbPromptInitialValues({
+  expect(await installStatics.buildDbPromptInitialValues({
       flags: {},
       downloadResults: {
         source: 'docker',
@@ -553,11 +539,8 @@ test('install does not seed built-in database host port for docker source or exp
         builtinDb: true,
         dbDialect: 'postgres',
       },
-    }),
-    {},
-  );
-  assert.deepEqual(
-    await installStatics.buildDbPromptInitialValues({
+    })).toEqual({});
+  expect(await installStatics.buildDbPromptInitialValues({
       flags: {
         'db-port': '15432',
       },
@@ -568,7 +551,5 @@ test('install does not seed built-in database host port for docker source or exp
         builtinDb: true,
         dbDialect: 'postgres',
       },
-    }),
-    {},
-  );
+    })).toEqual({});
 });

--- a/packages/core/cli/src/__tests__/install-force.test.ts
+++ b/packages/core/cli/src/__tests__/install-force.test.ts
@@ -7,11 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, test, vi } from 'vitest';
+import { afterEach, test, vi, expect } from 'vitest';
 import Install from '../commands/install.js';
 import { findAvailableTcpPort } from '../lib/prompt-validators.js';
 
@@ -93,7 +92,7 @@ test('startBuiltinDb removes the existing db container before docker run when --
     force: true,
   });
 
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(mocks.run.mock.calls).toEqual([
     [
       'docker',
       ['rm', '-f', plan.containerName],
@@ -144,9 +143,9 @@ test('downloadLocalApp delegates npm/git downloads through nb download and retur
     },
   });
 
-  assert.equal(resolvedProjectRoot, projectRoot);
-  assert.equal(appResults.appRootPath, projectRoot);
-  assert.deepEqual(runCommand.mock.calls, [
+  expect(resolvedProjectRoot).toBe(projectRoot);
+  expect(appResults.appRootPath).toBe(projectRoot);
+  expect(runCommand.mock.calls).toEqual([
     [
       'download',
       [
@@ -219,7 +218,7 @@ test('startLocalApp starts npm/git apps with quickstart daemon mode and install 
     },
   });
 
-  assert.deepEqual(mocks.runNocoBaseCommand.mock.calls, [
+  expect(mocks.runNocoBaseCommand.mock.calls).toEqual([
     [
       ['pm2', 'kill'],
       {
@@ -267,13 +266,13 @@ test('startLocalApp starts npm/git apps with quickstart daemon mode and install 
       },
     ],
   ]);
-  assert.equal(plan.source, 'npm');
-  assert.equal(plan.projectRoot, projectRoot);
-  assert.equal(plan.appPort, '14000');
-  assert.equal(plan.storagePath, storagePath);
-  assert.equal(plan.appKey.length, 64);
-  assert.equal(plan.timeZone.length > 0, true);
-  assert.deepEqual(plan.args, ['start', '--quickstart', '--daemon']);
+  expect(plan.source).toBe('npm');
+  expect(plan.projectRoot).toBe(projectRoot);
+  expect(plan.appPort).toBe('14000');
+  expect(plan.storagePath).toBe(storagePath);
+  expect(plan.appKey.length).toBe(64);
+  expect(plan.timeZone.length > 0).toBe(true);
+  expect(plan.args).toEqual(['start', '--quickstart', '--daemon']);
 });
 
 test('installDockerApp removes the existing app container before docker run when --force is enabled', async () => {
@@ -327,7 +326,7 @@ test('installDockerApp removes the existing app container before docker run when
     force: true,
   });
 
-  assert.deepEqual(mocks.run.mock.calls, [
+  expect(mocks.run.mock.calls).toEqual([
     [
       'docker',
       ['rm', '-f', plan.containerName],

--- a/packages/core/cli/src/__tests__/install-health.test.ts
+++ b/packages/core/cli/src/__tests__/install-health.test.ts
@@ -7,8 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
-import { afterEach, test, vi } from 'vitest';
+import { afterEach, test, vi, expect } from 'vitest';
 import Install from '../commands/install.js';
 
 const mocks = vi.hoisted(() => ({
@@ -67,17 +66,14 @@ test('waitForAppHealthCheck resolves after /api/__health_check returns ok', asyn
     fetchImpl: fetchImpl as unknown as typeof fetch,
   });
 
-  assert.equal(fetchImpl.mock.calls.length, 1);
-  assert.equal(fetchImpl.mock.calls[0][0], 'http://127.0.0.1:13000/api/__health_check');
-  assert.equal(fetchImpl.mock.calls[0][1].method, 'GET');
-  assert.ok(fetchImpl.mock.calls[0][1].signal);
-  assert.equal(mocks.startTask.mock.calls.length, 1);
-  assert.equal(mocks.updateTask.mock.calls.length, 0);
-  assert.equal(mocks.stopTask.mock.calls.length, 1);
-  assert.equal(
-    mocks.promptInfo.mock.calls.some((call) => String(call[0]).includes('/api/__health_check')),
-    true,
-  );
+  expect(fetchImpl.mock.calls.length).toBe(1);
+  expect(fetchImpl.mock.calls[0][0]).toBe('http://127.0.0.1:13000/api/__health_check');
+  expect(fetchImpl.mock.calls[0][1].method).toBe('GET');
+  expect(fetchImpl.mock.calls[0][1].signal).toBeTruthy();
+  expect(mocks.startTask.mock.calls.length).toBe(1);
+  expect(mocks.updateTask.mock.calls.length).toBe(0);
+  expect(mocks.stopTask.mock.calls.length).toBe(1);
+  expect(mocks.promptInfo.mock.calls.some((call) => String(call[0]).includes('/api/__health_check'))).toBe(true);
 });
 
 test('waitForAppHealthCheck throws when /api/__health_check never returns ok', async () => {
@@ -87,8 +83,7 @@ test('waitForAppHealthCheck throws when /api/__health_check never returns ok', a
       text: async () => 'starting',
     }));
 
-  await assert.rejects(
-    (
+  await expect((
       Install.prototype as unknown as {
         waitForAppHealthCheck: (
           apiBaseUrl: string,
@@ -107,22 +102,11 @@ test('waitForAppHealthCheck throws when /api/__health_check never returns ok', a
       requestTimeoutMs: 1,
       fetchImpl: fetchImpl as unknown as typeof fetch,
       containerName: 'test-app',
-    }),
-    /__health_check.*respond with `ok`.*docker logs test-app/i,
-  );
+    })).rejects.toThrow(/__health_check.*respond with `ok`.*docker logs test-app/i);
 
-  assert.equal(
-    mocks.startTask.mock.calls.some((call) => String(call[0]).includes('/api/__health_check')),
-    true,
-  );
-  assert.equal(
-    mocks.updateTask.mock.calls.some((call) => String(call[0]).includes('Still starting')),
-    true,
-  );
-  assert.equal(
-    mocks.stopTask.mock.calls.length > 0,
-    true,
-  );
+  expect(mocks.startTask.mock.calls.some((call) => String(call[0]).includes('/api/__health_check'))).toBe(true);
+  expect(mocks.updateTask.mock.calls.some((call) => String(call[0]).includes('Still starting'))).toBe(true);
+  expect(mocks.stopTask.mock.calls.length > 0).toBe(true);
 });
 
 test('waitForAppHealthCheck keeps polling while the app is still booting', async () => {
@@ -161,14 +145,8 @@ test('waitForAppHealthCheck keeps polling while the app is still booting', async
     fetchImpl: fetchImpl as unknown as typeof fetch,
   });
 
-  assert.equal(fetchImpl.mock.calls.length, 3);
-  assert.equal(
-    mocks.updateTask.mock.calls.some((call) => String(call[0]).includes('connection refused')),
-    true,
-  );
-  assert.equal(
-    mocks.updateTask.mock.calls.some((call) => String(call[0]).includes('HTTP 503')),
-    true,
-  );
-  assert.equal(mocks.stopTask.mock.calls.length, 1);
+  expect(fetchImpl.mock.calls.length).toBe(3);
+  expect(mocks.updateTask.mock.calls.some((call) => String(call[0]).includes('connection refused'))).toBe(true);
+  expect(mocks.updateTask.mock.calls.some((call) => String(call[0]).includes('HTTP 503'))).toBe(true);
+  expect(mocks.stopTask.mock.calls.length).toBe(1);
 });

--- a/packages/core/cli/src/__tests__/install-resume.test.ts
+++ b/packages/core/cli/src/__tests__/install-resume.test.ts
@@ -7,8 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
-import { beforeEach, test, vi } from 'vitest';
+import { beforeEach, test, vi, expect } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   runPromptCatalog: vi.fn(),
@@ -116,33 +115,33 @@ test('install --resume reuses the saved workspace env config for prompt values',
     'builtin-db': false,
   }, false);
 
-  assert.equal(mocks.getEnv.mock.calls.length, 1);
-  assert.deepEqual(mocks.getEnv.mock.calls[0], [
+  expect(mocks.getEnv.mock.calls.length).toBe(1);
+  expect(mocks.getEnv.mock.calls[0]).toEqual([
     'app1',
     { scope: 'project' },
   ]);
-  assert.equal(result.envName, 'app1');
-  assert.equal(result.appResults.appRootPath, './app1/source/');
-  assert.equal(result.appResults.appPort, '13080');
-  assert.equal(result.appResults.storagePath, './app1/storage/');
-  assert.equal(result.appResults.fetchSource, true);
-  assert.equal(result.downloadResults.source, 'docker');
-  assert.equal(result.downloadResults.version, 'alpha');
-  assert.equal(result.downloadResults.dockerRegistry, 'nocobase/nocobase');
-  assert.equal(result.downloadResults.dockerPlatform, 'linux/arm64');
-  assert.equal(result.downloadResults.build, false);
-  assert.equal(result.downloadResults.buildDts, true);
-  assert.equal(result.dbResults.builtinDb, true);
-  assert.equal(result.dbResults.dbDialect, 'postgres');
-  assert.equal(result.dbResults.builtinDbImage, 'registry.example.com/postgres:16');
-  assert.equal(result.dbResults.dbHost, 'app1-postgres');
-  assert.equal(result.dbResults.dbPort, '5432');
-  assert.equal(result.dbResults.dbDatabase, 'nocobase');
-  assert.equal(result.dbResults.dbUser, 'nocobase');
-  assert.equal(result.dbResults.dbPassword, 'secret');
-  assert.equal(result.envAddResults.authType, 'token');
-  assert.equal(result.envAddResults.accessToken, 'resume-token');
-  assert.equal(result.envAddResults.apiBaseUrl, 'http://127.0.0.1:13080/api');
+  expect(result.envName).toBe('app1');
+  expect(result.appResults.appRootPath).toBe('./app1/source/');
+  expect(result.appResults.appPort).toBe('13080');
+  expect(result.appResults.storagePath).toBe('./app1/storage/');
+  expect(result.appResults.fetchSource).toBe(true);
+  expect(result.downloadResults.source).toBe('docker');
+  expect(result.downloadResults.version).toBe('alpha');
+  expect(result.downloadResults.dockerRegistry).toBe('nocobase/nocobase');
+  expect(result.downloadResults.dockerPlatform).toBe('linux/arm64');
+  expect(result.downloadResults.build).toBe(false);
+  expect(result.downloadResults.buildDts).toBe(true);
+  expect(result.dbResults.builtinDb).toBe(true);
+  expect(result.dbResults.dbDialect).toBe('postgres');
+  expect(result.dbResults.builtinDbImage).toBe('registry.example.com/postgres:16');
+  expect(result.dbResults.dbHost).toBe('app1-postgres');
+  expect(result.dbResults.dbPort).toBe('5432');
+  expect(result.dbResults.dbDatabase).toBe('nocobase');
+  expect(result.dbResults.dbUser).toBe('nocobase');
+  expect(result.dbResults.dbPassword).toBe('secret');
+  expect(result.envAddResults.authType).toBe('token');
+  expect(result.envAddResults.accessToken).toBe('resume-token');
+  expect(result.envAddResults.apiBaseUrl).toBe('http://127.0.0.1:13080/api');
 });
 
 test('install --resume fails with a clear message when the env is missing', async () => {
@@ -151,8 +150,7 @@ test('install --resume fails with a clear message when the env is missing', asyn
   mocks.getEnv.mockResolvedValue(undefined);
 
   const command = Object.create(Install.prototype);
-  await assert.rejects(
-    () =>
+  await expect((() =>
       (
         Install.prototype as unknown as {
           collectPromptResults: (
@@ -167,11 +165,9 @@ test('install --resume fails with a clear message when the env is missing', asyn
         force: false,
         'fetch-source': false,
         'builtin-db': false,
-      }, false),
-    /Env "missing" is not configured in this workspace\./,
-  );
+      }, false))()).rejects.toThrow(/Env "missing" is not configured in this workspace\./);
 
-  assert.equal(mocks.runPromptCatalog.mock.calls.length, 0);
+  expect(mocks.runPromptCatalog.mock.calls.length).toBe(0);
 });
 
 test('install --resume --yes requires setup-only flags that are not saved in env config', async () => {
@@ -188,8 +184,7 @@ test('install --resume --yes requires setup-only flags that are not saved in env
   });
 
   const command = Object.create(Install.prototype);
-  await assert.rejects(
-    () =>
+  await expect((() =>
       (
         Install.prototype as unknown as {
           collectPromptResults: (
@@ -204,9 +199,7 @@ test('install --resume --yes requires setup-only flags that are not saved in env
         force: false,
         'fetch-source': false,
         'builtin-db': false,
-      }, true),
-    /These setup-only flags are not saved in the env config: --lang, --root-username, --root-email, --root-password, --root-nickname/,
-  );
+      }, true))()).rejects.toThrow(/These setup-only flags are not saved in the env config: --lang, --root-username, --root-email, --root-password, --root-nickname/);
 
-  assert.equal(mocks.runPromptCatalog.mock.calls.length, 0);
+  expect(mocks.runPromptCatalog.mock.calls.length).toBe(0);
 });

--- a/packages/core/cli/src/__tests__/prompt-validators-docker.test.ts
+++ b/packages/core/cli/src/__tests__/prompt-validators-docker.test.ts
@@ -7,9 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test, vi, expect } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
@@ -65,5 +64,5 @@ test('validateAvailableTcpPort treats Docker-published host ports as occupied', 
   const { validateAvailableTcpPort } = await import('../lib/prompt-validators.js');
   const error = await validateAvailableTcpPort('13000');
 
-  assert.match(error ?? '', /already in use by a docker container/i);
+  expect(error ?? '').toMatch(/already in use by a docker container/i);
 });

--- a/packages/core/cli/src/__tests__/prompt-validators.test.ts
+++ b/packages/core/cli/src/__tests__/prompt-validators.test.ts
@@ -7,12 +7,11 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test, vi, expect } from 'vitest';
 import Download, { defaultDockerRegistryForLang } from '../commands/download.js';
 import Init from '../commands/init.js';
 import EnvAdd from '../commands/env/add.js';
@@ -55,31 +54,22 @@ afterEach(() => {
 });
 
 test('validateApiBaseUrl accepts http and https URLs', () => {
-  assert.equal(validateApiBaseUrl('http://localhost:13000/api'), undefined);
-  assert.equal(validateApiBaseUrl('https://demo.example.com/api'), undefined);
+  expect(validateApiBaseUrl('http://localhost:13000/api')).toBe(undefined);
+  expect(validateApiBaseUrl('https://demo.example.com/api')).toBe(undefined);
 });
 
 test('validateApiBaseUrl rejects malformed URLs and unsupported schemes', () => {
-  assert.match(
-    validateApiBaseUrl('not a url') ?? '',
-    /Enter a valid URL/,
-  );
-  assert.match(
-    validateApiBaseUrl('ftp://example.com/api') ?? '',
-    /URL must start with http:\/\/ or https:\/\//,
-  );
+  expect(validateApiBaseUrl('not a url') ?? '').toMatch(/Enter a valid URL/);
+  expect(validateApiBaseUrl('ftp://example.com/api') ?? '').toMatch(/URL must start with http:\/\/ or https:\/\//);
 });
 
 test('validateEnvKey allows only letters and numbers', () => {
-  assert.equal(validateEnvKey('local01'), undefined);
-  assert.match(validateEnvKey('local-dev') ?? '', /letters and numbers only/i);
+  expect(validateEnvKey('local01')).toBe(undefined);
+  expect(validateEnvKey('local-dev') ?? '').toMatch(/letters and numbers only/i);
 });
 
 test('validateAvailableTcpPort rejects invalid and occupied ports', async () => {
-  assert.match(
-    await validateAvailableTcpPort('abc') ?? '',
-    /valid TCP port/i,
-  );
+  expect(await validateAvailableTcpPort('abc') ?? '').toMatch(/valid TCP port/i);
 
   const server = net.createServer();
   await new Promise<void>((resolve, reject) => {
@@ -88,11 +78,8 @@ test('validateAvailableTcpPort rejects invalid and occupied ports', async () => 
   });
 
   const address = server.address();
-  assert.ok(address && typeof address === 'object');
-  assert.match(
-    await validateAvailableTcpPort(String(address.port)) ?? '',
-    /already in use/i,
-  );
+  expect(address && typeof address === 'object').toBeTruthy();
+  expect(await validateAvailableTcpPort(String(address.port)) ?? '').toMatch(/already in use/i);
 
   await new Promise<void>((resolve, reject) => {
     server.close((error) => {
@@ -107,21 +94,15 @@ test('validateAvailableTcpPort rejects invalid and occupied ports', async () => 
 
 test('findAvailableTcpPort returns a free TCP port', async () => {
   const port = await findAvailableTcpPort();
-  assert.equal(typeof port, 'string');
-  assert.match(port, /^\d+$/);
-  assert.equal(await validateAvailableTcpPort(port), undefined);
+  expect(typeof port).toBe('string');
+  expect(port).toMatch(/^\d+$/);
+  expect(await validateAvailableTcpPort(port)).toBe(undefined);
 });
 
 test('validateTcpPort rejects invalid ports and accepts valid ones', () => {
-  assert.match(
-    validateTcpPort('abc') ?? '',
-    /valid TCP port/i,
-  );
-  assert.match(
-    validateTcpPort('70000') ?? '',
-    /valid TCP port/i,
-  );
-  assert.equal(validateTcpPort('5432'), undefined);
+  expect(validateTcpPort('abc') ?? '').toMatch(/valid TCP port/i);
+  expect(validateTcpPort('70000') ?? '').toMatch(/valid TCP port/i);
+  expect(validateTcpPort('5432')).toBe(undefined);
 });
 
 test('init and env add prompts validate apiBaseUrl', async () => {
@@ -129,17 +110,17 @@ test('init and env add prompts validate apiBaseUrl', async () => {
   const initPrompt = Init.prompts.apiBaseUrl;
   const envAddPrompt = EnvAdd.prompts.apiBaseUrl;
 
-  assert.equal(appNamePrompt.type, 'text');
-  assert.equal(appNamePrompt.initialValue, undefined);
-  assert.equal(appNamePrompt.yesInitialValue, undefined);
-  assert.equal(typeof appNamePrompt.validate, 'function');
-  assert.match(await appNamePrompt.validate?.('local-dev', {}) ?? '', /letters and numbers only/i);
-  assert.equal(initPrompt.type, 'text');
-  assert.equal(envAddPrompt.type, 'text');
-  assert.equal(typeof initPrompt.validate, 'function');
-  assert.equal(typeof envAddPrompt.validate, 'function');
-  assert.match(initPrompt.validate?.('not-a-url', {}) ?? '', /Enter a valid URL/);
-  assert.match(envAddPrompt.validate?.('ftp://example.com/api', {}) ?? '', /http:\/\/ or https:\/\//);
+  expect(appNamePrompt.type).toBe('text');
+  expect(appNamePrompt.initialValue).toBe(undefined);
+  expect(appNamePrompt.yesInitialValue).toBe(undefined);
+  expect(typeof appNamePrompt.validate).toBe('function');
+  expect(await appNamePrompt.validate?.('local-dev', {}) ?? '').toMatch(/letters and numbers only/i);
+  expect(initPrompt.type).toBe('text');
+  expect(envAddPrompt.type).toBe('text');
+  expect(typeof initPrompt.validate).toBe('function');
+  expect(typeof envAddPrompt.validate).toBe('function');
+  expect(initPrompt.validate?.('not-a-url', {}) ?? '').toMatch(/Enter a valid URL/);
+  expect(envAddPrompt.validate?.('ftp://example.com/api', {}) ?? '').toMatch(/http:\/\/ or https:\/\//);
 });
 
 test('init appName validates workspace env name uniqueness', async () => {
@@ -157,9 +138,9 @@ test('init appName validates workspace env name uniqueness', async () => {
     );
 
     const appNamePrompt = Init.prompts.appName;
-    assert.equal(appNamePrompt.type, 'text');
-    assert.match(await appNamePrompt.validate?.('local', {}) ?? '', /already exists/i);
-    assert.equal(await appNamePrompt.validate?.('newapp', {}), undefined);
+    expect(appNamePrompt.type).toBe('text');
+    expect(await appNamePrompt.validate?.('local', {}) ?? '').toMatch(/already exists/i);
+    expect(await appNamePrompt.validate?.('newapp', {})).toBe(undefined);
   });
 });
 
@@ -178,11 +159,11 @@ test('init appName allows reusing a workspace env name when --force is set', asy
     );
 
     const appNamePrompt = Init.prompts.appName;
-    assert.equal(appNamePrompt.type, 'text');
+    expect(appNamePrompt.type).toBe('text');
     const originalArgv = process.argv;
     process.argv = ['node', 'nb', 'init', '--force'];
     try {
-      assert.equal(await appNamePrompt.validate?.('local', {}), undefined);
+      expect(await appNamePrompt.validate?.('local', {})).toBe(undefined);
     } finally {
       process.argv = originalArgv;
     }
@@ -203,8 +184,7 @@ test('init --yes --env validates workspace env name uniqueness through preset va
       { scope: 'project' },
     );
 
-    await assert.rejects(
-      () =>
+    await expect((() =>
         runPromptCatalog(
           {
             appName: Init.prompts.appName,
@@ -220,9 +200,7 @@ test('init --yes --env validates workspace env name uniqueness through preset va
               },
             },
           },
-        ),
-      /already exists in this workspace/i,
-    );
+        ))()).rejects.toThrow(/already exists in this workspace/i);
   });
 });
 
@@ -242,119 +220,112 @@ test('install prompts expose the expected defaults and validators', () => {
   const rootPasswordPrompt = Install.rootUserPrompts.rootPassword;
   const rootNicknamePrompt = Install.rootUserPrompts.rootNickname;
 
-  assert.equal(envPrompt.type, 'text');
-  assert.equal(envPrompt.initialValue, undefined);
-  assert.equal(envPrompt.yesInitialValue, undefined);
-  assert.equal(typeof envPrompt.validate, 'function');
-  assert.match(envPrompt.validate?.('local-dev', {}) ?? '', /letters and numbers only/i);
+  expect(envPrompt.type).toBe('text');
+  expect(envPrompt.initialValue).toBe(undefined);
+  expect(envPrompt.yesInitialValue).toBe(undefined);
+  expect(typeof envPrompt.validate).toBe('function');
+  expect(envPrompt.validate?.('local-dev', {}) ?? '').toMatch(/letters and numbers only/i);
 
-  assert.equal(appPortPrompt.type, 'text');
-  assert.equal(appPortPrompt.initialValue, undefined);
-  assert.equal(appPortPrompt.yesInitialValue, undefined);
-  assert.equal(typeof appPortPrompt.validate, 'function');
+  expect(appPortPrompt.type).toBe('text');
+  expect(appPortPrompt.initialValue).toBe(undefined);
+  expect(appPortPrompt.yesInitialValue).toBe(undefined);
+  expect(typeof appPortPrompt.validate).toBe('function');
 
-  assert.equal(builtinDbPrompt.type, 'boolean');
-  assert.equal(builtinDbPrompt.initialValue, true);
-  assert.equal(builtinDbPrompt.yesInitialValue, true);
-  assert.equal(builtinDbPrompt.validate?.(true, { dbDialect: 'kingbase' }), undefined);
+  expect(builtinDbPrompt.type).toBe('boolean');
+  expect(builtinDbPrompt.initialValue).toBe(true);
+  expect(builtinDbPrompt.yesInitialValue).toBe(true);
+  expect(builtinDbPrompt.validate?.(true, { dbDialect: 'kingbase' })).toBe(undefined);
 
-  assert.equal(dbDialectPrompt.type, 'select');
-  assert.equal(dbDialectPrompt.initialValue, 'postgres');
-  assert.equal(dbDialectPrompt.yesInitialValue, 'postgres');
+  expect(dbDialectPrompt.type).toBe('select');
+  expect(dbDialectPrompt.initialValue).toBe('postgres');
+  expect(dbDialectPrompt.yesInitialValue).toBe('postgres');
 
-  assert.equal(dbHostPrompt.type, 'text');
-  assert.equal(typeof dbHostPrompt.initialValue, 'function');
-  assert.equal(dbHostPrompt.initialValue({ builtinDb: false }), '127.0.0.1');
-  assert.equal(dbHostPrompt.initialValue({ builtinDb: true }), 'postgres');
-  assert.equal(dbHostPrompt.yesInitialValue, 'postgres');
-  assert.equal(typeof dbHostPrompt.hidden, 'function');
-  assert.equal(dbHostPrompt.hidden?.({ builtinDb: true }), true);
-  assert.equal(dbHostPrompt.hidden?.({ builtinDb: false }), false);
+  expect(dbHostPrompt.type).toBe('text');
+  expect(typeof dbHostPrompt.initialValue).toBe('function');
+  expect(dbHostPrompt.initialValue({ builtinDb: false })).toBe('127.0.0.1');
+  expect(dbHostPrompt.initialValue({ builtinDb: true })).toBe('postgres');
+  expect(dbHostPrompt.yesInitialValue).toBe('postgres');
+  expect(typeof dbHostPrompt.hidden).toBe('function');
+  expect(dbHostPrompt.hidden?.({ builtinDb: true })).toBe(true);
+  expect(dbHostPrompt.hidden?.({ builtinDb: false })).toBe(false);
 
-  assert.equal(builtinDbImagePrompt.type, 'text');
-  assert.equal(typeof builtinDbImagePrompt.initialValue, 'function');
-  assert.equal(builtinDbImagePrompt.initialValue({ dbDialect: 'postgres' }), 'postgres:16');
-  assert.equal(builtinDbImagePrompt.initialValue({ dbDialect: 'mysql' }), 'mysql:8');
-  assert.equal(builtinDbImagePrompt.initialValue({ dbDialect: 'mariadb' }), 'mariadb:11');
-  assert.equal(
-    builtinDbImagePrompt.initialValue({ dbDialect: 'kingbase' }),
+  expect(builtinDbImagePrompt.type).toBe('text');
+  expect(typeof builtinDbImagePrompt.initialValue).toBe('function');
+  expect(builtinDbImagePrompt.initialValue({ dbDialect: 'postgres' })).toBe('postgres:16');
+  expect(builtinDbImagePrompt.initialValue({ dbDialect: 'mysql' })).toBe('mysql:8');
+  expect(builtinDbImagePrompt.initialValue({ dbDialect: 'mariadb' })).toBe('mariadb:11');
+  expect(builtinDbImagePrompt.initialValue({ dbDialect: 'kingbase' })).toBe(
     'registry.cn-shanghai.aliyuncs.com/nocobase/kingbase:v009r001c001b0030_single_x86',
   );
-  assert.equal(builtinDbImagePrompt.hidden?.({ builtinDb: false, dbDialect: 'postgres' }), true);
-  assert.equal(builtinDbImagePrompt.hidden?.({ builtinDb: true, dbDialect: 'postgres' }), false);
-  assert.equal(builtinDbImagePrompt.hidden?.({ builtinDb: true, dbDialect: 'kingbase' }), false);
+  expect(builtinDbImagePrompt.hidden?.({ builtinDb: false, dbDialect: 'postgres' })).toBe(true);
+  expect(builtinDbImagePrompt.hidden?.({ builtinDb: true, dbDialect: 'postgres' })).toBe(false);
+  expect(builtinDbImagePrompt.hidden?.({ builtinDb: true, dbDialect: 'kingbase' })).toBe(false);
 
-  assert.equal(dbPortPrompt.type, 'text');
-  assert.equal(typeof dbPortPrompt.initialValue, 'function');
-  assert.equal(typeof dbPortPrompt.validate, 'function');
-  assert.equal(dbPortPrompt.initialValue({ dbDialect: 'postgres' }), '5432');
-  assert.equal(dbPortPrompt.initialValue({ dbDialect: 'mysql' }), '3306');
-  assert.equal(dbPortPrompt.initialValue({ dbDialect: 'mariadb' }), '3306');
-  assert.equal(dbPortPrompt.initialValue({ dbDialect: 'kingbase' }), '54321');
-  assert.equal(dbPortPrompt.yesInitialValue, undefined);
-  assert.equal(dbPortPrompt.hidden?.({ builtinDb: true, source: 'docker' }), true);
-  assert.equal(dbPortPrompt.hidden?.({ builtinDb: true, source: 'npm' }), false);
-  assert.equal(dbPortPrompt.hidden?.({ builtinDb: true, source: 'git' }), false);
-  assert.equal(dbPortPrompt.hidden?.({ builtinDb: false }), false);
+  expect(dbPortPrompt.type).toBe('text');
+  expect(typeof dbPortPrompt.initialValue).toBe('function');
+  expect(typeof dbPortPrompt.validate).toBe('function');
+  expect(dbPortPrompt.initialValue({ dbDialect: 'postgres' })).toBe('5432');
+  expect(dbPortPrompt.initialValue({ dbDialect: 'mysql' })).toBe('3306');
+  expect(dbPortPrompt.initialValue({ dbDialect: 'mariadb' })).toBe('3306');
+  expect(dbPortPrompt.initialValue({ dbDialect: 'kingbase' })).toBe('54321');
+  expect(dbPortPrompt.yesInitialValue).toBe(undefined);
+  expect(dbPortPrompt.hidden?.({ builtinDb: true, source: 'docker' })).toBe(true);
+  expect(dbPortPrompt.hidden?.({ builtinDb: true, source: 'npm' })).toBe(false);
+  expect(dbPortPrompt.hidden?.({ builtinDb: true, source: 'git' })).toBe(false);
+  expect(dbPortPrompt.hidden?.({ builtinDb: false })).toBe(false);
 
-  assert.equal(dbDatabasePrompt.type, 'text');
-  assert.equal(typeof dbDatabasePrompt.initialValue, 'function');
-  assert.equal(dbDatabasePrompt.initialValue({ dbDialect: 'postgres' }), 'nocobase');
-  assert.equal(dbDatabasePrompt.initialValue({ dbDialect: 'kingbase' }), 'kingbase');
-  assert.equal(dbDatabasePrompt.yesInitialValue, undefined);
+  expect(dbDatabasePrompt.type).toBe('text');
+  expect(typeof dbDatabasePrompt.initialValue).toBe('function');
+  expect(dbDatabasePrompt.initialValue({ dbDialect: 'postgres' })).toBe('nocobase');
+  expect(dbDatabasePrompt.initialValue({ dbDialect: 'kingbase' })).toBe('kingbase');
+  expect(dbDatabasePrompt.yesInitialValue).toBe(undefined);
 
-  assert.equal(dbUserPrompt.type, 'text');
-  assert.equal(dbUserPrompt.initialValue, 'nocobase');
-  assert.equal(dbUserPrompt.yesInitialValue, 'nocobase');
+  expect(dbUserPrompt.type).toBe('text');
+  expect(dbUserPrompt.initialValue).toBe('nocobase');
+  expect(dbUserPrompt.yesInitialValue).toBe('nocobase');
 
-  assert.equal(dbPasswordPrompt.type, 'password');
-  assert.equal(dbPasswordPrompt.initialValue, 'nocobase');
-  assert.equal(dbPasswordPrompt.yesInitialValue, 'nocobase');
+  expect(dbPasswordPrompt.type).toBe('password');
+  expect(dbPasswordPrompt.initialValue).toBe('nocobase');
+  expect(dbPasswordPrompt.yesInitialValue).toBe('nocobase');
 
-  assert.equal(rootUsernamePrompt.type, 'text');
-  assert.equal(rootUsernamePrompt.initialValue, undefined);
-  assert.equal(rootUsernamePrompt.yesInitialValue, 'nocobase');
-  assert.equal(rootUsernamePrompt.required, true);
+  expect(rootUsernamePrompt.type).toBe('text');
+  expect(rootUsernamePrompt.initialValue).toBe(undefined);
+  expect(rootUsernamePrompt.yesInitialValue).toBe('nocobase');
+  expect(rootUsernamePrompt.required).toBe(true);
 
-  assert.equal(rootEmailPrompt.type, 'text');
-  assert.equal(rootEmailPrompt.initialValue, undefined);
-  assert.equal(rootEmailPrompt.yesInitialValue, 'admin@nocobase.com');
-  assert.equal(rootEmailPrompt.required, true);
+  expect(rootEmailPrompt.type).toBe('text');
+  expect(rootEmailPrompt.initialValue).toBe(undefined);
+  expect(rootEmailPrompt.yesInitialValue).toBe('admin@nocobase.com');
+  expect(rootEmailPrompt.required).toBe(true);
 
-  assert.equal(rootPasswordPrompt.type, 'password');
-  assert.equal(resolveLocalizedText(rootPasswordPrompt.message, { locale: 'en-US' }), 'Choose the initial admin password');
-  assert.equal(rootPasswordPrompt.initialValue, undefined);
-  assert.equal(rootPasswordPrompt.yesInitialValue, 'admin123');
-  assert.equal(rootPasswordPrompt.required, true);
+  expect(rootPasswordPrompt.type).toBe('password');
+  expect(resolveLocalizedText(rootPasswordPrompt.message, { locale: 'en-US' })).toBe('Choose the initial admin password');
+  expect(rootPasswordPrompt.initialValue).toBe(undefined);
+  expect(rootPasswordPrompt.yesInitialValue).toBe('admin123');
+  expect(rootPasswordPrompt.required).toBe(true);
 
-  assert.equal(rootNicknamePrompt.type, 'text');
-  assert.equal(rootNicknamePrompt.initialValue, undefined);
-  assert.equal(rootNicknamePrompt.yesInitialValue, 'Super Admin');
-  assert.equal(rootNicknamePrompt.required, true);
+  expect(rootNicknamePrompt.type).toBe('text');
+  expect(rootNicknamePrompt.initialValue).toBe(undefined);
+  expect(rootNicknamePrompt.yesInitialValue).toBe('Super Admin');
+  expect(rootNicknamePrompt.required).toBe(true);
 });
 
 test('docker image defaults follow app language', () => {
   const dockerRegistryPrompt = Download.prompts.dockerRegistry;
   const dockerPlatformPrompt = Download.prompts.dockerPlatform;
 
-  assert.equal(defaultDockerRegistryForLang('zh-CN'), 'registry.cn-shanghai.aliyuncs.com/nocobase/nocobase');
-  assert.equal(defaultDockerRegistryForLang('en-US'), 'nocobase/nocobase');
+  expect(defaultDockerRegistryForLang('zh-CN')).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/nocobase');
+  expect(defaultDockerRegistryForLang('en-US')).toBe('nocobase/nocobase');
 
-  assert.equal(dockerRegistryPrompt.type, 'text');
-  assert.equal(
-    dockerRegistryPrompt.initialValue?.({ lang: 'zh-CN' }),
-    'registry.cn-shanghai.aliyuncs.com/nocobase/nocobase',
-  );
-  assert.equal(
-    dockerRegistryPrompt.initialValue?.({ lang: 'en-US' }),
-    'nocobase/nocobase',
-  );
+  expect(dockerRegistryPrompt.type).toBe('text');
+  expect(dockerRegistryPrompt.initialValue?.({ lang: 'zh-CN' })).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/nocobase');
+  expect(dockerRegistryPrompt.initialValue?.({ lang: 'en-US' })).toBe('nocobase/nocobase');
 
-  assert.equal(dockerPlatformPrompt.type, 'select');
-  assert.equal(dockerPlatformPrompt.initialValue, 'auto');
-  assert.equal(dockerPlatformPrompt.yesInitialValue, 'auto');
-  assert.equal(dockerPlatformPrompt.hidden?.({ source: 'docker' }), false);
-  assert.equal(dockerPlatformPrompt.hidden?.({ source: 'npm' }), true);
+  expect(dockerPlatformPrompt.type).toBe('select');
+  expect(dockerPlatformPrompt.initialValue).toBe('auto');
+  expect(dockerPlatformPrompt.yesInitialValue).toBe('auto');
+  expect(dockerPlatformPrompt.hidden?.({ source: 'docker' })).toBe(false);
+  expect(dockerPlatformPrompt.hidden?.({ source: 'npm' })).toBe(true);
 });
 
 test('install download prompt options pass app language into docker image defaults', () => {
@@ -383,13 +354,10 @@ test('install download prompt options pass app language into docker image defaul
     },
     'zh-demo',
   );
-  assert.equal(zhOptions.initialValues.lang, 'zh-CN');
-  assert.equal(
-    zhOptions.initialValues.dockerRegistry,
-    'registry.cn-shanghai.aliyuncs.com/nocobase/nocobase',
-  );
-  assert.equal(zhOptions.initialValues.outputDir, './apps/zh-demo');
-  assert.equal(zhOptions.values.lang, 'zh-CN');
+  expect(zhOptions.initialValues.lang).toBe('zh-CN');
+  expect(zhOptions.initialValues.dockerRegistry).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/nocobase');
+  expect(zhOptions.initialValues.outputDir).toBe('./apps/zh-demo');
+  expect(zhOptions.values.lang).toBe('zh-CN');
 
   const enOptions = installStatics.buildDownloadPromptOptionsForInstall(
     {
@@ -398,9 +366,9 @@ test('install download prompt options pass app language into docker image defaul
     },
     'en-demo',
   );
-  assert.equal(enOptions.initialValues.lang, 'en-US');
-  assert.equal(enOptions.initialValues.dockerRegistry, 'nocobase/nocobase');
-  assert.equal(enOptions.values.lang, 'en-US');
+  expect(enOptions.initialValues.lang).toBe('en-US');
+  expect(enOptions.initialValues.dockerRegistry).toBe('nocobase/nocobase');
+  expect(enOptions.values.lang).toBe('en-US');
 
   const originalArgv = process.argv;
   process.argv = ['node', 'nb', 'install', '--yes'];
@@ -423,10 +391,10 @@ test('install download prompt options pass app language into docker image defaul
       true,
     );
 
-    assert.equal(preset.lang, 'en-US');
-    assert.equal(preset.source, 'docker');
-    assert.equal(preset.version, 'alpha');
-    assert.equal(preset.outputDir, './apps/en-demo');
+    expect(preset.lang).toBe('en-US');
+    expect(preset.source).toBe('docker');
+    expect(preset.version).toBe('alpha');
+    expect(preset.outputDir).toBe('./apps/en-demo');
   } finally {
     process.argv = originalArgv;
   }

--- a/packages/core/cli/src/__tests__/prompt-web-ui.test.ts
+++ b/packages/core/cli/src/__tests__/prompt-web-ui.test.ts
@@ -7,10 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import http from 'node:http';
 import net from 'node:net';
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test, vi, expect } from 'vitest';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
@@ -101,7 +100,7 @@ async function allocateLocalTcpPort(): Promise<string> {
   });
 
   const address = server.address();
-  assert.ok(address && typeof address === 'object');
+  expect(address && typeof address === 'object').toBeTruthy();
 
   const port = String(address.port);
   await new Promise<void>((resolve, reject) => {
@@ -160,9 +159,9 @@ test('runPromptCatalogWebUI resolves after submit even when the browser keeps a 
     });
 
     const page = await requestWithAgent(uiUrl, { agent });
-    assert.equal(page.statusCode, 200);
-    assert.match(page.body, /Submit &amp; continue in terminal/);
-    assert.match(page.body, /Saved\. This tab will close automatically in 5 seconds\./);
+    expect(page.statusCode).toBe(200);
+    expect(page.body).toMatch(/Submit &amp; continue in terminal/);
+    expect(page.body).toMatch(/Saved\. This tab will close automatically in 5 seconds\./);
 
     const submitUrl = new URL('/__pwc_ui_submit', uiUrl).toString();
     const submit = await requestWithAgent(submitUrl, {
@@ -171,7 +170,7 @@ test('runPromptCatalogWebUI resolves after submit even when the browser keeps a 
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ projectName: 'demo-app' }),
     });
-    assert.equal(submit.statusCode, 200);
+    expect(submit.statusCode).toBe(200);
 
     const resolved = await Promise.race([
       webUiPromise,
@@ -183,7 +182,7 @@ test('runPromptCatalogWebUI resolves after submit even when the browser keeps a 
       ),
     ]);
 
-    assert.deepEqual(resolved, { projectName: 'demo-app' });
+    expect(resolved).toEqual({ projectName: 'demo-app' });
   } finally {
     agent.destroy();
   }
@@ -225,15 +224,9 @@ test('hidden required fields are rendered disabled so browser validation does no
     });
 
     const page = await requestWithAgent(uiUrl, { agent });
-    assert.equal(page.statusCode, 200);
-    assert.match(
-      page.body,
-      /data-pwc-wrap="accessToken"[^>]*style="display:none"/,
-    );
-    assert.match(
-      page.body,
-      /name="accessToken" type="text"[^>]*required[^>]*disabled/,
-    );
+    expect(page.statusCode).toBe(200);
+    expect(page.body).toMatch(/data-pwc-wrap="accessToken"[^>]*style="display:none"/);
+    expect(page.body).toMatch(/name="accessToken" type="text"[^>]*required[^>]*disabled/);
 
     const submitUrl = new URL('/__pwc_ui_submit', uiUrl).toString();
     const submit = await requestWithAgent(submitUrl, {
@@ -247,7 +240,7 @@ test('hidden required fields are rendered disabled so browser validation does no
         authType: 'oauth',
       }),
     });
-    assert.equal(submit.statusCode, 200);
+    expect(submit.statusCode).toBe(200);
 
     const resolved = await Promise.race([
       webUiPromise,
@@ -259,7 +252,7 @@ test('hidden required fields are rendered disabled so browser validation does no
       ),
     ]);
 
-    assert.deepEqual(resolved, {
+    expect(resolved).toEqual({
       name: 'local',
       scope: 'project',
       apiBaseUrl: 'http://localhost:13000/api',
@@ -315,15 +308,15 @@ test('reflow returns default values for fields that become visible later', async
         version: 'latest',
       }),
     });
-    assert.equal(reflow.statusCode, 200);
+    expect(reflow.statusCode).toBe(200);
     const payload = JSON.parse(reflow.body) as {
       show?: Record<string, boolean>;
       values?: Record<string, string | boolean | number>;
     };
-    assert.equal(payload.show?.build, false);
-    assert.equal(payload.values?.build, undefined);
-    assert.equal(payload.show?.buildDts, true);
-    assert.equal(payload.values?.buildDts, false);
+    expect(payload.show?.build).toBe(false);
+    expect(payload.values?.build).toBe(undefined);
+    expect(payload.show?.buildDts).toBe(true);
+    expect(payload.values?.buildDts).toBe(false);
 
     const submitUrl = new URL('/__pwc_ui_submit', uiUrl).toString();
     await requestWithAgent(submitUrl, {
@@ -356,10 +349,10 @@ test('reflow recomputes init app paths from the current app name', async () => {
     appName: 'demoapp',
   });
 
-  assert.equal(state.show.appRootPath, true);
-  assert.equal(state.show.storagePath, true);
-  assert.equal(state.values.appRootPath, './demoapp/source/');
-  assert.equal(state.values.storagePath, './demoapp/storage/');
+  expect(state.show.appRootPath).toBe(true);
+  expect(state.show.storagePath).toBe(true);
+  expect(state.values.appRootPath).toBe('./demoapp/source/');
+  expect(state.values.storagePath).toBe('./demoapp/storage/');
 });
 
 test('reflow recomputes the built-in database image from the current database dialect until the field is edited', async () => {
@@ -373,8 +366,8 @@ test('reflow recomputes the built-in database image from the current database di
     builtinDb: true,
   });
 
-  assert.equal(initial.show.builtinDbImage, true);
-  assert.equal(initial.values.builtinDbImage, 'mysql:8');
+  expect(initial.show.builtinDbImage).toBe(true);
+  expect(initial.values.builtinDbImage).toBe('mysql:8');
 
   const updated = reflowWebFormState(Init.prompts, {
     hasNocobase: 'no',
@@ -383,7 +376,7 @@ test('reflow recomputes the built-in database image from the current database di
     builtinDb: true,
   });
 
-  assert.equal(updated.values.builtinDbImage, 'mariadb:11');
+  expect(updated.values.builtinDbImage).toBe('mariadb:11');
 
   const customized = reflowWebFormState(Init.prompts, {
     hasNocobase: 'no',
@@ -393,7 +386,7 @@ test('reflow recomputes the built-in database image from the current database di
     builtinDbImage: 'registry.example.com/custom-mariadb:11',
   });
 
-  assert.equal(customized.values.builtinDbImage, 'registry.example.com/custom-mariadb:11');
+  expect(customized.values.builtinDbImage).toBe('registry.example.com/custom-mariadb:11');
 
   const kingbase = reflowWebFormState(Init.prompts, {
     hasNocobase: 'no',
@@ -402,8 +395,7 @@ test('reflow recomputes the built-in database image from the current database di
     builtinDb: true,
   });
 
-  assert.equal(
-    kingbase.values.builtinDbImage,
+  expect(kingbase.values.builtinDbImage).toBe(
     'registry.cn-shanghai.aliyuncs.com/nocobase/kingbase:v009r001c001b0030_single_x86',
   );
 });
@@ -423,7 +415,7 @@ test('validate_field returns a field error for an occupied app port in web UI mo
 
   try {
     const busyAddress = busyServer.address();
-    assert.ok(busyAddress && typeof busyAddress === 'object');
+    expect(busyAddress && typeof busyAddress === 'object').toBeTruthy();
 
     const webUiPromise = runPromptCatalogWebUI({
       catalog: {
@@ -465,9 +457,9 @@ test('validate_field returns a field error for an occupied app port in web UI mo
       }),
     });
 
-    assert.equal(validateField.statusCode, 400);
-    assert.match(validateField.body, /fieldKey\":\"appPort\"/);
-    assert.match(validateField.body, /already in use/i);
+    expect(validateField.statusCode).toBe(400);
+    expect(validateField.body).toMatch(/fieldKey\":\"appPort\"/);
+    expect(validateField.body).toMatch(/already in use/i);
 
     const freePort = await allocateLocalTcpPort();
     const submitUrl = new URL('/__pwc_ui_submit', uiUrl).toString();

--- a/packages/core/cli/src/__tests__/run-npm.test.ts
+++ b/packages/core/cli/src/__tests__/run-npm.test.ts
@@ -7,7 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import assert from 'node:assert/strict';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/packages/core/cli/src/__tests__/runtime-help.test.ts
+++ b/packages/core/cli/src/__tests__/runtime-help.test.ts
@@ -1,5 +1,13 @@
-import assert from 'node:assert/strict';
-import { test } from 'vitest';
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { test, expect } from 'vitest';
 import { isTopicIndexCommand } from '../help/runtime-help.js';
 
 test('isTopicIndexCommand detects commands that are also topic namespaces', () => {
@@ -11,9 +19,9 @@ test('isTopicIndexCommand detects commands that are also topic namespaces', () =
     { name: 'api:resource:list' },
   ];
 
-  assert.equal(isTopicIndexCommand('api', topics), true);
-  assert.equal(isTopicIndexCommand('api:acl', topics), true);
-  assert.equal(isTopicIndexCommand('api:resource', topics), true);
-  assert.equal(isTopicIndexCommand('api:resource:list', topics), false);
-  assert.equal(isTopicIndexCommand('build', topics), false);
+  expect(isTopicIndexCommand('api', topics)).toBe(true);
+  expect(isTopicIndexCommand('api:acl', topics)).toBe(true);
+  expect(isTopicIndexCommand('api:resource', topics)).toBe(true);
+  expect(isTopicIndexCommand('api:resource:list', topics)).toBe(false);
+  expect(isTopicIndexCommand('build', topics)).toBe(false);
 });

--- a/packages/core/cli/src/lib/api-client.ts
+++ b/packages/core/cli/src/lib/api-client.ts
@@ -10,6 +10,9 @@
 import { promises as fs } from 'node:fs';
 import { resolveServerRequestTarget } from './env-auth.js';
 
+const CLI_REQUEST_SOURCE_HEADER = 'x-request-source';
+const CLI_REQUEST_SOURCE_VALUE = 'cli';
+
 export interface RequestParameter {
   name: string;
   flagName: string;
@@ -220,6 +223,7 @@ export async function executeApiRequest(options: RequestOptions) {
   const { baseUrl, token } = await resolveServerRequestTarget(options);
 
   const headers = new Headers();
+  headers.set(CLI_REQUEST_SOURCE_HEADER, CLI_REQUEST_SOURCE_VALUE);
   if (token) {
     headers.set('authorization', `Bearer ${token}`);
   }
@@ -291,6 +295,7 @@ export async function executeRawApiRequest(options: RawRequestOptions) {
   const { baseUrl, token } = await resolveServerRequestTarget(options);
 
   const headers = new Headers();
+  headers.set(CLI_REQUEST_SOURCE_HEADER, CLI_REQUEST_SOURCE_VALUE);
   if (token) {
     headers.set('authorization', `Bearer ${token}`);
   }

--- a/packages/core/logger/src/request-logger.ts
+++ b/packages/core/logger/src/request-logger.ts
@@ -9,6 +9,9 @@
 
 import { Logger, LoggerOptions } from './logger';
 import { pick, omit } from 'lodash';
+
+const REQUEST_SOURCE_HEADER = 'x-request-source';
+
 const defaultRequestWhitelist = [
   'action',
   'header.x-role',
@@ -17,6 +20,7 @@ const defaultRequestWhitelist = [
   'header.x-locale',
   'header.x-authenticator',
   'header.x-data-source',
+  'header.x-request-source',
   'header.referer',
 ];
 const defaultResponseWhitelist = ['status'];
@@ -38,6 +42,7 @@ export const requestLogger = (appName: string, requestLogger: Logger, options?: 
     const reqId = ctx.reqId;
     const path = /^\/api\/(.+):(.+)/.exec(ctx.path);
     const contextLogger = ctx.app.log.child({ reqId, module: path?.[1], submodule: path?.[2] });
+    const requestSource = ctx.request?.header?.[REQUEST_SOURCE_HEADER];
     // ctx.reqId = reqId;
     ctx.logger = ctx.log = contextLogger;
     const startTime = Date.now();
@@ -51,6 +56,7 @@ export const requestLogger = (appName: string, requestLogger: Logger, options?: 
       req: pick(ctx.request.toJSON(), options?.requestWhitelist || defaultRequestWhitelist),
       action: ctx.action?.toJSON?.(),
       app: appName,
+      ...(requestSource ? { requestSource } : {}),
       reqId,
     });
     ctx.res.setHeader('X-Request-Id', reqId);
@@ -73,6 +79,7 @@ export const requestLogger = (appName: string, requestLogger: Logger, options?: 
         status: ctx.status,
         cost,
         app: appName,
+        ...(requestSource ? { requestSource } : {}),
         reqId,
         bodySize: ctx.response.length,
       };

--- a/packages/core/server/src/__tests__/audit-manager.test.ts
+++ b/packages/core/server/src/__tests__/audit-manager.test.ts
@@ -344,4 +344,63 @@ describe('audit manager', () => {
       }
     `);
   });
+
+  it('includes CLI request source in audit log output', async () => {
+    app.auditManager.registerAction('list');
+
+    const logs: any[] = [];
+    app.auditManager.setLogger({
+      log: async (auditLog) => {
+        logs.push(auditLog);
+      },
+    });
+
+    const ctx: any = {
+      reqId: 'req-1',
+      status: 200,
+      body: {
+        data: [],
+      },
+      action: {
+        resourceName: 'users',
+        actionName: 'list',
+      },
+      request: {
+        header: {
+          'x-request-source': 'cli',
+        },
+        headers: {
+          'x-request-source': 'cli',
+        },
+        params: {},
+        query: {},
+        body: {},
+        path: '/api/users:list',
+        ip: '127.0.0.1',
+      },
+      response: {
+        status: 200,
+      },
+      state: {
+        currentUser: {
+          id: 1,
+        },
+        currentRole: 'root',
+      },
+    };
+
+    await app.auditManager.output(ctx, ctx.reqId);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      requestSource: 'cli',
+      metadata: {
+        request: {
+          headers: {
+            'x-request-source': 'cli',
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/core/server/src/__tests__/request-logger.test.ts
+++ b/packages/core/server/src/__tests__/request-logger.test.ts
@@ -1,0 +1,67 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { expect, test } from 'vitest';
+import { requestLogger } from '@nocobase/logger';
+
+test('request logger includes CLI request source in whitelist and top-level log fields', async () => {
+  const entries: any[] = [];
+  const middleware = requestLogger('main', {
+    info: (entry: any) => entries.push(entry),
+    warn: (entry: any) => entries.push(entry),
+    error: (entry: any) => entries.push(entry),
+  } as any);
+
+  const ctx = {
+    reqId: 'req-1',
+    path: '/api/users:list',
+    url: '/api/users:list?page=1',
+    method: 'GET',
+    action: {
+      toJSON: () => ({ resourceName: 'users', actionName: 'list' }),
+    },
+    app: {
+      log: {
+        child: () => ({}),
+      },
+    },
+    request: {
+      header: {
+        'x-request-source': 'cli',
+      },
+      toJSON: () => ({
+        header: {
+          'x-request-source': 'cli',
+        },
+      }),
+    },
+    response: {
+      length: 0,
+      status: 200,
+      toJSON: () => ({
+        status: 200,
+      }),
+    },
+    res: {
+      setHeader: () => {},
+    },
+    status: 200,
+    body: {
+      data: [],
+    },
+    auth: {},
+  };
+
+  await middleware(ctx, async () => {});
+
+  expect(entries).toHaveLength(2);
+  expect(entries[0].requestSource).toBe('cli');
+  expect(entries[0].req.header['x-request-source']).toBe('cli');
+  expect(entries[1].requestSource).toBe('cli');
+});

--- a/packages/core/server/src/audit-manager/index.ts
+++ b/packages/core/server/src/audit-manager/index.ts
@@ -11,6 +11,8 @@ import { Context } from '@nocobase/actions';
 import { head } from 'lodash';
 import Stream from 'stream';
 
+const REQUEST_SOURCE_HEADER = 'x-request-source';
+
 function isStream(obj) {
   return (
     obj instanceof Stream.Readable ||
@@ -25,6 +27,7 @@ export interface AuditLog {
   dataSource: string;
   resource: string;
   action: string;
+  requestSource?: string;
   sourceCollection?: string;
   sourceRecordUK?: string;
   targetCollection?: string;
@@ -240,6 +243,7 @@ export class AuditManager {
           'x-authenticator': ctx.request?.headers['x-authenticator'],
           'x-locale': ctx.request?.headers['x-locale'],
           'x-timezone': ctx.request?.headers['x-timezone'],
+          'x-request-source': ctx.request?.headers[REQUEST_SOURCE_HEADER],
         },
       },
       response: {
@@ -265,6 +269,7 @@ export class AuditManager {
       dataSource: (ctx.request.header['x-data-source'] || 'main') as string,
       resource: resourceName,
       action: ctx.action.actionName,
+      requestSource: ctx.request.header[REQUEST_SOURCE_HEADER] as string,
       userId: ctx.state?.currentUser?.id,
       roleName: ctx.state?.currentRole,
       ip: ips.length > 0 ? ips[0] : ctx.request.ip,

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -474,6 +474,7 @@ export class PluginDataSourceMainServer extends Plugin {
 
     this.registerErrorHandler();
     registerDataSourceMainMcpPostProcessors(this.ai.mcpToolsManager);
+    this.app.auditManager.registerActions(['collections:apply', 'fields:apply']);
 
     this.app.resourceManager.use(async function mergeReverseFieldWhenSaveCollectionField(ctx, next) {
       if (ctx.action.resourceName === 'collections.fields' && ['create', 'update'].includes(ctx.action.actionName)) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Improve NocoBase CLI API calls so server-side logs can distinguish requests coming from the CLI, and ensure the source is recorded consistently in request logs and audit logs.

### Description 
- Added the CLI request source header for `nb api` requests
- Recorded the CLI request source in request logs and audit logs
- Registered `collections:apply` and `fields:apply` in audit logging
- Migrated CLI test assertions to Vitest `expect` and resolved merge conflicts after syncing with `develop`

Potential risk:
- Low. The runtime behavior change is limited to adding a request header and logging metadata.

Testing suggestions:
- Run `nb api` against a local app and verify `x-request-source: cli` appears in request logs
- Trigger an audited write action such as `collections:apply` and verify `requestSource: cli` appears in audit logs

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added CLI request source tracking in request logs and audit logs |
| 🇨🇳 Chinese | 为请求日志和审计日志增加 CLI 请求来源标记 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
