### PR TITLE
fix: set popover max-height and scrolling safeguards so the submit area remains reachable

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/QuickEditFormModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/QuickEditFormModel.tsx
@@ -28,6 +28,18 @@ import { FieldModel } from '../../base';
 import { FormComponent } from './FormBlockModel';
 import { FormItemModel } from './FormItemModel';
 
+export const QUICK_EDIT_POPOVER_MAX_HEIGHT = 'calc(100vh - 96px)';
+export const QUICK_EDIT_FORM_MAX_HEIGHT = 'calc(100vh - 160px)';
+export const QUICK_EDIT_MARKDOWN_HEIGHT = 'min(480px, calc(100vh - 320px))';
+
+export function getQuickEditFieldProps(collectionField: CollectionField, fieldProps?: Record<string, any>) {
+  const nextProps = { ...collectionField.getComponentProps(), ...(fieldProps || {}) };
+  if (['markdown', 'vditor'].includes(collectionField.interface) && nextProps.height == null) {
+    nextProps.height = QUICK_EDIT_MARKDOWN_HEIGHT;
+  }
+  return nextProps;
+}
+
 export class QuickEditFormModel extends FlowModel {
   fieldPath: string;
 
@@ -99,7 +111,10 @@ export class QuickEditFormModel extends FlowModel {
       placement: 'rightTop',
       styles: {
         body: {
-          width: 400,
+          width: 420,
+          maxHeight: QUICK_EDIT_POPOVER_MAX_HEIGHT,
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
         },
       },
       content: (popover) => {
@@ -160,20 +175,28 @@ export class QuickEditFormModel extends FlowModel {
 
     return (
       <FormComponent model={this}>
-        {this.mapSubModels('fields', (field) => {
-          return (
-            <FormItem
-              showLabel={false}
-              name={this.fieldPath}
-              key={field.uid}
-              initialValue={this.context.record?.[this.fieldPath]}
-              {...this.props}
-            >
-              <FieldModelRenderer model={field} fallback={<Skeleton.Input size="small" />} />
-            </FormItem>
-          );
-        })}
-        <Space style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <div
+          style={{
+            minHeight: 0,
+            overflowY: 'auto',
+            maxHeight: QUICK_EDIT_FORM_MAX_HEIGHT,
+          }}
+        >
+          {this.mapSubModels('fields', (field) => {
+            return (
+              <FormItem
+                showLabel={false}
+                name={this.fieldPath}
+                key={field.uid}
+                initialValue={this.context.record?.[this.fieldPath]}
+                {...this.props}
+              >
+                <FieldModelRenderer model={field} fallback={<Skeleton.Input size="small" />} />
+              </FormItem>
+            );
+          })}
+        </div>
+        <Space style={{ display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
           <Button
             onClick={() => {
               this.viewContainer.close();
@@ -257,7 +280,7 @@ QuickEditFormModel.registerFlow({
               },
             },
           });
-          fieldModel.setProps({ ...collectionField.getComponentProps(), ...ctx.model._fieldProps });
+          fieldModel.setProps(getQuickEditFieldProps(collectionField, ctx.model._fieldProps));
           fieldModel.setProps({ sourceFieldModelUid: ctx.inputArgs.sourceFieldModelUid });
           ctx.model.context.defineProperty('collectionField', {
             get: () => collectionField,


### PR DESCRIPTION
…rea remains reachable

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      set popover max-height and scrolling safeguards so the submit area remains reachable     |
| 🇨🇳 Chinese |    设置快捷编辑 popover 的最大高度和滚动限制，确保底部提交按钮可达      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
