### PR TITLE
fix(idp-oauth): fix CLI OAuth registration and interaction

### DIFF
--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/client/InteractionPage.tsx
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/client/InteractionPage.tsx
@@ -59,18 +59,13 @@ export const InteractionPage = () => {
 
       const token = api.auth.getToken();
       const authenticator = api.auth.getAuthenticator() || 'basic';
-      const body = { ...(payload || {}) };
-      if (token) {
-        body.bridge_token = token;
-        body.bridge_authenticator = authenticator;
-      }
 
       const response = await api.request({
         url: interactionApiPath,
         method,
         skipNotify: true,
         withCredentials: true,
-        data: method === 'post' ? body : undefined,
+        data: method === 'post' ? payload : undefined,
         headers: token
           ? {
               Authorization: `Bearer ${token}`,

--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/__tests__/provider-dispatch.test.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/__tests__/provider-dispatch.test.ts
@@ -1,0 +1,80 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { dispatchToProvider } from '../provider-dispatch';
+
+function createContext(body: Record<string, any>) {
+  return {
+    method: 'POST',
+    path: '/api/idpOAuth/register',
+    headers: {
+      'content-type': 'application/json',
+    },
+    request: {
+      body,
+    },
+    get: (name: string) => (name.toLowerCase() === 'content-type' ? 'application/json' : ''),
+    set: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    },
+  } as any;
+}
+
+const service = {
+  getProviderContext: () => ({
+    appName: 'main',
+    origin: 'http://127.0.0.1:13000',
+    issuer: 'http://127.0.0.1:13000/api',
+    issuerPath: '/api',
+  }),
+} as any;
+
+describe('plugin-idp-oauth > provider dispatch', () => {
+  test('should reject dynamic registration redirect URIs that are not loopback callbacks', async () => {
+    const provider = {
+      issuer: 'http://127.0.0.1:13000/api',
+      callback: vi.fn(),
+    } as any;
+    const ctx = createContext({
+      redirect_uris: ['https://example.com/callback'],
+    });
+
+    await dispatchToProvider(ctx, provider, '/idpOAuth/register', service);
+
+    expect(ctx.status).toBe(400);
+    expect(ctx.body).toMatchObject({
+      error: 'invalid_client_metadata',
+    });
+    expect(provider.callback).not.toHaveBeenCalled();
+  });
+
+  test('should allow dynamic registration loopback redirect URIs', async () => {
+    const provider = {
+      issuer: 'http://127.0.0.1:13000/api',
+      callback: vi.fn(() => (_req: any, res: any) => {
+        res.statusCode = 201;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ client_id: 'client-1' }));
+      }),
+    } as any;
+    const ctx = createContext({
+      redirect_uris: ['http://127.0.0.1:53950/callback'],
+    });
+
+    await dispatchToProvider(ctx, provider, '/idpOAuth/register', service);
+
+    expect(ctx.status).toBe(201);
+    expect(ctx.body).toMatchObject({
+      client_id: 'client-1',
+    });
+    expect(provider.callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/plugin.ts
@@ -54,6 +54,7 @@ export class PluginIdpOauthServer extends Plugin {
       },
       {
         tag: 'idp-oauth-provider',
+        after: 'bodyParser',
         before: 'dataSource',
       },
     );

--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/provider-dispatch.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/provider-dispatch.ts
@@ -13,6 +13,8 @@ import { getProviderInternalPath } from './paths';
 
 type Provider = import('oidc-provider').Provider;
 
+const LOOPBACK_REDIRECT_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
 type DispatchContext = {
   method: string;
   path: string;
@@ -31,6 +33,50 @@ type DispatchContext = {
   status?: number;
   withoutDataWrapping?: boolean;
 };
+
+function getRequestBody(ctx: DispatchContext) {
+  const body = ctx.request.body;
+  if (typeof body === 'string') {
+    try {
+      return JSON.parse(body);
+    } catch (error) {
+      return undefined;
+    }
+  }
+  return body;
+}
+
+function isLoopbackRedirectUri(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' && LOOPBACK_REDIRECT_HOSTS.has(url.hostname) && !!url.port;
+  } catch (error) {
+    return false;
+  }
+}
+
+function assertRegistrationRedirectUris(ctx: DispatchContext, pathname: string) {
+  if (ctx.method !== 'POST' || pathname !== '/idpOAuth/register') {
+    return true;
+  }
+
+  const body = getRequestBody(ctx);
+  const redirectUris = body?.redirect_uris;
+  if (
+    !Array.isArray(redirectUris) ||
+    !redirectUris.length ||
+    !redirectUris.every((uri) => typeof uri === 'string' && isLoopbackRedirectUri(uri))
+  ) {
+    ctx.status = 400;
+    ctx.body = {
+      error: 'invalid_client_metadata',
+      error_description: 'redirect_uris must only contain http loopback callback URLs with an explicit port',
+    };
+    return false;
+  }
+
+  return true;
+}
 
 function buildPayload(ctx: DispatchContext) {
   const body = ctx.request.body;
@@ -237,6 +283,10 @@ export async function dispatchToProvider(
 ) {
   ctx.withoutDataWrapping = true;
   const search = ctx.querystring ? `?${ctx.querystring}` : '';
+  if (!assertRegistrationRedirectUris(ctx, pathname)) {
+    return;
+  }
+
   ctx.logger?.debug?.('idp-oauth provider request', {
     method: ctx.method,
     externalPath: ctx.path,

--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/service.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/service.ts
@@ -406,24 +406,17 @@ export class IdpOauthService {
   }
 
   async resolveInteractionBridgeUser(ctx: any) {
-    const { bridge_token: bridgeToken, bridge_authenticator: bridgeAuthenticator } =
-      (ctx.request.body as Record<string, any>) || {};
-    const bearerToken = ctx.getBearerToken?.();
-    const token = typeof bridgeToken === 'string' && bridgeToken ? bridgeToken : bearerToken;
+    const token = ctx.getBearerToken?.();
     if (!token || typeof token !== 'string') {
       ctx.logger?.debug?.('idp-oauth interaction bridge user missing token', {
         path: ctx.path,
-        hasBridgeToken: !!bridgeToken,
-        hasBearerToken: !!bearerToken,
+        hasBearerToken: !!token,
       });
       return undefined;
     }
 
     const headerAuthenticator = ctx.get?.('x-authenticator');
-    const authenticatorName =
-      typeof bridgeAuthenticator === 'string' && bridgeAuthenticator
-        ? bridgeAuthenticator
-        : headerAuthenticator || 'basic';
+    const authenticatorName = headerAuthenticator || 'basic';
     try {
       const auth = await ctx.app.authManager.get(authenticatorName, {
         app: ctx.app,

--- a/packages/plugins/@nocobase/plugin-idp-oauth/src/server/service.ts
+++ b/packages/plugins/@nocobase/plugin-idp-oauth/src/server/service.ts
@@ -406,12 +406,24 @@ export class IdpOauthService {
   }
 
   async resolveInteractionBridgeUser(ctx: any) {
-    const { bridge_token: token, bridge_authenticator: authenticator } = ctx.request.body || {};
+    const { bridge_token: bridgeToken, bridge_authenticator: bridgeAuthenticator } =
+      (ctx.request.body as Record<string, any>) || {};
+    const bearerToken = ctx.getBearerToken?.();
+    const token = typeof bridgeToken === 'string' && bridgeToken ? bridgeToken : bearerToken;
     if (!token || typeof token !== 'string') {
+      ctx.logger?.debug?.('idp-oauth interaction bridge user missing token', {
+        path: ctx.path,
+        hasBridgeToken: !!bridgeToken,
+        hasBearerToken: !!bearerToken,
+      });
       return undefined;
     }
 
-    const authenticatorName = typeof authenticator === 'string' && authenticator ? authenticator : 'basic';
+    const headerAuthenticator = ctx.get?.('x-authenticator');
+    const authenticatorName =
+      typeof bridgeAuthenticator === 'string' && bridgeAuthenticator
+        ? bridgeAuthenticator
+        : headerAuthenticator || 'basic';
     try {
       const auth = await ctx.app.authManager.get(authenticatorName, {
         app: ctx.app,
@@ -458,7 +470,12 @@ export class IdpOauthService {
         return user;
       }
       return undefined;
-    } catch (_error) {
+    } catch (error) {
+      ctx.logger?.debug?.('idp-oauth interaction bridge user failed', {
+        path: ctx.path,
+        authenticator: authenticatorName,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return undefined;
     }
   }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
OAuth sign-in from CLI clients could fail during dynamic client registration or return to the sign-in page after a successful NocoBase login. Dynamic registration also accepted broader redirect URI shapes than needed for the CLI/native OAuth flow.

### Description
This PR updates the IdP OAuth flow so provider requests run after request body parsing, interaction requests resolve the current NocoBase user from the Authorization header, and dynamic client registration only accepts loopback callback redirect URIs with an explicit port.

Potential risk: dynamic registration now rejects non-loopback redirect URIs. This is intended for the current CLI/native client flow, but any external client relying on HTTPS or custom-scheme redirects would need a separate trusted-client path.

Testing suggestions:
- Run CLI OAuth sign-in and confirm it can register a client, open the login page, complete login, and return to the CLI callback
- Verify dynamic registration rejects public redirect URIs

### Related issues

### Showcase
Not applicable

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed OAuth CLI sign-in failures and restricted dynamic registration to local callback URLs |
| 🇨🇳 Chinese | 修复 OAuth CLI 登录失败的问题，并限制动态注册只能使用本地回调地址 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |   |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
