### PR TITLE
fix(ai): variable parse not working during AI employee system prompt rending

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -574,15 +574,15 @@ export class AIEmployee {
       },
     });
 
-    let systemMessage = await parseVariables(this.ctx, this.employee.about ?? this.employee.defaultPrompt ?? '');
-    const dataSourceMessage = this.getEmployeeDataSourceContext();
-    if (dataSourceMessage) {
-      systemMessage = `${systemMessage}\n${dataSourceMessage}`;
-    }
+    const about = await parseVariables(this.ctx, this.employee.about ?? this.employee.defaultPrompt ?? '');
 
     let background = '';
     if (this.systemMessage) {
       background = await parseVariables(this.ctx, this.systemMessage);
+    }
+    const dataSourceMessage = this.getEmployeeDataSourceContext();
+    if (dataSourceMessage) {
+      background = `${background}\n${dataSourceMessage}`;
     }
 
     const aiMessages = await this.aiChatConversation.listMessages();
@@ -613,13 +613,12 @@ export class AIEmployee {
     const systemPrompt = getSystemPrompt({
       aiEmployee: {
         nickname: this.employee.nickname,
-        about: this.employee.about ?? this.employee.defaultPrompt,
+        about,
       },
       task: {
         background,
       },
       personal: userConfig?.prompt,
-      dataSources: dataSourceMessage,
       environment: {
         database: this.db.sequelize.getDialect(),
         locale: this.ctx.getCurrentLocale() || 'en-US',

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
@@ -12,14 +12,12 @@ export function getSystemPrompt({
   personal,
   task,
   environment,
-  dataSources,
   knowledgeBase,
 }: {
   aiEmployee: { nickname: string; about: string };
   personal?: string;
   task: { background: string; context?: string };
   environment: { database: string; locale: string };
-  dataSources?: string;
   knowledgeBase?: string;
 }) {
   // Helper function to get database-specific identifier quoting rules

--- a/packages/plugins/@nocobase/plugin-ai/src/server/resource/aiEmployees.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/resource/aiEmployees.ts
@@ -92,6 +92,9 @@ export const listByUser = async (ctx: Context, next: Next) => {
 
   ctx.body = rows.map((row) => {
     const skillSettings: { skills: { name: string; auto: boolean }[] } = row.skillSettings ?? { skills: [] };
+    if (!_.isArray(skillSettings.skills)) {
+      skillSettings.skills = [];
+    }
     for (const tool of tools) {
       skillSettings.skills.push({
         name: tool.definition.name,


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where variables in the system prompt of AI employees did not take effect |
| 🇨🇳 Chinese | 修复 AI 员工系统提示词中的变量不生效问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
