### PR TITLE
fix(auth): invalidate renewed sessions after password change

### DIFF
--- a/packages/core/auth/src/base/auth.ts
+++ b/packages/core/auth/src/base/auth.ts
@@ -162,7 +162,7 @@ export class BaseAuth extends Auth {
       tokenStatus = 'expired';
     }
 
-    if (tokenStatus === 'valid' && user.passwordChangeTz && iat * 1000 < user.passwordChangeTz) {
+    if (user.passwordChangeTz && iat * 1000 < user.passwordChangeTz) {
       this.ctx.throw(401, {
         message: this.ctx.t('User password changed, please signin again.', { ns: localeNamespace }),
         code: AuthErrorCode.INVALID_TOKEN,

--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
@@ -459,5 +459,37 @@ describe('actions', () => {
       expect(res3.statusCode).toEqual(401);
       expect(res3.text).toBe('User password changed, please signin again.');
     });
+
+    it('should not renew an expired token after password changed', async () => {
+      await app.authManager.tokenController.setConfig({
+        tokenExpirationTime: '1s',
+        sessionExpirationTime: '1d',
+        expiredTokenRenewLimit: '1d',
+      });
+
+      const userRepo = db.getRepository('users');
+      const user = await userRepo.create({
+        values: {
+          username: 'test',
+          password: '12345',
+        },
+      });
+      const firstAgent = await agent.login(user, null);
+      const secondAgent = await agent.login(user, null);
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const res = await firstAgent.post('/auth:changePassword').set({ 'X-Authenticator': 'basic' }).send({
+        oldPassword: '12345',
+        newPassword: '123456',
+        confirmPassword: '123456',
+      });
+      expect(res.statusCode).toEqual(200);
+
+      const res2 = await secondAgent.post('/auth:check').set({ 'X-Authenticator': 'basic' }).send();
+      expect(res2.statusCode).toEqual(401);
+      expect(res2.text).toBe('User password changed, please signin again.');
+      expect(res2.headers['x-new-token']).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Changing a user's password should invalidate existing sessions on other browsers or devices. Previously, an expired-but-renewable token could be refreshed after the password was changed, allowing the old session to continue.

### Description
This PR applies the password-change invalidation check before expired login tokens can be renewed.

It also adds a regression test that signs in from two sessions, changes the password in one session, and verifies the other expired token is rejected without returning a new token.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed old sessions remaining active after a password change |
| 🇨🇳 Chinese | 修复修改密码后旧会话仍可继续使用的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |   |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
