### PR TITLE
fix(client): preserve page query params in keep-alive pages

### DIFF
--- a/packages/core/client/src/application/CustomRouterContextProvider.tsx
+++ b/packages/core/client/src/application/CustomRouterContextProvider.tsx
@@ -48,7 +48,7 @@ IsInSettingsPageContext.displayName = 'IsInSettingsPageContext';
 export const CurrentTabUidContext = React.createContext<string>('');
 CurrentTabUidContext.displayName = 'CurrentTabUidContext';
 
-const SearchParamsContext = React.createContext<URLSearchParams>(new URLSearchParams());
+export const SearchParamsContext = React.createContext<URLSearchParams>(new URLSearchParams());
 SearchParamsContext.displayName = 'SearchParamsContext';
 
 const RouterBasenameContext = React.createContext<string>('');

--- a/packages/core/client/src/schema-component/antd/page/Page.tsx
+++ b/packages/core/client/src/schema-component/antd/page/Page.tsx
@@ -24,9 +24,12 @@ import { FormDialog, ICON_POPUP_Z_INDEX, withSearchParams, zIndexContext } from 
 import { antTableCell } from '../../../acl/style';
 import {
   CurrentTabUidContext,
+  LocationSearchContext,
+  SearchParamsContext,
   useCurrentSearchParams,
   useCurrentTabUid,
   useLocationNoUpdate,
+  useLocationSearch,
   useNavigateNoUpdate,
   useRouterBasename,
 } from '../../../application/CustomRouterContextProvider';
@@ -115,12 +118,27 @@ const InternalPage = React.memo((props: PageProps) => {
   );
 });
 
+export const useKeepAliveLocationSearch = () => {
+  const { active } = useKeepAlive();
+  const locationSearch = useLocationSearch();
+  const locationSearchRef = useRef(locationSearch);
+
+  // 缓存页失活后保留自己的查询串，避免被其他页面的 URL 参数污染。
+  if (active) {
+    locationSearchRef.current = locationSearch;
+  }
+
+  return active ? locationSearch : locationSearchRef.current;
+};
+
 export const Page = React.memo((props: PageProps) => {
   const { hashId, componentCls } = useStyles();
   const { active: pageActive } = useKeepAlive();
   const currentTabUid = useCurrentTabUid();
+  const locationSearch = useKeepAliveLocationSearch();
   const tabUidRef = useRef(currentTabUid);
   const engineCtx = useFlowEngineContext();
+  const searchParams = useMemo(() => new URLSearchParams(locationSearch), [locationSearch]);
   useEffect(() => {
     if (pageActive && engineCtx?.pageInfo) {
       engineCtx.pageInfo.version = 'v1';
@@ -134,10 +152,14 @@ export const Page = React.memo((props: PageProps) => {
   return (
     <AllDataBlocksProvider>
       <div className={`${componentCls} ${hashId} ${antTableCell}`}>
-        {/* Avoid passing values down to improve rendering performance */}
-        <CurrentTabUidContext.Provider value={''}>
-          <InternalPage currentTabUid={tabUidRef.current} className={props.className} />
-        </CurrentTabUidContext.Provider>
+        <LocationSearchContext.Provider value={locationSearch}>
+          <SearchParamsContext.Provider value={searchParams}>
+            {/* Avoid passing values down to improve rendering performance */}
+            <CurrentTabUidContext.Provider value={''}>
+              <InternalPage currentTabUid={tabUidRef.current} className={props.className} />
+            </CurrentTabUidContext.Provider>
+          </SearchParamsContext.Provider>
+        </LocationSearchContext.Provider>
       </div>
     </AllDataBlocksProvider>
   );

--- a/packages/core/client/src/schema-component/antd/page/__tests__/useKeepAliveLocationSearch.test.tsx
+++ b/packages/core/client/src/schema-component/antd/page/__tests__/useKeepAliveLocationSearch.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { renderHook } from '@nocobase/test/client';
+import { useKeepAliveLocationSearch } from '../Page';
+
+const { mockKeepAliveState, mockLocationSearch } = vi.hoisted(() => ({
+  mockKeepAliveState: { active: true },
+  mockLocationSearch: vi.fn(() => '?f=1'),
+}));
+
+vi.mock('../../../../route-switch/antd/admin-layout/KeepAlive', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../route-switch/antd/admin-layout/KeepAlive')>();
+  return {
+    ...actual,
+    useKeepAlive: () => mockKeepAliveState,
+  };
+});
+
+vi.mock('../../../../application/CustomRouterContextProvider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../application/CustomRouterContextProvider')>();
+  return {
+    ...actual,
+    useLocationSearch: () => mockLocationSearch(),
+  };
+});
+
+describe('useKeepAliveLocationSearch', () => {
+  beforeEach(() => {
+    mockKeepAliveState.active = true;
+    mockLocationSearch.mockReset();
+    mockLocationSearch.mockReturnValue('?f=1');
+  });
+
+  it('should keep the previous search string while the keep-alive page is inactive', () => {
+    const { result, rerender } = renderHook(() => useKeepAliveLocationSearch());
+
+    expect(result.current).toBe('?f=1');
+
+    mockKeepAliveState.active = false;
+    mockLocationSearch.mockReturnValue('?f=2');
+    rerender();
+
+    expect(result.current).toBe('?f=1');
+
+    mockKeepAliveState.active = true;
+    rerender();
+
+    expect(result.current).toBe('?f=2');
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
KeepAlive 缓存页面在失活后仍会读取全局最新的 URL 查询串，导致页面里配置的 URL 查询参数变量被其他页面的 query 覆盖或清空，重新返回页面时会错误地展示全量数据。

### Description 
- 在 `Page` 组件中为 KeepAlive 页面保留失活前的 `location.search` 快照，避免隐藏页面被其他页面的 URL 参数污染
- 允许页面子树覆写 `LocationSearchContext` 与 `SearchParamsContext`，确保缓存页面恢复后仍使用自己的查询参数上下文
- 增加单测覆盖 KeepAlive 页面在失活和重新激活时的查询串行为
- 风险较小，仅影响 KeepAlive 页面子树读取 URL 查询参数的方式
- 建议回归：访问带 `?f=2` 的目标页面，切换到其他页面后再返回，确认列表不会变成全量数据

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where URL query parameter variables become invalid after switching cached pages |
| 🇨🇳 Chinese | 修复缓存页面切换后 URL 查询参数变量失效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
