### PR TITLE
fix(flow-engine): restore values in horizontal subforms

### DIFF
--- a/packages/core/flow-engine/src/components/FormItem.tsx
+++ b/packages/core/flow-engine/src/components/FormItem.tsx
@@ -57,6 +57,16 @@ export const FormItem = ({
   labelWidth,
   ...rest
 }: ExtendedFormItemProps & ChildExtraProps) => {
+  const normalizeLabelWidth = (value?: number | string) => {
+    if (value === undefined || value === null || value === '') {
+      return undefined;
+    }
+    if (typeof value === 'number') {
+      return `${value}px`;
+    }
+    return /^\d+(\.\d+)?$/.test(value) ? `${value}px` : value;
+  };
+
   // 过滤掉 Form.Item 专用 props，只保留要传给子组件的
   const childProps = Object.fromEntries(
     Object.entries(rest).filter(([key]) => !formItemPropKeys.includes(key as keyof ExtendedFormItemProps)),
@@ -72,6 +82,32 @@ export const FormItem = ({
           return child;
         });
   const { label, labelWrap, colon = true, layout } = rest;
+  const normalizedLabelWidth = normalizeLabelWidth(labelWidth);
+  const isHorizontalLayout = layout === 'horizontal';
+  const labelColStyle = {
+    ...(rest.labelCol?.style || {}),
+    ...(normalizedLabelWidth
+      ? {
+          width: normalizedLabelWidth,
+        }
+      : {}),
+    ...(isHorizontalLayout && normalizedLabelWidth
+      ? {
+          flex: `0 1 ${normalizedLabelWidth}`,
+          maxWidth: normalizedLabelWidth,
+          minWidth: 0,
+        }
+      : {}),
+  };
+  const wrapperColStyle = {
+    ...(rest.wrapperCol?.style || {}),
+    ...(isHorizontalLayout
+      ? {
+          flex: '1 1 0',
+          minWidth: 0,
+        }
+      : {}),
+  };
   const effectiveLabelWrap = !layout || layout === 'vertical' ? true : labelWrap;
   const renderLabel = () => {
     if (!showLabel) return null;
@@ -118,7 +154,8 @@ export const FormItem = ({
   return (
     <Form.Item
       {...rest}
-      labelCol={{ style: { width: labelWidth } }}
+      labelCol={{ ...rest.labelCol, style: labelColStyle }}
+      wrapperCol={{ ...rest.wrapperCol, style: wrapperColStyle }}
       layout={layout}
       label={renderLabel()}
       colon={false}

--- a/packages/core/flow-engine/src/components/__tests__/FormItem.test.tsx
+++ b/packages/core/flow-engine/src/components/__tests__/FormItem.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Form } from 'antd';
+import { describe, expect, it } from 'vitest';
+import { FormItem } from '../FormItem';
+
+describe('FlowEngine FormItem', () => {
+  it('allows horizontal label columns to shrink in narrow layouts', () => {
+    const { container } = render(
+      <Form>
+        <FormItem label="公司名称" layout="horizontal" labelWidth={120}>
+          <span>测试值</span>
+        </FormItem>
+      </Form>,
+    );
+
+    const label = container.querySelector('.ant-form-item-label') as HTMLElement;
+    const control = container.querySelector('.ant-form-item-control') as HTMLElement;
+
+    expect(label.style.width).toBe('120px');
+    expect(label.style.flex).toBe('0 1 120px');
+    expect(label.style.maxWidth).toBe('120px');
+    expect(label.style.minWidth).toBe('0');
+    expect(control.style.flex).toBe('1 1 0px');
+    expect(control.style.minWidth).toBe('0');
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

修复详情区块中 v1 水平布局子表单在一行展示多个字段时，字段标签列固定占宽导致值区域被过度压缩，最终表现为字段值看起来不显示的问题。

### Description 

- 调整 `flow-engine` 通用 `FormItem` 在水平布局下的列样式，让标签列在保留 `labelWidth` 基准宽度的同时允许收缩
- 为内容列补充 `flex` 和 `min-width: 0`，避免在窄列或子表单多列场景中被挤压到不可见
- 新增针对性单测，覆盖水平布局窄列场景下标签列和内容列的布局行为

风险较小，改动只影响 `flow-engine` 通用表单项在水平布局下的列样式。建议在详情区块、子表单和普通水平表单场景下做一次展示回归。

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where values disappear in horizontal subforms when multiple fields are placed in one row |
| 🇨🇳 Chinese | 修复水平子表单一行放多个字段时值不显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
