### PR TITLE
fix: support SQL Server datetime filters

### DIFF
--- a/packages/core/database/src/__tests__/operator/date/datetime-no-tz.test.ts
+++ b/packages/core/database/src/__tests__/operator/date/datetime-no-tz.test.ts
@@ -7,7 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { createMockDatabase, Database, Repository } from '@nocobase/database';
+import { createMockDatabase, Database, DatetimeNoTzField, Repository } from '@nocobase/database';
+
+class CustomDatetimeNoTzField extends DatetimeNoTzField {}
 
 describe('datetimeNoTz date operator test', () => {
   let db: Database;
@@ -204,5 +206,43 @@ describe('datetimeNoTz date operator test', () => {
     });
 
     expect(count).toBe(2);
+  });
+
+  test('custom datetimeNoTz field class should use no-timezone date filter', async () => {
+    await db.close();
+    db = await createMockDatabase({
+      timezone: '+08:00',
+    });
+
+    db.registerFieldTypes({
+      datetimeNoTz: CustomDatetimeNoTzField,
+    });
+
+    await db.clean({ drop: true });
+    const Test = db.collection({
+      name: 'custom_tests',
+      fields: [
+        {
+          name: 'date1',
+          type: 'datetimeNoTz',
+        },
+      ],
+    });
+    repository = Test.repository;
+    await db.sync();
+
+    await repository.create({
+      values: {
+        date1: '2023-01-01 00:00:00',
+      },
+    });
+
+    const count = await repository.count({
+      filter: {
+        'date1.$dateOn': '2023-01-01',
+      },
+    });
+
+    expect(count).toBe(1);
   });
 });

--- a/packages/core/database/src/operators/date.ts
+++ b/packages/core/database/src/operators/date.ts
@@ -15,6 +15,14 @@ function isDate(input) {
   return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
 }
 
+function isDatetimeNoTzField(field) {
+  return field?.type === 'datetimeNoTz' || field?.constructor.name === 'DatetimeNoTzField';
+}
+
+function isDateOnlyField(field) {
+  return field?.type === 'dateOnly' || field?.constructor.name === 'DateOnlyField';
+}
+
 const toDate = (date, options: any = {}) => {
   const { ctx } = options;
   let val = isDate(date) ? date : new Date(date);
@@ -28,11 +36,11 @@ const toDate = (date, options: any = {}) => {
     val = field.dateToValue(val);
   }
 
-  if (field.constructor.name === 'DatetimeNoTzField') {
+  if (isDatetimeNoTzField(field)) {
     val = moment(val).utcOffset('+00:00').format('YYYY-MM-DD HH:mm:ss');
   }
 
-  if (field.constructor.name === 'DateOnlyField') {
+  if (isDateOnlyField(field)) {
     val = moment.utc(val).format('YYYY-MM-DD HH:mm:ss');
   }
 
@@ -53,11 +61,11 @@ function parseDateTimezone(ctx) {
     return ctx.db.options.timezone;
   }
 
-  if (field.constructor.name === 'DatetimeNoTzField') {
+  if (isDatetimeNoTzField(field)) {
     return '+00:00';
   }
 
-  if (field.constructor.name === 'DateOnlyField') {
+  if (isDateOnlyField(field)) {
     return '+00:00';
   }
 

--- a/packages/core/utils/src/parse-filter.ts
+++ b/packages/core/utils/src/parse-filter.ts
@@ -104,6 +104,15 @@ function isDate(input) {
   return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
 }
 
+function isDateFieldWithoutTimezone(field) {
+  return (
+    field?.type === 'dateOnly' ||
+    field?.type === 'datetimeNoTz' ||
+    field?.constructor.name === 'DateOnlyField' ||
+    field?.constructor.name === 'DatetimeNoTzField'
+  );
+}
+
 const dateValueWrapper = (value: any, timezone?: string) => {
   if (!value) {
     return null;
@@ -187,7 +196,7 @@ export const parseFilter = async (filter: any, opts: ParseFilterOptions = {}) =>
       if (isDateOperator(operator)) {
         const field = getField?.(path);
 
-        if (field?.constructor.name === 'DateOnlyField' || field?.constructor.name === 'DatetimeNoTzField') {
+        if (isDateFieldWithoutTimezone(field)) {
           if (value.type) {
             return getDayRangeByParams({ ...value, timezone: field?.timezone || timezone });
           }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Filtering SQL Server external data source datetime fields could fail because custom no-timezone date field classes were not recognized by the date filter normalization logic.

### Description
This change makes date filter normalization detect `dateOnly` and `datetimeNoTz` fields by field type, while keeping the existing class-name checks for compatibility.

It also adds a regression test with a custom `datetimeNoTz` field class to cover external data source field implementations.

Testing performed:
- `yarn test packages/core/database/src/__tests__/operator/date/datetime-no-tz.test.ts`
- `yarn test packages/core/utils/src/__tests__/parse-filter.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where SQL Server external data source datetime filters could fail |
| 🇨🇳 Chinese | 修复 SQL Server 外部数据源日期时间字段筛选可能失败的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |   |
| 🇨🇳 Chinese |   |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
