### PR TITLE
fix(data-visualization): use flow data sources in chart query builder

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/query-builder.service.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/__tests__/query-builder.service.test.ts
@@ -7,9 +7,104 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { buildOrderFieldOptions, validateQuery } from '../flow/models/QueryBuilder.service';
+import {
+  buildOrderFieldOptions,
+  getCollectionOptions,
+  getFieldOptions,
+  getFormatterOptionsByField,
+  validateQuery,
+} from '../flow/models/QueryBuilder.service';
 
 describe('query builder service', () => {
+  test('should build options from flow data source manager', () => {
+    const createdAt = {
+      name: 'createdAt',
+      interface: 'datetime',
+      filterable: { operators: [] },
+      uiSchema: { title: 'Created at' },
+    };
+    const customerName = {
+      name: 'name',
+      interface: 'input',
+      filterable: { operators: [] },
+      uiSchema: { title: 'Customer name' },
+    };
+    const customers = {
+      name: 'customers',
+      title: 'Customers',
+      getFields: () => [customerName],
+    };
+    const customer = {
+      name: 'customer',
+      interface: 'm2o',
+      filterable: { nested: true },
+      target: 'customers',
+      uiSchema: { title: 'Customer' },
+      targetCollection: customers,
+    };
+    const orders = {
+      name: 'orders',
+      title: 'Orders',
+      getFields: () => [createdAt, customer],
+    };
+    const main = {
+      key: 'main',
+      displayName: 'Main',
+      getCollections: () => [orders, customers],
+    };
+    const external = {
+      key: 'external',
+      displayName: 'External',
+      options: {
+        isDBInstance: true,
+      },
+      getCollections: () => [
+        {
+          name: 'externalOrders',
+          title: 'External orders',
+        },
+      ],
+    };
+    const dm = {
+      getCollection: (_dataSourceKey: string, collectionName: string) =>
+        collectionName === 'orders' ? orders : collectionName === 'customers' ? customers : undefined,
+      getDataSources: () => [main, external],
+    };
+
+    expect(getCollectionOptions(dm, (value) => value)).toEqual([
+      {
+        value: 'main',
+        label: 'Main',
+        children: [
+          { value: 'orders', label: 'Orders' },
+          { value: 'customers', label: 'Customers' },
+        ],
+      },
+      {
+        value: 'external',
+        label: 'External',
+        children: [{ value: 'externalOrders', label: 'External orders' }],
+      },
+    ]);
+    expect(getFieldOptions(dm, (value) => value, ['main', 'orders'])).toMatchObject([
+      {
+        name: 'createdAt',
+        title: 'Created at',
+      },
+      {
+        name: 'customer',
+        title: 'Customer',
+        children: [
+          {
+            name: 'name',
+            title: 'Customer name',
+          },
+        ],
+      },
+    ]);
+    expect(getFormatterOptionsByField(dm, ['main', 'orders'], ['createdAt'])).not.toEqual([]);
+  });
+
   test('should use aliases in aggregated order field options', () => {
     const fieldOptions = [
       {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/ChartOptionsPanel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/ChartOptionsPanel.tsx
@@ -16,7 +16,7 @@ import { FunctionOutlined, LineChartOutlined } from '@ant-design/icons';
 import { ChartOptionsBuilder } from './ChartOptionsBuilder';
 import { configStore } from './config-store';
 import { observer, useFlowSettingsContext } from '@nocobase/flow-engine';
-import { useCompile, useDataSourceManager } from '@nocobase/client';
+import { useCompile } from '@nocobase/client';
 import { getFieldOptions } from './QueryBuilder.service';
 
 const flattenFieldTitleMap = (options: any[] = [], prefix: string[] = [], map = new Map<string, string>()) => {
@@ -55,7 +55,7 @@ export const ChartOptionsPanel: React.FC = observer(() => {
   const form = useForm();
   // 从 flow ctx 和 configStore 计算 columns
   const ctx = useFlowSettingsContext<any>();
-  const dm = useDataSourceManager();
+  const dm = ctx?.model?.context?.dataSourceManager;
   const compile = useCompile();
   const uid = ctx?.model?.uid;
   const previewData = configStore.results[uid]?.result || [];

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/QueryBuilder.service.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/QueryBuilder.service.ts
@@ -10,32 +10,65 @@
 import { DEFAULT_DATA_SOURCE_KEY } from '@nocobase/client';
 import { formatters, debugLog } from '../utils';
 
+function isDatabaseDataSource(dataSource: any) {
+  return dataSource?.key === DEFAULT_DATA_SOURCE_KEY || dataSource?.options?.isDBInstance || dataSource?.isDBInstance;
+}
+
+function getFieldInterface(dm: any, field: any) {
+  return field?.getInterfaceOptions?.() || dm?.collectionFieldInterfaceManager?.getFieldInterface?.(field?.interface);
+}
+
+function getFieldFilterable(dm: any, field: any) {
+  if (field?.filterable === false) {
+    return false;
+  }
+  return field?.filterable || getFieldInterface(dm, field)?.filterable;
+}
+
+function getFieldTitle(field: any) {
+  return field?.uiSchema?.title ?? field?.options?.uiSchema?.title ?? field?.title ?? field?.name;
+}
+
+function getTargetFields(dm: any, dataSourceKey: string, field: any) {
+  try {
+    return (
+      field?.getFields?.() ||
+      field?.targetCollection?.getFields?.() ||
+      dm.getCollection?.(dataSourceKey, field.target)?.getFields?.() ||
+      []
+    );
+  } catch {
+    return [];
+  }
+}
+
 // 纯函数：构建字段树
 export function getFieldOptions(dm: any, compile: (v: any) => string, collectionPath?: string[]) {
   const [dataSourceKey, collectionName] = collectionPath || [];
-  const ds = dm.getDataSource(dataSourceKey || DEFAULT_DATA_SOURCE_KEY);
-  const cm = ds?.collectionManager;
-  const fim = dm.collectionFieldInterfaceManager;
+  if (!dm || !collectionName) return [];
 
-  if (!cm || !fim || !collectionName) return [];
+  const dsKey = dataSourceKey || DEFAULT_DATA_SOURCE_KEY;
+  const collection = dm.getCollection?.(dsKey, collectionName);
 
-  const collectionFields = cm.getCollectionFields(collectionName) || [];
+  if (!collection) return [];
+
+  const collectionFields = collection.getFields?.() || [];
 
   const toOption = (field: any, depth: number, prefix?: string) => {
     if (!field?.interface) return undefined;
-    const iface = fim.getFieldInterface(field.interface);
-    if (!iface?.filterable) return undefined;
+    const filterable = getFieldFilterable(dm, field);
+    if (!filterable) return undefined;
 
     const value = prefix ? `${prefix}.${field.name}` : field.name;
     const opt: any = {
       name: field.name,
-      title: compile(field?.uiSchema?.title ?? field.name),
+      title: compile(getFieldTitle(field)),
       key: value,
       value: field.name,
     };
 
     if (depth < 1) {
-      const children = iface.filterable?.children || [];
+      const children = filterable?.children || [];
       if (children.length) {
         opt.children = children.map((c: any) => ({
           ...c,
@@ -44,8 +77,8 @@ export function getFieldOptions(dm: any, compile: (v: any) => string, collection
           value: c.name,
         }));
       }
-      if (iface.filterable?.nested && field.target) {
-        const targetFields = cm.getCollectionFields(field.target) || [];
+      if (filterable?.nested && field.target) {
+        const targetFields = getTargetFields(dm, dsKey, field);
         const nested = targetFields.map((tf: any) => toOption(tf, depth + 1, field.name)).filter(Boolean);
         opt.children = [...(opt.children || []), ...nested];
       }
@@ -124,20 +157,22 @@ export function getFormatterOptionsByField(dm: any, collectionPath: string[] | u
   if (!alias) return [];
 
   const [dataSourceKey, collectionName] = collectionPath || [];
-  const ds = dm.getDataSource(dataSourceKey || DEFAULT_DATA_SOURCE_KEY);
-  const cm = ds?.collectionManager;
-  if (!cm || !collectionName) return [];
+  if (!dm || !collectionName) return [];
+
+  const dsKey = dataSourceKey || DEFAULT_DATA_SOURCE_KEY;
+  const collection = dm.getCollection?.(dsKey, collectionName);
+  if (!collection) return [];
 
   const parts = alias.split('.');
   const [first, second] = parts;
 
-  const rootFields = cm.getCollectionFields(collectionName) || [];
+  const rootFields = collection.getFields?.() || [];
   const root = rootFields.find((f: any) => f.name === first);
   if (!root) return [];
 
   const iface =
     second && root.target
-      ? (cm.getCollectionFields(root.target) || []).find((f: any) => f.name === second)?.interface
+      ? getTargetFields(dm, dsKey, root).find((f: any) => f.name === second)?.interface
       : root.interface;
 
   switch (iface) {
@@ -159,9 +194,16 @@ export function getFormatterOptionsByField(dm: any, collectionPath: string[] | u
 
 // 新增：纯函数，构建“数据源/集合”选项（保持原有签名）
 export function getCollectionOptions(dm: any, compile: (v: any) => string) {
-  const allCollections = dm.getAllCollections();
-  return allCollections
-    .filter(({ key, isDBInstance }: any) => key === DEFAULT_DATA_SOURCE_KEY || isDBInstance)
+  if (!dm) return [];
+
+  const dataSources = dm.getDataSources?.() || [];
+  return dataSources
+    .filter(isDatabaseDataSource)
+    .map((dataSource: any) => ({
+      key: dataSource.key,
+      displayName: dataSource.displayName,
+      collections: dataSource.getCollections?.() || [],
+    }))
     .map(({ key, displayName, collections }: any) => ({
       value: key,
       label: compile(displayName),

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/QueryBuilder.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/QueryBuilder.tsx
@@ -21,7 +21,7 @@ import { Form, Space, Cascader, Select, Input, Checkbox, Button, InputNumber } f
 import { DeleteOutlined, ArrowUpOutlined, ArrowDownOutlined, PlusOutlined } from '@ant-design/icons';
 import isEqual from 'lodash/isEqual';
 import { useT } from '../../locale';
-import { FilterGroup, VariableFilterItem, useCompile, useDataSourceManager } from '@nocobase/client';
+import { FilterGroup, VariableFilterItem, useCompile } from '@nocobase/client';
 import { useForm as useFormilyForm } from '@formily/react';
 import {
   getFieldOptions,
@@ -117,7 +117,7 @@ const QueryBuilderInner: FC<{
   const [form] = Form.useForm();
   const ctx = useFlowSettingsContext<any>();
   const lang = ctx?.i18n?.language;
-  const dm = useDataSourceManager();
+  const dm = ctx?.model?.context?.dataSourceManager;
   const compile = useCompile();
 
   const rawQuery = stepForm.values?.query;

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/SQLEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/flow/models/SQLEditor.tsx
@@ -12,7 +12,7 @@ import { connect, mapProps, useForm } from '@formily/react';
 import { Select, Form } from 'antd';
 import { CodeEditor, CodeEditorHandle } from '../components/CodeEditor';
 import { FlowContextSelector, observer, useFlowContext } from '@nocobase/flow-engine';
-import { useDataSourceManager, useCompile, DEFAULT_DATA_SOURCE_KEY } from '@nocobase/client';
+import { useCompile, DEFAULT_DATA_SOURCE_KEY } from '@nocobase/client';
 import { useT } from '../../locale';
 
 const SQLEditorBase: React.FC<any> = observer((props) => {
@@ -21,15 +21,18 @@ const SQLEditorBase: React.FC<any> = observer((props) => {
   const ctx = useFlowContext();
 
   const form = useForm();
-  const dm = useDataSourceManager();
+  const dm = ctx?.dataSourceManager;
   const compile = useCompile();
   const t = useT();
 
   // 数据源选项
   const dsOptions = React.useMemo(() => {
-    const all = dm.getAllCollections();
-    return all
-      .filter(({ key, isDBInstance }: any) => key === DEFAULT_DATA_SOURCE_KEY || isDBInstance)
+    const dataSources = dm?.getDataSources?.() || [];
+    return dataSources
+      .filter(
+        (dataSource: any) =>
+          dataSource?.key === DEFAULT_DATA_SOURCE_KEY || dataSource?.options?.isDBInstance || dataSource?.isDBInstance,
+      )
       .map(({ key, displayName }: any) => ({ value: key, label: compile(displayName) }));
   }, [dm, compile]);
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Chart query configuration in flow pages used legacy data source manager APIs. In V2 flow pages this could prevent data sources from being resolved correctly and leave measure or dimension field selectors empty.

### Description
Use the flow context data source manager when building chart query and SQL data source options.

Update chart query field option generation to read V2 collections and fields through `getDataSources()`, `getCollection()`, `getFields()`, and field-level filterable metadata.

Support external database data sources whose `isDBInstance` flag is stored on V2 data source options.

Added focused tests for V2 flow data source manager behavior, including external database data sources and field option generation without relying on the legacy manager shape.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed empty field selectors in chart query configuration on flow pages |
| 🇨🇳 Chinese | 修复流程页面中图表查询配置字段下拉为空的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
