### PR TITLE
fix: preserve null data scope variables

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts
@@ -1,0 +1,158 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { dataScope } from '../dataScope';
+import { normalizeDataScopeFilter } from '../dataScopeFilter';
+import { setTargetDataScope } from '../setTargetDataScope';
+
+describe('normalizeDataScopeFilter', () => {
+  it('keeps null when a right-side variable resolves to empty', () => {
+    const rawFilter = {
+      logic: '$and',
+      items: [{ path: 'departmentId', operator: '$eq', value: '{{ ctx.formValues.department.id }}' }],
+    };
+    const resolvedFilter = {
+      logic: '$and',
+      items: [{ path: 'departmentId', operator: '$eq', value: undefined }],
+    };
+
+    expect(normalizeDataScopeFilter(rawFilter, resolvedFilter)).toEqual({
+      $and: [{ departmentId: { $eq: null } }],
+    });
+  });
+
+  it('keeps null when a right-side variable resolves to an empty string', () => {
+    const rawFilter = {
+      logic: '$and',
+      items: [{ path: 'departmentId', operator: '$eq', value: '{{ ctx.formValues.department.id }}' }],
+    };
+    const resolvedFilter = {
+      logic: '$and',
+      items: [{ path: 'departmentId', operator: '$eq', value: '' }],
+    };
+
+    expect(normalizeDataScopeFilter(rawFilter, resolvedFilter)).toEqual({
+      $and: [{ departmentId: { $eq: null } }],
+    });
+  });
+
+  it('still prunes empty constant values', () => {
+    const filter = {
+      logic: '$and',
+      items: [{ path: 'departmentId', operator: '$eq', value: undefined }],
+    };
+
+    expect(normalizeDataScopeFilter(filter, filter)).toBeUndefined();
+  });
+
+  it('handles nested groups and keeps non-empty values unchanged', () => {
+    const rawFilter = {
+      logic: '$and',
+      items: [
+        { path: 'status', operator: '$eq', value: 'active' },
+        {
+          logic: '$or',
+          items: [{ path: 'departmentId', operator: '$eq', value: '{{ ctx.formValues.department.id }}' }],
+        },
+      ],
+    };
+    const resolvedFilter = {
+      logic: '$and',
+      items: [
+        { path: 'status', operator: '$eq', value: 'active' },
+        {
+          logic: '$or',
+          items: [{ path: 'departmentId', operator: '$eq', value: null }],
+        },
+      ],
+    };
+
+    expect(normalizeDataScopeFilter(rawFilter, resolvedFilter)).toEqual({
+      $and: [{ status: { $eq: 'active' } }, { $or: [{ departmentId: { $eq: null } }] }],
+    });
+  });
+
+  it('does not preserve explicit null constants', () => {
+    const filter = {
+      logic: '$and',
+      items: [{ path: 'departmentId', operator: '$eq', value: null }],
+    };
+
+    expect(normalizeDataScopeFilter(filter, filter)).toBeUndefined();
+  });
+
+  it('dataScope handler sends null for empty variable dependencies', async () => {
+    const resource = {
+      addFilterGroup: vi.fn(),
+      removeFilterGroup: vi.fn(),
+    };
+    const ctx = {
+      model: {
+        uid: 'field-1',
+        resource,
+      },
+      resolveJsonTemplate: vi.fn(async (template) => ({
+        ...template,
+        items: [{ ...template.items[0], value: undefined }],
+      })),
+    };
+    const params = {
+      filter: {
+        logic: '$and',
+        items: [{ path: 'departmentId', operator: '$eq', value: '{{ ctx.formValues.department.id }}' }],
+      },
+    };
+
+    await (dataScope as any).handler(ctx, params);
+
+    expect(resource.addFilterGroup).toHaveBeenCalledWith('field-1', {
+      $and: [{ departmentId: { $eq: null } }],
+    });
+    expect(resource.removeFilterGroup).not.toHaveBeenCalled();
+  });
+
+  it('setTargetDataScope handler sends null for empty variable dependencies', async () => {
+    const resource = {
+      addFilterGroup: vi.fn(),
+      removeFilterGroup: vi.fn(),
+      hasData: vi.fn(() => false),
+      refresh: vi.fn(),
+    };
+    const targetModel = { resource };
+    const ctx = {
+      model: {
+        uid: 'action-1',
+        scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
+      },
+      resolveJsonTemplate: vi.fn(async (template) => ({
+        ...template,
+        filter: {
+          ...template.filter,
+          items: [{ ...template.filter.items[0], value: undefined }],
+        },
+      })),
+    };
+    const params = {
+      targetBlockUid: 'target-1',
+      filter: {
+        logic: '$and',
+        items: [{ path: 'departmentId', operator: '$eq', value: '{{ ctx.formValues.department.id }}' }],
+      },
+    };
+
+    await (setTargetDataScope as any).handler(ctx, params);
+
+    expect(ctx.model.scheduleModelOperation).toHaveBeenCalledWith('target-1', expect.any(Function));
+    expect(resource.addFilterGroup).toHaveBeenCalledWith('setTargetDataScope_action-1', {
+      $and: [{ departmentId: { $eq: null } }],
+    });
+    expect(resource.removeFilterGroup).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/client/src/flow/actions/dataScope.tsx
+++ b/packages/core/client/src/flow/actions/dataScope.tsx
@@ -7,12 +7,12 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { defineAction, MultiRecordResource, pruneFilter, tExpr, useFlowSettingsContext } from '@nocobase/flow-engine';
-import { isEmptyFilter, transformFilter } from '@nocobase/utils/client';
-import _ from 'lodash';
+import { defineAction, MultiRecordResource, tExpr, useFlowSettingsContext } from '@nocobase/flow-engine';
+import { isEmptyFilter } from '@nocobase/utils/client';
 import React from 'react';
 import { FilterGroup, VariableFilterItem } from '../components/filter';
 import { FieldModel } from '../models/base/FieldModel';
+import { normalizeDataScopeFilter } from './dataScopeFilter';
 
 export const dataScope = defineAction({
   name: 'dataScope',
@@ -43,6 +43,7 @@ export const dataScope = defineAction({
       filter: { logic: '$and', items: [] },
     };
   },
+  useRawParams: true,
   async handler(ctx, params) {
     // @ts-ignore
     const resource = ctx.model?.resource as MultiRecordResource;
@@ -50,7 +51,8 @@ export const dataScope = defineAction({
       return;
     }
 
-    const filter = pruneFilter(transformFilter(params.filter));
+    const resolvedFilter = await ctx.resolveJsonTemplate(params.filter);
+    const filter = normalizeDataScopeFilter(params.filter, resolvedFilter);
 
     if (isEmptyFilter(filter)) {
       resource.removeFilterGroup(ctx.model.uid);

--- a/packages/core/client/src/flow/actions/dataScopeFilter.ts
+++ b/packages/core/client/src/flow/actions/dataScopeFilter.ts
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { isVariableExpression, pruneFilter } from '@nocobase/flow-engine';
+import { transformFilter } from '@nocobase/utils/client';
+import _ from 'lodash';
+
+const PRESERVE_NULL = { __nocobaseDataScopeNull__: true };
+
+function isPreserveNull(value: any) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    value.__nocobaseDataScopeNull__ === true &&
+    Object.keys(value).length === 1
+  );
+}
+
+function restorePreservedNull(value: any): any {
+  if (isPreserveNull(value)) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => restorePreservedNull(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value).reduce<Record<string, any>>((result, key) => {
+      result[key] = restorePreservedNull(value[key]);
+      return result;
+    }, {});
+  }
+  return value;
+}
+
+function markEmptyVariableValues(rawNode: any, resolvedNode: any) {
+  if (!rawNode || !resolvedNode || typeof rawNode !== 'object' || typeof resolvedNode !== 'object') {
+    return;
+  }
+
+  if ('path' in rawNode && 'operator' in rawNode) {
+    if (
+      isVariableExpression(rawNode.value) &&
+      (resolvedNode.value === undefined || resolvedNode.value === null || resolvedNode.value === '')
+    ) {
+      resolvedNode.value = PRESERVE_NULL;
+    }
+    return;
+  }
+
+  if (Array.isArray(rawNode.items) && Array.isArray(resolvedNode.items)) {
+    rawNode.items.forEach((rawItem, index) => {
+      markEmptyVariableValues(rawItem, resolvedNode.items[index]);
+    });
+  }
+}
+
+export function normalizeDataScopeFilter(rawFilter: any, resolvedFilter: any) {
+  const filterForTransform = _.cloneDeep(resolvedFilter);
+  markEmptyVariableValues(rawFilter, filterForTransform);
+
+  const filter = pruneFilter(transformFilter(filterForTransform));
+  return restorePreservedNull(filter);
+}

--- a/packages/core/client/src/flow/actions/setTargetDataScope.tsx
+++ b/packages/core/client/src/flow/actions/setTargetDataScope.tsx
@@ -12,14 +12,13 @@ import {
   defineAction,
   FlowModel,
   MultiRecordResource,
-  pruneFilter,
   useFlowContext,
   tExpr,
 } from '@nocobase/flow-engine';
-import { isEmptyFilter, transformFilter } from '@nocobase/utils/client';
-import _ from 'lodash';
+import { isEmptyFilter } from '@nocobase/utils/client';
 import React from 'react';
 import { FilterGroup, VariableFilterItem } from '../components/filter';
+import { normalizeDataScopeFilter } from './dataScopeFilter';
 
 export const setTargetDataScope = defineAction({
   name: 'setTargetDataScope',
@@ -62,8 +61,10 @@ export const setTargetDataScope = defineAction({
       filter: { logic: '$and', items: [] },
     };
   },
+  useRawParams: true,
   async handler(ctx, params) {
-    const targetBlockUid = params.targetBlockUid;
+    const resolvedParams = await ctx.resolveJsonTemplate(params);
+    const targetBlockUid = resolvedParams.targetBlockUid;
     if (!targetBlockUid) {
       return;
     }
@@ -74,7 +75,7 @@ export const setTargetDataScope = defineAction({
         return;
       }
 
-      const filter = pruneFilter(transformFilter(params.filter));
+      const filter = normalizeDataScopeFilter(params.filter, resolvedParams.filter);
 
       if (isEmptyFilter(filter)) {
         resource.removeFilterGroup(`setTargetDataScope_${ctx.model.uid}`);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 form relationship field Data scope should match v1 behavior. When a dependent field has no value, v2 previously dropped the filter condition, while v1 sent `null`.

### Description
- Preserve raw Data scope params and resolve variables inside the action handlers.
- Normalize Data scope filters so empty right-side variable values are sent as `null`, while empty constant values are still pruned.
- Apply the same normalization to `setTargetDataScope`.
- Add tests for filter normalization and action handlers.

Tested with:
`yarn test:client packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts`

### Related issues
Task: 3685

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Preserve null values for empty Data scope variable dependencies in v2 forms. |
| 🇨🇳 Chinese | 修复 v2 表单 Data scope 变量依赖字段无值时未传递 null 的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary