### PR TITLE
fix(gantt): add drag reschedule setting

### DIFF
--- a/packages/plugins/@nocobase/plugin-gantt/src/client/Gantt.Settings.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/Gantt.Settings.tsx
@@ -13,6 +13,7 @@ import {
   SchemaSettingsBlockTitleItem,
   SchemaSettingsDataScope,
   SchemaSettingsSelectItem,
+  SchemaSettingsSwitchItem,
   SchemaSettingsTemplate,
   removeNullCondition,
   setDataLoadingModeSettingsItem,
@@ -28,6 +29,29 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useGanttBlockContext } from './GanttBlockProvider';
 import { useGanttTranslation, useOptions } from './utils';
+
+const useEnableDragToRescheduleProps = () => {
+  const { t } = useGanttTranslation();
+  const fieldSchema = useFieldSchema();
+  const field = useField();
+  const { dn } = useDesignable();
+
+  return {
+    title: t('Enable drag to reschedule'),
+    checked: field.decoratorProps?.enableDragToReschedule !== false,
+    onChange: (enableDragToReschedule) => {
+      field.decoratorProps.enableDragToReschedule = enableDragToReschedule;
+      fieldSchema['x-decorator-props']['enableDragToReschedule'] = enableDragToReschedule;
+      dn.emit('patch', {
+        schema: {
+          ['x-uid']: fieldSchema['x-uid'],
+          'x-decorator-props': field.decoratorProps,
+        },
+      });
+      dn.refresh();
+    },
+  };
+};
 
 /**
  * @deprecated
@@ -222,6 +246,11 @@ export const oldGanttSettings = new SchemaSettings({
           },
         };
       },
+    },
+    {
+      name: 'enableDragToReschedule',
+      Component: SchemaSettingsSwitchItem,
+      useComponentProps: useEnableDragToRescheduleProps,
     },
     {
       name: 'dataScope',
@@ -476,6 +505,11 @@ export const ganttSettings = new SchemaSettings({
           },
         };
       },
+    },
+    {
+      name: 'enableDragToReschedule',
+      Component: SchemaSettingsSwitchItem,
+      useComponentProps: useEnableDragToRescheduleProps,
     },
     {
       name: 'dataScope',

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/GanttBlockProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/GanttBlockProvider.tsx
@@ -78,7 +78,7 @@ const formatData = (
   return tasks;
 };
 const InternalGanttBlockProvider = (props) => {
-  const { fieldNames, timeRange, resource } = props;
+  const { fieldNames, timeRange, resource, enableDragToReschedule } = props;
   const field = useField();
   const { service } = useBlockRequestContext();
   // if (service.loading) {
@@ -92,6 +92,7 @@ const InternalGanttBlockProvider = (props) => {
         resource,
         fieldNames,
         timeRange,
+        enableDragToReschedule: enableDragToReschedule !== false,
       }}
     >
       {props.children}
@@ -180,6 +181,7 @@ export const useGanttBlockProps = () => {
   return {
     fieldNames: ctx.fieldNames,
     timeRange: ctx.timeRange,
+    enableDragToReschedule: ctx.enableDragToReschedule,
     onExpanderClick,
     expandAndCollapseAll,
     tasks,

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/__tests__/createGanttBlockSchema.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/__tests__/createGanttBlockSchema.test.ts
@@ -140,6 +140,7 @@ describe('createGanttBlockSchema', () => {
           "action": "list",
           "collection": "TestCollection",
           "dataSource": "TestDataSource",
+          "enableDragToReschedule": true,
           "fieldNames": {
             "label": "field1",
             "value": "field2",

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/components/gantt/gantt.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/components/gantt/gantt.tsx
@@ -112,6 +112,7 @@ export const Gantt: any = withDynamicSchemaProps((props: any) => {
     tasks,
     expandAndCollapseAll,
     fieldNames,
+    enableDragToReschedule = true,
     loading,
   } = useProps(props); // 新版 UISchema（1.0 之后）中已经废弃了 useProps，这里之所以继续保留是为了兼容旧版的 UISchema
   const { designable } = useDesignable();
@@ -499,6 +500,7 @@ export const Gantt: any = withDynamicSchemaProps((props: any) => {
     onDoubleClick,
     onClick: handleBarClick,
     onDelete,
+    enableDragToReschedule,
     loading,
   };
 

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/components/gantt/task-gantt-content.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/components/gantt/task-gantt-content.tsx
@@ -38,6 +38,7 @@ export type TaskGanttContentProps = {
   setFailedTask: (value: BarTask | null) => void;
   setSelectedTask: (taskId: string) => void;
   loading?: boolean;
+  enableDragToReschedule?: boolean;
 } & EventOption;
 
 export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
@@ -63,6 +64,7 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
   onDoubleClick,
   onClick,
   onDelete,
+  enableDragToReschedule = true,
 }) => {
   const point = svg?.current?.createSVGPoint();
   const [xStep, setXStep] = useState(0);
@@ -299,7 +301,7 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
               arrowIndent={arrowIndent}
               taskHeight={taskHeight}
               isProgressChangeable={!!onProgressChange && !task.isDisabled}
-              isDateChangeable={!!onDateChange && !task.isDisabled}
+              isDateChangeable={enableDragToReschedule && !!onDateChange && !task.isDisabled}
               isDelete={!task.isDisabled}
               onEventStart={handleBarEvent}
               key={task.id}

--- a/packages/plugins/@nocobase/plugin-gantt/src/client/createGanttBlockUISchema.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client/createGanttBlockUISchema.tsx
@@ -27,6 +27,7 @@ export const createGanttBlockUISchema = (options: {
       dataSource,
       action: 'list',
       fieldNames,
+      enableDragToReschedule: true,
       params: {
         paginate: false,
       },

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/de-DE.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/de-DE.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Enddatumsfeld",
   "Progress field": "Fortschrittsfeld",
   "Start date field": "Startdatumsfeld",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/en-US.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "End date field",
   "Progress field": "Progress field",
   "Start date field": "Start date field",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/es-ES.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/es-ES.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Campo de fecha de final",
   "Progress field": "Campo de progreso",
   "Start date field": "Campo de fecha de inicio",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/fr-FR.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/fr-FR.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "End date field",
   "Progress field": "Progress field",
   "Start date field": "Start date field",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/hu-HU.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/hu-HU.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Befejezés dátuma mező",
   "Progress field": "Előrehaladás mező",
   "Start date field": "Kezdés dátuma mező",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/id-ID.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/id-ID.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Bidang tanggal akhir",
   "Progress field": "Bidang kemajuan",
   "Start date field": "Bidang tanggal mulai",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/it-IT.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/it-IT.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Campo data di fine",
   "Progress field": "Campo progresso",
   "Start date field": "Campo data di inizio",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/ja-JP.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/ja-JP.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "終了日フィールド",
   "Progress field": "進行状況フィールド",
   "Start date field": "開始日フィールド",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/ko-KR.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/ko-KR.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "종료 날짜 필드",
   "Progress field": "진행률 필드",
   "Start date field": "시작 날짜 필드",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/nl-NL.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/nl-NL.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "End date field",
   "Progress field": "Voortgangsveld",
   "Start date field": "Begindatumveld",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/pt-BR.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/pt-BR.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Campo de data de término",
   "Progress field": "Progress field",
   "Start date field": "Campo de data de início",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/ru-RU.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/ru-RU.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Поле даты окончания",
   "Progress field": "Поле прогресса",
   "Start date field": "Поле даты начала",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/tr-TR.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/tr-TR.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "End date field",
   "Progress field": "Progress field",
   "Start date field": "Start date field",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/uk-UA.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/uk-UA.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "End date field",
   "Progress field": "Progress field",
   "Start date field": "Start date field",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/vi-VN.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/vi-VN.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "Enable drag to reschedule",
   "End date field": "Trường ngày kết thúc",
   "Progress field": "Progress field",
   "Start date field": "Start date field",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/zh-CN.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "启用拖动重新排期",
   "End date field": "结束日期字段",
   "Progress field": "进度字段",
   "Start date field": "开始日期字段",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/zh-TW.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/zh-TW.json
@@ -1,4 +1,5 @@
 {
+  "Enable drag to reschedule": "啟用拖動重新排程",
   "End date field": "End date field",
   "Progress field": "Progress field",
   "Start date field": "Start date field",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Add a v1 Gantt block setting to control whether tasks can be dragged to reschedule dates, while keeping old blocks enabled by default when the setting does not exist.

### Description
This PR adds an `Enable drag to reschedule` switch to the v1 Gantt block settings.

Key changes:
- Adds `enableDragToReschedule` to new Gantt block UI schema with default `true`.
- Treats missing `enableDragToReschedule` as enabled for old schema compatibility.
- Disables task bar date dragging and start/end date handle dragging when the setting is off.
- Keeps progress dragging and record click behavior unchanged.
- Adds locale entries for the new setting label.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add a Gantt block setting to enable drag to reschedule. |
| 🇨🇳 Chinese | 新增甘特图区块“启用拖动重新排期”配置。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
