### PR TITLE
fix(kanban): reduce default column width

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/utils.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/utils.ts
@@ -9,7 +9,7 @@
 
 export const KANBAN_UNKNOWN_COLUMN_KEY = '__unknown__';
 export const DEFAULT_KANBAN_PAGE_SIZE = 10;
-export const DEFAULT_KANBAN_COLUMN_WIDTH = 300;
+export const DEFAULT_KANBAN_COLUMN_WIDTH = 250;
 
 export const KANBAN_COLOR_OPTIONS = [
   'default',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Adjust the default kanban column width to make kanban columns more compact.

### Description
Reduced the default kanban column width from 300 to 250.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reduced the default kanban column width. |
| 🇨🇳 Chinese | 调整看板默认列宽。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
