### PR TITLE
chore(docs): add multi-language alignment and bloat detection scripts

### DIFF
--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,0 +1,67 @@
+# 文档校对脚本
+
+NocoBase 文档站维护 `cn / en / ja / es / pt / de / fr / ru / id / vi` 共 10 个语言版本，路径都在 `docs/docs/<lang>/`，文件树和侧边栏结构必须保持一致。这套脚本以 cn 作为基准，校对其他语言是否对齐，并兼带翻译膨胀检测。
+
+## 脚本一览
+
+| 脚本 | 检查内容 | 退出码 |
+|---|---|---|
+| `check-tree-alignment.mjs` | 各语言文件树是否对齐 cn | 不齐 = 1 |
+| `check-meta-alignment.mjs` | 各语言 `_meta.json` 侧边栏的 link/name 集合是否对齐 cn | 不齐 = 1 |
+| `check-nav-alignment.mjs` | 各语言 `_nav.json` 顶部导航条目数和 link 是否对齐 cn | 不齐 = 1 |
+| `check-home-alignment.mjs` | 各语言首页 `index.md` frontmatter 的 hero.actions / features / items 结构和 link 是否对齐 cn | 不齐 = 1 |
+| `check-bloated-files.mjs` | 翻译膨胀（巨型单行 / 超大文件，会让 rspress 编译卡死） | 有膨胀 = 1 |
+
+五个脚本都用 cn 作基准，只读不写，不会改任何文件。
+
+## 用法
+
+从仓库根目录运行：
+
+```bash
+# 默认扫 docs/docs 下所有非 cn 语言（ar 除外，见下文）
+node docs/scripts/check-tree-alignment.mjs
+node docs/scripts/check-meta-alignment.mjs
+node docs/scripts/check-nav-alignment.mjs
+node docs/scripts/check-home-alignment.mjs
+node docs/scripts/check-bloated-files.mjs
+
+# 只查特定语言
+node docs/scripts/check-bloated-files.mjs --lang=es
+
+# 指定不同的 docs 根目录
+node docs/scripts/check-tree-alignment.mjs path/to/docs/docs
+```
+
+## 典型输出
+
+```
+[es] OK (985 files)
+[pt] OK (985 files)
+[de] DIFF: 2 missing, 0 extra
+  - missing: workflow/nodes/javascript.md
+  - missing: workflow/nodes/parallel.md
+```
+
+```
+[ja] DIFF:
+  - hero.actions[0].link: cn=/get-started/how-nocobase-works lang=/quickstart
+  - features[2].items 数量不一致 (cn=3, lang=2)
+```
+
+```
+[BLOATED+OVERSIZED] es/plugin-development/client/index.md (size 1292019 vs cn 4322, max line 1220031 vs cn 345)
+```
+
+## 依赖
+
+- `check-home-alignment.mjs` 用 `js-yaml` 解析 frontmatter，从当前工作目录的 `node_modules` 解析。仓库执行过 `yarn install` 后默认包含，无需额外安装。
+- 其他四个脚本仅用 Node 内置模块（`fs` / `path`），零依赖。
+
+## 平台兼容
+
+五个脚本路径处理统一用 `path.posix.join` 拼相对路径，CRLF / LF 都能解析。Windows、macOS、Linux 都能跑，输出里的相对路径统一是正斜杠。
+
+## 暂不维护的语言
+
+`ar`（阿拉伯语）目前不在对齐范围内，所有脚本默认都会跳过它。如果以后要把 ar 重新纳入维护，从各脚本顶部的 `SKIP_LANGS` 集合里移除即可，或在调用时显式传 `--lang=ar` 强制检查（用于查现状）。

--- a/docs/scripts/check-bloated-files.mjs
+++ b/docs/scripts/check-bloated-files.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * 检测：翻译膨胀文件
+ *
+ * 某些 AI 翻译工具会给 markdown 表格塞几十万空格做"视觉对齐"，把单行炸到 100KB-1MB，
+ * rspress 编译会卡死。这个脚本用双信号识别这种文件：
+ *
+ *   1. 单行长度 > MAX_LINE_LEN 且比 CN 同名文件多 LINE_SLACK 字符 → BLOATED
+ *   2. 文件大小 > CN 同名文件 SIZE_FACTOR 倍                       → OVERSIZED
+ *
+ * Usage:
+ *   node check-bloated-files.mjs [docs-root] [--lang=<code>]
+ *
+ * 输出：每个有问题的文件一行。
+ * 退出码：发现任何膨胀 = 1；干净 = 0。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MAX_LINE_LEN = 1500;
+const LINE_SLACK = 500;
+const SIZE_FACTOR = 5;
+const MIN_SIZE_TO_CHECK = 8000;
+const MIN_CN_SIZE = 500;
+// 暂不参与膨胀检测的语言；显式 --lang=<code> 仍可强制检查。
+const SKIP_LANGS = new Set(['ar']);
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) args[m[1]] = m[2];
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+function listMdFiles(root) {
+  const out = [];
+  function walk(dir, rel) {
+    if (!fs.existsSync(dir)) return;
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, ent.name);
+      const r = path.posix.join(rel, ent.name);
+      if (ent.isDirectory()) walk(full, r);
+      else if (ent.name.endsWith('.md') || ent.name.endsWith('.mdx')) out.push(r);
+    }
+  }
+  walk(root, '');
+  return out;
+}
+
+function maxLineLength(file) {
+  // 读字节数较小的文件用同步读全文；大文件可能本身就是膨胀的，整读也无所谓。
+  const content = fs.readFileSync(file, 'utf-8');
+  let max = 0;
+  let cur = 0;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10 /* \n */) {
+      if (cur > max) max = cur;
+      cur = 0;
+    } else cur++;
+  }
+  if (cur > max) max = cur;
+  return max;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const docsRoot = args.positional[0] || 'docs/docs';
+  const cnRoot = path.join(docsRoot, 'cn');
+
+  const langs = args.lang
+    ? [args.lang]
+    : fs
+        .readdirSync(docsRoot, { withFileTypes: true })
+        .filter(
+          (e) =>
+            e.isDirectory() &&
+            e.name !== 'cn' &&
+            !SKIP_LANGS.has(e.name) &&
+            !e.name.startsWith('.'),
+        )
+        .map((e) => e.name);
+
+  let bad = 0;
+  for (const lang of langs) {
+    const langRoot = path.join(docsRoot, lang);
+    if (!fs.existsSync(langRoot)) continue;
+    const files = listMdFiles(langRoot);
+    for (const rel of files) {
+      const langFile = path.join(langRoot, rel);
+      const cnFile = path.join(cnRoot, rel);
+      if (!fs.existsSync(cnFile)) continue;
+
+      const size = fs.statSync(langFile).size;
+      const cnSize = fs.statSync(cnFile).size;
+      const maxLen = maxLineLength(langFile);
+      const cnMaxLen = maxLineLength(cnFile);
+
+      const bloated =
+        maxLen > MAX_LINE_LEN && maxLen > cnMaxLen + LINE_SLACK;
+      const oversized =
+        size > MIN_SIZE_TO_CHECK &&
+        cnSize > MIN_CN_SIZE &&
+        size > cnSize * SIZE_FACTOR;
+
+      if (bloated || oversized) {
+        bad++;
+        const tags = [];
+        if (bloated) tags.push('BLOATED');
+        if (oversized) tags.push('OVERSIZED');
+        console.log(
+          `[${tags.join('+')}] ${lang}/${rel} (size ${size} vs cn ${cnSize}, max line ${maxLen} vs cn ${cnMaxLen})`,
+        );
+      }
+    }
+  }
+  if (bad === 0) console.log('clean');
+  process.exit(bad ? 1 : 0);
+}
+
+main();

--- a/docs/scripts/check-home-alignment.mjs
+++ b/docs/scripts/check-home-alignment.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * 校对：首页 index.md 区块结构对齐检查
+ *
+ * 比较 cn 和指定语言（或全部其他语言）的 docs/<lang>/index.md frontmatter：
+ * - hero.actions 数组长度必须一致
+ * - features 数组长度必须一致
+ * - 每个 feature.items 数组长度必须一致（按位置匹配）
+ * - 所有 link 值必须一致（按位置匹配）
+ * - 不比较 title / details / name / tagline / text 等翻译文案
+ * - 外链 http(s):// 整体忽略具体地址（locale-specific 营销站跨语言天然不同），
+ *   只比较"有没有外链"
+ * - 末尾斜杠、/index 后缀、锚点统一归一化
+ *
+ * 依赖：使用当前工作目录下 node_modules 里的 js-yaml。NocoBase 主仓库执行过
+ * `yarn install` 后默认已包含，无需额外安装。
+ *
+ * Usage:
+ *   node check-home-alignment.mjs [docs-root] [--lang=<code>]
+ *
+ *   docs-root  默认 docs/docs（相对当前工作目录）
+ *   --lang     可选；不传则检查所有非 cn / 非 ar 语言
+ *
+ * 退出码：全部对齐 = 0；任一不齐 = 1。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const SKIP_LANGS = new Set(['ar']);
+
+// js-yaml 从当前 cwd 的 node_modules 解析（脚本随 skill 分发，不带 deps）
+const cwdRequire = createRequire(path.join(process.cwd(), '__pkg__'));
+let yaml;
+try {
+  yaml = cwdRequire('js-yaml');
+} catch (err) {
+  console.error('找不到 js-yaml。请在 NocoBase 主仓库根目录下运行（确保已执行 yarn install）。');
+  console.error(`原始错误：${err.message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) args[m[1]] = m[2];
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+function isExternalLink(link) {
+  return /^https?:\/\//i.test(link);
+}
+
+function normalizeLink(link) {
+  if (typeof link !== 'string') return link;
+  if (isExternalLink(link)) return '__EXTERNAL__';
+  const hashIdx = link.indexOf('#');
+  let s = hashIdx === -1 ? link : link.slice(0, hashIdx);
+  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
+  if (s.endsWith('/index')) s = s.slice(0, -'/index'.length);
+  return s;
+}
+
+// 提取 frontmatter 并解析。失败返回 null。
+function readFrontmatter(file) {
+  const content = fs.readFileSync(file, 'utf-8');
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  return yaml.load(m[1]);
+}
+
+// 提炼可比较结构
+function summarize(fm) {
+  const out = { heroActions: [], features: [] };
+  if (fm && fm.hero && Array.isArray(fm.hero.actions)) {
+    out.heroActions = fm.hero.actions.map((a) => normalizeLink(a?.link));
+  }
+  if (fm && Array.isArray(fm.features)) {
+    out.features = fm.features.map((f) => ({
+      items: Array.isArray(f?.items) ? f.items.map((it) => normalizeLink(it?.link)) : [],
+    }));
+  }
+  return out;
+}
+
+function diff(cn, lang) {
+  const issues = [];
+
+  if (cn.heroActions.length !== lang.heroActions.length) {
+    issues.push(`hero.actions 数量不一致 (cn=${cn.heroActions.length}, lang=${lang.heroActions.length})`);
+  } else {
+    for (let i = 0; i < cn.heroActions.length; i++) {
+      if (cn.heroActions[i] !== lang.heroActions[i]) {
+        issues.push(`hero.actions[${i}].link: cn=${cn.heroActions[i] ?? '∅'} lang=${lang.heroActions[i] ?? '∅'}`);
+      }
+    }
+  }
+
+  if (cn.features.length !== lang.features.length) {
+    issues.push(`features 数量不一致 (cn=${cn.features.length}, lang=${lang.features.length})`);
+    return issues;
+  }
+
+  for (let i = 0; i < cn.features.length; i++) {
+    const cnItems = cn.features[i].items;
+    const langItems = lang.features[i].items;
+    if (cnItems.length !== langItems.length) {
+      issues.push(`features[${i}].items 数量不一致 (cn=${cnItems.length}, lang=${langItems.length})`);
+      continue;
+    }
+    for (let j = 0; j < cnItems.length; j++) {
+      if (cnItems[j] !== langItems[j]) {
+        issues.push(`features[${i}].items[${j}].link: cn=${cnItems[j] ?? '∅'} lang=${langItems[j] ?? '∅'}`);
+      }
+    }
+  }
+  return issues;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const docsRoot = args.positional[0] || 'docs/docs';
+  const cnFile = path.join(docsRoot, 'cn', 'index.md');
+  if (!fs.existsSync(cnFile)) {
+    console.error(`找不到 ${cnFile}（请在 NocoBase 主仓库根目录运行，或传入 docs 根的绝对路径）`);
+    process.exit(1);
+  }
+
+  const langs = args.lang
+    ? [args.lang]
+    : fs
+        .readdirSync(docsRoot, { withFileTypes: true })
+        .filter(
+          (e) =>
+            e.isDirectory() &&
+            e.name !== 'cn' &&
+            !SKIP_LANGS.has(e.name) &&
+            !e.name.startsWith('.'),
+        )
+        .map((e) => e.name);
+
+  let cnFm;
+  try {
+    cnFm = readFrontmatter(cnFile);
+    if (!cnFm) throw new Error('未发现 frontmatter');
+  } catch (err) {
+    console.error(`解析 ${cnFile} 失败：${err.message}`);
+    process.exit(1);
+  }
+  const cnSummary = summarize(cnFm);
+
+  let bad = 0;
+  for (const lang of langs) {
+    const langFile = path.join(docsRoot, lang, 'index.md');
+    if (!fs.existsSync(langFile)) {
+      console.log(`[${lang}] MISSING: ${langFile}`);
+      bad++;
+      continue;
+    }
+    try {
+      const langFm = readFrontmatter(langFile);
+      if (!langFm) {
+        console.log(`[${lang}] PARSE ERROR: 未发现 frontmatter`);
+        bad++;
+        continue;
+      }
+      const langSummary = summarize(langFm);
+      const issues = diff(cnSummary, langSummary);
+      if (issues.length === 0) {
+        console.log(`[${lang}] OK (${cnSummary.features.length} features, ${cnSummary.heroActions.length} hero actions)`);
+        continue;
+      }
+      bad++;
+      console.log(`[${lang}] DIFF:`);
+      for (const issue of issues) console.log(`  - ${issue}`);
+    } catch (err) {
+      console.log(`[${lang}] PARSE ERROR: ${err.message}`);
+      bad++;
+    }
+  }
+  process.exit(bad ? 1 : 0);
+}
+
+main();

--- a/docs/scripts/check-meta-alignment.mjs
+++ b/docs/scripts/check-meta-alignment.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * 校对：_meta.json 结构对齐检查
+ *
+ * 比较 cn 和指定语言（或全部其他语言）的 _meta.json：所有 link / name 集合是否一致。
+ * 不比较 label 文本（label 翻译本来就不一样）。
+ * 不比较 link 的锚点 `#xxx` 部分——锚点跟着翻译后的标题走，跨语言天然不同。
+ * 末尾斜杠归一化：`/foo/` 与 `/foo` 视为同一个 link。
+ * `/foo/index` 等价于 `/foo`（rspress 目录视为 index 页）。
+ * 外链 `http(s)://...` 直接忽略——跨语言常常是 locale-specific（营销站、外部教程等）。
+ *
+ * Usage:
+ *   node check-meta-alignment.mjs [docs-root] [--lang=<code>]
+ *
+ * 退出码：全部对齐 = 0；任一不齐 = 1。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+// 暂不参与对齐校对的语言；显式 --lang=<code> 仍可强制检查。
+const SKIP_LANGS = new Set(['ar']);
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) args[m[1]] = m[2];
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+function isExternalLink(link) {
+  return /^https?:\/\//i.test(link);
+}
+
+function normalizeLink(link) {
+  // 去掉锚点（锚点跟翻译后的标题走，跨语言天然不同）
+  const hashIdx = link.indexOf('#');
+  let s = hashIdx === -1 ? link : link.slice(0, hashIdx);
+  // 统一去掉末尾斜杠：/foo 和 /foo/ 在 rspress 里等价
+  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
+  // /foo/index 与 /foo 也等价（rspress 把目录视为 index）
+  if (s.endsWith('/index')) s = s.slice(0, -'/index'.length);
+  return s;
+}
+
+function collectKeys(node, out) {
+  if (Array.isArray(node)) {
+    for (const item of node) collectKeys(item, out);
+    return;
+  }
+  if (node && typeof node === 'object') {
+    if (typeof node.link === 'string') {
+      // 外链跨语言天然不同（locale-specific 的营销站、社交媒体、外部教程等），直接忽略
+      if (!isExternalLink(node.link)) out.add(normalizeLink(node.link));
+    } else if (typeof node.name === 'string') {
+      out.add(node.name);
+    }
+    if (Array.isArray(node.items)) collectKeys(node.items, out);
+  }
+}
+
+function readMetaKeys(file) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  const keys = new Set();
+  collectKeys(data, keys);
+  return keys;
+}
+
+function listMetaFiles(root) {
+  // 用 path.posix.join 拼相对路径，确保 Windows 上输出和 Set key 都是正斜杠，
+  // 跟 cn/lang 拼回绝对路径用 path.join 时也不会出问题。
+  const out = [];
+  function walk(dir, rel) {
+    if (!fs.existsSync(dir)) return;
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, ent.name);
+      const r = path.posix.join(rel, ent.name);
+      if (ent.isDirectory()) {
+        if (ent.name === 'node_modules' || ent.name.startsWith('.')) continue;
+        walk(full, r);
+      } else if (ent.name === '_meta.json') out.push(r);
+    }
+  }
+  walk(root, '');
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const docsRoot = args.positional[0] || 'docs/docs';
+  const cnRoot = path.join(docsRoot, 'cn');
+  const cnMetas = listMetaFiles(cnRoot);
+
+  const langs = args.lang
+    ? [args.lang]
+    : fs
+        .readdirSync(docsRoot, { withFileTypes: true })
+        .filter(
+          (e) =>
+            e.isDirectory() &&
+            e.name !== 'cn' &&
+            !SKIP_LANGS.has(e.name) &&
+            !e.name.startsWith('.'),
+        )
+        .map((e) => e.name);
+
+  let bad = 0;
+  for (const lang of langs) {
+    const langRoot = path.join(docsRoot, lang);
+    if (!fs.existsSync(langRoot)) continue;
+
+    let langBad = 0;
+    for (const meta of cnMetas) {
+      const cnFile = path.join(cnRoot, meta);
+      const langFile = path.join(langRoot, meta);
+      if (!fs.existsSync(langFile)) {
+        console.log(`[${lang}] MISSING: ${meta}`);
+        langBad++;
+        continue;
+      }
+      try {
+        const cnKeys = readMetaKeys(cnFile);
+        const langKeys = readMetaKeys(langFile);
+        const onlyCn = [...cnKeys].filter((k) => !langKeys.has(k));
+        const onlyLang = [...langKeys].filter((k) => !cnKeys.has(k));
+        if (onlyCn.length === 0 && onlyLang.length === 0) continue;
+        langBad++;
+        console.log(`[${lang}] DIFF: ${meta}`);
+        for (const k of onlyCn) console.log(`  - cn-only:   ${k}`);
+        for (const k of onlyLang) console.log(`  + lang-only: ${k}`);
+      } catch (err) {
+        console.log(`[${lang}] PARSE ERROR: ${meta} — ${err.message}`);
+        langBad++;
+      }
+    }
+    if (langBad === 0) console.log(`[${lang}] OK (${cnMetas.length} _meta.json files)`);
+    else bad++;
+  }
+  process.exit(bad ? 1 : 0);
+}
+
+main();

--- a/docs/scripts/check-nav-alignment.mjs
+++ b/docs/scripts/check-nav-alignment.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * 校对：_nav.json 顶部导航对齐检查
+ *
+ * 比较 cn 和指定语言（或全部其他语言）的 docs/<lang>/_nav.json：
+ * - 顶层条目数必须一致
+ * - 每个条目（按位置匹配）的 link 必须一致
+ * - 嵌套 items（如有）按相同规则递归比较
+ * - text 不比较（翻译差异天然存在）
+ * - 外链 http(s):// 整体忽略具体地址，只比较"有没有外链"——locale-specific 营销站
+ *   （比如 nocobase.com/cn/ vs nocobase.com/）跨语言天然不同
+ * - 末尾斜杠、/index 后缀、锚点统一归一化（同 check-meta-alignment）
+ *
+ * Usage:
+ *   node check-nav-alignment.mjs [docs-root] [--lang=<code>]
+ *
+ *   docs-root  默认 docs/docs（相对当前工作目录）
+ *   --lang     可选；不传则检查所有非 cn / 非 ar 语言
+ *
+ * 退出码：全部对齐 = 0；任一不齐 = 1。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+// 暂不参与对齐校对的语言；显式 --lang=<code> 仍可强制检查。
+const SKIP_LANGS = new Set(['ar']);
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) args[m[1]] = m[2];
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+function isExternalLink(link) {
+  return /^https?:\/\//i.test(link);
+}
+
+function normalizeLink(link) {
+  const hashIdx = link.indexOf('#');
+  let s = hashIdx === -1 ? link : link.slice(0, hashIdx);
+  if (s.length > 1 && s.endsWith('/')) s = s.slice(0, -1);
+  if (s.endsWith('/index')) s = s.slice(0, -'/index'.length);
+  return s;
+}
+
+// 把 nav 节点规约成可比较结构：{link?, items?[]}
+// 外链统一标记为 __EXTERNAL__（要求两边都得是外链，但具体 URL 可不同）
+function summarize(nav) {
+  if (!Array.isArray(nav)) return [];
+  return nav.map((entry) => {
+    const out = {};
+    if (typeof entry.link === 'string') {
+      out.link = isExternalLink(entry.link) ? '__EXTERNAL__' : normalizeLink(entry.link);
+    }
+    if (Array.isArray(entry.items)) {
+      out.items = summarize(entry.items);
+    }
+    return out;
+  });
+}
+
+function diff(a, b, pathLabel = '') {
+  const issues = [];
+  if (a.length !== b.length) {
+    issues.push(`${pathLabel || '<root>'}: 条目数不一致 (cn=${a.length}, lang=${b.length})`);
+    return issues;
+  }
+  for (let i = 0; i < a.length; i++) {
+    const itemPath = `${pathLabel}[${i}]`;
+    const ai = a[i];
+    const bi = b[i];
+    if (ai.link !== bi.link) {
+      issues.push(`${itemPath}.link: cn=${ai.link ?? '∅'} lang=${bi.link ?? '∅'}`);
+    }
+    const aHas = Array.isArray(ai.items);
+    const bHas = Array.isArray(bi.items);
+    if (aHas !== bHas) {
+      issues.push(`${itemPath}.items: cn=${aHas ? `array(${ai.items.length})` : '∅'} lang=${bHas ? `array(${bi.items.length})` : '∅'}`);
+    } else if (aHas && bHas) {
+      issues.push(...diff(ai.items, bi.items, `${itemPath}.items`));
+    }
+  }
+  return issues;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const docsRoot = args.positional[0] || 'docs/docs';
+  const cnFile = path.join(docsRoot, 'cn', '_nav.json');
+  if (!fs.existsSync(cnFile)) {
+    console.error(`找不到 ${cnFile}（请在 NocoBase 主仓库根目录运行，或传入 docs 根的绝对路径）`);
+    process.exit(1);
+  }
+
+  const langs = args.lang
+    ? [args.lang]
+    : fs
+        .readdirSync(docsRoot, { withFileTypes: true })
+        .filter(
+          (e) =>
+            e.isDirectory() &&
+            e.name !== 'cn' &&
+            !SKIP_LANGS.has(e.name) &&
+            !e.name.startsWith('.'),
+        )
+        .map((e) => e.name);
+
+  let cnNav;
+  try {
+    cnNav = JSON.parse(fs.readFileSync(cnFile, 'utf-8'));
+  } catch (err) {
+    console.error(`解析 ${cnFile} 失败：${err.message}`);
+    process.exit(1);
+  }
+  const cnSummary = summarize(cnNav);
+
+  let bad = 0;
+  for (const lang of langs) {
+    const langFile = path.join(docsRoot, lang, '_nav.json');
+    if (!fs.existsSync(langFile)) {
+      console.log(`[${lang}] MISSING: ${langFile}`);
+      bad++;
+      continue;
+    }
+    try {
+      const langNav = JSON.parse(fs.readFileSync(langFile, 'utf-8'));
+      const langSummary = summarize(langNav);
+      const issues = diff(cnSummary, langSummary);
+      if (issues.length === 0) {
+        console.log(`[${lang}] OK (${cnNav.length} top-level entries)`);
+        continue;
+      }
+      bad++;
+      console.log(`[${lang}] DIFF:`);
+      for (const issue of issues) console.log(`  - ${issue}`);
+    } catch (err) {
+      console.log(`[${lang}] PARSE ERROR: ${err.message}`);
+      bad++;
+    }
+  }
+  process.exit(bad ? 1 : 0);
+}
+
+main();

--- a/docs/scripts/check-tree-alignment.mjs
+++ b/docs/scripts/check-tree-alignment.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * 校对：文件树对齐检查
+ *
+ * 用 cn 作为基准，检查指定语言（或全部其他语言）是否有相同的文件集。
+ *
+ * Usage:
+ *   node check-tree-alignment.mjs [docs-root] [--lang=<code>]
+ *
+ *   docs-root  默认 docs/docs（相对当前工作目录）
+ *   --lang     可选；不传则检查所有非 cn 语言
+ *
+ * 输出：每个不一致语言列出 missing / extra 文件。
+ * 退出码：所有语言对齐 = 0；任一语言不对齐 = 1。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOC_EXTS = new Set(['.md', '.mdx', '.json', '.tsx']);
+// 暂不参与对齐校对的语言；显式 --lang=<code> 仍可强制检查。
+const SKIP_LANGS = new Set(['ar']);
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) args[m[1]] = m[2];
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+function listDocFiles(root) {
+  const out = new Set();
+  function walk(dir, rel) {
+    if (!fs.existsSync(dir)) return;
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, ent.name);
+      const r = path.posix.join(rel, ent.name);
+      if (ent.isDirectory()) {
+        // 跳过构建中间产物和隐藏目录
+        if (ent.name === 'node_modules' || ent.name.startsWith('.')) continue;
+        walk(full, r);
+      } else if (DOC_EXTS.has(path.extname(ent.name))) out.add(r);
+    }
+  }
+  walk(root, '');
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const docsRoot = args.positional[0] || 'docs/docs';
+  const cnRoot = path.join(docsRoot, 'cn');
+  if (!fs.existsSync(cnRoot)) {
+    console.error(`找不到 ${cnRoot}`);
+    process.exit(1);
+  }
+
+  const cnFiles = listDocFiles(cnRoot);
+  const langs = args.lang
+    ? [args.lang]
+    : fs
+        .readdirSync(docsRoot, { withFileTypes: true })
+        .filter(
+          (e) =>
+            e.isDirectory() &&
+            e.name !== 'cn' &&
+            !SKIP_LANGS.has(e.name) &&
+            !e.name.startsWith('.'),
+        )
+        .map((e) => e.name);
+
+  let bad = 0;
+  for (const lang of langs) {
+    const langRoot = path.join(docsRoot, lang);
+    if (!fs.existsSync(langRoot)) {
+      console.log(`[${lang}] 目录不存在，跳过`);
+      continue;
+    }
+    const langFiles = listDocFiles(langRoot);
+    const missing = [...cnFiles].filter((f) => !langFiles.has(f)).sort();
+    const extra = [...langFiles].filter((f) => !cnFiles.has(f)).sort();
+    if (missing.length === 0 && extra.length === 0) {
+      console.log(`[${lang}] OK (${langFiles.size} files)`);
+      continue;
+    }
+    bad++;
+    console.log(`[${lang}] DIFF: ${missing.length} missing, ${extra.length} extra`);
+    for (const f of missing) console.log(`  - missing: ${f}`);
+    for (const f of extra) console.log(`  + extra:   ${f}`);
+  }
+  process.exit(bad ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
### This is a ...
- [x] Others

### Motivation

NocoBase 文档站维护 10 个语言版本（`cn / en / ja / es / pt / de / fr / ru / id / vi`），文件树和侧边栏结构需要保持一致。但实际工作中常出现：

- 改了 cn 但忘了同步其他语言的 `_meta.json`，导致侧边栏跨语言不一致
- 翻译时新增/移动文件，其他语言没跟上
- 某些 AI 翻译工具会给 markdown 表格塞几十万空格做"视觉对齐"，把单行炸到 100KB-1MB，rspress 编译会卡死、`yarn dev` 启动不了

这次新增一组 Node 脚本作为基础设施，支撑后续 CI 接入，让多语言对齐和翻译膨胀变得可见、可拦截。

### Description

`docs/scripts/` 下新增五个脚本，全部以 cn 作基准，只读不写，exit 1 表示有问题：

- `check-tree-alignment.mjs` — 各语言 md/mdx/json/tsx 文件树是否对齐 cn
- `check-meta-alignment.mjs` — 各语言 `_meta.json` 侧边栏的 link/name 集合
- `check-nav-alignment.mjs` — 各语言 `_nav.json` 顶部导航条目数和 link
- `check-home-alignment.mjs` — 各语言首页 `index.md` frontmatter 的 hero.actions / features / items 结构和 link
- `check-bloated-files.mjs` — 翻译膨胀（单行 > 1500 字符且比 cn 多 500+ 字符 → BLOATED；文件大小 > cn 5 倍 → OVERSIZED）

链接归一化：忽略锚点 `#xxx`、末尾斜杠、`/index` 后缀；外链 `http(s)://` 整体忽略具体地址（locale-specific 营销站跨语言天然不同）。`ar`（阿拉伯语）目前不在维护范围内，所有脚本默认跳过，显式传 `--lang=ar` 可强制检查。

路径处理统一用 `path.posix.join`，跨平台一致；`check-home-alignment.mjs` 用 `js-yaml`（仓库执行过 `yarn install` 后已包含），其他四个脚本零依赖。

`docs/scripts/README.md` 文档化用法、依赖、典型输出、平台兼容、暂不维护的语言。

后续 nocobase-ci 仓会基于这套脚本接一个并行的 `check-docs` job，跟 `build-docs` 并行跑、不阻塞 `assemble-image`，但会进入 `update-status` 的最终 conclusion——CI 改动单独提 PR。

### Related issues

### Showcase

```
$ node docs/scripts/check-meta-alignment.mjs
[de] OK (43 _meta.json files)
[en] OK (43 _meta.json files)
...

$ node docs/scripts/check-bloated-files.mjs --lang=es
[BLOATED+OVERSIZED] es/plugin-development/client/index.md (size 1292019 vs cn 4322, max line 1220031 vs cn 345)
```

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add five docs alignment and bloat detection scripts under `docs/scripts/`. |
| 🇨🇳 Chinese | 在 `docs/scripts/` 下新增 5 个文档对齐和翻译膨胀检测脚本。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |     |
| 🇨🇳 Chinese |   |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
