### PR TITLE
chore(docs): add i18n coverage check for cn → other-language sync

### DIFF
--- a/docs/plugins/pluginCrossRef.ts
+++ b/docs/plugins/pluginCrossRef.ts
@@ -239,7 +239,11 @@ export function pluginCrossRefSidebar(): RspressPlugin {
       // 1. 扫描所有 _meta.json 检测跨模块引用（以顶层目录为单位判断）
       for (const metaFile of findAllMetaJson(root)) {
         const dir = path.dirname(metaFile);
-        const relDir = '/' + path.relative(root, dir);
+        // path.relative 在 Windows 上返回反斜杠分隔的路径，必须规范化成 POSIX
+        // 风格的 URL 路径，否则下游 getTopLevelDir 按 '/' split 拿到的 topDir
+        // 会被污染（如 '/api\cli'），最终生成 '/api\cli/start' 这种带反斜杠
+        // 的虚拟路由跟正常路由冲突，rspress 报 routePath ... has already been added。
+        const relDir = '/' + path.relative(root, dir).split(path.sep).join('/');
         const topDir = getTopLevelDir(relDir);
 
         const meta: unknown = JSON.parse(fs.readFileSync(metaFile, 'utf-8'));

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -17,23 +17,29 @@ NocoBase 文档站维护 `cn / en / ja / es / pt / de / fr / ru / id / vi` 共 1
 
 ## 用法
 
-从仓库根目录运行：
+脚本会自己探测 docsRoot——支持两种 cwd：仓库根目录或 `docs/` 目录。从哪儿跑都行：
 
 ```bash
-# 默认扫 docs/docs 下所有非 cn 语言（ar 除外，见下文）
+# 从仓库根目录跑
 node docs/scripts/check-tree-alignment.mjs
 node docs/scripts/check-meta-alignment.mjs
 node docs/scripts/check-nav-alignment.mjs
 node docs/scripts/check-home-alignment.mjs
 node docs/scripts/check-bloated-files.mjs
 
+# 或从 docs/ 目录跑（CI 一般在这里跑）
+cd docs
+node scripts/check-tree-alignment.mjs
+node scripts/check-meta-alignment.mjs
+# ...
+
 # 只查特定语言
 node docs/scripts/check-bloated-files.mjs --lang=es
 
-# 指定不同的 docs 根目录
-node docs/scripts/check-tree-alignment.mjs path/to/docs/docs
+# 显式传 docs 根目录（cwd 不在仓库内时）
+node docs/scripts/check-tree-alignment.mjs /abs/path/to/docs/docs
 
-# i18n coverage：跟前五个不一样，输入是 PR 改动的文件列表（不扫文件树）
+# i18n coverage：输入是 PR 改动的文件列表（不扫文件树，cwd 无所谓）
 gh pr view <pr-number> --json files --jq '.files[].path' | node docs/scripts/check-i18n-coverage.mjs
 node docs/scripts/check-i18n-coverage.mjs --files=changed-files.txt
 ```
@@ -82,12 +88,12 @@ gh pr edit <pr-number> --add-label skip-i18n-check
 
 ## 依赖
 
-- `check-home-alignment.mjs` 用 `js-yaml` 解析 frontmatter，从当前工作目录的 `node_modules` 解析。仓库执行过 `yarn install` 后默认包含，无需额外安装。
-- 其他四个脚本仅用 Node 内置模块（`fs` / `path`），零依赖。
+- `check-home-alignment.mjs` 用 `js-yaml` 解析 frontmatter，按 cwd 链路找它的 `node_modules`：先看 `<cwd>/node_modules`，再看 `<cwd>/docs/node_modules`，覆盖「从 repo root 跑」和「从 docs/ 跑」两种场景。`yarn install` 之后会作为 rspress 间接依赖装到 `docs/node_modules`，无需手动安装。
+- 其他五个脚本仅用 Node 内置模块（`fs` / `path`），零依赖。
 
 ## 平台兼容
 
-五个脚本路径处理统一用 `path.posix.join` 拼相对路径，CRLF / LF 都能解析。Windows、macOS、Linux 都能跑，输出里的相对路径统一是正斜杠。
+六个脚本路径处理统一用 `path.posix.join` 拼相对路径，CRLF / LF 都能解析。Windows、macOS、Linux 都能跑，输出里的相对路径统一是正斜杠。
 
 ## 暂不维护的语言
 

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -11,8 +11,9 @@ NocoBase 文档站维护 `cn / en / ja / es / pt / de / fr / ru / id / vi` 共 1
 | `check-nav-alignment.mjs` | 各语言 `_nav.json` 顶部导航条目数和 link 是否对齐 cn | 不齐 = 1 |
 | `check-home-alignment.mjs` | 各语言首页 `index.md` frontmatter 的 hero.actions / features / items 结构和 link 是否对齐 cn | 不齐 = 1 |
 | `check-bloated-files.mjs` | 翻译膨胀（巨型单行 / 超大文件，会让 rspress 编译卡死） | 有膨胀 = 1 |
+| `check-i18n-coverage.mjs` | **本 PR 内** cn `.md`/`.mdx` 改动是否同步到了其他 9 个语言（单向检查） | 有未同步 = 1 |
 
-五个脚本都用 cn 作基准，只读不写，不会改任何文件。
+六个脚本都用 cn 作基准，只读不写，不会改任何文件。前五个看「结构对不对齐」，最后一个看「内容修改有没有跟」。
 
 ## 用法
 
@@ -31,6 +32,10 @@ node docs/scripts/check-bloated-files.mjs --lang=es
 
 # 指定不同的 docs 根目录
 node docs/scripts/check-tree-alignment.mjs path/to/docs/docs
+
+# i18n coverage：跟前五个不一样，输入是 PR 改动的文件列表（不扫文件树）
+gh pr view <pr-number> --json files --jq '.files[].path' | node docs/scripts/check-i18n-coverage.mjs
+node docs/scripts/check-i18n-coverage.mjs --files=changed-files.txt
 ```
 
 ## 典型输出
@@ -51,6 +56,28 @@ node docs/scripts/check-tree-alignment.mjs path/to/docs/docs
 
 ```
 [BLOATED+OVERSIZED] es/plugin-development/client/index.md (size 1292019 vs cn 4322, max line 1220031 vs cn 345)
+```
+
+```
+cn changes: 2 file(s)
+[en] OK
+[ja] STALE: 2 cn change(s) without ja sync
+  - workflow/index.md
+  - workflow/nodes/manual.md
+[es] OK
+...
+```
+
+## i18n coverage 与 `skip-i18n-check` label
+
+`check-i18n-coverage.mjs` 只在 PR 维度有意义——它要的是「这个 PR 相对 base 改了哪些文件」。CI 里推荐用 `gh pr view <pr> --json files` 拿改动列表，不要用 `git diff origin/<base>...HEAD`，原因是 `actions/checkout` 默认 shallow clone 拿不到 base。
+
+某些 cn 改动确实不需要其他语言跟（比如 typo 修复、纯排版调整、中国独有的注释或链接）。这种情况下，PR 上打 `skip-i18n-check` label，CI 的 i18n-coverage step 会读到 label 后整体跳过。打 label 需要仓库写权限，避免被随手滥用——用法和理由建议在 PR 描述里说明。
+
+打 label：
+
+```bash
+gh pr edit <pr-number> --add-label skip-i18n-check
 ```
 
 ## 依赖

--- a/docs/scripts/check-bloated-files.mjs
+++ b/docs/scripts/check-bloated-files.mjs
@@ -35,6 +35,15 @@ function parseArgs(argv) {
   return args;
 }
 
+// 探测 docsRoot：兼容两种 cwd——repo root（'docs/docs'）和 docs/（'./docs'）。
+// 找到带 cn/ 子目录的就用，都没有再退回到 'docs/docs' 让后续校验报清晰错。
+function defaultDocsRoot() {
+  for (const candidate of ['docs/docs', './docs']) {
+    if (fs.existsSync(path.join(candidate, 'cn'))) return candidate;
+  }
+  return 'docs/docs';
+}
+
 function listMdFiles(root) {
   const out = [];
   function walk(dir, rel) {
@@ -67,8 +76,12 @@ function maxLineLength(file) {
 
 function main() {
   const args = parseArgs(process.argv);
-  const docsRoot = args.positional[0] || 'docs/docs';
+  const docsRoot = args.positional[0] || defaultDocsRoot();
   const cnRoot = path.join(docsRoot, 'cn');
+  if (!fs.existsSync(cnRoot)) {
+    console.error(`找不到 ${cnRoot}（请在 NocoBase 主仓库根目录或 docs/ 目录下运行，或传 docs 根的绝对路径作为第一个位置参数）`);
+    process.exit(1);
+  }
 
   const langs = args.lang
     ? [args.lang]

--- a/docs/scripts/check-home-alignment.mjs
+++ b/docs/scripts/check-home-alignment.mjs
@@ -29,16 +29,36 @@ import { createRequire } from 'node:module';
 
 const SKIP_LANGS = new Set(['ar']);
 
-// js-yaml 从当前 cwd 的 node_modules 解析（脚本随 skill 分发，不带 deps）
-const cwdRequire = createRequire(path.join(process.cwd(), '__pkg__'));
-let yaml;
-try {
-  yaml = cwdRequire('js-yaml');
-} catch (err) {
-  console.error('找不到 js-yaml。请在 NocoBase 主仓库根目录下运行（确保已执行 yarn install）。');
-  console.error(`原始错误：${err.message}`);
+// 探测 docsRoot：兼容两种 cwd——repo root（'docs/docs'）和 docs/（'./docs'）。
+// 找到带 cn/ 子目录的就用，都没有再退回到 'docs/docs' 让后续校验报清晰错。
+function defaultDocsRoot() {
+  for (const candidate of ['docs/docs', './docs']) {
+    if (fs.existsSync(path.join(candidate, 'cn'))) return candidate;
+  }
+  return 'docs/docs';
+}
+
+// js-yaml 从 cwd 链路上的多个候选位置解析。脚本随仓库分发不带 deps，
+// js-yaml 来自 yarn install 装下来的 docs/node_modules（rspress 间接 dep）。
+// 兼容两种 cwd：repo root（找 docs/node_modules）和 docs/（找 ./node_modules）。
+function loadJsYaml() {
+  const candidates = [
+    path.join(process.cwd(), '__pkg__'),                  // <cwd>/node_modules
+    path.join(process.cwd(), 'docs', '__pkg__'),          // <cwd>/docs/node_modules
+  ];
+  let lastErr;
+  for (const c of candidates) {
+    try {
+      return createRequire(c)('js-yaml');
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  console.error('找不到 js-yaml。请在 NocoBase 主仓库根目录或 docs/ 目录下运行（确保已执行 yarn install）。');
+  console.error(`原始错误：${lastErr?.message ?? '(unknown)'}`);
   process.exit(1);
 }
+const yaml = loadJsYaml();
 
 function parseArgs(argv) {
   const args = { positional: [] };
@@ -122,10 +142,10 @@ function diff(cn, lang) {
 
 function main() {
   const args = parseArgs(process.argv);
-  const docsRoot = args.positional[0] || 'docs/docs';
+  const docsRoot = args.positional[0] || defaultDocsRoot();
   const cnFile = path.join(docsRoot, 'cn', 'index.md');
   if (!fs.existsSync(cnFile)) {
-    console.error(`找不到 ${cnFile}（请在 NocoBase 主仓库根目录运行，或传入 docs 根的绝对路径）`);
+    console.error(`找不到 ${cnFile}（请在 NocoBase 主仓库根目录或 docs/ 目录下运行，或传 docs 根的绝对路径作为第一个位置参数）`);
     process.exit(1);
   }
 

--- a/docs/scripts/check-i18n-coverage.mjs
+++ b/docs/scripts/check-i18n-coverage.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * 校对：本 PR 的 cn 文档改动是否同步到了其他语言
+ *
+ * 跟前面 5 个「结构对齐」脚本互补：那些看「文件存不存在 / _meta 链接是否对得上」，
+ * 这个看「同一个 PR 内，cn 内容改了，其他语言有没有跟」。
+ *
+ * 单向：只检查 cn → 其他 9 个语言（en / ja / es / pt / de / fr / ru / id / vi）。
+ * 单独修 en / ja 等语言（修正翻译错别字、本地化措辞）属于合法操作，不报错。
+ * ar 不在维护范围内，跳过。
+ *
+ * 输入：本 PR 改动的文件列表（stdin 或 --files=<path>）。每行一个路径，相对仓库根。
+ *      只关心 docs/docs/<lang>/**\/*.{md,mdx}，其他全部忽略。
+ *
+ * 逻辑：
+ * - 收集 PR 内所有改动到 changedByLang[lang] = Set<rel>
+ * - cn 改了某个 .md/.mdx，每个 target 语言的同名相对路径必须也在 PR 改动里
+ * - 没改 → 标 STALE
+ *
+ * Usage（典型）：
+ *   gh pr view <pr> --json files --jq '.files[].path' | node check-i18n-coverage.mjs
+ *   node check-i18n-coverage.mjs --files=changed.txt
+ *
+ * 退出码：发现 STALE = 1；干净 / 没有 cn 改动 = 0；输入异常 = 2。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+// 暂不参与对齐校对的语言；显式 --lang=<code> 不适用于这个脚本（输入是 PR 改动而非全语言扫描）
+const SKIP_LANGS = new Set(['ar']);
+// cn 之外要求同步的语言（需要跟 SKIP_LANGS 互斥）
+const TARGET_LANGS = ['en', 'ja', 'es', 'pt', 'de', 'fr', 'ru', 'id', 'vi'];
+const DOC_EXTS = new Set(['.md', '.mdx']);
+
+function parseArgs(argv) {
+  const args = { positional: [] };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([^=]+)=(.*)$/);
+    if (m) args[m[1]] = m[2];
+    else args.positional.push(a);
+  }
+  return args;
+}
+
+async function readChangedFiles(args) {
+  if (args.files) {
+    return fs.readFileSync(args.files, 'utf-8').split(/\r?\n/).filter(Boolean);
+  }
+  if (process.stdin.isTTY) {
+    console.error('没有从 stdin 收到改动文件列表，也没传 --files=<path>');
+    console.error('用法示例：gh pr view <pr> --json files --jq \'.files[].path\' | node check-i18n-coverage.mjs');
+    process.exit(2);
+  }
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8').split(/\r?\n/).filter(Boolean);
+}
+
+// 解析 docs/docs/<lang>/<rel> → { lang, rel }；其他路径返回 null
+function parseDocPath(p) {
+  // 兼容 Windows 反斜杠
+  const normalized = p.replace(/\\/g, '/');
+  const m = normalized.match(/^docs\/docs\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  const [, lang, rel] = m;
+  const ext = path.posix.extname(rel);
+  if (!DOC_EXTS.has(ext)) return null;
+  return { lang, rel };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const files = await readChangedFiles(args);
+
+  // 按语言归集 PR 内的改动
+  const changedByLang = {};
+  for (const f of files) {
+    const parsed = parseDocPath(f);
+    if (!parsed) continue;
+    if (SKIP_LANGS.has(parsed.lang)) continue;
+    if (!changedByLang[parsed.lang]) changedByLang[parsed.lang] = new Set();
+    changedByLang[parsed.lang].add(parsed.rel);
+  }
+
+  const cnChanges = changedByLang.cn || new Set();
+  if (cnChanges.size === 0) {
+    console.log('No cn doc changes in this PR; nothing to check');
+    process.exit(0);
+  }
+
+  console.log(`cn changes: ${cnChanges.size} file(s)`);
+  let bad = 0;
+  for (const lang of TARGET_LANGS) {
+    const langChanges = changedByLang[lang] || new Set();
+    const missing = [...cnChanges].filter((rel) => !langChanges.has(rel)).sort();
+    if (missing.length === 0) {
+      console.log(`[${lang}] OK`);
+      continue;
+    }
+    bad++;
+    console.log(`[${lang}] STALE: ${missing.length} cn change(s) without ${lang} sync`);
+    for (const rel of missing) console.log(`  - ${rel}`);
+  }
+  process.exit(bad ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/docs/scripts/check-meta-alignment.mjs
+++ b/docs/scripts/check-meta-alignment.mjs
@@ -30,6 +30,15 @@ function parseArgs(argv) {
   return args;
 }
 
+// 探测 docsRoot：兼容两种 cwd——repo root（'docs/docs'）和 docs/（'./docs'）。
+// 找到带 cn/ 子目录的就用，都没有再退回到 'docs/docs' 让后续校验报清晰错。
+function defaultDocsRoot() {
+  for (const candidate of ['docs/docs', './docs']) {
+    if (fs.existsSync(path.join(candidate, 'cn'))) return candidate;
+  }
+  return 'docs/docs';
+}
+
 function isExternalLink(link) {
   return /^https?:\/\//i.test(link);
 }
@@ -89,8 +98,12 @@ function listMetaFiles(root) {
 
 function main() {
   const args = parseArgs(process.argv);
-  const docsRoot = args.positional[0] || 'docs/docs';
+  const docsRoot = args.positional[0] || defaultDocsRoot();
   const cnRoot = path.join(docsRoot, 'cn');
+  if (!fs.existsSync(cnRoot)) {
+    console.error(`找不到 ${cnRoot}（请在 NocoBase 主仓库根目录或 docs/ 目录下运行，或传 docs 根的绝对路径作为第一个位置参数）`);
+    process.exit(1);
+  }
   const cnMetas = listMetaFiles(cnRoot);
 
   const langs = args.lang

--- a/docs/scripts/check-nav-alignment.mjs
+++ b/docs/scripts/check-nav-alignment.mjs
@@ -35,6 +35,15 @@ function parseArgs(argv) {
   return args;
 }
 
+// 探测 docsRoot：兼容两种 cwd——repo root（'docs/docs'）和 docs/（'./docs'）。
+// 找到带 cn/ 子目录的就用，都没有再退回到 'docs/docs' 让后续校验报清晰错。
+function defaultDocsRoot() {
+  for (const candidate of ['docs/docs', './docs']) {
+    if (fs.existsSync(path.join(candidate, 'cn'))) return candidate;
+  }
+  return 'docs/docs';
+}
+
 function isExternalLink(link) {
   return /^https?:\/\//i.test(link);
 }
@@ -89,10 +98,10 @@ function diff(a, b, pathLabel = '') {
 
 function main() {
   const args = parseArgs(process.argv);
-  const docsRoot = args.positional[0] || 'docs/docs';
+  const docsRoot = args.positional[0] || defaultDocsRoot();
   const cnFile = path.join(docsRoot, 'cn', '_nav.json');
   if (!fs.existsSync(cnFile)) {
-    console.error(`找不到 ${cnFile}（请在 NocoBase 主仓库根目录运行，或传入 docs 根的绝对路径）`);
+    console.error(`找不到 ${cnFile}（请在 NocoBase 主仓库根目录或 docs/ 目录下运行，或传 docs 根的绝对路径作为第一个位置参数）`);
     process.exit(1);
   }
 

--- a/docs/scripts/check-tree-alignment.mjs
+++ b/docs/scripts/check-tree-alignment.mjs
@@ -30,6 +30,15 @@ function parseArgs(argv) {
   return args;
 }
 
+// 探测 docsRoot：兼容两种 cwd——repo root（'docs/docs'）和 docs/（'./docs'）。
+// 找到带 cn/ 子目录的就用，都没有再退回到 'docs/docs' 让后续校验报清晰错。
+function defaultDocsRoot() {
+  for (const candidate of ['docs/docs', './docs']) {
+    if (fs.existsSync(path.join(candidate, 'cn'))) return candidate;
+  }
+  return 'docs/docs';
+}
+
 function listDocFiles(root) {
   const out = new Set();
   function walk(dir, rel) {
@@ -50,10 +59,10 @@ function listDocFiles(root) {
 
 function main() {
   const args = parseArgs(process.argv);
-  const docsRoot = args.positional[0] || 'docs/docs';
+  const docsRoot = args.positional[0] || defaultDocsRoot();
   const cnRoot = path.join(docsRoot, 'cn');
   if (!fs.existsSync(cnRoot)) {
-    console.error(`找不到 ${cnRoot}`);
+    console.error(`找不到 ${cnRoot}（请在 NocoBase 主仓库根目录或 docs/ 目录下运行，或传 docs 根的绝对路径作为第一个位置参数）`);
     process.exit(1);
   }
 


### PR DESCRIPTION
### This is a ...
- [x] Others

### Motivation

之前合并的 #9309 提供了五个结构对齐脚本（文件树 / `_meta.json` / `_nav.json` / 首页 / 翻译膨胀），都只看「结构是否一致」。

但有一类更常见的同步漏检它们都抓不到：cn 文档**内容**改了一句话或几行，其他 9 个语言的对应文件没跟。比如改了 cn 的某段说明、修了某个步骤的描述、补了一段提示——文件还在、`_meta.json` 没动、文件大小也正常，结构脚本全绿，但其他语言已经悄悄过期了。

时间一长翻译会偏离 cn 越来越远。这次加一个脚本来拦截这类内容漂移。

### Description

新增 `docs/scripts/check-i18n-coverage.mjs`：

- **输入**：本 PR 改动的文件列表（stdin 或 `--files=<path>`），每行一个路径，相对仓库根
- **范围**：只看 `docs/docs/<lang>/**/*.{md,mdx}`，其他文件忽略（`_meta.json` 由 `check-meta-alignment.mjs` 管，源码不在范围内）
- **逻辑**：cn 改了某个 `.md` / `.mdx`，每个 target 语言（`en / ja / es / pt / de / fr / ru / id / vi`）的同名相对路径必须也在 PR 改动里。没改 → 标 STALE，退出码 1
- **方向**：单向。只检查 cn → 其他。单独修 en / ja 等语言（修正翻译错别字、本地化措辞）是合法操作，不报错
- **范围排除**：ar 不在维护范围内，直接跳过

CI 里用 `gh pr view <pr> --json files --jq '.files[].path'` 拿改动列表，不要用 `git diff origin/<base>...HEAD`——`actions/checkout` 默认 shallow clone，base 不在本地，diff 会失败。

跨平台兼容：路径解析时把反斜杠规范化到正斜杠，Windows / macOS / Linux 都能跑。

### Opt-out 设计

某些 cn 改动确实不需要其他语言跟（typo 修复、纯排版、中国独有注释/链接）。这种情况下 PR 上打 `skip-i18n-check` label，CI 的 i18n-coverage step 会整体跳过。

label 已在仓库创建好。具体 CI 接入会在 nocobase-ci 仓另开 PR 处理。

### Showcase

```
$ printf 'docs/docs/cn/foo.md\ndocs/docs/en/foo.md\ndocs/docs/ja/foo.md\n' | node docs/scripts/check-i18n-coverage.mjs
cn changes: 1 file(s)
[en] OK
[ja] OK
[es] STALE: 1 cn change(s) without es sync
  - foo.md
[pt] STALE: 1 cn change(s) without pt sync
  - foo.md
... (de/fr/ru/id/vi 同样 STALE)
exit 1

$ printf 'docs/docs/en/typo-fix.md\n' | node docs/scripts/check-i18n-coverage.mjs
No cn doc changes in this PR; nothing to check
exit 0
```

### Related issues

延伸自 #9309。

### Showcase

无 UI 改动。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `check-i18n-coverage.mjs` to flag cn doc changes that aren't synced to other languages in the same PR. |
| 🇨🇳 Chinese | 新增 `check-i18n-coverage.mjs`，检查同一 PR 内 cn 文档改动是否同步到了其他 9 个语言。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |     |
| 🇨🇳 Chinese |   |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
