### PR TITLE
fix(build): handle both path separators in deleteServerFiles for cross platform

### DIFF
--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -7,6 +7,15 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { rspack } from '@rspack/core';
 import ncc from '@vercel/ncc';
@@ -307,10 +316,10 @@ export function deleteServerFiles(cwd: string, log: PkgLog) {
     onlyDirectories: true,
   });
   [...files, ...dirs.filter((item) => !extraClientDirs.includes(item)), ...extraClientDirs].forEach((item) => {
-    if (item.endsWith(`${path.sep}client-v2`)) {
+    if (item.endsWith(`${path.sep}client-v2`) || item.endsWith(`/client-v2`)) {
       return;
     }
-    if (item.endsWith(`${path.sep}client`)) {
+    if (item.endsWith(`${path.sep}client`) || item.endsWith(`/client`)) {
       return;
     }
     fs.removeSync(item);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
On Windows, the `client-v2` build artifact (`dist/client-v2/index.js`) disappears after the build completes, despite being successfully emitted by rspack. This is because `deleteServerFiles()` uses `path.sep` (backslash on Windows) to check whether a path ends with `client-v2`, but `fast-glob` returns POSIX-style paths (with `/`) on all platforms. The mismatch causes the skip-check to fail, and the directory gets deleted.

This is a **critical bug that blocks Windows plugin development entirely** — any plugin using the `client-v2` lane will fail to load at runtime with a 404.

### Description
In `packages/core/build/src/buildPlugin.ts`, the `deleteServerFiles()` function checks path endings using only `path.sep`:

```typescript
// BEFORE
if (item.endsWith(`${path.sep}client-v2`)) { return; }
if (item.endsWith(`${path.sep}client`)) { return; }
```

The fix adds an explicit check for forward-slash paths returned by `fast-glob`:

```typescript
// AFTER
if (item.endsWith(`${path.sep}client-v2`) || item.endsWith(`/client-v2`)) { return; }
if (item.endsWith(`${path.sep}client`) || item.endsWith(`/client`)) { return; }
```

**Root cause**: `fast-glob ^3.3.1` returns POSIX-style paths (using `/`) on all platforms, including Windows. This is [documented behavior](https://github.com/mrmlnc/fast-glob/issues/370). The `deleteServerFiles()` function's skip-check only matched `path.sep` (which is `\` on Windows), so paths like `D:/.../dist/client-v2` were never matched and the directory was deleted.

**Risk**: Minimal. This is a defensive fix that adds a fallback check — the original logic for `path.sep` paths is preserved, and the new `/client` and `/client-v2` checks only add coverage for fast-glob's POSIX-style output.

**Testing suggestion**:
- On Windows: run `yarn build @nocobase/<plugin-with-client-v2> --no-dts` and verify `dist/client-v2/index.js` exists after build
- Verify that `dist/client/`, `dist/client-v2/`, `dist/server/` directories are handled correctly

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(build): handle cross-platform path separators in deleteServerFiles to preserve client-v2 artifacts on Windows |
| 🇨🇳 Chinese | 修复(build): 处理 deleteServerFiles 中的跨平台路径分隔符问题，确保 Windows 环境下 client-v2 构建产物不被误删 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
