### PR TITLE
test(build): add deleteServerFiles regression coverage

### DIFF
--- a/packages/core/build/src/__tests__/deleteServerFiles.test.ts
+++ b/packages/core/build/src/__tests__/deleteServerFiles.test.ts
@@ -1,0 +1,63 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { deleteServerFiles, shouldPreserveDistEntry } from '../deleteServerFiles';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fs.remove(dir)));
+  tempDirs.length = 0;
+});
+
+async function createTempPluginDir() {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'nocobase-build-plugin-'));
+  tempDirs.push(cwd);
+  return {
+    cwd,
+    distDir: path.join(cwd, 'dist'),
+  };
+}
+
+describe('shouldPreserveDistEntry', () => {
+  test('preserves client lanes for both Windows and POSIX paths', () => {
+    expect(shouldPreserveDistEntry('C:/repo/dist/client')).toBe(true);
+    expect(shouldPreserveDistEntry('C:/repo/dist/client-v2')).toBe(true);
+    expect(shouldPreserveDistEntry('C:\\repo\\dist\\client')).toBe(true);
+    expect(shouldPreserveDistEntry('C:\\repo\\dist\\client-v2')).toBe(true);
+    expect(shouldPreserveDistEntry('/repo/dist/client')).toBe(true);
+    expect(shouldPreserveDistEntry('/repo/dist/client-v2')).toBe(true);
+    expect(shouldPreserveDistEntry('/repo/dist/server')).toBe(false);
+  });
+});
+
+describe('deleteServerFiles', () => {
+  test('removes server artifacts and keeps client lanes', async () => {
+    const { cwd, distDir } = await createTempPluginDir();
+
+    await fs.outputFile(path.join(distDir, 'index.js'), 'server entry');
+    await fs.outputFile(path.join(distDir, 'server', 'index.js'), 'server build');
+    await fs.outputFile(path.join(distDir, 'client', 'index.js'), 'client build');
+    await fs.outputFile(path.join(distDir, 'client-v2', 'index.js'), 'client-v2 build');
+    await fs.outputFile(path.join(distDir, 'node_modules', 'pkg', 'index.js'), 'dependency');
+
+    deleteServerFiles(cwd, () => {});
+
+    await expect(fs.pathExists(path.join(distDir, 'index.js'))).resolves.toBe(false);
+    await expect(fs.pathExists(path.join(distDir, 'server'))).resolves.toBe(false);
+    await expect(fs.pathExists(path.join(distDir, 'client'))).resolves.toBe(true);
+    await expect(fs.pathExists(path.join(distDir, 'client-v2'))).resolves.toBe(true);
+    await expect(fs.pathExists(path.join(distDir, 'node_modules'))).resolves.toBe(true);
+  });
+});

--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -7,15 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-/**
- * This file is part of the NocoBase (R) project.
- * Copyright (c) 2020-2024 NocoBase Co., Ltd.
- * Authors: NocoBase Team.
- *
- * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
- * For more information, please refer to: https://www.nocobase.com/agreement.
- */
-
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { rspack } from '@rspack/core';
 import ncc from '@vercel/ncc';
@@ -27,6 +18,7 @@ import path from 'path';
 import { build as tsupBuild } from 'tsup';
 import { EsbuildSupportExts, globExcludeFiles, PLUGIN_COMMERCIAL } from './constant';
 import pluginEsbuildCommercialInject from './plugins/pluginEsbuildCommercialInject';
+import { deleteServerFiles } from './deleteServerFiles';
 import { getPackageJson, PkgLog, UserConfig } from './utils';
 import {
   buildCheck,
@@ -293,37 +285,6 @@ async function copyAiDocSources(cwd: string, log: PkgLog) {
     await fs.ensureDir(path.dirname(rootMetaPath));
     await fs.writeJSON(rootMetaPath, Array.from(rootMetaMap.values()), { spaces: 2 });
   }
-}
-
-export function deleteServerFiles(cwd: string, log: PkgLog) {
-  log('delete server files');
-  const files = fg.globSync(['*'], {
-    cwd: path.join(cwd, target_dir),
-    absolute: true,
-    deep: 1,
-    onlyFiles: true,
-  });
-  const dirs = fg.globSync(['*', '!client', '!node_modules'], {
-    cwd: path.join(cwd, target_dir),
-    absolute: true,
-    deep: 1,
-    onlyDirectories: true,
-  });
-  const extraClientDirs = fg.globSync(['client-v2'], {
-    cwd: path.join(cwd, target_dir),
-    absolute: true,
-    deep: 1,
-    onlyDirectories: true,
-  });
-  [...files, ...dirs.filter((item) => !extraClientDirs.includes(item)), ...extraClientDirs].forEach((item) => {
-    if (item.endsWith(`${path.sep}client-v2`) || item.endsWith(`/client-v2`)) {
-      return;
-    }
-    if (item.endsWith(`${path.sep}client`) || item.endsWith(`/client`)) {
-      return;
-    }
-    fs.removeSync(item);
-  });
 }
 
 export function writeExternalPackageVersion(cwd: string, log: PkgLog) {

--- a/packages/core/build/src/deleteServerFiles.ts
+++ b/packages/core/build/src/deleteServerFiles.ts
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import fg from 'fast-glob';
+import fs from 'fs-extra';
+import path from 'path';
+import type { PkgLog } from './utils';
+
+const targetDir = 'dist';
+const preservedDistEntries = new Set(['client', 'client-v2']);
+
+export function shouldPreserveDistEntry(item: string) {
+  // fast-glob may return POSIX-style absolute paths on Windows, so use the
+  // win32 parser here to recognize both `\` and `/` as path separators.
+  return preservedDistEntries.has(path.win32.basename(item));
+}
+
+export function deleteServerFiles(cwd: string, log: PkgLog) {
+  log('delete server files');
+  const distDir = path.join(cwd, targetDir);
+  const files = fg.globSync(['*'], {
+    cwd: distDir,
+    absolute: true,
+    deep: 1,
+    onlyFiles: true,
+  });
+  const dirs = fg.globSync(['*', '!node_modules'], {
+    cwd: distDir,
+    absolute: true,
+    deep: 1,
+    onlyDirectories: true,
+  });
+
+  [...files, ...dirs].forEach((item) => {
+    if (shouldPreserveDistEntry(item)) {
+      return;
+    }
+
+    fs.removeSync(item);
+  });
+}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The previous `deleteServerFiles` Windows compatibility fix was merged into `next`, but it still left two follow-up issues: a duplicated file header in `buildPlugin.ts` and no regression coverage for the cleanup logic. Without a test, the path-handling behavior for `client` and `client-v2` can regress again, especially on Windows where `fast-glob` may return POSIX-style paths.

### Description
- Extract `deleteServerFiles` into a dedicated helper and remove the duplicated file header left in `buildPlugin.ts`
- Preserve `client` and `client-v2` by entry name with an inline note explaining why `path.win32.basename()` is used
- Add regression tests covering Windows/POSIX path parsing and the actual `dist` cleanup behavior

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added regression coverage to keep `deleteServerFiles` from removing `client` and `client-v2` build artifacts across Windows and POSIX paths. |
| 🇨🇳 Chinese | 补充了 `deleteServerFiles` 的回归测试，确保在 Windows 和 POSIX 路径场景下不会误删 `client` 和 `client-v2` 构建产物。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
