### PR TITLE
fix(ci): fail check-deps build when pro plugin setup breaks

### DIFF
--- a/.github/workflows/check-deps-and-build.yml
+++ b/.github/workflows/check-deps-and-build.yml
@@ -40,7 +40,6 @@ jobs:
       status: ${{ steps.check.outputs.status }}
     steps:
       - uses: actions/create-github-app-token@v1
-        continue-on-error: true
         id: app-token
         with:
           app-id: ${{ vars.NOCOBASE_APP_ID }}
@@ -51,7 +50,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Checkout pro-plugins
-        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: nocobase/pro-plugins
@@ -61,7 +59,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Switch pro-plugins branch
-        continue-on-error: true
         run: |
           cd packages/pro-plugins
           if git show-ref --quiet refs/remotes/origin/${{ github.head_ref || github.ref_name }}; then
@@ -78,18 +75,22 @@ jobs:
           TARGET_BRANCH="${{ github.base_ref || github.ref_name }}"
           case "$TARGET_BRANCH" in
             develop)
-              echo "plugins=${{ needs.get-plugins.outputs.alpha-plugins || '[]' }}" >> "$GITHUB_OUTPUT"
+              plugins='${{ needs.get-plugins.outputs.alpha-plugins || '[]' }}'
               ;;
             next)
-              echo "plugins=${{ needs.get-plugins.outputs.beta-plugins || '[]' }}" >> "$GITHUB_OUTPUT"
+              plugins='${{ needs.get-plugins.outputs.beta-plugins || '[]' }}'
               ;;
             *)
-              echo "plugins=${{ needs.get-plugins.outputs.rc-plugins || '[]' }}" >> "$GITHUB_OUTPUT"
+              plugins='${{ needs.get-plugins.outputs.rc-plugins || '[]' }}'
               ;;
           esac
+          {
+            echo "plugins<<PLUGIN_SET_EOF"
+            echo "$plugins"
+            echo "PLUGIN_SET_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Clone standalone plugin repos
-        continue-on-error: true
         shell: bash
         run: |
           PLUGINS='${{ steps.plugin-set.outputs.plugins }}'
@@ -102,7 +103,7 @@ jobs:
               echo "Cloning $repo..."
               git clone -b ${{ github.base_ref || github.ref_name }} \
                 https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git \
-                packages/pro-plugins/@nocobase/$repo 2>/dev/null || true
+                packages/pro-plugins/@nocobase/$repo
             fi
           done
 
@@ -190,7 +191,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
-        continue-on-error: true
         id: app-token
         with:
           app-id: ${{ vars.NOCOBASE_APP_ID }}
@@ -201,7 +201,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Checkout pro-plugins
-        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: nocobase/pro-plugins
@@ -211,7 +210,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Switch pro-plugins branch
-        continue-on-error: true
         run: |
           cd packages/pro-plugins
           if git show-ref --quiet refs/remotes/origin/${{ github.head_ref || github.ref_name }}; then
@@ -228,18 +226,22 @@ jobs:
           TARGET_BRANCH="${{ github.base_ref || github.ref_name }}"
           case "$TARGET_BRANCH" in
             develop)
-              echo "plugins=${{ needs.get-plugins.outputs.alpha-plugins || '[]' }}" >> "$GITHUB_OUTPUT"
+              plugins='${{ needs.get-plugins.outputs.alpha-plugins || '[]' }}'
               ;;
             next)
-              echo "plugins=${{ needs.get-plugins.outputs.beta-plugins || '[]' }}" >> "$GITHUB_OUTPUT"
+              plugins='${{ needs.get-plugins.outputs.beta-plugins || '[]' }}'
               ;;
             *)
-              echo "plugins=${{ needs.get-plugins.outputs.rc-plugins || '[]' }}" >> "$GITHUB_OUTPUT"
+              plugins='${{ needs.get-plugins.outputs.rc-plugins || '[]' }}'
               ;;
           esac
+          {
+            echo "plugins<<PLUGIN_SET_EOF"
+            echo "$plugins"
+            echo "PLUGIN_SET_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Clone standalone plugin repos
-        continue-on-error: true
         shell: bash
         run: |
           PLUGINS='${{ steps.plugin-set.outputs.plugins }}'
@@ -250,7 +252,7 @@ jobs:
             if [[ ! -d "packages/pro-plugins/@nocobase/$repo" ]]; then
               git clone -b ${{ github.base_ref || github.ref_name }} \
                 https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git \
-                packages/pro-plugins/@nocobase/$repo 2>/dev/null || true
+                packages/pro-plugins/@nocobase/$repo
             fi
           done
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
`check-deps-and-build.yml` writes the standalone pro plugin list to `GITHUB_OUTPUT` as invalid JSON, which breaks the later `jq` parsing in the clone step. The workflow also swallows failures from the critical pro plugin setup steps, so CI can continue without cloning the full standalone pro plugin set and miss release-blocking build errors.

### Description
- write the selected standalone pro plugin set to `GITHUB_OUTPUT` with a multiline block so downstream steps receive valid JSON
- stop ignoring failures from the GitHub App token setup, pro-plugins checkout, branch switch, and standalone plugin clone steps
- remove the clone-step `|| true` fallback so missing standalone pro plugins fail the workflow instead of silently reducing build coverage

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the dependency-and-build workflow so standalone pro plugin checkout failures break CI instead of silently skipping build coverage. |
| 🇨🇳 Chinese | 修复依赖与构建校验流水线，避免独立 pro 插件 checkout 失败时被静默跳过而导致构建覆盖缺失。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
