### PR TITLE
fix(client): avoid duplicate .js suffix for remote plugin urls

### DIFF
--- a/packages/core/client-v2/src/__tests__/remotePlugins.test.ts
+++ b/packages/core/client-v2/src/__tests__/remotePlugins.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { Plugin } from '../Plugin';
+import { getRequireJs } from '../utils/requirejs';
 import { defineDevPlugins, definePluginClient, getPlugins } from '../utils/remotePlugins';
 
 describe('client-v2 remotePlugins', () => {
@@ -68,5 +69,31 @@ describe('client-v2 remotePlugins', () => {
     expect(plugins).toEqual([['@nocobase/demo', DemoPlugin]]);
     expect(mockDefine).toHaveBeenCalledWith('@nocobase/demo/client-v2', expect.any(Function));
     expect(mockDefine).not.toHaveBeenCalledWith('@nocobase/demo/client', expect.any(Function));
+  });
+
+  it('should not append duplicate .js for plugin URLs without query strings', () => {
+    const requirejs = getRequireJs();
+
+    requirejs.requirejs.config({
+      paths: {
+        '@nocobase/demo': '/static/plugins/@nocobase/demo/dist/client-v2/index.js',
+      },
+    });
+
+    expect(requirejs.requirejs.toUrl('@nocobase/demo')).toBe('/static/plugins/@nocobase/demo/dist/client-v2/index.js');
+  });
+
+  it('should keep hashed plugin URLs unchanged', () => {
+    const requirejs = getRequireJs();
+
+    requirejs.requirejs.config({
+      paths: {
+        '@nocobase/demo': '/static/plugins/@nocobase/demo/dist/client-v2/index.js?hash=12345678',
+      },
+    });
+
+    expect(requirejs.requirejs.toUrl('@nocobase/demo')).toBe(
+      '/static/plugins/@nocobase/demo/dist/client-v2/index.js?hash=12345678',
+    );
   });
 });

--- a/packages/core/client-v2/src/utils/requirejs.ts
+++ b/packages/core/client-v2/src/utils/requirejs.ts
@@ -1686,7 +1686,7 @@ export function getRequireJs(): RequireJS {
 
           //Join the path parts together, then figure out if baseUrl is needed.
           url = syms.join('/');
-          url += (ext || (/^data\:|^blob\:|\?/.test(url) || skipExt ? '' : '.js'));
+          url += (ext || (/^data\:|^blob\:|\?/.test(url) || /\.js(?:$|[?#])/.test(url) || skipExt ? '' : '.js'));
           url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
         }
 

--- a/packages/core/client/src/application/__tests__/utils/remotePlugins.test.ts
+++ b/packages/core/client/src/application/__tests__/utils/remotePlugins.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { Plugin } from '../../Plugin';
+import { getRequireJs } from '../../utils/requirejs';
 import {
   configRequirejs,
   defineDevPlugins,
@@ -108,6 +109,32 @@ describe('remotePlugins', () => {
         '@nocobase/demo': 'https://demo.com',
       },
     });
+  });
+
+  test('should not append duplicate .js for plugin URLs without query strings', () => {
+    const requirejs = getRequireJs();
+
+    requirejs.requirejs.config({
+      paths: {
+        '@nocobase/demo': '/static/plugins/@nocobase/demo/dist/client/index.js',
+      },
+    });
+
+    expect(requirejs.requirejs.toUrl('@nocobase/demo')).toBe('/static/plugins/@nocobase/demo/dist/client/index.js');
+  });
+
+  test('should keep hashed plugin URLs unchanged', () => {
+    const requirejs = getRequireJs();
+
+    requirejs.requirejs.config({
+      paths: {
+        '@nocobase/demo': '/static/plugins/@nocobase/demo/dist/client/index.js?hash=12345678',
+      },
+    });
+
+    expect(requirejs.requirejs.toUrl('@nocobase/demo')).toBe(
+      '/static/plugins/@nocobase/demo/dist/client/index.js?hash=12345678',
+    );
   });
 
   describe('processRemotePlugins()', () => {

--- a/packages/core/client/src/application/utils/requirejs.ts
+++ b/packages/core/client/src/application/utils/requirejs.ts
@@ -1686,7 +1686,7 @@ export function getRequireJs(): RequireJS {
 
           //Join the path parts together, then figure out if baseUrl is needed.
           url = syms.join('/');
-          url += (ext || (/^data\:|^blob\:|\?/.test(url) || skipExt ? '' : '.js'));
+          url += (ext || (/^data\:|^blob\:|\?/.test(url) || /\.js(?:$|[?#])/.test(url) || skipExt ? '' : '.js'));
           url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
         }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Remote plugin URLs that already end with `.js` can still be resolved as `*.js.js` after `requirejs` path substitution. This breaks plugin loading when the resolved URL does not include a query string.

### Description 
- Update the shared `requirejs` URL resolution in both `client` and `client-v2` to skip appending `.js` when the resolved URL already points to a JavaScript file.
- Add regression tests for plain `.js` plugin URLs and hashed `.js?hash=...` plugin URLs in both client lanes.
- Testing suggestions: verify remote plugin loading from both `pm:listEnabled` and `pm:listEnabledV2` paths when plugin URLs are returned with and without query strings.

### Related issues
- Refs #9335

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed remote plugin loading so plugin URLs that already end with `.js` are not resolved to duplicate `.js.js` paths. |
| 🇨🇳 Chinese | 修复远程插件加载时已带 `.js` 后缀的插件 URL 被错误解析成重复 `.js.js` 路径的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
