### PR TITLE
fix(cli): support negated generated boolean flags

### DIFF
--- a/packages/core/cli/src/__tests__/generated-command-body-modes.test.ts
+++ b/packages/core/cli/src/__tests__/generated-command-body-modes.test.ts
@@ -43,11 +43,34 @@ const testApiOperation: GeneratedOperation = {
   examples: [],
 };
 
+const testListOperation: GeneratedOperation = {
+  commandId: 'test list',
+  method: 'get',
+  pathTemplate: '/test:list',
+  parameters: [
+    {
+      name: 'paginate',
+      flagName: 'paginate',
+      in: 'query',
+      type: 'boolean',
+    },
+  ],
+  examples: [],
+};
+
 class ParseOnlyTestApiCommand extends Command {
   static override flags = createGeneratedFlags(testApiOperation);
 
   async run() {
     return this.parse(ParseOnlyTestApiCommand);
+  }
+}
+
+class ParseOnlyTestListCommand extends Command {
+  static override flags = createGeneratedFlags(testListOperation);
+
+  async run() {
+    return this.parse(ParseOnlyTestListCommand);
   }
 }
 
@@ -64,6 +87,12 @@ test('body-file path should not require inline body or body field flags at parse
   const result = await ParseOnlyTestApiCommand.run(['--body-file', '/tmp/test-api.json']);
   expect(result.flags['body-file']).toBe('/tmp/test-api.json');
   expect(result.flags.body).toBe(undefined);
+});
+
+test('generated boolean flags should accept --no-* form', async () => {
+  const result = await ParseOnlyTestListCommand.run(['--no-paginate']);
+
+  expect(result.flags.paginate).toBe(false);
 });
 
 test('parseBody should still enforce required body fields when flag mode is used', async () => {

--- a/packages/core/cli/src/lib/generated-command.ts
+++ b/packages/core/cli/src/lib/generated-command.ts
@@ -80,6 +80,7 @@ function buildParameterFlag(parameter: GeneratedParameter, options?: { required?
   if (parameter.type === 'boolean') {
     return Flags.boolean({
       description,
+      allowNo: true,
       ...(helpGroup ? {helpGroup} : {}),
       ...(required ? {required: true as const} : {}),
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Generated CLI boolean options could not be disabled through the expected negated flag form, which made commands such as collection listing unable to request non-paginated results from the CLI.

### Description 
Enable negated forms for generated boolean flags, such as `--no-paginate`, and add coverage to verify generated API commands parse these flags as `false`.

Potential risk is low and limited to generated CLI boolean flag parsing.

Testing:
- `yarn --cwd ../../.. vitest run packages/core/cli/src/__tests__/generated-command-body-modes.test.ts packages/core/cli/src/__tests__/api-client.test.ts`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed CLI boolean options so they can be disabled with negated flags |
| 🇨🇳 Chinese | 修复 CLI 布尔选项无法通过否定参数关闭的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
