### PR TITLE
feat: add Feishu failure notification for manual release workflows

### DIFF
--- a/.github/workflows/manual-release-develop.yml
+++ b/.github/workflows/manual-release-develop.yml
@@ -101,3 +101,25 @@ jobs:
           git push origin develop --atomic --tags
           cd ../../
           git push origin develop --tags --atomic
+  feishu-notify:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs:
+      - get-plugins
+      - update-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Set current date
+        run: echo "CURRENT_DATE=$(TZ='Asia/Shanghai' date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+      - name: Send Feishu notification
+        shell: bash
+        env:
+          WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
+          TITLE: "NocoBase ${{ github.workflow }} 失败通知"
+          STATUS: failure
+          CONTENT: "**触发者：**${{ github.actor }}\n**时间：**${{ env.CURRENT_DATE }}\n**状态：**❌ 构建失败"
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/feishu-notify.sh

--- a/.github/workflows/manual-release-next.yml
+++ b/.github/workflows/manual-release-next.yml
@@ -157,3 +157,26 @@ jobs:
           git checkout develop
           git merge -X ours next --no-edit
           git push origin develop --tags --atomic
+  feishu-notify:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs:
+      - get-plugins
+      - pre-merge-next-into-develop
+      - update-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Set current date
+        run: echo "CURRENT_DATE=$(TZ='Asia/Shanghai' date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+      - name: Send Feishu notification
+        shell: bash
+        env:
+          WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
+          TITLE: "NocoBase ${{ github.workflow }} 失败通知"
+          STATUS: failure
+          CONTENT: "**触发者：**${{ github.actor }}\n**时间：**${{ env.CURRENT_DATE }}\n**状态：**❌ 构建失败"
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/feishu-notify.sh

--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -213,3 +213,26 @@ jobs:
           git push origin v1 --atomic --tags
           cd ../../
           git push origin v1 --atomic --tags
+
+  feishu-notify:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs:
+      - get-plugins
+      - update-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Set current date
+        run: echo "CURRENT_DATE=$(TZ='Asia/Shanghai' date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+      - name: Send Feishu notification
+        shell: bash
+        env:
+          WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
+          TITLE: "NocoBase ${{ github.workflow }} 失败通知"
+          STATUS: failure
+          CONTENT: "**触发者：**${{ github.actor }}\n**时间：**${{ env.CURRENT_DATE }}\n**状态：**❌ 构建失败"
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/feishu-notify.sh

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -149,3 +149,26 @@ jobs:
           git checkout next
           git merge -X ours main --no-edit
           git push origin next --tags --atomic
+  feishu-notify:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs:
+      - get-plugins
+      - pre-merge-main-into-next
+      - update-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Set current date
+        run: echo "CURRENT_DATE=$(TZ='Asia/Shanghai' date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+      - name: Send Feishu notification
+        shell: bash
+        env:
+          WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
+          TITLE: "NocoBase ${{ github.workflow }} 失败通知"
+          STATUS: failure
+          CONTENT: "**触发者：**${{ github.actor }}\n**时间：**${{ env.CURRENT_DATE }}\n**状态：**❌ 构建失败"
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/feishu-notify.sh


### PR DESCRIPTION
### This is a ...
- [x] Improvement

### Motivation
The four manual release workflows (`manual-release.yml`, `manual-release-v1.yml`, `manual-release-next.yml`, `manual-release-develop.yml`) currently send no proactive signal when version-bump, tag push, or cross-branch merge prep fails — the team has to check GitHub Actions manually to notice. PR #9069 already wired up Feishu notifications for `release.yml`; this PR extends the same mechanism to the four manual-release workflows.

### Description
- Append a `feishu-notify` job to each of the four `manual-release-*.yml` workflows.
- Use `if: failure()` so notifications fire only when an upstream job actually fails (`success` / `cancelled` / `skipped` do not trigger).
- Each `needs:` lists all upstream jobs in the workflow so every failure point is covered.
- Reuse the existing `scripts/feishu-notify.sh` and `secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL`.
- Card title uses `${{ github.workflow }}` to distinguish the four workflows; body shows actor, time, and status.
- Pin the notification job's `actions/checkout` to `ref: main` so the script is reachable regardless of which branch the workflow was dispatched from (the `v1` branch does not contain `scripts/feishu-notify.sh`).

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - |
| 🇨🇳 Chinese | - |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
