### PR TITLE
fix(kanban): resolve association runtime resource params

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/kanban-block.shared.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/kanban-block.shared.test.ts
@@ -8,7 +8,9 @@
  */
 
 import { describe, expect, test } from 'vitest';
+import { FlowEngine, MultiRecordResource } from '@nocobase/flow-engine';
 import {
+  createColumnResource,
   getKanbanDesignSettingsHost,
   isKanbanDesignSettingsHost,
   shouldHideUnknownColumn,
@@ -115,5 +117,68 @@ describe('kanban design settings host', () => {
 
     expect(shouldMountUnknownColumn(options)).toBe(true);
     expect(shouldHideUnknownColumn(options)).toBe(false);
+  });
+
+  test('column resource uses resolved association sourceId from the base resource', () => {
+    const engine = new FlowEngine();
+    const createResource = () => engine.context.createResource(MultiRecordResource);
+    const baseResource = createResource();
+    baseResource.setSourceId(12);
+
+    const columnResource = createColumnResource(
+      {
+        getResourceSettingsInitParams: () => ({
+          dataSourceKey: 'main',
+          collectionName: 'tasks',
+          associationName: 'users.tasks',
+          sourceId: '{{ctx.view.inputArgs.filterByTk}}',
+        }),
+        resource: baseResource,
+        context: {
+          createResource,
+        },
+        getPageSize: () => 20,
+        getGroupField: () => ({ name: 'status' }),
+        getConfiguredGroupOptions: () => [],
+      } as any,
+      { key: 'todo', value: 'todo', label: 'Todo', color: 'blue' },
+      1,
+      20,
+    );
+
+    expect(columnResource.getResourceName()).toBe('users.tasks');
+    expect(columnResource.getSourceId()).toBe(12);
+    expect(columnResource.getFilterByTk()).toBeNull();
+  });
+
+  test('column resource does not copy unresolved runtime templates into request params', () => {
+    const engine = new FlowEngine();
+    const createResource = () => engine.context.createResource(MultiRecordResource);
+    const baseResource = createResource();
+
+    const columnResource = createColumnResource(
+      {
+        getResourceSettingsInitParams: () => ({
+          dataSourceKey: 'main',
+          collectionName: 'tasks',
+          associationName: 'users.tasks',
+          sourceId: '{{ctx.view.inputArgs.filterByTk}}',
+          filterByTk: '{{ctx.view.inputArgs.filterByTk}}',
+        }),
+        resource: baseResource,
+        context: {
+          createResource,
+        },
+        getPageSize: () => 20,
+        getGroupField: () => ({ name: 'status' }),
+        getConfiguredGroupOptions: () => [],
+      } as any,
+      { key: 'todo', value: 'todo', label: 'Todo', color: 'blue' },
+      1,
+      20,
+    );
+
+    expect(columnResource.getSourceId()).toBeNull();
+    expect(columnResource.getFilterByTk()).toBeNull();
   });
 });

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/shared.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/shared.ts
@@ -354,6 +354,18 @@ export const reuseKanbanRecordReferences = (options: {
   });
 };
 
+const hasKanbanResourceValue = (value: any) => value !== undefined && value !== null && value !== '';
+
+const isKanbanRuntimeTemplateValue = (value: any) => typeof value === 'string' && /\{\{[\s\S]*?\}\}/.test(value);
+
+const resolveKanbanRuntimeResourceValue = (runtimeValue: any, initValue: any) => {
+  if (hasKanbanResourceValue(runtimeValue)) {
+    return runtimeValue;
+  }
+
+  return isKanbanRuntimeTemplateValue(initValue) ? undefined : initValue;
+};
+
 export const createColumnResource = (
   model: KanbanBlockModel,
   column: RuntimeColumn,
@@ -366,11 +378,13 @@ export const createColumnResource = (
 
   resource.setDataSourceKey(params.dataSourceKey);
   resource.setResourceName(params.associationName || params.collectionName);
-  if (params.sourceId !== undefined && params.sourceId !== null) {
-    resource.setSourceId(params.sourceId as any);
+  const sourceId = resolveKanbanRuntimeResourceValue(baseResource.getSourceId(), params.sourceId);
+  if (hasKanbanResourceValue(sourceId)) {
+    resource.setSourceId(sourceId as any);
   }
-  if (baseResource.getFilterByTk() !== undefined && baseResource.getFilterByTk() !== null) {
-    resource.setFilterByTk(baseResource.getFilterByTk());
+  const filterByTk = resolveKanbanRuntimeResourceValue(baseResource.getFilterByTk(), params.filterByTk);
+  if (hasKanbanResourceValue(filterByTk)) {
+    resource.setFilterByTk(filterByTk);
   }
   if (baseResource.getAppends()?.length) {
     resource.setAppends([...baseResource.getAppends()]);

--- a/packages/presets/nocobase/package.json
+++ b/packages/presets/nocobase/package.json
@@ -132,6 +132,7 @@
     "@nocobase/plugin-block-list",
     "@nocobase/plugin-block-grid-card",
     "@nocobase/plugin-block-markdown",
+    "@nocobase/plugin-block-tree",
     "@nocobase/plugin-calendar",
     "@nocobase/plugin-client",
     "@nocobase/plugin-collection-sql",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Kanban blocks can be displayed inside popups or secondary pages. When adding an associated kanban block in that context, the kanban column resource may receive runtime resource params such as `{{ctx.view.inputArgs.filterByTk}}`. If those expressions are not resolved before the column request is built, the server receives the raw template string and may fail with errors like `invalid input syntax for type bigint`.

### Description
This PR updates kanban column resource creation to inherit the resolved runtime `sourceId` and `filterByTk` from the base block resource. If a persisted runtime template has not been resolved, it is not copied into request params.

It also adds `@nocobase/plugin-block-tree` to the NocoBase preset plugin list.

Regression tests cover:
- using the resolved association `sourceId` from the base resource
- preventing unresolved runtime templates from entering column resource request params

Tested with:
- `yarn vitest packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/kanban-block.shared.test.ts packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts --run`
- `yarn vitest packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts --run`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed kanban associated blocks using unresolved runtime resource params in popup or secondary-page contexts. |
| 🇨🇳 Chinese | 修复弹窗或二级页面中关联看板区块使用未解析运行时资源参数的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
