### PR TITLE
fix: required option field in subtable not validated correctly on fir…

### DIFF
--- a/packages/core/client/src/flow/models/fields/mobile-components/MobileSelect.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/MobileSelect.tsx
@@ -13,7 +13,7 @@ import { Button, CheckList, Popup, SearchBar } from 'antd-mobile';
 import React, { useEffect, useMemo, useState } from 'react';
 
 export function MobileSelect(props) {
-  const { value, onChange, disabled, options = [], mode } = props;
+  const { value, onChange, onChangeComplete, disabled, options = [], mode } = props;
   const ctx = useFlowModelContext();
   const t = ctx.t;
   const [visible, setVisible] = useState(false);
@@ -28,6 +28,7 @@ export function MobileSelect(props) {
 
   const handleConfirm = () => {
     onChange(selected);
+    onChangeComplete?.();
     setVisible(false);
   };
   useEffect(() => {
@@ -36,12 +37,18 @@ export function MobileSelect(props) {
     } else {
       setSearchText(null);
     }
-  }, [visible]);
+  }, [visible, value]);
 
   return (
     <>
       <div onClick={() => !disabled && setVisible(true)}>
-        <Select {...props} dropdownStyle={{ display: 'none' }} showSearch={false} />
+        <Select
+          {...props}
+          open={false}
+          dropdownStyle={{ display: 'none' }}
+          showSearch={false}
+          style={{ pointerEvents: 'none', width: '100%' }}
+        />
       </div>
       <Popup
         visible={visible}
@@ -71,6 +78,7 @@ export function MobileSelect(props) {
               } else {
                 setSelected(val[0]);
                 onChange(val[0]);
+                onChangeComplete?.();
                 setVisible(false);
               }
             }}

--- a/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@nocobase/test/client';
+import { MobileSelect } from '../MobileSelect';
+
+const DEFAULT_OPTIONS = [
+  { label: 'Option A', value: 'a' },
+  { label: 'Option B', value: 'b' },
+];
+
+const mockState = vi.hoisted(() => ({
+  selectProps: undefined as any,
+  popupProps: undefined as any,
+  checklistProps: undefined as any,
+  confirmButtonProps: undefined as any,
+}));
+
+function resetMockState() {
+  mockState.selectProps = undefined;
+  mockState.popupProps = undefined;
+  mockState.checklistProps = undefined;
+  mockState.confirmButtonProps = undefined;
+}
+
+function clickTrigger() {
+  const trigger = screen.getByTestId('antd-select').parentElement as HTMLElement | null;
+  expect(trigger).toBeTruthy();
+  act(() => {
+    fireEvent.click(trigger as HTMLElement);
+  });
+}
+
+function openPopup() {
+  clickTrigger();
+  expect(screen.getByTestId('popup')).toBeInTheDocument();
+}
+
+function selectValues(values: string[]) {
+  act(() => {
+    mockState.checklistProps?.onChange?.(values);
+  });
+}
+
+function confirmSelection() {
+  act(() => {
+    mockState.confirmButtonProps?.onClick?.();
+  });
+}
+
+function renderMobileSelect(props: Record<string, any> = {}) {
+  const onChange = props.onChange ?? vi.fn();
+  const onChangeComplete = props.onChangeComplete ?? vi.fn();
+
+  render(
+    <MobileSelect
+      value={undefined}
+      options={DEFAULT_OPTIONS}
+      onChange={onChange}
+      onChangeComplete={onChangeComplete}
+      {...props}
+    />,
+  );
+
+  return { onChange, onChangeComplete };
+}
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<any>('@nocobase/flow-engine');
+  return {
+    ...actual,
+    useFlowModelContext: () => ({
+      t: (value: string) => value,
+    }),
+  };
+});
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<any>('antd');
+  return {
+    ...actual,
+    Select: (props: any) => {
+      mockState.selectProps = props;
+      return <div data-testid="antd-select" />;
+    },
+  };
+});
+
+vi.mock('antd-mobile', () => {
+  const MockCheckList: any = (props: any) => {
+    mockState.checklistProps = props;
+    return <div data-testid="checklist">{props.children}</div>;
+  };
+
+  MockCheckList.Item = ({ value, children }: any) => <div data-testid={`item-${value}`}>{children}</div>;
+
+  return {
+    Button: (props: any) => {
+      mockState.confirmButtonProps = props;
+      return (
+        <button type="button" data-testid="confirm" onClick={props.onClick}>
+          {props.children}
+        </button>
+      );
+    },
+    Popup: (props: any) => {
+      mockState.popupProps = props;
+      return props.visible ? <div data-testid="popup">{props.children}</div> : null;
+    },
+    SearchBar: ({ value, onChange }: any) => (
+      <input data-testid="search" value={value ?? ''} onChange={(e) => onChange?.(e.target.value)} />
+    ),
+    CheckList: MockCheckList,
+  };
+});
+
+describe('MobileSelect', () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  it('commits the selected value immediately in single mode', () => {
+    const { onChange, onChangeComplete } = renderMobileSelect();
+
+    openPopup();
+    selectValues(['a']);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('a');
+    expect(onChangeComplete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+  });
+
+  it('renders filtered options based on search text', () => {
+    const { onChange, onChangeComplete } = renderMobileSelect();
+    openPopup();
+    act(() => {
+      fireEvent.change(screen.getByTestId('search'), { target: { value: 'Option A' } });
+    });
+
+    expect(screen.getByTestId('item-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('item-b')).not.toBeInTheDocument();
+
+    selectValues(['a']);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('a');
+    expect(onChangeComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers commit until confirm in multiple mode', () => {
+    const { onChange, onChangeComplete } = renderMobileSelect({ value: [], mode: 'multiple' });
+    openPopup();
+
+    selectValues(['a', 'b']);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onChangeComplete).not.toHaveBeenCalled();
+
+    confirmSelection();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(['a', 'b']);
+    expect(onChangeComplete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+  });
+
+  it('does not open popup when disabled', () => {
+    renderMobileSelect({ disabled: true });
+
+    clickTrigger();
+    expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+  });
+});
+
+function SubTableCellHarness({ value, onCommit, mode }: { value: any; onCommit: (value: any) => void; mode?: string }) {
+  const pendingValueRef = React.useRef<any>(value);
+  return (
+    <div>
+      <MobileSelect
+        value={value}
+        mode={mode}
+        options={DEFAULT_OPTIONS}
+        onChange={(next) => {
+          pendingValueRef.current = next;
+          if (Array.isArray(next)) {
+            onCommit(next);
+          }
+        }}
+        onChangeComplete={() => {
+          onCommit(pendingValueRef.current);
+        }}
+      />
+    </div>
+  );
+}
+
+describe('MobileSelect in SubForm/SubTable containers', () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  it('SubTable: single selection commits final value via onChangeComplete', () => {
+    const onCommit = vi.fn();
+
+    render(<SubTableCellHarness value={undefined} onCommit={onCommit} />);
+
+    openPopup();
+    selectValues(['b']);
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('b');
+  });
+
+  it('SubTable: multiple mode only commits after confirm, and commit receives the full array', () => {
+    const onCommit = vi.fn();
+
+    render(<SubTableCellHarness value={[]} onCommit={onCommit} mode="multiple" />);
+
+    openPopup();
+    selectValues(['a', 'b']);
+    confirmSelection();
+
+    expect(onCommit).toHaveBeenCalledTimes(2);
+    expect(onCommit).toHaveBeenNthCalledWith(1, ['a', 'b']);
+    expect(onCommit).toHaveBeenNthCalledWith(2, ['a', 'b']);
+  });
+});


### PR DESCRIPTION
…st selection in mobile

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix required option field in subtable not validated correctly on first selection in mobile       |
| 🇨🇳 Chinese |    修复子表格中选项字段必填在移动端需选择两次才生效的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
