### PR TITLE
fix: prevent single-word wrapping in long text field of v1 kanban block

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/Kanban.Card.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/Kanban.Card.tsx
@@ -29,11 +29,17 @@ import { KanbanCardContext } from './context';
 
 const cardCss = css`
   text-wrap: wrap;
-  word-break: break-all;
-  word-wrap: break-word;
+  word-break: normal;
+  overflow-wrap: normal;
+  word-wrap: normal;
 
   .ant-card-body {
     padding: 16px;
+  }
+  .ant-description-textarea {
+    word-break: normal !important;
+    overflow-wrap: normal !important;
+    word-wrap: normal !important;
   }
   .nb-row-divider {
     height: 16px;
@@ -54,10 +60,11 @@ const cardCss = css`
       }
     }
   }
-  .ant-formily-item-control .ant-space-item: {
-    whitespace: normal;
-    wordbreak: break-all;
-    wordwrap: break-word;
+  .ant-formily-item-control .ant-space-item {
+    white-space: normal;
+    word-break: normal;
+    overflow-wrap: normal;
+    word-wrap: normal;
   }
   // .ant-formily-item-label {
   //   color: #8c8c8c;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix prevent single-word wrapping in long text field of v1 kanban block         |
| 🇨🇳 Chinese |  修复 v1 看板区块长文本字段中单个单词被换行的问题         |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
