### PR TITLE
fix: hide quick create option for association select field in v2 subt…

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/RecordSelectFieldModel.tsx
@@ -39,6 +39,7 @@ import { MobileLazySelect } from '../mobile-components/MobileLazySelect';
 import { BlockSceneEnum } from '../../base';
 import { ActionWithoutPermission } from '../../base/ActionModel';
 import { EditFormModel } from '../../blocks';
+import { hasAncestorModel } from './recordSelectSettingsUtils';
 
 function isPlainObject(val: unknown): val is Record<string, any> {
   return !!val && typeof val === 'object' && !Array.isArray(val);
@@ -816,6 +817,9 @@ RecordSelectFieldModel.registerFlow({
       },
       hideInSettings(ctx) {
         if (ctx?.blockModel?.constructor?.scene === BlockSceneEnum.filter) {
+          return true;
+        }
+        if (hasAncestorModel(ctx?.model, ['SubTableColumnModel', 'SubTableFieldModel'])) {
           return true;
         }
         return false;

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/recordSelectSettingsUtils.ts
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/recordSelectSettingsUtils.ts
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export function hasAncestorModel(model: any, modelNames: string[]) {
+  let cursor = model;
+  while (cursor) {
+    const modelName = cursor?.constructor?.name;
+    if (modelName && modelNames.includes(modelName)) {
+      return true;
+    }
+    cursor = cursor?.parent;
+  }
+  return false;
+}


### PR DESCRIPTION
…able

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix hide quick create option for association select field in v2 subtable        |
| 🇨🇳 Chinese |    修复 v2 子表格中关系字段下拉选项组件错误显示快捷编辑配置项的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
