### PR TITLE
feat(localization): add translation pack api and cli support

### DIFF
--- a/packages/core/cli/nocobase-ctl.config.json
+++ b/packages/core/cli/nocobase-ctl.config.json
@@ -215,6 +215,31 @@
         }
       }
     },
+    "localization": {
+      "name": "localization",
+      "description": "Manage localization translation packs and locale cache.",
+      "include": true,
+      "resources": {
+        "includes": ["localization"],
+        "excludes": [],
+        "overrides": {
+          "localization": {
+            "name": "localization",
+            "description": "Sync, export, import, and publish localization resources.",
+            "topLevel": true,
+            "operations": {
+              "includes": [
+                "localization:getSources",
+                "localization:sync",
+                "localization:export",
+                "localization:import",
+                "localization:publish"
+              ]
+            }
+          }
+        }
+      }
+    },
     "backup": {
       "name": "backup",
       "description": "Create, inspect, download, remove, and restore NocoBase backups.",
@@ -308,7 +333,7 @@
           "systemSettings": {
             "name": "system-settings",
             "description": "Manage global system settings.",
-            "topLevel": false
+            "topLevel": true
           }
         }
       }

--- a/packages/plugins/@nocobase/plugin-localization/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-localization/src/server/__tests__/actions.test.ts
@@ -131,5 +131,389 @@ describe('actions', () => {
       expect(resources2.test).toBeDefined();
       expect(resources2.test.text).toBe('translation');
     });
+
+    describe('translation packs', () => {
+      afterEach(async () => {
+        await clear();
+      });
+
+      it('should export translations by locale and module', async () => {
+        await repo.create({
+          values: [
+            {
+              module: 'resources.test',
+              text: 'text',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '文本',
+                },
+              ],
+            },
+            {
+              module: 'resources.test',
+              text: 'missing',
+              translations: [
+                {
+                  locale: 'en-US',
+                  translation: 'Missing',
+                },
+              ],
+            },
+            {
+              module: 'resources.other',
+              text: 'other',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '其他',
+                },
+              ],
+            },
+          ],
+        });
+
+        const res = await agent.resource('localization').export({
+          values: {
+            locale: 'zh-CN',
+            modules: ['test'],
+          },
+        });
+
+        expect(res.body.data).toMatchObject({
+          locale: 'zh-CN',
+          referenceLocale: 'en-US',
+          entries: [
+            {
+              module: 'resources.test',
+              text: 'missing',
+              translation: '',
+              referenceTranslation: 'Missing',
+            },
+            {
+              module: 'resources.test',
+              text: 'text',
+              translation: '文本',
+            },
+          ],
+        });
+      });
+
+      it('should export translated texts', async () => {
+        await repo.create({
+          values: [
+            {
+              module: 'resources.test',
+              text: 'translated',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '已翻译',
+                },
+              ],
+            },
+            {
+              module: 'resources.test',
+              text: 'missing',
+              translations: [
+                {
+                  locale: 'en-US',
+                  translation: 'Missing',
+                },
+              ],
+            },
+            {
+              module: 'resources.test',
+              text: 'empty',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '',
+                },
+                {
+                  locale: 'en-US',
+                  translation: 'Empty',
+                },
+              ],
+            },
+          ],
+        });
+
+        const res = await agent.resource('localization').export({
+          values: {
+            locale: 'zh-CN',
+            hasTranslation: true,
+          },
+        });
+
+        expect(res.body.data.entries).toEqual([
+          {
+            module: 'resources.test',
+            text: 'translated',
+            translation: '已翻译',
+          },
+        ]);
+      });
+
+      it('should export untranslated texts', async () => {
+        await repo.create({
+          values: [
+            {
+              module: 'resources.test',
+              text: 'translated',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '已翻译',
+                },
+              ],
+            },
+            {
+              module: 'resources.test',
+              text: 'missing',
+              translations: [
+                {
+                  locale: 'en-US',
+                  translation: 'Missing',
+                },
+              ],
+            },
+            {
+              module: 'resources.test',
+              text: 'empty',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '',
+                },
+                {
+                  locale: 'en-US',
+                  translation: 'Empty',
+                },
+              ],
+            },
+          ],
+        });
+
+        const res = await agent.resource('localization').export({
+          values: {
+            locale: 'zh-CN',
+            hasTranslation: false,
+            includeEmpty: true,
+          },
+        });
+
+        expect(res.body.data.entries).toEqual([
+          {
+            module: 'resources.test',
+            text: 'empty',
+            translation: '',
+            referenceTranslation: 'Empty',
+          },
+          {
+            module: 'resources.test',
+            text: 'missing',
+            translation: '',
+            referenceTranslation: 'Missing',
+          },
+        ]);
+      });
+
+      it('should import translations in createOnly mode without overwriting', async () => {
+        await repo.create({
+          values: [
+            {
+              module: 'resources.test',
+              text: 'exists',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '已有',
+                },
+              ],
+            },
+          ],
+        });
+
+        const res = await agent.resource('localization').import({
+          values: {
+            locale: 'zh-CN',
+            mode: 'createOnly',
+            entries: [
+              {
+                module: 'test',
+                text: 'exists',
+                translation: '覆盖',
+              },
+              {
+                module: 'test',
+                text: 'new',
+                translation: '新增',
+              },
+            ],
+          },
+        });
+
+        expect(res.body.data.summary).toMatchObject({
+          total: 2,
+          createdTexts: 1,
+          createdTranslations: 1,
+          updatedTranslations: 0,
+          skipped: 1,
+          invalid: 0,
+        });
+
+        const texts = await repo.find({
+          filter: {
+            module: 'resources.test',
+          },
+          sort: ['text'],
+          appends: ['translations'],
+        });
+        expect(texts.map((text) => text.text)).toEqual(['exists', 'new']);
+        expect(texts[0].translations[0].translation).toBe('已有');
+        expect(texts[1].translations[0].translation).toBe('新增');
+      });
+
+      it('should update translations in upsert mode and skip empty values', async () => {
+        await repo.create({
+          values: [
+            {
+              module: 'resources.test',
+              text: 'exists',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '旧值',
+                },
+              ],
+            },
+          ],
+        });
+
+        const res = await agent.resource('localization').import({
+          values: {
+            locale: 'zh-CN',
+            mode: 'upsert',
+            entries: [
+              {
+                module: 'resources.test',
+                text: 'exists',
+                translation: '新值',
+              },
+              {
+                module: 'resources.test',
+                text: 'empty',
+                translation: '',
+              },
+            ],
+          },
+        });
+
+        expect(res.body.data.summary).toMatchObject({
+          total: 2,
+          createdTexts: 0,
+          createdTranslations: 0,
+          updatedTranslations: 1,
+          skipped: 1,
+          invalid: 0,
+        });
+
+        const text = await repo.findOne({
+          filter: {
+            module: 'resources.test',
+            text: 'exists',
+          },
+          appends: ['translations'],
+        });
+        expect(text.translations[0].translation).toBe('新值');
+      });
+
+      it('should overwrite translations with empty values', async () => {
+        await repo.create({
+          values: [
+            {
+              module: 'resources.test',
+              text: 'exists',
+              translations: [
+                {
+                  locale: 'zh-CN',
+                  translation: '旧值',
+                },
+              ],
+            },
+          ],
+        });
+
+        const res = await agent.resource('localization').import({
+          values: {
+            locale: 'zh-CN',
+            mode: 'overwrite',
+            entries: [
+              {
+                module: 'resources.test',
+                text: 'exists',
+                translation: '',
+              },
+            ],
+          },
+        });
+
+        expect(res.body.data.summary.updatedTranslations).toBe(1);
+        const text = await repo.findOne({
+          filter: {
+            module: 'resources.test',
+            text: 'exists',
+          },
+          appends: ['translations'],
+        });
+        expect(text.translations[0].translation).toBe('');
+      });
+
+      it('should dry run imports without writing records', async () => {
+        const res = await agent.resource('localization').import({
+          values: {
+            locale: 'zh-CN',
+            dryRun: true,
+            entries: [
+              {
+                module: 'resources.test',
+                text: 'new',
+                translation: '新增',
+              },
+            ],
+          },
+        });
+
+        expect(res.body.data.summary).toMatchObject({
+          total: 1,
+          createdTexts: 1,
+          createdTranslations: 1,
+        });
+        expect(await repo.count()).toBe(0);
+      });
+
+      it('should publish imported translations', async () => {
+        const { resources } = await app.localeManager.get('zh-CN');
+        expect(resources.test).toBeUndefined();
+
+        await agent.resource('localization').import({
+          values: {
+            locale: 'zh-CN',
+            publish: true,
+            entries: [
+              {
+                module: 'resources.test',
+                text: 'published',
+                translation: '已发布',
+              },
+            ],
+          },
+        });
+
+        const { resources: publishedResources } = await app.localeManager.get('zh-CN');
+        expect(publishedResources.test.published).toBe('已发布');
+      });
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-localization/src/server/actions/localization.ts
+++ b/packages/plugins/@nocobase/plugin-localization/src/server/actions/localization.ts
@@ -8,8 +8,63 @@
  */
 
 import { Context, Next } from '@nocobase/actions';
-import { Model } from '@nocobase/database';
+import { Model, Op } from '@nocobase/database';
 import { PluginLocalizationServer } from '../plugin';
+
+type LocalizationPackEntry = {
+  module: string;
+  text: string;
+  translation?: string;
+  referenceTranslation?: string;
+};
+
+type NormalizedLocalizationPackEntry = {
+  module: string;
+  text: string;
+  translation: string;
+};
+
+type ImportMode = 'createOnly' | 'upsert' | 'overwrite';
+
+const normalizeModule = (module: string) => {
+  if (!module) {
+    return module;
+  }
+  return module.startsWith('resources.') ? module : `resources.${module}`;
+};
+
+const getActionValues = (ctx: Context) => ctx.action.params.values || ctx.request.body || {};
+
+const parseBoolean = (value: any) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return Boolean(value);
+};
+
+const getTranslationByLocale = (text: Model, locale: string) => {
+  const translations = text.get('translations') || text['translations'] || [];
+  return translations.find((translation) => {
+    return (translation?.get('locale') ?? translation?.locale) === locale;
+  });
+};
+
+const getTextKey = (module: string, text: string) => `${module}\0${text}`;
+
+const createSummary = () => ({
+  total: 0,
+  createdTexts: 0,
+  createdTranslations: 0,
+  updatedTranslations: 0,
+  skipped: 0,
+  invalid: 0,
+});
 
 const sync = async (ctx: Context, next: Next) => {
   const startTime = Date.now();
@@ -77,4 +132,236 @@ const getSources = async (ctx: Context, next: Next) => {
   await next();
 };
 
-export default { publish, sync, getSources };
+const exportPack = async (ctx: Context, next: Next) => {
+  const values = getActionValues(ctx);
+  const locale = values.locale || ctx.get('X-Locale') || 'en-US';
+  const referenceLocale = values.referenceLocale || 'en-US';
+  const modules = Array.isArray(values.modules) ? values.modules.map(normalizeModule).filter(Boolean) : [];
+  const hasTranslation = parseBoolean(values.hasTranslation);
+
+  const where: any = {};
+  if (modules.length) {
+    where.module = { [Op.in]: modules };
+  }
+
+  const texts = await ctx.db.getModel('localizationTexts').findAll({
+    include: [
+      {
+        association: 'translations',
+        where: {
+          locale: referenceLocale === locale ? locale : { [Op.in]: [locale, referenceLocale] },
+        },
+        required: false,
+      },
+    ],
+    where,
+    order: [
+      ['module', 'ASC'],
+      ['text', 'ASC'],
+    ],
+  });
+
+  const entries: LocalizationPackEntry[] = [];
+  for (const text of texts) {
+    const translation = getTranslationByLocale(text, locale);
+    const translationValue = translation?.get('translation') ?? translation?.translation;
+    const translated = translationValue !== undefined && translationValue !== null && translationValue !== '';
+    const untranslated = translationValue === undefined || translationValue === null || translationValue === '';
+
+    if (hasTranslation === true && !translated) {
+      continue;
+    }
+    if (hasTranslation === false && !untranslated) {
+      continue;
+    }
+
+    const entry: LocalizationPackEntry = {
+      module: text.get('module') as string,
+      text: text.get('text') as string,
+      translation: translationValue ?? '',
+    };
+    const referenceTranslation = getTranslationByLocale(text, referenceLocale);
+    const referenceTranslationValue = referenceTranslation?.get('translation') ?? referenceTranslation?.translation;
+    if (referenceTranslationValue !== undefined && referenceTranslationValue !== null) {
+      entry.referenceTranslation = referenceTranslationValue;
+    }
+    entries.push(entry);
+  }
+
+  ctx.body = {
+    locale,
+    referenceLocale,
+    entries,
+  };
+  await next();
+};
+
+const importPack = async (ctx: Context, next: Next) => {
+  const values = getActionValues(ctx);
+  const locale = values.locale || ctx.get('X-Locale') || 'en-US';
+  const mode = (values.mode || 'createOnly') as ImportMode;
+  const dryRun = parseBoolean(values.dryRun) === true;
+  const shouldPublish = parseBoolean(values.publish) === true;
+  const createTexts = parseBoolean(values.createTexts) !== false;
+  const entries = Array.isArray(values.entries) ? values.entries : [];
+  const summary = createSummary();
+  const errors = [];
+
+  if (!['createOnly', 'upsert', 'overwrite'].includes(mode)) {
+    ctx.throw(400, ctx.t('Invalid import mode.'));
+  }
+  if (!entries.length) {
+    ctx.throw(400, ctx.t('Please provide localization entries.'));
+  }
+
+  summary.total = entries.length;
+  const normalizedEntries: NormalizedLocalizationPackEntry[] = [];
+  const seen = new Set<string>();
+
+  entries.forEach((entry, index) => {
+    const module = normalizeModule(entry?.module);
+    const text = entry?.text;
+    const translation = entry?.translation;
+
+    if (!module || typeof text !== 'string' || translation === undefined || translation === null) {
+      summary.invalid += 1;
+      errors.push({ index, message: 'Invalid localization entry.' });
+      return;
+    }
+
+    const key = getTextKey(module, text);
+    if (seen.has(key)) {
+      summary.skipped += 1;
+      errors.push({ index, module, text, message: 'Duplicate localization entry.' });
+      return;
+    }
+    seen.add(key);
+
+    if (mode !== 'overwrite' && translation === '') {
+      summary.skipped += 1;
+      return;
+    }
+
+    normalizedEntries.push({
+      module,
+      text,
+      translation: String(translation),
+    });
+  });
+
+  const applyImport = async (transaction?: any) => {
+    const modules = [...new Set(normalizedEntries.map((entry) => entry.module))];
+    const entryTexts = [...new Set(normalizedEntries.map((entry) => entry.text))];
+    const texts = modules.length
+      ? await ctx.db.getModel('localizationTexts').findAll({
+          where: {
+            module: { [Op.in]: modules },
+            text: { [Op.in]: entryTexts },
+          },
+          transaction,
+        })
+      : [];
+    const textsMap = new Map<string, Model>();
+    texts.forEach((text: Model) =>
+      textsMap.set(getTextKey(text.get('module') as string, text.get('text') as string), text),
+    );
+
+    const textIds = texts.map((text: Model) => text.get('id'));
+    const translations = textIds.length
+      ? await ctx.db.getModel('localizationTranslations').findAll({
+          where: {
+            locale,
+            textId: { [Op.in]: textIds },
+          },
+          transaction,
+        })
+      : [];
+    const translationsMap = new Map<any, Model>();
+    translations.forEach((translation: Model) => translationsMap.set(translation.get('textId'), translation));
+
+    const newTexts: Model[] = [];
+    for (const entry of normalizedEntries) {
+      const key = getTextKey(entry.module, entry.text);
+      let text = textsMap.get(key);
+
+      if (!text) {
+        if (!createTexts) {
+          summary.skipped += 1;
+          continue;
+        }
+        summary.createdTexts += 1;
+        if (!dryRun) {
+          text = await ctx.db.getModel('localizationTexts').create(
+            {
+              module: entry.module,
+              text: entry.text,
+            },
+            { transaction },
+          );
+          textsMap.set(key, text);
+          newTexts.push(text);
+        }
+      }
+
+      const textId = text?.get('id');
+      const translation = textId ? translationsMap.get(textId) : undefined;
+
+      if (!translation) {
+        summary.createdTranslations += 1;
+        if (!dryRun && textId) {
+          const newTranslation = await ctx.db.getModel('localizationTranslations').create(
+            {
+              locale,
+              textId,
+              translation: entry.translation,
+            },
+            { transaction },
+          );
+          translationsMap.set(textId, newTranslation);
+        }
+        continue;
+      }
+
+      if (mode === 'createOnly') {
+        summary.skipped += 1;
+        continue;
+      }
+
+      summary.updatedTranslations += 1;
+      if (!dryRun) {
+        await translation.update({ translation: entry.translation }, { transaction });
+      }
+    }
+
+    if (!dryRun && newTexts.length) {
+      const plugin = ctx.app.pm.get('localization') as PluginLocalizationServer;
+      await plugin.resources.updateCacheTexts(newTexts, transaction);
+      plugin.sendSyncMessage(
+        {
+          type: 'updateCacheTexts',
+          texts: newTexts,
+        },
+        { transaction },
+      );
+    }
+  };
+
+  if (dryRun) {
+    await applyImport();
+  } else {
+    await ctx.db.sequelize.transaction(async (transaction) => {
+      await applyImport(transaction);
+    });
+    if (shouldPublish) {
+      ctx.app.localeManager.reload();
+    }
+  }
+
+  ctx.body = {
+    summary,
+    errors,
+  };
+  await next();
+};
+
+export default { publish, sync, getSources, export: exportPack, import: importPack };

--- a/packages/plugins/@nocobase/plugin-localization/src/swagger/index.json
+++ b/packages/plugins/@nocobase/plugin-localization/src/swagger/index.json
@@ -5,6 +5,35 @@
   },
   "tags": [],
   "paths": {
+    "/localization:getSources": {
+      "get": {
+        "tags": ["localization"],
+        "description": "List synchronization sources for localization resources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/localization:sync": {
       "post": {
         "tags": ["localization"],
@@ -25,14 +54,172 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "type": {
+                  "types": {
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["local", "menu", "db"]
+                      "enum": ["local", "db"]
                     }
                   }
                 }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/localization:export": {
+      "post": {
+        "tags": ["localization"],
+        "description": "Export localization translations as a portable translation pack",
+        "parameters": [
+          {
+            "name": "X-Locale",
+            "in": "header",
+            "defalut": "en-US",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "locale": {
+                    "type": "string"
+                  },
+                  "referenceLocale": {
+                    "type": "string",
+                    "default": "en-US"
+                  },
+                  "modules": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "hasTranslation": {
+                    "type": "boolean"
+                  },
+                  "includeEmpty": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "locale": {
+                      "type": "string"
+                    },
+                    "referenceLocale": {
+                      "type": "string"
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "module": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "translation": {
+                            "type": "string"
+                          },
+                          "referenceTranslation": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/localization:import": {
+      "post": {
+        "tags": ["localization"],
+        "description": "Import localization translations from a translation pack",
+        "parameters": [
+          {
+            "name": "X-Locale",
+            "in": "header",
+            "defalut": "en-US",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "locale": {
+                    "type": "string"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": ["createOnly", "upsert", "overwrite"],
+                    "default": "createOnly"
+                  },
+                  "dryRun": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "publish": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "createTexts": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "entries": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "module": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "translation": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["module", "text", "translation"]
+                    }
+                  }
+                },
+                "required": ["entries"]
               }
             }
           }

--- a/packages/plugins/@nocobase/plugin-system-settings/src/swagger/index.json
+++ b/packages/plugins/@nocobase/plugin-system-settings/src/swagger/index.json
@@ -16,10 +16,78 @@
         }
       }
     },
-    "/systemSettings:update": {
+    "/systemSettings:put": {
       "post": {
-        "description": "",
+        "description": "Update system settings. This command maps to the server-side systemSettings:put action and performs a partial update. Omitted fields remain unchanged.",
         "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "raw_title": {
+                    "type": "string",
+                    "description": "System title before localization rendering"
+                  },
+                  "showLogoOnly": {
+                    "type": "boolean",
+                    "description": "Whether to show only the logo without the system title"
+                  },
+                  "allowSignUp": {
+                    "type": "boolean",
+                    "description": "Whether self-service sign up is allowed"
+                  },
+                  "smsAuthEnabled": {
+                    "type": "boolean",
+                    "description": "Whether SMS authentication is enabled"
+                  },
+                  "logo": {
+                    "type": "object",
+                    "nullable": true,
+                    "description": "Logo attachment record",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "filename": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      },
+                      "extname": {
+                        "type": "string"
+                      },
+                      "mimetype": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "enabledLanguages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Enabled system languages"
+                  },
+                  "appLang": {
+                    "type": "string",
+                    "description": "Default application language"
+                  },
+                  "options": {
+                    "type": "object",
+                    "description": "Additional system settings options",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK"


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The localization workflow was missing a translation-pack export/import API surface and matching runtime CLI commands, which made it hard to move missing translations through a reviewable file-based process.

### Description 
Added localization translation-pack export/import actions, swagger definitions, and CLI runtime exposure for `nb api localization`.

Added translation import modes, dry-run summaries, missing-only export support with reference translations, and publish handling for localization packs.

Exposed `system-settings` as a top-level CLI resource and aligned its swagger update route with the existing `put` action so localization setup can enable target languages through `nb api system-settings put`.

Potential risk is concentrated in import mode behavior and CLI runtime generation; server tests were expanded around export/import flows and the commands were verified against a local environment.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added localization translation pack export/import commands and CLI support |
| 🇨🇳 Chinese | 新增本地化翻译包导入导出命令及对应 CLI 支持 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
