### PR TITLE
fix(client-v2): fix grid drag overlay

### DIFF
--- a/packages/core/client-v2/src/flow/models/base/GridModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/GridModel.tsx
@@ -118,6 +118,14 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
   private dragState?: DragState;
   private _memoItemFlowSettings?: Exclude<FlowModelRendererProps['showFlowSettings'], boolean>;
 
+  onInit(options) {
+    super.onInit(options);
+    // 历史数据里可能残留拖拽高亮框，初始化时立即清理，避免刷新页面后常驻显示。
+    if (this.props.dragOverlayRect) {
+      this.setProps('dragOverlayRect', null);
+    }
+  }
+
   private updateDragPointerPosition = (event: Event) => {
     if (!this.dragState) {
       return;
@@ -241,6 +249,12 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
 
   getGridLayout(): GridLayoutV2 {
     return this.normalizeLayoutFromSource();
+  }
+
+  serialize(): Record<string, any> {
+    const data = super.serialize();
+    data.props = _.omit(data.props, ['dragOverlayRect']);
+    return data;
   }
 
   syncLayoutProps(layout: GridLayoutV2) {
@@ -801,9 +815,15 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     this.setProps('dragOverlayRect', null);
   }
 
-  handleDragEnd(_event: DragEndEvent) {
+  handleDragEnd(event: DragEndEvent) {
     if (!this.dragState) {
       return;
+    }
+
+    const finalPoint = this.computePointerPosition(event);
+    if (finalPoint) {
+      const finalSlot = this.resolveDragSlot(finalPoint);
+      this.applyPreview(finalSlot);
     }
 
     const previewLayout = this.dragState.previewLayout;

--- a/packages/core/client-v2/src/flow/models/base/__tests__/GridModel.dragSnapshotContainer.test.ts
+++ b/packages/core/client-v2/src/flow/models/base/__tests__/GridModel.dragSnapshotContainer.test.ts
@@ -283,4 +283,102 @@ describe('GridModel drag snapshot container', () => {
       type: 'column',
     });
   });
+
+  it('clears persisted drag overlay on init', () => {
+    const model = engine.createModel<GridModel>({
+      use: 'GridModel',
+      uid: 'grid-hidden-stale-overlay',
+      props: {
+        dragOverlayRect: {
+          top: 10,
+          left: 20,
+          width: 100,
+          height: 40,
+          type: 'column',
+        },
+      },
+      structure: {} as any,
+    });
+
+    expect(model.props.dragOverlayRect).toBeNull();
+  });
+
+  it('omits drag overlay rect from serialized props', () => {
+    const model = engine.createModel<GridModel>({
+      use: 'GridModel',
+      uid: 'grid-serialize-overlay',
+      props: {
+        rowGap: 24,
+        dragOverlayRect: {
+          top: 10,
+          left: 20,
+          width: 100,
+          height: 40,
+          type: 'column',
+        },
+      },
+      structure: {} as any,
+    });
+
+    const serialized = model.serialize();
+
+    expect(serialized.props).toMatchObject({ rowGap: 24 });
+    expect(serialized.props).not.toHaveProperty('dragOverlayRect');
+  });
+
+  it('recomputes the final slot from drag end position before saving layout', () => {
+    const model = engine.createModel<GridModel>({
+      use: 'GridModel',
+      uid: 'grid-drag-final-slot',
+      props: {},
+      structure: {} as any,
+    });
+    const applyPreview = vi.fn((slot) => {
+      (model as any).dragState.previewLayout = slot
+        ? {
+            rows: { 'row-final': [['item-1']] },
+            sizes: { 'row-final': [24] },
+          }
+        : undefined;
+    });
+    const resolveDragSlot = vi.fn(() => ({
+      type: 'row-gap',
+      targetRowId: 'row-final',
+      position: 'below',
+      rect: { top: 200, left: 20, width: 440, height: 32 },
+    }));
+    const saveGridLayout = vi.fn();
+    const syncLayoutProps = vi.fn();
+    const finishDrag = vi.fn();
+
+    (model as any).applyPreview = applyPreview;
+    (model as any).resolveDragSlot = resolveDragSlot;
+    (model as any).saveGridLayout = saveGridLayout;
+    (model as any).syncLayoutProps = syncLayoutProps;
+    (model as any).finishDrag = finishDrag;
+    (model as any).dragState = {
+      sourceUid: 'item-1',
+      snapshot: { rows: {}, sizes: {} },
+      slots: [],
+      containerEl: null,
+      containerRect: { top: 0, left: 0, width: 0, height: 0 },
+      pointerOrigin: { x: 100, y: 100 },
+      activeSlotKey: null,
+      previewLayout: undefined,
+      refreshTimer: null,
+      generatedIds: new Map(),
+    };
+
+    model.handleDragEnd({
+      delta: { x: 30, y: 220 },
+    } as any);
+
+    expect(resolveDragSlot).toHaveBeenCalledWith({ x: 130, y: 320 });
+    expect(applyPreview).toHaveBeenCalledOnce();
+    expect(saveGridLayout).toHaveBeenCalledWith({
+      rows: { 'row-final': [['item-1']] },
+      sizes: { 'row-final': [24] },
+    });
+    expect(finishDrag).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/core/flow-engine/src/components/__tests__/gridDragPlanner.test.ts
+++ b/packages/core/flow-engine/src/components/__tests__/gridDragPlanner.test.ts
@@ -829,6 +829,52 @@ describe('simulateLayoutForSlot', () => {
     expect(nestedRows[1].sizes).toEqual([12, 12]);
   });
 
+  it('keeps nested column insertion target when removing a sibling collapses the original path', () => {
+    const layout = createLayout(
+      {
+        vyvfw2jw071: [['6ad3ccaabd5', 'ff8b4b57f65']],
+        ablhoqw51gb: [['21b422021b8']],
+      },
+      {
+        vyvfw2jw071: [24],
+        ablhoqw51gb: [24],
+      },
+      ['vyvfw2jw071', 'ablhoqw51gb'],
+    );
+    layout.layout = normalizeGridLayout({
+      rows: layout.rows,
+      sizes: layout.sizes,
+      rowOrder: layout.rowOrder,
+      itemUids: ['6ad3ccaabd5', 'ff8b4b57f65', '21b422021b8'],
+    });
+
+    const slot: LayoutSlot = {
+      type: 'column',
+      rowId: 'll5vo5pzj3u',
+      columnIndex: 0,
+      insertIndex: 1,
+      position: 'after',
+      path: [
+        { rowId: 'vyvfw2jw071', cellId: 'vyvfw2jw071:cell:0' },
+        { rowId: 'll5vo5pzj3u', cellId: 'ghy612j5zzg' },
+      ],
+      rect,
+    };
+
+    const result = simulateLayoutForSlot({ slot, sourceUid: 'ff8b4b57f65', layout });
+
+    expect(result.layout!.rows).toMatchObject([
+      {
+        id: 'vyvfw2jw071',
+        cells: [{ items: ['6ad3ccaabd5', 'ff8b4b57f65'] }],
+      },
+      {
+        id: 'ablhoqw51gb',
+        cells: [{ items: ['21b422021b8'] }],
+      },
+    ]);
+  });
+
   it('treats dragging an item to its own item-edge as no-op', () => {
     const layout = createLayout(
       {

--- a/packages/core/flow-engine/src/components/dnd/gridDragPlanner.ts
+++ b/packages/core/flow-engine/src/components/dnd/gridDragPlanner.ts
@@ -1146,6 +1146,21 @@ const findCellByPath = (layout: GridLayoutV2, path?: GridLayoutPath) => {
   return null;
 };
 
+const findCellByPathOrClosestAncestor = (layout: GridLayoutV2, path?: GridLayoutPath) => {
+  if (!path?.length) {
+    return null;
+  }
+
+  for (let length = path.length; length > 0; length -= 1) {
+    const target = findCellByPath(layout, path.slice(0, length));
+    if (target) {
+      return target;
+    }
+  }
+
+  return null;
+};
+
 const removeItemFromGridLayout = (layout: GridLayoutV2, sourceUid: string) => {
   const removeFromRows = (rows: GridRowV2[]): GridRowV2[] =>
     rows
@@ -1231,7 +1246,7 @@ const simulateGridLayoutForSlot = ({
 
   switch (slot.type) {
     case 'column': {
-      const target = findCellByPath(cloned, targetPath);
+      const target = findCellByPathOrClosestAncestor(cloned, targetPath);
       if (!target) {
         break;
       }
@@ -1247,7 +1262,7 @@ const simulateGridLayoutForSlot = ({
       break;
     }
     case 'empty-column': {
-      const target = findCellByPath(cloned, targetPath);
+      const target = findCellByPathOrClosestAncestor(cloned, targetPath);
       if (target) {
         delete target.cell.rows;
         target.cell.items = [sourceUid];
@@ -1255,7 +1270,7 @@ const simulateGridLayoutForSlot = ({
       break;
     }
     case 'column-edge': {
-      const target = findCellByPath(cloned, targetPath);
+      const target = findCellByPathOrClosestAncestor(cloned, targetPath);
       if (!target) {
         break;
       }
@@ -1282,7 +1297,7 @@ const simulateGridLayoutForSlot = ({
       if (!targetItemUid) {
         break;
       }
-      const target = findCellByPath(cloned, targetPath);
+      const target = findCellByPathOrClosestAncestor(cloned, targetPath);
       if (!target?.cell.items) {
         break;
       }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
- 修复 v2 页面区块拖拽时的两个回归问题：拖拽结束后区块可能落到错误位置，以及刷新页面后残留拖拽高亮框。

### Description 
- 在 `GridModel` 中补上 `drag end` 的最终落点重算，确保鼠标释放位置会参与最终布局保存。
- 修复嵌套 grid 列插入时的 layout 规划逻辑，避免目标路径因折叠失效后把区块错误追加到末尾。
- 清理历史残留的 `dragOverlayRect`，并在序列化时排除该临时状态，避免刷新页面后显示不该常驻的蓝色高亮框。
- 为最终落点重算、嵌套列插入、刷新清理高亮框补充回归测试。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the v2 page block drag placeholder and drop position issues |
| 🇨🇳 Chinese | 修复 v2 页面区块拖拽时占位高亮和落点错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
