### PR TITLE
fix: nginx outdated version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=app-builder /nocobase.tar.gz /nocobase.tar.gz
 
 FROM node:22-bookworm-slim as runtime
 ARG COMMIT_HASH
+ARG NGINX_VERSION=1.30.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates \
   && rm -rf /var/lib/apt/lists/*
@@ -45,7 +46,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/pgdg.asc] http://apt.postgresql.org
 RUN wget --quiet -O /usr/share/keyrings/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  nginx \
   libaio1 \
   postgresql-client-16 \
   postgresql-client-17 \
@@ -54,9 +54,37 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libgssapi-krb5-2 \
   fonts-liberation \
   fonts-noto-cjk \
+  wget \
+  build-essential \
+  libssl-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  libpcre3-dev \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /etc/nginx/sites-enabled/default
+RUN wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz -O /tmp/nginx.tar.gz \
+ && tar -zxvf /tmp/nginx.tar.gz -C /tmp \
+ && mv /tmp/nginx-${NGINX_VERSION} /tmp/nginx \
+ && rm -f /tmp/nginx.tar.gz
+
+RUN cd /tmp/nginx && ./configure \
+    --prefix=/usr/share/nginx \
+    --sbin-path=/usr/sbin/nginx \
+    --conf-path=/etc/nginx/nginx.conf \
+    --pid-path=/run/nginx.pid \
+    --lock-path=/run/lock/nginx.lock \
+    --error-log-path=/var/log/nginx/error.log \
+    --http-log-path=/var/log/nginx/access.log \
+    --modules-path=/usr/lib/nginx/modules \
+    --with-compat \
+    --with-http_ssl_module \
+ && make \
+ && make install \
+ && rm -rf /tmp/nginx
+
+RUN mkdir -p /etc/nginx/sites-enabled/ \
+ && rm -f /etc/nginx/sites-enabled/default
 COPY ./docker/nocobase/nocobase-docs.conf /etc/nginx/sites-enabled/nocobase-docs.conf
 COPY nocobase.tar.gz /app/nocobase.tar.gz
 COPY dist.tar.gz /app/nocobase-docs.tar.gz
@@ -69,5 +97,17 @@ RUN mkdir -p /app/nocobase/storage/uploads/ && \
 
 COPY ./docker/nocobase/docker-entrypoint.sh /app/
 RUN chmod +x /app/docker-entrypoint.sh
+
+RUN apt-get purge -y \
+    build-essential \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libpcre3-dev \
+    zlib1g-dev \
+    linux-libc-dev \
+ && apt-get autoremove -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 CMD ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The previous NGINX version (1.22.x) contains known security vulnerabilities that may impact service availability and security. This PR upgrades NGINX to a patched version to address these issues.

### Description 
This PR upgrades the NGINX version used in the build process.

Key changes:
- Upgraded NGINX from 1.22.x to `1.30.0`
- Fixed the following security vulnerabilities:
  - CVE-2026-32647 — Out-of-Bounds Read
  - CVE-2023-44487 — HTTP/2 Rapid Reset Attack

Potential risks:
- Possible compatibility issues with existing NGINX modules or configuration directives

Testing suggestions:
- Build the container image successfully
- Start the application and confirm NGINX initializes correctly
- Validate HTTP/HTTPS endpoints
- Validate HTTP/2 functionality
- Run vulnerability scanning to confirm the CVEs are no longer detected

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upgraded NGINX to a patched version to fix CVE-2026-32647 (Out-of-Bounds Read) and CVE-2023-44487 (HTTP/2 Rapid Reset Attack). |
| 🇨🇳 Chinese | 升级 NGINX 至已修复版本，修复 CVE-2026-32647（越界读取）和 CVE-2023-44487（HTTP/2 Rapid Reset 攻击）漏洞。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |   |
| 🇨🇳 Chinese |  |
