### PR TITLE
fix(table-v2): keep subtable required style schema-driven

### DIFF
--- a/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Decorator.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Decorator.tsx
@@ -86,7 +86,11 @@ export const TableColumnDecorator = (props) => {
 
   if (isInSubTable) {
     const path = field.path?.splice(field.path?.length - 1, 1);
-    const realField = field.form.query(`${path.concat(`*.` + fieldSchema.name)}`).take() as Field;
+    const realField = field.form.query(`${path.concat(`*.` + fieldSchema.name)}`).take() as Field & {
+      schema?: {
+        required?: boolean;
+      };
+    };
     // 子表格列头的星号只表示 schema 配置态的必填，不应跟随联动规则的运行时 required 校验态变化。
     required = typeof realField?.schema?.required === 'boolean' ? realField.schema.required : fieldSchema?.required;
   }

--- a/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Decorator.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/Table.Column.Decorator.tsx
@@ -87,7 +87,8 @@ export const TableColumnDecorator = (props) => {
   if (isInSubTable) {
     const path = field.path?.splice(field.path?.length - 1, 1);
     const realField = field.form.query(`${path.concat(`*.` + fieldSchema.name)}`).take() as Field;
-    required = typeof realField?.required === 'boolean' ? realField.required : fieldSchema?.required;
+    // 子表格列头的星号只表示 schema 配置态的必填，不应跟随联动规则的运行时 required 校验态变化。
+    required = typeof realField?.schema?.required === 'boolean' ? realField.schema.required : fieldSchema?.required;
   }
 
   useEffect(() => {

--- a/packages/core/client/src/schema-component/antd/table-v2/__tests__/Table.Column.Decorator.test.tsx
+++ b/packages/core/client/src/schema-component/antd/table-v2/__tests__/Table.Column.Decorator.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createForm } from '@formily/core';
+import { FieldContext, FormContext, SchemaContext, SchemaOptionsContext } from '@formily/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FlagProvider } from '../../../../flag-provider';
+import { BlockContext } from '../../../../block-provider/BlockProvider';
+import { CollectionContext } from '../../../../data-source/collection/CollectionProvider';
+import { CollectionManagerContext } from '../../../../data-source/collection/CollectionManagerProvider';
+import { SchemaComponentContext } from '../../../context';
+import { TableColumnDecorator } from '../Table.Column.Decorator';
+
+vi.mock('../__builtins__', () => ({
+  useToken: () => ({ token: { margin: 8, marginXS: 4 } }),
+}));
+
+vi.mock('../Table.Column.ActionBar', () => ({
+  designerCss: () => '',
+  TableColumnActionBar: () => null,
+}));
+
+const Designer = () => null;
+Designer.isNullComponent = true;
+
+describe('TableColumnDecorator', () => {
+  it('does not show required asterisk for subtable column when only runtime field.required becomes true', () => {
+    const form = createForm();
+    const columnField: any = {
+      title: '',
+      path: ['users', '0', 'name'],
+      form: {
+        query: vi.fn(() => ({
+          take: () => ({
+            required: true,
+            schema: { required: false },
+          }),
+        })),
+      },
+    };
+    const columnSchema: any = {
+      name: 'name',
+      required: false,
+      parent: {},
+      reduceProperties: (reducer) => reducer(null, { name: 'name', 'x-component': 'CollectionField' }),
+    };
+    const collection = {
+      getField: () => ({ uiSchema: { title: 'Name' } }),
+    } as any;
+    const collectionManager = {
+      getCollectionJoinField: () => null,
+    } as any;
+
+    render(
+      <FormContext.Provider value={form}>
+        <FieldContext.Provider value={columnField}>
+          <SchemaContext.Provider value={columnSchema}>
+            <SchemaOptionsContext.Provider value={{ components: {} }}>
+              <CollectionManagerContext.Provider value={collectionManager}>
+                <CollectionContext.Provider value={collection}>
+                  <SchemaComponentContext.Provider value={{ designable: false }}>
+                    <FlagProvider isInSubTable>
+                      <BlockContext.Provider value={{ name: 'table' } as any}>
+                        <TableColumnDecorator />
+                      </BlockContext.Provider>
+                    </FlagProvider>
+                  </SchemaComponentContext.Provider>
+                </CollectionContext.Provider>
+              </CollectionManagerContext.Provider>
+            </SchemaOptionsContext.Provider>
+          </SchemaContext.Provider>
+        </FieldContext.Provider>
+      </FormContext.Provider>,
+    );
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(document.querySelector('.ant-formily-item-asterisk')).toBeNull();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

v1 子表格的联动规则在切换字段“必填/不必填”时，会把运行时校验状态错误地同步到列头星号样式，导致界面表现与预期不一致。

### Description 

- 调整 v1 子表格列头必填星号的判断逻辑，只读取 schema 配置态的必填状态，不再跟随联动规则运行时的 required 校验状态变化
- 新增回归测试，覆盖“运行时 required 变为 true，但 schema.required 仍为 false 时不显示星号”的场景
- 风险较小，影响范围限定在 v1 子表格列头必填样式展示

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where v1 subtable linkage rules incorrectly change required field styles |
| 🇨🇳 Chinese | 修复 v1 子表格联动规则错误改变字段必填样式的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
