### PR TITLE
fix: validate plugin package names before filesystem operations

### DIFF
--- a/packages/core/server/src/__tests__/plugin-manager-utils.test.ts
+++ b/packages/core/server/src/__tests__/plugin-manager-utils.test.ts
@@ -1,0 +1,60 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import path from 'path';
+import {
+  assertSafePluginPackageName,
+  getNodeModulesPluginDir,
+  getStoragePluginDir,
+  removePluginPackage,
+  resolveSafeChildPath,
+} from '../plugin-manager/utils';
+
+describe('plugin-manager utils security', () => {
+  const oldNodeModulesPath = process.env.NODE_MODULES_PATH;
+  const oldPluginStoragePath = process.env.PLUGIN_STORAGE_PATH;
+
+  beforeEach(() => {
+    process.env.NODE_MODULES_PATH = '/tmp/node_modules';
+    process.env.PLUGIN_STORAGE_PATH = '/tmp/storage/plugins';
+  });
+
+  afterEach(() => {
+    process.env.NODE_MODULES_PATH = oldNodeModulesPath;
+    process.env.PLUGIN_STORAGE_PATH = oldPluginStoragePath;
+  });
+
+  test('accepts valid unscoped package names', () => {
+    expect(() => assertSafePluginPackageName('my-plugin')).not.toThrow();
+    expect(getStoragePluginDir('my-plugin')).toBe(path.resolve('/tmp/storage/plugins', 'my-plugin'));
+  });
+
+  test('accepts valid scoped package names', () => {
+    expect(() => assertSafePluginPackageName('@nocobase/plugin-acl')).not.toThrow();
+    expect(getNodeModulesPluginDir('@acme/plugin-demo')).toBe(path.resolve('/tmp/node_modules', '@acme/plugin-demo'));
+  });
+
+  test('rejects path traversal package names', async () => {
+    expect(() => assertSafePluginPackageName('../../../tmp/pwn')).toThrow('Invalid plugin package name');
+    expect(() => getStoragePluginDir('../../../tmp/pwn')).toThrow('Invalid plugin package name');
+    expect(() => getNodeModulesPluginDir('..\\..\\evil')).toThrow('Invalid plugin package name');
+    expect(() => removePluginPackage('../../../tmp/pwn')).toThrow('Invalid plugin package name');
+  });
+
+  test('rejects absolute path package names', () => {
+    expect(() => assertSafePluginPackageName('/etc/passwd')).toThrow('Invalid plugin package name');
+  });
+
+  test('resolveSafeChildPath keeps paths within base dir', () => {
+    expect(resolveSafeChildPath('/tmp/storage/plugins', '@scope/demo')).toBe(
+      path.resolve('/tmp/storage/plugins', '@scope/demo'),
+    );
+    expect(() => resolveSafeChildPath('/tmp/storage/plugins', '../../etc/passwd')).toThrow('Path traversal detected');
+  });
+});

--- a/packages/core/server/src/plugin-manager/utils.ts
+++ b/packages/core/server/src/plugin-manager/utils.ts
@@ -50,6 +50,40 @@ export function getPluginStoragePath() {
   return path.isAbsolute(pluginStoragePath) ? pluginStoragePath : path.join(process.cwd(), pluginStoragePath);
 }
 
+export function assertSafePluginPackageName(packageName: string) {
+  if (!packageName || typeof packageName !== 'string') {
+    throw new Error('Invalid plugin package name');
+  }
+
+  if (packageName.includes('\0')) {
+    throw new Error('Invalid plugin package name');
+  }
+
+  if (path.isAbsolute(packageName)) {
+    throw new Error('Invalid plugin package name');
+  }
+
+  if (packageName.includes('..') || packageName.includes('\\')) {
+    throw new Error('Invalid plugin package name');
+  }
+
+  const valid = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/i.test(packageName);
+  if (!valid) {
+    throw new Error('Invalid plugin package name');
+  }
+}
+
+export function resolveSafeChildPath(baseDir: string, child: string) {
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedTarget = path.resolve(baseDir, child);
+
+  if (resolvedTarget !== resolvedBase && !resolvedTarget.startsWith(`${resolvedBase}${path.sep}`)) {
+    throw new Error('Path traversal detected');
+  }
+
+  return resolvedTarget;
+}
+
 export function getLocalPluginPackagesPathArr(): string[] {
   const pluginPackagesPathArr = process.env.PLUGIN_PATH || DEFAULT_PLUGIN_PATH;
   return pluginPackagesPathArr.split(',').map((pluginPackagesPath) => {
@@ -60,7 +94,8 @@ export function getLocalPluginPackagesPathArr(): string[] {
 
 export function getStoragePluginDir(packageName: string) {
   const pluginStoragePath = getPluginStoragePath();
-  return path.join(pluginStoragePath, packageName);
+  assertSafePluginPackageName(packageName);
+  return resolveSafeChildPath(pluginStoragePath, packageName);
 }
 
 export function getLocalPluginDir(packageDirBasename: string) {
@@ -76,7 +111,8 @@ export function getLocalPluginDir(packageDirBasename: string) {
 }
 
 export function getNodeModulesPluginDir(packageName: string) {
-  return path.join(process.env.NODE_MODULES_PATH, packageName);
+  assertSafePluginPackageName(packageName);
+  return resolveSafeChildPath(process.env.NODE_MODULES_PATH, packageName);
 }
 
 export function getAuthorizationHeaders(registry?: string, authToken?: string) {
@@ -204,6 +240,7 @@ export async function downloadAndUnzipToTempDir(fileUrl: string, authToken?: str
   }
 
   const packageJson = await readJSONFileContent(packageJsonPath);
+  assertSafePluginPackageName(packageJson.name);
   const mainFile = path.join(tempPackageContentDir, packageJson.main);
   if (!fs.existsSync(mainFile)) {
     await removeTmpDir(tempFile, tempPackageContentDir);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | validate plugin package names before filesystem operations |
| 🇨🇳 Chinese |  验证插件包名称 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
