### PR TITLE
fix(kanban): constrain quick create popup templates

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts
@@ -1618,6 +1618,25 @@ describe('KanbanBlockModel.filterCollection', () => {
     );
   });
 
+  test('kanban model delegates openView handler to the global action', async () => {
+    const handler = vi.fn().mockResolvedValue('handled');
+    const ctx = {
+      engine: {
+        getAction: vi.fn().mockReturnValue({
+          name: 'openView',
+          handler,
+        }),
+      },
+    };
+
+    const result = await (KanbanBlockModel as any).actionRegistry.getAction('openView')?.handler?.(ctx, {
+      uid: 'popup-action-1',
+    });
+
+    expect(result).toBe('handled');
+    expect(handler).toHaveBeenCalledWith(ctx, { uid: 'popup-action-1' });
+  });
+
   test('block quick-create popup settings reject non add-new popup templates before delegating to openView', async () => {
     const flow: any = (KanbanBlockModel as any).globalFlowRegistry.getFlow('kanbanSettings');
     const step: any = flow?.steps?.popup;

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts
@@ -9,7 +9,12 @@
 
 import { KanbanBlockModel } from '../models';
 import { KanbanCardItemModel } from '../models/KanbanCardItemModel';
+import {
+  createKanbanQuickCreatePopupTemplateShadowCtx,
+  getKanbanQuickCreatePopupTemplateComponent,
+} from '../models/KanbanQuickCreatePopupTemplateSelect';
 import { FlowEngine } from '@nocobase/flow-engine';
+import { registerOpenViewPopupTemplateAction } from '../../../../plugin-ui-templates/src/client/openViewActionExtensions';
 
 describe('KanbanBlockModel.filterCollection', () => {
   test('defaults dragging to disabled for newly created blocks', () => {
@@ -1570,6 +1575,163 @@ describe('KanbanBlockModel.filterCollection', () => {
     });
     expect(ensureQuickCreateAction).toHaveBeenCalledTimes(1);
     expect(syncQuickCreateAction).toHaveBeenCalledWith({ uid: 'quick-create-action' });
+  });
+
+  test('kanban model wraps openView popup template selector without changing the global action', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ KanbanBlockModel });
+    const OriginalPopupTemplateSelect = () => null;
+    engine.registerActions({
+      openView: {
+        name: 'openView',
+        uiSchema: {
+          mode: { type: 'string' },
+          popupTemplateUid: {
+            type: 'string',
+            'x-component': OriginalPopupTemplateSelect,
+          },
+        },
+        handler: vi.fn(),
+      },
+    });
+
+    const model = engine.createModel<KanbanBlockModel>({
+      uid: 'kanban-open-view-action',
+      use: 'KanbanBlockModel',
+    });
+
+    const schema = await model.getAction('openView')?.uiSchema?.(model.context as any);
+
+    expect(engine.getAction('openView')?.uiSchema).toMatchObject({
+      popupTemplateUid: {
+        'x-component': OriginalPopupTemplateSelect,
+      },
+    });
+    expect(schema).toMatchObject({
+      mode: { type: 'string' },
+      popupTemplateUid: {
+        type: 'string',
+      },
+    });
+    expect(schema?.popupTemplateUid?.['x-component']).toBe(
+      getKanbanQuickCreatePopupTemplateComponent(OriginalPopupTemplateSelect),
+    );
+  });
+
+  test('block quick-create popup settings reject non add-new popup templates before delegating to openView', async () => {
+    const flow: any = (KanbanBlockModel as any).globalFlowRegistry.getFlow('kanbanSettings');
+    const step: any = flow?.steps?.popup;
+    const engine = new FlowEngine();
+    class RecordOnlyModel {
+      static _isScene(scene: string) {
+        return scene === 'record';
+      }
+    }
+    class CollectionOnlyModel {
+      static _isScene(scene: string) {
+        return scene === 'collection';
+      }
+    }
+    engine.registerModels({
+      KanbanBlockModel,
+      ViewActionModel: RecordOnlyModel,
+      KanbanQuickCreateActionModel: CollectionOnlyModel,
+    } as any);
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds?.addCollection({
+      name: 'posts',
+      filterTargetKey: 'id',
+      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+    });
+    const baseBeforeParamsSave = vi.fn(async () => {});
+    engine.registerActions({
+      openView: {
+        name: 'openView',
+        title: 'openView',
+        uiSchema: {
+          uid: { type: 'string' },
+        },
+        beforeParamsSave: baseBeforeParamsSave as any,
+        handler: vi.fn(async () => undefined) as any,
+      },
+    });
+    registerOpenViewPopupTemplateAction(engine);
+    const setProps = vi.fn();
+    const ensureQuickCreateAction = vi.fn().mockResolvedValue({ uid: 'quick-create-action' });
+    const syncQuickCreateAction = vi.fn().mockResolvedValue(undefined);
+    const model = engine.createModel<KanbanBlockModel>({
+      uid: 'kanban-quick-create-popup',
+      use: 'KanbanBlockModel',
+      stepParams: {
+        resourceSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'posts',
+          },
+        },
+      },
+    });
+    model.setProps = setProps as any;
+    model.ensureQuickCreateAction = ensureQuickCreateAction as any;
+    model.syncQuickCreateAction = syncQuickCreateAction as any;
+
+    const ctx: any = {
+      api: {
+        resource: (name: string) => {
+          if (name !== 'flowModelTemplates') {
+            throw new Error('unexpected resource');
+          }
+          return {
+            get: vi.fn().mockResolvedValue({
+              data: {
+                data: {
+                  uid: 'tpl-view',
+                  targetUid: 'popup-view',
+                  useModel: 'ViewActionModel',
+                  dataSourceKey: 'main',
+                  collectionName: 'posts',
+                },
+              },
+            }),
+          };
+        },
+      },
+      model,
+      engine,
+      t: (key: string) => key,
+    };
+
+    await expect(
+      step.beforeParamsSave(
+        ctx,
+        {
+          popupTemplateUid: 'tpl-view',
+          mode: 'dialog',
+          size: 'large',
+        },
+        {},
+      ),
+    ).rejects.toThrow('Cannot resolve template parameter');
+
+    expect(baseBeforeParamsSave).not.toHaveBeenCalled();
+    expect(setProps).not.toHaveBeenCalled();
+    expect(ensureQuickCreateAction).not.toHaveBeenCalled();
+    expect(syncQuickCreateAction).not.toHaveBeenCalled();
+  });
+
+  test('quick-create popup shadow context marks the settings scene as KanbanQuickCreateActionModel', () => {
+    const originalCtx: any = {
+      model: {
+        use: 'KanbanBlockModel',
+      },
+    };
+
+    const shadowCtx = createKanbanQuickCreatePopupTemplateShadowCtx(originalCtx);
+
+    expect(shadowCtx).not.toBe(originalCtx);
+    expect(shadowCtx.model).not.toBe(originalCtx.model);
+    expect(shadowCtx.model.use).toBe('KanbanQuickCreateActionModel');
+    expect(originalCtx.model.use).toBe('KanbanBlockModel');
   });
 
   test('block popup settings do not default the popup target uid back to the kanban block itself', async () => {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/__tests__/KanbanBlockModel.test.ts
@@ -14,7 +14,6 @@ import {
   getKanbanQuickCreatePopupTemplateComponent,
 } from '../models/KanbanQuickCreatePopupTemplateSelect';
 import { FlowEngine } from '@nocobase/flow-engine';
-import { registerOpenViewPopupTemplateAction } from '../../../../plugin-ui-templates/src/client/openViewActionExtensions';
 
 describe('KanbanBlockModel.filterCollection', () => {
   test('defaults dragging to disabled for newly created blocks', () => {
@@ -1635,107 +1634,6 @@ describe('KanbanBlockModel.filterCollection', () => {
 
     expect(result).toBe('handled');
     expect(handler).toHaveBeenCalledWith(ctx, { uid: 'popup-action-1' });
-  });
-
-  test('block quick-create popup settings reject non add-new popup templates before delegating to openView', async () => {
-    const flow: any = (KanbanBlockModel as any).globalFlowRegistry.getFlow('kanbanSettings');
-    const step: any = flow?.steps?.popup;
-    const engine = new FlowEngine();
-    class RecordOnlyModel {
-      static _isScene(scene: string) {
-        return scene === 'record';
-      }
-    }
-    class CollectionOnlyModel {
-      static _isScene(scene: string) {
-        return scene === 'collection';
-      }
-    }
-    engine.registerModels({
-      KanbanBlockModel,
-      ViewActionModel: RecordOnlyModel,
-      KanbanQuickCreateActionModel: CollectionOnlyModel,
-    } as any);
-    const ds = engine.dataSourceManager.getDataSource('main');
-    ds?.addCollection({
-      name: 'posts',
-      filterTargetKey: 'id',
-      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
-    });
-    const baseBeforeParamsSave = vi.fn(async () => {});
-    engine.registerActions({
-      openView: {
-        name: 'openView',
-        title: 'openView',
-        uiSchema: {
-          uid: { type: 'string' },
-        },
-        beforeParamsSave: baseBeforeParamsSave as any,
-        handler: vi.fn(async () => undefined) as any,
-      },
-    });
-    registerOpenViewPopupTemplateAction(engine);
-    const setProps = vi.fn();
-    const ensureQuickCreateAction = vi.fn().mockResolvedValue({ uid: 'quick-create-action' });
-    const syncQuickCreateAction = vi.fn().mockResolvedValue(undefined);
-    const model = engine.createModel<KanbanBlockModel>({
-      uid: 'kanban-quick-create-popup',
-      use: 'KanbanBlockModel',
-      stepParams: {
-        resourceSettings: {
-          init: {
-            dataSourceKey: 'main',
-            collectionName: 'posts',
-          },
-        },
-      },
-    });
-    model.setProps = setProps as any;
-    model.ensureQuickCreateAction = ensureQuickCreateAction as any;
-    model.syncQuickCreateAction = syncQuickCreateAction as any;
-
-    const ctx: any = {
-      api: {
-        resource: (name: string) => {
-          if (name !== 'flowModelTemplates') {
-            throw new Error('unexpected resource');
-          }
-          return {
-            get: vi.fn().mockResolvedValue({
-              data: {
-                data: {
-                  uid: 'tpl-view',
-                  targetUid: 'popup-view',
-                  useModel: 'ViewActionModel',
-                  dataSourceKey: 'main',
-                  collectionName: 'posts',
-                },
-              },
-            }),
-          };
-        },
-      },
-      model,
-      engine,
-      t: (key: string) => key,
-    };
-
-    await expect(
-      step.beforeParamsSave(
-        ctx,
-        {
-          popupTemplateUid: 'tpl-view',
-          mode: 'dialog',
-          size: 'large',
-        },
-        {},
-      ),
-    ).rejects.toThrow('Cannot resolve template parameter');
-
-    expect(baseBeforeParamsSave).not.toHaveBeenCalled();
-    expect(setProps).not.toHaveBeenCalled();
-    expect(ensureQuickCreateAction).not.toHaveBeenCalled();
-    expect(syncQuickCreateAction).not.toHaveBeenCalled();
   });
 
   test('quick-create popup shadow context marks the settings scene as KanbanQuickCreateActionModel', () => {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanBlockModel.tsx
@@ -262,6 +262,20 @@ const getKanbanBaseOpenViewAction = (ctx: any): ActionDefinition | undefined => 
   return ctx?.engine?.getAction?.('openView');
 };
 
+const resolveKanbanBaseOpenViewDefaultParams = async (ctx: any) => {
+  const defaultParams = getKanbanBaseOpenViewAction(ctx)?.defaultParams;
+  return typeof defaultParams === 'function' ? await defaultParams(ctx) : defaultParams;
+};
+
+const resolveKanbanBaseOpenViewHidden = async (ctx: any) => {
+  const hideInSettings = getKanbanBaseOpenViewAction(ctx)?.hideInSettings;
+  return typeof hideInSettings === 'function' ? await hideInSettings(ctx) : hideInSettings;
+};
+
+const runKanbanBaseOpenViewHandler = async (ctx: any, params: any) => {
+  return await getKanbanBaseOpenViewAction(ctx)?.handler?.(ctx, params);
+};
+
 const resolveKanbanQuickCreateOpenViewUiSchema = async (ctx: any) => {
   const actionSchema = getKanbanBaseOpenViewAction(ctx)?.uiSchema;
   const resolvedActionSchema =
@@ -1076,6 +1090,10 @@ export class KanbanBlockModel extends CollectionBlockModel<{
 
 KanbanBlockModel.registerAction({
   name: 'openView',
+  title: tExpr('Edit popup'),
+  defaultParams: resolveKanbanBaseOpenViewDefaultParams,
+  hideInSettings: resolveKanbanBaseOpenViewHidden,
+  handler: runKanbanBaseOpenViewHandler,
   async uiSchema(ctx: FlowSettingsContext) {
     return resolveKanbanQuickCreateOpenViewUiSchema(ctx);
   },

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanBlockModel.tsx
@@ -11,9 +11,11 @@ import { SettingOutlined } from '@ant-design/icons';
 import { CollectionBlockModel } from '@nocobase/client';
 import {
   AddSubModelButton,
+  type ActionDefinition,
   DndProvider,
   DragHandler,
   Droppable,
+  type FlowSettingsContext,
   FlowModelRenderer,
   FlowSettingsButton,
   MultiRecordResource,
@@ -30,6 +32,10 @@ import {
   normalizeKanbanPopupTemplateUid,
   resolveKanbanOpenViewDefaultParams,
 } from './popupSettings';
+import {
+  createKanbanQuickCreatePopupTemplateShadowCtx,
+  getKanbanQuickCreatePopupTemplateComponent,
+} from './KanbanQuickCreatePopupTemplateSelect';
 import {
   DEFAULT_KANBAN_COLUMN_WIDTH,
   DEFAULT_KANBAN_PAGE_SIZE,
@@ -250,6 +256,35 @@ const applyKanbanBlockPopupSettings = async (model: KanbanBlockModel, params: Re
 
   const action = await model.ensureQuickCreateAction();
   await model.syncQuickCreateAction(action);
+};
+
+const getKanbanBaseOpenViewAction = (ctx: any): ActionDefinition | undefined => {
+  return ctx?.engine?.getAction?.('openView');
+};
+
+const resolveKanbanQuickCreateOpenViewUiSchema = async (ctx: any) => {
+  const actionSchema = getKanbanBaseOpenViewAction(ctx)?.uiSchema;
+  const resolvedActionSchema =
+    typeof actionSchema === 'function' ? (await actionSchema(ctx)) || {} : (actionSchema as any) || {};
+  const popupTemplateField = resolvedActionSchema?.popupTemplateUid;
+  const popupTemplateComponent = popupTemplateField?.['x-component'];
+
+  if (!popupTemplateField || !popupTemplateComponent) {
+    return resolvedActionSchema;
+  }
+
+  const wrappedComponent = getKanbanQuickCreatePopupTemplateComponent(popupTemplateComponent);
+  if (wrappedComponent === popupTemplateComponent) {
+    return resolvedActionSchema;
+  }
+
+  return {
+    ...resolvedActionSchema,
+    popupTemplateUid: {
+      ...popupTemplateField,
+      'x-component': wrappedComponent,
+    },
+  };
 };
 
 const applyKanbanDragSortingSettings = (model: KanbanBlockModel, params: Record<string, any>) => {
@@ -1038,6 +1073,17 @@ export class KanbanBlockModel extends CollectionBlockModel<{
     return <KanbanBlockView model={this} />;
   }
 }
+
+KanbanBlockModel.registerAction({
+  name: 'openView',
+  async uiSchema(ctx: FlowSettingsContext) {
+    return resolveKanbanQuickCreateOpenViewUiSchema(ctx);
+  },
+  async beforeParamsSave(ctx: FlowSettingsContext, params: any, previousParams: any) {
+    const shadowCtx = createKanbanQuickCreatePopupTemplateShadowCtx(ctx);
+    await getKanbanBaseOpenViewAction(ctx)?.beforeParamsSave?.(shadowCtx, params, previousParams);
+  },
+});
 
 KanbanBlockModel.registerFlow({
   key: 'resourceSettings2',

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanCardItemModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanCardItemModel.tsx
@@ -169,6 +169,10 @@ export class KanbanCardItemModel extends FlowModel<KanbanCardItemStructure> {
     });
 
     const { colon, labelAlign, labelWidth, labelWrap, layout } = this.props;
+    const token = this.context.themeToken || {};
+    const cardBodyPaddingBlock = token.paddingContentVertical ?? 12;
+    const cardBodyPaddingInline = token.paddingContentHorizontal ?? 16;
+    const cardFieldGap = token.marginSM ?? 4;
     const clickEnabled = this.props.enableCardClick !== false;
     const clickable = clickEnabled && !!onCardClick;
     const handleCardClick = clickable
@@ -199,9 +203,18 @@ export class KanbanCardItemModel extends FlowModel<KanbanCardItemStructure> {
 
           .ant-card-body {
             height: 100%;
+            padding: ${cardBodyPaddingBlock}px ${cardBodyPaddingInline}px;
             display: flex;
             flex-direction: column;
             justify-content: space-between;
+          }
+
+          .ant-form-item {
+            margin-bottom: ${cardFieldGap}px;
+          }
+
+          .ant-form-item:last-child {
+            margin-bottom: 0;
           }
         `}
       >

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanQuickCreatePopupTemplateSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanQuickCreatePopupTemplateSelect.tsx
@@ -1,0 +1,58 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React, { useMemo } from 'react';
+import { FlowSettingsContextProvider, useFlowSettingsContext } from '@nocobase/flow-engine';
+
+export const createKanbanQuickCreatePopupTemplateShadowCtx = (ctx: any) => {
+  const shadowModel = Object.create(ctx?.model || {});
+  Object.defineProperty(shadowModel, 'use', {
+    value: 'KanbanQuickCreateActionModel',
+    configurable: true,
+  });
+
+  const shadowCtx = Object.create(ctx || {});
+  Object.defineProperty(shadowCtx, 'model', {
+    value: shadowModel,
+    configurable: true,
+  });
+
+  return shadowCtx;
+};
+
+const quickCreatePopupTemplateComponentCache = new WeakMap<object, React.ComponentType<any>>();
+
+export const getKanbanQuickCreatePopupTemplateComponent = (Component: any) => {
+  if (!Component || typeof Component === 'string' || typeof Component !== 'function') {
+    return Component;
+  }
+
+  const cacheKey = Component as object;
+  const cached = quickCreatePopupTemplateComponentCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const WrappedComponent = function KanbanQuickCreatePopupTemplateComponent(props: any) {
+    const ctx = useFlowSettingsContext();
+    const shadowCtx = useMemo(() => createKanbanQuickCreatePopupTemplateShadowCtx(ctx), [ctx]);
+
+    return (
+      <FlowSettingsContextProvider value={shadowCtx}>
+        <Component {...props} />
+      </FlowSettingsContextProvider>
+    );
+  };
+
+  WrappedComponent.displayName = `KanbanQuickCreatePopupTemplate(${
+    Component.displayName || Component.name || 'Component'
+  })`;
+  quickCreatePopupTemplateComponentCache.set(cacheKey, WrappedComponent);
+  return WrappedComponent;
+};

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/CardRenderer.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/CardRenderer.tsx
@@ -164,7 +164,7 @@ export const DraggableKanbanCard = memo(
             className={css`
               margin-bottom: 12px;
               backface-visibility: hidden;
-              contain: layout paint;
+              contain: layout;
             `}
           >
             <LazyCardRenderer


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Kanban quick-create popup settings should optimize popup template selection for the quick-create action scene, without changing the global openView action behavior.

### Description
Wrap the openView popup template selector for Kanban quick-create settings with a Kanban-specific shadow context, so template filtering resolves against `KanbanQuickCreateActionModel`.

Also tightens Kanban card spacing and adds regression coverage for the wrapped selector, invalid template rejection, and shadow context behavior.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved Kanban card compact styling and optimized quick-create popup template selection. |
| 🇨🇳 Chinese | 优化看板卡片紧凑样式，优化快速创建弹窗模板选择。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
