### PR TITLE
fix: adapt DividerItem to theme in v2

### DIFF
--- a/packages/core/client/src/flow/models/fields/DividerItemModel.tsx
+++ b/packages/core/client/src/flow/models/fields/DividerItemModel.tsx
@@ -8,25 +8,40 @@
  */
 
 import { FormItem } from '@nocobase/flow-engine';
-import { Divider } from 'antd';
+import { Divider, theme } from 'antd';
 import React from 'react';
 import { CommonItemModel } from '../base';
 import { NBColorPicker } from '../fields/ColorFieldModel';
 
+const resolveThemeColor = (value: string | undefined, fallback: string) => {
+  return value ? value : fallback;
+};
+
+const DividerItem = (props: any) => {
+  const { token } = theme.useToken();
+  const { color, borderColor, label, orientation, dashed } = props;
+
+  return (
+    <Divider
+      type="horizontal"
+      style={{
+        color: resolveThemeColor(color, token.colorText),
+        borderColor: resolveThemeColor(borderColor, token.colorSplit),
+      }}
+      orientationMargin="0"
+      orientation={orientation}
+      dashed={dashed}
+    >
+      {label}
+    </Divider>
+  );
+};
+
 export class DividerItemModel extends CommonItemModel {
   render() {
-    const { color, borderColor, label, orientation, dashed } = this.props;
     return (
       <FormItem shouldUpdate showLabel={false}>
-        <Divider
-          type="horizontal"
-          style={{ color, borderColor }}
-          orientationMargin="0"
-          orientation={orientation}
-          dashed={dashed}
-        >
-          {label}
-        </Divider>
+        <DividerItem {...this.props} />
       </FormItem>
     );
   }
@@ -38,12 +53,12 @@ DividerItemModel.registerFlow({
   steps: {
     title: {
       title: '{{t("Edit divider")}}',
-      defaultParams: {
+      defaultParams: (ctx) => ({
         label: '{{t("Text")}}',
         orientation: 'left',
-        color: 'rgba(0, 0, 0, 0.88)',
-        borderColor: 'rgba(5, 5, 5, 0.06)',
-      },
+        color: ctx.themeToken?.colorText,
+        borderColor: ctx.themeToken?.colorSplit,
+      }),
       uiSchema(ctx) {
         return {
           label: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix adapt DividerItem to theme in v2       |
| 🇨🇳 Chinese |     修复 v2 DividerItem 未适配主题的问题      |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
