### PR TITLE
fix: restore hidden reserved value field preview and assignment input

### DIFF
--- a/packages/core/client/src/flow/components/FieldAssignValueInput.tsx
+++ b/packages/core/client/src/flow/components/FieldAssignValueInput.tsx
@@ -485,6 +485,7 @@ type AssignValueFieldSource = {
 const ASSIGN_VALUE_IGNORED_PROP_KEYS = new Set([
   'value',
   'defaultValue',
+  'hidden',
   'onChange',
   'onClick',
   'open',

--- a/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
@@ -22,6 +22,7 @@ import { FieldModel } from '../../base';
 import { DetailsItemModel } from '../details/DetailsItemModel';
 import { EditFormModel } from './EditFormModel';
 import _ from 'lodash';
+import { Tooltip } from 'antd';
 import { coerceForToOneField } from '../../../internal/utils/associationValueCoercion';
 import { buildDynamicNamePath } from './dynamicNamePath';
 
@@ -99,54 +100,63 @@ export class FormItemModel<T extends DefaultStructure = DefaultStructure> extend
 
   renderItem() {
     const fieldModel = this.subModels.field as FieldModel;
-    // 行索引（来自数组子表单）
     const idx = this.context.fieldIndex;
     const fieldKey = this.context.fieldKey;
     const parentFieldPathArray = this.parent?.context.fieldPathArray || [];
+    const isHiddenReservedValuePreview =
+      !!this.context.flowSettingsEnabled && !!this.props.hidden && !this.hidden && !this.forbidden;
 
-    // 嵌套场景下继续传透，为字段子模型创建 fork
     const modelForRender =
-      idx != null
+      idx != null || isHiddenReservedValuePreview
         ? (() => {
-            const fork = fieldModel.createFork({}, `${fieldKey}`);
-            fork.context.defineProperty('fieldIndex', {
-              get: () => idx,
-            });
-            fork.context.defineProperty('fieldKey', {
-              get: () => fieldKey,
-            });
-            if (this.context.currentObject) {
-              fork.context.defineProperty('currentObject', {
-                get: () => this.context.currentObject,
+            const forkKey = isHiddenReservedValuePreview ? `${this.uid}:config-visible` : `${fieldKey}`;
+            const fork = fieldModel.createFork({}, forkKey);
+            if (idx != null) {
+              fork.context.defineProperty('fieldIndex', {
+                get: () => idx,
               });
+              fork.context.defineProperty('fieldKey', {
+                get: () => fieldKey,
+              });
+              if (this.context.currentObject) {
+                fork.context.defineProperty('currentObject', {
+                  get: () => this.context.currentObject,
+                });
+              }
+              const itemOptions = this.context.getPropertyOptions('item');
+              if (this.context.item) {
+                const { value: _value, ...rest } = (itemOptions || {}) as any;
+                fork.context.defineProperty('item', {
+                  ...rest,
+                  get: () => this.context.item,
+                  cache: false,
+                });
+              }
+              if (this.context.pattern) {
+                fork.context.defineProperty('pattern', {
+                  get: () => this.context.pattern,
+                });
+              }
             }
-            const itemOptions = this.context.getPropertyOptions('item');
-            if (this.context.item) {
-              const { value: _value, ...rest } = (itemOptions || {}) as any;
-              fork.context.defineProperty('item', {
-                ...rest,
-                get: () => this.context.item,
-                cache: false,
-              });
-            }
-            if (this.context.pattern) {
-              fork.context.defineProperty('pattern', {
-                get: () => this.context.pattern,
-              });
+            if (isHiddenReservedValuePreview) {
+              fork.setProps({ hidden: false });
             }
             return fork;
           })()
         : fieldModel;
     const mergedProps = this.context.pattern ? { ...this.props, pattern: this.context.pattern } : this.props;
-    const { initialValue, ...mergedPropsWithoutInitial } = mergedProps as any;
+    const { initialValue, hidden, ...mergedPropsWithoutInitial } = mergedProps as any;
+    const formItemProps = isHiddenReservedValuePreview
+      ? mergedPropsWithoutInitial
+      : { hidden, ...mergedPropsWithoutInitial };
     const fieldPath = buildDynamicNamePath(this.props.name, idx);
     this.context.defineProperty('fieldPathArray', {
       value: [...parentFieldPathArray, ..._.castArray(fieldPath)],
     });
     const record = this.context.item?.value || this.context.record;
-    return (
+    const content = (
       <FormItem
-        {...mergedPropsWithoutInitial}
+        {...formItemProps}
         name={fieldPath}
         validateFirst={true}
         disabled={
@@ -158,6 +168,16 @@ export class FormItemModel<T extends DefaultStructure = DefaultStructure> extend
         <FieldModelRenderer model={modelForRender} name={fieldPath} />
       </FormItem>
     );
+
+    if (isHiddenReservedValuePreview) {
+      return (
+        <Tooltip title={this.context.t('The field is hidden and only visible when the UI Editor is active')}>
+          <div style={{ opacity: 0.3 }}>{content}</div>
+        </Tooltip>
+      );
+    }
+
+    return content;
   }
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix regressions around `Hidden (reserved value)` in form blocks so editor behavior and field assignment stay usable.

### Description 
- Keep `Hidden (reserved value)` form fields visible in UI Editor mode with the hidden-state tooltip
- Preserve runtime hidden-reserved-value behavior outside UI Editor mode
- Prevent Field assignment value editors from inheriting the target field's `hidden` prop

Potential risk:
- The UI Editor preview path for form items now creates a visible fork when `props.hidden=true` and `model.hidden=false`, scoped to the hidden-reserved-value case

Testing suggestions:
- In a form block, set a field to `Hidden (reserved value)` through linkage rules and verify it still appears in UI Editor with the tooltip
- In runtime mode, verify the same field remains hidden while preserving its value
- In Field assignment, verify the same target field still shows the value input and accepts values

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed `Hidden (reserved value)` fields in form blocks so they remain visible in UI Editor mode, and restored value input support for assigning them in Field assignment |
| 🇨🇳 Chinese | 修复表单区块中设置为 `隐藏并保留值` 的字段在页面编辑模式下不显示的问题，并恢复在字段赋值中为这类字段设置值的输入能力 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
