### PR TITLE
fix: limit association field nesting in table field menus

### DIFF
--- a/packages/core/client/src/flow/models/base/AssociationFieldGroupModel.tsx
+++ b/packages/core/client/src/flow/models/base/AssociationFieldGroupModel.tsx
@@ -11,9 +11,14 @@ import { Collection, DisplayItemModel, FlowModel, FlowModelContext } from '@noco
 
 export class AssociationFieldGroupModel extends FlowModel {
   static itemModelName = 'DetailsItemModel';
+  static maxAssociationDepth?: number;
   static defineChildren(ctx: FlowModelContext) {
     const itemModel = this.itemModelName;
-    const displayAssociationFields = (targetCollection: Collection, fieldPath = '') => {
+    const maxAssociationDepth =
+      typeof this.maxAssociationDepth === 'number' && this.maxAssociationDepth > 0
+        ? this.maxAssociationDepth
+        : Number.POSITIVE_INFINITY;
+    const displayAssociationFields = (targetCollection: Collection, fieldPath = '', associationDepth = 1) => {
       return targetCollection
         .getToOneAssociationFields()
         .map((field) => {
@@ -28,7 +33,7 @@ export class AssociationFieldGroupModel extends FlowModel {
             key: `${fPath}-assocationField`,
             label: field.title,
             children: () => {
-              return [
+              const groups = [
                 {
                   key: `${fPath}-children-collectionField`,
                   // @ts-ignore
@@ -77,13 +82,20 @@ export class AssociationFieldGroupModel extends FlowModel {
                     })
                     .filter(Boolean),
                 },
-                {
+              ];
+
+              if (associationDepth < maxAssociationDepth) {
+                groups.push({
                   key: `${fPath}-children-associationField`,
                   label: 'Display association fields',
                   type: 'group',
-                  children: (displayAssociationFields(field.targetCollection, fPath) || []).filter(Boolean),
-                },
-              ];
+                  children: (
+                    displayAssociationFields(field.targetCollection, fPath, associationDepth + 1) || []
+                  ).filter(Boolean),
+                });
+              }
+
+              return groups;
             },
           };
         })

--- a/packages/core/client/src/flow/models/base/__tests__/AssociationFieldGroupModel.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/AssociationFieldGroupModel.test.ts
@@ -1,0 +1,105 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { DisplayItemModel, FlowEngine } from '@nocobase/flow-engine';
+import { AssociationFieldGroupModel } from '../AssociationFieldGroupModel';
+
+class LimitedAssociationFieldGroupModel extends AssociationFieldGroupModel {
+  static itemModelName = 'TableColumnModel';
+  static maxAssociationDepth = 2;
+}
+
+describe('AssociationFieldGroupModel depth control', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('limits table association field nesting to relation / relation / normal field', async () => {
+    vi.spyOn(DisplayItemModel, 'getDefaultBindingByField').mockReturnValue({
+      modelName: 'MockFieldModel',
+    } as any);
+
+    const engine = new FlowEngine();
+    const ds = engine.dataSourceManager.getDataSource('main');
+
+    ds.addCollection({
+      name: 'profiles',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'nickname', title: 'Nickname', type: 'string', interface: 'input' },
+      ],
+    });
+    ds.addCollection({
+      name: 'users',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'name', title: 'Name', type: 'string', interface: 'input' },
+        { name: 'profile_id', type: 'integer', interface: 'number' },
+        {
+          name: 'profile',
+          title: 'Profile',
+          type: 'belongsTo',
+          target: 'profiles',
+          interface: 'm2o',
+          foreignKey: 'profile_id',
+        },
+      ],
+    });
+    ds.addCollection({
+      name: 'posts',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'title', title: 'Title', type: 'string', interface: 'input' },
+        { name: 'user_id', type: 'integer', interface: 'number' },
+        {
+          name: 'user',
+          title: 'User',
+          type: 'belongsTo',
+          target: 'users',
+          interface: 'm2o',
+          foreignKey: 'user_id',
+        },
+      ],
+    });
+
+    const posts = ds.getCollection('posts');
+    const ctx = {
+      collection: posts,
+      blockModel: {
+        context: {
+          collection: posts,
+        },
+      },
+      t: (value: string) => value,
+      engine,
+    } as any;
+
+    const children = LimitedAssociationFieldGroupModel.defineChildren(ctx) as any[];
+    expect(children).toHaveLength(1);
+
+    const firstLevelGroups = children[0].children();
+    const associationGroup = firstLevelGroups.find((group) => group.key === 'user-children-associationField');
+    expect(associationGroup).toBeTruthy();
+
+    const secondLevelChildren = associationGroup.children;
+    expect(secondLevelChildren).toHaveLength(1);
+    expect(secondLevelChildren[0].key).toBe('user.profile-assocationField');
+
+    const secondLevelGroups = secondLevelChildren[0].children();
+    const nestedAssociationGroup = secondLevelGroups.find(
+      (group) => group.key === 'user.profile-children-associationField',
+    );
+    expect(nestedAssociationGroup).toBeUndefined();
+
+    const fieldGroup = secondLevelGroups.find((group) => group.key === 'user.profile-children-collectionField');
+    expect(fieldGroup).toBeTruthy();
+    expect(fieldGroup.children.some((item) => item.key === 'c-user.profile.nickname')).toBe(true);
+  });
+});

--- a/packages/core/client/src/flow/models/blocks/table/TableAssociationFieldGroupModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableAssociationFieldGroupModel.tsx
@@ -11,6 +11,7 @@ import { AssociationFieldGroupModel } from '../../base';
 
 export class TableAssociationFieldGroupModel extends AssociationFieldGroupModel {
   static itemModelName = 'TableColumnModel';
+  static maxAssociationDepth = 2;
 }
 
 TableAssociationFieldGroupModel.define({


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Task 3158 reported that table field selection for association fields should stop at `relation / relation / normal field` and must not keep drilling deeper.

### Description 
This PR adds configurable association-depth limiting to the shared association field group builder and applies a depth cap of 2 for table field menus.
It keeps the existing recursive structure reusable while ensuring table scenarios only allow `relation / relation / normal field`.
A regression test was added to cover the new depth rule.

Tests:
- `./node_modules/.bin/vitest --run packages/core/client/src/flow/models/base/__tests__/AssociationFieldGroupModel.test.ts`
- `./node_modules/.bin/vitest --run packages/core/client/src/flow/models/blocks/utils/__tests__/transformChildrenToJS.test.ts`

Potential risks:
- The shared builder now supports depth limits, so other scenes should remain unchanged unless they explicitly set `maxAssociationDepth`.

### Related issues
- Task 3158
- https://forum.nocobase.com/t/v2/11495/2

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed table association field menus so nested selection stops at `relation / relation / normal field` and does not continue into deeper relations |
| 🇨🇳 Chinese | 修复表格中关联字段的选择层级，限制为“关系字段 / 关系字段 / 普通字段”，不再继续深入更深层关系 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
