### PR TITLE
fix(ai): ai employee instruction can`t get attachments which is assoc…

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/files.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/files.ts
@@ -29,7 +29,9 @@ export abstract class Files {
           if (!repository) {
             throw new Error(`Attachment collection [${collection}] not existed`);
           }
-          const attachmentKeys = attachmentGroup[collection as string]?.map((it) => it.value);
+          const attachmentKeys = attachmentGroup[collection as string]?.flatMap((it) =>
+            _.isArray(it.value) ? it.value : [it.value],
+          );
           const attachmentModels = await repository.find({
             filter: {
               id: {
@@ -49,13 +51,14 @@ export abstract class Files {
     };
 
     const resolveUrls = async (files: AIEmployeeInstructionFiles[]) => {
-      const urls = files.filter((it) => it.type === 'file_url');
-      if (urls.length) {
+      const attachmentFiles = files.filter((it) => it.type === 'file_url');
+      if (attachmentFiles.length) {
+        const urls = attachmentFiles.flatMap(({ value }) => (_.isArray(value) ? value : [value]));
         const fileManager = plugin.pm.get('file-manager') as PluginFileManagerServer;
         const settings = await plugin.db.getRepository('aiSettings').findOne();
         const storageName = settings?.options?.storage;
         const attachments = await Promise.all(
-          urls.map(async ({ value: url }) => {
+          urls.map(async (url) => {
             const response = await axios.get(url, {
               responseType: 'arraybuffer',
             });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/types.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/types.ts
@@ -32,5 +32,5 @@ export type AIEmployeeInstructionConfig = {
 export type AIEmployeeInstructionFiles = {
   type: 'file_id' | 'file_url';
   collection?: string;
-  value: string;
+  value: string | string[];
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix AI employee node reading associations field attachment error in workflow |
| 🇨🇳 Chinese | 修复工作流 AI 员工节点读取关系字段附件报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
