### PR TITLE
fix(ai): ai employee tools filter should not exclude system tools

### DIFF
--- a/packages/core/ai/src/tools-manager/index.ts
+++ b/packages/core/ai/src/tools-manager/index.ts
@@ -105,4 +105,12 @@ export function defineTools(options: ToolsOptions) {
   return options;
 }
 
+export const SYSTEM_TOOLS = {
+  WEB_SEARCH: 'subAgentWebSearch',
+  KNOWLEDGE_BASE: 'knowledge-base-retrieve',
+  WORK_FLOW_TASK_OUTPUT: 'aiEmployeeWorkflowTaskOutput',
+};
+
+export const listSystemTools = () => Object.values(SYSTEM_TOOLS);
+
 export * from './types';

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -28,7 +28,7 @@ import {
   toolInteractionMiddleware,
   workflowHistoryMiddleware,
 } from './middleware';
-import { SkillsEntry, ToolsEntry, ToolsFilter, ToolsManager } from '@nocobase/ai';
+import { listSystemTools, SkillsEntry, SYSTEM_TOOLS, ToolsEntry, ToolsFilter, ToolsManager } from '@nocobase/ai';
 import { AIToolMessage } from '../types/ai-message.type';
 import { SequelizeCollectionSaver } from './checkpoints';
 import { createAgent as createLangChainAgent } from 'langchain';
@@ -1334,17 +1334,17 @@ If information is missing, clearly state it in the summary.</Important>`;
   private async getAIEmployeeTools() {
     const tools: ToolsEntry[] = await this.listTools({ scope: 'GENERAL' });
     if (this.webSearch === true) {
-      const subAgentWebSearch = await this.toolsManager.getTools('subAgentWebSearch');
+      const subAgentWebSearch = await this.toolsManager.getTools(SYSTEM_TOOLS.WEB_SEARCH);
       tools.push(subAgentWebSearch);
     }
     const generalToolsNameSet = new Set(tools.map((x) => x.definition.name));
     const toolMap = await this.getToolsMap();
-    const employeeTools = this.employee.skillSettings?.tools ?? [];
-    employeeTools.push(...this.tools);
+    const settingsTools = this.employee.skillSettings?.tools ?? [];
+    const employeeTools = [...settingsTools, ...this.tools];
     if (await this.plugin.knowledgeBaseManager.isEnabledKnowledgeBase(this.employee.toJSON() as AIEmployeeType)) {
-      const knowledgeBaseRetrieveTool = await this.toolsManager.getTools('knowledge-base-retrieve');
+      const knowledgeBaseRetrieveTool = await this.toolsManager.getTools(SYSTEM_TOOLS.KNOWLEDGE_BASE);
       if (knowledgeBaseRetrieveTool) {
-        employeeTools.push({ name: 'knowledge-base-retrieve' });
+        employeeTools.push({ name: SYSTEM_TOOLS.KNOWLEDGE_BASE });
       }
     }
     for (const toolSetting of employeeTools) {
@@ -1357,15 +1357,19 @@ If information is missing, clearly state it in the summary.</Important>`;
       }
       tools.push(tool);
     }
+    const systemTools = listSystemTools();
     if (!this.skillSettings) {
       return tools;
     } else if (!this.skillSettings.toolsVersion) {
       const toolFilter = this.skillSettings.tools ?? [];
-      return tools.filter((t) => toolFilter.length === 0 || toolFilter.includes(t.definition.name));
+      return tools.filter(
+        (t) =>
+          toolFilter.length === 0 || systemTools.includes(t.definition.name) || toolFilter.includes(t.definition.name),
+      );
     } else {
       const toolFilter = this.skillSettings.tools;
       if (_.isArray(toolFilter)) {
-        return tools.filter((t) => toolFilter.includes(t.definition.name));
+        return tools.filter((t) => systemTools.includes(t.definition.name) || toolFilter.includes(t.definition.name));
       } else {
         return tools;
       }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
@@ -14,6 +14,7 @@ import { AIEmployee } from '../../../ai-employees/ai-employee';
 import { AIEmployeeInstructionConfig } from './types';
 import { Files } from './files';
 import { isValidFilter } from '@nocobase/utils';
+import { SYSTEM_TOOLS } from '@nocobase/ai';
 
 export class AIEmployeeInstruction extends Instruction {
   async run(node: FlowNodeModel, input: any, processor: Processor) {
@@ -28,7 +29,7 @@ export class AIEmployeeInstruction extends Instruction {
       files,
     }: AIEmployeeInstructionConfig = processor.getParsedValue(node.config, node.id);
 
-    const toolName = 'aiEmployeeWorkflowTaskOutput';
+    const toolName = SYSTEM_TOOLS.WORK_FLOW_TASK_OUTPUT;
     const workflowSystemPrompt = `
 You are operating inside a workflow.
 Your job is to complete the workflow task and return the final outcome to the workflow, not to reply freely as a normal assistant.
@@ -160,8 +161,8 @@ Do not treat **${toolName}** as optional, and do not finish the task without cal
                     role: 'user',
                     content: {
                       type: 'text',
-                      content: `You failed to call the required tool "aiEmployeeWorkflowTaskOutput" in your previous response.
-Call "aiEmployeeWorkflowTaskOutput" now to submit the workflow outcome.
+                      content: `You failed to call the required tool "${SYSTEM_TOOLS.WORK_FLOW_TASK_OUTPUT}" in your previous response.
+Call "${SYSTEM_TOOLS.WORK_FLOW_TASK_OUTPUT}" now to submit the workflow outcome.
 Do not send another normal assistant response without invoking it.
                   `,
                     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix workflow AI employee node not ending properly after tool assignment. |
| 🇨🇳 Chinese |  修复工作流 AI 员工节点指定使用工具后无法正常结束节点调用  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
