### PR TITLE
fix(plugin-file-manager): fix filename is not correct when download from attachment url field

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -38,6 +38,7 @@ import { useProps } from '../../hooks/useProps';
 import {
   FILE_SIZE_LIMIT_DEFAULT,
   attachmentFileTypes,
+  getFileDownloadName,
   getThumbnailPlaceholderURL,
   matchMimetype,
   normalizeFile,
@@ -96,7 +97,7 @@ attachmentFileTypes.add({
       (e) => {
         e.preventDefault();
         const file = list[index];
-        saveAs(file.url, `${file.title}${file.extname}`);
+        saveAs(file.url, getFileDownloadName(file));
       },
       [index, list],
     );
@@ -203,9 +204,9 @@ function IframePreviewer({ index, list, onSwitchIndex }) {
     (e) => {
       e.preventDefault();
       e.stopPropagation();
-      saveAs(url, `${file.title}${file.extname}`);
+      saveAs(url, getFileDownloadName(file));
     },
-    [file.extname, file.title, url],
+    [file, url],
   );
   const onClose = useCallback(() => {
     onSwitchIndex(null);
@@ -356,7 +357,7 @@ function AttachmentListItem(props) {
     propsOnDelete?.(file);
   }, [file, propsOnDelete]);
   const onDownload = useCallback(() => {
-    saveAs(file.url, `${file.title}${file.extname}`);
+    saveAs(file.url, getFileDownloadName(file));
   }, [file]);
   const { ThumbnailPreviewer = DefaultThumbnailPreviewer } = attachmentFileTypes.getTypeByFile(file) ?? {};
   const item = [

--- a/packages/core/client/src/schema-component/antd/upload/__tests__/shared.test.ts
+++ b/packages/core/client/src/schema-component/antd/upload/__tests__/shared.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getFileDownloadName, toFileList } from '../shared';
+
+describe('upload shared helpers', () => {
+  it('应为仅包含 URL 的值补齐 title、filename 和 extname', () => {
+    const [file] = toFileList('https://example.com/folder/report%20final.jpg?token=1');
+
+    expect(file.title).toBe('report final');
+    expect(file.filename).toBe('report final.jpg');
+    expect(file.extname).toBe('.jpg');
+  });
+
+  it('应为仅包含 URL 的文件生成可下载文件名', () => {
+    expect(getFileDownloadName({ url: 'https://example.com/folder/report%20final.jpg?token=1' })).toBe(
+      'report final.jpg',
+    );
+  });
+
+  it('应优先保留已有 filename', () => {
+    expect(
+      getFileDownloadName({
+        url: 'https://example.com/folder/other.jpg?token=1',
+        filename: 'custom-name.png',
+      }),
+    ).toBe('custom-name.png');
+  });
+});

--- a/packages/core/client/src/schema-component/antd/upload/shared.ts
+++ b/packages/core/client/src/schema-component/antd/upload/shared.ts
@@ -43,6 +43,50 @@ export interface AttachmentFileType {
   Previewer?: React.ComponentType<PreviewerProps>;
 }
 
+const stripQueryAndHash = (value?: string) => value?.split('?')[0].split('#')[0] || '';
+
+const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    return value;
+  }
+};
+
+export const getNameFromUrl = (url?: string) => {
+  if (!url) {
+    return '';
+  }
+  const clean = stripQueryAndHash(url);
+  const index = clean.lastIndexOf('/');
+  return safeDecodeURIComponent(index === -1 ? clean : clean.slice(index + 1));
+};
+
+export const getExtname = (value?: string) => {
+  if (!value) {
+    return '';
+  }
+  const name = stripQueryAndHash(value);
+  const index = name.lastIndexOf('.');
+  return index === -1 ? '' : name.slice(index);
+};
+
+export const getTitleFromName = (value?: string) => {
+  if (!value) {
+    return '';
+  }
+  const extname = getExtname(value);
+  return extname ? value.slice(0, -extname.length) : value;
+};
+
+export const getFileDownloadName = (file: Partial<FileModel> & Record<string, any>) => {
+  const filename = file?.filename || getNameFromUrl(file?.url);
+  const extname = file?.extname || getExtname(filename || file?.name);
+  const title = file?.title || getTitleFromName(filename || file?.name);
+
+  return filename || `${title || 'file'}${extname}`;
+};
+
 export class AttachmentFileTypes {
   types: AttachmentFileType[] = [];
   add(type: AttachmentFileType) {
@@ -197,7 +241,7 @@ export function toValueItem(data) {
 
 export const toItem = (file) => {
   if (typeof file === 'string') {
-    return {
+    file = {
       url: file,
     };
   }
@@ -210,7 +254,9 @@ export const toItem = (file) => {
   const result = {
     ...file,
     id: file.id || file.uid,
-    title: file.title || file.name,
+    title: file.title || getTitleFromName(file.filename || file.name || getNameFromUrl(file.url)),
+    filename: file.filename || file.name || getNameFromUrl(file.url),
+    extname: file.extname || getExtname(file.filename || file.name || getNameFromUrl(file.url)),
   };
   if (file.url) {
     result.url =

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/DisplayPreviewFieldModel.tsx
@@ -15,8 +15,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   FilePreviewRenderer,
+  getDownloadFileName,
   getFallbackIcon,
-  getFileExt,
   getFileName,
   getPreviewThumbnailUrl,
   getPreviewFileUrl,
@@ -98,7 +98,7 @@ const FilePreview = ({
 
 const Preview = (props) => {
   const { value = [], size = 28, showFileName } = props;
-  const { t } = useTranslation(); //  i18n added
+  const { t } = useTranslation();
   const [current, setCurrent] = React.useState(0);
   const [previewOpen, setPreviewOpen] = React.useState(false);
   const list = React.useMemo(
@@ -132,16 +132,7 @@ const Preview = (props) => {
       if (!url) {
         return;
       }
-
-      let filename = getFileName(file, url);
-      const ext = getFileExt(file, url);
-
-      if (filename && ext && !filename.toLowerCase().endsWith(`.${ext}`)) {
-        filename = `${filename}.${ext}`;
-      }
-
-      const downloadName = `${Date.now()}_${filename || 'file'}`;
-
+      const downloadName = getDownloadFileName(file, url);
       let blobUrl: string | undefined;
       let link: HTMLAnchorElement | undefined;
 
@@ -158,13 +149,10 @@ const Preview = (props) => {
         link = document.createElement('a');
         link.href = blobUrl;
         link.download = downloadName;
-
         document.body.appendChild(link);
         link.click();
       } catch (error) {
         console.error('File download failed:', error);
-
-        // FIXED (i18n)
         message.error(t('file-manager:File download failed'));
       } finally {
         if (link) {
@@ -178,7 +166,7 @@ const Preview = (props) => {
         }
       }
     },
-    [current, list, t], // added t dependency
+    [current, list, t],
   );
   const onOpenAtIndex = React.useCallback((index: number) => {
     setCurrent(index);

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/models/UploadFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/models/UploadFieldModel.tsx
@@ -16,7 +16,7 @@ import { largeField, tExpr, EditableItemModel, observable } from '@nocobase/flow
 import React, { useLayoutEffect, useState } from 'react';
 import { FieldContext } from '@formily/react';
 import { FieldModel, RecordPickerContent } from '@nocobase/client';
-import { FilePreviewRenderer } from '../previewer/filePreviewTypes';
+import { FilePreviewRenderer, getDownloadFileName } from '../previewer/filePreviewTypes';
 import {
   getUploadFieldPreviewIndex,
   normalizeUploadFieldFileList,
@@ -77,10 +77,7 @@ export const CardUpload = (props) => {
     if (!url) {
       return;
     }
-    const cleanUrl = url.split('?')[0].split('#')[0];
-    const nameFromUrl = cleanUrl ? cleanUrl.substring(cleanUrl.lastIndexOf('/') + 1) : url;
-    const suffix = nameFromUrl.slice(nameFromUrl.lastIndexOf('.'));
-    const filename = `${Date.now()}_${target.filename}${suffix}`;
+    const filename = getDownloadFileName(target, url);
     // eslint-disable-next-line promise/catch-or-return
     fetch(url)
       .then((response) => response.blob())

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
@@ -1,0 +1,48 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDownloadFileName } from '../filePreviewTypes';
+
+describe('getDownloadFileName', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('应为仅包含 URL 的文件推导出下载名，兼容 AttachmentURL 字段', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    expect(getDownloadFileName({ url: 'https://example.com/files/report.xlsx?token=1' })).toBe(
+      '1700000000000_report.xlsx',
+    );
+  });
+
+  it('应为缺少扩展名的 filename 补齐后缀', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    expect(
+      getDownloadFileName({
+        filename: 'avatar',
+        extname: '.png',
+        url: 'https://example.com/files/avatar.png',
+      }),
+    ).toBe('1700000000000_avatar.png');
+  });
+
+  it('不应重复追加已有扩展名', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    expect(
+      getDownloadFileName({
+        filename: 'contract.pdf',
+        url: 'https://example.com/files/contract.pdf?download=1',
+      }),
+    ).toBe('1700000000000_contract.pdf');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/filePreviewTypes.tsx
@@ -156,6 +156,18 @@ export const getFileName = (file: any, url?: string) => {
   return file.name || file.filename || file.title || nameFromUrl;
 };
 
+export const getDownloadFileName = (file: any, url?: string) => {
+  const resolvedUrl = url || getFileUrl(file);
+  let filename = getFileName(file, resolvedUrl);
+  const ext = getFileExt(file, resolvedUrl);
+
+  if (filename && ext && !filename.toLowerCase().endsWith(`.${ext}`)) {
+    filename = `${filename}.${ext}`;
+  }
+
+  return `${Date.now()}_${filename || 'file'}`;
+};
+
 export const getFallbackIcon = (file: any, url?: string) => {
   const ext = getFileExt(file, url);
   return FALLBACK_ICON_MAP[ext] || FALLBACK_ICON_MAP.default;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AttachmentURL 字段在界面下载文件时，部分场景会得到 `undefinedundefined.xxx` 这样的错误文件名。根因是该字段通常只保存 URL，进入通用 Upload 展示/下载链路后缺少 `title` 和 `extname`，而现有下载逻辑直接拼接了这两个字段。

### Description 
- Normalize URL-only file values in core upload shared helpers, and derive `filename` / `title` / `extname` from the URL when metadata is missing.
- Reuse a unified download filename helper in both core upload and plugin file-manager preview/download flows to avoid duplicated fallback logic.
- Add client tests covering URL-only AttachmentURL values and file-manager download filename derivation.
- Risk is low and scoped to client-side file display/download naming; the main regression surface is upload/read-pretty preview and download behaviors.
- Suggested testing: verify AttachmentURL download in form/table/read-pretty views, and verify normal attachment download names remain unchanged.

### Related issues
- N/A

### Showcase
<!-- Including any screenshots of the changes. -->
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect download filenames for AttachmentURL fields when file metadata is missing. |
| 🇨🇳 Chinese | 修复 AttachmentURL 字段在缺少文件元数据时下载文件名异常的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary

### Tests
- `yarn test:client packages/core/client/src/schema-component/antd/upload`
- `yarn test:client packages/plugins/@nocobase/plugin-file-manager`
