### PR TITLE
fix(idp-oauth): preserve sub app path when proxying OAuth discovery requests

### DIFF
--- a/packages/core/server/src/__tests__/gateway.test.ts
+++ b/packages/core/server/src/__tests__/gateway.test.ts
@@ -63,6 +63,26 @@ describe('gateway', () => {
       expect((req as any).originalUrl).toBe('/api/__app/demo/idpOAuth:authorize?foo=bar');
     });
 
+    it('should proxy sub app requests with original url', async () => {
+      const req = {
+        url: '/api/__app/demo/.well-known/oauth-authorization-server',
+        headers: {},
+      } as any;
+      const res = {} as any;
+
+      const supervisor = AppSupervisor.getInstance();
+      const proxyWeb = vi.spyOn(supervisor, 'proxyWeb').mockImplementation(async (_appName, forwardedReq) => {
+        expect(forwardedReq.url).toBe('/api/__app/demo/.well-known/oauth-authorization-server');
+        return true;
+      });
+
+      await gateway.requestHandler(req, res);
+
+      expect(proxyWeb).toHaveBeenCalledWith('demo', req, res);
+      expect(req.url).toBe('/api/.well-known/oauth-authorization-server');
+      expect((req as any).originalUrl).toBe('/api/__app/demo/.well-known/oauth-authorization-server');
+    });
+
     it('should add same middleware into app selector once', async () => {
       const fn = async (ctx, next) => {
         ctx.resolvedAppName = 'test';

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -105,6 +105,25 @@ export class Gateway extends EventEmitter {
   private v2IndexTemplateCache: { file: string; mtimeMs: number; html: string } | null = null;
   private terminating = false;
 
+  private getOriginalRequestUrl(req: IncomingMessage) {
+    return ((req as any).originalUrl as string | undefined) || req.url;
+  }
+
+  private async proxyRequestToSubApp(
+    supervisor: AppSupervisor,
+    appName: string,
+    req: IncomingMessage,
+    res: ServerResponse,
+  ) {
+    const internalUrl = req.url;
+    req.url = this.getOriginalRequestUrl(req);
+    try {
+      return await supervisor.proxyWeb(appName, req, res);
+    } finally {
+      req.url = internalUrl;
+    }
+  }
+
   private onTerminate = async (signal?: NodeJS.Signals) => {
     if (this.terminating) {
       return;
@@ -402,7 +421,7 @@ export class Gateway extends EventEmitter {
 
     if (pathname.startsWith(APP_PUBLIC_PATH + 'storage/uploads/')) {
       if (handleApp !== 'main') {
-        const isProxy = await supervisor.proxyWeb(handleApp, req, res);
+        const isProxy = await this.proxyRequestToSubApp(supervisor, handleApp, req, res);
         if (isProxy) {
           return;
         }
@@ -419,7 +438,7 @@ export class Gateway extends EventEmitter {
     // protect server files
     if (pathname.startsWith(PLUGIN_STATICS_PATH) && !pathname.includes('/server/')) {
       if (handleApp !== 'main') {
-        const isProxy = await supervisor.proxyWeb(handleApp, req, res);
+        const isProxy = await this.proxyRequestToSubApp(supervisor, handleApp, req, res);
         if (isProxy) {
           return;
         }
@@ -444,7 +463,7 @@ export class Gateway extends EventEmitter {
     if (!pathname.startsWith(process.env.API_BASE_PATH)) {
       if (this.isV2Request(pathname)) {
         if (handleApp !== 'main') {
-          const isProxy = await supervisor.proxyWeb(handleApp, req, res);
+          const isProxy = await this.proxyRequestToSubApp(supervisor, handleApp, req, res);
           if (isProxy) {
             return;
           }
@@ -467,7 +486,7 @@ export class Gateway extends EventEmitter {
       }
 
       if (handleApp !== 'main') {
-        const isProxy = await supervisor.proxyWeb(handleApp, req, res);
+        const isProxy = await this.proxyRequestToSubApp(supervisor, handleApp, req, res);
         if (isProxy) {
           return;
         }
@@ -481,7 +500,7 @@ export class Gateway extends EventEmitter {
     }
 
     if (handleApp !== 'main') {
-      const isProxy = await supervisor.proxyWeb(handleApp, req, res);
+      const isProxy = await this.proxyRequestToSubApp(supervisor, handleApp, req, res);
       if (isProxy) {
         return;
       }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Sub-application OAuth discovery requests could be proxied to workers with the rewritten internal path instead of the original sub-app path, causing the worker to resolve the request as the main app.

### Description
Preserve the original request URL when proxying sub-application requests from the gateway to workers, so worker-side routing still sees the `/api/__app/<appName>/...` path.

This keeps OAuth discovery and related sub-application routes bound to the correct app context.

Testing suggestion:
- Request `/api/__app/<appName>/.well-known/oauth-authorization-server`
- Confirm the worker handles the request as the target sub application instead of `main`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed sub-application OAuth discovery requests being routed as main-app requests |
| 🇨🇳 Chinese | 修复子应用 OAuth 发现请求被错误路由为主应用请求的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
