### PR TITLE
fix(filter-form): preserve collapsed rows

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormCollapseActionModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormCollapseActionModel.tsx
@@ -23,6 +23,9 @@ const collapseState = observable({
 
 const CollapseButton = observer(() => {
   const model = useFlowModel<FilterFormActionModel>();
+  if (model.context.flowSettingsEnabled) {
+    return null;
+  }
   const props = { ...model.defaultProps, ...model.props };
 
   const handleClick = () => {
@@ -54,6 +57,11 @@ export class FilterFormCollapseActionModel extends FilterFormActionModel {
     super.onMount();
     const defaultCollapsed = this.getStepParams('collapseSettings', 'defaultCollapsed')?.value || false;
     const collapsedRows = this.getStepParams('collapseSettings', 'toggle')?.collapsedRows || 1;
+    if (this.context.flowSettingsEnabled) {
+      collapseState.collapsed = false;
+      this.context.filterFormGridModel.toggleFormFieldsCollapse(false, collapsedRows);
+      return;
+    }
     collapseState.collapsed = defaultCollapsed;
     this.context.filterFormGridModel.toggleFormFieldsCollapse(collapseState.collapsed, collapsedRows);
   }
@@ -84,6 +92,9 @@ FilterFormCollapseActionModel.registerFlow({
         },
       },
       async handler(ctx, params) {
+        if (ctx.model.context.flowSettingsEnabled) {
+          return;
+        }
         const collapsedRows = params.collapsedRows || 1;
         collapseState.collapsed = !collapseState.collapsed;
         ctx.model.context.filterFormGridModel.toggleFormFieldsCollapse(collapseState.collapsed, collapsedRows);
@@ -99,6 +110,10 @@ FilterFormCollapseActionModel.registerFlow({
         },
       },
       beforeParamsSave(ctx, params) {
+        if (ctx.model.context.flowSettingsEnabled) {
+          collapseState.collapsed = false;
+          return;
+        }
         const defaultCollapsed = params.value || false;
         collapseState.collapsed = defaultCollapsed;
         const collapsedRows = ctx.model.getStepParams('collapseSettings', 'toggle')?.collapsedRows || 1;

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormCollapseActionModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormCollapseActionModel.tsx
@@ -23,9 +23,6 @@ const collapseState = observable({
 
 const CollapseButton = observer(() => {
   const model = useFlowModel<FilterFormActionModel>();
-  if (model.context.flowSettingsEnabled) {
-    return null;
-  }
   const props = { ...model.defaultProps, ...model.props };
 
   const handleClick = () => {
@@ -57,11 +54,6 @@ export class FilterFormCollapseActionModel extends FilterFormActionModel {
     super.onMount();
     const defaultCollapsed = this.getStepParams('collapseSettings', 'defaultCollapsed')?.value || false;
     const collapsedRows = this.getStepParams('collapseSettings', 'toggle')?.collapsedRows || 1;
-    if (this.context.flowSettingsEnabled) {
-      collapseState.collapsed = false;
-      this.context.filterFormGridModel.toggleFormFieldsCollapse(false, collapsedRows);
-      return;
-    }
     collapseState.collapsed = defaultCollapsed;
     this.context.filterFormGridModel.toggleFormFieldsCollapse(collapseState.collapsed, collapsedRows);
   }
@@ -92,9 +84,6 @@ FilterFormCollapseActionModel.registerFlow({
         },
       },
       async handler(ctx, params) {
-        if (ctx.model.context.flowSettingsEnabled) {
-          return;
-        }
         const collapsedRows = params.collapsedRows || 1;
         collapseState.collapsed = !collapseState.collapsed;
         ctx.model.context.filterFormGridModel.toggleFormFieldsCollapse(collapseState.collapsed, collapsedRows);
@@ -110,10 +99,6 @@ FilterFormCollapseActionModel.registerFlow({
         },
       },
       beforeParamsSave(ctx, params) {
-        if (ctx.model.context.flowSettingsEnabled) {
-          collapseState.collapsed = false;
-          return;
-        }
         const defaultCollapsed = params.value || false;
         collapseState.collapsed = defaultCollapsed;
         const collapsedRows = ctx.model.getStepParams('collapseSettings', 'toggle')?.collapsedRows || 1;

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -12,8 +12,10 @@ import {
   AddSubModelButton,
   DragOverlayConfig,
   FlowSettingsButton,
+  GridCellV2,
   GridLayoutData,
   GridLayoutV2,
+  GridRowV2,
   normalizeGridLayout,
   observable,
   projectLayoutToLegacyRows,
@@ -26,6 +28,7 @@ import { FilterFormItemModel } from './FilterFormItemModel';
 export class FilterFormGridModel extends GridModel {
   private fullLayoutBeforeCollapse?: GridLayoutV2;
   private normalizedItemUidsOverride?: string[];
+  private readingFullLayoutForSettingsInteraction = false;
   itemSettingsMenuLevel = 2;
   itemFlowSettings = {
     showBackground: true,
@@ -87,12 +90,49 @@ export class FilterFormGridModel extends GridModel {
     });
   }
 
+  private normalizeStoredFullLayout(): GridLayoutV2 {
+    const params = this.getStepParams(GRID_FLOW_KEY, GRID_STEP) || {};
+
+    return normalizeGridLayout({
+      layout: this.fullLayoutBeforeCollapse ?? params.layout ?? this.props.layout,
+      rows: params.rows ?? this.props.rows,
+      sizes: params.sizes ?? this.props.sizes,
+      rowOrder: params.rowOrder ?? this.props.rowOrder,
+      itemUids: this.getItemUids(),
+      gridUid: this.uid,
+      logger: console,
+    });
+  }
+
   protected override normalizeLayoutFromSource(source?: Partial<GridLayoutData>): GridLayoutV2 {
     // 只有运行时读取当前展示布局时才应用折叠态可见字段覆盖；
     // 带 source 的路径通常用于重算/持久化布局，必须始终基于完整字段集。
+    if (!source && this.readingFullLayoutForSettingsInteraction) {
+      return this.normalizeStoredFullLayout();
+    }
+
     return this.normalizeFilterFormLayout(source, {
-      useVisibleItemUids: !source,
+      useVisibleItemUids: !source && !this.readingFullLayoutForSettingsInteraction,
     });
+  }
+
+  getGridLayout(): GridLayoutV2 {
+    if (this.context.flowSettingsEnabled && this.normalizedItemUidsOverride) {
+      return this.normalizeStoredFullLayout();
+    }
+
+    return super.getGridLayout();
+  }
+
+  handleDragStart(event: Parameters<GridModel['handleDragStart']>[0]) {
+    this.readingFullLayoutForSettingsInteraction = Boolean(
+      this.context.flowSettingsEnabled && this.normalizedItemUidsOverride,
+    );
+    try {
+      super.handleDragStart(event);
+    } finally {
+      this.readingFullLayoutForSettingsInteraction = false;
+    }
   }
 
   private collectLayoutItemUids(rows: GridLayoutV2['rows']) {
@@ -117,6 +157,75 @@ export class FilterFormGridModel extends GridModel {
     visitRows(rows);
 
     return Array.from(itemUids);
+  }
+
+  private getCellVisibleRowCount(cell: GridCellV2): number {
+    if (cell.rows?.length) {
+      return cell.rows.reduce((count, row) => count + this.getRowVisibleRowCount(row), 0);
+    }
+
+    return cell.items?.length || 0;
+  }
+
+  private getRowVisibleRowCount(row: GridRowV2): number {
+    return row.cells.reduce((count, cell) => Math.max(count, this.getCellVisibleRowCount(cell)), 0);
+  }
+
+  private limitCellByVisibleCount(cell: GridCellV2, visibleRows: number): GridCellV2 | null {
+    if (visibleRows <= 0) {
+      return null;
+    }
+
+    if (cell.rows?.length) {
+      const rows = this.limitLayoutRowsByVisibleCount(cell.rows, visibleRows);
+      return rows.length ? { id: cell.id, rows } : null;
+    }
+
+    if (cell.items) {
+      const items = cell.items.slice(0, visibleRows);
+      return items.length ? { id: cell.id, items } : null;
+    }
+
+    return null;
+  }
+
+  private limitRowByVisibleCount(row: GridRowV2, visibleRows: number): GridRowV2 | null {
+    const cellsWithSizes = row.cells
+      .map((cell, index) => {
+        const limitedCell = this.limitCellByVisibleCount(cell, visibleRows);
+        return limitedCell ? { cell: limitedCell, size: row.sizes?.[index] } : null;
+      })
+      .filter(Boolean) as { cell: GridCellV2; size?: number }[];
+
+    if (!cellsWithSizes.length) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      cells: cellsWithSizes.map((entry) => entry.cell),
+      sizes: cellsWithSizes.map((entry) => entry.size ?? 1),
+    };
+  }
+
+  private limitLayoutRowsByVisibleCount(rows: GridLayoutV2['rows'], visibleRows: number): GridLayoutV2['rows'] {
+    const limitedRows: GridLayoutV2['rows'] = [];
+    let remainingRows = visibleRows;
+
+    rows.forEach((row) => {
+      if (remainingRows <= 0) {
+        return;
+      }
+
+      const rowHeight = this.getRowVisibleRowCount(row);
+      const limitedRow = this.limitRowByVisibleCount(row, Math.min(rowHeight, remainingRows));
+      if (limitedRow) {
+        limitedRows.push(limitedRow);
+        remainingRows -= Math.min(rowHeight, remainingRows);
+      }
+    });
+
+    return limitedRows;
   }
 
   /**
@@ -162,37 +271,6 @@ export class FilterFormGridModel extends GridModel {
     };
   }
 
-  /**
-   * 按“可视字段行数”裁剪布局，而不是只按 grid row 数裁剪。
-   * 这样即使拖拽后多个字段被排进同一个 cell，也仍然可以正确折叠。
-   */
-  private limitRowsByVisibleCount(
-    rows: Record<string, string[][]>,
-    rowOrder: string[],
-    visibleRows: number,
-  ): Record<string, string[][]> {
-    const limitedRows: Record<string, string[][]> = {};
-    let remainingRows = visibleRows;
-
-    rowOrder.forEach((rowKey) => {
-      if (remainingRows <= 0 || !rows[rowKey]) {
-        return;
-      }
-
-      const cells = rows[rowKey];
-      const rowHeight = cells.reduce((max, cell) => Math.max(max, cell.length), 0);
-      const visibleCount = Math.min(rowHeight, remainingRows);
-      const nextCells = cells.map((cell) => cell.slice(0, visibleCount));
-
-      if (nextCells.some((cell) => cell.length > 0)) {
-        limitedRows[rowKey] = nextCells;
-        remainingRows -= visibleCount;
-      }
-    });
-
-    return limitedRows;
-  }
-
   toggleFormFieldsCollapse(collapse: boolean, visibleRows: number) {
     const { rows: fullRows, rowOrder, layout } = this.getFullLayout();
 
@@ -219,10 +297,18 @@ export class FilterFormGridModel extends GridModel {
         });
     }
 
-    const limitedRows = this.limitRowsByVisibleCount(fullRows, rowOrder, visibleRows);
+    const fullLayout =
+      layout ||
+      normalizeGridLayout({
+        rows: fullRows,
+        rowOrder,
+        itemUids: this.getItemUids(),
+      });
     const limitedLayout = normalizeGridLayout({
-      rows: limitedRows,
-      rowOrder,
+      layout: {
+        version: 2,
+        rows: this.limitLayoutRowsByVisibleCount(fullLayout.rows, visibleRows),
+      },
     });
 
     this.normalizedItemUidsOverride = this.collectLayoutItemUids(limitedLayout.rows);

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -87,7 +87,11 @@ export class FilterFormGridModel extends GridModel {
   }
 
   protected override normalizeLayoutFromSource(source?: Partial<GridLayoutData>): GridLayoutV2 {
-    return this.normalizeFilterFormLayout(source);
+    // 只有运行时读取当前展示布局时才应用折叠态可见字段覆盖；
+    // 带 source 的路径通常用于重算/持久化布局，必须始终基于完整字段集。
+    return this.normalizeFilterFormLayout(source, {
+      useVisibleItemUids: !source,
+    });
   }
 
   private collectLayoutItemUids(rows: GridLayoutV2['rows']) {

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -124,6 +124,23 @@ export class FilterFormGridModel extends GridModel {
     return super.getGridLayout();
   }
 
+  saveGridLayout(layout?: GridLayoutData | GridLayoutV2) {
+    super.saveGridLayout(layout);
+
+    if (this.context.flowSettingsEnabled && this.normalizedItemUidsOverride) {
+      const params = this.getStepParams(GRID_FLOW_KEY, GRID_STEP) || {};
+      this.fullLayoutBeforeCollapse = normalizeGridLayout({
+        layout: params.layout ?? this.props.layout,
+        rows: params.rows ?? this.props.rows,
+        sizes: params.sizes ?? this.props.sizes,
+        rowOrder: params.rowOrder ?? this.props.rowOrder,
+        itemUids: this.getItemUids(),
+        gridUid: this.uid,
+        logger: console,
+      });
+    }
+  }
+
   handleDragStart(event: Parameters<GridModel['handleDragStart']>[0]) {
     this.readingFullLayoutForSettingsInteraction = Boolean(
       this.context.flowSettingsEnabled && this.normalizedItemUidsOverride,

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -12,6 +12,7 @@ import {
   AddSubModelButton,
   DragOverlayConfig,
   FlowSettingsButton,
+  GridLayoutData,
   GridLayoutV2,
   normalizeGridLayout,
   observable,

--- a/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/FilterFormGridModel.tsx
@@ -24,6 +24,7 @@ import { FilterFormItemModel } from './FilterFormItemModel';
 
 export class FilterFormGridModel extends GridModel {
   private fullLayoutBeforeCollapse?: GridLayoutV2;
+  private normalizedItemUidsOverride?: string[];
   itemSettingsMenuLevel = 2;
   itemFlowSettings = {
     showBackground: true,
@@ -64,6 +65,55 @@ export class FilterFormGridModel extends GridModel {
     return filterTargetKey || 'id';
   }
 
+  private normalizeFilterFormLayout(
+    source?: Partial<GridLayoutData>,
+    options?: {
+      useVisibleItemUids?: boolean;
+    },
+  ): GridLayoutV2 {
+    const params = this.getStepParams(GRID_FLOW_KEY, GRID_STEP) || {};
+    const useVisibleItemUids = options?.useVisibleItemUids !== false;
+
+    return normalizeGridLayout({
+      layout: source?.layout ?? this.props.layout ?? params.layout,
+      rows: source?.rows ?? this.props.rows ?? params.rows,
+      sizes: source?.sizes ?? this.props.sizes ?? params.sizes,
+      rowOrder: source?.rowOrder ?? this.props.rowOrder ?? params.rowOrder,
+      // 折叠态只保留当前可见字段，避免归一化时把被裁掉的字段重新补回布局。
+      itemUids: useVisibleItemUids ? this.normalizedItemUidsOverride ?? this.getItemUids() : this.getItemUids(),
+      gridUid: this.uid,
+      logger: console,
+    });
+  }
+
+  protected override normalizeLayoutFromSource(source?: Partial<GridLayoutData>): GridLayoutV2 {
+    return this.normalizeFilterFormLayout(source);
+  }
+
+  private collectLayoutItemUids(rows: GridLayoutV2['rows']) {
+    const itemUids = new Set<string>();
+
+    const visitRows = (currentRows: GridLayoutV2['rows']) => {
+      currentRows.forEach((row) => {
+        row.cells.forEach((cell) => {
+          cell.items?.forEach((uid) => {
+            if (uid && this.flowEngine.getModel(uid)) {
+              itemUids.add(uid);
+            }
+          });
+
+          if (cell.rows?.length) {
+            visitRows(cell.rows);
+          }
+        });
+      });
+    };
+
+    visitRows(rows);
+
+    return Array.from(itemUids);
+  }
+
   /**
    * 获取筛选表单当前“完整布局”。
    * 折叠态会临时裁剪 props.rows，因此这里优先选取行数更多的那份布局，
@@ -71,8 +121,12 @@ export class FilterFormGridModel extends GridModel {
    */
   private getFullLayout() {
     const params = this.getStepParams(GRID_FLOW_KEY, GRID_STEP) || {};
-    const currentLayout = this.props.layout ? this.getGridLayout() : undefined;
-    const savedLayout = params.layout ? this.normalizeLayoutFromSource(params) : undefined;
+    const currentLayout = this.props.layout
+      ? this.normalizeFilterFormLayout(undefined, { useVisibleItemUids: false })
+      : undefined;
+    const savedLayout = params.layout
+      ? this.normalizeFilterFormLayout(params, { useVisibleItemUids: false })
+      : undefined;
     const currentProjection = currentLayout
       ? projectLayoutToLegacyRows(currentLayout)
       : { rows: this.props.rows || {}, rowOrder: this.props.rowOrder };
@@ -138,6 +192,7 @@ export class FilterFormGridModel extends GridModel {
     const { rows: fullRows, rowOrder, layout } = this.getFullLayout();
 
     if (!collapse) {
+      this.normalizedItemUidsOverride = undefined;
       const restoredLayout = this.fullLayoutBeforeCollapse || layout;
       if (restoredLayout) {
         this.syncLayoutProps(restoredLayout);
@@ -165,6 +220,7 @@ export class FilterFormGridModel extends GridModel {
       rowOrder,
     });
 
+    this.normalizedItemUidsOverride = this.collectLayoutItemUids(limitedLayout.rows);
     this.syncLayoutProps(limitedLayout);
     this.setProps('rowOrder', rowOrder);
   }

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
@@ -147,6 +147,71 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
     expect(model.props.layout.rows[0].cells[0].items).toEqual(['field-1', 'field-2', 'field-3']);
   });
 
+  it('keeps nested columns inside the first visible row when collapsing a v2 layout', () => {
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-collapse-nested-v2',
+      use: 'FilterFormGridModel',
+      props: {
+        layout: {
+          version: 2,
+          rows: [
+            {
+              id: 'first',
+              cells: [
+                {
+                  id: 'first-cell',
+                  rows: [
+                    {
+                      id: 'first-nested-row',
+                      cells: [
+                        { id: 'first-nested-cell-1', items: ['field-1'] },
+                        { id: 'first-nested-cell-2', items: ['field-2'] },
+                      ],
+                      sizes: [12, 12],
+                    },
+                  ],
+                },
+              ],
+              sizes: [24],
+            },
+            {
+              id: 'second',
+              cells: [{ id: 'second-cell', items: ['field-3'] }],
+              sizes: [24],
+            },
+          ],
+        },
+      },
+      structure: {} as any,
+    });
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
+      ],
+    };
+
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      layout: model.props.layout,
+    });
+
+    model.toggleFormFieldsCollapse(true, 1);
+
+    const collapsedNestedRow = model.props.layout.rows[0].cells[0].rows?.[0];
+    expect(collapsedNestedRow?.cells.map((cell) => cell.items)).toEqual([['field-1'], ['field-2']]);
+    expect(collapsedNestedRow?.sizes).toEqual([12, 12]);
+    expect(model.props.layout.rows).toHaveLength(1);
+
+    model.toggleFormFieldsCollapse(false, 1);
+
+    expect(model.props.layout.rows).toHaveLength(2);
+    expect(model.props.layout.rows[0].cells[0].rows?.[0].cells.map((cell) => cell.items)).toEqual([
+      ['field-1'],
+      ['field-2'],
+    ]);
+  });
+
   it('restores the persisted full layout when current props rows were already truncated', () => {
     const model = engine.createModel<FilterFormGridModel>({
       uid: 'filter-grid-collapse-restore',
@@ -272,6 +337,63 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
     expect(persistedItems).toEqual(['field-1', 'field-2', 'field-3']);
     expect(projectLayoutToLegacyRows(model.getGridLayout()).rows).toEqual({
       first: [['field-1']],
+    });
+  });
+
+  it('uses the full layout for flow-settings layout reads during collapsed mode', () => {
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-collapse-settings-full-layout',
+      use: 'FilterFormGridModel',
+      props: {
+        layout: {
+          version: 2,
+          rows: [
+            {
+              id: 'first',
+              cells: [{ id: 'first-cell', items: ['field-1'] }],
+              sizes: [24],
+            },
+            {
+              id: 'second',
+              cells: [
+                { id: 'second-cell-1', items: ['field-2'] },
+                { id: 'second-cell-2', items: ['field-3'] },
+              ],
+              sizes: [12, 12],
+            },
+          ],
+        },
+      },
+      structure: {} as any,
+    });
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
+      ],
+    };
+    (model.context as any).flowSettingsEnabled = true;
+
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      layout: model.props.layout,
+    });
+
+    model.toggleFormFieldsCollapse(true, 1);
+
+    expect(projectLayoutToLegacyRows((model as any).normalizeLayoutFromSource()).rows).toEqual({
+      first: [['field-1']],
+    });
+    expect(projectLayoutToLegacyRows(model.getGridLayout()).rows).toEqual({
+      first: [['field-1']],
+      second: [['field-2'], ['field-3']],
+    });
+
+    model.saveGridLayout(model.getGridLayout());
+
+    expect(projectLayoutToLegacyRows(model.getStepParams(GRID_FLOW_KEY, GRID_STEP).layout).rows).toEqual({
+      first: [['field-1']],
+      second: [['field-2'], ['field-3']],
     });
   });
 });

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { FlowEngine, projectLayoutToLegacyRows } from '@nocobase/flow-engine';
 import '@nocobase/client';
 import { GRID_FLOW_KEY, GRID_STEP } from '../../../base';
+import { FilterFormCollapseActionModel } from '../FilterFormCollapseActionModel';
 import { FilterFormGridModel } from '../FilterFormGridModel';
 
 describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
@@ -18,8 +19,63 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
 
   beforeEach(() => {
     engine = new FlowEngine();
-    engine.registerModels({ FilterFormGridModel });
+    engine.registerModels({ FilterFormGridModel, FilterFormCollapseActionModel });
   });
+
+  const createGridModel = () => {
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-shared',
+      use: 'FilterFormGridModel',
+      props: {
+        rows: {
+          first: [['field-1']],
+          second: [['field-2']],
+          third: [['field-3']],
+        },
+        rowOrder: ['first', 'second', 'third'],
+      },
+      structure: {} as any,
+    });
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
+      ],
+    };
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      rows: {
+        first: [['field-1']],
+        second: [['field-2']],
+        third: [['field-3']],
+      },
+      rowOrder: ['first', 'second', 'third'],
+    });
+    return model;
+  };
+
+  const createCollapseActionModel = (gridModel: FilterFormGridModel, flowSettingsEnabled = false) => {
+    const model = engine.createModel<FilterFormCollapseActionModel>({
+      uid: `collapse-action-${flowSettingsEnabled ? 'settings' : 'runtime'}`,
+      use: 'FilterFormCollapseActionModel',
+      stepParams: {
+        collapseSettings: {
+          toggle: {
+            collapsedRows: 1,
+          },
+          defaultCollapsed: {
+            value: true,
+          },
+        },
+      },
+      structure: {} as any,
+    });
+    Object.assign(model.context as any, {
+      flowSettingsEnabled,
+      filterFormGridModel: gridModel,
+    });
+    return model;
+  };
 
   it('uses rowOrder from the full layout when collapsing after reorder', () => {
     const model = engine.createModel<FilterFormGridModel>({
@@ -187,35 +243,7 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
   });
 
   it('does not reinsert collapsed items when the render layout is normalized again', () => {
-    const model = engine.createModel<FilterFormGridModel>({
-      uid: 'filter-grid-collapse-visible-item-uids',
-      use: 'FilterFormGridModel',
-      props: {
-        rows: {
-          first: [['field-1']],
-          second: [['field-2']],
-          third: [['field-3']],
-        },
-        rowOrder: ['first', 'second', 'third'],
-      },
-      structure: {} as any,
-    });
-    (model as any).subModels = {
-      items: [
-        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
-        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
-        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
-      ],
-    };
-
-    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
-      rows: {
-        first: [['field-1']],
-        second: [['field-2']],
-        third: [['field-3']],
-      },
-      rowOrder: ['first', 'second', 'third'],
-    });
+    const model = createGridModel();
 
     model.toggleFormFieldsCollapse(true, 1);
 
@@ -226,6 +254,43 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
     model.toggleFormFieldsCollapse(false, 1);
 
     expect(projectLayoutToLegacyRows(model.getGridLayout()).rows).toEqual({
+      first: [['field-1']],
+      second: [['field-2']],
+      third: [['field-3']],
+    });
+  });
+
+  it('always expands the grid in flow settings mode even if defaultCollapsed is enabled', () => {
+    const gridModel = createGridModel();
+    gridModel.toggleFormFieldsCollapse(true, 1);
+
+    const collapseActionModel = createCollapseActionModel(gridModel, true);
+    collapseActionModel.onMount();
+
+    expect(projectLayoutToLegacyRows(gridModel.getGridLayout()).rows).toEqual({
+      first: [['field-1']],
+      second: [['field-2']],
+      third: [['field-3']],
+    });
+    expect(gridModel.props.rows).toEqual({
+      first: [['field-1']],
+      second: [['field-2']],
+      third: [['field-3']],
+    });
+  });
+
+  it('does not collapse the grid from collapse settings while flow settings are enabled', async () => {
+    const gridModel = createGridModel();
+    const collapseActionModel = createCollapseActionModel(gridModel, true);
+    const collapseFlow = collapseActionModel.getFlow('collapseSettings');
+    expect(collapseFlow).toBeDefined();
+    const defaultCollapsedStep = collapseFlow.steps.defaultCollapsed as any;
+    const toggleStep = collapseFlow.steps.toggle as any;
+
+    defaultCollapsedStep.beforeParamsSave({ model: collapseActionModel }, { value: true });
+    await toggleStep.handler({ model: collapseActionModel }, { collapsedRows: 1 });
+
+    expect(projectLayoutToLegacyRows(gridModel.getGridLayout()).rows).toEqual({
       first: [['field-1']],
       second: [['field-2']],
       third: [['field-3']],

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
@@ -11,7 +11,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { FlowEngine, projectLayoutToLegacyRows } from '@nocobase/flow-engine';
 import '@nocobase/client';
 import { GRID_FLOW_KEY, GRID_STEP } from '../../../base';
-import { FilterFormCollapseActionModel } from '../FilterFormCollapseActionModel';
 import { FilterFormGridModel } from '../FilterFormGridModel';
 
 describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
@@ -19,63 +18,8 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
 
   beforeEach(() => {
     engine = new FlowEngine();
-    engine.registerModels({ FilterFormGridModel, FilterFormCollapseActionModel });
+    engine.registerModels({ FilterFormGridModel });
   });
-
-  const createGridModel = () => {
-    const model = engine.createModel<FilterFormGridModel>({
-      uid: 'filter-grid-shared',
-      use: 'FilterFormGridModel',
-      props: {
-        rows: {
-          first: [['field-1']],
-          second: [['field-2']],
-          third: [['field-3']],
-        },
-        rowOrder: ['first', 'second', 'third'],
-      },
-      structure: {} as any,
-    });
-    (model as any).subModels = {
-      items: [
-        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
-        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
-        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
-      ],
-    };
-    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
-      rows: {
-        first: [['field-1']],
-        second: [['field-2']],
-        third: [['field-3']],
-      },
-      rowOrder: ['first', 'second', 'third'],
-    });
-    return model;
-  };
-
-  const createCollapseActionModel = (gridModel: FilterFormGridModel, flowSettingsEnabled = false) => {
-    const model = engine.createModel<FilterFormCollapseActionModel>({
-      uid: `collapse-action-${flowSettingsEnabled ? 'settings' : 'runtime'}`,
-      use: 'FilterFormCollapseActionModel',
-      stepParams: {
-        collapseSettings: {
-          toggle: {
-            collapsedRows: 1,
-          },
-          defaultCollapsed: {
-            value: true,
-          },
-        },
-      },
-      structure: {} as any,
-    });
-    Object.assign(model.context as any, {
-      flowSettingsEnabled,
-      filterFormGridModel: gridModel,
-    });
-    return model;
-  };
 
   it('uses rowOrder from the full layout when collapsing after reorder', () => {
     const model = engine.createModel<FilterFormGridModel>({
@@ -243,7 +187,35 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
   });
 
   it('does not reinsert collapsed items when the render layout is normalized again', () => {
-    const model = createGridModel();
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-collapse-visible-item-uids',
+      use: 'FilterFormGridModel',
+      props: {
+        rows: {
+          first: [['field-1']],
+          second: [['field-2']],
+          third: [['field-3']],
+        },
+        rowOrder: ['first', 'second', 'third'],
+      },
+      structure: {} as any,
+    });
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
+      ],
+    };
+
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      rows: {
+        first: [['field-1']],
+        second: [['field-2']],
+        third: [['field-3']],
+      },
+      rowOrder: ['first', 'second', 'third'],
+    });
 
     model.toggleFormFieldsCollapse(true, 1);
 
@@ -260,40 +232,46 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
     });
   });
 
-  it('always expands the grid in flow settings mode even if defaultCollapsed is enabled', () => {
-    const gridModel = createGridModel();
-    gridModel.toggleFormFieldsCollapse(true, 1);
-
-    const collapseActionModel = createCollapseActionModel(gridModel, true);
-    collapseActionModel.onMount();
-
-    expect(projectLayoutToLegacyRows(gridModel.getGridLayout()).rows).toEqual({
-      first: [['field-1']],
-      second: [['field-2']],
-      third: [['field-3']],
+  it('keeps the persisted layout intact when resetRows runs during collapsed mode', () => {
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-collapse-reset-rows',
+      use: 'FilterFormGridModel',
+      props: {
+        rows: {
+          first: [['field-1']],
+          second: [['field-2']],
+          third: [['field-3']],
+        },
+        rowOrder: ['first', 'second', 'third'],
+      },
+      structure: {} as any,
     });
-    expect(gridModel.props.rows).toEqual({
-      first: [['field-1']],
-      second: [['field-2']],
-      third: [['field-3']],
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
+      ],
+    };
+
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      rows: {
+        first: [['field-1']],
+        second: [['field-2']],
+        third: [['field-3']],
+      },
+      rowOrder: ['first', 'second', 'third'],
     });
-  });
 
-  it('does not collapse the grid from collapse settings while flow settings are enabled', async () => {
-    const gridModel = createGridModel();
-    const collapseActionModel = createCollapseActionModel(gridModel, true);
-    const collapseFlow = collapseActionModel.getFlow('collapseSettings');
-    expect(collapseFlow).toBeDefined();
-    const defaultCollapsedStep = collapseFlow.steps.defaultCollapsed as any;
-    const toggleStep = collapseFlow.steps.toggle as any;
+    model.toggleFormFieldsCollapse(true, 1);
+    model.resetRows(true);
 
-    defaultCollapsedStep.beforeParamsSave({ model: collapseActionModel }, { value: true });
-    await toggleStep.handler({ model: collapseActionModel }, { collapsedRows: 1 });
-
-    expect(projectLayoutToLegacyRows(gridModel.getGridLayout()).rows).toEqual({
+    const persistedLayout = model.getStepParams(GRID_FLOW_KEY, GRID_STEP).layout;
+    const persistedRows = projectLayoutToLegacyRows(persistedLayout).rows;
+    const persistedItems = Object.values(persistedRows).flat().flat().sort();
+    expect(persistedItems).toEqual(['field-1', 'field-2', 'field-3']);
+    expect(projectLayoutToLegacyRows(model.getGridLayout()).rows).toEqual({
       first: [['field-1']],
-      second: [['field-2']],
-      third: [['field-3']],
     });
   });
 });

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
@@ -396,4 +396,62 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
       second: [['field-2'], ['field-3']],
     });
   });
+
+  it('restores the latest saved full layout after editing while collapsed in flow settings', () => {
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-collapse-settings-latest-layout',
+      use: 'FilterFormGridModel',
+      props: {
+        layout: {
+          version: 2,
+          rows: [
+            {
+              id: 'first',
+              cells: [{ id: 'first-cell', items: ['field-1'] }],
+              sizes: [24],
+            },
+            {
+              id: 'second',
+              cells: [{ id: 'second-cell', items: ['field-2'] }],
+              sizes: [24],
+            },
+          ],
+        },
+      },
+      structure: {} as any,
+    });
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+      ],
+    };
+    (model.context as any).flowSettingsEnabled = true;
+
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      layout: model.props.layout,
+    });
+    model.toggleFormFieldsCollapse(true, 1);
+
+    const editedLayout = {
+      version: 2 as const,
+      rows: [
+        {
+          id: 'first',
+          cells: [
+            { id: 'first-cell-1', items: ['field-1'] },
+            { id: 'first-cell-2', items: ['field-2'] },
+          ],
+          sizes: [12, 12],
+        },
+      ],
+    };
+
+    model.saveGridLayout(editedLayout);
+    model.toggleFormFieldsCollapse(false, 1);
+
+    expect(projectLayoutToLegacyRows(model.props.layout).rows).toEqual({
+      first: [['field-1'], ['field-2']],
+    });
+  });
 });

--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/FilterFormGridModel.toggleFormFieldsCollapse.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
-import { FlowEngine } from '@nocobase/flow-engine';
+import { FlowEngine, projectLayoutToLegacyRows } from '@nocobase/flow-engine';
 import '@nocobase/client';
 import { GRID_FLOW_KEY, GRID_STEP } from '../../../base';
 import { FilterFormGridModel } from '../FilterFormGridModel';
@@ -184,5 +184,51 @@ describe('FilterFormGridModel.toggleFormFieldsCollapse', () => {
       third: [['field-3']],
     });
     expect(model.props.rowOrder).toEqual(['first', 'second', 'third']);
+  });
+
+  it('does not reinsert collapsed items when the render layout is normalized again', () => {
+    const model = engine.createModel<FilterFormGridModel>({
+      uid: 'filter-grid-collapse-visible-item-uids',
+      use: 'FilterFormGridModel',
+      props: {
+        rows: {
+          first: [['field-1']],
+          second: [['field-2']],
+          third: [['field-3']],
+        },
+        rowOrder: ['first', 'second', 'third'],
+      },
+      structure: {} as any,
+    });
+    (model as any).subModels = {
+      items: [
+        engine.createModel({ use: 'FlowModel', uid: 'field-1' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-2' }),
+        engine.createModel({ use: 'FlowModel', uid: 'field-3' }),
+      ],
+    };
+
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, {
+      rows: {
+        first: [['field-1']],
+        second: [['field-2']],
+        third: [['field-3']],
+      },
+      rowOrder: ['first', 'second', 'third'],
+    });
+
+    model.toggleFormFieldsCollapse(true, 1);
+
+    expect(projectLayoutToLegacyRows(model.getGridLayout()).rows).toEqual({
+      first: [['field-1']],
+    });
+
+    model.toggleFormFieldsCollapse(false, 1);
+
+    expect(projectLayoutToLegacyRows(model.getGridLayout()).rows).toEqual({
+      first: [['field-1']],
+      second: [['field-2']],
+      third: [['field-3']],
+    });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
筛选表单的折叠按钮在运行态点击后虽然会切换成展开状态，但被折叠的字段会在布局再次归一化时被补回，导致页面看起来没有真正折叠。


### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix filter forms that could not collapse |
| 🇨🇳 Chinese | 修复筛选表单无法折叠的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
