### PR TITLE
fix(client): normalize filter operators

### DIFF
--- a/packages/core/client/src/flow/models/blocks/filter-form/__tests__/customFieldOperators.test.tsx
+++ b/packages/core/client/src/flow/models/blocks/filter-form/__tests__/customFieldOperators.test.tsx
@@ -37,6 +37,8 @@ function createEngineWithCollections() {
     fields: [
       { name: 'id', type: 'integer', interface: 'number', filterable: { operators: [] } },
       { name: 'uid', type: 'string', interface: 'input', filterable: { operators: [] } },
+      { name: 'status', type: 'string', interface: 'select', filterable: { operators: [] } },
+      { name: 'tags', type: 'array', interface: 'multipleSelect', filterable: { operators: [] } },
       { name: 'createdAt', type: 'date', interface: 'datetime', filterable: { operators: [] } },
       {
         name: 'pluginInSource',
@@ -104,6 +106,27 @@ describe('custom field operators', () => {
       fieldModelProps: {},
     });
     expect(checkboxGroupOps.some((item) => item.value === '$match')).toBe(true);
+  });
+
+  it('uses multi-value scalar operators for multiple select custom fields bound to scalar source fields', () => {
+    const engine = createEngineWithCollections();
+
+    const scalarSourceOps = resolveCustomFieldOperatorList({
+      flowEngine: engine,
+      fieldModel: 'SelectFieldModel',
+      fieldModelProps: { mode: 'multiple' },
+      source: ['main', 'users', 'status'],
+    });
+    expect(scalarSourceOps[0]?.value).toBe('$in');
+    expect(scalarSourceOps.some((item) => item.value === '$match')).toBe(false);
+
+    const arraySourceOps = resolveCustomFieldOperatorList({
+      flowEngine: engine,
+      fieldModel: 'SelectFieldModel',
+      fieldModelProps: { mode: 'multiple' },
+      source: ['main', 'users', 'tags'],
+    });
+    expect(arraySourceOps[0]?.value).toBe('$match');
   });
 
   it('resolves record select operators by value field and multiple mode', () => {

--- a/packages/core/client/src/flow/models/blocks/filter-form/customFieldOperators.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/customFieldOperators.ts
@@ -8,6 +8,7 @@
  */
 
 import * as operators from '../../../../collection-manager/interfaces/properties/operators';
+import { isArrayLikeField } from '../shared/filterOperators';
 
 type OperatorMeta = {
   label: string;
@@ -79,12 +80,6 @@ function getOperatorListByModel(fieldModel: string, fieldModelProps: Record<stri
   const value = MODEL_OPERATOR_MAP[fieldModel];
   if (!value) return [];
   return typeof value === 'function' ? value(fieldModelProps) || [] : value || [];
-}
-
-function isArrayLikeField(field: any) {
-  return (
-    ['multipleSelect', 'checkboxGroup'].includes(field?.interface) || ['array', 'json', 'jsonb'].includes(field?.type)
-  );
 }
 
 function getSourceField(flowEngine: any, source: string[] = [], fallbackDataSourceKey?: string) {

--- a/packages/core/client/src/flow/models/blocks/filter-form/customFieldOperators.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-form/customFieldOperators.ts
@@ -81,6 +81,12 @@ function getOperatorListByModel(fieldModel: string, fieldModelProps: Record<stri
   return typeof value === 'function' ? value(fieldModelProps) || [] : value || [];
 }
 
+function isArrayLikeField(field: any) {
+  return (
+    ['multipleSelect', 'checkboxGroup'].includes(field?.interface) || ['array', 'json', 'jsonb'].includes(field?.type)
+  );
+}
+
 function getSourceField(flowEngine: any, source: string[] = [], fallbackDataSourceKey?: string) {
   if (!Array.isArray(source) || source.length === 0) return;
   const hasDataSourceKey = !!flowEngine?.dataSourceManager?.getDataSource?.(source[0]);
@@ -186,12 +192,22 @@ function resolveByModelOrSource(params: ResolveOperatorParams): { operatorList: 
     return resolveByRecordSelect(params);
   }
 
+  const sourceField = getSourceField(flowEngine, source);
+  if (fieldModel === 'SelectFieldModel' && fieldModelProps?.mode === 'multiple' && sourceField) {
+    const sourceOperators = getFieldOperators(sourceField);
+    return {
+      operatorList: isArrayLikeField(sourceField)
+        ? getOperatorListByModel(fieldModel, fieldModelProps)
+        : toMultiValueOperators(sourceOperators),
+      meta: sourceField,
+    };
+  }
+
   const modelOperators = getOperatorListByModel(fieldModel, fieldModelProps);
   if (modelOperators.length > 0) {
     return { operatorList: modelOperators, meta: { fieldModel } };
   }
 
-  const sourceField = getSourceField(flowEngine, source);
   return {
     operatorList: getFieldOperators(sourceField),
     meta: sourceField,

--- a/packages/core/client/src/flow/models/blocks/filter-manager/FilterManager.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-manager/FilterManager.ts
@@ -10,6 +10,7 @@
 import { FilterGroup, FilterItem, FlowModel } from '@nocobase/flow-engine';
 import _ from 'lodash';
 import { CollectionBlockModel } from '../../base/CollectionBlockModel';
+import { isArrayLikeField } from '../shared/filterOperators';
 import { getDefaultOperator, isFilterValueEmpty } from './utils';
 
 type FilterConfig = {
@@ -38,12 +39,6 @@ export type ConnectFieldsConfig = {
     filterPaths: string[];
   }[];
 };
-
-function isArrayLikeField(field: any) {
-  return (
-    ['multipleSelect', 'checkboxGroup'].includes(field?.interface) || ['array', 'json', 'jsonb'].includes(field?.type)
-  );
-}
 
 function getTargetField(targetModel: any, fieldPath: string) {
   const dataSourceManager = targetModel?.context?.dataSourceManager;

--- a/packages/core/client/src/flow/models/blocks/filter-manager/FilterManager.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-manager/FilterManager.ts
@@ -23,6 +23,13 @@ type FilterConfig = {
   operator?: string;
 };
 
+const ARRAY_FIELD_OPERATORS_TO_SCALAR_OPERATORS: Record<string, string> = {
+  $match: '$in',
+  $anyOf: '$in',
+  $notMatch: '$notIn',
+  $noneOf: '$notIn',
+};
+
 export type ConnectFieldsConfig = {
   targets: {
     /** 数据区块或者图表区块的 model uid */
@@ -31,6 +38,50 @@ export type ConnectFieldsConfig = {
     filterPaths: string[];
   }[];
 };
+
+function isArrayLikeField(field: any) {
+  return (
+    ['multipleSelect', 'checkboxGroup'].includes(field?.interface) || ['array', 'json', 'jsonb'].includes(field?.type)
+  );
+}
+
+function getTargetField(targetModel: any, fieldPath: string) {
+  const dataSourceManager = targetModel?.context?.dataSourceManager;
+  const collection = targetModel?.collection;
+  if (!dataSourceManager || !collection?.dataSourceKey || !collection?.name || !fieldPath) {
+    return;
+  }
+
+  let collectionName = collection.name;
+  const fieldNames = fieldPath.split('.').filter(Boolean);
+  for (let index = 0; index < fieldNames.length; index += 1) {
+    const field = dataSourceManager.getCollectionField?.(
+      `${collection.dataSourceKey}.${collectionName}.${fieldNames[index]}`,
+    );
+    if (!field || index === fieldNames.length - 1) {
+      return field;
+    }
+
+    collectionName = field.target || field.targetCollection?.name;
+    if (!collectionName) {
+      return;
+    }
+  }
+}
+
+function normalizeOperatorForTargetField(operator: string, targetModel: any, fieldPath: string) {
+  const scalarOperator = ARRAY_FIELD_OPERATORS_TO_SCALAR_OPERATORS[operator];
+  if (!scalarOperator) {
+    return operator;
+  }
+
+  const targetField = getTargetField(targetModel, fieldPath);
+  if (!targetField || isArrayLikeField(targetField)) {
+    return operator;
+  }
+
+  return scalarOperator;
+}
 
 export class FilterManager {
   private filterConfigs: FilterConfig[];
@@ -300,7 +351,11 @@ export class FilterManager {
       // 构建筛选条件
       const filterConditions = config.filterPaths.map((fieldPath) => ({
         path: fieldPath,
-        operator: config.operator || getDefaultOperator(filterModel),
+        operator: normalizeOperatorForTargetField(
+          config.operator || getDefaultOperator(filterModel),
+          targetModel,
+          fieldPath,
+        ),
         value: filterValue,
       }));
 

--- a/packages/core/client/src/flow/models/blocks/filter-manager/__tests__/FilterManager.test.ts
+++ b/packages/core/client/src/flow/models/blocks/filter-manager/__tests__/FilterManager.test.ts
@@ -496,6 +496,81 @@ describe('FilterManager', () => {
       expect(mockTargetModel2.resource.refresh).toHaveBeenCalledTimes(1);
     });
 
+    it('should normalize array operators when the target field is scalar', async () => {
+      const filterConfigs = [
+        {
+          filterId: 'filter-1',
+          targetId: 'target-scalar',
+          filterPaths: ['status'],
+          operator: '$match',
+        },
+        {
+          filterId: 'filter-1',
+          targetId: 'target-array',
+          filterPaths: ['tags'],
+          operator: '$match',
+        },
+        {
+          filterId: 'filter-1',
+          targetId: 'target-deep-array',
+          filterPaths: ['org.company.tags'],
+          operator: '$match',
+        },
+      ];
+
+      (filterManager as any).filterConfigs = filterConfigs;
+
+      const createTargetModel = (getCollectionField: any) => ({
+        collection: {
+          dataSourceKey: 'main',
+          name: 'users',
+        },
+        context: {
+          dataSourceManager: {
+            getCollectionField,
+          },
+        },
+        resource: {
+          addFilterGroup: vi.fn(),
+          removeFilterGroup: vi.fn(),
+          refresh: vi.fn().mockResolvedValue(undefined),
+        },
+        setFilterActive: vi.fn(),
+        getDataLoadingMode: vi.fn().mockReturnValue('auto'),
+      });
+      const mockScalarTargetModel = createTargetModel(vi.fn().mockReturnValue({ interface: 'select', type: 'string' }));
+      const mockArrayTargetModel = createTargetModel(
+        vi.fn().mockReturnValue({ interface: 'multipleSelect', type: 'array' }),
+      );
+      const mockDeepArrayTargetModel = createTargetModel(
+        vi.fn((key: string) => {
+          const fields = {
+            'main.users.org': { target: 'orgs' },
+            'main.orgs.company': { target: 'companies' },
+            'main.companies.tags': { interface: 'multipleSelect', type: 'array' },
+          };
+          return fields[key];
+        }),
+      );
+      const mockFilterModel = {
+        getFilterValue: vi.fn().mockReturnValue(['a1']),
+      };
+
+      (mockFlowModel.flowEngine.getModel as any).mockImplementation((uid: string) => {
+        if (uid === 'target-scalar') return mockScalarTargetModel;
+        if (uid === 'target-array') return mockArrayTargetModel;
+        if (uid === 'target-deep-array') return mockDeepArrayTargetModel;
+        if (uid === 'filter-1') return mockFilterModel;
+        return null;
+      });
+
+      await filterManager.refreshTargetsByFilter('filter-1');
+
+      expect(mockScalarTargetModel.resource.addFilterGroup.mock.calls[0][1].options.operator).toBe('$in');
+      expect(mockArrayTargetModel.resource.addFilterGroup.mock.calls[0][1].options.operator).toBe('$match');
+      expect(mockDeepArrayTargetModel.resource.addFilterGroup.mock.calls[0][1].options.operator).toBe('$match');
+    });
+
     it('should process multiple filterIds successfully', async () => {
       // Setup filter configs
       const filterConfigs = [

--- a/packages/core/client/src/flow/models/blocks/shared/filterOperators.ts
+++ b/packages/core/client/src/flow/models/blocks/shared/filterOperators.ts
@@ -1,0 +1,14 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export function isArrayLikeField(field: any) {
+  return (
+    ['multipleSelect', 'checkboxGroup'].includes(field?.interface) || ['array', 'json', 'jsonb'].includes(field?.type)
+  );
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
修复 v2 筛选表单中，自定义下拉多选字段绑定到标量字段时，筛选后数据区块请求报错的问题。

### Description
本次调整了筛选表单自定义字段的操作符解析逻辑：当下拉多选自定义字段绑定到标量来源字段时，默认使用适合标量字段的多值操作符。

同时在筛选条件应用到目标区块时，根据目标字段类型对历史配置中的数组字段操作符做兼容处理，避免标量字段继续使用 `$match` 这类数组操作符；如果目标字段本身是数组字段，包括深层关系路径下的数组字段，则保留原有数组操作符。

已补充相关单元测试，并在本地前端通过 Playwright CLI 按原复现步骤完成回归验证。

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error when filtering scalar fields with custom multi-select filters |
| 🇨🇳 Chinese | 修复自定义下拉多选筛选标量字段时报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary