### PR TITLE
fix: align v2 spacing with theme tokens

### DIFF
--- a/packages/core/flow-engine/src/components/FormItem.tsx
+++ b/packages/core/flow-engine/src/components/FormItem.tsx
@@ -19,6 +19,9 @@ interface ExtendedFormItemProps extends FormItemProps {
   showLabel?: boolean;
 }
 
+export const verticalFormItemLabelStyle = { paddingBottom: 0 };
+export const formItemStyle = { marginBottom: 12 };
+
 const formItemPropKeys: (keyof ExtendedFormItemProps)[] = [
   'colon',
   'dependencies',
@@ -73,6 +76,8 @@ export const FormItem = ({
         });
   const { label, labelWrap, colon = true, layout } = rest;
   const effectiveLabelWrap = !layout || layout === 'vertical' ? true : labelWrap;
+  const labelColStyle =
+    layout === 'vertical' ? { width: labelWidth, ...verticalFormItemLabelStyle } : { width: labelWidth };
   const renderLabel = () => {
     if (!showLabel) return null;
     if (effectiveLabelWrap) {
@@ -118,7 +123,8 @@ export const FormItem = ({
   return (
     <Form.Item
       {...rest}
-      labelCol={{ style: { width: labelWidth } }}
+      style={{ ...formItemStyle, ...rest.style }}
+      labelCol={{ style: labelColStyle }}
       layout={layout}
       label={renderLabel()}
       colon={false}

--- a/packages/core/flow-engine/src/components/__tests__/FormItem.test.tsx
+++ b/packages/core/flow-engine/src/components/__tests__/FormItem.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formItemStyle, verticalFormItemLabelStyle } from '../FormItem';
+
+describe('FormItem', () => {
+  it('keeps vertical label-to-value spacing consistent with v1', () => {
+    expect(verticalFormItemLabelStyle).toEqual({
+      paddingBottom: 0,
+    });
+  });
+
+  it('keeps spacing between form items consistent with v1', () => {
+    expect(formItemStyle).toEqual({
+      marginBottom: 12,
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanCardItemModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/KanbanCardItemModel.tsx
@@ -170,7 +170,7 @@ export class KanbanCardItemModel extends FlowModel<KanbanCardItemStructure> {
 
     const { colon, labelAlign, labelWidth, labelWrap, layout } = this.props;
     const token = this.context.themeToken || {};
-    const cardBodyPaddingBlock = token.paddingContentVertical ?? 12;
+    const cardBodyPaddingTop = token.paddingContentVertical ?? 12;
     const cardBodyPaddingInline = token.paddingContentHorizontal ?? 16;
     const cardFieldGap = token.marginSM ?? 4;
     const clickEnabled = this.props.enableCardClick !== false;
@@ -203,7 +203,7 @@ export class KanbanCardItemModel extends FlowModel<KanbanCardItemStructure> {
 
           .ant-card-body {
             height: 100%;
-            padding: ${cardBodyPaddingBlock}px ${cardBodyPaddingInline}px;
+            padding: ${cardBodyPaddingTop}px ${cardBodyPaddingInline}px 0;
             display: flex;
             flex-direction: column;
             justify-content: space-between;

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanBlock.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanBlock.tsx
@@ -23,7 +23,7 @@ import {
   type KanbanGroupOption,
 } from '../utils';
 import { ColumnPanel } from './kanban-block/ColumnPanel';
-import { CardPlaceholder } from './kanban-block/CardRenderer';
+import { CardPlaceholder, getKanbanCardGap, getKanbanCardRadius } from './kanban-block/CardRenderer';
 import {
   applyKanbanColumnOverride,
   areKanbanRecordListsEqual,
@@ -94,6 +94,8 @@ export const KanbanBlockView = observer(({ model }: { model: KanbanBlockModel })
   const [actionsHeight, setActionsHeight] = useState(0);
   const [errorHeight, setErrorHeight] = useState(0);
   const groupField = model.getGroupField();
+  const token = model.context.themeToken || {};
+  const boardGap = token.margin ?? 16;
   const groupFieldName = groupField?.name;
   const groupFieldScopeKey = getKanbanFieldScopeKey(groupField);
   const showActionsBar = !!model.context.flowSettingsEnabled || model.hasSubModel('actions');
@@ -198,8 +200,8 @@ export const KanbanBlockView = observer(({ model }: { model: KanbanBlockModel })
 
     const gapCount =
       Number(Boolean(showActionsBar && actionsHeight)) + Number(Boolean(groupOptionsError && errorHeight));
-    return Math.max(containerHeight - actionsHeight - errorHeight - gapCount * 16, 0);
-  }, [actionsHeight, containerHeight, errorHeight, groupOptionsError, isFixedHeight, showActionsBar]);
+    return Math.max(containerHeight - actionsHeight - errorHeight - gapCount * boardGap, 0);
+  }, [actionsHeight, boardGap, containerHeight, errorHeight, groupOptionsError, isFixedHeight, showActionsBar]);
 
   useEffect(() => {
     let cancelled = false;
@@ -558,12 +560,14 @@ export const KanbanBlockView = observer(({ model }: { model: KanbanBlockModel })
         overflow-y: ${contentHeight ? 'hidden' : 'visible'};
         display: flex;
         align-items: stretch;
-        gap: 16px;
+        gap: ${boardGap}px;
         width: 100%;
       `}
       style={{ height: contentHeight }}
     >
-      {groupOptionsLoading && !groupOptions.length ? <CardPlaceholder /> : null}
+      {groupOptionsLoading && !groupOptions.length ? (
+        <CardPlaceholder cardGap={getKanbanCardGap(model)} cardRadius={getKanbanCardRadius(model)} />
+      ) : null}
       {mountedColumns.map((column) => {
         const hidden =
           column.isUnknown &&
@@ -600,7 +604,7 @@ export const KanbanBlockView = observer(({ model }: { model: KanbanBlockModel })
         display: 'flex',
         flexDirection: 'column',
         minHeight: isFixedHeight ? 0 : DEFAULT_KANBAN_BLOCK_MIN_HEIGHT,
-        gap: 16,
+        gap: boardGap,
         height: isFixedHeight ? '100%' : 'auto',
       }}
     >

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanCreateSortFieldSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanCreateSortFieldSelect.tsx
@@ -120,6 +120,7 @@ export const KanbanCreateSortFieldSelect = observer(
     const schemaOptions = useContext(SchemaOptionsContext);
     const flowSettingsContext = useFlowSettingsContext<any>();
     const model = flowSettingsContext?.model;
+    const token = model?.context?.themeToken || {};
     const collection = model?.collection || flowSettingsContext?.collection;
     const flowSettings = flowSettingsContext?.model?.context?.engine?.flowSettings;
     const grouping = useGroupingFormValues ? form?.values?.grouping || {} : {};
@@ -231,7 +232,7 @@ export const KanbanCreateSortFieldSelect = observer(
           : undefined;
 
       return (
-        <span style={{ color: 'rgba(0, 0, 0, 0.25)' }}>
+        <span style={{ color: token.colorTextDisabled || 'rgba(0, 0, 0, 0.25)' }}>
           (
           {scopedFieldTitle
             ? t('Grouped sorting based on', { ns: NAMESPACE }) + `「${scopedFieldTitle}」`

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanGroupOptionsTable.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanGroupOptionsTable.tsx
@@ -159,6 +159,7 @@ export const KanbanGroupOptionsTable = observer(
 
     const api = useAPIClient();
     const resolvedModel = model || settingsContext?.model;
+    const token = resolvedModel?.context?.themeToken || {};
     const resolvedCollection = resolvedModel?.collection || collection || settingsContext?.collection;
     const resolvedDataSourceKey =
       resolvedCollection?.dataSourceKey || dataSourceKey || settingsContext?.dataSource?.key;
@@ -330,7 +331,7 @@ export const KanbanGroupOptionsTable = observer(
           width: '100%',
           display: 'flex',
           flexDirection: 'column',
-          gap: optionsError ? 8 : 0,
+          gap: optionsError ? token.marginXS ?? 8 : 0,
         }}
       >
         {optionsError ? <Alert type="error" message={optionsError} showIcon /> : null}

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanGroupingSelector.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/KanbanGroupingSelector.tsx
@@ -63,6 +63,7 @@ export const KanbanGroupingSelector = observer(
     }
 
     const resolvedModel = model || settingsContext?.model;
+    const token = resolvedModel?.context?.themeToken || {};
     const resolvedCollection = resolvedModel?.collection || collection || settingsContext?.collection;
 
     const translate = useCallback(
@@ -184,7 +185,7 @@ export const KanbanGroupingSelector = observer(
     const selectedValues = groupOptions.map((item) => item.value);
 
     return (
-      <Space direction="vertical" size={12} style={{ width: '100%' }}>
+      <Space direction="vertical" size={token.marginSM ?? 12} style={{ width: '100%' }}>
         {optionsError ? <Alert type="error" message={optionsError} showIcon /> : null}
         <Spin spinning={optionsLoading}>
           <Select

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/CardRenderer.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/CardRenderer.tsx
@@ -15,13 +15,16 @@ import { useInView } from 'react-intersection-observer';
 import type { KanbanBlockModel } from '../../KanbanBlockModel';
 import { getKanbanCardRenderKey, getRuntimeRecordKey, type KanbanRuntimeRecord } from './shared';
 
-export const CardPlaceholder = () => {
+export const getKanbanCardGap = (model: KanbanBlockModel) => model.context.themeToken?.marginSM ?? 12;
+export const getKanbanCardRadius = (model: KanbanBlockModel) => model.context.themeToken?.borderRadiusLG ?? 12;
+
+export const CardPlaceholder = ({ cardGap = 12, cardRadius = 12 }: { cardGap?: number; cardRadius?: number }) => {
   return (
     <div
       className={css`
-        margin-bottom: 12px;
+        margin-bottom: ${cardGap}px;
         min-height: 132px;
-        border-radius: 12px;
+        border-radius: ${cardRadius}px;
         background: var(--ant-colorFillQuaternary);
         opacity: 0.55;
       `}
@@ -92,7 +95,7 @@ export const LazyCardRenderer = memo(
     if (!shouldRenderContent) {
       return (
         <div ref={ref}>
-          <CardPlaceholder />
+          <CardPlaceholder cardGap={getKanbanCardGap(model)} cardRadius={getKanbanCardRadius(model)} />
         </div>
       );
     }
@@ -146,6 +149,7 @@ export const DraggableKanbanCard = memo(
   }: DraggableKanbanCardProps) => {
     const recordKey = getRuntimeRecordKey(record, model.collection);
     const draggableId = String(recordKey || `${columnKey}:${index}`);
+    const cardGap = getKanbanCardGap(model);
 
     return (
       <Draggable draggableId={draggableId} index={index} isDragDisabled={!dragInteractionEnabled || !recordKey}>
@@ -162,7 +166,7 @@ export const DraggableKanbanCard = memo(
               willChange: snapshot.isDragging ? 'transform' : undefined,
             }}
             className={css`
-              margin-bottom: 12px;
+              margin-bottom: ${cardGap}px;
               backface-visibility: hidden;
               contain: layout;
             `}

--- a/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/ColumnPanel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client/models/components/kanban-block/ColumnPanel.tsx
@@ -14,7 +14,7 @@ import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Droppable } from 'react-beautiful-dnd';
 import type { KanbanBlockModel } from '../../KanbanBlockModel';
 import { toKanbanAlphaColor } from '../../utils';
-import { CardPlaceholder, DraggableKanbanCard, LazyCardRenderer } from './CardRenderer';
+import { CardPlaceholder, DraggableKanbanCard, getKanbanCardGap, LazyCardRenderer } from './CardRenderer';
 import {
   type ColumnRefreshMeta,
   createColumnResource,
@@ -84,6 +84,14 @@ const ColumnPanelComponent = ({
       ? toKanbanAlphaColor(column.color, column.isUnknown ? 0.14 : 0.18)
       : 'var(--colorBgLayout)'
     : 'var(--colorBgLayout)';
+  const token = model.context.themeToken || {};
+  const cardGap = getKanbanCardGap(model);
+  const columnPadding = token.paddingSM ?? 12;
+  const columnBorderRadius = token.borderRadiusLG ?? 12;
+  const headerGap = token.marginSM ?? 8;
+  const headerPaddingBlock = token.paddingSM ?? 12;
+  const headerPaddingInline = token.padding ?? 14;
+  const countTextColor = token.colorTextDescription || 'rgba(0, 0, 0, 0.45)';
 
   const loadPage = useCallback(
     async (page: number, append = false) => {
@@ -287,7 +295,7 @@ const ColumnPanelComponent = ({
         min-height: ${fixedHeight ? '0' : '180px'};
         overflow-x: hidden;
         overflow-y: ${fixedHeight ? 'auto' : 'visible'};
-        padding: 12px;
+        padding: ${columnPadding}px;
         scrollbar-gutter: stable;
         transition: background 0.2s ease;
       `}
@@ -300,7 +308,7 @@ const ColumnPanelComponent = ({
         `}
       >
         {runtimeState.loading && !displayItems.length ? (
-          <CardPlaceholder />
+          <CardPlaceholder cardGap={cardGap} />
         ) : displayItems.length ? (
           displayItems.map((record, index) => {
             const recordKey = getRuntimeRecordKey(record, model.collection);
@@ -318,7 +326,7 @@ const ColumnPanelComponent = ({
                 <div
                   key={`card-wrap:${cardRenderKey}`}
                   className={css`
-                    margin-bottom: 12px;
+                    margin-bottom: ${cardGap}px;
                   `}
                 >
                   <LazyCardRenderer
@@ -370,7 +378,7 @@ const ColumnPanelComponent = ({
         min-height: ${fixedHeight ? '0' : DEFAULT_KANBAN_BLOCK_MIN_HEIGHT};
         height: ${fixedHeight ? '100%' : 'auto'};
         background: ${panelBackgroundColor};
-        border-radius: 12px;
+        border-radius: ${columnBorderRadius}px;
         border: 1px solid ${panelBorderColor};
         overflow: hidden;
         flex-shrink: 0;
@@ -381,13 +389,13 @@ const ColumnPanelComponent = ({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          gap: 8,
-          padding: '12px 14px',
+          gap: headerGap,
+          padding: `${headerPaddingBlock}px ${headerPaddingInline}px`,
           background: panelHeaderBackgroundColor,
           borderBottom: `1px solid ${panelBorderColor}`,
         }}
       >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: '1 1 auto', minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: headerGap, flex: '1 1 auto', minWidth: 0 }}>
           <Badge color={column.color}></Badge>
           <span
             style={{
@@ -400,7 +408,7 @@ const ColumnPanelComponent = ({
           >
             {column.label}
           </span>
-          <span style={{ flexShrink: 0, color: 'rgba(0, 0, 0, 0.45)' }}>{displayCount}</span>
+          <span style={{ flexShrink: 0, color: countTextColor }}>{displayCount}</span>
         </div>
         {model.getQuickCreateEnabled() ? (
           <Tooltip title={model.translate('Add new')}>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 detail form item spacing and kanban card/column spacing did not consistently match the v1 behavior or current theme tokens.

### Description 
This PR aligns v2 form item vertical label spacing and item spacing with the v1 behavior, removes the bottom padding from kanban card bodies, and updates kanban spacing, radius, and secondary text colors to use theme tokens with existing visual fallback values.

Tested with focused FormItem and kanban model/component tests.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved v2 detail field spacing consistency and made kanban card and column spacing better adapt to theme settings. |
| 🇨🇳 Chinese | 优化 v2 详情字段间距一致性，并使看板卡片和列间距更好地适配主题设置。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
