### PR TITLE
fix(auth): prevent authenticator fallback for explicit requests

### DIFF
--- a/packages/core/auth/src/__tests__/auth-manager.test.ts
+++ b/packages/core/auth/src/__tests__/auth-manager.test.ts
@@ -20,6 +20,10 @@ class MockStorer {
   async get(name: string) {
     return this.elements.get(name);
   }
+
+  async getDefault() {
+    return this.elements.values().next().value;
+  }
 }
 
 class BasicAuth extends Auth {

--- a/packages/core/auth/src/auth-manager.ts
+++ b/packages/core/auth/src/auth-manager.ts
@@ -25,6 +25,7 @@ export interface Authenticator {
 
 export interface Storer {
   get: (name: string) => Promise<Authenticator>;
+  getDefault?: () => Promise<Authenticator>;
 }
 
 export type AuthManagerOptions = {
@@ -101,11 +102,14 @@ export class AuthManager {
    * @param name - The name of the authenticator.
    * @return authenticator instance.
    */
-  async get(name: string, ctx: Context) {
+  async get(name: string, ctx: Context, options?: { fallbackToDefault?: boolean }) {
     if (!this.storer) {
       throw new Error('AuthManager.storer is not set.');
     }
-    const authenticator = await this.storer.get(name);
+    let authenticator = await this.storer.get(name);
+    if (!authenticator && options?.fallbackToDefault && this.storer.getDefault) {
+      authenticator = await this.storer.getDefault();
+    }
     if (!authenticator) {
       throw new Error(`Authenticator [${name}] is not found.`);
     }
@@ -124,14 +128,18 @@ export class AuthManager {
     const self = this;
 
     return async function AuthManagerMiddleware(ctx: Context & { auth: Auth }, next: Next) {
-      const name = ctx.get(self.options.authKey) || self.options.default;
+      const headerName = ctx.get(self.options.authKey);
+      const name = headerName || self.options.default;
       let authenticator: Auth;
       try {
-        authenticator = await ctx.app.authManager.get(name, ctx);
+        authenticator = await ctx.app.authManager.get(name, ctx, { fallbackToDefault: !headerName });
         ctx.auth = authenticator;
       } catch (err) {
         ctx.auth = {} as Auth;
         ctx.logger.warn(err.message, { method: 'check', authenticator: name });
+        if (headerName) {
+          ctx.throw(401, err.message);
+        }
         return next();
       }
 

--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
@@ -9,6 +9,7 @@
 
 import Database, { Repository } from '@nocobase/database';
 import { createMockServer, MockServer } from '@nocobase/test';
+import { presetAuthType } from '../../preset';
 
 describe('actions', () => {
   describe('authenticators', () => {
@@ -162,6 +163,31 @@ describe('actions', () => {
 
       res = await agent.get('/auth:check').set({ Authorization: `Bearer ${token}`, 'X-Authenticator': 'basic' });
       expect(res.body.data.id).toBeDefined();
+    });
+
+    it('should not fall back to another authenticator when the requested authenticator is disabled', async () => {
+      await db.getRepository('authenticators').create({
+        values: {
+          name: 'another-password',
+          authType: presetAuthType,
+          enabled: true,
+        },
+      });
+      await db.getRepository('authenticators').update({
+        filter: {
+          name: 'basic',
+        },
+        values: {
+          enabled: false,
+        },
+      });
+
+      const res = await agent.post('/auth:signIn').set({ 'X-Authenticator': 'basic' }).send({
+        account: process.env.INIT_ROOT_USERNAME,
+        password: process.env.INIT_ROOT_PASSWORD,
+      });
+      expect(res.statusCode).toEqual(401);
+      expect(res.error.text).toBe('Authenticator [basic] is not found.');
     });
 
     it('should disable sign up', async () => {

--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/storer.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/storer.test.ts
@@ -75,6 +75,15 @@ describe('storer', () => {
     expect(authenticator).toBeDefined();
   });
 
+  it('should not fall back when authenticator is not found by name', async () => {
+    expect(await storer.get('not-exists')).toBeUndefined();
+  });
+
+  it('should get default authenticator', async () => {
+    const authenticator = await storer.getDefault();
+    expect(authenticator).toMatchObject({ name: 'test1' });
+  });
+
   it('should delete from cache on afterDestory', async () => {
     expect(await storer.get('test1')).toBeDefined();
     await db.emitAsync('authenticators.afterDestroy', data[0]);

--- a/packages/plugins/@nocobase/plugin-auth/src/server/storer.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/storer.ts
@@ -88,6 +88,17 @@ export class Storer implements IStorer {
       authenticators = await this.getCache();
     }
     const authenticator = authenticators.find((authenticator: Model) => authenticator.name === name);
-    return authenticator || authenticators[0];
+    return authenticator;
+  }
+
+  async getDefault() {
+    let authenticators = await this.getCache();
+    if (!authenticators.length) {
+      const repo = this.db.getRepository('authenticators');
+      authenticators = await repo.find({ filter: { enabled: true } });
+      await this.setCache(authenticators);
+      authenticators = await this.getCache();
+    }
+    return authenticators[0];
   }
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When the password authenticator is disabled, requests that explicitly specify it should not be handled by another enabled authenticator through fallback behavior.

### Description 
This change separates exact authenticator lookup from default authenticator fallback. Explicit authenticator requests now fail when that authenticator is unavailable, while requests without an authenticator header can still use the default enabled authenticator.

Added regression tests for disabled password authenticator sign-in and storer fallback behavior.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where API calls can still be authenticated after password authentication has been disabled |
| 🇨🇳 Chinese | 修复禁用密码认证后仍能通过接口调用使用的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
