### PR TITLE
fix(flow-engine): translate data source validation messages in flow forms

### DIFF
--- a/packages/core/flow-engine/src/data-source/__tests__/index.test.ts
+++ b/packages/core/flow-engine/src/data-source/__tests__/index.test.ts
@@ -79,4 +79,38 @@ describe('DataSource & Collection APIs', () => {
       ]),
     ).toThrow(/circular/);
   });
+
+  it('translates validation messages from data-source-main in component rules', async () => {
+    const { m, engine } = makeManager();
+    engine.context.i18n = {
+      t: (key: string, options?: Record<string, any>) => {
+        if (key === 'string.length' && options?.ns === 'data-source-main') {
+          return `${options.label} 长度必须为 ${options.limit} 个字符`;
+        }
+        return key;
+      },
+    } as any;
+
+    const ds = new DataSource({ key: 'main' });
+    m.addDataSource(ds);
+    ds.addCollection({
+      name: 'posts',
+      fields: [
+        {
+          name: 'title',
+          type: 'string',
+          interface: 'text',
+          title: '单行文本',
+          validation: {
+            type: 'string',
+            rules: [{ name: 'length', args: { limit: 18 } }],
+          },
+        },
+      ],
+    });
+
+    const rules = ds.getCollection('posts')!.getField('title')!.getComponentProps().rules;
+
+    await expect(rules[0].validator({}, '123')).rejects.toBe('单行文本 长度必须为 18 个字符');
+  });
 });

--- a/packages/core/flow-engine/src/data-source/index.ts
+++ b/packages/core/flow-engine/src/data-source/index.ts
@@ -862,7 +862,21 @@ export class CollectionField {
           });
 
           if (error) {
-            const message = error.details.map((d: any) => d.message.replace(/"value"/g, `"${label}"`)).join(', ');
+            const message = error.details
+              .map((d: any) => {
+                const translated = this.flowEngine.translate(d.type, {
+                  ...d.context,
+                  ns: 'data-source-main',
+                  label,
+                });
+
+                if (translated && translated !== d.type) {
+                  return translated;
+                }
+
+                return d.message.replace(/"value"/g, `"${label}"`);
+              })
+              .join(', ');
             return Promise.reject(message);
           }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Flow v2 forms were using raw Joi validation messages for collection field rules in flow-engine, so validation messages like `string.length` were shown in English instead of using the `data-source-main` locale resources.

### Description 
This PR updates flow-engine collection field validation handling to translate Joi detail types through the `data-source-main` namespace before falling back to the original Joi message.

It also adds a focused regression test covering `string.length` translation in flow form validation.

Risk is low because the change is limited to flow-engine validation message generation and preserves the original fallback behavior when no translation is found.

Testing:
- Run `yarn test:client packages/core/flow-engine/src/data-source/__tests__/index.test.ts --run`
- In a v2 flow form, configure a data table field validation rule such as fixed string length and verify the validation message is localized on submit

### Related issues
- Task: 3519

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed untranslated data table field validation messages in v2 flow forms |
| 🇨🇳 Chinese | 修复 v2 Flow 表单中数据表字段校验提示未翻译的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
