### PR TITLE
fix(client): sync page tabs setting

### DIFF
--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -48,6 +48,17 @@ export class PageModel extends FlowModel<PageModelStructure> {
   private unmounted = false;
   private documentTitleUpdateVersion = 0;
 
+  /**
+   * 根页面标签页开关以路由表为准，避免 flow model 里的旧配置覆盖路由管理设置。
+   */
+  private getEnableTabs(): boolean {
+    const routeEnableTabs = (this.context as any)?.currentRoute?.enableTabs;
+    if (this.props.routeId != null && typeof routeEnableTabs === 'boolean') {
+      return routeEnableTabs;
+    }
+    return !!this.props.enableTabs;
+  }
+
   private getActiveTabKey(): string | undefined {
     const viewParams = this.context.view?.navigation?.viewParams;
     if (viewParams) {
@@ -192,7 +203,7 @@ export class PageModel extends FlowModel<PageModelStructure> {
     };
 
     let nextTitle = '';
-    if (this.props.enableTabs) {
+    if (this.getEnableTabs()) {
       const activeTabKey = preferredActiveTabKey || this.getActiveTabKey();
       const activeTabModel = activeTabKey
         ? (this.flowEngine.getModel(activeTabKey) as BasePageTabModel | undefined)
@@ -355,13 +366,14 @@ export class PageModel extends FlowModel<PageModelStructure> {
       headerStyle.paddingBlock = token.paddingSM;
       headerStyle.paddingInline = token.paddingLG;
     }
-    if (this.props.enableTabs) {
+    const enableTabs = this.getEnableTabs();
+    if (enableTabs) {
       headerStyle.paddingBottom = 0;
     }
     return (
       <>
         {this.props.displayTitle && <PageHeader title={this.props.title} style={headerStyle} />}
-        {this.props.enableTabs ? this.renderTabs() : this.renderFirstTab()}
+        {enableTabs ? this.renderTabs() : this.renderFirstTab()}
       </>
     );
   }

--- a/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
@@ -18,6 +18,31 @@ export class RootPageModel extends PageModel {
   mounted = false;
 
   /**
+   * 打开页面设置前，把标签页开关表单值同步为路由表中的当前状态。
+   */
+  private syncPageSettingsEnableTabsFromRoute() {
+    const routeEnableTabs = (this.context as any)?.currentRoute?.enableTabs;
+    if (typeof routeEnableTabs !== 'boolean') {
+      return;
+    }
+    this.setStepParams('pageSettings', 'general', {
+      enableTabs: routeEnableTabs,
+    });
+  }
+
+  /**
+   * 保存页面设置后立即同步当前页面状态，让标签页显隐无需等路由列表刷新或页面重载。
+   */
+  private syncEnableTabsToCurrentPage(enableTabs: boolean) {
+    const currentRoute = (this.context as any)?.currentRoute;
+    const routeId = this.props.routeId;
+    if (currentRoute && (routeId == null || currentRoute.id == null || String(currentRoute.id) === String(routeId))) {
+      currentRoute.enableTabs = enableTabs;
+    }
+    this.setProps('enableTabs', enableTabs);
+  }
+
+  /**
    * 新建 tab 在首次保存完成前，前端 route 里可能还没有数据库 id。
    * 拖拽前兜底触发一次保存，确保 move 接口拿到真实主键。
    *
@@ -65,18 +90,26 @@ export class RootPageModel extends PageModel {
     );
   }
 
+  async openFlowSettings(options?: Parameters<PageModel['openFlowSettings']>[0]) {
+    this.syncPageSettingsEnableTabsFromRoute();
+    return super.openFlowSettings(options);
+  }
+
   async saveStepParams() {
     await super.saveStepParams();
 
     if (this.stepParams.pageSettings) {
+      const enableTabs = !!this.stepParams.pageSettings.general.enableTabs;
       // 更新路由
-      this.context.api.request({
+      await this.context.api.request({
         url: `desktopRoutes:update?filter[id]=${this.props.routeId}`,
         method: 'post',
         data: {
-          enableTabs: !!this.stepParams.pageSettings.general.enableTabs,
+          enableTabs,
         },
       });
+      this.syncEnableTabsToCurrentPage(enableTabs);
+      await this.context.refreshDesktopRoutes?.();
     }
   }
 

--- a/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/RootPageModel.tsx
@@ -91,7 +91,9 @@ export class RootPageModel extends PageModel {
   }
 
   async openFlowSettings(options?: Parameters<PageModel['openFlowSettings']>[0]) {
-    this.syncPageSettingsEnableTabsFromRoute();
+    if (options?.flowKey === 'pageSettings' && options?.stepKey === 'general') {
+      this.syncPageSettingsEnableTabsFromRoute();
+    }
     return super.openFlowSettings(options);
   }
 

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
@@ -412,6 +412,7 @@ describe('PageModel', () => {
   describe('render header spacing with tabs', () => {
     it('should compact page header bottom spacing when tabs are enabled', () => {
       pageModel.props = {
+        routeId: 'route-1',
         displayTitle: true,
         enableTabs: true,
         title: 'Title',
@@ -430,6 +431,7 @@ describe('PageModel', () => {
 
     it('should keep original header style when tabs are disabled', () => {
       pageModel.props = {
+        routeId: 'route-1',
         displayTitle: true,
         enableTabs: false,
         title: 'Title',
@@ -441,6 +443,57 @@ describe('PageModel', () => {
       const header = result.props.children[0];
 
       expect(header.props.style).toEqual({ backgroundColor: 'var(--colorBgLayout)' });
+    });
+
+    it('should use desktop route enableTabs=false before flow model props', () => {
+      pageModel.props = {
+        routeId: 'route-1',
+        displayTitle: true,
+        enableTabs: true,
+        title: 'Title',
+        headerStyle: { backgroundColor: 'var(--colorBgLayout)' },
+      } as any;
+      (pageModel as any).context = {
+        currentRoute: {
+          enableTabs: false,
+        },
+      };
+      pageModel.renderTabs = vi.fn(() => null);
+      pageModel.renderFirstTab = vi.fn(() => null);
+
+      const result = pageModel.render() as any;
+      const header = result.props.children[0];
+
+      expect(pageModel.renderTabs).not.toHaveBeenCalled();
+      expect(pageModel.renderFirstTab).toHaveBeenCalled();
+      expect(header.props.style).toEqual({ backgroundColor: 'var(--colorBgLayout)' });
+    });
+
+    it('should use desktop route enableTabs=true before flow model props', () => {
+      pageModel.props = {
+        routeId: 'route-1',
+        displayTitle: true,
+        enableTabs: false,
+        title: 'Title',
+        headerStyle: { backgroundColor: 'var(--colorBgLayout)' },
+      } as any;
+      (pageModel as any).context = {
+        currentRoute: {
+          enableTabs: true,
+        },
+      };
+      pageModel.renderTabs = vi.fn(() => null);
+      pageModel.renderFirstTab = vi.fn(() => null);
+
+      const result = pageModel.render() as any;
+      const header = result.props.children[0];
+
+      expect(pageModel.renderTabs).toHaveBeenCalled();
+      expect(pageModel.renderFirstTab).not.toHaveBeenCalled();
+      expect(header.props.style).toMatchObject({
+        backgroundColor: 'var(--colorBgLayout)',
+        paddingBottom: 0,
+      });
     });
   });
 
@@ -572,6 +625,26 @@ describe('PageModel', () => {
       await (pageModel as any).updateDocumentTitle();
 
       expect(document.title).toBe('Resolved tab doc title');
+    });
+
+    it('should use page documentTitle when desktop route disables tabs even if flow model enables tabs', async () => {
+      pageModel.props = { routeId: 'route-1', enableTabs: true, title: 'Route page title' } as any;
+      (pageModel as any).context.currentRoute = {
+        enableTabs: false,
+      };
+      (pageModel as any).stepParams = {
+        pageSettings: {
+          general: {
+            documentTitle: 'Route page doc title',
+          },
+        },
+      };
+      (pageModel as any).context.resolveJsonTemplate = vi.fn(async () => 'Resolved route page doc title');
+
+      await (pageModel as any).updateDocumentTitle();
+
+      expect((pageModel as any).context.resolveJsonTemplate).toHaveBeenCalledWith('Route page doc title');
+      expect(document.title).toBe('Resolved route page doc title');
     });
 
     it('should fallback to tab title when active tab documentTitle is empty', async () => {

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/RootPageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/RootPageModel.test.ts
@@ -130,6 +130,25 @@ describe('RootPageModel', () => {
 
       expect((rootPageModel as any).stepParams.pageSettings.general.enableTabs).toBe(true);
     });
+
+    it('should not sync enableTabs when opening other settings steps', async () => {
+      mockContext.currentRoute.enableTabs = false;
+      (rootPageModel as any).stepParams = {
+        pageSettings: {
+          general: {
+            enableTabs: true,
+          },
+        },
+      };
+
+      await rootPageModel.openFlowSettings({ flowKey: 'otherSettings', stepKey: 'general' } as any);
+
+      expect((rootPageModel as any).stepParams.pageSettings.general.enableTabs).toBe(true);
+      expect(mockPageModelOpenFlowSettings).toHaveBeenCalledWith({
+        flowKey: 'otherSettings',
+        stepKey: 'general',
+      });
+    });
   });
 
   describe('saveStepParams', () => {

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/RootPageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/RootPageModel.test.ts
@@ -12,9 +12,31 @@ import { RootPageModel } from '../RootPageModel';
 
 // Mock PageModel
 const mockPageModelSaveStepParams = vi.fn();
+const mockPageModelOpenFlowSettings = vi.fn();
 vi.mock('../PageModel', () => ({
   PageModel: class {
+    props: any = {};
+    stepParams: any = {};
+
     static registerFlow() {}
+
+    setProps(key: string, value: any) {
+      this.props[key] = value;
+    }
+
+    setStepParams(flowKey: string, stepKey: string, params: Record<string, any>) {
+      if (!this.stepParams[flowKey]) {
+        this.stepParams[flowKey] = {};
+      }
+      this.stepParams[flowKey][stepKey] = {
+        ...this.stepParams[flowKey][stepKey],
+        ...params,
+      };
+    }
+
+    async openFlowSettings(options?: any) {
+      return mockPageModelOpenFlowSettings(options);
+    }
 
     async saveStepParams() {
       return mockPageModelSaveStepParams();
@@ -26,6 +48,7 @@ describe('RootPageModel', () => {
   let rootPageModel: RootPageModel;
   let mockContext: any;
   let mockApi: any;
+  let mockRefreshDesktopRoutes: any;
   let mockFlowEngine: any;
 
   beforeEach(() => {
@@ -35,6 +58,7 @@ describe('RootPageModel', () => {
     mockApi = {
       request: vi.fn().mockResolvedValue({ data: { success: true } }),
     };
+    mockRefreshDesktopRoutes = vi.fn().mockResolvedValue(undefined);
 
     // Mock FlowEngine
     mockFlowEngine = {
@@ -45,6 +69,11 @@ describe('RootPageModel', () => {
     // Mock context
     mockContext = {
       api: mockApi,
+      refreshDesktopRoutes: mockRefreshDesktopRoutes,
+      currentRoute: {
+        id: 'route-123',
+        enableTabs: true,
+      },
     };
 
     // Create RootPageModel instance
@@ -61,6 +90,46 @@ describe('RootPageModel', () => {
         },
       },
     };
+  });
+
+  describe('openFlowSettings', () => {
+    it('should use desktop route enableTabs as settings dialog initial value', async () => {
+      mockContext.currentRoute.enableTabs = false;
+      (rootPageModel as any).stepParams = {
+        pageSettings: {
+          general: {
+            displayTitle: true,
+            enableTabs: true,
+          },
+        },
+      };
+
+      await rootPageModel.openFlowSettings({ flowKey: 'pageSettings', stepKey: 'general' } as any);
+
+      expect((rootPageModel as any).stepParams.pageSettings.general).toMatchObject({
+        displayTitle: true,
+        enableTabs: false,
+      });
+      expect(mockPageModelOpenFlowSettings).toHaveBeenCalledWith({
+        flowKey: 'pageSettings',
+        stepKey: 'general',
+      });
+    });
+
+    it('should keep flow model enableTabs when route status is unavailable', async () => {
+      mockContext.currentRoute = {};
+      (rootPageModel as any).stepParams = {
+        pageSettings: {
+          general: {
+            enableTabs: true,
+          },
+        },
+      };
+
+      await rootPageModel.openFlowSettings({ flowKey: 'pageSettings', stepKey: 'general' } as any);
+
+      expect((rootPageModel as any).stepParams.pageSettings.general.enableTabs).toBe(true);
+    });
   });
 
   describe('saveStepParams', () => {
@@ -88,6 +157,34 @@ describe('RootPageModel', () => {
           enableTabs: true,
         },
       });
+    });
+
+    it('should refresh desktop routes after route update is persisted', async () => {
+      await rootPageModel.saveStepParams();
+
+      expect(mockApi.request).toHaveBeenCalledTimes(1);
+      expect(mockRefreshDesktopRoutes).toHaveBeenCalledTimes(1);
+      expect(mockApi.request.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRefreshDesktopRoutes.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should apply enableTabs to current page immediately after route update is persisted', async () => {
+      (rootPageModel as any).stepParams = {
+        pageSettings: {
+          general: {
+            enableTabs: false,
+          },
+        },
+      };
+
+      await rootPageModel.saveStepParams();
+
+      expect(mockContext.currentRoute.enableTabs).toBe(false);
+      expect((rootPageModel as any).props.enableTabs).toBe(false);
+      expect(mockApi.request.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRefreshDesktopRoutes.mock.invocationCallOrder[0],
+      );
     });
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 页面中，页面是否启用标签页的设置会同时出现在路由管理和页面配置弹窗里。用户在路由管理或页面配置中关闭标签页后，页面显示、配置弹窗状态和保存后的即时效果以及路由管理页可能不同步。

### Description 
本次修复让 v2 页面标签页的显示状态以路由中的设置为准，并在打开页面配置弹窗时同步当前路由状态。

保存页面配置后，当前页面会立即更新标签页显示状态，无需刷新页面。同时补充了相关单元测试，覆盖页面显示、文档标题、弹窗初始值和保存后立即生效的场景。

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where v2 page tabs do not sync immediately after saving settings |
| 🇨🇳 Chinese | 修复路由管理页的配置不和页面标签页的配置同步的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary