### PR TITLE
fix: stabilize v2 linkage field options

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
@@ -7,8 +7,11 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FlowSettingsContextProvider } from '@nocobase/flow-engine';
 import { describe, expect, it, vi } from 'vitest';
-import { subFormLinkageSetFieldProps } from '../linkageRules';
+import { fieldLinkageRules, linkageSetFieldProps, subFormLinkageSetFieldProps } from '../linkageRules';
 
 describe('subFormLinkageSetFieldProps action', () => {
   it('should not throw when engine.getModel returns undefined', () => {
@@ -105,5 +108,305 @@ describe('subFormLinkageSetFieldProps action', () => {
     expect(getFork).toHaveBeenCalledTimes(1);
     expect(getFork).toHaveBeenCalledWith('roles:0:field-2');
     expect(setProps).toHaveBeenCalledWith(formItemModel, { disabled: false });
+  });
+
+  it('should limit options on the fork model', () => {
+    const setProps = vi.fn();
+    const selectedOptions = [{ label: 'Open', value: 'open' }];
+    const forkModel: any = {
+      uid: 'field-3',
+      isFork: true,
+    };
+    const formItemModel: any = {
+      uid: 'field-3',
+      getFork: vi.fn(() => forkModel),
+    };
+
+    const ctx: any = {
+      model: {
+        context: {
+          fieldKey: ['roles:0'],
+        },
+      },
+      engine: {
+        getModel: vi.fn(() => formItemModel),
+      },
+    };
+
+    subFormLinkageSetFieldProps.handler(ctx, {
+      value: {
+        fields: ['field-3'],
+        state: 'limitOptions',
+        selectedOptions,
+      },
+      setProps,
+    });
+
+    expect(setProps).toHaveBeenCalledWith(forkModel, { options: selectedOptions });
+  });
+});
+
+describe('linkageSetFieldProps action', () => {
+  it('should limit field options', () => {
+    const setProps = vi.fn();
+    const selectedOptions = [{ label: 'Draft', value: 'draft' }];
+    const fieldComponentModel: any = {
+      uid: 'status-field-component',
+    };
+    const fieldModel: any = {
+      uid: 'status-field',
+      subModels: {
+        field: fieldComponentModel,
+      },
+    };
+    const ctx: any = {
+      model: {
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+    };
+
+    linkageSetFieldProps.handler(ctx, {
+      value: {
+        fields: ['status-field'],
+        state: 'limitOptions',
+        selectedOptions,
+      },
+      setProps,
+    });
+
+    expect(setProps).toHaveBeenCalledWith(fieldComponentModel, { options: selectedOptions });
+  });
+
+  it('should sync limited options to existing field forks immediately', async () => {
+    const selectedOptions = [{ label: 'Draft', value: 'draft' }];
+    const forkModel: any = {
+      uid: 'status-field-component',
+      isFork: true,
+      setProps: vi.fn(),
+    };
+    const fieldComponentModel: any = {
+      uid: 'status-field-component',
+      props: {
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+      },
+      forks: new Set([forkModel]),
+      setProps(key: any, value?: any) {
+        if (typeof key === 'string') {
+          this.props[key] = value;
+        } else {
+          this.props = { ...this.props, ...key };
+        }
+      },
+    };
+    const staleFieldComponentModel: any = {
+      uid: 'status-field-component',
+      props: {
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+      },
+      forks: new Set(),
+      setProps: vi.fn(),
+    };
+    const fieldModel: any = {
+      uid: 'status-field',
+      subModels: {
+        field: fieldComponentModel,
+      },
+    };
+    const ctx: any = {
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      model: {
+        __allModels: [staleFieldComponentModel],
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+      getAction: (name: string) => (name === 'linkageSetFieldProps' ? linkageSetFieldProps : null),
+      resolveJsonTemplate: vi.fn(async (value) => value),
+    };
+
+    await fieldLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'rule-1',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [
+            {
+              key: 'action-1',
+              name: 'linkageSetFieldProps',
+              params: {
+                value: {
+                  fields: ['status-field'],
+                  state: 'limitOptions',
+                  selectedOptions,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fieldComponentModel.props.options).toEqual(selectedOptions);
+    expect(staleFieldComponentModel.setProps).not.toHaveBeenCalledWith({ options: selectedOptions });
+    expect(forkModel.setProps).toHaveBeenCalledWith({ options: selectedOptions });
+  });
+
+  it('should not clear form value when limit options reruns after selection', async () => {
+    const selectedOptions = [{ label: 'Draft', value: 'draft' }];
+    const form = {
+      getFieldValue: vi.fn(() => 'draft'),
+      setFieldValue: vi.fn(),
+    };
+    const fieldComponentModel: any = {
+      uid: 'status-field-component',
+      context: { form },
+      props: {
+        name: 'status',
+        value: undefined,
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+      },
+      setProps(key: any, value?: any) {
+        if (typeof key === 'string') {
+          this.props[key] = value;
+        } else {
+          this.props = { ...this.props, ...key };
+        }
+      },
+    };
+    const fieldModel: any = {
+      uid: 'status-field',
+      subModels: {
+        field: fieldComponentModel,
+      },
+    };
+    const ctx: any = {
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      model: {
+        context: { form },
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+      getAction: (name: string) => (name === 'linkageSetFieldProps' ? linkageSetFieldProps : null),
+      resolveJsonTemplate: vi.fn(async (value) => value),
+    };
+
+    await fieldLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'rule-1',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [
+            {
+              key: 'action-1',
+              name: 'linkageSetFieldProps',
+              params: {
+                value: {
+                  fields: ['status-field'],
+                  state: 'limitOptions',
+                  selectedOptions,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fieldComponentModel.props.options).toEqual(selectedOptions);
+    expect(form.setFieldValue).not.toHaveBeenCalled();
+  });
+
+  it('should keep all options selectable after options were limited once', async () => {
+    const fieldComponentModel: any = {
+      uid: 'status-field-component',
+      props: {
+        options: [{ label: 'Draft', value: 'draft' }],
+      },
+    };
+    const fieldModel: any = {
+      uid: 'status-field',
+      props: {
+        label: 'Status',
+      },
+      collectionField: {
+        uiSchema: {
+          enum: [
+            { label: 'Draft', value: 'draft' },
+            { label: 'Published', value: 'published' },
+          ],
+        },
+      },
+      subModels: {
+        field: fieldComponentModel,
+      },
+    };
+    const ctx: any = {
+      model: {
+        translate: (text: string) => text,
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+    };
+    const Comp: any = linkageSetFieldProps.uiSchema.value['x-component'];
+    const value = {
+      fields: ['status-field'],
+      state: 'limitOptions',
+      selectedOptions: [{ label: 'Draft', value: 'draft' }],
+    };
+    const renderEditor = () =>
+      React.createElement(
+        FlowSettingsContextProvider,
+        { value: ctx },
+        React.createElement(Comp, { value, onChange: () => {} }),
+      );
+    render(renderEditor());
+
+    expect(fieldComponentModel._originalOptionsFallback).toEqual([
+      { label: 'Draft', value: 'draft' },
+      { label: 'Published', value: 'published' },
+    ]);
+
+    fireEvent.mouseDown(screen.getByText('Draft'));
+
+    expect(await screen.findByText('Published')).toBeTruthy();
   });
 });

--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
@@ -363,6 +363,7 @@ describe('linkageSetFieldProps action', () => {
         label: 'Status',
       },
       collectionField: {
+        interface: 'select',
         uiSchema: {
           enum: [
             { label: 'Draft', value: 'draft' },
@@ -392,21 +393,192 @@ describe('linkageSetFieldProps action', () => {
       state: 'limitOptions',
       selectedOptions: [{ label: 'Draft', value: 'draft' }],
     };
-    const renderEditor = () =>
+    const view = render(
       React.createElement(
         FlowSettingsContextProvider,
         { value: ctx },
         React.createElement(Comp, { value, onChange: () => {} }),
-      );
-    render(renderEditor());
+      ),
+    );
 
-    expect(fieldComponentModel._originalOptionsFallback).toEqual([
-      { label: 'Draft', value: 'draft' },
-      { label: 'Published', value: 'published' },
-    ]);
-
-    fireEvent.mouseDown(screen.getByText('Draft'));
-
+    const selectors = view.container.querySelectorAll('.ant-select-selector');
+    fireEvent.mouseDown(selectors[2] as Element);
     expect(await screen.findByText('Published')).toBeTruthy();
+  });
+
+  it('should only show options state for supported single field selection', () => {
+    const supportedField: any = {
+      uid: 'status-field',
+      props: {
+        label: 'Status',
+      },
+      collectionField: {
+        interface: 'select',
+        uiSchema: {
+          enum: [{ label: 'Draft', value: 'draft' }],
+        },
+      },
+      subModels: {
+        field: {
+          uid: 'status-field-component',
+          props: {
+            options: [{ label: 'Draft', value: 'draft' }],
+          },
+        },
+      },
+    };
+    const unsupportedField: any = {
+      uid: 'note-field',
+      props: {
+        label: 'Note',
+      },
+      collectionField: {
+        interface: 'input',
+      },
+      subModels: {
+        field: {
+          uid: 'note-field-component',
+          props: {},
+        },
+      },
+    };
+    const ctx: any = {
+      model: {
+        translate: (text: string) => text,
+        subModels: {
+          grid: {
+            subModels: {
+              items: [supportedField, unsupportedField],
+            },
+          },
+        },
+      },
+    };
+    const Comp: any = linkageSetFieldProps.uiSchema.value['x-component'];
+
+    const { rerender } = render(
+      React.createElement(
+        FlowSettingsContextProvider,
+        { value: ctx },
+        React.createElement(Comp, {
+          value: {
+            fields: ['status-field'],
+            state: 'limitOptions',
+          },
+          onChange: () => {},
+        }),
+      ),
+    );
+
+    expect(screen.getAllByText('Options')).toHaveLength(2);
+
+    rerender(
+      React.createElement(
+        FlowSettingsContextProvider,
+        { value: ctx },
+        React.createElement(Comp, {
+          value: {
+            fields: ['status-field', 'note-field'],
+            state: 'limitOptions',
+          },
+          onChange: () => {},
+        }),
+      ),
+    );
+
+    expect(screen.queryAllByText('Options')).toHaveLength(1);
+  });
+
+  it('should clear selected options when changing fields under limit options', () => {
+    const statusField: any = {
+      uid: 'status-field',
+      props: {
+        label: 'Status',
+      },
+      collectionField: {
+        interface: 'select',
+        uiSchema: {
+          enum: [
+            { label: 'Draft', value: 'draft' },
+            { label: 'Published', value: 'published' },
+          ],
+        },
+      },
+      subModels: {
+        field: {
+          uid: 'status-field-component',
+          props: {
+            options: [
+              { label: 'Draft', value: 'draft' },
+              { label: 'Published', value: 'published' },
+            ],
+          },
+        },
+      },
+    };
+    const categoryField: any = {
+      uid: 'category-field',
+      props: {
+        label: 'Category',
+      },
+      collectionField: {
+        interface: 'select',
+        uiSchema: {
+          enum: [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ],
+        },
+      },
+      subModels: {
+        field: {
+          uid: 'category-field-component',
+          props: {
+            options: [
+              { label: 'A', value: 'a' },
+              { label: 'B', value: 'b' },
+            ],
+          },
+        },
+      },
+    };
+    const ctx: any = {
+      model: {
+        translate: (text: string) => text,
+        subModels: {
+          grid: {
+            subModels: {
+              items: [statusField, categoryField],
+            },
+          },
+        },
+      },
+    };
+    const onChange = vi.fn();
+    const Comp: any = linkageSetFieldProps.uiSchema.value['x-component'];
+    const view = render(
+      React.createElement(
+        FlowSettingsContextProvider,
+        { value: ctx },
+        React.createElement(Comp, {
+          value: {
+            fields: ['status-field'],
+            state: 'limitOptions',
+            selectedOptions: [{ label: 'Draft', value: 'draft' }],
+          },
+          onChange,
+        }),
+      ),
+    );
+
+    const selectors = view.container.querySelectorAll('.ant-select-selector');
+    fireEvent.mouseDown(selectors[0] as Element);
+    fireEvent.click(screen.getByText('Category'));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      fields: ['status-field', 'category-field'],
+      state: undefined,
+      selectedOptions: [],
+    });
   });
 });

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -124,6 +124,16 @@ const getFormFields = (ctx: any) => {
 const cloneOptions = (options: any[]) =>
   options.map((option) => (option && typeof option === 'object' ? { ...option } : option));
 
+const LIMIT_OPTIONS_INTERFACES = new Set(['select', 'multipleSelect', 'radioGroup', 'checkboxGroup']);
+
+const getFieldInterface = (fieldModel: any) => {
+  return fieldModel?.collectionField?.interface || fieldModel?.subModels?.field?.context?.collectionField?.interface;
+};
+
+const supportsLimitOptions = (fieldModel: any) => {
+  return LIMIT_OPTIONS_INTERFACES.has(getFieldInterface(fieldModel));
+};
+
 const getOriginalFieldOptions = (fieldModel: any) => {
   const field = fieldModel?.subModels?.field || fieldModel;
   const enumOptions = enumToOptions(fieldModel?.collectionField?.uiSchema?.enum, (text) => text) || [];
@@ -156,6 +166,7 @@ const getFieldModelOptions = (fieldModel: any, t: (s: string) => string) => {
 const getFieldOptionsBySelectedFields = (fieldOptions: any[], fields: string[] = [], t: (s: string) => string) => {
   const selected = fields
     .map((fieldUid) => fieldOptions.find((option) => option.value === fieldUid)?.model)
+    .filter((model) => supportsLimitOptions(model))
     .filter(Boolean);
 
   const options = selected.flatMap((model) => getFieldModelOptions(model, t));
@@ -214,6 +225,11 @@ const FieldStateEditor = ({
   const t = ctx.model.translate.bind(ctx.model);
 
   const fieldOptions = fieldOptionsGetter(ctx);
+  const selectedFieldModels = (value.fields || [])
+    .map((fieldUid) => fieldOptions.find((option) => option.value === fieldUid)?.model)
+    .filter(Boolean);
+  const canConfigureLimitOptions =
+    selectedFieldModels.length === 1 && selectedFieldModels.every((model: any) => supportsLimitOptions(model));
   const stateOptions = [
     { label: t('Visible'), value: 'visible' },
     { label: t('Hidden'), value: 'hidden' },
@@ -222,15 +238,25 @@ const FieldStateEditor = ({
     includeFormStates && { label: t('Not required'), value: 'notRequired' },
     includeFormStates && { label: t('Disabled'), value: 'disabled' },
     includeFormStates && { label: t('Enabled'), value: 'enabled' },
-    includeFormStates && { label: t('Options'), value: 'limitOptions' },
+    includeFormStates && canConfigureLimitOptions && { label: t('Options'), value: 'limitOptions' },
   ].filter(Boolean);
   const selectableOptions = getFieldOptionsBySelectedFields(fieldOptions, value.fields, t);
 
   const handleFieldsChange = (selectedFields: string[]) => {
+    const nextSelectedFieldModels = selectedFields
+      .map((fieldUid) => fieldOptions.find((option) => option.value === fieldUid)?.model)
+      .filter(Boolean);
+    const nextCanConfigureLimitOptions =
+      nextSelectedFieldModels.length === 1 &&
+      nextSelectedFieldModels.every((model: any) => supportsLimitOptions(model));
+    const nextState = value.state === 'limitOptions' && !nextCanConfigureLimitOptions ? undefined : value.state;
+    const nextSelectedOptions =
+      value.state === 'limitOptions' || nextState === 'limitOptions' ? [] : value.selectedOptions;
     onChange({
       ...value,
       fields: selectedFields,
-      selectedOptions: value.state === 'limitOptions' ? [] : value.selectedOptions,
+      state: nextState,
+      selectedOptions: nextSelectedOptions,
     });
   };
 
@@ -277,7 +303,7 @@ const FieldStateEditor = ({
           allowClear
         />
       </div>
-      {value.state === 'limitOptions' && (
+      {value.state === 'limitOptions' && canConfigureLimitOptions && (
         <div>
           <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('Options')}</div>
           <Select

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -46,16 +46,13 @@ import { useAssociationTitleFieldSync } from '../components/useAssociationTitleF
 import _ from 'lodash';
 import { SubFormFieldModel, SubFormListFieldModel } from '../models';
 import { coerceForToOneField } from '../internal/utils/associationValueCoercion';
+import { enumToOptions } from '../internal/utils/enumOptionsUtils';
 import {
   findFormItemModelByFieldPath,
   getCollectionFromModel,
   isToManyAssociationField,
 } from '../internal/utils/modelUtils';
-import {
-  namePathToPathKey,
-  parsePathString,
-  resolveDynamicNamePath,
-} from '../models/blocks/form/value-runtime/path';
+import { namePathToPathKey, parsePathString, resolveDynamicNamePath } from '../models/blocks/form/value-runtime/path';
 import { ensureFormValueDrivenLinkageRefresh } from './linkageRulesFormValueRefresh';
 
 interface LinkageRule {
@@ -122,6 +119,182 @@ const getFormFields = (ctx: any) => {
     console.warn('Failed to get form fields:', error);
     return [];
   }
+};
+
+const cloneOptions = (options: any[]) =>
+  options.map((option) => (option && typeof option === 'object' ? { ...option } : option));
+
+const getOriginalFieldOptions = (fieldModel: any) => {
+  const field = fieldModel?.subModels?.field || fieldModel;
+  const enumOptions = enumToOptions(fieldModel?.collectionField?.uiSchema?.enum, (text) => text) || [];
+  if (enumOptions.length > 0) {
+    field._originalOptionsFallback = cloneOptions(enumOptions);
+    return field._originalOptionsFallback;
+  }
+  if (Array.isArray(field?._originalOptionsFallback) && field._originalOptionsFallback.length > 0) {
+    return field._originalOptionsFallback;
+  }
+  if (Array.isArray(field?.props?.options) && field.props.options.length > 0) {
+    field._originalOptionsFallback = cloneOptions(field.props.options);
+    return field._originalOptionsFallback;
+  }
+  return null;
+};
+
+const getFieldModelOptions = (fieldModel: any, t: (s: string) => string) => {
+  const originalOptions = getOriginalFieldOptions(fieldModel);
+  if (originalOptions) {
+    return originalOptions.map((option: any) =>
+      option && typeof option === 'object' && typeof option.label === 'string'
+        ? { ...option, label: t(option.label) }
+        : option,
+    );
+  }
+  return [];
+};
+
+const getFieldOptionsBySelectedFields = (fieldOptions: any[], fields: string[] = [], t: (s: string) => string) => {
+  const selected = fields
+    .map((fieldUid) => fieldOptions.find((option) => option.value === fieldUid)?.model)
+    .filter(Boolean);
+
+  const options = selected.flatMap((model) => getFieldModelOptions(model, t));
+  const deduped = new Map<string, any>();
+  options.forEach((option) => {
+    deduped.set(JSON.stringify(option?.value), option);
+  });
+  return Array.from(deduped.values());
+};
+
+const getFieldStateProps = (state: string, selectedOptions?: any[]) => {
+  switch (state) {
+    case 'visible':
+      return { hiddenModel: false };
+    case 'hidden':
+      return { hiddenModel: true };
+    case 'hiddenReservedValue':
+      return { hidden: true };
+    case 'required':
+      return { required: true };
+    case 'notRequired':
+      return { required: false };
+    case 'disabled':
+      return { disabled: true };
+    case 'enabled':
+      return { disabled: false };
+    case 'limitOptions':
+      return Array.isArray(selectedOptions) ? { options: selectedOptions } : {};
+    default:
+      return null;
+  }
+};
+
+const getFieldStateTargetModel = (state: string, model: any) => {
+  return state === 'limitOptions' ? model?.subModels?.field || model : model;
+};
+
+const isFieldOptionsPatch = (props: any) => {
+  return props && typeof props === 'object' && Object.keys(props).length === 1 && Array.isArray(props.options);
+};
+
+const syncFieldOptionsToForks = (model: any, props: any) => {
+  if (!isFieldOptionsPatch(props) || !model?.forks || typeof model.forks.forEach !== 'function') return;
+  model.forks.forEach((fork: any) => {
+    fork?.setProps?.({ options: cloneOptions(props.options) });
+  });
+};
+
+const FieldStateEditor = ({
+  value = { fields: [] },
+  onChange,
+  includeFormStates = true,
+  fieldOptionsGetter = getFormFields,
+}) => {
+  const ctx = useFlowContext();
+  const t = ctx.model.translate.bind(ctx.model);
+
+  const fieldOptions = fieldOptionsGetter(ctx);
+  const stateOptions = [
+    { label: t('Visible'), value: 'visible' },
+    { label: t('Hidden'), value: 'hidden' },
+    { label: t('Hidden (reserved value)'), value: 'hiddenReservedValue' },
+    includeFormStates && { label: t('Required'), value: 'required' },
+    includeFormStates && { label: t('Not required'), value: 'notRequired' },
+    includeFormStates && { label: t('Disabled'), value: 'disabled' },
+    includeFormStates && { label: t('Enabled'), value: 'enabled' },
+    includeFormStates && { label: t('Options'), value: 'limitOptions' },
+  ].filter(Boolean);
+  const selectableOptions = getFieldOptionsBySelectedFields(fieldOptions, value.fields, t);
+
+  const handleFieldsChange = (selectedFields: string[]) => {
+    onChange({
+      ...value,
+      fields: selectedFields,
+      selectedOptions: value.state === 'limitOptions' ? [] : value.selectedOptions,
+    });
+  };
+
+  const handleStateChange = (selectedState: string) => {
+    onChange({
+      ...value,
+      state: selectedState,
+      selectedOptions: selectedState === 'limitOptions' ? value.selectedOptions || [] : undefined,
+    });
+  };
+
+  const handleSelectedOptionsChange = (selectedValues: any[]) => {
+    onChange({
+      ...value,
+      selectedOptions: selectableOptions.filter((option) => selectedValues.includes(option.value)),
+    });
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      <div>
+        <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('Fields')}</div>
+        <Select
+          mode="multiple"
+          value={value.fields}
+          onChange={handleFieldsChange}
+          placeholder={t('Please select fields')}
+          style={{ width: '100%' }}
+          options={fieldOptions}
+          showSearch
+          // @ts-ignore
+          filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
+          allowClear
+        />
+      </div>
+      <div>
+        <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('State')}</div>
+        <Select
+          value={value.state}
+          onChange={handleStateChange}
+          placeholder={t('Please select state')}
+          style={{ width: '100%' }}
+          options={stateOptions}
+          allowClear
+        />
+      </div>
+      {value.state === 'limitOptions' && (
+        <div>
+          <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('Options')}</div>
+          <Select
+            mode="multiple"
+            value={(value.selectedOptions || []).map((option: any) => option.value)}
+            onChange={handleSelectedOptionsChange}
+            style={{ width: '100%' }}
+            options={selectableOptions}
+            showSearch
+            // @ts-ignore
+            filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
+            allowClear
+          />
+        </div>
+      )}
+    </div>
+  );
 };
 
 const getFormFieldsByForkModel = (ctx: any) => {
@@ -492,68 +665,7 @@ export const linkageSetFieldProps = defineAction({
     value: {
       type: 'object',
       'x-component': (props) => {
-        const { value = { fields: [] }, onChange } = props;
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const ctx = useFlowContext();
-        const t = ctx.model.translate.bind(ctx.model);
-
-        const fieldOptions = getFormFields(ctx);
-
-        // 状态选项
-        const stateOptions = [
-          { label: t('Visible'), value: 'visible' },
-          { label: t('Hidden'), value: 'hidden' },
-          { label: t('Hidden (reserved value)'), value: 'hiddenReservedValue' },
-          { label: t('Required'), value: 'required' },
-          { label: t('Not required'), value: 'notRequired' },
-          { label: t('Disabled'), value: 'disabled' },
-          { label: t('Enabled'), value: 'enabled' },
-        ];
-
-        const handleFieldsChange = (selectedFields: string[]) => {
-          onChange({
-            ...value,
-            fields: selectedFields,
-          });
-        };
-
-        const handleStateChange = (selectedState: string) => {
-          onChange({
-            ...value,
-            state: selectedState,
-          });
-        };
-
-        return (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <div>
-              <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('Fields')}</div>
-              <Select
-                mode="multiple"
-                value={value.fields}
-                onChange={handleFieldsChange}
-                placeholder={t('Please select fields')}
-                style={{ width: '100%' }}
-                options={fieldOptions}
-                showSearch
-                // @ts-ignore
-                filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
-                allowClear
-              />
-            </div>
-            <div>
-              <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('State')}</div>
-              <Select
-                value={value.state}
-                onChange={handleStateChange}
-                placeholder={t('Please select state')}
-                style={{ width: '100%' }}
-                options={stateOptions}
-                allowClear
-              />
-            </div>
-          </div>
-        );
+        return <FieldStateEditor {...props} />;
       },
     },
   },
@@ -571,36 +683,13 @@ export const linkageSetFieldProps = defineAction({
         const fieldModel = gridModels.find((model: any) => model.uid === fieldUid);
 
         if (fieldModel) {
-          let props: any = {};
-
-          switch (state) {
-            case 'visible':
-              props = { hiddenModel: false };
-              break;
-            case 'hidden':
-              props = { hiddenModel: true };
-              break;
-            case 'hiddenReservedValue':
-              props = { hidden: true };
-              break;
-            case 'required':
-              props = { required: true };
-              break;
-            case 'notRequired':
-              props = { required: false };
-              break;
-            case 'disabled':
-              props = { disabled: true };
-              break;
-            case 'enabled':
-              props = { disabled: false };
-              break;
-            default:
-              console.warn(`Unknown state: ${state}`);
-              return;
+          const props = getFieldStateProps(state, value?.selectedOptions);
+          if (!props) {
+            console.warn(`Unknown state: ${state}`);
+            return;
           }
 
-          setProps(fieldModel as FlowModel, props);
+          setProps(getFieldStateTargetModel(state, fieldModel) as FlowModel, props);
         }
       } catch (error) {
         console.warn(`Failed to set props for field ${fieldUid}:`, error);
@@ -618,68 +707,7 @@ export const subFormLinkageSetFieldProps = defineAction({
     value: {
       type: 'object',
       'x-component': (props) => {
-        const { value = { fields: [] }, onChange } = props;
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const ctx = useFlowContext();
-        const t = ctx.model.translate.bind(ctx.model);
-
-        const fieldOptions = getFormFieldsByForkModel(ctx);
-
-        // 状态选项
-        const stateOptions = [
-          { label: t('Visible'), value: 'visible' },
-          { label: t('Hidden'), value: 'hidden' },
-          { label: t('Hidden (reserved value)'), value: 'hiddenReservedValue' },
-          { label: t('Required'), value: 'required' },
-          { label: t('Not required'), value: 'notRequired' },
-          { label: t('Disabled'), value: 'disabled' },
-          { label: t('Enabled'), value: 'enabled' },
-        ];
-
-        const handleFieldsChange = (selectedFields: string[]) => {
-          onChange({
-            ...value,
-            fields: selectedFields,
-          });
-        };
-
-        const handleStateChange = (selectedState: string) => {
-          onChange({
-            ...value,
-            state: selectedState,
-          });
-        };
-
-        return (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <div>
-              <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('Fields')}</div>
-              <Select
-                mode="multiple"
-                value={value.fields}
-                onChange={handleFieldsChange}
-                placeholder={t('Please select fields')}
-                style={{ width: '100%' }}
-                options={fieldOptions}
-                showSearch
-                // @ts-ignore
-                filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
-                allowClear
-              />
-            </div>
-            <div>
-              <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('State')}</div>
-              <Select
-                value={value.state}
-                onChange={handleStateChange}
-                placeholder={t('Please select state')}
-                style={{ width: '100%' }}
-                options={stateOptions}
-                allowClear
-              />
-            </div>
-          </div>
-        );
+        return <FieldStateEditor {...props} fieldOptionsGetter={getFormFieldsByForkModel} />;
       },
     },
   },
@@ -717,36 +745,13 @@ export const subFormLinkageSetFieldProps = defineAction({
         }
 
         if (model) {
-          let props: any = {};
-
-          switch (state) {
-            case 'visible':
-              props = { hiddenModel: false };
-              break;
-            case 'hidden':
-              props = { hiddenModel: true };
-              break;
-            case 'hiddenReservedValue':
-              props = { hidden: true };
-              break;
-            case 'required':
-              props = { required: true };
-              break;
-            case 'notRequired':
-              props = { required: false };
-              break;
-            case 'disabled':
-              props = { disabled: true };
-              break;
-            case 'enabled':
-              props = { disabled: false };
-              break;
-            default:
-              console.warn(`Unknown state: ${state}`);
-              return;
+          const props = getFieldStateProps(state, value?.selectedOptions);
+          if (!props) {
+            console.warn(`Unknown state: ${state}`);
+            return;
           }
 
-          setProps(model as FlowModel, props);
+          setProps(getFieldStateTargetModel(state, model) as FlowModel, props);
         }
       } catch (error) {
         console.warn(`Failed to set props for field ${fieldUid}:`, error);
@@ -764,64 +769,7 @@ export const linkageSetDetailsFieldProps = defineAction({
     value: {
       type: 'object',
       'x-component': (props) => {
-        const { value = { fields: [] }, onChange } = props;
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const ctx = useFlowContext();
-        const t = ctx.model.translate.bind(ctx.model);
-
-        const fieldOptions = getFormFields(ctx);
-
-        // 状态选项
-        const stateOptions = [
-          { label: t('Visible'), value: 'visible' },
-          { label: t('Hidden'), value: 'hidden' },
-          { label: t('Hidden (reserved value)'), value: 'hiddenReservedValue' },
-        ];
-
-        const handleFieldsChange = (selectedFields: string[]) => {
-          onChange({
-            ...value,
-            fields: selectedFields,
-          });
-        };
-
-        const handleStateChange = (selectedState: string) => {
-          onChange({
-            ...value,
-            state: selectedState,
-          });
-        };
-
-        return (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <div>
-              <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('Fields')}</div>
-              <Select
-                mode="multiple"
-                value={value.fields}
-                onChange={handleFieldsChange}
-                placeholder={t('Please select fields')}
-                style={{ width: '100%' }}
-                options={fieldOptions}
-                showSearch
-                // @ts-ignore
-                filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
-                allowClear
-              />
-            </div>
-            <div>
-              <div style={{ marginBottom: '4px', fontSize: '14px' }}>{t('State')}</div>
-              <Select
-                value={value.state}
-                onChange={handleStateChange}
-                placeholder={t('Please select state')}
-                style={{ width: '100%' }}
-                options={stateOptions}
-                allowClear
-              />
-            </div>
-          </div>
-        );
+        return <FieldStateEditor {...props} includeFormStates={false} />;
       },
     },
   },
@@ -839,24 +787,13 @@ export const linkageSetDetailsFieldProps = defineAction({
         const fieldModel = gridModels.find((model: any) => model.uid === fieldUid);
 
         if (fieldModel) {
-          let props: any = {};
-
-          switch (state) {
-            case 'visible':
-              props = { hiddenModel: false };
-              break;
-            case 'hidden':
-              props = { hiddenModel: true };
-              break;
-            case 'hiddenReservedValue':
-              props = { hidden: true };
-              break;
-            default:
-              console.warn(`Unknown state: ${state}`);
-              return;
+          const props = getFieldStateProps(state);
+          if (!props) {
+            console.warn(`Unknown state: ${state}`);
+            return;
           }
 
-          setProps(fieldModel as FlowModel, props);
+          setProps(getFieldStateTargetModel(state, fieldModel) as FlowModel, props);
         }
       } catch (error) {
         console.warn(`Failed to set props for field ${fieldUid}:`, error);
@@ -1943,9 +1880,15 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       mergedPropsByUid.set(uid, { ...curProps });
     } else {
       // 合并属性：后写覆盖先写；优先选择 fork 模型作为应用目标
-      mergedPropsByUid.set(uid, { ...mergedPropsByUid.get(uid), ...curProps });
+      const prevProps = mergedPropsByUid.get(uid) || {};
+      const nextProps = { ...prevProps, ...curProps };
+      mergedPropsByUid.set(uid, nextProps);
       const exist = mergedByUid.get(uid) as any;
-      if (m.isFork && !exist.isFork) {
+      const hasCurrentPatch = Object.keys(curProps).length > 0;
+      const hasExistingPatch = Object.keys(prevProps).length > 0;
+      if (hasCurrentPatch && (!hasExistingPatch || !m.isFork || !exist.isFork)) {
+        mergedByUid.set(uid, m);
+      } else if (m.isFork && !exist.isFork) {
         mergedByUid.set(uid, m);
       }
     }
@@ -1956,6 +1899,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
     const newProps = { ...model.__originalProps, ...patchProps };
 
     model.setProps(_.omit(newProps, ['hiddenModel', 'value', 'hiddenText']));
+    syncFieldOptionsToForks(model, patchProps);
     model.hidden = !!newProps.hiddenModel;
 
     if (newProps.required === true) {
@@ -1974,8 +1918,10 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       model.setProps('title', '');
     }
 
-    // 目前只有表单的“字段赋值”有 value 属性
-    if ('value' in newProps && model.context.form) {
+    // 只有本轮联动动作显式写入 value 时，才应执行表单赋值。
+    // 普通字段组件也会由 Form.Item/FieldModelRenderer 注入 value；如果从 __originalProps 继承该值，
+    // limitOptions/disabled 等状态联动会误把当前表单值清空。
+    if (Object.prototype.hasOwnProperty.call(patchProps, 'value') && model.context.form) {
       const targetPath = getModelTargetPathForPatch(model);
       if (!targetPath) {
         console.warn('[linkageRules] Skip linkage assignment due to missing target path', {

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -215,8 +215,14 @@ const syncFieldOptionsToForks = (model: any, props: any) => {
   });
 };
 
+type FieldStateEditorValue = {
+  fields: string[];
+  state?: string;
+  selectedOptions?: any[];
+};
+
 const FieldStateEditor = ({
-  value = { fields: [] },
+  value = { fields: [] } as FieldStateEditorValue,
   onChange,
   includeFormStates = true,
   fieldOptionsGetter = getFormFields,

--- a/packages/core/client/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts
+++ b/packages/core/client/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { enumToOptions, translateOptions } from '../enumOptionsUtils';
+import { enumToOptions, getSelectedEnumLabels, translateOptions } from '../enumOptionsUtils';
 
 // 一个极简的 t：
 // - 直接返回传入 key；
@@ -54,5 +54,14 @@ describe('enumOptions utils', () => {
       { label: '草稿', value: 'draft' },
       { label: '否', value: false },
     ]);
+  });
+
+  it('getSelectedEnumLabels: keeps label for selected value missing from limited options', () => {
+    const labels = getSelectedEnumLabels('published', [
+      { label: 'Draft', value: 'draft' },
+      { label: 'Published', value: 'published' },
+    ]);
+
+    expect(labels).toEqual([{ label: 'Published', value: 'published' }]);
   });
 });

--- a/packages/core/client/src/flow/internal/utils/enumOptionsUtils.ts
+++ b/packages/core/client/src/flow/internal/utils/enumOptionsUtils.ts
@@ -46,6 +46,20 @@ export function enumToOptions(uiEnum: UiSchemaEnumItem[] | undefined, t: (s: str
   return translateOptions(normalized, t);
 }
 
+export function getSelectedEnumLabels(value: any, fallbackOptions: Option[] = []): Array<{ value: any; label: any }> {
+  const values = Array.isArray(value) ? value : value == null ? [] : [value];
+  return values.map((item) => {
+    const fallback = fallbackOptions.find((option) => option?.value === item);
+    if (fallback) {
+      return { value: item, label: fallback.label };
+    }
+    return {
+      value: item,
+      label: item?.toString?.() ?? item,
+    };
+  });
+}
+
 // Populate model.props.options from uiSchema.enum if missing; returns whether options were injected
 export function ensureOptionsFromUiSchemaEnumIfAbsent(model: FlowModel, collectionField: CollectionField): boolean {
   const iface = collectionField?.interface;

--- a/packages/core/client/src/flow/models/blocks/form/FormBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormBlockModel.tsx
@@ -699,11 +699,14 @@ FormBlockModel.registerFlow({
     linkageRules: {
       use: 'fieldLinkageRules',
       afterParamsSave(ctx) {
-        // 保存后，自动运行一次
-        ctx.model.applyFlow('eventSettings', {
-          changedValues: {},
-          allValues: ctx.form?.getFieldsValue(true),
-        });
+        // FlowSettings 保存后还会触发一次 beforeRender/rerender，
+        // 这里延迟到该刷新之后再重放联动规则，避免字段组件被 beforeRender 恢复为原始属性。
+        setTimeout(() => {
+          ctx.model.applyFlow('eventSettings', {
+            changedValues: {},
+            allValues: ctx.form?.getFieldsValue(true),
+          });
+        }, 0);
       },
     },
   },

--- a/packages/core/client/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
@@ -339,6 +339,31 @@ describe('FormBlockModel (form/formValues injection & server resolve anchors)', 
     expect(flows.has('eventSettings')).toBe(true);
   });
 
+  it('replays linkage rules after the settings rerender tick', async () => {
+    vi.useFakeTimers();
+    const engine = new FlowEngine();
+    const TestFormModel = await createTestFormModelSubclass();
+    const model = new TestFormModel({ uid: 'form-linkage-save', flowEngine: engine } as any);
+    const applyFlow = vi.spyOn(model, 'applyFlow').mockResolvedValue(undefined as any);
+    const flow = model.getFlow('eventSettings') as any;
+    const afterParamsSave = flow?.steps?.linkageRules?.afterParamsSave;
+    const ctx: any = {
+      model,
+      form: {
+        getFieldsValue: vi.fn(() => ({ status: 'draft' })),
+      },
+    };
+
+    afterParamsSave(ctx);
+
+    expect(applyFlow).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(applyFlow).toHaveBeenCalledWith('eventSettings', {
+      changedValues: {},
+      allValues: { status: 'draft' },
+    });
+  });
+
   it('delegates layout/assignRules/linkageRules stepParams to grid model', async () => {
     const model = await setupFormModel();
     const engine = model.flowEngine as FlowEngine;

--- a/packages/core/client/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/__tests__/FormBlockModel.test.tsx
@@ -22,6 +22,11 @@ import {
   NumberFieldInterface,
 } from '../../../../../collection-manager/interfaces';
 import { Form } from 'antd';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 // -----------------------------
 // Helpers
 // -----------------------------

--- a/packages/core/client/src/flow/models/blocks/form/value-runtime/rules.ts
+++ b/packages/core/client/src/flow/models/blocks/form/value-runtime/rules.ts
@@ -1508,16 +1508,21 @@ export class RuleEngine {
   private getRowTargetKey(baseCtx: any, rowPath: NamePath): string | string[] {
     let collection = this.getRootCollection() || this.getCollectionFromContext(baseCtx);
     let field: any;
+    let lastAssociationField: any;
     for (const seg of rowPath) {
       if (typeof seg === 'number') continue;
       if (typeof seg !== 'string' || !seg || !collection?.getField) break;
 
       field = collection?.getField?.(seg);
       if (!field?.isAssociationField?.()) break;
+      lastAssociationField = field;
       collection = field?.targetCollection;
     }
 
-    const raw = field?.targetCollection?.filterTargetKey ?? field?.targetCollection?.filterByTk ?? field?.targetKey;
+    const raw =
+      lastAssociationField?.targetCollection?.filterTargetKey ??
+      lastAssociationField?.targetCollection?.filterByTk ??
+      lastAssociationField?.targetKey;
     if (Array.isArray(raw)) {
       const keys = raw.filter((key): key is string => typeof key === 'string' && !!key);
       return keys.length ? keys : 'id';

--- a/packages/core/client/src/flow/models/blocks/form/value-runtime/runtime.ts
+++ b/packages/core/client/src/flow/models/blocks/form/value-runtime/runtime.ts
@@ -359,16 +359,21 @@ export class FormValueRuntime {
   private getArrayItemTargetKey(arrayPath?: NamePath): string | string[] {
     let collection = this.model?.context?.collection;
     let field: any;
+    let lastAssociationField: any;
     for (const seg of arrayPath || []) {
       if (typeof seg === 'number') continue;
       if (typeof seg !== 'string' || !collection?.getField) break;
 
       field = collection?.getField?.(seg);
       if (!field?.isAssociationField?.()) break;
+      lastAssociationField = field;
       collection = field?.targetCollection;
     }
 
-    const raw = field?.targetCollection?.filterTargetKey ?? field?.targetCollection?.filterByTk ?? field?.targetKey;
+    const raw =
+      lastAssociationField?.targetCollection?.filterTargetKey ??
+      lastAssociationField?.targetCollection?.filterByTk ??
+      lastAssociationField?.targetKey;
     if (Array.isArray(raw)) {
       const keys = raw.filter((key): key is string => typeof key === 'string' && !!key);
       return keys.length ? keys : 'id';

--- a/packages/core/client/src/flow/models/fields/SelectFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/SelectFieldModel.tsx
@@ -12,25 +12,55 @@ import { Select, Tag, Tooltip } from 'antd';
 import React from 'react';
 import { FieldModel } from '../base';
 import { MobileSelect } from './mobile-components/MobileSelect';
+import { enumToOptions, getSelectedEnumLabels } from '../../internal/utils/enumOptionsUtils';
+
+const getOriginalEnumOptions = (model: SelectFieldModel) => {
+  const fromEnum = enumToOptions(model.context.collectionField?.uiSchema?.enum, (text) => text) || [];
+  if (fromEnum.length > 0) {
+    return fromEnum.map((option) => ({ ...option }));
+  }
+  const current = Array.isArray(model.props.options) ? model.props.options : [];
+  return current.map((option) => ({ ...option }));
+};
 
 export class SelectFieldModel extends FieldModel {
   render() {
+    const fallbackOptions = getOriginalEnumOptions(this);
     const options = this.props.options?.map((v) => {
       return {
         ...v,
         label: this.translate(v.label),
       };
     });
+    const selectedLabels = getSelectedEnumLabels(this.props.value, fallbackOptions).map((item) => ({
+      ...item,
+      label: this.translate(item.label),
+    }));
+    const value = Array.isArray(this.props.value)
+      ? selectedLabels
+      : selectedLabels.length > 0
+        ? selectedLabels[0]
+        : this.props.value;
 
     // TODO: 移动端相关的代码需迁移到单独的插件中
     if (this.context.isMobileLayout) {
-      return <MobileSelect {...this.props} options={options} />;
+      return <MobileSelect {...this.props} options={options} displayValue={value} />;
     }
 
     return (
       <Select
         {...this.props}
+        value={value}
+        labelInValue
+        onChange={(nextValue) => {
+          if (Array.isArray(nextValue)) {
+            this.props.onChange?.(nextValue.map((item: any) => item?.value));
+            return;
+          }
+          this.props.onChange?.(nextValue?.value);
+        }}
         options={options}
+        labelRender={(item) => item.label}
         maxTagCount="responsive"
         maxTagPlaceholder={(omittedValues) => (
           <Tooltip

--- a/packages/core/client/src/flow/models/fields/mobile-components/MobileSelect.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/MobileSelect.tsx
@@ -13,7 +13,7 @@ import { Button, CheckList, Popup, SearchBar } from 'antd-mobile';
 import React, { useEffect, useMemo, useState } from 'react';
 
 export function MobileSelect(props) {
-  const { value, onChange, onChangeComplete, disabled, options = [], mode } = props;
+  const { value, displayValue, onChange, onChangeComplete, disabled, options = [], mode } = props;
   const ctx = useFlowModelContext();
   const t = ctx.t;
   const [visible, setVisible] = useState(false);
@@ -44,6 +44,7 @@ export function MobileSelect(props) {
       <div onClick={() => !disabled && setVisible(true)}>
         <Select
           {...props}
+          value={displayValue ?? value}
           open={false}
           dropdownStyle={{ display: 'none' }}
           showSearch={false}

--- a/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
@@ -178,6 +178,13 @@ describe('MobileSelect', () => {
     clickTrigger();
     expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
   });
+
+  it('prefers displayValue for trigger rendering', () => {
+    const displayValue = [{ label: 'Published', value: 'published' }];
+    renderMobileSelect({ value: ['published'], displayValue, mode: 'multiple' });
+
+    expect(mockState.selectProps?.value).toEqual(displayValue);
+  });
 });
 
 function SubTableCellHarness({ value, onCommit, mode }: { value: any; onCommit: (value: any) => void; mode?: string }) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v2 联动规则中的字段可选项设置在配置与运行时存在不一致问题，导致字段不支持稳定地设置可选项。

### Description
This PR fixes v2 linkage rules so fields can reliably use selectable option settings.

It adds the missing v2 field option state handling, keeps the linkage editor sourced from the field's original options, replays linkage rules after the settings rerender tick so saved changes apply immediately, and prevents runtime option updates from clearing the current Select value.

Potential risk is limited to v2 linkage runtime and editor behavior around field state updates and form replay timing.

Testing suggestions:
- Configure a linkage rule with `Options` on a select field and verify the form applies the restricted options immediately after saving.
- Reopen the linkage rule and verify all original options are still available in the configuration panel.
- Select a valid option in the form after the rule is active and verify the value remains stable.
- Repeat the same checks in subform scenarios.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed V2 linkage rules to support setting selectable options for fields |
| 🇨🇳 Chinese | 修复 V2 联动规则支持字段设置可选项 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
