### PR TITLE
fix(mcp-server): copy uri-js in build output

### DIFF
--- a/packages/plugins/@nocobase/plugin-mcp-server/build.config.ts
+++ b/packages/plugins/@nocobase/plugin-mcp-server/build.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       '@jsdevtools/ono',
       'call-me-maybe',
       'fast-uri',
+      'uri-js',
     ];
     for (const packageName of packagesToCopy) {
       const source = getPackageRoot(packageName);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix MCP server packaging so runtime dependencies needed by swagger parsing are copied into the build output.

### Description 
Add `uri-js` to the plugin build copy list so the packaged MCP server includes the dependency at runtime.

### Related issues
Fixes #9384

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed MCP server packaging so runtime dependencies are included |
| 🇨🇳 Chinese | 修复 MCP 服务器打包时运行时依赖未包含的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
