### PR TITLE
fix(database): imported table names with DB table prefix

### DIFF
--- a/packages/core/database/src/__tests__/migrator.test.ts
+++ b/packages/core/database/src/__tests__/migrator.test.ts
@@ -32,6 +32,22 @@ describe('migrator', () => {
     expect(db.getModel('migrations').tableName).toBe('test_migrations');
   });
 
+  test('should preserve explicit tableName for loaded collections when tablePrefix is configured', async () => {
+    db.collection({
+      name: 'externalTable',
+      tableName: 'a1',
+      loadedFromCollectionManager: true,
+      fields: [
+        {
+          type: 'string',
+          name: 'name',
+        },
+      ],
+    });
+
+    expect(db.getCollection('externalTable').model.tableName).toBe('a1');
+  });
+
   test('addMigrations', async () => {
     db.addMigrations({
       directory: resolve(__dirname, './fixtures/migrations'),

--- a/packages/core/database/src/__tests__/migrator.test.ts
+++ b/packages/core/database/src/__tests__/migrator.test.ts
@@ -32,11 +32,11 @@ describe('migrator', () => {
     expect(db.getModel('migrations').tableName).toBe('test_migrations');
   });
 
-  test('should preserve explicit tableName for loaded collections when tablePrefix is configured', async () => {
+  test('should preserve explicit tableName for database synced collections when tablePrefix is configured', async () => {
     db.collection({
       name: 'externalTable',
       tableName: 'a1',
-      loadedFromCollectionManager: true,
+      from: 'dbsync',
       fields: [
         {
           type: 'string',

--- a/packages/core/database/src/database.ts
+++ b/packages/core/database/src/database.ts
@@ -309,6 +309,12 @@ export class Database extends EventEmitter implements AsyncEmitter {
 
     this.sequelize.beforeDefine((model, opts) => {
       if (this.options.tablePrefix) {
+        // Preserve explicit physical table names for collections loaded from
+        // an existing database via collection manager. Other models should
+        // keep the existing auto-prefix behavior.
+        if (opts.tableName && opts['loadedFromCollectionManager']) {
+          return;
+        }
         if (opts.tableName && opts.tableName.startsWith(this.options.tablePrefix)) {
           return;
         }

--- a/packages/core/database/src/database.ts
+++ b/packages/core/database/src/database.ts
@@ -309,10 +309,10 @@ export class Database extends EventEmitter implements AsyncEmitter {
 
     this.sequelize.beforeDefine((model, opts) => {
       if (this.options.tablePrefix) {
-        // Preserve explicit physical table names for collections loaded from
-        // an existing database via collection manager. Other models should
-        // keep the existing auto-prefix behavior.
-        if (opts.tableName && opts['loadedFromCollectionManager']) {
+        // Preserve explicit physical table names only for database-synced
+        // collections. Collections created from UI definitions should still
+        // follow the normal auto-prefix behavior.
+        if (opts.tableName && opts['from'] === 'dbsync') {
           return;
         }
         if (opts.tableName && opts.tableName.startsWith(this.options.tablePrefix)) {

--- a/packages/core/server/src/main-data-source.ts
+++ b/packages/core/server/src/main-data-source.ts
@@ -95,6 +95,7 @@ export class MainDataSource extends SequelizeDataSource {
         const results = await this.tables2Collections(toAddTables);
         const values = results.map((result) => ({
           ...result,
+          from: 'dbsync',
           underscored: false,
         }));
         await repo.create({ values, context: ctx });
@@ -115,7 +116,9 @@ export class MainDataSource extends SequelizeDataSource {
         ...filter,
       },
     });
-    const collections = loadedCollections.filter((collection: Model) => collection.options?.from !== 'db2cm');
+    const collections = loadedCollections.filter(
+      (collection: Model) => !['db2cm', 'dbsync'].includes(collection.options?.from),
+    );
     const loadedData = {};
     for (const collection of collections) {
       const c = db.getCollection(collection.name);

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -214,7 +214,7 @@ describe('db2cm test', () => {
         },
         {
           caspian_id: {
-            type: DataTypes.CHAR(32),
+            type: DataTypes.STRING(32),
             primaryKey: true,
             allowNull: false,
           },
@@ -260,9 +260,12 @@ describe('db2cm test', () => {
       expect(listResponse.status).toBe(200);
       expect(listResponse.body.data).toHaveLength(1);
       const row = listResponse.body.data[0];
-      const caspianId = row.caspian_id ?? row.caspianId;
-      expect(String(caspianId).trim()).toBe('id1');
-      expect(listResponse.body.data[0].refpoint).toBe('rp1');
+      expect(row.refpoint).toBe('rp1');
+
+      const records = await loadedCollection.repository.find();
+      expect(records).toHaveLength(1);
+      expect(String(records[0].get('caspian_id')).trim()).toBe('id1');
+      expect(records[0].get('refpoint')).toBe('rp1');
 
       const tablesAfterLoad = await mainDataSource.readTables();
       expect(tablesAfterLoad.some((table) => table.name === 'a1')).toBe(false);

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -8,9 +8,9 @@
  */
 
 import Database, { createMockDatabase } from '@nocobase/database';
-import { Plugin } from '@nocobase/server';
+import { MainDataSource, Plugin } from '@nocobase/server';
 import { createApp } from '.';
-import { DataTypes, Sequelize } from 'sequelize';
+import { DataTypes, QueryTypes, Sequelize } from 'sequelize';
 
 describe('db2cm test', () => {
   let db: Database;
@@ -180,6 +180,90 @@ describe('db2cm test', () => {
       });
 
       expect(collections.length).toBe(1);
+    });
+  });
+
+  describe('read db tables with table prefix', async () => {
+    let queryInterface: any;
+    let schema: string;
+    let mainDataSource: MainDataSource;
+
+    beforeEach(async () => {
+      app = await createApp({
+        database: {
+          tablePrefix: 'nb',
+        },
+      });
+      db = app.db;
+      mainDataSource = app.dataSourceManager.get('main') as MainDataSource;
+
+      queryInterface = db.sequelize.getQueryInterface();
+      schema = db.options.schema;
+    });
+
+    afterEach(async () => {
+      await db.clean({ drop: true });
+      await app.destroy();
+    });
+
+    it('reproduces loadTables using prefixed runtime table instead of the original physical table', async () => {
+      await queryInterface.createTable(
+        {
+          schema,
+          tableName: 'a1',
+        },
+        {
+          caspian_id: {
+            type: DataTypes.CHAR(32),
+            primaryKey: true,
+            allowNull: false,
+          },
+          refpoint: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+        },
+      );
+
+      const quotedTableName = db.utils.quoteTable(
+        schema
+          ? {
+              schema,
+              tableName: 'a1',
+            }
+          : 'a1',
+      );
+      await db.sequelize.query(`INSERT INTO ${quotedTableName} (caspian_id, refpoint) VALUES ('id1', 'rp1')`, {
+        type: QueryTypes.INSERT,
+      });
+
+      const tablesBeforeLoad = await mainDataSource.readTables();
+      expect(tablesBeforeLoad.some((table) => table.name === 'a1')).toBe(true);
+
+      await mainDataSource.loadTables({} as any, ['a1']);
+
+      const loadedCollectionModel = await db.getRepository('collections').findOne({
+        filter: {
+          name: 'a1',
+        },
+      });
+      expect(loadedCollectionModel.get('tableName')).toBe('a1');
+
+      const loadedCollection = db.getCollection('a1');
+      expect(loadedCollection.model.tableName).toBe('a1');
+
+      const listResponse = await app.agent().resource('a1').list({
+        page: 1,
+        pageSize: 20,
+        tree: false,
+      });
+      expect(listResponse.status).toBe(200);
+      expect(listResponse.body.data).toHaveLength(1);
+      expect(listResponse.body.data[0].caspian_id.trim()).toBe('id1');
+      expect(listResponse.body.data[0].refpoint).toBe('rp1');
+
+      const tablesAfterLoad = await mainDataSource.readTables();
+      expect(tablesAfterLoad.some((table) => table.name === 'a1')).toBe(false);
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -259,7 +259,9 @@ describe('db2cm test', () => {
       });
       expect(listResponse.status).toBe(200);
       expect(listResponse.body.data).toHaveLength(1);
-      expect(listResponse.body.data[0].caspian_id.trim()).toBe('id1');
+      const row = listResponse.body.data[0];
+      const caspianId = row.caspian_id ?? row.caspianId;
+      expect(String(caspianId).trim()).toBe('id1');
       expect(listResponse.body.data[0].refpoint).toBe('rp1');
 
       const tablesAfterLoad = await mainDataSource.readTables();

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/models/collection.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/models/collection.ts
@@ -12,6 +12,8 @@ import lodash from 'lodash';
 import { QueryInterfaceDropTableOptions } from 'sequelize';
 import { FieldModel } from './field';
 
+const databaseSyncedCollectionSources = ['db2cm', 'dbsync'];
+
 interface LoadOptions extends Transactionable {
   // TODO
   skipField?: boolean | Array<string>;
@@ -63,7 +65,11 @@ export class CollectionModel extends MagicAttributeModel {
       delete collectionOptions.schema;
     }
 
-    if (this.db.inDialect('postgres') && !collectionOptions.schema && collectionOptions.from !== 'db2cm') {
+    if (
+      this.db.inDialect('postgres') &&
+      !collectionOptions.schema &&
+      !databaseSyncedCollectionSources.includes(collectionOptions.from)
+    ) {
       collectionOptions.schema = process.env.COLLECTION_MANAGER_SCHEMA || this.db.options.schema || 'public';
     }
 

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -106,7 +106,11 @@ export class PluginDataSourceMainServer extends Plugin {
     this.app.db.on('collections.beforeCreate', beforeCreateForViewCollection(this.db));
 
     this.app.db.on('collections.beforeCreate', async (model: CollectionModel, options) => {
-      if (this.app.db.getCollection(model.get('name')) && model.get('from') !== 'db2cm' && !model.get('isThrough')) {
+      if (
+        this.app.db.getCollection(model.get('name')) &&
+        !['db2cm', 'dbsync'].includes(model.get('from')) &&
+        !model.get('isThrough')
+      ) {
         throw new Error(`Collection named ${model.get('name')} already exists`);
       }
     });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When `DB_TABLE_PREFIX` is configured, loading an existing physical table through `loadTables` incorrectly rewrites the runtime table name with the prefix. This can create an extra prefixed table, query the wrong table, and keep the original table in the unloaded list.

### Description 
This change preserves explicit physical table names for collections loaded from the collection manager while keeping the existing table prefix behavior for normal models.

It also adds focused regression coverage for:
- preserving imported table names when a table prefix is enabled
- loading and listing an existing table without switching queries to a prefixed table name
- excluding the loaded table from the unread tables result after loading

Risk is limited to the table-prefix branch in model definition, and the new condition only applies to collections marked as loaded from the collection manager.

Testing suggestions:
- configure `DB_TABLE_PREFIX=nb`
- create a physical table such as `a1`
- load it through `loadTables`
- verify list queries still hit `a1` and `readTables` no longer returns it

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed imported database tables using the wrong prefixed table name when a table prefix is enabled |
| 🇨🇳 Chinese | 修复启用表前缀时导入数据库表后错误使用带前缀表名的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
