### PR TITLE
fix: can't configure js for js field after change to readonly

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/pattern.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/pattern.test.ts
@@ -1,0 +1,156 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import { FieldModel } from '../../models/base/FieldModel';
+import { JSEditableFieldModel } from '../../models/fields/JSEditableFieldModel';
+import { DetailsItemModel } from '../../models/blocks/details/DetailsItemModel';
+import { pattern } from '../pattern';
+
+class DummyDisplayFieldModel extends FieldModel {}
+
+class DummyFormItemModel extends FlowModel<{ subModels: { field?: FieldModel } }> {
+  collectionField: any;
+
+  static getDefaultBindingByField() {
+    return { modelName: 'FieldModel' };
+  }
+
+  getFieldSettingsInitParams() {
+    return { mock: true };
+  }
+}
+
+function makeCollectionField() {
+  return {
+    targetCollection: undefined,
+    isAssociationField: () => false,
+  };
+}
+
+function makeCtx(parent: DummyFormItemModel) {
+  const collectionField = makeCollectionField();
+  parent.collectionField = collectionField;
+  return {
+    model: parent,
+    collectionField,
+    engine: parent.flowEngine,
+  } as any;
+}
+
+describe('pattern action', () => {
+  it('keeps JS editable field model when switching to display only', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+      JSEditableFieldModel,
+      DummyDisplayFieldModel,
+    });
+
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'form-item-js',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'field-js',
+          stepParams: {
+            fieldBinding: {
+              use: 'JSEditableFieldModel',
+            },
+            jsSettings: {
+              runJs: {
+                code: 'ctx.render("hello")',
+              },
+            },
+          },
+        },
+      },
+    });
+    const field = parent.subModels.field;
+    const saveSpy = vi.spyOn(engine, 'saveModel');
+
+    await pattern.afterParamsSave?.(makeCtx(parent), { pattern: 'readPretty' }, { pattern: 'editable' });
+
+    expect(parent.subModels.field).toBe(field);
+    expect(parent.subModels.field).toBeInstanceOf(JSEditableFieldModel);
+    expect(parent.subModels.field?.uid).toBe('field-js');
+    expect(parent.subModels.field?.getStepParams('jsSettings', 'runJs')).toMatchObject({
+      code: 'ctx.render("hello")',
+    });
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps JS editable field model when leaving display only', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+      JSEditableFieldModel,
+      DummyDisplayFieldModel,
+    });
+
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'form-item-js-leave',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'field-js-leave',
+          stepParams: {
+            fieldBinding: {
+              use: 'JSEditableFieldModel',
+            },
+          },
+        },
+      },
+    });
+    const field = parent.subModels.field;
+    const saveSpy = vi.spyOn(engine, 'saveModel');
+
+    await pattern.afterParamsSave?.(makeCtx(parent), { pattern: 'editable' }, { pattern: 'readPretty' });
+
+    expect(parent.subModels.field).toBe(field);
+    expect(parent.subModels.field).toBeInstanceOf(JSEditableFieldModel);
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('still rebuilds regular fields when switching to display only', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+      DummyDisplayFieldModel,
+    });
+
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'form-item-regular',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'field-regular',
+        },
+      },
+    });
+    const ctx = makeCtx(parent);
+    const displayBinding = { modelName: 'DummyDisplayFieldModel', defaultProps: { display: true } } as any;
+    const getDisplayBindingSpy = vi.spyOn(DetailsItemModel, 'getDefaultBindingByField').mockReturnValue(displayBinding);
+
+    await pattern.afterParamsSave?.(ctx, { pattern: 'readPretty' }, { pattern: 'editable' });
+
+    expect(parent.subModels.field).toBeInstanceOf(DummyDisplayFieldModel);
+    expect(parent.subModels.field?.uid).toBe('field-regular');
+    expect(parent.subModels.field?.props).toMatchObject({ display: true });
+
+    getDisplayBindingSpy.mockRestore();
+  });
+});

--- a/packages/core/client/src/flow/actions/__tests__/pattern.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/pattern.test.ts
@@ -77,6 +77,7 @@ describe('pattern action', () => {
     });
     const field = parent.subModels.field;
     const saveSpy = vi.spyOn(engine, 'saveModel');
+    const applyJsSettingsSpy = vi.spyOn(field as JSEditableFieldModel, 'scheduleApplyJsSettings');
 
     await pattern.afterParamsSave?.(makeCtx(parent), { pattern: 'readPretty' }, { pattern: 'editable' });
 
@@ -87,6 +88,7 @@ describe('pattern action', () => {
       code: 'ctx.render("hello")',
     });
     expect(saveSpy).not.toHaveBeenCalled();
+    expect(applyJsSettingsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('keeps JS editable field model when leaving display only', async () => {
@@ -115,12 +117,44 @@ describe('pattern action', () => {
     });
     const field = parent.subModels.field;
     const saveSpy = vi.spyOn(engine, 'saveModel');
+    const applyJsSettingsSpy = vi.spyOn(field as JSEditableFieldModel, 'scheduleApplyJsSettings');
 
     await pattern.afterParamsSave?.(makeCtx(parent), { pattern: 'editable' }, { pattern: 'readPretty' });
 
     expect(parent.subModels.field).toBe(field);
     expect(parent.subModels.field).toBeInstanceOf(JSEditableFieldModel);
     expect(saveSpy).not.toHaveBeenCalled();
+    expect(applyJsSettingsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reapply JS settings when pattern is unchanged', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+      JSEditableFieldModel,
+    });
+
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'form-item-js-unchanged',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'field-js-unchanged',
+          stepParams: {
+            fieldBinding: {
+              use: 'JSEditableFieldModel',
+            },
+          },
+        },
+      },
+    });
+    const applyJsSettingsSpy = vi.spyOn(parent.subModels.field as JSEditableFieldModel, 'scheduleApplyJsSettings');
+
+    await pattern.afterParamsSave?.(makeCtx(parent), { pattern: 'readPretty' }, { pattern: 'readPretty' });
+
+    expect(applyJsSettingsSpy).not.toHaveBeenCalled();
   });
 
   it('still rebuilds regular fields when switching to display only', async () => {

--- a/packages/core/client/src/flow/actions/pattern.tsx
+++ b/packages/core/client/src/flow/actions/pattern.tsx
@@ -7,9 +7,21 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { BindingOptions, defineAction, tExpr, DisplayItemModel } from '@nocobase/flow-engine';
+import { defineAction, tExpr } from '@nocobase/flow-engine';
 import { DetailsItemModel } from '../models/blocks/details/DetailsItemModel';
-import { rebuildFieldSubModel } from '../internal/utils/rebuildFieldSubModel';
+import { getFieldBindingUse, rebuildFieldSubModel } from '../internal/utils/rebuildFieldSubModel';
+
+type PatternAwareFieldModelMeta = {
+  preserveOnPatternChange?: boolean;
+};
+
+function shouldPreserveFieldModelOnPatternChange(ctx: any) {
+  const fieldModel = ctx.model.subModels.field;
+  const fieldUse = getFieldBindingUse(fieldModel) ?? fieldModel?.use;
+  const ModelClass = typeof fieldUse === 'string' ? ctx.engine.getModelClass(fieldUse) : fieldUse;
+
+  return ((ModelClass?.meta as PatternAwareFieldModelMeta | undefined)?.preserveOnPatternChange ?? false) === true;
+}
 
 export const pattern = defineAction({
   name: 'pattern',
@@ -56,6 +68,10 @@ export const pattern = defineAction({
     };
   },
   afterParamsSave: async (ctx: any, params, previousParams) => {
+    if (shouldPreserveFieldModelOnPatternChange(ctx)) {
+      return;
+    }
+
     const targetCollection = ctx.collectionField.targetCollection;
     const targetCollectionTitleField = targetCollection?.getField(
       ctx.model.subModels.field.props?.fieldNames?.label || ctx.model.props.titleField,

--- a/packages/core/client/src/flow/actions/pattern.tsx
+++ b/packages/core/client/src/flow/actions/pattern.tsx
@@ -15,6 +15,10 @@ type PatternAwareFieldModelMeta = {
   preserveOnPatternChange?: boolean;
 };
 
+type PatternAwareFieldModel = {
+  scheduleApplyJsSettings?: () => void;
+};
+
 function shouldPreserveFieldModelOnPatternChange(ctx: any) {
   const fieldModel = ctx.model.subModels.field;
   const fieldUse = getFieldBindingUse(fieldModel) ?? fieldModel?.use;
@@ -69,6 +73,9 @@ export const pattern = defineAction({
   },
   afterParamsSave: async (ctx: any, params, previousParams) => {
     if (shouldPreserveFieldModelOnPatternChange(ctx)) {
+      if (params.pattern !== previousParams.pattern) {
+        (ctx.model.subModels.field as PatternAwareFieldModel | undefined)?.scheduleApplyJsSettings?.();
+      }
       return;
     }
 

--- a/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
@@ -35,6 +35,10 @@ function JsEditableField() {
     ctx.setValue?.(v);
   };
 
+  if (ctx.readOnly) {
+    return <span>{String(value ?? '')}</span>;
+  }
+
   return (
     <Input
       {...ctx.model.props}
@@ -47,6 +51,25 @@ function JsEditableField() {
 // Mount to the field container
 ctx.render(<JsEditableField />);
 `;
+
+type PatternAwareModel = {
+  props?: { readOnly?: boolean; pattern?: string };
+  context?: { pattern?: string };
+  parent?: { props?: { pattern?: string } };
+};
+
+function getEffectivePattern(model?: PatternAwareModel) {
+  return model?.props?.pattern ?? model?.context?.pattern ?? model?.parent?.props?.pattern;
+}
+
+function isReadOnlyMode(model?: PatternAwareModel) {
+  return !!model?.props?.readOnly || getEffectivePattern(model) === 'readPretty';
+}
+
+function resolveScriptCode(codeParam?: string) {
+  const raw = codeParam ?? DEFAULT_CODE;
+  return typeof raw === 'string' ? raw.trim() : '';
+}
 
 const JSFormRuntime: React.FC<{
   model: JSEditableFieldModel;
@@ -66,26 +89,22 @@ const JSFormRuntime: React.FC<{
   // 统一获取&裁剪脚本代码，直接依赖具体 code 字符串，避免顶层 stepParams 引用未变化导致不更新
   const codeParam = model.getStepParams('jsSettings', 'runJs')?.code as string | undefined;
   const scriptCode = useMemo(() => {
-    const raw = codeParam ?? DEFAULT_CODE;
-    return typeof raw === 'string' ? raw.trim() : '';
+    return resolveScriptCode(codeParam);
   }, [codeParam]);
 
   useEffect(() => {
-    if (!containerRef.current || !scriptCode) return;
+    if (readOnly || !containerRef.current || !scriptCode) return;
     const event = new CustomEvent('js-field:value-change', { detail: value });
     containerRef.current.dispatchEvent(event);
-  }, [value, scriptCode]);
+  }, [value, scriptCode, readOnly]);
 
-  // 无自定义 JS 时默认渲染 Input，保持可用性
+  if (readOnly) {
+    return <span>{String(value ?? '')}</span>;
+  }
+
   if (!scriptCode) {
     return (
-      <Input
-        value={value}
-        onChange={(e) => onChange?.(e.target.value)}
-        disabled={disabled}
-        readOnly={readOnly}
-        style={{ width: '100%' }}
-      />
+      <Input value={value} onChange={(e) => onChange?.(e.target.value)} disabled={disabled} style={{ width: '100%' }} />
     );
   }
 
@@ -100,14 +119,31 @@ const JSFormRuntime: React.FC<{
  */
 export class JSEditableFieldModel extends FieldModel {
   private _mountedOnce = false;
+
+  useHooksBeforeRender() {
+    const codeParam = this.getStepParams('jsSettings', 'runJs')?.code as string | undefined;
+    const scriptCode = resolveScriptCode(codeParam);
+    const value = this.props?.value;
+    const disabled = this.props?.disabled;
+    const effectiveReadOnly = isReadOnlyMode(this);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      if (effectiveReadOnly || !scriptCode) return;
+      void this.applyFlow('jsSettings');
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scriptCode, value, disabled, effectiveReadOnly, this.props?.pattern]);
+  }
+
   render() {
+    const readOnly = isReadOnlyMode(this);
     return (
       <JSFormRuntime
         model={this as JSEditableFieldModel}
         value={this.props?.value}
         onChange={this.props?.onChange}
         disabled={this.props?.disabled}
-        readOnly={this.props?.readOnly}
+        readOnly={readOnly}
       />
     );
   }
@@ -128,9 +164,12 @@ export class JSEditableFieldModel extends FieldModel {
   }
 }
 
-JSEditableFieldModel.define({
+const jsEditableFieldModelMeta = {
   label: tExpr('JS field'),
-});
+  preserveOnPatternChange: true,
+};
+
+JSEditableFieldModel.define(jsEditableFieldModelMeta);
 
 JSEditableFieldModel.registerFlow({
   key: 'jsSettings',
@@ -173,7 +212,15 @@ JSEditableFieldModel.registerFlow({
         };
       },
       async handler(ctx, params) {
+        if (isReadOnlyMode(ctx.model)) {
+          return;
+        }
+
         const { code, version } = resolveRunJsParams(ctx, params);
+        if (!code?.trim()) {
+          return;
+        }
+
         ctx.onRefReady(ctx.ref, async (element) => {
           // 暴露容器与读写能力（使用动态 getter 绑定 ref.current，避免容器变更失效）
           ctx.defineProperty('element', {
@@ -201,7 +248,10 @@ JSEditableFieldModel.registerFlow({
           });
           ctx.defineProperty('namePath', { get: () => ctx.model.props?.name, cache: false });
           ctx.defineProperty('disabled', { get: () => !!ctx.model.props?.disabled, cache: false });
-          ctx.defineProperty('readOnly', { get: () => !!ctx.model.props?.readOnly, cache: false });
+          ctx.defineProperty('readOnly', {
+            get: () => isReadOnlyMode(ctx.model),
+            cache: false,
+          });
           const navigator = createSafeNavigator();
           await ctx.runjs(
             code,

--- a/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
@@ -91,12 +91,17 @@ const JSFormRuntime: React.FC<{
   }, [codeParam]);
 
   useEffect(() => {
-    if (readOnly || !containerRef.current || !scriptCode) return;
+    if (!containerRef.current || !scriptCode) return;
+    model.scheduleApplyJsSettings();
+  }, [model, scriptCode]);
+
+  useEffect(() => {
+    if (!containerRef.current || !scriptCode) return;
     const event = new CustomEvent('js-field:value-change', { detail: value });
     containerRef.current.dispatchEvent(event);
-  }, [value, scriptCode, readOnly]);
+  }, [value, scriptCode]);
 
-  if (readOnly) {
+  if (readOnly && !scriptCode) {
     return <span>{String(value ?? '')}</span>;
   }
 
@@ -117,19 +122,66 @@ const JSFormRuntime: React.FC<{
  */
 export class JSEditableFieldModel extends FieldModel {
   private _mountedOnce = false;
+  private _pendingJsSettingsApply = false;
+  private _lastAppliedJsSettings?: {
+    code: string;
+    disabled: boolean;
+    readOnly: boolean;
+    element: HTMLSpanElement | null;
+  };
+
+  scheduleApplyJsSettings() {
+    const codeParam = this.getStepParams('jsSettings', 'runJs')?.code as string | undefined;
+    if (!resolveScriptCode(codeParam)) return;
+
+    if (this._pendingJsSettingsApply) {
+      return;
+    }
+
+    this._pendingJsSettingsApply = true;
+    queueMicrotask(() => {
+      this._pendingJsSettingsApply = false;
+
+      const nextCodeParam = this.getStepParams('jsSettings', 'runJs')?.code as string | undefined;
+      const nextCode = resolveScriptCode(nextCodeParam);
+      const nextElement = this.context.ref?.current as HTMLSpanElement | null;
+      if (!nextCode || !nextElement) {
+        return;
+      }
+
+      const nextRun = {
+        code: nextCode,
+        disabled: !!this.props?.disabled,
+        readOnly: isReadOnlyMode(this),
+        element: nextElement,
+      };
+      const lastRun = this._lastAppliedJsSettings;
+      if (
+        lastRun &&
+        lastRun.code === nextRun.code &&
+        lastRun.disabled === nextRun.disabled &&
+        lastRun.readOnly === nextRun.readOnly &&
+        lastRun.element === nextRun.element
+      ) {
+        return;
+      }
+
+      this._lastAppliedJsSettings = nextRun;
+      void this.applyFlow('jsSettings');
+    });
+  }
 
   useHooksBeforeRender() {
     const codeParam = this.getStepParams('jsSettings', 'runJs')?.code as string | undefined;
     const scriptCode = resolveScriptCode(codeParam);
     const disabled = this.props?.disabled;
-    const effectiveReadOnly = isReadOnlyMode(this);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
-      if (effectiveReadOnly || !scriptCode) return;
-      void this.applyFlow('jsSettings');
+      if (!scriptCode) return;
+      this.scheduleApplyJsSettings();
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scriptCode, disabled, effectiveReadOnly, this.props?.pattern]);
+    }, [scriptCode, disabled]);
   }
 
   render() {
@@ -171,6 +223,7 @@ JSEditableFieldModel.define(jsEditableFieldModelMeta);
 JSEditableFieldModel.registerFlow({
   key: 'jsSettings',
   title: tExpr('JavaScript settings'),
+  manual: true,
   steps: {
     runJs: {
       title: tExpr('Write JavaScript'),
@@ -209,10 +262,6 @@ JSEditableFieldModel.registerFlow({
         };
       },
       async handler(ctx, params) {
-        if (isReadOnlyMode(ctx.model)) {
-          return;
-        }
-
         const { code, version } = resolveRunJsParams(ctx, params);
         if (!code?.trim()) {
           return;

--- a/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
@@ -121,7 +121,6 @@ export class JSEditableFieldModel extends FieldModel {
   useHooksBeforeRender() {
     const codeParam = this.getStepParams('jsSettings', 'runJs')?.code as string | undefined;
     const scriptCode = resolveScriptCode(codeParam);
-    const value = this.props?.value;
     const disabled = this.props?.disabled;
     const effectiveReadOnly = isReadOnlyMode(this);
 
@@ -130,7 +129,7 @@ export class JSEditableFieldModel extends FieldModel {
       if (effectiveReadOnly || !scriptCode) return;
       void this.applyFlow('jsSettings');
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scriptCode, value, disabled, effectiveReadOnly, this.props?.pattern]);
+    }, [scriptCode, disabled, effectiveReadOnly, this.props?.pattern]);
   }
 
   render() {

--- a/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/JSEditableFieldModel.tsx
@@ -52,17 +52,15 @@ function JsEditableField() {
 ctx.render(<JsEditableField />);
 `;
 
-type PatternAwareModel = {
-  props?: { readOnly?: boolean; pattern?: string };
-  context?: { pattern?: string };
-  parent?: { props?: { pattern?: string } };
-};
-
-function getEffectivePattern(model?: PatternAwareModel) {
-  return model?.props?.pattern ?? model?.context?.pattern ?? model?.parent?.props?.pattern;
+function getEffectivePattern(model?: JSEditableFieldModel) {
+  return (
+    model?.props?.pattern ??
+    (model?.context as { pattern?: string } | undefined)?.pattern ??
+    (model?.parent as { props?: { pattern?: string } } | undefined)?.props?.pattern
+  );
 }
 
-function isReadOnlyMode(model?: PatternAwareModel) {
+function isReadOnlyMode(model?: JSEditableFieldModel) {
   return !!model?.props?.readOnly || getEffectivePattern(model) === 'readPretty';
 }
 

--- a/packages/core/client/src/flow/models/fields/__tests__/JSEditableFieldModel.test.tsx
+++ b/packages/core/client/src/flow/models/fields/__tests__/JSEditableFieldModel.test.tsx
@@ -68,13 +68,22 @@ function JsEditableField() {
 ctx.render(<JsEditableField />);
 `;
 
+const READONLY_AWARE_CODE = `
+const React = ctx.React;
+ctx.render(<span data-testid="js-readonly-state">{String(ctx.readOnly)}</span>);
+`;
+
 class ParentModel extends FlowModel<any> {
   render() {
     return <FlowModelRenderer model={this.subModels.field} />;
   }
 }
 
-function renderParentFieldWithFlowRenderer(fieldProps?: Record<string, any>, parentProps?: Record<string, any>) {
+function renderParentFieldWithFlowRenderer(
+  fieldProps?: Record<string, any>,
+  parentProps?: Record<string, any>,
+  code = EDITABLE_CODE,
+) {
   const engine = new FlowEngine();
   engine.registerModels({ JSEditableFieldModel, ParentModel });
   const parent = engine.createModel<ParentModel>({
@@ -89,7 +98,7 @@ function renderParentFieldWithFlowRenderer(fieldProps?: Record<string, any>, par
         stepParams: {
           jsSettings: {
             runJs: {
-              code: EDITABLE_CODE,
+              code,
             },
           },
         },
@@ -107,8 +116,21 @@ function renderParentFieldWithFlowRenderer(fieldProps?: Record<string, any>, par
 }
 
 describe('JSEditableFieldModel', () => {
-  it('renders fallback as text in display only mode', () => {
-    renderField({ pattern: 'readPretty', value: 'hello' }, EDITABLE_CODE);
+  it('renders configured JavaScript in display only mode', async () => {
+    const field = renderParentFieldWithFlowRenderer(
+      { pattern: 'readPretty', value: 'hello' },
+      undefined,
+      READONLY_AWARE_CODE,
+    ).subModels.field as JSEditableFieldModel;
+
+    await waitFor(() => {
+      expect(screen.getByTestId('js-readonly-state')).toHaveTextContent('true');
+      expect(field.context.ref.current).toBeInstanceOf(HTMLSpanElement);
+    });
+  });
+
+  it('renders fallback as text in display only mode when code is empty', () => {
+    renderField({ pattern: 'readPretty', value: 'hello' });
 
     expect(screen.getByText('hello')).toBeInTheDocument();
     expect(screen.queryByDisplayValue('hello')).not.toBeInTheDocument();
@@ -121,7 +143,7 @@ describe('JSEditableFieldModel', () => {
   });
 
   it('rerenders as text when owner form item switches to display only', async () => {
-    const parent = renderParentFieldWithFlowRenderer({ value: 'hello' });
+    const parent = renderParentFieldWithFlowRenderer({ value: 'hello' }, undefined, '');
 
     await act(async () => {
       parent.setProps({ pattern: 'readPretty' });
@@ -149,5 +171,40 @@ describe('JSEditableFieldModel', () => {
     });
 
     expect(applyFlowSpy).not.toHaveBeenCalled();
+  });
+
+  it('coalesces script and pattern changes into one JavaScript settings run', async () => {
+    const parent = renderParentFieldWithFlowRenderer({ value: 'hello' }, undefined, '');
+    const field = parent.subModels.field as JSEditableFieldModel;
+    const applyFlowSpy = vi.spyOn(field, 'applyFlow');
+
+    await act(async () => {
+      field.setStepParams('jsSettings', 'runJs', { code: READONLY_AWARE_CODE });
+      parent.setProps({ pattern: 'readPretty' });
+      field.scheduleApplyJsSettings();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('js-readonly-state')).toHaveTextContent('true');
+    });
+
+    expect(applyFlowSpy).toHaveBeenCalledTimes(1);
+    expect(applyFlowSpy).toHaveBeenCalledWith('jsSettings');
+  });
+
+  it('applies JavaScript settings once on initial render', async () => {
+    const applyFlowSpy = vi.spyOn(FlowModel.prototype, 'applyFlow');
+    renderParentFieldWithFlowRenderer({ value: 'hello' });
+
+    try {
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+      });
+
+      expect(applyFlowSpy).toHaveBeenCalledTimes(1);
+      expect(applyFlowSpy.mock.calls).toEqual([['jsSettings']]);
+    } finally {
+      applyFlowSpy.mockRestore();
+    }
   });
 });

--- a/packages/core/client/src/flow/models/fields/__tests__/JSEditableFieldModel.test.tsx
+++ b/packages/core/client/src/flow/models/fields/__tests__/JSEditableFieldModel.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { FlowEngine, FlowEngineProvider, FlowModel, FlowModelRenderer } from '@nocobase/flow-engine';
 import { JSEditableFieldModel } from '../JSEditableFieldModel';
 
@@ -131,5 +131,23 @@ describe('JSEditableFieldModel', () => {
       expect(screen.getByText('hello')).toBeInTheDocument();
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     });
+  });
+
+  it('does not rerun JavaScript settings when field value changes', async () => {
+    const parent = renderParentFieldWithFlowRenderer({ value: 'hello' });
+    const field = parent.subModels.field as JSEditableFieldModel;
+    const applyFlowSpy = vi.spyOn(field, 'applyFlow');
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    applyFlowSpy.mockClear();
+
+    await act(async () => {
+      field.setProps({ value: 'hello1' });
+    });
+
+    expect(applyFlowSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/client/src/flow/models/fields/__tests__/JSEditableFieldModel.test.tsx
+++ b/packages/core/client/src/flow/models/fields/__tests__/JSEditableFieldModel.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FlowEngine, FlowEngineProvider, FlowModel, FlowModelRenderer } from '@nocobase/flow-engine';
+import { JSEditableFieldModel } from '../JSEditableFieldModel';
+
+function createField(props?: Record<string, any>, code = '') {
+  const engine = new FlowEngine();
+  engine.registerModels({ JSEditableFieldModel });
+  return engine.createModel<JSEditableFieldModel>({
+    use: 'JSEditableFieldModel',
+    uid: `js-field-${props?.pattern || 'editable'}`,
+    props,
+    stepParams: {
+      jsSettings: {
+        runJs: {
+          code,
+        },
+      },
+    },
+  });
+}
+
+function renderField(props?: Record<string, any>, code?: string) {
+  const field = createField(props, code);
+
+  render(<>{field.render()}</>);
+
+  return field;
+}
+
+const EDITABLE_CODE = `
+function JsEditableField() {
+  const React = ctx.React;
+  const { Input } = ctx.antd;
+  const [value, setValue] = React.useState(ctx.getValue?.() ?? '');
+
+  React.useEffect(() => {
+    const handler = (ev) => setValue(ev?.detail ?? '');
+    ctx.element?.addEventListener('js-field:value-change', handler);
+    return () => ctx.element?.removeEventListener('js-field:value-change', handler);
+  }, []);
+
+  const onChange = (e) => {
+    const v = e?.target?.value ?? '';
+    setValue(v);
+    ctx.setValue?.(v);
+  };
+
+  return (
+    <Input
+      {...ctx.model.props}
+      value={value}
+      onChange={onChange}
+    />
+  );
+}
+
+ctx.render(<JsEditableField />);
+`;
+
+class ParentModel extends FlowModel<any> {
+  render() {
+    return <FlowModelRenderer model={this.subModels.field} />;
+  }
+}
+
+function renderParentFieldWithFlowRenderer(fieldProps?: Record<string, any>, parentProps?: Record<string, any>) {
+  const engine = new FlowEngine();
+  engine.registerModels({ JSEditableFieldModel, ParentModel });
+  const parent = engine.createModel<ParentModel>({
+    use: ParentModel,
+    uid: 'js-field-parent',
+    props: parentProps,
+    subModels: {
+      field: {
+        use: 'JSEditableFieldModel',
+        uid: 'js-field-with-parent',
+        props: fieldProps,
+        stepParams: {
+          jsSettings: {
+            runJs: {
+              code: EDITABLE_CODE,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  render(
+    <FlowEngineProvider engine={engine}>
+      <FlowModelRenderer model={parent} />
+    </FlowEngineProvider>,
+  );
+
+  return parent;
+}
+
+describe('JSEditableFieldModel', () => {
+  it('renders fallback as text in display only mode', () => {
+    renderField({ pattern: 'readPretty', value: 'hello' }, EDITABLE_CODE);
+
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('hello')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback input for editable mode', () => {
+    renderField({ value: 'hello' });
+
+    expect(screen.getByDisplayValue('hello')).toBeInTheDocument();
+  });
+
+  it('rerenders as text when owner form item switches to display only', async () => {
+    const parent = renderParentFieldWithFlowRenderer({ value: 'hello' });
+
+    await act(async () => {
+      parent.setProps({ pattern: 'readPretty' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('hello')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where JS code could no longer be edited after a JS field was set to read-only. |
| 🇨🇳 Chinese | 修复 JS field 改为只读后 js 代码无法再次被修改的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
