### PR TITLE
fix(plugin-notification-in-app-message): refresh inbox on realtime messages

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/Inbox.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/Inbox.tsx
@@ -93,6 +93,10 @@ const InnerInbox = (props) => {
   const currUserId = ctx.data?.data?.id;
 
   const onMessageCreated = useCallback(({ detail }: CustomEvent) => {
+    messageMapObs.value[detail.id] = detail;
+    fetchChannels({ filter: { name: detail.channelName, status: 'all' } });
+    updateUnreadMsgsCount();
+
     notification.info({
       message: (
         <div
@@ -113,7 +117,6 @@ const InnerInbox = (props) => {
       },
       duration: detail.options.duration,
     });
-    unreadMsgsCountObs.value = (unreadMsgsCountObs.value ?? 0) + 1;
   }, []);
 
   const onMessageUpdated = useCallback(({ detail }: CustomEvent) => {
@@ -142,7 +145,7 @@ const InnerInbox = (props) => {
       app.eventBus.removeEventListener('ws:message:in-app-message:created', onMessageCreated);
       app.eventBus.removeEventListener('ws:message:in-app-message:updated', onMessageUpdated);
     };
-  }, [app.eventBus, onMessageUpdated]);
+  }, [app.eventBus, onMessageCreated, onMessageUpdated]);
 
   return (
     <ConfigProvider

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/Inbox.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/Inbox.tsx
@@ -134,7 +134,6 @@ const InnerInbox = (props) => {
   }, [currUserId]);
   const onIconClick = useCallback(() => {
     inboxVisible.value = true;
-    fetchChannels({});
   }, []);
 
   useEffect(() => {

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/components/InboxContent.tsx
@@ -33,6 +33,7 @@ const InnerInboxContent = () => {
   const { t } = useLocalTranslation();
   const channels = channelListObs.value;
   const selectedChannelName = selectedChannelNameObs.value;
+  const visible = inboxVisible.value;
 
   const onLoadChannelsMore = useCallback(() => {
     const filter: Record<string, any> = {};
@@ -46,10 +47,10 @@ const InnerInboxContent = () => {
   }, [channels]);
 
   useEffect(() => {
-    if (inboxVisible.value) {
+    if (visible) {
       fetchChannels({ limit: 30 });
     }
-  }, [inboxVisible.value]);
+  }, [visible]);
 
   const loadChannelsMore = showChannelLoadingMoreObs.value ? (
     <div

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/observables/channel.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/observables/channel.ts
@@ -49,10 +49,11 @@ export const selectedChannelObs = observable.computed(() => {
 export const fetchChannels = async (params: any) => {
   const apiClient = getAPIClient();
   isFetchingChannelsObs.value = true;
+  const requestParams = merge({ filter: { status: channelStatusFilterObs.value } }, params ?? {});
   const res = await apiClient.request({
     url: 'myInAppChannels:list',
     method: 'get',
-    params: merge({ filter: { status: channelStatusFilterObs.value } }, params ?? {}),
+    params: requestParams,
   });
   const channels = res.data?.data;
   if (Array.isArray(channels)) {
@@ -60,19 +61,9 @@ export const fetchChannels = async (params: any) => {
       channelMapObs.value[channel.name] = channel;
     });
   }
-  await countChannels();
-  isFetchingChannelsObs.value = false;
-};
-
-export const countChannels = async () => {
-  const apiClient = getAPIClient();
-  const res = await apiClient.request({
-    url: 'myInAppChannels:list',
-    method: 'get',
-    params: { filter: { status: channelStatusFilterObs.value } },
-  });
   const count = res.data?.meta?.count;
-  if (count >= 0) channelCountObs.value = count;
+  if (!requestParams?.filter?.name && count >= 0) channelCountObs.value = count;
+  isFetchingChannelsObs.value = false;
 };
 
 autorun(() => {

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/observables/message.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client/observables/message.ts
@@ -32,7 +32,9 @@ export const selectedMessageListObs = observable.computed(() => {
   if (selectedChannelNameObs.value) {
     const filteredMessages = messageListObs.value.filter(
       (message) =>
-        message.channelName === selectedChannelNameObs.value && filterMessageByStatus(message) && filterMessageByUserId,
+        message.channelName === selectedChannelNameObs.value &&
+        filterMessageByStatus(message) &&
+        filterMessageByUserId(message),
     );
     return filteredMessages;
   } else {

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
@@ -143,6 +143,16 @@ describe('inapp message channels', () => {
       expect(res.body.data[0].latestMsgTitle).toBe('user-0');
       expect(res.body.data[0].unreadMsgCnt).toBe(1);
       expect(res.body.data[0].latestMsgReceiveTimestamp).toBe(now);
+      expect(res.body.data[0]).toMatchObject({
+        name: channelsRes[0].name,
+        title: '测试渠道',
+        totalMsgCnt: 1,
+        userId: String(users[0].id),
+      });
+      expect(res.body.data[0]).not.toHaveProperty('options');
+      expect(res.body.data[0]).not.toHaveProperty('meta');
+      expect(res.body.data[0]).not.toHaveProperty('notificationType');
+      expect(res.body.data[0]).not.toHaveProperty('description');
     });
 
     test('filter channel by status', async () => {

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
@@ -203,6 +203,37 @@ describe('inapp message channels', () => {
       });
       expect(allChannelsRes.body.data.length).toBe(3);
     });
+
+    test('filter channel by name', async () => {
+      const channels = await channelsRepo.create({
+        values: [
+          {
+            title: 'target_channel',
+            notificationType: 'in-app-message',
+          },
+          {
+            title: 'other_channel',
+            notificationType: 'in-app-message',
+          },
+        ],
+      });
+      const targetChannel = channels.find((channel) => channel.title === 'target_channel');
+      const otherChannel = channels.find((channel) => channel.title === 'other_channel');
+
+      await createMessages(
+        { messagesRepo },
+        { unreadNum: 1, readNum: 0, channelName: targetChannel.name, startTimeStamp: Date.now(), userId: currUserId },
+      );
+      await createMessages(
+        { messagesRepo },
+        { unreadNum: 1, readNum: 0, channelName: otherChannel.name, startTimeStamp: Date.now(), userId: currUserId },
+      );
+
+      const res = await currUserAgent.resource('myInAppChannels').list({ filter: { name: targetChannel.name } });
+
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].name).toBe(targetChannel.name);
+    });
     // test('channel last receive timestamp filter', () => {
     //   const currentTS = Date.now();
     // });

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
@@ -88,21 +88,22 @@ export default function defineMyInAppChannels(app: Application) {
           try {
             const channelsRes = channelsRepo.find({
               limit,
-              attributes: {
-                include: [
-                  [
-                    Sequelize.literal(`(
+              attributes: [
+                'name',
+                'title',
+                [
+                  Sequelize.literal(`(
                                 SELECT COUNT(*)
                                 FROM ${messagesTableName} AS messages
                                 WHERE
                                     messages.${messagesFieldName.channelName} = ${channelsTableAliasName}.${channelsFieldName.name}
                                     AND messages.${messagesFieldName.userId} = ${userId}
                             )`),
-                    'totalMsgCnt',
-                  ],
-                  [Sequelize.literal(`'${userId}'`), 'userId'],
-                  [
-                    Sequelize.literal(`(
+                  'totalMsgCnt',
+                ],
+                [Sequelize.literal(`'${userId}'`), 'userId'],
+                [
+                  Sequelize.literal(`(
                                 SELECT COUNT(*)
                                 FROM ${messagesTableName} AS messages
                                 WHERE
@@ -110,11 +111,11 @@ export default function defineMyInAppChannels(app: Application) {
                                     AND messages.${messagesFieldName.status} = 'unread'
                                     AND messages.${messagesFieldName.userId} = ${userId}
                             )`),
-                    'unreadMsgCnt',
-                  ],
-                  [Sequelize.literal(latestMsgReceiveTimestampSQL), 'latestMsgReceiveTimestamp'],
-                  [
-                    Sequelize.literal(`(
+                  'unreadMsgCnt',
+                ],
+                [Sequelize.literal(latestMsgReceiveTimestampSQL), 'latestMsgReceiveTimestamp'],
+                [
+                  Sequelize.literal(`(
                       SELECT messages.${messagesFieldName.title}
                               FROM ${messagesTableName} AS messages
                               WHERE
@@ -123,10 +124,9 @@ export default function defineMyInAppChannels(app: Application) {
                               ORDER BY messages.${messagesFieldName.receiveTimestamp} DESC
                               LIMIT 1
                   )`),
-                    'latestMsgTitle',
-                  ],
+                  'latestMsgTitle',
                 ],
-              },
+              ],
               //@ts-ignore
               where: {
                 [Op.and]: [

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
@@ -63,6 +63,7 @@ export default function defineMyInAppChannels(app: Application) {
             ? Sequelize.literal(`${latestMsgReceiveTimestampSQL} < ${filter.latestMsgReceiveTimestamp.$lt}`)
             : null;
           const channelIdFilter = filter?.id ? { id: filter.id } : null;
+          const channelNameFilter = filter?.name ? { name: filter.name } : null;
           const statusMap = {
             all: 'read|unread',
             unread: 'unread',
@@ -128,7 +129,13 @@ export default function defineMyInAppChannels(app: Application) {
               },
               //@ts-ignore
               where: {
-                [Op.and]: [userFilter, latestMsgReceiveTSFilter, channelIdFilter, channelStatusFilter].filter(Boolean),
+                [Op.and]: [
+                  userFilter,
+                  latestMsgReceiveTSFilter,
+                  channelIdFilter,
+                  channelNameFilter,
+                  channelStatusFilter,
+                ].filter(Boolean),
               },
               sort: ['-latestMsgReceiveTimestamp'],
             });
@@ -136,7 +143,7 @@ export default function defineMyInAppChannels(app: Application) {
             const countRes = channelsRepo.count({
               //@ts-ignore
               where: {
-                [Op.and]: [userFilter, channelStatusFilter].filter(Boolean),
+                [Op.and]: [userFilter, channelNameFilter, channelStatusFilter].filter(Boolean),
               },
             });
             const [channels, count] = await Promise.all([channelsRes, countRes]);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Users can receive the realtime in-app message websocket event and see the unread badge, but the opened inbox message list may still show stale data until navigating away and back.

### Description
This PR fixes the in-app message refresh timing after realtime websocket delivery:

- Cache newly created websocket messages in `messageMapObs` immediately so the current message list can render the latest message without waiting for route changes.
- Refresh the affected channel and unread count when receiving `in-app-message:created`.
- Support `filter.name` in `myInAppChannels:list`, matching existing frontend calls that refresh one channel by name.
- Fix selected message user filtering by invoking `filterMessageByUserId(message)`.
- Add a regression test for filtering in-app channels by name.

Testing suggestions:

- Send an in-app message from a workflow while the target user is online.
- Open the message drawer from the badge immediately after the websocket notification.
- Confirm the latest message appears in the selected channel without navigating away.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the in-app message list did not refresh after receiving realtime notifications |
| 🇨🇳 Chinese | 修复收到实时站内信后通知列表未及时刷新的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
