### PR TITLE
fix: expose after-success settings for form submit action

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/FormActionModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormActionModel.tsx
@@ -94,8 +94,6 @@ FormSubmitActionModel.registerFlow({
         try {
           ctx.model.setProps('loading', true);
           await submitHandler(ctx, params);
-          ctx.message.success(ctx.t('Saved successfully'));
-          ctx.model.setProps('loading', false);
         } catch (error) {
           ctx.model.setProps('loading', false);
           // 显示保存失败提示
@@ -107,12 +105,8 @@ FormSubmitActionModel.registerFlow({
         }
       },
     },
-    refreshAndClose: {
-      async handler(ctx) {
-        if (ctx.view) {
-          ctx.view.close();
-        }
-      },
+    afterSuccess: {
+      use: 'afterSuccess',
     },
   },
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Form submit actions did not expose the visible "After successful submission" setting.

### Description 
- replace the old implicit close behavior with the visible `afterSuccess` action
- remove the hardcoded success message from the submit save step

### Related issues
- #3529

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added the "After successful submission" setting for form submit actions. |
| 🇨🇳 Chinese | 为表单提交动作补充“提交成功后”设置项。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
