### PR TITLE
fix(flow-engine): keep submodel relation dropdown stable

### DIFF
--- a/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
+++ b/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
@@ -357,27 +357,15 @@ const SearchInputWithAutoFocus: FC<InputProps & { visible: boolean }> = (props) 
 // ==================== Utility Functions ====================
 
 const getKeyPath = (path: string[], key: string) => [...path, key].join('/');
-const getAncestorKeyPath = (path: string[]) => path.filter(Boolean).join('/');
 
-const toOpenKeyChain = (keyPath: string) => {
-  const parts = keyPath.split('/').filter(Boolean);
-  return parts.map((_, index) => parts.slice(0, index + 1).join('/'));
-};
+const normalizeOpenKeys = (nextOpenKeys: string[]) => {
+  const latestKey = nextOpenKeys[nextOpenKeys.length - 1];
 
-const normalizeOpenKeyChain = (nextOpenKeys: string[], preferredKeyPath?: string | null) => {
-  if (!nextOpenKeys.length) {
+  if (!latestKey) {
     return [];
   }
 
-  const chooseKey =
-    (preferredKeyPath &&
-      nextOpenKeys.find(
-        (key) =>
-          key === preferredKeyPath || key.startsWith(`${preferredKeyPath}/`) || preferredKeyPath.startsWith(`${key}/`),
-      )) ||
-    nextOpenKeys.sort((a, b) => b.split('/').length - a.split('/').length)[0];
-
-  return chooseKey ? toOpenKeyChain(chooseKey) : [];
+  return nextOpenKeys.filter((key) => latestKey === key || latestKey.startsWith(`${key}/`));
 };
 
 const createSearchItem = (
@@ -428,6 +416,11 @@ const createEmptyItem = (itemKey: string, t: (key: string) => string) => ({
   disabled: true,
 });
 
+const KEEP_OPEN_LABEL_STYLE: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+};
+
 // ==================== Main Component ====================
 
 // 短暂保持打开状态的注册表（用于跨父节点快速重建时的恢复）
@@ -442,7 +435,6 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
   const [rootLoading, setRootLoading] = useState(false);
   const dropdownMaxHeight = useNiceDropdownMaxHeight();
   const t = engine.translate.bind(engine);
-  const lastHoveredKeyPathRef = useRef<string | null>(null);
 
   // 解构 menu，避免在 effect 中直接依赖整个对象，减少不必要的重跑并满足 exhaustive-deps
   const { items: menuItems, keepDropdownOpen, persistKey, stateVersion, refreshKeys, ...dropdownMenuProps } = menu;
@@ -460,17 +452,16 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
   useSubmenuStyles(menuVisible, dropdownMaxHeight);
   const handleMenuOpenChange = useCallback(
     (nextOpenKeys: string[]) => {
-      if (!nextOpenKeys.length && shouldPreventClose() && lastHoveredKeyPathRef.current) {
-        const preserved = toOpenKeyChain(lastHoveredKeyPathRef.current);
-        setOpenKeys(new Set(preserved));
-        dropdownMenuProps.onOpenChange?.(preserved);
+      if (!nextOpenKeys.length && shouldPreventClose()) {
+        dropdownMenuProps.onOpenChange?.(Array.from(openKeys));
         return;
       }
 
-      setOpenKeys(new Set(normalizeOpenKeyChain(nextOpenKeys, lastHoveredKeyPathRef.current)));
-      dropdownMenuProps.onOpenChange?.(nextOpenKeys);
+      const normalized = normalizeOpenKeys(nextOpenKeys);
+      setOpenKeys(new Set(normalized));
+      dropdownMenuProps.onOpenChange?.(normalized);
     },
-    [dropdownMenuProps, shouldPreventClose],
+    [dropdownMenuProps, openKeys, shouldPreventClose],
   );
 
   // 在挂载时，若存在 persistKey 且仍在持久期内，则尝试恢复打开状态
@@ -499,7 +490,6 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
 
   useEffect(() => {
     if (!menuVisible) {
-      lastHoveredKeyPathRef.current = null;
       setOpenKeys(new Set());
     }
   }, [menuVisible]);
@@ -632,55 +622,73 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
         return { type: 'divider', key: keyPath };
       }
 
+      const label = typeof item.label === 'string' ? t(item.label) : item.label;
+
       // 非 group 的“子菜单”也支持本层级搜索：当 item.searchable = true 且存在 children 时
       if (item.searchable && children) {
         return {
           key: keyPath,
-          label: typeof item.label === 'string' ? t(item.label) : item.label,
+          label,
           onClick: (info: any) => {},
-          onMouseEnter: () => {
-            lastHoveredKeyPathRef.current = keyPath;
-            setOpenKeys(new Set(toOpenKeyChain(keyPath)));
-          },
           children: buildSearchChildren(children, item, keyPath, path, menuVisible, resolveItems),
         };
       }
 
+      const itemShouldKeepOpen = !children && (item.keepDropdownOpen ?? keepDropdownOpen ?? false);
+      const handleLeafClick = (info: any) => {
+        if (children) {
+          return;
+        }
+
+        if (itemShouldKeepOpen) {
+          requestKeepOpen();
+        }
+
+        const extendedInfo: ExtendedMenuInfo = {
+          ...info,
+          key: info?.key ?? keyPath,
+          keyPath: info?.keyPath ?? [keyPath],
+          item: info?.item || item,
+          originalItem: item,
+          keepDropdownOpen: itemShouldKeepOpen,
+        };
+
+        menu.onClick?.(extendedInfo);
+      };
+
       return {
         key: keyPath,
-        label: typeof item.label === 'string' ? t(item.label) : item.label,
+        label: itemShouldKeepOpen ? (
+          <div
+            style={KEEP_OPEN_LABEL_STYLE}
+            onMouseDown={(event) => {
+              event.stopPropagation();
+              requestKeepOpen();
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              handleLeafClick({
+                key: keyPath,
+                keyPath: [keyPath],
+                item,
+                domEvent: event,
+              });
+            }}
+          >
+            {label}
+          </div>
+        ) : (
+          label
+        ),
         onClick: (info: any) => {
-          if (children) {
+          if (!itemShouldKeepOpen) handleLeafClick(info);
+        },
+        onMouseDown: () => {
+          if (!itemShouldKeepOpen) {
             return;
           }
 
-          // 检查是否应该保持下拉菜单打开
-          const itemShouldKeepOpen = item.keepDropdownOpen ?? keepDropdownOpen ?? false;
-          const ancestorKeyPath = getAncestorKeyPath(path);
-
-          // 如果需要保持菜单打开，请求保持打开状态
-          if (itemShouldKeepOpen) {
-            if (ancestorKeyPath) {
-              lastHoveredKeyPathRef.current = ancestorKeyPath;
-              setOpenKeys(new Set(toOpenKeyChain(ancestorKeyPath)));
-            }
-            requestKeepOpen();
-          }
-
-          const extendedInfo: ExtendedMenuInfo = {
-            ...info,
-            item: info.item || item,
-            originalItem: item,
-            keepDropdownOpen: itemShouldKeepOpen,
-          };
-
-          menu.onClick?.(extendedInfo);
-        },
-        onMouseEnter: () => {
-          if (children) {
-            lastHoveredKeyPathRef.current = keyPath;
-            setOpenKeys(new Set(toOpenKeyChain(keyPath)));
-          }
+          requestKeepOpen();
         },
         children:
           children && children.length > 0

--- a/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
+++ b/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
@@ -357,6 +357,28 @@ const SearchInputWithAutoFocus: FC<InputProps & { visible: boolean }> = (props) 
 // ==================== Utility Functions ====================
 
 const getKeyPath = (path: string[], key: string) => [...path, key].join('/');
+const getAncestorKeyPath = (path: string[]) => path.filter(Boolean).join('/');
+
+const toOpenKeyChain = (keyPath: string) => {
+  const parts = keyPath.split('/').filter(Boolean);
+  return parts.map((_, index) => parts.slice(0, index + 1).join('/'));
+};
+
+const normalizeOpenKeyChain = (nextOpenKeys: string[], preferredKeyPath?: string | null) => {
+  if (!nextOpenKeys.length) {
+    return [];
+  }
+
+  const chooseKey =
+    (preferredKeyPath &&
+      nextOpenKeys.find(
+        (key) =>
+          key === preferredKeyPath || key.startsWith(`${preferredKeyPath}/`) || preferredKeyPath.startsWith(`${key}/`),
+      )) ||
+    nextOpenKeys.sort((a, b) => b.split('/').length - a.split('/').length)[0];
+
+  return chooseKey ? toOpenKeyChain(chooseKey) : [];
+};
 
 const createSearchItem = (
   item: Item,
@@ -420,6 +442,7 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
   const [rootLoading, setRootLoading] = useState(false);
   const dropdownMaxHeight = useNiceDropdownMaxHeight();
   const t = engine.translate.bind(engine);
+  const lastHoveredKeyPathRef = useRef<string | null>(null);
 
   // 解构 menu，避免在 effect 中直接依赖整个对象，减少不必要的重跑并满足 exhaustive-deps
   const { items: menuItems, keepDropdownOpen, persistKey, stateVersion, refreshKeys, ...dropdownMenuProps } = menu;
@@ -435,6 +458,20 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
   const { searchValues, isSearching, updateSearchValue } = useMenuSearch();
   const { requestKeepOpen, shouldPreventClose } = useKeepDropdownOpen();
   useSubmenuStyles(menuVisible, dropdownMaxHeight);
+  const handleMenuOpenChange = useCallback(
+    (nextOpenKeys: string[]) => {
+      if (!nextOpenKeys.length && shouldPreventClose() && lastHoveredKeyPathRef.current) {
+        const preserved = toOpenKeyChain(lastHoveredKeyPathRef.current);
+        setOpenKeys(new Set(preserved));
+        dropdownMenuProps.onOpenChange?.(preserved);
+        return;
+      }
+
+      setOpenKeys(new Set(normalizeOpenKeyChain(nextOpenKeys, lastHoveredKeyPathRef.current)));
+      dropdownMenuProps.onOpenChange?.(nextOpenKeys);
+    },
+    [dropdownMenuProps, shouldPreventClose],
+  );
 
   // 在挂载时，若存在 persistKey 且仍在持久期内，则尝试恢复打开状态
   useEffect(() => {
@@ -459,6 +496,13 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
       }
     };
   }, [persistKey, menuVisible]);
+
+  useEffect(() => {
+    if (!menuVisible) {
+      lastHoveredKeyPathRef.current = null;
+      setOpenKeys(new Set());
+    }
+  }, [menuVisible]);
 
   // 加载根 items，支持同步/异步函数
   useEffect(() => {
@@ -591,16 +635,12 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
       // 非 group 的“子菜单”也支持本层级搜索：当 item.searchable = true 且存在 children 时
       if (item.searchable && children) {
         return {
-          key: item.key,
+          key: keyPath,
           label: typeof item.label === 'string' ? t(item.label) : item.label,
           onClick: (info: any) => {},
           onMouseEnter: () => {
-            setOpenKeys((prev) => {
-              if (prev.has(keyPath)) return prev;
-              const next = new Set(prev);
-              next.add(keyPath);
-              return next;
-            });
+            lastHoveredKeyPathRef.current = keyPath;
+            setOpenKeys(new Set(toOpenKeyChain(keyPath)));
           },
           children: buildSearchChildren(children, item, keyPath, path, menuVisible, resolveItems),
         };
@@ -616,9 +656,14 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
 
           // 检查是否应该保持下拉菜单打开
           const itemShouldKeepOpen = item.keepDropdownOpen ?? keepDropdownOpen ?? false;
+          const ancestorKeyPath = getAncestorKeyPath(path);
 
           // 如果需要保持菜单打开，请求保持打开状态
           if (itemShouldKeepOpen) {
+            if (ancestorKeyPath) {
+              lastHoveredKeyPathRef.current = ancestorKeyPath;
+              setOpenKeys(new Set(toOpenKeyChain(ancestorKeyPath)));
+            }
             requestKeepOpen();
           }
 
@@ -632,12 +677,10 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
           menu.onClick?.(extendedInfo);
         },
         onMouseEnter: () => {
-          setOpenKeys((prev) => {
-            if (prev.has(keyPath)) return prev;
-            const next = new Set(prev);
-            next.add(keyPath);
-            return next;
-          });
+          if (children) {
+            lastHoveredKeyPathRef.current = keyPath;
+            setOpenKeys(new Set(toOpenKeyChain(keyPath)));
+          }
         },
         children:
           children && children.length > 0
@@ -684,8 +727,10 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
       placement="bottomLeft"
       menu={{
         ...dropdownMenuProps,
+        openKeys: Array.from(openKeys),
         items: items,
         onClick: () => {},
+        onOpenChange: handleMenuOpenChange,
         style: {
           maxHeight: dropdownMaxHeight,
           overflowY: 'auto',

--- a/packages/core/flow-engine/src/components/subModel/__tests__/AddSubModelButton.test.tsx
+++ b/packages/core/flow-engine/src/components/subModel/__tests__/AddSubModelButton.test.tsx
@@ -21,6 +21,8 @@ import {
 import { SubModelItem, mergeSubModelItems, transformItems } from '../AddSubModelButton';
 import { App, ConfigProvider } from 'antd';
 
+const getSubmenuTitle = (label: string) => screen.getByText(label).closest('.ant-dropdown-menu-submenu-title');
+
 describe('AddSubModelButton - preset settings open on add', () => {
   test('calls openFlowSettings with preset=true for subModel with preset steps', async () => {
     // Arrange: set up engine and models
@@ -214,6 +216,68 @@ describe('AddSubModelButton - async group children (nested)', () => {
     await waitFor(() => expect(screen.getByText('G-Leaf-1')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('Nested-Leaf-1')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('Nested-Leaf-2')).toBeInTheDocument());
+  });
+
+  it('keeps root dropdown open while only the current nested group stays expanded', async () => {
+    const engine = new FlowEngine();
+    await engine.flowSettings.forceEnable();
+    class Parent extends FlowModel {}
+    engine.registerModels({ Parent });
+    const parent = engine.createModel<FlowModel>({ use: 'Parent', uid: 'p-multi-open' });
+
+    const items = [
+      {
+        key: 'group-a',
+        label: 'Group A',
+        children: [
+          { key: 'a-1', label: 'A-1', createModelOptions: { use: 'Parent' } },
+          { key: 'a-2', label: 'A-2', createModelOptions: { use: 'Parent' } },
+        ],
+      },
+      {
+        key: 'group-b',
+        label: 'Group B',
+        children: [
+          { key: 'b-1', label: 'B-1', createModelOptions: { use: 'Parent' } },
+          { key: 'b-2', label: 'B-2', createModelOptions: { use: 'Parent' } },
+        ],
+      },
+    ];
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <AddSubModelButton model={parent} subModelKey="items" items={items as any}>
+              Open Menu
+            </AddSubModelButton>
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    await act(async () => {
+      await userEvent.click(screen.getByText('Open Menu'));
+    });
+
+    await waitFor(() => expect(screen.getByText('Group A')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Group B')).toBeInTheDocument());
+
+    await act(async () => {
+      await userEvent.hover(screen.getByText('Group A'));
+    });
+    await waitFor(() => expect(screen.getByText('A-1')).toBeInTheDocument());
+    await waitFor(() => expect(getSubmenuTitle('Group A')).toHaveAttribute('aria-expanded', 'true'));
+    expect(getSubmenuTitle('Group B')).toHaveAttribute('aria-expanded', 'false');
+
+    await act(async () => {
+      await userEvent.hover(screen.getByText('Group B'));
+    });
+    await waitFor(() => expect(screen.getByText('B-1')).toBeInTheDocument());
+    await waitFor(() => expect(getSubmenuTitle('Group B')).toHaveAttribute('aria-expanded', 'true'));
+    expect(getSubmenuTitle('Group A')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Group A')).toBeInTheDocument();
+    expect(screen.getByText('Group B')).toBeInTheDocument();
   });
 });
 
@@ -1378,6 +1442,72 @@ describe('AddSubModelButton toggleable behavior', () => {
     await user.hover(screen.getByText('Fields'));
     await waitFor(() => expect(screen.getByText('Leaf Toggle')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true'));
+  });
+
+  test('keepDropdownOpen keeps root menu visible after clicking a nested relation-style leaf', async () => {
+    const engine = new FlowEngine();
+    await engine.flowSettings.forceEnable();
+
+    class Parent extends FlowModel {}
+    class RelationLeafModel extends FlowModel {}
+
+    engine.registerModels({ Parent, RelationLeafModel });
+    engine.setModelRepository(new FakeRepo());
+    vi.spyOn(engine.flowSettings, 'open').mockResolvedValue(false as any);
+
+    const parent = engine.createModel<FlowModel>({ use: 'Parent' });
+
+    const items = [
+      {
+        key: 'relation-fields',
+        label: 'Display association fields',
+        children: [
+          {
+            key: 'users',
+            label: 'Users',
+            type: 'group' as const,
+            children: [
+              {
+                key: 'user-name',
+                label: 'User name',
+                createModelOptions: { use: 'RelationLeafModel' },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <AddSubModelButton
+              model={parent}
+              items={items as any}
+              subModelType="array"
+              subModelKey="subs"
+              keepDropdownOpen
+            >
+              Open
+            </AddSubModelButton>
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Open'));
+
+    await waitFor(() => expect(screen.getByText('Display association fields')).toBeInTheDocument());
+    await user.hover(screen.getByText('Display association fields'));
+    await waitFor(() => expect(screen.getByText('Users')).toBeInTheDocument());
+    await waitFor(() => expect(getSubmenuTitle('Display association fields')).toHaveAttribute('aria-expanded', 'true'));
+
+    await user.click(screen.getByText('User name'));
+
+    await waitFor(() => expect(screen.getByText('Display association fields')).toBeInTheDocument());
+    await waitFor(() => expect(getSubmenuTitle('Display association fields')).toHaveAttribute('aria-expanded', 'true'));
   });
 
   test('top-level toggle updates after opening a second-level branch', async () => {

--- a/packages/core/flow-engine/src/components/subModel/__tests__/AddSubModelButton.test.tsx
+++ b/packages/core/flow-engine/src/components/subModel/__tests__/AddSubModelButton.test.tsx
@@ -1435,11 +1435,8 @@ describe('AddSubModelButton toggleable behavior', () => {
     // click leaf toggle to add
     await user.click(screen.getByText('Leaf Toggle'));
 
-    // menu should remain visible; submenu parent still visible
+    // menu and submenu should remain visible after toggling a submenu leaf
     expect(screen.getByText('Fields')).toBeInTheDocument();
-
-    // 由于点击叶子项后二级子菜单可能被收起，这里先重新展开再断言开关状态
-    await user.hover(screen.getByText('Fields'));
     await waitFor(() => expect(screen.getByText('Leaf Toggle')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true'));
   });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When adding relation fields in the v2 table block, opening nested relation items could close the current popup unexpectedly. Hovering between sibling relation groups could also leave multiple second-level popups visible at the same time.

### Description 
This PR keeps the root dropdown visible when `keepDropdownOpen` is enabled and a nested relation leaf is clicked. It also normalizes controlled submenu open keys so only the active submenu chain stays expanded while switching hover across sibling relation groups.

Regression coverage was added for both cases in `AddSubModelButton.test.tsx`.

Risk is low because the change is localized to `LazyDropdown` submenu open-state handling. Testing suggestion: verify relation field expansion in the v2 table block, including repeated hover across different relation groups and clicking nested fields while the root menu should remain open.

### Related issues
- #1654

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed unstable relation-field submenus in submodel menus |
| 🇨🇳 Chinese | 修复子模型菜单中关系字段子菜单状态不稳定的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
