### PR TITLE
fix(mobile): constrain notification popup

### DIFF
--- a/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.style.ts
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.style.ts
@@ -45,19 +45,10 @@ export const useMobileActionDrawerStyle = genStyleHook('nb-mobile-action-drawer'
       '.nb-mobile-action-drawer-body': {
         borderTopLeftRadius: 8,
         borderTopRightRadius: 8,
-        maxHeight: 'calc(100vh - var(--nb-mobile-page-header-height, 46px))',
-        overflowY: 'auto',
-        overflowX: 'hidden',
-        scrollbarWidth: 'none',
-        msOverflowStyle: 'none',
         backgroundColor: token.colorBgLayout,
 
         '&::-webkit-scrollbar': {
           display: 'none',
-        },
-
-        '@supports (height: 100dvh)': {
-          maxHeight: 'calc(100dvh - var(--nb-mobile-page-header-height, 46px))',
         },
 
         // 不带 tab 页的半窗

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.style.ts
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.style.ts
@@ -45,10 +45,20 @@ export const useMobileActionDrawerStyle = genStyleHook('nb-mobile-action-drawer'
       '.nb-mobile-action-drawer-body': {
         borderTopLeftRadius: 8,
         borderTopRightRadius: 8,
-        maxHeight: 'calc(100% - var(--nb-mobile-page-header-height))',
+        maxHeight: 'calc(100vh - var(--nb-mobile-page-header-height, 46px))',
         overflowY: 'auto',
         overflowX: 'hidden',
+        scrollbarWidth: 'none',
+        msOverflowStyle: 'none',
         backgroundColor: token.colorBgLayout,
+
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+
+        '@supports (height: 100dvh)': {
+          maxHeight: 'calc(100dvh - var(--nb-mobile-page-header-height, 46px))',
+        },
 
         // 不带 tab 页的半窗
         '& > .nb-grid-container': {

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.tsx
@@ -35,6 +35,14 @@ export interface MobilePopupProps {
   children: ReactNode;
 }
 
+const getMobilePopupMaxHeight = () => {
+  if (typeof CSS !== 'undefined' && CSS.supports?.('height', '100dvh')) {
+    return 'calc(100dvh - var(--nb-mobile-page-header-height, 46px))';
+  }
+
+  return 'calc(100vh - var(--nb-mobile-page-header-height, 46px))';
+};
+
 export const MobilePopup: FC<MobilePopupProps> = (props) => {
   const { title, visible, onClose: closePopup, children, minHeight } = props;
   const { t } = useTranslation();
@@ -51,6 +59,16 @@ export const MobilePopup: FC<MobilePopupProps> = (props) => {
       minHeight,
     };
   }, [newZIndex, minHeight]);
+  const bodyStyle = useMemo(() => {
+    return {
+      ...zIndexStyle,
+      maxHeight: getMobilePopupMaxHeight(),
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      scrollbarWidth: 'none',
+      msOverflowStyle: 'none',
+    };
+  }, [zIndexStyle]);
 
   const theme = useMemo(() => {
     return {
@@ -77,7 +95,7 @@ export const MobilePopup: FC<MobilePopupProps> = (props) => {
           onMaskClick={closePopup}
           getContainer={() => popupContainerRef.current}
           bodyClassName="nb-mobile-action-drawer-body"
-          bodyStyle={zIndexStyle}
+          bodyStyle={bodyStyle}
           maskStyle={zIndexStyle}
           style={zIndexStyle}
           destroyOnClose

--- a/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-mobile/src/client/adaptor-of-desktop/ActionDrawer.tsx
@@ -21,7 +21,7 @@ import {
 import { ConfigProvider } from 'antd';
 import { Popup } from 'antd-mobile';
 import { CloseOutline } from 'antd-mobile-icons';
-import React, { FC, ReactNode, useCallback, useEffect, useMemo } from 'react';
+import React, { CSSProperties, FC, ReactNode, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMobileActionDrawerStyle } from './ActionDrawer.style';
 import { usePopupContainer } from './FilterAction';
@@ -59,7 +59,7 @@ export const MobilePopup: FC<MobilePopupProps> = (props) => {
       minHeight,
     };
   }, [newZIndex, minHeight]);
-  const bodyStyle = useMemo(() => {
+  const bodyStyle: CSSProperties = useMemo(() => {
     return {
       ...zIndexStyle,
       maxHeight: getMobilePopupMaxHeight(),
@@ -93,7 +93,7 @@ export const MobilePopup: FC<MobilePopupProps> = (props) => {
           visible={visible}
           onClose={closePopup}
           onMaskClick={closePopup}
-          getContainer={() => popupContainerRef.current}
+          getContainer={() => popupContainerRef.current || document.body}
           bodyClassName="nb-mobile-action-drawer-body"
           bodyStyle={bodyStyle}
           maskStyle={zIndexStyle}
@@ -127,7 +127,7 @@ export const ActionDrawerUsedInMobile: any = observer((props: { footerNodeName?:
   const fieldSchema = useFieldSchema();
   const field = useField();
   const { visible, setVisible } = useActionContext();
-  const { visiblePopup } = usePopupContainer(visible);
+  const { visiblePopup } = usePopupContainer(!!visible);
 
   // 克隆的目的是为了把底部按钮的 schema 去掉，避免重复渲染。
   // 不使用 filterProperties 的原因是防止 Iphone 中出现卡死的问题，具体原因未知。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
移动端消息弹窗内容较多时，弹窗会超过屏幕高度，导致顶部关闭按钮不可见，也无法像正常移动端弹窗一样在内容区域内滑动查看。

### Description 
修复移动端消息弹窗在内容较多时的高度限制问题，弹窗现在会保持在可见屏幕范围内，关闭按钮可见，内容区域可以滑动。同时隐藏移动端弹窗的滚动条，避免影响移动端显示效果。

已在本地连接测试环境接口，并使用 iPhone 14 Pro Max 尺寸验证消息弹窗可关闭、可滑动，且不会显示滚动条。

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix mobile message popups that could not be closed or scrolled |
| 🇨🇳 Chinese | 修复移动端消息弹窗无法关闭和滑动的问题 |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary