### PR TITLE
fix(tree): refine tree filter settings and search behavior

### DIFF
--- a/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
+++ b/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
@@ -52,8 +52,7 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
   const field = useField<Field>();
   const fieldSchema = useFieldSchema();
   const { getInterface } = useCollectionManager_deprecated();
-  const collectionField = useCollectionField();
-  const { uiSchema: uiSchemaOrigin, defaultValue, interface: collectionInterface } = collectionField;
+  const { uiSchema: uiSchemaOrigin, defaultValue, interface: collectionInterface } = useCollectionField();
   const { isAllowToSetDefaultValue } = useIsAllowToSetDefaultValue();
   const targetInterface = getInterface(collectionInterface);
   const operator =
@@ -71,10 +70,6 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
   useEffect(() => {
     if (!uiSchemaOrigin) {
       return;
-    }
-    const isTreeCollection = !!collectionField?.collection?.tree;
-    if (isTreeCollection) {
-      field.componentProps = merge(field.componentProps || {}, { disableFieldClickToOpen: true });
     }
     const uiSchema = compile(uiSchemaOrigin);
     setFieldProps(field, 'content', uiSchema['x-content']);

--- a/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
+++ b/packages/core/client/src/modules/blocks/filter-blocks/FilterCollectionField.tsx
@@ -52,7 +52,8 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
   const field = useField<Field>();
   const fieldSchema = useFieldSchema();
   const { getInterface } = useCollectionManager_deprecated();
-  const { uiSchema: uiSchemaOrigin, defaultValue, interface: collectionInterface } = useCollectionField();
+  const collectionField = useCollectionField();
+  const { uiSchema: uiSchemaOrigin, defaultValue, interface: collectionInterface } = collectionField;
   const { isAllowToSetDefaultValue } = useIsAllowToSetDefaultValue();
   const targetInterface = getInterface(collectionInterface);
   const operator =
@@ -70,6 +71,10 @@ export const FilterCollectionFieldInternalField: React.FC = (props: Props) => {
   useEffect(() => {
     if (!uiSchemaOrigin) {
       return;
+    }
+    const isTreeCollection = !!collectionField?.collection?.tree;
+    if (isTreeCollection) {
+      field.componentProps = merge(field.componentProps || {}, { disableFieldClickToOpen: true });
     }
     const uiSchema = compile(uiSchemaOrigin);
     setFieldProps(field, 'content', uiSchema['x-content']);

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client/__tests__/tree-component.test.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client/__tests__/tree-component.test.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import AppBasic from '../demos/component-basic';
 import { Tree } from '../component';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 describe('TreeComponent', () => {
   test('basic', () => {
@@ -81,5 +81,34 @@ describe('TreeComponent', () => {
 
     expect(container.querySelector('.ant-tree-treenode-switcher-close')).toBeInTheDocument();
     expect(container.querySelector('.ant-tree-treenode-switcher-open')).not.toBeInTheDocument();
+  });
+
+  test('clears search state when searchable is turned off', async () => {
+    const onSearch = vi.fn();
+    const { rerender } = render(
+      <Tree
+        searchable
+        onSearch={onSearch}
+        treeData={[{ key: 'parent', title: 'Parent', children: [{ key: 'child', title: 'Child' }] }]}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'Parent' } });
+
+    await waitFor(() => {
+      expect(onSearch).toHaveBeenCalledWith('Parent');
+    });
+
+    rerender(
+      <Tree
+        searchable={false}
+        onSearch={onSearch}
+        treeData={[{ key: 'parent', title: 'Parent', children: [{ key: 'child', title: 'Child' }] }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onSearch).toHaveBeenLastCalledWith('');
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client/component/Tree.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client/component/Tree.tsx
@@ -273,6 +273,17 @@ export const Tree: FC<TreeProps> = withDynamicSchemaProps(
     );
 
     useEffect(() => {
+      if (searchable || (inputValue === '' && searchValue === '')) {
+        return;
+      }
+
+      onSearch.cancel();
+      setInputValue('');
+      setSearchValue('');
+      propsOnSearch?.('');
+    }, [inputValue, onSearch, propsOnSearch, searchValue, searchable]);
+
+    useEffect(() => {
       if (deferredSearchValue) {
         if (!expandedKeysBeforeSearchRef.current) {
           expandedKeysBeforeSearchRef.current = expandedKeysRef.current;

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client/models/TreeBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client/models/TreeBlockModel.tsx
@@ -118,6 +118,66 @@ const buildTreeNodeActionItems = (ctx: FlowModelContext) =>
 export class TreeBlockModel extends CollectionBlockModel {
   static scene = BlockSceneEnum.filter;
 
+  static getSupportedAssociatedFields(ctx: FlowModelContext) {
+    const { dataSourceKey, collectionName } = ctx.view.inputArgs || {};
+    if (!dataSourceKey || !collectionName) {
+      return [];
+    }
+
+    const collection = ctx.dataSourceManager.getCollection(dataSourceKey, collectionName);
+    return (
+      collection?.getAssociationFields(this._getScene()).filter((field) => {
+        if (!field.targetCollection) {
+          return false;
+        }
+        if (['belongsTo', 'hasOne', 'belongsToArray'].includes(field.type)) {
+          return false;
+        }
+        if (!this.filterCollection(field.targetCollection)) {
+          return false;
+        }
+        if (!this.isCollectionAvailable(field.targetCollection)) {
+          return false;
+        }
+        return true;
+      }) || []
+    );
+  }
+
+  static async defineChildren(ctx: FlowModelContext) {
+    const items = ((await super.defineChildren(ctx)) || []) as any[];
+    const { collectionName } = ctx.view.inputArgs || {};
+
+    if (!collectionName) {
+      return items;
+    }
+
+    const supportedAssociatedFields = this.getSupportedAssociatedFields(ctx);
+    const associatedGroupKey = `${this.name}associated`;
+
+    if (!supportedAssociatedFields.length) {
+      return items.filter((item) => item?.key !== associatedGroupKey);
+    }
+
+    const supportedAssociatedKeys = new Set(
+      supportedAssociatedFields.map((field) => `${this.name}associated-${field.name}`),
+    );
+
+    return items.map((item) => {
+      if (item?.key !== associatedGroupKey || typeof item.children !== 'function') {
+        return item;
+      }
+
+      return {
+        ...item,
+        children: (...args) => {
+          const children = item.children(...args) || [];
+          return children.filter((child) => supportedAssociatedKeys.has(child?.key));
+        },
+      };
+    });
+  }
+
   static async getExtraMenuItems(model, t) {
     const items = await super.getExtraMenuItems(model, t);
     return items.filter((item) => item.key !== 'block-reference:convert-to-template');
@@ -324,6 +384,7 @@ export class TreeBlockModel extends CollectionBlockModel {
         showBorder={false}
         showDeleteButton={false}
         showCopyUidButton={false}
+        showDynamicFlowsEditor={false}
         settingsMenuLevel={2}
       >
         {children}
@@ -470,6 +531,13 @@ export class TreeTitleFieldSettingsModel extends FlowModel<{
     field: FlowModel;
   };
 }> {
+  onInit(options) {
+    super.onInit(options);
+    this.context.defineProperty('disableFieldClickToOpen', {
+      value: true,
+    });
+  }
+
   get treeBlockModel() {
     return this.parent as TreeBlockModel;
   }

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client/models/__tests__/TreeBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client/models/__tests__/TreeBlockModel.test.ts
@@ -10,11 +10,117 @@
 import { DisplayItemModel, FlowEngine, FlowModel } from '@nocobase/flow-engine';
 import { AddChildActionModel, PopupActionModel } from '@nocobase/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { TreeBlockModel } from '../TreeBlockModel';
+import { TreeBlockModel, TreeTitleFieldSettingsModel } from '../TreeBlockModel';
 
 describe('TreeBlockModel', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('hides single relation entries from associated records in tree filter block menu', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ TreeBlockModel });
+
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds.addCollection({
+      name: 'categories',
+      filterTargetKey: 'id',
+      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+    });
+    ds.addCollection({
+      name: 'profiles',
+      filterTargetKey: 'id',
+      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+    });
+    ds.addCollection({
+      name: 'products',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        {
+          name: 'category',
+          title: 'Category',
+          type: 'belongsTo',
+          target: 'categories',
+          interface: 'm2o',
+        },
+        {
+          name: 'profile',
+          title: 'Profile',
+          type: 'hasOne',
+          target: 'profiles',
+          interface: 'o2o',
+        },
+      ],
+    });
+
+    const designerCtx = {
+      dataSourceManager: engine.dataSourceManager,
+      view: { inputArgs: { dataSourceKey: 'main', collectionName: 'products', filterByTk: 1 } },
+    } as any;
+
+    const children = (await TreeBlockModel.defineChildren(designerCtx)) as any[];
+    expect(children.some((item) => String(item?.key).includes('associated'))).toBe(false);
+  });
+
+  it('keeps multi relation entries in associated records for tree filter block menu', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ TreeBlockModel });
+
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds.addCollection({
+      name: 'categories',
+      filterTargetKey: 'id',
+      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+    });
+    ds.addCollection({
+      name: 'tags',
+      filterTargetKey: 'id',
+      fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+    });
+    ds.addCollection({
+      name: 'products',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        {
+          name: 'categories',
+          title: 'Categories',
+          type: 'hasMany',
+          target: 'categories',
+          interface: 'o2m',
+        },
+        {
+          name: 'tags',
+          title: 'Tags',
+          type: 'belongsToMany',
+          target: 'tags',
+          interface: 'm2m',
+        },
+        {
+          name: 'category',
+          title: 'Category',
+          type: 'belongsTo',
+          target: 'categories',
+          interface: 'm2o',
+        },
+      ],
+    });
+
+    const designerCtx = {
+      dataSourceManager: engine.dataSourceManager,
+      view: { inputArgs: { dataSourceKey: 'main', collectionName: 'products', filterByTk: 1 } },
+    } as any;
+
+    const children = (await TreeBlockModel.defineChildren(designerCtx)) as any[];
+    const associated = children.find((item) => String(item?.key).includes('associated'));
+
+    expect(associated).toBeTruthy();
+
+    const associatedChildren = (associated.children?.() || []) as any[];
+    expect(associatedChildren.some((item) => String(item?.key).includes('associated-categories'))).toBe(true);
+    expect(associatedChildren.some((item) => String(item?.key).includes('associated-tags'))).toBe(true);
+    expect(associatedChildren.some((item) => String(item?.key).includes('associated-category'))).toBe(false);
   });
 
   it('creates title field sub model with the matched display field model', async () => {
@@ -402,6 +508,17 @@ describe('TreeBlockModel', () => {
 
     expect(destroyModel).toHaveBeenCalledWith('field-model-uid');
     expect(removeModelWithSubModels).not.toHaveBeenCalled();
+  });
+
+  it('disables click-to-open in tree title field settings context', () => {
+    const engine = new FlowEngine();
+    const model = new TreeTitleFieldSettingsModel({
+      uid: 'tree-title-field-settings',
+      flowEngine: engine,
+    });
+    model.onInit({} as any);
+
+    expect(model.context.disableFieldClickToOpen).toBe(true);
   });
 
   it('injects cached add-child formData before the popup opens during route replay', async () => {

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client/models/components/TreeBlockView.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client/models/components/TreeBlockView.tsx
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
 import {
   createRecordMetaFactory,
@@ -18,9 +19,10 @@ import {
   observer,
 } from '@nocobase/flow-engine';
 import type { ForkFlowModel, PropertyMetaFactory } from '@nocobase/flow-engine';
-import { Checkbox, DatePicker, Input, InputNumber, Radio, Select, Space, Switch } from 'antd';
-import React, { useCallback, useMemo } from 'react';
+import { Checkbox, DatePicker, Input, InputNumber, Radio, Select, Space, Switch, Tooltip } from 'antd';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Tree, TreeProps } from '../../component';
+import { useTreeTranslation } from '../../locale';
 import type { TreeBlockModel } from '../TreeBlockModel';
 
 const SEARCH_FILTER_GROUP = '__tree_search__';
@@ -66,6 +68,56 @@ const normalizeChangeValue = (input: any) => {
 
 const omitUndefined = (props: Record<string, any> = {}) => {
   return Object.fromEntries(Object.entries(props).filter(([, value]) => value !== undefined));
+};
+
+export const getTreeTitleFieldDeletedMessage = (
+  model: Pick<TreeBlockModel, 'collection' | 'getTitleFieldName'>,
+  t: (key: string, options?: any) => string,
+) => {
+  const collection: any = model.collection;
+  const dataSource = collection?.dataSource;
+  const titleFieldName = model.getTitleFieldName();
+  const dataSourcePrefix = dataSource ? `${t(dataSource.displayName || dataSource.key)} > ` : '';
+  const collectionPrefix = collection ? `${t(collection.title) || collection.name || collection.tableName} > ` : '';
+  const nameValue = `${dataSourcePrefix}${collectionPrefix}${titleFieldName}`;
+
+  return t('The title field "{{name}}" may have been deleted. Please select another field.', {
+    name: nameValue,
+  }).replaceAll('&gt;', '>');
+};
+
+export const getTreeNodeTitleContent = ({
+  model,
+  collectionField,
+  titleFieldModel,
+  value,
+  node,
+  fallbackTitle,
+}: {
+  model: TreeBlockModel;
+  collectionField: any;
+  titleFieldModel: any;
+  value: any;
+  node: any;
+  fallbackTitle?: React.ReactNode;
+}) => {
+  const isTitleFieldMissing = !collectionField && !!model.getTitleFieldName();
+
+  if (isTitleFieldMissing) {
+    return (
+      <TreeNodeTitleContent model={model} record={node} title={<TreeTitleFieldDeletedPlaceholder model={model} />} />
+    );
+  }
+
+  if (value === null || value === undefined || value === '') {
+    return <TreeNodeTitleContent model={model} record={node} title="N/A" />;
+  }
+
+  if (!titleFieldModel?.createFork) {
+    return <TreeNodeTitleContent model={model} record={node} title={fallbackTitle || String(value)} />;
+  }
+
+  return null;
 };
 
 const renderFilterInput = (app: any, schema: any, value: any, onChange: (value: any) => void): React.ReactElement => {
@@ -401,9 +453,25 @@ const TreeNodeTitleContent = ({
   );
 };
 
+const TreeTitleFieldDeletedPlaceholder = ({ model }: { model: TreeBlockModel }) => {
+  const { t } = useTreeTranslation();
+  const content = useMemo(() => getTreeTitleFieldDeletedMessage(model, t), [model, t]);
+
+  return (
+    <Tooltip title={content}>
+      <ExclamationCircleOutlined style={{ opacity: '0.3' }} />
+    </Tooltip>
+  );
+};
+
 export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => {
   const resource = model.resource;
+  const treeData = resource.getData();
   const collection = model.collection;
+  const [searchValue, setSearchValue] = useState<any>();
+  const fullTreeDataRef = useRef<any[]>([]);
+  const previousTreeDataRef = useRef<any[]>();
+  const awaitingSearchResetRef = useRef(false);
   const collectionFilterTargetKey = collection?.filterTargetKey;
   const propsFieldNames = model.props?.fieldNames;
   const fieldNames = useMemo(
@@ -437,13 +505,40 @@ export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => 
     [model.context.app, schema],
   );
 
+  useEffect(() => {
+    if (searchValue === '' || searchValue == null) {
+      if (awaitingSearchResetRef.current) {
+        if (previousTreeDataRef.current !== treeData) {
+          fullTreeDataRef.current = treeData || [];
+          awaitingSearchResetRef.current = false;
+        }
+      } else {
+        fullTreeDataRef.current = treeData || [];
+      }
+    }
+
+    previousTreeDataRef.current = treeData;
+  }, [searchValue, treeData]);
+
   const onSearch = useCallback<NonNullable<TreeProps['onSearch']>>(
     (value) => {
       if (!resource) {
         return;
       }
 
-      if (value === '' || value == null) {
+      const isClearingSearch = value === '' || value == null;
+      const hadSearchValue = !(searchValue === '' || searchValue == null);
+
+      if (!isClearingSearch && !hadSearchValue) {
+        fullTreeDataRef.current = treeData || [];
+      }
+      if (isClearingSearch && hadSearchValue) {
+        awaitingSearchResetRef.current = true;
+      }
+
+      setSearchValue(value);
+
+      if (isClearingSearch) {
         resource.removeFilterGroup(SEARCH_FILTER_GROUP);
       } else {
         resource.addFilterGroup(SEARCH_FILTER_GROUP, {
@@ -456,7 +551,7 @@ export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => 
       resource.setPage(1);
       void resource.refresh();
     },
-    [operator?.value, resource, titleField],
+    [operator?.value, resource, searchValue, titleField, treeData],
   );
 
   const onSelect = useCallback<NonNullable<TreeProps['onSelect']>>(
@@ -468,24 +563,29 @@ export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => 
       if (selectedKey === undefined || selectedKey === null) {
         model.setSelectedFilterValues([]);
       } else {
-        const selectedNode = findNodeByKey(resource.getData() || [], fieldNames.key, selectedKey);
+        const treeDataForFilter =
+          searchValue === '' || searchValue == null ? treeData || [] : fullTreeDataRef.current || [];
+        const selectedNode = findNodeByKey(treeDataForFilter, fieldNames.key, selectedKey);
         const keys = collectDescendantKeys(selectedNode, fieldNames.key, []);
         model.setSelectedFilterValues(keys.length ? keys : [selectedKey]);
       }
 
       void model.context.filterManager?.refreshTargetsByFilter?.(model.uid);
     },
-    [fieldNames.key, model, resource],
+    [fieldNames.key, model, searchValue, treeData],
   );
 
   const renderNodeTitle = useCallback<NonNullable<TreeProps['renderNodeTitle']>>(
     (value, node, fallbackTitle) => {
-      if (value === null || value === undefined || value === '') {
-        return <TreeNodeTitleContent model={model} record={node} title="N/A" />;
-      }
-
-      if (!titleFieldModel?.createFork || !collectionField) {
-        return <TreeNodeTitleContent model={model} record={node} title={fallbackTitle || String(value)} />;
+      if (!collectionField || value === null || value === undefined || value === '' || !titleFieldModel?.createFork) {
+        return getTreeNodeTitleContent({
+          model,
+          collectionField,
+          titleFieldModel,
+          value,
+          node,
+          fallbackTitle,
+        });
       }
 
       const nodeKey = node?.[fieldNames.key] ?? `${titleField}-${String(value)}`;
@@ -564,7 +664,7 @@ export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => 
         searchable={model.props.searchable ?? true}
         defaultExpandAll={model.props.defaultExpandAll ?? false}
         fieldNames={fieldNames}
-        treeData={resource.getData()}
+        treeData={treeData}
         loading={resource.loading}
         selectedKeys={model.selectedKeys.value}
         onSearch={onSearch}

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client/models/components/__tests__/TreeBlockView.test.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client/models/components/__tests__/TreeBlockView.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getTreeNodeTitleContent, getTreeTitleFieldDeletedMessage } from '../TreeBlockView';
+
+describe('TreeBlockView', () => {
+  it('uses deleted-field hint when title field is missing', () => {
+    const model: any = {
+      collection: {
+        dataSource: { displayName: 'Main' },
+        title: 'Posts',
+        name: 'posts',
+      },
+      getTitleFieldName: () => 'title',
+    };
+
+    const result = getTreeTitleFieldDeletedMessage(model, (key, options) => {
+      if (!options) return key;
+      return `标题字段“${options.name}”可能已被删除，请选择其他字段。`;
+    });
+
+    expect(result).toContain('请选择其他字段');
+  });
+
+  it('returns deleted placeholder content when collection field is missing', () => {
+    const model: any = {
+      collection: {
+        dataSource: { displayName: 'Main' },
+        title: 'Posts',
+        name: 'posts',
+      },
+      getTitleFieldName: () => 'title',
+    };
+
+    const result = getTreeNodeTitleContent({
+      model,
+      collectionField: undefined,
+      titleFieldModel: {},
+      value: 'Deleted title',
+      node: { id: 1 },
+      fallbackTitle: 'fallback',
+    }) as any;
+
+    expect(result.props.title.type.name).toBe('TreeTitleFieldDeletedPlaceholder');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-block-tree/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/locale/zh-CN.json
@@ -11,5 +11,6 @@
   "Tree settings": "树区块设置",
   "Tree": "树",
   "Unconnected": "未连接",
-  "Include child nodes when filtering": "筛选时包含子节点"
+  "Include child nodes when filtering": "筛选时包含子节点",
+  "The title field \"{{name}}\" may have been deleted. Please select another field.": "标题字段“{{name}}”可能已被删除，请选择其他字段。"
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Tree filter blocks had several usability and configuration issues, including unsupported association entries, missing feedback when the configured title field was deleted, stale search state when disabling the search box, and unnecessary event-flow/click-to-open options in tree-specific settings.

### Description 
This PR refines tree filter block behavior and settings in the block-tree plugin and related filter field integration.

Key changes:
- hide unsupported single-relation entries from `Associated records` when creating tree filter blocks
- disable click-to-open related behavior for tree filter title fields
- hide `Edit event flows` from tree node title settings
- show a clearer message when the configured tree title field has been deleted
- reset the active tree search when `Searchable` is turned off
- add focused tests for menu filtering, title-field fallback, and search reset behavior

Potential risk:
- the tree search and descendant-filter interaction path in `TreeBlockView` is still relatively stateful and should be watched during QA, especially around data scope changes

Testing suggestions:
- create tree filter blocks from current collection and associated records
- verify single relations are not offered in tree filter creation
- delete the configured title field and confirm the new fallback hint appears
- search in the tree filter, then disable `Searchable`, and confirm the tree data resets
- verify tree node settings no longer show `Edit event flows`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved tree filter block settings and fixed unsupported association, title-field fallback, and search reset behavior. |
| 🇨🇳 Chinese | 优化树筛选区块设置，并修复不支持的关联记录入口、标题字段缺失提示以及关闭搜索后的重置行为。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
