### PR TITLE
fix(client-v2): isolate v2 menus

### DIFF
--- a/packages/core/client-v2/src/__tests__/nocobase-buildin-plugin-auth.test.tsx
+++ b/packages/core/client-v2/src/__tests__/nocobase-buildin-plugin-auth.test.tsx
@@ -8,12 +8,28 @@
  */
 
 import { createMockClient } from '@nocobase/client-v2';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { NocoBaseBuildInPlugin } from '../nocobase-buildin-plugin';
 
 describe('nocobase buildin plugin auth redirect', () => {
   const originalLocation = globalThis.window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis.window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
 
   afterEach(() => {
     Object.defineProperty(globalThis.window, 'location', {
@@ -92,7 +108,7 @@ describe('nocobase buildin plugin auth redirect', () => {
     });
   });
 
-  it('should redirect authenticated v2 admin root to legacy default page before layout render', async () => {
+  it('should render v2 admin root without redirecting to legacy default page', async () => {
     const replace = vi.fn();
     Object.defineProperty(globalThis.window, 'location', {
       configurable: true,
@@ -118,6 +134,7 @@ describe('nocobase buildin plugin auth redirect', () => {
       },
     });
     app.apiMock.onGet('/auth:check').reply(200, { data: { id: 1 } });
+    app.apiMock.onGet('systemSettings:get').reply(200, { data: {} });
     app.apiMock.onGet('/desktopRoutes:listAccessible').reply(200, {
       data: [
         {
@@ -133,53 +150,57 @@ describe('nocobase buildin plugin auth redirect', () => {
     const { container } = render(<Root />);
 
     await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith('/admin/legacy-page');
+      expect(container.innerHTML).toContain('No pages yet, please configure first');
     });
+    expect(replace).not.toHaveBeenCalled();
     expect(container.innerHTML).not.toContain('Legacy page');
   });
 
-  it('should redirect authenticated direct legacy v2 page access to v1 path', async () => {
-    const replace = vi.fn();
-    Object.defineProperty(globalThis.window, 'location', {
-      configurable: true,
-      value: {
-        ...originalLocation,
-        pathname: '/v2/admin/legacy-page/tab/tab-1',
-        search: '?from=direct',
-        hash: '#dialog',
-        replace,
-      },
-    });
-
-    const app = createMockClient({
-      publicPath: '/v2/',
-      plugins: [NocoBaseBuildInPlugin as any],
-      router: { type: 'memory', initialEntries: ['/v2/admin/legacy-page/tab/tab-1'] },
-    });
-    app.apiMock.onGet('app:getLang').reply(200, {
-      data: {
-        lang: 'en-US',
-        resources: { client: {} },
-        cron: {},
-      },
-    });
-    app.apiMock.onGet('/auth:check').reply(200, { data: { id: 1 } });
-    app.apiMock.onGet('/desktopRoutes:listAccessible').reply(200, {
-      data: [
-        {
-          id: 1,
-          title: 'Legacy page',
-          schemaUid: 'legacy-page',
-          type: 'page',
+  it.each(['/v2/admin/legacy-page/tab/tab-1', '/v2/admin/legacy-page/view/detail'])(
+    'should show 404 for authenticated direct legacy v2 page access: %s',
+    async (pathname) => {
+      const replace = vi.fn();
+      Object.defineProperty(globalThis.window, 'location', {
+        configurable: true,
+        value: {
+          ...originalLocation,
+          pathname,
+          search: '?from=direct',
+          hash: '#dialog',
+          replace,
         },
-      ],
-    });
+      });
 
-    const Root = app.getRootComponent();
-    render(<Root />);
+      const app = createMockClient({
+        publicPath: '/v2/',
+        plugins: [NocoBaseBuildInPlugin as any],
+        router: { type: 'memory', initialEntries: [pathname] },
+      });
+      app.apiMock.onGet('app:getLang').reply(200, {
+        data: {
+          lang: 'en-US',
+          resources: { client: {} },
+          cron: {},
+        },
+      });
+      app.apiMock.onGet('/auth:check').reply(200, { data: { id: 1 } });
+      app.apiMock.onGet('systemSettings:get').reply(200, { data: {} });
+      app.apiMock.onGet('/desktopRoutes:listAccessible').reply(200, {
+        data: [
+          {
+            id: 1,
+            title: 'Legacy page',
+            schemaUid: 'legacy-page',
+            type: 'page',
+          },
+        ],
+      });
 
-    await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith('/admin/legacy-page/tabs/tab-1?from=direct#dialog');
-    });
-  });
+      const Root = app.getRootComponent();
+      render(<Root />);
+
+      expect(await screen.findByText('404')).toBeInTheDocument();
+      expect(replace).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
+++ b/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { FlowEngine, FlowEngineProvider, type FlowModel } from '@nocobase/flow-engine';
 import FlowRoute from '../components/FlowRoute';
 
@@ -219,7 +219,7 @@ describe('FlowRoute', () => {
     });
   });
 
-  it('should replace to legacy page when current route is page', async () => {
+  it('should show 404 when current route is a legacy page in v2 runtime', async () => {
     const originalLocation = window.location;
     const replace = vi.fn();
     Object.defineProperty(window, 'location', {
@@ -271,9 +271,8 @@ describe('FlowRoute', () => {
         </FlowEngineProvider>,
       );
 
-      await waitFor(() => {
-        expect(replace).toHaveBeenCalledWith('/admin/test-page/tabs/tab-1?from=direct#dialog');
-      });
+      expect(await screen.findByText('404')).toBeInTheDocument();
+      expect(replace).not.toHaveBeenCalled();
       expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalled();
       expect(adminLayoutModel.updateRoutePage).not.toHaveBeenCalled();
     } finally {

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
@@ -28,7 +28,6 @@ import {
   reconcileAdminLayoutMenuItems,
   shouldRenderIconInTitle,
 } from './AdminLayoutMenuUtils';
-import { findFirstPageRoute } from './AdminLayoutCompat';
 import {
   buildMenuBasicSchema,
   buildLinkSettingSchema,
@@ -41,7 +40,13 @@ import {
   matchesRoutePath,
   toTreeSelectItems,
 } from './AdminLayoutMenuFlowUtils';
-import { resolveAdminRouteRuntimeTarget, toRouterNavigationPath } from './resolveAdminRouteRuntimeTarget';
+import {
+  findFirstAccessiblePageRoute,
+  findFirstV2LandingRoute,
+  isV2AdminRuntime,
+  resolveAdminRouteRuntimeTarget,
+  toRouterNavigationPath,
+} from './resolveAdminRouteRuntimeTarget';
 
 export * from './AdminLayoutMenuUtils';
 const insertPositionToMethod = {
@@ -546,6 +551,11 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
         app: this.context.app,
         route,
       });
+
+      if (runtimeTarget.reason === 'unsupportedV2Runtime') {
+        return null;
+      }
+
       const path = route.schemaUid
         ? `/admin/${route.schemaUid}`
         : getAdminLayoutMenuVirtualPath('link', `${this.uid}-invalid`);
@@ -579,13 +589,20 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
           )
           .filter(Boolean) || [];
 
+      if (isV2AdminRuntime(this.context.app) && children.length === 0) {
+        return null;
+      }
+
       if (options.designable && depth === 0) {
         children.push(getAdminLayoutMenuInitializerButton('schema-initializer-Menu-side', this, route));
       }
 
+      const landingRoute = isV2AdminRuntime(this.context.app)
+        ? findFirstV2LandingRoute(itemChildren)
+        : findFirstAccessiblePageRoute(itemChildren);
       const runtimeTarget = resolveAdminRouteRuntimeTarget({
         app: this.context.app,
-        route,
+        route: isV2AdminRuntime(this.context.app) && landingRoute ? landingRoute : route,
       });
 
       const groupRoute: AdminLayoutMenuNode = {
@@ -593,9 +610,7 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
         icon,
         path: `/admin/${route.id}`,
         redirect:
-          children[0]?.key === 'x-designer-button'
-            ? undefined
-            : `/admin/${findFirstPageRoute(itemChildren)?.schemaUid || route.id}`,
+          children[0]?.key === 'x-designer-button' ? undefined : `/admin/${landingRoute?.schemaUid || route.id}`,
         hideInMenu: route.hideInMenu,
         _runtimePath: runtimeTarget.runtimePath,
         _navigationMode: runtimeTarget.navigationMode,

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuUtils.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuUtils.tsx
@@ -16,8 +16,7 @@ import {
   FlowModelRenderer,
   FlowSettingsButton,
 } from '@nocobase/flow-engine';
-import { App, Badge, Tooltip } from 'antd';
-import type { HookAPI } from 'antd/es/modal/useModal';
+import { Badge, Tooltip } from 'antd';
 import qs from 'qs';
 import React, { FC, useCallback, useContext, useEffect } from 'react';
 import { Link, useLocation, type NavigateFunction } from 'react-router-dom';
@@ -284,33 +283,6 @@ const translateByModel = (model: FlowModel, value: any) => {
   return typeof model.context.t === 'function' ? model.context.t(value) : value;
 };
 
-const translateMenuNode = (item: AdminLayoutMenuNode, value: any) => {
-  return item._model ? translateByModel(item._model, value) : value;
-};
-
-/**
- * 经典页面需要整页跳回 v1，先给用户一个明确确认，避免误离开当前 v2 上下文。
- */
-const confirmLegacyPageNavigation = async (options: { item: AdminLayoutMenuNode; confirm?: HookAPI['confirm'] }) => {
-  const { item, confirm } = options;
-
-  if (!item._isLegacy || typeof confirm !== 'function') {
-    return true;
-  }
-
-  const confirmed = await confirm({
-    title: translateMenuNode(item, 'Open classic page access'),
-    content: translateMenuNode(
-      item,
-      'This page requires the classic version to open properly. Do you want to go there now?',
-    ),
-    okText: translateMenuNode(item, 'Yes'),
-    cancelText: translateMenuNode(item, 'Cancel'),
-  });
-
-  return !!confirmed;
-};
-
 const MENU_TYPE_ITEMS: Array<{ key: string; label: string; menuType: AdminLayoutMenuCreationType }> = [
   { key: 'group', label: 'Group', menuType: 'group' },
   { key: 'flow-page', label: 'Page', menuType: 'flowPage' },
@@ -520,7 +492,6 @@ export function resolveAdminLayoutMenuDragMoveOptionsFromEvent(
 const GroupItem: FC<{ item: AdminLayoutMenuNode; options?: AdminLayoutMenuRenderOptions }> = (props) => {
   const { item } = props;
   const badgeCount = useEvaluatedExpression(item._route.options?.badge?.count, item._model?.context);
-  const { modal } = App.useApp();
   const navigate = useNavigateNoUpdate();
   const routerBasename = useRouterBasename();
   const { closeMobileMenu } = useContext(MobileMenuControlContext);
@@ -556,23 +527,13 @@ const GroupItem: FC<{ item: AdminLayoutMenuNode; options?: AdminLayoutMenuRender
 
         event.preventDefault();
         event.stopPropagation();
-        void (async () => {
-          const confirmed = await confirmLegacyPageNavigation({
-            item,
-            confirm: item._model?.context?.modal?.confirm || modal?.confirm,
-          });
-          if (!confirmed) {
-            return;
-          }
-
-          runAfterMobileMenuClosed({
-            isMobile: !!props.options?.isMobile,
-            closeMobileMenu,
-            callback: () => {
-              window.location.assign(runtimePath);
-            },
-          });
-        })();
+        runAfterMobileMenuClosed({
+          isMobile: !!props.options?.isMobile,
+          closeMobileMenu,
+          callback: () => {
+            window.location.assign(runtimePath);
+          },
+        });
         return;
       }
 
@@ -589,16 +550,7 @@ const GroupItem: FC<{ item: AdminLayoutMenuNode; options?: AdminLayoutMenuRender
         },
       });
     },
-    [
-      closeMobileMenu,
-      item,
-      item._navigationMode,
-      modal,
-      navigate,
-      props.options?.isMobile,
-      runtimePath,
-      spaRuntimePath,
-    ],
+    [closeMobileMenu, item, item._navigationMode, navigate, props.options?.isMobile, runtimePath, spaRuntimePath],
   );
 
   const landingEntryAriaLabel = ariaLabel ? `${ariaLabel}-landing-entry` : 'group-landing-entry';
@@ -656,7 +608,6 @@ const MenuItem: FC<{ item: AdminLayoutMenuNode; options?: AdminLayoutMenuRenderO
   const { item } = props;
   const location = useLocation();
   const badgeCount = useEvaluatedExpression(item._route.options?.badge?.count, item._model?.context);
-  const { modal } = App.useApp();
   const navigate = useNavigateNoUpdate();
   const basenameOfCurrentRouter = useRouterBasename();
   const { closeMobileMenu } = useContext(MobileMenuControlContext);
@@ -717,23 +668,13 @@ const MenuItem: FC<{ item: AdminLayoutMenuNode; options?: AdminLayoutMenuRenderO
 
         event.preventDefault();
         event.stopPropagation();
-        void (async () => {
-          const confirmed = await confirmLegacyPageNavigation({
-            item,
-            confirm: item._model?.context?.modal?.confirm || modal?.confirm,
-          });
-          if (!confirmed) {
-            return;
-          }
-
-          runAfterMobileMenuClosed({
-            isMobile: !!props.options?.isMobile,
-            closeMobileMenu,
-            callback: () => {
-              window.location.assign(runtimePath);
-            },
-          });
-        })();
+        runAfterMobileMenuClosed({
+          isMobile: !!props.options?.isMobile,
+          closeMobileMenu,
+          callback: () => {
+            window.location.assign(runtimePath);
+          },
+        });
         return;
       }
 
@@ -757,16 +698,7 @@ const MenuItem: FC<{ item: AdminLayoutMenuNode; options?: AdminLayoutMenuRenderO
         },
       });
     },
-    [
-      props.options?.isMobile,
-      closeMobileMenu,
-      isDocumentNavigation,
-      item,
-      modal,
-      navigate,
-      runtimePath,
-      spaRuntimePath,
-    ],
+    [props.options?.isMobile, closeMobileMenu, isDocumentNavigation, item, navigate, runtimePath, spaRuntimePath],
   );
 
   if (item._route?.type === NocoBaseDesktopRouteType.link) {

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutSlotModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutSlotModels.tsx
@@ -14,6 +14,7 @@ import { Result, theme as antdTheme } from 'antd';
 import React, { FC, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation } from 'react-router-dom';
+import { isV2AdminRuntime, isV2MenuRoute } from './resolveAdminRouteRuntimeTarget';
 
 type AdminLayoutContentProps = {
   onContentElementChange?: (element: HTMLDivElement | null) => void;
@@ -67,9 +68,12 @@ const ShowTipWhenNoPages = observer(() => {
   const { t } = useTranslation();
   const location = useLocation();
   const allAccessRoutes = flowEngine.context.routeRepository?.listAccessible?.() || [];
+  const visibleRoutes = isV2AdminRuntime(flowEngine.context.app)
+    ? allAccessRoutes.filter((route) => isV2MenuRoute(route))
+    : allAccessRoutes;
   const designable = !!flowEngine.context.flowSettingsEnabled;
 
-  if (allAccessRoutes.length === 0 && !designable && ['/admin', '/admin/'].includes(location.pathname)) {
+  if (visibleRoutes.length === 0 && !designable && ['/admin', '/admin/'].includes(location.pathname)) {
     return (
       <Result
         icon={<HighlightOutlined style={{ fontSize: '8em', color: token.colorText }} />}

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/AdminLayoutMenuModels.test.ts
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/AdminLayoutMenuModels.test.ts
@@ -211,7 +211,7 @@ describe('AdminLayoutModel menu items', () => {
             id: 11,
             title: 'Page 1',
             schemaUid: 'page-1',
-            type: NocoBaseDesktopRouteType.page,
+            type: NocoBaseDesktopRouteType.flowPage,
           },
         ],
       },
@@ -264,7 +264,7 @@ describe('AdminLayoutModel menu items', () => {
             id: 11,
             title: 'Page 1',
             schemaUid: 'page-1',
-            type: NocoBaseDesktopRouteType.page,
+            type: NocoBaseDesktopRouteType.flowPage,
           },
         ],
       },
@@ -285,21 +285,21 @@ describe('AdminLayoutModel menu items', () => {
     expect(route.children).toHaveLength(2);
     expect(route.children[0].path).toBe('/admin/1');
     expect(route.children[0].redirect).toBe('/admin/page-1');
-    expect(route.children[0]._runtimePath).toBe('/apps/demo/admin/page-1');
-    expect(route.children[0]._navigationMode).toBe('document');
-    expect(route.children[0]._isLegacy).toBe(true);
+    expect(route.children[0]._runtimePath).toBe('/apps/demo/v2/admin/page-1');
+    expect(route.children[0]._navigationMode).toBe('spa');
+    expect(route.children[0]._isLegacy).toBe(false);
     expect(route.children[0]._depth).toBe(0);
     expect(route.children[0]._route).toMatchObject({ id: 1, type: NocoBaseDesktopRouteType.group });
     expect(route.children[0]._model).toBe(adminLayoutModel.subModels.menuItems?.[0]);
     expect(route.children[0].routes).toHaveLength(1);
     expect(route.children[0].routes?.[0].path).toBe('/admin/page-1');
     expect(route.children[0].routes?.[0].redirect).toBe('/admin/page-1');
-    expect(route.children[0].routes?.[0]._runtimePath).toBe('/apps/demo/admin/page-1');
-    expect(route.children[0].routes?.[0]._navigationMode).toBe('document');
+    expect(route.children[0].routes?.[0]._runtimePath).toBe('/apps/demo/v2/admin/page-1');
+    expect(route.children[0].routes?.[0]._navigationMode).toBe('spa');
     expect(route.children[0].routes?.[0]._depth).toBe(1);
     expect(route.children[0].routes?.[0]._route).toMatchObject({
       schemaUid: 'page-1',
-      type: NocoBaseDesktopRouteType.page,
+      type: NocoBaseDesktopRouteType.flowPage,
     });
     expect(route.children[0].routes?.[0]._model).toBe(
       adminLayoutModel.subModels.menuItems?.[0].subModels.menuItems?.[0],
@@ -308,6 +308,84 @@ describe('AdminLayoutModel menu items', () => {
     expect(route.children[1]._depth).toBe(0);
     expect(route.children[1]._route).toMatchObject({ id: 2, type: NocoBaseDesktopRouteType.link });
     expect(route.children[1]._model).toBe(adminLayoutModel.subModels.menuItems?.[1]);
+  });
+
+  it('should filter legacy page menu routes in v2 admin layout', () => {
+    const adminLayoutModel = engine.createModel<AdminLayoutModel>({
+      uid: 'admin-layout-model',
+      use: AdminLayoutModel,
+    });
+
+    adminLayoutModel.syncMenuRoutes([
+      {
+        id: 1,
+        title: 'Legacy page',
+        schemaUid: 'legacy-page',
+        type: NocoBaseDesktopRouteType.page,
+      },
+      {
+        id: 2,
+        title: 'Legacy only group',
+        type: NocoBaseDesktopRouteType.group,
+        children: [
+          {
+            id: 21,
+            title: 'Nested legacy page',
+            schemaUid: 'nested-legacy-page',
+            type: NocoBaseDesktopRouteType.page,
+          },
+        ],
+      },
+      {
+        id: 3,
+        title: 'Mixed group',
+        type: NocoBaseDesktopRouteType.group,
+        children: [
+          {
+            id: 31,
+            title: 'Nested legacy page',
+            schemaUid: 'nested-legacy-page-2',
+            type: NocoBaseDesktopRouteType.page,
+          },
+          {
+            id: 32,
+            title: 'Nested flow page',
+            schemaUid: 'nested-flow-page',
+            type: NocoBaseDesktopRouteType.flowPage,
+          },
+        ],
+      },
+      {
+        id: 4,
+        title: 'Link',
+        type: NocoBaseDesktopRouteType.link,
+      },
+    ]);
+
+    const route = adminLayoutModel.toProLayoutRoute({
+      designable: false,
+      isMobile: false,
+      t: (title) => title,
+    });
+
+    expect(route.children).toHaveLength(2);
+    expect(route.children[0]).toMatchObject({
+      path: '/admin/3',
+      redirect: '/admin/nested-flow-page',
+      _runtimePath: '/apps/demo/v2/admin/nested-flow-page',
+      _navigationMode: 'spa',
+      _isLegacy: false,
+    });
+    expect(route.children[0].routes).toHaveLength(1);
+    expect(route.children[0].routes?.[0]).toMatchObject({
+      path: '/admin/nested-flow-page',
+      _runtimePath: '/apps/demo/v2/admin/nested-flow-page',
+      _navigationMode: 'spa',
+      _isLegacy: false,
+    });
+    expect(route.children[1]).toMatchObject({
+      path: '/admin/__admin_layout__/link/4',
+    });
   });
 
   it('should resolve modern flowPage menu runtime target to v2 path', () => {
@@ -406,7 +484,7 @@ describe('AdminLayoutModel menu items', () => {
     );
   });
 
-  it('should render legacy menu item as native anchor and use assign on left click', () => {
+  it('should render document menu item as native anchor and use assign on left click', () => {
     const assign = vi.fn();
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -452,15 +530,8 @@ describe('AdminLayoutModel menu items', () => {
     fireEvent.click(link, { button: 0 });
 
     return waitFor(() => {
-      expect(modalConfirmMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Open classic page access',
-          content: 'This page requires the classic version to open properly. Do you want to go there now?',
-          okText: 'Yes',
-          cancelText: 'Cancel',
-        }),
-      );
       expect(assign).toHaveBeenCalledWith('/apps/demo/admin/legacy-page');
+      expect(modalConfirmMock).not.toHaveBeenCalled();
       expect(navigateMock).not.toHaveBeenCalled();
     });
   });
@@ -518,7 +589,7 @@ describe('AdminLayoutModel menu items', () => {
     }
   });
 
-  it('should not navigate to legacy page when user cancels confirm dialog', async () => {
+  it('should not ask for confirmation before document navigation', async () => {
     modalConfirmMock.mockResolvedValue(false);
     const assign = vi.fn();
     Object.defineProperty(window, 'location', {
@@ -562,9 +633,9 @@ describe('AdminLayoutModel menu items', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Legacy page' }), { button: 0 });
 
     await waitFor(() => {
-      expect(modalConfirmMock).toHaveBeenCalledTimes(1);
+      expect(assign).toHaveBeenCalledWith('/apps/demo/admin/legacy-page');
     });
-    expect(assign).not.toHaveBeenCalled();
+    expect(modalConfirmMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -684,8 +755,8 @@ describe('AdminLayoutModel menu items', () => {
 
     fireEvent.click(screen.getByRole('link', { name: 'Legacy group-landing-entry' }), { button: 0 });
     return waitFor(() => {
-      expect(modalConfirmMock).toHaveBeenCalledTimes(1);
       expect(assign).toHaveBeenCalledWith('/apps/demo/admin/legacy-page');
+      expect(modalConfirmMock).not.toHaveBeenCalled();
     });
   });
 
@@ -741,7 +812,7 @@ describe('AdminLayoutModel menu items', () => {
             id: 11,
             title: 'Page 1',
             schemaUid: 'page-1',
-            type: NocoBaseDesktopRouteType.page,
+            type: NocoBaseDesktopRouteType.flowPage,
           },
         ],
       },
@@ -801,7 +872,7 @@ describe('AdminLayoutModel menu items', () => {
           id: 1,
           title: 'Page 1',
           schemaUid: 'page-1',
-          type: NocoBaseDesktopRouteType.page,
+          type: NocoBaseDesktopRouteType.flowPage,
         },
       ]);
     });
@@ -1630,7 +1701,7 @@ describe('AdminLayoutModel menu items', () => {
         id: 2,
         title: 'Next page',
         schemaUid: 'next-page',
-        type: NocoBaseDesktopRouteType.page,
+        type: NocoBaseDesktopRouteType.flowPage,
       },
     ];
     engine.context.api.resource = vi.fn(() => ({
@@ -1655,8 +1726,8 @@ describe('AdminLayoutModel menu items', () => {
 
     expect(deleteRoute).toHaveBeenCalledWith(1);
     expect(removeSchema).not.toHaveBeenCalled();
-    expect(assign).toHaveBeenCalledWith('/apps/demo/admin/next-page');
-    expect(navigate).not.toHaveBeenCalled();
+    expect(assign).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/apps/demo/v2/admin/next-page');
   });
 
   it('should match current route with router basename before navigating away after delete', async () => {
@@ -1684,16 +1755,16 @@ describe('AdminLayoutModel menu items', () => {
         id: 2,
         title: 'Next page',
         schemaUid: 'next-page',
-        type: NocoBaseDesktopRouteType.page,
+        type: NocoBaseDesktopRouteType.flowPage,
       },
     ];
     engine.context.api.resource = vi.fn(() => ({
       'remove/current-page': removeSchema,
     }));
-    engine.context.location.pathname = '/apps/demo/admin/current-page';
+    engine.context.location.pathname = '/apps/demo/v2/admin/current-page';
     engine.context.defineProperty('router', {
       value: {
-        basename: '/apps/demo',
+        basename: '/apps/demo/v2',
         navigate,
       },
     });
@@ -1715,8 +1786,8 @@ describe('AdminLayoutModel menu items', () => {
 
     expect(deleteRoute).toHaveBeenCalledWith(1);
     expect(removeSchema).not.toHaveBeenCalled();
-    expect(assign).toHaveBeenCalledWith('/apps/demo/admin/next-page');
-    expect(navigate).not.toHaveBeenCalled();
+    expect(assign).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/admin/next-page');
   });
 
   it('should reject inner move when target is not a group', async () => {

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/resolveAdminRouteRuntimeTarget.test.ts
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/resolveAdminRouteRuntimeTarget.test.ts
@@ -10,6 +10,8 @@
 import { NocoBaseDesktopRouteType, type NocoBaseDesktopRoute } from '../../../flow-compat';
 import {
   findFirstAccessiblePageRoute,
+  findFirstV2LandingRoute,
+  isV2MenuRoute,
   resolveAdminRouteRuntimeTarget,
   toRouterNavigationPath,
 } from './resolveAdminRouteRuntimeTarget';
@@ -35,10 +37,11 @@ describe('resolveAdminRouteRuntimeTarget', () => {
       runtimePath: '/nocobase/v2/admin/flow-page-1',
       navigationMode: 'spa',
       isLegacy: false,
+      reason: 'ok',
     });
   });
 
-  it('should resolve page to legacy document runtime target', () => {
+  it('should mark page unsupported in v2 admin runtime', () => {
     expect(
       resolveAdminRouteRuntimeTarget({
         app,
@@ -48,9 +51,10 @@ describe('resolveAdminRouteRuntimeTarget', () => {
         },
       }),
     ).toEqual({
-      runtimePath: '/nocobase/admin/legacy-page-1',
-      navigationMode: 'document',
-      isLegacy: true,
+      runtimePath: null,
+      navigationMode: 'spa',
+      isLegacy: false,
+      reason: 'unsupportedV2Runtime',
     });
   });
 
@@ -74,10 +78,11 @@ describe('resolveAdminRouteRuntimeTarget', () => {
       runtimePath: '/apps/demo/admin/legacy-page-1',
       navigationMode: 'spa',
       isLegacy: false,
+      reason: 'ok',
     });
   });
 
-  it('should preserve current search and hash for direct legacy correction', () => {
+  it('should not preserve current search and hash when direct legacy page is unsupported', () => {
     expect(
       resolveAdminRouteRuntimeTarget({
         app,
@@ -93,13 +98,14 @@ describe('resolveAdminRouteRuntimeTarget', () => {
         preserveLocationState: true,
       }),
     ).toEqual({
-      runtimePath: '/nocobase/admin/legacy-page-1/tabs/tab-1/popups/detail?from=direct#dialog',
-      navigationMode: 'document',
-      isLegacy: true,
+      runtimePath: null,
+      navigationMode: 'spa',
+      isLegacy: false,
+      reason: 'unsupportedV2Runtime',
     });
   });
 
-  it('should resolve group by DFS first accessible route', () => {
+  it('should resolve group by DFS first v2 landing route in v2 runtime', () => {
     const route: NocoBaseDesktopRoute = {
       type: NocoBaseDesktopRouteType.group,
       children: [
@@ -124,9 +130,10 @@ describe('resolveAdminRouteRuntimeTarget', () => {
     };
 
     expect(resolveAdminRouteRuntimeTarget({ app, route })).toEqual({
-      runtimePath: '/nocobase/admin/legacy-page-2',
-      navigationMode: 'document',
-      isLegacy: true,
+      runtimePath: '/nocobase/v2/admin/flow-page-2',
+      navigationMode: 'spa',
+      isLegacy: false,
+      reason: 'ok',
     });
   });
 
@@ -158,6 +165,35 @@ describe('resolveAdminRouteRuntimeTarget', () => {
     });
   });
 
+  it('should find v2 landing route and skip legacy page routes', () => {
+    const routes = [
+      {
+        type: NocoBaseDesktopRouteType.page,
+        schemaUid: 'legacy-page',
+      },
+      {
+        type: NocoBaseDesktopRouteType.group,
+        children: [
+          {
+            type: NocoBaseDesktopRouteType.page,
+            schemaUid: 'nested-legacy-page',
+          },
+          {
+            type: NocoBaseDesktopRouteType.flowPage,
+            schemaUid: 'nested-flow-page',
+          },
+        ],
+      },
+    ];
+
+    expect(findFirstV2LandingRoute(routes)).toMatchObject({
+      type: NocoBaseDesktopRouteType.flowPage,
+      schemaUid: 'nested-flow-page',
+    });
+    expect(isV2MenuRoute(routes[0])).toBe(false);
+    expect(isV2MenuRoute(routes[1])).toBe(true);
+  });
+
   it('should return empty target when group has no accessible landing page', () => {
     expect(
       resolveAdminRouteRuntimeTarget({
@@ -181,6 +217,7 @@ describe('resolveAdminRouteRuntimeTarget', () => {
       runtimePath: null,
       navigationMode: 'spa',
       isLegacy: false,
+      reason: 'emptyGroup',
     });
   });
 
@@ -199,6 +236,7 @@ describe('resolveAdminRouteRuntimeTarget', () => {
       runtimePath: null,
       navigationMode: 'spa',
       isLegacy: false,
+      reason: 'missingSchemaUid',
     });
     expect(log).toHaveBeenCalledWith(
       '[NocoBase] Admin route runtime target:',

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/resolveAdminRouteRuntimeTarget.ts
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/resolveAdminRouteRuntimeTarget.ts
@@ -197,7 +197,10 @@ export function findFirstAccessiblePageRoute(
   return undefined;
 }
 
-function resolvePageRuntimeTarget(options: ResolveAdminRouteRuntimeTargetOptions, route: NocoBaseDesktopRoute) {
+function resolvePageRuntimeTarget(
+  options: ResolveAdminRouteRuntimeTargetOptions,
+  route: NocoBaseDesktopRoute,
+): AdminRouteRuntimeTarget {
   const { app, preserveLocationState, location, log = console.warn } = options;
 
   if (!route.schemaUid) {

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/resolveAdminRouteRuntimeTarget.ts
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/resolveAdminRouteRuntimeTarget.ts
@@ -8,15 +8,21 @@
  */
 
 import type { BaseApplication } from '../../../BaseApplication';
-import { convertV2AdminPathToLegacy } from '../../../authRedirect';
 import { NocoBaseDesktopRouteType, type NocoBaseDesktopRoute } from '../../../flow-compat';
 
 export type AdminRouteNavigationMode = 'spa' | 'document';
+export type AdminRouteRuntimeTargetReason =
+  | 'ok'
+  | 'missingSchemaUid'
+  | 'unsupportedV2Runtime'
+  | 'emptyGroup'
+  | 'unsupportedRouteType';
 
 export type AdminRouteRuntimeTarget = {
   runtimePath: string | null;
   navigationMode: AdminRouteNavigationMode;
   isLegacy: boolean;
+  reason: AdminRouteRuntimeTargetReason;
 };
 
 const V2_PUBLIC_PATH_SUFFIX = '/v2/';
@@ -45,6 +51,7 @@ const EMPTY_TARGET: AdminRouteRuntimeTarget = {
   runtimePath: null,
   navigationMode: 'spa',
   isLegacy: false,
+  reason: 'unsupportedRouteType',
 };
 
 function normalizeRootRelativePath(pathname: string) {
@@ -60,14 +67,8 @@ function normalizePublicPath(value = '/') {
   return normalized.endsWith('/') ? normalized : `${normalized}/`;
 }
 
-/**
- * 判断当前应用是否运行在需要兼容跳回 v1 的 `/v2/` 路径下。
- *
- * @param {ResolveAdminRouteRuntimeTargetOptions['app']} app 当前应用实例
- * @returns {boolean} 是否启用 v2 到 v1 的经典页跳转
- */
-function shouldUseLegacyDocumentNavigation(app: ResolveAdminRouteRuntimeTargetOptions['app']) {
-  return normalizePublicPath(app.getPublicPath()).endsWith(V2_PUBLIC_PATH_SUFFIX);
+export function isV2AdminRuntime(app?: ResolveAdminRouteRuntimeTargetOptions['app']) {
+  return !!app?.getPublicPath && normalizePublicPath(app.getPublicPath()).endsWith(V2_PUBLIC_PATH_SUFFIX);
 }
 
 export function toRouterNavigationPath(pathname: string, basename?: string) {
@@ -114,12 +115,6 @@ function appendLocationState(pathname: string, location?: LocationLike) {
   return `${pathname}${search}${hash}`;
 }
 
-function isSameOrDescendantPath(pathname: string, basePath: string) {
-  const normalizedPathname = normalizeRootRelativePath(pathname);
-  const normalizedBasePath = normalizeRootRelativePath(basePath);
-  return normalizedPathname === normalizedBasePath || normalizedPathname.startsWith(`${normalizedBasePath}/`);
-}
-
 function logInvalidTarget(
   logger: ResolveAdminRouteRuntimeTargetOptions['log'],
   reason: string,
@@ -132,6 +127,47 @@ function isSkippableRoute(route: NocoBaseDesktopRoute | undefined) {
   return (
     !!route && (route.type === NocoBaseDesktopRouteType.tabs || route.hideInMenu === true || route.hidden === true)
   );
+}
+
+export function isV2MenuRoute(route: NocoBaseDesktopRoute | undefined): boolean {
+  if (!route || route.hidden === true || route.hideInMenu === true) {
+    return false;
+  }
+
+  if (route.type === NocoBaseDesktopRouteType.flowPage || route.type === NocoBaseDesktopRouteType.link) {
+    return true;
+  }
+
+  if (route.type === NocoBaseDesktopRouteType.group) {
+    return Array.isArray(route.children) && route.children.some((child) => isV2MenuRoute(child));
+  }
+
+  return false;
+}
+
+export function findFirstV2LandingRoute(routes: NocoBaseDesktopRoute[] | undefined): NocoBaseDesktopRoute | undefined {
+  if (!Array.isArray(routes)) {
+    return undefined;
+  }
+
+  for (const route of routes) {
+    if (!route || route.hidden === true || route.hideInMenu === true || route.type === NocoBaseDesktopRouteType.tabs) {
+      continue;
+    }
+
+    if (route.type === NocoBaseDesktopRouteType.flowPage) {
+      return route;
+    }
+
+    if (route.type === NocoBaseDesktopRouteType.group) {
+      const nested = findFirstV2LandingRoute(route.children);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 export function findFirstAccessiblePageRoute(
@@ -166,7 +202,10 @@ function resolvePageRuntimeTarget(options: ResolveAdminRouteRuntimeTargetOptions
 
   if (!route.schemaUid) {
     logInvalidTarget(log, 'Missing schemaUid.', route);
-    return EMPTY_TARGET;
+    return {
+      ...EMPTY_TARGET,
+      reason: 'missingSchemaUid',
+    };
   }
 
   if (route.type === NocoBaseDesktopRouteType.flowPage) {
@@ -174,51 +213,25 @@ function resolvePageRuntimeTarget(options: ResolveAdminRouteRuntimeTargetOptions
       runtimePath: getV2AdminPath(app, route.schemaUid),
       navigationMode: 'spa' as const,
       isLegacy: false,
+      reason: 'ok' as const,
     };
   }
 
-  if (!shouldUseLegacyDocumentNavigation(app)) {
+  if (isV2AdminRuntime(app)) {
     return {
-      runtimePath:
-        preserveLocationState && location
-          ? appendLocationState(getV2AdminPath(app, route.schemaUid), location)
-          : getV2AdminPath(app, route.schemaUid),
-      navigationMode: 'spa' as const,
-      isLegacy: false,
-    };
-  }
-
-  const v2RuntimePath = getV2AdminPath(app, route.schemaUid);
-  const legacyPath = convertV2AdminPathToLegacy(app, v2RuntimePath);
-
-  if (!legacyPath) {
-    logInvalidTarget(log, 'Failed to resolve legacy runtimePath.', route);
-    return EMPTY_TARGET;
-  }
-
-  if (preserveLocationState && location) {
-    if (isSameOrDescendantPath(location.pathname, v2RuntimePath)) {
-      const correctedCurrentPath = convertV2AdminPathToLegacy(app, location);
-      if (correctedCurrentPath) {
-        return {
-          runtimePath: correctedCurrentPath,
-          navigationMode: 'document' as const,
-          isLegacy: true,
-        };
-      }
-    }
-
-    return {
-      runtimePath: appendLocationState(legacyPath, location),
-      navigationMode: 'document' as const,
-      isLegacy: true,
+      ...EMPTY_TARGET,
+      reason: 'unsupportedV2Runtime',
     };
   }
 
   return {
-    runtimePath: legacyPath,
-    navigationMode: 'document' as const,
-    isLegacy: true,
+    runtimePath:
+      preserveLocationState && location
+        ? appendLocationState(getV2AdminPath(app, route.schemaUid), location)
+        : getV2AdminPath(app, route.schemaUid),
+    navigationMode: 'spa' as const,
+    isLegacy: false,
+    reason: 'ok' as const,
   };
 }
 
@@ -242,9 +255,14 @@ export function resolveAdminRouteRuntimeTarget(
   }
 
   if (route.type === NocoBaseDesktopRouteType.group) {
-    const firstAccessibleRoute = findFirstAccessiblePageRoute(route.children);
+    const firstAccessibleRoute = isV2AdminRuntime(options.app)
+      ? findFirstV2LandingRoute(route.children)
+      : findFirstAccessiblePageRoute(route.children);
     if (!firstAccessibleRoute) {
-      return EMPTY_TARGET;
+      return {
+        ...EMPTY_TARGET,
+        reason: 'emptyGroup',
+      };
     }
     return resolveAdminRouteRuntimeTarget({
       ...options,

--- a/packages/core/client-v2/src/flow/components/AdminLayout.tsx
+++ b/packages/core/client-v2/src/flow/components/AdminLayout.tsx
@@ -14,7 +14,7 @@ import { useApp } from '../../hooks/useApp';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { NocoBaseDesktopRouteType } from '../../flow-compat';
 import {
-  findFirstAccessiblePageRoute,
+  findFirstV2LandingRoute,
   resolveAdminRouteRuntimeTarget,
   toRouterNavigationPath,
 } from '../admin-shell/admin-layout/resolveAdminRouteRuntimeTarget';
@@ -92,7 +92,7 @@ const AdminLayoutEntryGuard: FC<{ children: React.ReactNode }> = ({ children }) 
         return;
       }
 
-      const firstAccessibleRoute = findFirstAccessiblePageRoute(routeRepository?.listAccessible?.() || []);
+      const firstAccessibleRoute = findFirstV2LandingRoute(routeRepository?.listAccessible?.() || []);
       if (!firstAccessibleRoute) {
         if (active) {
           setReady(true);

--- a/packages/core/client-v2/src/flow/components/FlowRoute.tsx
+++ b/packages/core/client-v2/src/flow/components/FlowRoute.tsx
@@ -15,10 +15,12 @@ import { useParams } from 'react-router-dom';
 import { useApp } from '../../hooks/useApp';
 import { NocoBaseDesktopRouteType } from '../../flow-compat';
 import { resolveAdminRouteRuntimeTarget } from '../admin-shell/admin-layout/resolveAdminRouteRuntimeTarget';
+import { AppNotFound } from '../../components';
 
 type FlowRouteGuardState = {
   pending: boolean;
   allowBridge: boolean;
+  notFound: boolean;
 };
 
 const BridgeFlowRoute = ({ pageUid }: { pageUid: string }) => {
@@ -91,6 +93,7 @@ const FlowRoute = () => {
   const [guardState, setGuardState] = useState<FlowRouteGuardState>({
     pending: true,
     allowBridge: false,
+    notFound: false,
   });
   const replaceTriggeredRef = useRef(false);
   const requestIdRef = useRef(0);
@@ -104,14 +107,14 @@ const FlowRoute = () => {
     const requestId = ++requestIdRef.current;
 
     const run = async () => {
-      setGuardState({ pending: true, allowBridge: false });
+      setGuardState({ pending: true, allowBridge: false, notFound: false });
 
       if (!routeRepository?.isAccessibleLoaded?.()) {
         try {
           await routeRepository?.ensureAccessibleLoaded?.();
         } catch (_error) {
           if (active && requestId === requestIdRef.current) {
-            setGuardState({ pending: false, allowBridge: true });
+            setGuardState({ pending: false, allowBridge: true, notFound: false });
           }
           return;
         }
@@ -139,10 +142,15 @@ const FlowRoute = () => {
           window.location.replace(target.runtimePath);
           return;
         }
+
+        if (target.reason === 'unsupportedV2Runtime') {
+          setGuardState({ pending: false, allowBridge: false, notFound: true });
+          return;
+        }
       }
 
       if (active && requestId === requestIdRef.current) {
-        setGuardState({ pending: false, allowBridge: true });
+        setGuardState({ pending: false, allowBridge: true, notFound: false });
       }
     };
 
@@ -159,11 +167,14 @@ const FlowRoute = () => {
     }
 
     if (!guardState.allowBridge) {
+      if (guardState.notFound) {
+        return <AppNotFound />;
+      }
       return null;
     }
 
     return <BridgeFlowRoute pageUid={pageUid} />;
-  }, [guardState.allowBridge, guardState.pending, pageUid]);
+  }, [guardState.allowBridge, guardState.notFound, guardState.pending, pageUid]);
 
   return content;
 };

--- a/packages/core/client-v2/src/flow/components/FlowRoute.tsx
+++ b/packages/core/client-v2/src/flow/components/FlowRoute.tsx
@@ -144,7 +144,9 @@ const FlowRoute = () => {
         }
 
         if (target.reason === 'unsupportedV2Runtime') {
-          setGuardState({ pending: false, allowBridge: false, notFound: true });
+          if (active && requestId === requestIdRef.current) {
+            setGuardState({ pending: false, allowBridge: false, notFound: true });
+          }
           return;
         }
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
在访问 v2 管理端时，旧版页面菜单仍会出现在顶部菜单中。用户点击这些旧版菜单后，还会看到跳转到旧版页面的确认弹窗。现在 v2 管理端需要和旧版页面彻底区分，迁移到 v2 后不应继续展示或引导访问旧版菜单。

### Description 
本次调整让 `/v2/` 管理端只展示 v2 支持的菜单项。旧版页面菜单不会再出现在 v2 菜单中，只包含旧版页面的分组也会被隐藏。

直接访问旧版页面对应的 `/v2/admin/...` 地址时，现在会显示 404，而不会再跳回旧版页面。原来点击旧版菜单时出现的确认弹窗链路也已移除。

已补充和更新相关测试，覆盖菜单过滤、默认落点、旧版页面直达访问和确认弹窗移除等场景。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Filter out v1 menus in the v2 layout and only show v2 menus |
| 🇨🇳 Chinese | v2 布局中过滤掉 v1 的菜单，只显示 v2 菜单 |


### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary