### PR TITLE
fix(build): externalize */client-v2 subpaths in v1 client plugin lane

### DIFF
--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -59,7 +59,7 @@ const pluginClientLaneConfig: Record<
     distDir: 'client',
     entryDir: 'client',
     rootEntryFile: 'client.js',
-    externalSubpaths: ['client'],
+    externalSubpaths: ['client', 'client-v2'],
   },
   'client-v2': {
     distDir: 'client-v2',


### PR DESCRIPTION
### This is a ...
- [x] Bug fix

### Motivation
Building any plugin whose v1 `src/client/` code references another plugin's `*/client-v2` entry (e.g. `@nocobase/plugin-field-attachment-url` importing `UploadFieldModel` from `@nocobase/plugin-file-manager/client-v2`) fails with `Module not found: Can't resolve 'fs' / 'path' / 'querystring'` and similar errors against `@budibase/handlebars-helpers`, `picomatch`, etc.

Root cause: the v1 `client` build lane only listed `client` in `externalSubpaths`, so `@nocobase/plugin-xxx/client-v2` was not externalized. Combined with the tsconfig path alias mapping `@nocobase/plugin-xxx/client-v2` to source, Rspack walked into the v2 source tree of other plugins, transitively pulling in `@nocobase/utils/client` (CJS) and its Node-only dependency chain.

### Description
- Add `'client-v2'` to `externalSubpaths` for the v1 `client` lane in `pluginClientLaneConfig`, mirroring what the `client-v2` lane already does for both subpaths.
- Runtime is safe: `packages/core/client-v2/src/utils/remotePlugins.ts` already registers `${packageName}/client-v2` as a RequireJS alias for every plugin that ships a v2 client, so v1 UMD bundles can resolve the external at runtime.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix plugin build failure when v1 client code imports another plugin's `/client-v2` entry. |
| 🇨🇳 Chinese | 修复 v1 client 构建在引用其他插件 `/client-v2` 入口时报错的问题。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
