### PR TITLE
fix:  hide subtable component for to-many association fields in v2 subtable

### DIFF
--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next';
 import { buildRecordPickerPopupContextInputArgs, RecordPickerContent } from '../RecordPickerFieldModel';
 import { AssociationFieldModel } from '../AssociationFieldModel';
 import { adjustColumnOrder } from '../../../blocks/table/utils';
+import { isSubTableColumnFieldComponentContext } from '../SubTableFieldModel/SubTableColumnModel';
 import { EditFormContent } from './actions/PopupSubTableEditActionModel';
 import { QuickEditFormModel } from '../../../blocks/form/QuickEditFormModel';
 import { ActionWithoutPermission } from '../../../base/ActionModel';
@@ -901,6 +902,9 @@ PopupSubTableFieldModel.define({
 EditableItemModel.bindModelToInterface('PopupSubTableFieldModel', ['m2m', 'o2m', 'mbm'], {
   order: 300,
   when: (ctx, field) => {
+    if (isSubTableColumnFieldComponentContext(ctx)) {
+      return false;
+    }
     if (field.targetCollection) {
       return field.targetCollection.template !== 'file';
     }

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
@@ -36,7 +36,11 @@ import { FieldDeletePlaceholder, CustomWidth } from '../../../blocks/table/Table
 import { buildDynamicNamePath } from '../../../blocks/form/dynamicNamePath';
 import { getSubTableRowIdentity } from './rowIdentity';
 
-const nestedSubTableFieldModels = ['SubTableFieldModel', 'PopupSubTableFieldModel'];
+export const SUB_TABLE_COLUMN_FIELD_COMPONENT_CONTEXT = 'subTableColumn';
+
+export function isSubTableColumnFieldComponentContext(ctx) {
+  return (ctx?.model?.constructor as any)?.fieldComponentContext === SUB_TABLE_COLUMN_FIELD_COMPONENT_CONTEXT;
+}
 
 const SubTableRowRuleBinder: React.FC<{ model: any }> = ({ model }) => {
   React.useEffect(() => {
@@ -403,20 +407,7 @@ export class SubTableColumnModel<
   T extends SubTableColumnModelStructure = SubTableColumnModelStructure,
 > extends EditableItemModel<T> {
   static renderMode = ModelRenderMode.RenderFunction;
-
-  static getBindingsByField(ctx, collectionField) {
-    return super
-      .getBindingsByField(ctx, collectionField)
-      ?.filter((binding) => !nestedSubTableFieldModels.includes(binding.modelName));
-  }
-
-  static getDefaultBindingByField(ctx, collectionField, options = {}) {
-    const binding = super.getDefaultBindingByField(ctx, collectionField, options);
-    if (binding && !nestedSubTableFieldModels.includes(binding.modelName)) {
-      return binding;
-    }
-    return this.getBindingsByField(ctx, collectionField)?.[0] || null;
-  }
+  static fieldComponentContext = SUB_TABLE_COLUMN_FIELD_COMPONENT_CONTEXT;
 
   renderHiddenInConfig() {
     return <FieldWithoutPermissionPlaceholder targetModel={this} />;

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
@@ -36,6 +36,8 @@ import { FieldDeletePlaceholder, CustomWidth } from '../../../blocks/table/Table
 import { buildDynamicNamePath } from '../../../blocks/form/dynamicNamePath';
 import { getSubTableRowIdentity } from './rowIdentity';
 
+const nestedSubTableFieldModels = ['SubTableFieldModel', 'PopupSubTableFieldModel'];
+
 const SubTableRowRuleBinder: React.FC<{ model: any }> = ({ model }) => {
   React.useEffect(() => {
     const emitter = model?.flowEngine?.emitter;
@@ -401,6 +403,20 @@ export class SubTableColumnModel<
   T extends SubTableColumnModelStructure = SubTableColumnModelStructure,
 > extends EditableItemModel<T> {
   static renderMode = ModelRenderMode.RenderFunction;
+
+  static getBindingsByField(ctx, collectionField) {
+    return super
+      .getBindingsByField(ctx, collectionField)
+      ?.filter((binding) => !nestedSubTableFieldModels.includes(binding.modelName));
+  }
+
+  static getDefaultBindingByField(ctx, collectionField, options = {}) {
+    const binding = super.getDefaultBindingByField(ctx, collectionField, options);
+    if (binding && !nestedSubTableFieldModels.includes(binding.modelName)) {
+      return binding;
+    }
+    return this.getBindingsByField(ctx, collectionField)?.[0] || null;
+  }
 
   renderHiddenInConfig() {
     return <FieldWithoutPermissionPlaceholder targetModel={this} />;

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/index.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/index.tsx
@@ -21,7 +21,7 @@ import { uid } from '@formily/shared';
 import { FormItemModel } from '../../../blocks/form';
 import { AssociationFieldModel } from '../AssociationFieldModel';
 import { buildRecordPickerPopupContextInputArgs, RecordPickerContent } from '../RecordPickerFieldModel';
-import { SubTableColumnModel } from './SubTableColumnModel';
+import { isSubTableColumnFieldComponentContext, SubTableColumnModel } from './SubTableColumnModel';
 import { SubTableField } from './SubTableField';
 import { adjustColumnOrder } from '../../../blocks/table/utils';
 
@@ -389,6 +389,9 @@ export { SubTableColumnModel };
 FormItemModel.bindModelToInterface('SubTableFieldModel', ['m2m', 'o2m', 'mbm'], {
   order: 200,
   when: (ctx, field) => {
+    if (isSubTableColumnFieldComponentContext(ctx)) {
+      return false;
+    }
     if (field.targetCollection) {
       return field.targetCollection.template !== 'file';
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    hide subtable component for to-many association fields in v2 subtable       |
| 🇨🇳 Chinese |    修复 v2 子表格中的对多关系字段组件列表出现子表格组件的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
