### PR TITLE
fix: incorrectly set data scope when unselect table row

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts
@@ -8,9 +8,30 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { FlowEngine, MultiRecordResource } from '@nocobase/flow-engine';
 import { dataScope } from '../dataScope';
 import { normalizeDataScopeFilter } from '../dataScopeFilter';
 import { setTargetDataScope } from '../setTargetDataScope';
+
+function createSetTargetDataScopeContext(resource: any, options: { selected?: boolean; resolvedValue?: any } = {}) {
+  const targetModel = { resource };
+  const inputArgs = options.selected === undefined ? undefined : { selected: options.selected };
+
+  return {
+    ...(inputArgs ? { inputArgs } : {}),
+    model: {
+      uid: 'action-1',
+      scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
+    },
+    resolveJsonTemplate: vi.fn(async (template) => ({
+      ...template,
+      filter: {
+        ...template.filter,
+        items: [{ ...template.filter.items[0], value: options.resolvedValue }],
+      },
+    })),
+  };
+}
 
 describe('normalizeDataScopeFilter', () => {
   it('keeps null when a right-side variable resolves to empty', () => {
@@ -125,20 +146,7 @@ describe('normalizeDataScopeFilter', () => {
       hasData: vi.fn(() => false),
       refresh: vi.fn(),
     };
-    const targetModel = { resource };
-    const ctx = {
-      model: {
-        uid: 'action-1',
-        scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
-      },
-      resolveJsonTemplate: vi.fn(async (template) => ({
-        ...template,
-        filter: {
-          ...template.filter,
-          items: [{ ...template.filter.items[0], value: undefined }],
-        },
-      })),
-    };
+    const ctx = createSetTargetDataScopeContext(resource);
     const params = {
       targetBlockUid: 'target-1',
       filter: {
@@ -163,23 +171,7 @@ describe('normalizeDataScopeFilter', () => {
       hasData: vi.fn(() => true),
       refresh: vi.fn(),
     };
-    const targetModel = { resource };
-    const ctx = {
-      inputArgs: {
-        selected: false,
-      },
-      model: {
-        uid: 'action-1',
-        scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
-      },
-      resolveJsonTemplate: vi.fn(async (template) => ({
-        ...template,
-        filter: {
-          ...template.filter,
-          items: [{ ...template.filter.items[0], value: null }],
-        },
-      })),
-    };
+    const ctx = createSetTargetDataScopeContext(resource, { selected: false, resolvedValue: null });
     const params = {
       targetBlockUid: 'target-1',
       filter: {
@@ -203,23 +195,7 @@ describe('normalizeDataScopeFilter', () => {
       hasData: vi.fn(() => false),
       refresh: vi.fn(),
     };
-    const targetModel = { resource };
-    const ctx = {
-      inputArgs: {
-        selected: true,
-      },
-      model: {
-        uid: 'action-1',
-        scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
-      },
-      resolveJsonTemplate: vi.fn(async (template) => ({
-        ...template,
-        filter: {
-          ...template.filter,
-          items: [{ ...template.filter.items[0], value: null }],
-        },
-      })),
-    };
+    const ctx = createSetTargetDataScopeContext(resource, { selected: true, resolvedValue: null });
     const params = {
       targetBlockUid: 'target-1',
       filter: {
@@ -234,5 +210,28 @@ describe('normalizeDataScopeFilter', () => {
       $and: [{ departmentId: { $eq: null } }],
     });
     expect(resource.removeFilterGroup).not.toHaveBeenCalled();
+  });
+
+  it('setTargetDataScope handler refreshes empty loaded target while preserving its own data scope', async () => {
+    const engine = new FlowEngine();
+    const resource = engine.createResource(MultiRecordResource);
+    resource.addFilterGroup('target-table', { status: { $eq: 'active' } });
+    resource.addFilterGroup('setTargetDataScope_action-1', { id: { $eq: 1 } });
+    resource.setData([]);
+    resource.setMeta({ count: 0, hasNext: false });
+    const refresh = vi.spyOn(resource, 'refresh').mockResolvedValue(undefined);
+    const ctx = createSetTargetDataScopeContext(resource, { selected: false, resolvedValue: null });
+    const params = {
+      targetBlockUid: 'target-1',
+      filter: {
+        logic: '$and',
+        items: [{ path: 'id', operator: '$eq', value: '{{ ctx.clickedRowRecord.id }}' }],
+      },
+    };
+
+    await (setTargetDataScope as any).handler(ctx, params);
+
+    expect(resource.getRequestParameter('filter')).toBe(JSON.stringify({ $and: [{ status: { $eq: 'active' } }] }));
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/dataScopeFilter.test.ts
@@ -155,4 +155,84 @@ describe('normalizeDataScopeFilter', () => {
     });
     expect(resource.removeFilterGroup).not.toHaveBeenCalled();
   });
+
+  it('setTargetDataScope handler removes clicked-row data scope when row click deselects', async () => {
+    const resource = {
+      addFilterGroup: vi.fn(),
+      removeFilterGroup: vi.fn(),
+      hasData: vi.fn(() => true),
+      refresh: vi.fn(),
+    };
+    const targetModel = { resource };
+    const ctx = {
+      inputArgs: {
+        selected: false,
+      },
+      model: {
+        uid: 'action-1',
+        scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
+      },
+      resolveJsonTemplate: vi.fn(async (template) => ({
+        ...template,
+        filter: {
+          ...template.filter,
+          items: [{ ...template.filter.items[0], value: null }],
+        },
+      })),
+    };
+    const params = {
+      targetBlockUid: 'target-1',
+      filter: {
+        logic: '$and',
+        items: [{ path: 'id', operator: '$eq', value: '{{ ctx.clickedRowRecord.id }}' }],
+      },
+    };
+
+    await (setTargetDataScope as any).handler(ctx, params);
+
+    expect(ctx.model.scheduleModelOperation).toHaveBeenCalledWith('target-1', expect.any(Function));
+    expect(resource.removeFilterGroup).toHaveBeenCalledWith('setTargetDataScope_action-1');
+    expect(resource.addFilterGroup).not.toHaveBeenCalled();
+    expect(resource.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('setTargetDataScope handler keeps null clicked-row field values while row is selected', async () => {
+    const resource = {
+      addFilterGroup: vi.fn(),
+      removeFilterGroup: vi.fn(),
+      hasData: vi.fn(() => false),
+      refresh: vi.fn(),
+    };
+    const targetModel = { resource };
+    const ctx = {
+      inputArgs: {
+        selected: true,
+      },
+      model: {
+        uid: 'action-1',
+        scheduleModelOperation: vi.fn((_uid, callback) => callback(targetModel)),
+      },
+      resolveJsonTemplate: vi.fn(async (template) => ({
+        ...template,
+        filter: {
+          ...template.filter,
+          items: [{ ...template.filter.items[0], value: null }],
+        },
+      })),
+    };
+    const params = {
+      targetBlockUid: 'target-1',
+      filter: {
+        logic: '$and',
+        items: [{ path: 'departmentId', operator: '$eq', value: '{{ ctx.clickedRowRecord.departmentId }}' }],
+      },
+    };
+
+    await (setTargetDataScope as any).handler(ctx, params);
+
+    expect(resource.addFilterGroup).toHaveBeenCalledWith('setTargetDataScope_action-1', {
+      $and: [{ departmentId: { $eq: null } }],
+    });
+    expect(resource.removeFilterGroup).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/client/src/flow/actions/setTargetDataScope.tsx
+++ b/packages/core/client/src/flow/actions/setTargetDataScope.tsx
@@ -10,6 +10,7 @@
 import {
   ActionScene,
   defineAction,
+  extractUsedVariablePaths,
   FlowModel,
   MultiRecordResource,
   useFlowContext,
@@ -19,6 +20,14 @@ import { isEmptyFilter } from '@nocobase/utils/client';
 import React from 'react';
 import { FilterGroup, VariableFilterItem } from '../components/filter';
 import { normalizeDataScopeFilter } from './dataScopeFilter';
+
+function usesClickedRowRecord(filter: any) {
+  if (!filter) {
+    return false;
+  }
+  const used = extractUsedVariablePaths(filter) || {};
+  return Object.prototype.hasOwnProperty.call(used, 'clickedRowRecord');
+}
 
 export const setTargetDataScope = defineAction({
   name: 'setTargetDataScope',
@@ -69,13 +78,18 @@ export const setTargetDataScope = defineAction({
       return;
     }
     const model: FlowModel = ctx.model;
+    const shouldClearClickedRowRecordDataScope =
+      ctx.inputArgs?.selected === false && usesClickedRowRecord(params.filter);
+
     model.scheduleModelOperation(targetBlockUid, (targetModel) => {
       const resource = targetModel['resource'] as MultiRecordResource;
       if (!resource) {
         return;
       }
 
-      const filter = normalizeDataScopeFilter(params.filter, resolvedParams.filter);
+      const filter = shouldClearClickedRowRecordDataScope
+        ? undefined
+        : normalizeDataScopeFilter(params.filter, resolvedParams.filter);
 
       if (isEmptyFilter(filter)) {
         resource.removeFilterGroup(`setTargetDataScope_${ctx.model.uid}`);

--- a/packages/core/client/src/flow/actions/setTargetDataScope.tsx
+++ b/packages/core/client/src/flow/actions/setTargetDataScope.tsx
@@ -21,12 +21,32 @@ import React from 'react';
 import { FilterGroup, VariableFilterItem } from '../components/filter';
 import { normalizeDataScopeFilter } from './dataScopeFilter';
 
-function usesClickedRowRecord(filter: any) {
+function dependsOnClickedRowRecord(filter: any) {
   if (!filter) {
     return false;
   }
   const used = extractUsedVariablePaths(filter) || {};
   return Object.prototype.hasOwnProperty.call(used, 'clickedRowRecord');
+}
+
+function shouldClearClickedRowDataScope(ctx: any, params: any) {
+  return ctx.inputArgs?.selected === false && dependsOnClickedRowRecord(params.filter);
+}
+
+function resolveTargetDataScopeFilter(ctx: any, params: any, resolvedParams: any) {
+  if (shouldClearClickedRowDataScope(ctx, params)) {
+    return undefined;
+  }
+
+  return normalizeDataScopeFilter(params.filter, resolvedParams.filter);
+}
+
+function shouldRefreshTargetResource(resource: MultiRecordResource) {
+  if (resource.hasData()) {
+    return true;
+  }
+
+  return resource.getMeta?.('count') !== undefined || resource.getMeta?.('hasNext') !== undefined;
 }
 
 export const setTargetDataScope = defineAction({
@@ -78,8 +98,7 @@ export const setTargetDataScope = defineAction({
       return;
     }
     const model: FlowModel = ctx.model;
-    const shouldClearClickedRowRecordDataScope =
-      ctx.inputArgs?.selected === false && usesClickedRowRecord(params.filter);
+    const filter = resolveTargetDataScopeFilter(ctx, params, resolvedParams);
 
     model.scheduleModelOperation(targetBlockUid, (targetModel) => {
       const resource = targetModel['resource'] as MultiRecordResource;
@@ -87,16 +106,12 @@ export const setTargetDataScope = defineAction({
         return;
       }
 
-      const filter = shouldClearClickedRowRecordDataScope
-        ? undefined
-        : normalizeDataScopeFilter(params.filter, resolvedParams.filter);
-
       if (isEmptyFilter(filter)) {
         resource.removeFilterGroup(`setTargetDataScope_${ctx.model.uid}`);
       } else {
         resource.addFilterGroup(`setTargetDataScope_${ctx.model.uid}`, filter);
       }
-      if (resource.hasData()) {
+      if (shouldRefreshTargetResource(resource)) {
         resource.refresh();
       }
     });

--- a/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -930,12 +930,12 @@ const HighPerformanceTable = React.memo(
 
         return {
           onClick: async (event) => {
-            if (highlightedRowKey !== rowKey) {
-              defineClickedRowRecordVariable(model, record);
-              await model.dispatchEvent('rowClick', { record, rowIndex, event });
+            const selected = highlightedRowKey !== rowKey;
+            defineClickedRowRecordVariable(model, selected ? record : null);
+            try {
+              await model.dispatchEvent('rowClick', { record, rowIndex, event, selected });
+            } finally {
               removeClickedRowRecordVariable(model);
-            } else {
-              await model.dispatchEvent('rowClick', { record, rowIndex, event });
             }
           },
           rowIndex,
@@ -1070,7 +1070,12 @@ TableBlockModel.registerEvents({
 
       const model = ctx.model as TableBlockModel;
       const rowKey = getRowKey(ctx.inputArgs.record, model.collection.filterTargetKey);
-      if (model.props.highlightedRowKey !== rowKey) {
+      const selected = ctx.inputArgs.selected;
+      if (selected === true) {
+        model.highlightRow(ctx.inputArgs.record);
+      } else if (selected === false) {
+        model.clearHighlight();
+      } else if (model.props.highlightedRowKey !== rowKey) {
         model.highlightRow(ctx.inputArgs.record);
       } else {
         model.clearHighlight();

--- a/packages/core/client/src/flow/models/blocks/table/__tests__/TableBlockModel.rowClick.test.ts
+++ b/packages/core/client/src/flow/models/blocks/table/__tests__/TableBlockModel.rowClick.test.ts
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it } from 'vitest';
+import '@nocobase/client';
+import { TableBlockModel } from '../TableBlockModel';
+
+function createTableModel() {
+  const engine = new FlowEngine();
+  engine.registerModels({ TableBlockModel });
+
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'posts',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'title', type: 'string', interface: 'input' },
+    ],
+  });
+
+  return engine.createModel<TableBlockModel>({
+    uid: 'posts-table',
+    use: 'TableBlockModel',
+    stepParams: {
+      resourceSettings: {
+        init: {
+          dataSourceKey: 'main',
+          collectionName: 'posts',
+        },
+      },
+    },
+  });
+}
+
+describe('TableBlockModel rowClick event', () => {
+  it('highlights the clicked row when selected is true', async () => {
+    const model = createTableModel();
+    const record = { id: 1, title: 'first post' };
+    const rowClick = model.getEvent('rowClick');
+
+    await rowClick?.handler({ model, inputArgs: { record, selected: true } } as any, {
+      condition: { logic: '$and', items: [] },
+    });
+
+    expect(model.props.highlightedRowKey).toBe(1);
+  });
+
+  it('clears the highlighted row when selected is false', async () => {
+    const model = createTableModel();
+    const record = { id: 1, title: 'first post' };
+    const rowClick = model.getEvent('rowClick');
+
+    model.highlightRow(record);
+
+    await rowClick?.handler({ model, inputArgs: { record, selected: false } } as any, {
+      condition: { logic: '$and', items: [] },
+    });
+
+    expect(model.props.highlightedRowKey).toBeNull();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the target block data scope was set incorrectly when deselecting row data in a table block event flow. |
| 🇨🇳 Chinese | 修复表格区块事件流行数据取消选择时设置目标区块数据范围不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
