### PR TITLE
fix: incorrect linkage rule after form submit

### DIFF
--- a/packages/core/flow-engine/src/__tests__/createViewMeta.popup.test.ts
+++ b/packages/core/flow-engine/src/__tests__/createViewMeta.popup.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { FlowContext } from '../flowContext';
 import { FlowEngine } from '../flowEngine';
 import type { FlowView } from '../views/FlowView';
-import { createPopupMeta } from '../views/createViewMeta';
+import { buildPopupRuntime, createPopupMeta } from '../views/createViewMeta';
 
 describe('createPopupMeta - popup variables', () => {
   function makeCtx() {
@@ -21,6 +21,62 @@ describe('createPopupMeta - popup variables', () => {
     // 简化 i18n：直接返回 key
     ctx.defineProperty('t', { value: (s: string) => s });
     return { engine, ctx };
+  }
+
+  function makeNestedPopupView(viewUid: string, filterByTk: number): FlowView {
+    return {
+      type: 'drawer',
+      inputArgs: {
+        viewUid,
+        filterByTk,
+        sourceId: 13,
+      },
+      Header: null,
+      Footer: null,
+      close: () => void 0,
+      update: () => void 0,
+      navigation: {
+        viewStack: [
+          { viewUid: 'base-page-uid' },
+          { viewUid: 'parent-popup-uid', filterByTk: 13, sourceId: 13 },
+          { viewUid: 'child-popup-uid', filterByTk: 24, sourceId: 13 },
+        ],
+      } as any,
+    } as any;
+  }
+
+  function mockNestedPopupModels(engine: FlowEngine) {
+    vi.spyOn(engine as any, 'getModel').mockImplementation((uid: string) => {
+      if (uid === 'parent-popup-uid') {
+        return {
+          getStepParams: vi.fn((_fk: string, sk: string) =>
+            sk === 'openView'
+              ? {
+                  collectionName: 'users',
+                  dataSourceKey: 'main',
+                  associationName: 'users.orgs',
+                }
+              : undefined,
+          ),
+        };
+      }
+      if (uid === 'child-popup-uid') {
+        return {
+          getStepParams: vi.fn((_fk: string, sk: string) =>
+            sk === 'openView'
+              ? {
+                  collectionName: 'orgs',
+                  dataSourceKey: 'main',
+                  associationName: 'users.orgs',
+                }
+              : undefined,
+          ),
+        };
+      }
+      return {
+        getStepParams: vi.fn(() => undefined),
+      };
+    });
   }
 
   it('buildVariablesParams(record) uses anchor view instead of ctx.view', async () => {
@@ -106,6 +162,64 @@ describe('createPopupMeta - popup variables', () => {
 
     // 确认没有误用 ctx.view（settings-uid）的集合
     expect(vars.record.collection).not.toBe('comments');
+  });
+
+  it('buildPopupRuntime anchors current popup even when the navigation stack already has a child popup', async () => {
+    const { engine, ctx } = makeCtx();
+    const parentView = makeNestedPopupView('parent-popup-uid', 13);
+    mockNestedPopupModels(engine);
+
+    const popup = await buildPopupRuntime(ctx, parentView);
+
+    expect(popup?.uid).toBe('parent-popup-uid');
+    expect(popup?.resource).toEqual({
+      dataSourceKey: 'main',
+      collectionName: 'users',
+      associationName: 'users.orgs',
+      filterByTk: 13,
+      sourceId: 13,
+    });
+  });
+
+  it('buildVariablesParams(record) keeps the parent view record when a child popup is open', async () => {
+    const { engine, ctx } = makeCtx();
+    const parentView = makeNestedPopupView('parent-popup-uid', 13);
+    mockNestedPopupModels(engine);
+
+    const meta = (await createPopupMeta(ctx, parentView)())!;
+    const vars = (await meta.buildVariablesParams!(ctx)) as any;
+
+    expect(vars.record).toEqual({
+      collection: 'users',
+      dataSourceKey: 'main',
+      filterByTk: 13,
+      associationName: 'users.orgs',
+      sourceId: 13,
+    });
+  });
+
+  it('buildVariablesParams(parent.record) is still relative to the child popup view', async () => {
+    const { engine, ctx } = makeCtx();
+    const childView = makeNestedPopupView('child-popup-uid', 24);
+    mockNestedPopupModels(engine);
+
+    const meta = (await createPopupMeta(ctx, childView)())!;
+    const vars = (await meta.buildVariablesParams!(ctx)) as any;
+
+    expect(vars.record).toEqual({
+      collection: 'orgs',
+      dataSourceKey: 'main',
+      filterByTk: 24,
+      associationName: 'users.orgs',
+      sourceId: 13,
+    });
+    expect(vars.parent.record).toEqual({
+      collection: 'users',
+      dataSourceKey: 'main',
+      filterByTk: 13,
+      sourceId: 13,
+      associationName: 'users.orgs',
+    });
   });
 
   it('properties() provides a record factory node (lazy) with title', async () => {

--- a/packages/core/flow-engine/src/views/createViewMeta.ts
+++ b/packages/core/flow-engine/src/views/createViewMeta.ts
@@ -15,6 +15,82 @@ import type { FlowView } from './FlowView';
 
 type PopupModelLike = { getStepParams?: (a: string, b: string) => any } | undefined;
 
+function isDefined(value: any) {
+  return value !== undefined && value !== null;
+}
+
+function isSameViewParamValue(left: any, right: any) {
+  if (left === right) return true;
+  if (!isDefined(left) || !isDefined(right)) return false;
+
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch (_) {
+    return String(left) === String(right);
+  }
+}
+
+function getViewStack(view?: FlowView): any[] {
+  const stack = view?.navigation?.viewStack;
+  return Array.isArray(stack) ? stack : [];
+}
+
+function getAnchoredViewStackIndex(view?: FlowView, stack = getViewStack(view)): number {
+  if (!stack.length) return -1;
+
+  const args = view?.inputArgs || {};
+  const navParams = view?.navigation?.viewParams || {};
+  const viewUid = args.viewUid ?? navParams.viewUid;
+
+  if (!viewUid) {
+    return stack.length - 1;
+  }
+
+  const candidates = stack.map((item, index) => ({ item, index })).filter(({ item }) => item?.viewUid === viewUid);
+
+  if (!candidates.length) {
+    return stack.length - 1;
+  }
+
+  const keys = ['filterByTk', 'sourceId', 'tabUid'];
+  let bestIndex = candidates[candidates.length - 1].index;
+  let bestScore = -1;
+
+  for (const { item, index } of candidates) {
+    let score = 0;
+    let matched = true;
+
+    for (const key of keys) {
+      if (!isDefined(args[key])) continue;
+      if (!isSameViewParamValue(item?.[key], args[key])) {
+        matched = false;
+        break;
+      }
+      score += 1;
+    }
+
+    if (!matched) continue;
+    if (score >= bestScore) {
+      bestIndex = index;
+      bestScore = score;
+    }
+  }
+
+  return bestIndex;
+}
+
+function getPopupView(ctx: FlowContext, anchorView?: FlowView) {
+  return anchorView ?? ctx.view;
+}
+
+function isPopupView(view?: FlowView): boolean {
+  if (!view) return false;
+  const stack = getViewStack(view);
+  const openerUids = view?.inputArgs?.openerUids;
+  const hasOpener = Array.isArray(openerUids) && openerUids.length > 0;
+  return getAnchoredViewStackIndex(view, stack) >= 1 || hasOpener;
+}
+
 // 判断是否为普通对象（Plain Object），避免对类实例/代理等进行深度遍历
 function isPlainObject(val: any) {
   if (val === null || typeof val !== 'object') return false;
@@ -79,19 +155,11 @@ function makeMetaFromValue(value: any, title?: string, seen?: WeakSet<any>): any
 export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): PropertyMetaFactory {
   const t = (k: string) => ctx.t(k);
 
-  const isPopupView = (view?: FlowView): boolean => {
-    if (!view) return false;
-    const stack = Array.isArray(view.navigation?.viewStack) ? view.navigation.viewStack : [];
-    const openerUids = view?.inputArgs?.openerUids;
-    const hasOpener = Array.isArray(openerUids) && openerUids.length > 0;
-    return stack.length >= 2 || hasOpener;
-  };
-
-  const hasPopupNow = (): boolean => isPopupView(anchorView ?? ctx.view);
+  const hasPopupNow = (flowCtx: FlowContext = ctx): boolean => isPopupView(getPopupView(flowCtx, anchorView));
 
   // 统一解析锚定视图下的 RecordRef，避免在设置弹窗等二级视图中被误导
   const resolveRecordRef = async (flowCtx: FlowContext): Promise<RecordRef | undefined> => {
-    const view = anchorView ?? flowCtx.view;
+    const view = getPopupView(flowCtx, anchorView);
     if (!view || !isPopupView(view)) return undefined;
 
     const base = await buildPopupRuntime(flowCtx, view);
@@ -119,11 +187,12 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
   const getParentRecordRef = async (level: number, flowCtx?: FlowContext): Promise<RecordRef | undefined> => {
     try {
       const useCtx = flowCtx || ctx;
-      const nav = useCtx.view?.navigation;
-      const stack = Array.isArray(nav?.viewStack) ? nav.viewStack : [];
-      if (stack.length < 2 || level < 1) return undefined;
-      const idx = stack.length - 1 - level;
-      if (idx < 0) return undefined;
+      const view = getPopupView(useCtx, anchorView);
+      const stack = getViewStack(view);
+      const currentIndex = getAnchoredViewStackIndex(view, stack);
+      if (currentIndex < 1 || level < 1) return undefined;
+      const idx = currentIndex - level;
+      if (idx < 1) return undefined;
       const parent = stack[idx];
       if (!parent?.viewUid) return undefined;
 
@@ -156,9 +225,10 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
 
   const hasParentNow = (level: number): boolean => {
     try {
-      const nav = (anchorView ?? ctx.view)?.navigation;
-      const stack = Array.isArray(nav?.viewStack) ? nav.viewStack : [];
-      return stack.length >= level + 1; // level=1 需要至少2层
+      const view = getPopupView(ctx, anchorView);
+      const stack = getViewStack(view);
+      const currentIndex = getAnchoredViewStackIndex(view, stack);
+      return currentIndex - level >= 1; // level=1 需要至少一个上级弹窗
     } catch (_) {
       return false;
     }
@@ -231,9 +301,10 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
       disabled: () => !hasPopupNow(),
       hidden: () => !hasPopupNow(),
       buildVariablesParams: async (c) => {
-        if (!hasPopupNow()) return undefined;
+        if (!hasPopupNow(c)) return undefined;
         const ref = await resolveRecordRef(c);
-        const inputArgs = c.view?.inputArgs;
+        const view = getPopupView(c, anchorView);
+        const inputArgs = view?.inputArgs;
         type PopupVariableParams = {
           record?: RecordRef;
           sourceRecord?: RecordRef;
@@ -253,9 +324,9 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
 
         // 构建 parent 链（用于服务端解析 ctx.popup.parent[.parent...].record.*）
         try {
-          const nav = c.view?.navigation;
-          const stack = Array.isArray(nav?.viewStack) ? nav.viewStack : [];
-          if (stack.length >= 2) {
+          const stack = getViewStack(view);
+          const currentIndex = getAnchoredViewStackIndex(view, stack);
+          if (currentIndex >= 2) {
             let cur: Record<string, any> = params;
             let level = 1;
             let parentRef = await getParentRecordRef(level, c);
@@ -315,20 +386,21 @@ export function createPopupMeta(ctx: FlowContext, anchorView?: FlowView): Proper
         }
         // 当 view.inputArgs 带有 sourceId + associationName 时，提供“上级记录”变量（基于 sourceId 推断）
         try {
-          const inputArgs = ctx.view?.inputArgs;
+          const view = getPopupView(ctx, anchorView);
+          const inputArgs = view?.inputArgs;
           const srcId = inputArgs?.sourceId;
           let assoc: string | undefined = inputArgs?.associationName;
           let dsKey: string = inputArgs?.dataSourceKey || 'main';
 
           // 兜底：若 associationName 缺失或不含“.”，尝试从当前视图模型的 openView 参数推断
           if (!assoc || typeof assoc !== 'string' || !assoc.includes('.')) {
-            const nav = ctx.view?.navigation;
-            const stack = Array.isArray(nav?.viewStack) ? nav.viewStack : [];
-            const last = stack?.[stack.length - 1];
-            if (last?.viewUid) {
-              let model = ctx?.engine?.getModel(last.viewUid, true) as PopupModelLike;
+            const stack = getViewStack(view);
+            const currentIndex = getAnchoredViewStackIndex(view, stack);
+            const current = currentIndex >= 0 ? stack?.[currentIndex] : undefined;
+            if (current?.viewUid) {
+              let model = ctx?.engine?.getModel(current.viewUid, true) as PopupModelLike;
               if (!model) {
-                model = (await ctx.engine.loadModel({ uid: last.viewUid })) as PopupModelLike;
+                model = (await ctx.engine.loadModel({ uid: current.viewUid })) as PopupModelLike;
               }
               const p = model?.getStepParams?.('popupSettings', 'openView') || {};
               assoc = p?.associationName || assoc;
@@ -406,12 +478,12 @@ interface PopupNode {
 }
 
 export async function buildPopupRuntime(ctx: FlowContext, view: FlowView): Promise<PopupNode | undefined> {
-  const nav = view?.navigation;
-  const stack = Array.isArray(nav?.viewStack) ? nav.viewStack : [];
+  const stack = getViewStack(view);
+  const currentIndex = getAnchoredViewStackIndex(view, stack);
 
   const openerUids = view?.inputArgs?.openerUids;
   const hasOpener = Array.isArray(openerUids) && openerUids.length > 0;
-  const hasStackPopup = stack.length >= 2;
+  const hasStackPopup = currentIndex >= 1;
   const isPopup = hasStackPopup || hasOpener;
   if (!isPopup) return undefined;
 
@@ -457,7 +529,7 @@ export async function buildPopupRuntime(ctx: FlowContext, view: FlowView): Promi
     if (parentNode) node.parent = parentNode;
     return node;
   };
-  const currentNode = await buildNode((view?.navigation?.viewStack?.length || 1) - 1);
+  const currentNode = await buildNode(currentIndex);
   return currentNode;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where table action linkage rules would execute incorrectly after a form was successfully submitted in a popup. |
| 🇨🇳 Chinese | 修复弹窗中表单提交成功后表格操作联动规则执行错误的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
