### PR TITLE
fix(build): exclude client-v2 directory from deleteServerFiles

### DIFF
--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -259,7 +259,7 @@ export function deleteServerFiles(cwd: string, log: PkgLog) {
     deep: 1,
     onlyFiles: true,
   });
-  const dirs = fg.globSync(['*', '!client', '!node_modules'], {
+  const dirs = fg.globSync(['*', '!client', '!client-v2', '!node_modules'], {
     cwd: path.join(cwd, target_dir),
     absolute: true,
     deep: 1,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The `deleteServerFiles` function silently deletes the `client-v2` build artifact on all platforms, causing runtime 404 errors for plugins that depend on the `client-v2` lane.

### Description

The `dirs` glob pattern in `deleteServerFiles` already excludes `client` and `node_modules` directories from cleanup, but was missing `client-v2`. This one-line fix adds `'!client-v2'` to the glob exclusion list, matching the existing pattern for `client`.

**Root cause**: When `deleteServerFiles` runs after `buildPluginClient('client-v2')` completes, `fast-glob` enumerates the `dist/` directory and the `client-v2` directory (not excluded) gets passed to `fs.removeSync()`.

### Related issues

Fixes #9316

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed `deleteServerFiles` to preserve `client-v2` build output by adding it to the glob exclusion list.  |
| 🇨🇳 Chinese |              |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
