### PR TITLE
fix(plugin-workflow): restore flowmodel workflow binding hints

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client/flows.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client/flows.tsx
@@ -15,6 +15,8 @@ import React, { useCallback } from 'react';
 import { CONTEXT_TYPE, EVENT_TYPE, NAMESPACE } from '../common/constants';
 import { ContextDataJsonInput } from './components';
 
+const customActionDescription = `{{t('Workflow will be triggered directly once the button clicked, without data saving. Only supports to be bound with "Custom action event".', { ns: "${NAMESPACE}" })}}`;
+
 export class FormTriggerWorkflowActionModel extends FormActionModel {
   defaultProps: ButtonProps = {
     title: tExpr('Trigger workflow', { ns: NAMESPACE }),
@@ -39,6 +41,7 @@ FormTriggerWorkflowActionModel.registerFlow({
         filter: {
           type: EVENT_TYPE,
         },
+        description: customActionDescription,
         optionFilter({ config }) {
           return config.type === CONTEXT_TYPE.SINGLE_RECORD;
         },
@@ -114,6 +117,7 @@ RecordTriggerWorkflowActionModel.registerFlow({
         filter: {
           type: EVENT_TYPE,
         },
+        description: customActionDescription,
         optionFilter({ config }) {
           return config.type === CONTEXT_TYPE.SINGLE_RECORD;
         },
@@ -231,14 +235,17 @@ CollectionTriggerWorkflowActionModel.registerFlow({
     triggerWorkflows: {
       title: `{{t('Bind workflows', { ns: 'workflow' })}}`,
       uiSchema: (ctx) => {
+        const { type } = ctx.model.stepParams.customCollectionTriggerWorkflowsActionSettings?.setContextType ?? {};
         const baseSchema = createTriggerWorkflowsSchema({
           WorkflowSelectComponent: CollectionActionWorkflowSelectComponent,
           filter: {
             type: EVENT_TYPE,
           },
           usingContext: false,
+          description: type
+            ? `{{t('Only support custom action workflow with context type set to "Multiple records".', { ns: "${NAMESPACE}" })}}`
+            : `{{t('Only support custom action workflow with context type set to "Custom context".', { ns: "${NAMESPACE}" })}}`,
         })(ctx);
-        const { type } = ctx.model.stepParams.customCollectionTriggerWorkflowsActionSettings?.setContextType ?? {};
         if (!type) {
           return {
             ...baseSchema,
@@ -369,6 +376,7 @@ function globalTriggerWorkflowUiSchema(ctx) {
     filter: {
       type: EVENT_TYPE,
     },
+    description: `{{t('Only support custom action workflow with context type set to "Custom context".', { ns: "${NAMESPACE}" })}}`,
     optionFilter({ config }) {
       return !config.type;
     },

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/flows/triggerWorkflows.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/flows/triggerWorkflows.tsx
@@ -22,6 +22,7 @@ type SchemaOptions = {
   optionFilter?: (option: { key: string; type: string; config: any }) => boolean;
   usingContext?: boolean;
   filter?: Record<string, any>;
+  description?: string | ((ctx: any) => string | undefined);
 };
 
 export function createTriggerWorkflowsSchema({
@@ -29,13 +30,31 @@ export function createTriggerWorkflowsSchema({
   optionFilter,
   usingContext = true,
   filter,
+  description,
 }: SchemaOptions = {}) {
   return (ctx) => {
     const { collection: collectionModel } = ctx.blockModel as CollectionBlockModel;
     const workflowCollection = collectionModel
       ? joinCollectionName(collectionModel.dataSource.name, collectionModel.name)
       : null;
+    const workflowDescription = typeof description === 'function' ? description(ctx) : description;
     return {
+      ...(workflowDescription
+        ? {
+            description: {
+              type: 'void',
+              'x-component': 'Alert',
+              'x-component-props': {
+                type: 'info',
+                showIcon: true,
+                message: workflowDescription,
+                style: {
+                  marginBottom: '1em',
+                },
+              },
+            },
+          }
+        : {}),
       group: {
         type: 'array',
         'x-decorator': 'FormItem',
@@ -142,13 +161,17 @@ export function createTriggerWorkflowsSchema({
   };
 }
 
+const operationEventDescription = `{{t('Support pre-action event (local mode), post-action event (local mode), and approval event here.', { ns: "${NAMESPACE}" })}}`;
+
 FormSubmitActionModel.registerFlow({
   key: 'formTriggerWorkflowsActionSettings',
   title: `{{t('Workflow', { ns: 'workflow' })}}`,
   steps: {
     setTriggerWorkflows: {
       title: `{{t('Bind workflows', { ns: "${NAMESPACE}" })}}`,
-      uiSchema: createTriggerWorkflowsSchema(),
+      uiSchema: createTriggerWorkflowsSchema({
+        description: operationEventDescription,
+      }),
       handler(ctx, params) {
         const triggerWorkflows = params.group?.length
           ? params.group.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
@@ -169,7 +192,9 @@ UpdateRecordActionModel.registerFlow({
   steps: {
     setTriggerWorkflows: {
       title: `{{t('Bind workflows', { ns: "${NAMESPACE}" })}}`,
-      uiSchema: createTriggerWorkflowsSchema(),
+      uiSchema: createTriggerWorkflowsSchema({
+        description: operationEventDescription,
+      }),
       handler(ctx, params) {
         const triggerWorkflows = params.group?.length
           ? params.group.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The workflow binding configuration dialog based on FlowModel was missing the helper text that previously existed in the SchemaComponent-based implementation. This made it unclear which workflow trigger types could be bound in the current button context.

### Description 
This PR restores the missing helper text in FlowModel-based workflow binding dialogs.

- Add a reusable description area to the FlowModel workflow binding schema.
- Restore operation-button guidance for pre-action event (local mode), post-action event (local mode), and approval event.
- Restore custom action guidance for direct trigger buttons, including context restrictions for custom context and multiple records.

Risk is low because the change is limited to settings UI copy in workflow binding dialogs and does not change workflow execution logic.

Testing suggestions:
- Open FlowModel-based submit/update action workflow binding dialogs and confirm the operation-event helper text is visible.
- Open FlowModel-based custom trigger action workflow binding dialogs and confirm the custom-action helper text is visible.
- Verify collection/global custom trigger dialogs show the correct context restriction helper text.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: restore helper text in FlowModel workflow binding dialogs for operation and custom action events |
| 🇨🇳 Chinese | 修复：补回 FlowModel 工作流绑定弹窗中操作类事件与自定义操作事件的提示文案 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
