### PR TITLE
refactor: exclude already associated records in association selection dial…

### DIFF
--- a/packages/core/client/src/flow/models/actions/AssociateActionModel.tsx
+++ b/packages/core/client/src/flow/models/actions/AssociateActionModel.tsx
@@ -16,6 +16,7 @@ import { SkeletonFallback } from '../../components/SkeletonFallback';
 import { ActionModel, ActionSceneEnum } from '../base';
 import {
   applyAssociateAction,
+  getAssociationSelectorContextInputArgs,
   getAssociationTargetResourceSettings,
   isAssociationBlockContext,
 } from './AssociationActionUtils';
@@ -139,7 +140,6 @@ AssociateActionModel.registerFlow({
   steps: {
     openSelector: {
       async handler(ctx, params) {
-        const blockModel = ctx.blockModel;
         const targetResourceSettings = getAssociationTargetResourceSettings(ctx);
         const openMode = ctx.inputArgs?.isMobileLayout ? 'embed' : ctx.inputArgs?.mode || params?.mode || 'drawer';
         const size = ctx.inputArgs?.size || params?.size || 'medium';
@@ -168,9 +168,9 @@ AssociateActionModel.registerFlow({
             scene: 'select',
             dataSourceKey: targetResourceSettings.dataSourceKey,
             collectionName: targetResourceSettings.collectionName,
+            ...getAssociationSelectorContextInputArgs(ctx),
             rowSelectionProps: {
               type: 'checkbox',
-              defaultSelectedRows: () => blockModel?.resource?.getData?.() || [],
               renderCell: undefined,
               selectedRowKeys: undefined,
               onChange: (_, selectedRows) => {

--- a/packages/core/client/src/flow/models/actions/AssociationActionUtils.ts
+++ b/packages/core/client/src/flow/models/actions/AssociationActionUtils.ts
@@ -38,10 +38,12 @@ export const getAssociationSelectorContextInputArgs = (ctx: FlowModelContext | a
   const association = blockModel?.association;
   const resourceSettings = getAssociationBlockResourceSettings(ctx);
   const sourceId = blockModel?.resource?.getSourceId?.() ?? resourceSettings?.sourceId;
+  const associatedRecords = blockModel?.resource?.getData?.() || [];
 
   return {
     collectionField: association,
     sourceId,
+    associatedRecords,
   };
 };
 

--- a/packages/core/client/src/flow/models/actions/AssociationActionUtils.ts
+++ b/packages/core/client/src/flow/models/actions/AssociationActionUtils.ts
@@ -33,6 +33,18 @@ export const getAssociationTargetResourceSettings = (ctx: FlowModelContext | any
   };
 };
 
+export const getAssociationSelectorContextInputArgs = (ctx: FlowModelContext | any) => {
+  const blockModel = ctx?.blockModel || ctx?.model?.context?.blockModel;
+  const association = blockModel?.association;
+  const resourceSettings = getAssociationBlockResourceSettings(ctx);
+  const sourceId = blockModel?.resource?.getSourceId?.() ?? resourceSettings?.sourceId;
+
+  return {
+    collectionField: association,
+    sourceId,
+  };
+};
+
 const callAssociationResourceAction = async (resource: any, action: 'add' | 'remove', values: any[]) => {
   if (typeof resource?.[action] === 'function') {
     return await resource[action]({ values });

--- a/packages/core/client/src/flow/models/actions/__tests__/AssociationActionModel.test.ts
+++ b/packages/core/client/src/flow/models/actions/__tests__/AssociationActionModel.test.ts
@@ -16,6 +16,7 @@ import {
   AssociateActionModel,
   CollectionActionGroupModel,
   DisassociateActionModel,
+  getAssociationSelectorContextInputArgs,
   getAssociationTargetResourceSettings,
   PopupActionModel,
   RecordActionGroupModel,
@@ -84,6 +85,35 @@ describe('association action models', () => {
     expect(getAssociationTargetResourceSettings(ctx)).toEqual({
       dataSourceKey: 'main',
       collectionName: 'transports',
+    });
+  });
+
+  it('passes one-to-many association context to selector table blocks', () => {
+    const association = {
+      name: 'orders',
+      interface: 'o2m',
+      target: 'orders',
+      sourceKey: 'id',
+      foreignKey: 'userId',
+    };
+    const ctx: any = {
+      blockModel: {
+        association,
+        resource: {
+          getSourceId: () => 362872646860800,
+        },
+        getResourceSettingsInitParams: () => ({
+          dataSourceKey: 'main',
+          collectionName: 'orders',
+          associationName: 'users.orders',
+          sourceId: '{{ctx.popup.record.id}}',
+        }),
+      },
+    };
+
+    expect(getAssociationSelectorContextInputArgs(ctx)).toEqual({
+      collectionField: association,
+      sourceId: 362872646860800,
     });
   });
 

--- a/packages/core/client/src/flow/models/actions/__tests__/AssociationActionModel.test.ts
+++ b/packages/core/client/src/flow/models/actions/__tests__/AssociationActionModel.test.ts
@@ -114,6 +114,39 @@ describe('association action models', () => {
     expect(getAssociationSelectorContextInputArgs(ctx)).toEqual({
       collectionField: association,
       sourceId: 362872646860800,
+      associatedRecords: [],
+    });
+  });
+
+  it('passes current associated records to selector table blocks', () => {
+    const associatedRecords = [{ id: 11 }, { id: 12 }];
+    const association = {
+      name: 'tags',
+      interface: 'm2m',
+      target: 'tags',
+      sourceKey: 'id',
+      targetKey: 'id',
+    };
+    const ctx: any = {
+      blockModel: {
+        association,
+        resource: {
+          getSourceId: () => 1,
+          getData: () => associatedRecords,
+        },
+        getResourceSettingsInitParams: () => ({
+          dataSourceKey: 'main',
+          collectionName: 'tags',
+          associationName: 'posts.tags',
+          sourceId: '{{ctx.popup.record.id}}',
+        }),
+      },
+    };
+
+    expect(getAssociationSelectorContextInputArgs(ctx)).toEqual({
+      collectionField: association,
+      sourceId: 1,
+      associatedRecords,
     });
   });
 

--- a/packages/core/client/src/flow/models/blocks/table/TableSelectModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableSelectModel.tsx
@@ -48,9 +48,11 @@ export class TableSelectModel extends TableBlockModel {
         return v[this.collection.filterTargetKey];
       })
       .filter(Boolean);
-    this.resource.addFilterGroup(`${this.uid}-select`, {
-      [`${this.collection.filterTargetKey}.$ne`]: filterKeys,
-    });
+    if (filterKeys.length) {
+      this.resource.addFilterGroup(`${this.uid}-select`, {
+        [`${this.collection.filterTargetKey}.$ne`]: filterKeys,
+      });
+    }
   }
 }
 

--- a/packages/core/client/src/flow/models/blocks/table/TableSelectModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableSelectModel.tsx
@@ -25,6 +25,21 @@ export function getAssociationSelectForeignKeyFilter(collectionField: any) {
   };
 }
 
+export function getAssociationSelectAssociatedRecordsFilter(collection: any, associatedRecords: any[] = []) {
+  const targetKey = collection?.filterTargetKey || 'id';
+  const filterKeys = associatedRecords
+    .map((record) => record?.[targetKey])
+    .filter((value) => value !== undefined && value !== null && value !== '');
+
+  if (!filterKeys.length) {
+    return null;
+  }
+
+  return {
+    [`${targetKey}.$ne`]: filterKeys,
+  };
+}
+
 export class TableSelectModel extends TableBlockModel {
   static scene = BlockSceneEnum.select;
   rowSelectionProps: any = observable.deep({});
@@ -41,16 +56,10 @@ export class TableSelectModel extends TableBlockModel {
 
     const getSelectedRows = this.rowSelectionProps?.defaultSelectedRows;
     const selectData = typeof getSelectedRows === 'function' ? getSelectedRows() : getSelectedRows;
-    const data = (selectData && castArray(selectData)) || [];
-    const filterKeys = data
-      .map((v) => {
-        return v[this.collection.filterTargetKey];
-      })
-      .filter(Boolean);
-    if (filterKeys.length) {
-      this.resource.addFilterGroup(`${this.uid}-select`, {
-        [`${this.collection.filterTargetKey}.$ne`]: filterKeys,
-      });
+    const data = [...castArray(selectData || []), ...castArray(this.context.view.inputArgs.associatedRecords || [])];
+    const associatedRecordsFilter = getAssociationSelectAssociatedRecordsFilter(this.collection, data);
+    if (associatedRecordsFilter) {
+      this.resource.addFilterGroup(`${this.uid}-select`, associatedRecordsFilter);
     }
   }
 }

--- a/packages/core/client/src/flow/models/blocks/table/TableSelectModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableSelectModel.tsx
@@ -12,30 +12,29 @@ import { castArray } from 'lodash';
 import { BlockSceneEnum } from '../../base';
 import { TableBlockModel } from './TableBlockModel';
 
+export function getAssociationSelectForeignKeyFilter(collectionField: any) {
+  const isOToAny = ['oho', 'o2m'].includes(collectionField?.interface);
+  const foreignKey = collectionField?.foreignKey;
+  if (!isOToAny || !foreignKey) {
+    return null;
+  }
+  return {
+    [foreignKey]: {
+      $is: null,
+    },
+  };
+}
+
 export class TableSelectModel extends TableBlockModel {
   static scene = BlockSceneEnum.select;
   rowSelectionProps: any = observable.deep({});
   onInit(options: any) {
     super.onInit(options);
     const collectionField = this.context.view.inputArgs.collectionField || {};
-    const isOToAny = ['oho', 'o2m'].includes(collectionField?.interface);
-    const sourceId = this.context.view.inputArgs.sourceId;
-    if (isOToAny) {
-      const foreignKey = collectionField.foreignKey;
+    const foreignKeyFilter = getAssociationSelectForeignKeyFilter(collectionField);
+    if (foreignKeyFilter) {
       const filterGroupKey = `${this.uid}-${collectionField.name}`;
-      if (foreignKey) {
-        if (sourceId != null) {
-          this.resource.addFilterGroup(filterGroupKey, {
-            $or: [{ [foreignKey]: { $is: null } }, { [foreignKey]: { $eq: sourceId } }],
-          });
-        } else {
-          this.resource.addFilterGroup(filterGroupKey, {
-            [foreignKey]: {
-              $is: null,
-            },
-          });
-        }
-      }
+      this.resource.addFilterGroup(filterGroupKey, foreignKeyFilter);
     }
 
     Object.assign(this.rowSelectionProps, this.context.view.inputArgs.rowSelectionProps || {});

--- a/packages/core/client/src/flow/models/blocks/table/__tests__/TableSelectModel.test.ts
+++ b/packages/core/client/src/flow/models/blocks/table/__tests__/TableSelectModel.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 import '@nocobase/client';
-import { getAssociationSelectForeignKeyFilter } from '../TableSelectModel';
+import { getAssociationSelectAssociatedRecordsFilter, getAssociationSelectForeignKeyFilter } from '../TableSelectModel';
 
 describe('TableSelectModel', () => {
   it('filters out already associated o2m records in association select table', () => {
@@ -23,6 +23,19 @@ describe('TableSelectModel', () => {
       f_y2quq75zibi: {
         $is: null,
       },
+    });
+  });
+
+  it('filters out already associated m2m records in association select table', () => {
+    expect(
+      getAssociationSelectAssociatedRecordsFilter(
+        {
+          filterTargetKey: 'id',
+        },
+        [{ id: 11 }, { id: 12 }],
+      ),
+    ).toEqual({
+      'id.$ne': [11, 12],
     });
   });
 });

--- a/packages/core/client/src/flow/models/blocks/table/__tests__/TableSelectModel.test.ts
+++ b/packages/core/client/src/flow/models/blocks/table/__tests__/TableSelectModel.test.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import '@nocobase/client';
+import { getAssociationSelectForeignKeyFilter } from '../TableSelectModel';
+
+describe('TableSelectModel', () => {
+  it('filters out already associated o2m records in association select table', () => {
+    expect(
+      getAssociationSelectForeignKeyFilter({
+        interface: 'o2m',
+        name: 'orders',
+        foreignKey: 'f_y2quq75zibi',
+      }),
+    ).toEqual({
+      f_y2quq75zibi: {
+        $is: null,
+      },
+    });
+  });
+});

--- a/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
+++ b/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
@@ -7,13 +7,12 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState, useContext } from 'react';
 import { RecordPickerProvider, RecordPickerContext } from '../../../schema-component/antd/record-picker';
 import {
   SchemaComponentOptions,
   useActionContext,
   useBlockRequestContext,
-  useCollection,
   ActionContextProvider,
   useOpenModeContext,
 } from '../../../';
@@ -21,6 +20,9 @@ import {
   TableSelectorParamsProvider,
   useTableSelectorProps as useTsp,
 } from '../../../block-provider/TableSelectorProvider';
+import { useCollectionManager_deprecated } from '../../../collection-manager';
+import { useRecord } from '../../../record-provider';
+import { buildToManyAssociationFilter } from './utils';
 
 const useTableSelectorProps = () => {
   const { setSelectedRows } = useContext(RecordPickerContext);
@@ -40,21 +42,12 @@ const useTableSelectorProps = () => {
 
 export const AssociateActionProvider = (props) => {
   const [selectedRows, setSelectedRows] = useState([]);
-  const collection = useCollection();
-  const { resource, block, __parent, service } = useBlockRequestContext();
+  const record = useRecord();
+  const { getCollectionJoinField } = useCollectionManager_deprecated();
+  const { resource, block, __parent, props: blockProps } = useBlockRequestContext();
   const actionCtx = useActionContext();
   const { isMobile } = useOpenModeContext() || {};
-  const [associationData, setAssociationData] = useState([]);
-  const { data } = service || {};
-  useEffect(() => {
-    resource
-      ?.list?.({
-        paginate: false,
-      })
-      .then((res) => {
-        setAssociationData(res.data?.data || []);
-      });
-  }, [resource, data?.meta.count]);
+  const collectionField = getCollectionJoinField(blockProps?.association);
 
   const pickerProps = {
     size: 'small',
@@ -84,13 +77,7 @@ export const AssociateActionProvider = (props) => {
     };
   };
   const getFilter = () => {
-    const targetKey = collection?.filterTargetKey || 'id';
-    if (associationData) {
-      const list = associationData.map((option) => option[targetKey]).filter(Boolean);
-      const filter = list.length ? { $and: [{ [`${targetKey}.$ne`]: list }] } : {};
-      return filter;
-    }
-    return {};
+    return buildToManyAssociationFilter(collectionField, record);
   };
 
   return (

--- a/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
+++ b/packages/core/client/src/modules/actions/associate/AssociateActionProvider.tsx
@@ -44,7 +44,7 @@ export const AssociateActionProvider = (props) => {
   const [selectedRows, setSelectedRows] = useState([]);
   const record = useRecord();
   const { getCollectionJoinField } = useCollectionManager_deprecated();
-  const { resource, block, __parent, props: blockProps } = useBlockRequestContext();
+  const { resource, service, block, __parent, props: blockProps } = useBlockRequestContext();
   const actionCtx = useActionContext();
   const { isMobile } = useOpenModeContext() || {};
   const collectionField = getCollectionJoinField(blockProps?.association);
@@ -77,7 +77,7 @@ export const AssociateActionProvider = (props) => {
     };
   };
   const getFilter = () => {
-    return buildToManyAssociationFilter(collectionField, record);
+    return buildToManyAssociationFilter(collectionField, record, service?.data?.data || []);
   };
 
   return (

--- a/packages/core/client/src/modules/actions/associate/__tests__/utils.test.ts
+++ b/packages/core/client/src/modules/actions/associate/__tests__/utils.test.ts
@@ -1,0 +1,101 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildToManyAssociationFilter } from '../utils';
+
+describe('associate action utils', () => {
+  it('builds a filter for one-to-many association records', () => {
+    expect(
+      buildToManyAssociationFilter(
+        {
+          interface: 'o2m',
+          foreignKey: 'f_y2quq75zibi',
+          sourceKey: 'id',
+        },
+        {
+          id: 362872646860800,
+        },
+      ),
+    ).toEqual({
+      $or: [
+        {
+          f_y2quq75zibi: {
+            $is: null,
+          },
+        },
+        {
+          f_y2quq75zibi: {
+            $eq: 362872646860800,
+          },
+        },
+      ],
+    });
+  });
+
+  it('keeps valid falsy source key values', () => {
+    expect(
+      buildToManyAssociationFilter(
+        {
+          interface: 'o2m',
+          foreignKey: 'parentId',
+          sourceKey: 'id',
+        },
+        {
+          id: 0,
+        },
+      ),
+    ).toEqual({
+      $or: [
+        {
+          parentId: {
+            $is: null,
+          },
+        },
+        {
+          parentId: {
+            $eq: 0,
+          },
+        },
+      ],
+    });
+  });
+
+  it('only filters null foreign key when the source key value is empty', () => {
+    expect(
+      buildToManyAssociationFilter(
+        {
+          interface: 'o2m',
+          foreignKey: 'parentId',
+          sourceKey: 'id',
+        },
+        {},
+      ),
+    ).toEqual({
+      parentId: {
+        $is: null,
+      },
+    });
+  });
+
+  it('returns an empty filter for non one-to-many fields', () => {
+    expect(
+      buildToManyAssociationFilter(
+        {
+          interface: 'm2m',
+          foreignKey: 'parentId',
+          sourceKey: 'id',
+        },
+        {
+          id: 1,
+        },
+      ),
+    ).toEqual({});
+  });
+});

--- a/packages/core/client/src/modules/actions/associate/__tests__/utils.test.ts
+++ b/packages/core/client/src/modules/actions/associate/__tests__/utils.test.ts
@@ -98,4 +98,21 @@ describe('associate action utils', () => {
       ),
     ).toEqual({});
   });
+
+  it('filters already associated many-to-many records', () => {
+    expect(
+      buildToManyAssociationFilter(
+        {
+          interface: 'm2m',
+          targetKey: 'id',
+        },
+        {
+          id: 1,
+        },
+        [{ id: 11 }, { id: 12 }],
+      ),
+    ).toEqual({
+      'id.$ne': [11, 12],
+    });
+  });
 });

--- a/packages/core/client/src/modules/actions/associate/utils.ts
+++ b/packages/core/client/src/modules/actions/associate/utils.ts
@@ -9,7 +9,29 @@
 
 const hasValue = (value: any) => value !== undefined && value !== null && value !== '';
 
-export const buildToManyAssociationFilter = (collectionField: any, record: any) => {
+export const buildAssociatedRecordsFilter = (collectionField: any, associatedRecords: any[] = []) => {
+  if (collectionField?.interface !== 'm2m') {
+    return {};
+  }
+
+  const targetKey = collectionField.targetKey || 'id';
+  const values = associatedRecords.map((record) => record?.[targetKey]).filter(hasValue);
+
+  if (!values.length) {
+    return {};
+  }
+
+  return {
+    [`${targetKey}.$ne`]: values,
+  };
+};
+
+export const buildToManyAssociationFilter = (collectionField: any, record: any, associatedRecords: any[] = []) => {
+  const associatedRecordsFilter = buildAssociatedRecordsFilter(collectionField, associatedRecords);
+  if (Object.keys(associatedRecordsFilter).length) {
+    return associatedRecordsFilter;
+  }
+
   if (!collectionField || !['oho', 'o2m'].includes(collectionField.interface) || !collectionField.foreignKey) {
     return {};
   }

--- a/packages/core/client/src/modules/actions/associate/utils.ts
+++ b/packages/core/client/src/modules/actions/associate/utils.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+const hasValue = (value: any) => value !== undefined && value !== null && value !== '';
+
+export const buildToManyAssociationFilter = (collectionField: any, record: any) => {
+  if (!collectionField || !['oho', 'o2m'].includes(collectionField.interface) || !collectionField.foreignKey) {
+    return {};
+  }
+
+  const sourceKey = collectionField.sourceKey || 'id';
+  const sourceValue = record?.[sourceKey];
+  if (!hasValue(sourceValue)) {
+    return {
+      [collectionField.foreignKey]: {
+        $is: null,
+      },
+    };
+  }
+
+  return {
+    $or: [
+      {
+        [collectionField.foreignKey]: {
+          $is: null,
+        },
+      },
+      {
+        [collectionField.foreignKey]: {
+          $eq: sourceValue,
+        },
+      },
+    ],
+  };
+};


### PR DESCRIPTION
…og of one-to-many table block

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  exclude already associated records in association selection dialog of one-to-many table block         |
| 🇨🇳 Chinese |   一对多关系表格区块的关联操作中，弹窗选择区块应排除已关联数据        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
