### PR TITLE
fix: show confirm message when closing event flow editor without saving

### DIFF
--- a/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
+++ b/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
@@ -26,6 +26,8 @@ import {
   GLOBAL_EMBED_CONTAINER_ID,
   EMBED_REPLACING_DATA_KEY,
   shouldHideEventInSettings,
+  observable,
+  FlowDefinitionOptions,
 } from '@nocobase/flow-engine';
 import { Collapse, Input, Button, Space, Tooltip, Empty, Dropdown, Select } from 'antd';
 import { uid } from '@formily/shared';
@@ -33,6 +35,91 @@ import { useUpdate } from 'ahooks';
 import _ from 'lodash';
 
 type FlowOnObject = Exclude<FlowDefinition['on'], string | undefined>;
+type SerializedFlowRegistry = Record<string, Omit<FlowDefinitionOptions, 'key'> & { key?: string }>;
+type EditableFlowRegistry = {
+  addFlow(flowKey: string, flowOptions: Omit<FlowDefinitionOptions, 'key'> & { key?: string }): FlowDefinition;
+  addFlows(flows: SerializedFlowRegistry): void;
+  removeFlow(flowKey: string): void;
+  getFlows(): Map<string, FlowDefinition>;
+  mapFlows<T = any>(callback: (flow: FlowDefinition) => T): T[];
+  hasFlow(flowKey: string): boolean;
+  getFlow(flowKey: string): FlowDefinition | undefined;
+};
+
+class DraftFlowRegistry implements EditableFlowRegistry {
+  private flows = observable.shallow(new Map<string, FlowDefinition>());
+
+  constructor(flows: SerializedFlowRegistry) {
+    this.addFlows(flows);
+  }
+
+  addFlows(flows: SerializedFlowRegistry) {
+    for (const [flowKey, flowOptions] of Object.entries(flows || {})) {
+      this.addFlow(flowKey, flowOptions);
+    }
+  }
+
+  addFlow(flowKey: string, flowOptions: Omit<FlowDefinitionOptions, 'key'> & { key?: string }) {
+    const flow = new FlowDefinition(
+      {
+        ..._.cloneDeep(flowOptions),
+        key: flowKey,
+      },
+      this as any,
+    );
+    this.flows.set(flowKey, flow);
+    return flow;
+  }
+
+  removeFlow(flowKey: string) {
+    this.flows.delete(flowKey);
+  }
+
+  getFlows() {
+    return this.flows;
+  }
+
+  mapFlows<T = any>(callback: (flow: FlowDefinition) => T): T[] {
+    return [...this.flows.values()].map(callback);
+  }
+
+  hasFlow(flowKey: string) {
+    return this.flows.has(flowKey);
+  }
+
+  getFlow(flowKey: string) {
+    return this.flows.get(flowKey);
+  }
+
+  saveFlow(): void {}
+
+  destroyFlow(flowKey: string) {
+    this.removeFlow(flowKey);
+  }
+
+  moveStep(flowKey: string, sourceStepKey: string, targetStepKey: string) {
+    const flow = this.getFlow(flowKey);
+    if (!flow) {
+      throw new Error(`Flow '${flowKey}' not found`);
+    }
+    flow.moveStep(sourceStepKey, targetStepKey);
+  }
+}
+
+function serializeFlowRegistry(registry: Pick<EditableFlowRegistry, 'getFlows'>): SerializedFlowRegistry {
+  const flows: SerializedFlowRegistry = {};
+  for (const [key, flow] of registry.getFlows()) {
+    flows[key] = _.cloneDeep(flow.toData());
+  }
+  return flows;
+}
+
+function replaceFlowRegistry(registry: EditableFlowRegistry, flows: SerializedFlowRegistry) {
+  for (const key of Array.from(registry.getFlows().keys())) {
+    registry.removeFlow(key);
+  }
+  registry.addFlows(flows);
+}
 
 function isFlowOnObject(on: FlowDefinition['on']): on is FlowOnObject {
   return !!on && typeof on === 'object';
@@ -91,7 +178,7 @@ function validateFlowOnPhase(onObj: FlowOnObject): 'flowKey' | 'stepKey' | undef
 
 export const DynamicFlowsIcon: React.FC<{ model: FlowModel }> = (props) => {
   const { model } = props;
-  const t = model.translate.bind(model);
+  const t = React.useMemo(() => model.translate.bind(model), [model]);
 
   const handleClick = () => {
     const target = document.querySelector<HTMLDivElement>(`#${GLOBAL_EMBED_CONTAINER_ID}`);
@@ -188,7 +275,17 @@ const FieldLabel = ({
 
 // 事件配置组件 - 独立的 observer 组件确保响应式更新
 const EventConfigSection = observer(
-  ({ flow, model, flowEngine }: { flow: FlowDefinition; model: FlowModel; flowEngine: any }) => {
+  ({
+    flow,
+    model,
+    flowEngine,
+    flowRegistry,
+  }: {
+    flow: FlowDefinition;
+    model: FlowModel;
+    flowEngine: any;
+    flowRegistry: EditableFlowRegistry;
+  }) => {
     const ctx = useFlowContext<FlowEngineContext>();
     const t = model.translate.bind(model);
     const refresh = useUpdate();
@@ -268,9 +365,9 @@ const EventConfigSection = observer(
       return staticFlows.map((f) => ({
         value: f.key,
         label: formatKeyWithTitle(String(f.key), f.title),
-        disabled: model.flowRegistry.hasFlow(f.key),
+        disabled: flowRegistry.hasFlow(f.key),
       }));
-    }, [formatKeyWithTitle, model.flowRegistry, staticFlows]);
+    }, [flowRegistry, formatKeyWithTitle, staticFlows]);
 
     const stepOptions = React.useMemo(() => {
       if (!flowKeyValue) return [];
@@ -444,12 +541,49 @@ const DynamicFlowsEditor = observer((props: { model: FlowModel }) => {
   const { model } = props;
   const ctx = useFlowContext<FlowEngineContext>();
   const flowEngine = model.flowEngine;
+  const initialFlows = React.useMemo(() => serializeFlowRegistry(model.flowRegistry), [model]);
+  const initialFlowsRef = React.useRef(initialFlows);
+  const [draftFlowRegistry] = React.useState(() => new DraftFlowRegistry(initialFlows));
   const [submitLoading, setSubmitLoading] = React.useState(false);
-  const t = model.translate.bind(model);
+  const t = React.useMemo(() => model.translate.bind(model), [model]);
+  const hasUnsavedChanges = React.useCallback(() => {
+    return !_.isEqual(initialFlowsRef.current, serializeFlowRegistry(draftFlowRegistry));
+  }, [draftFlowRegistry]);
+
+  React.useEffect(() => {
+    const view = ctx.view;
+    const previousBeforeClose = view.beforeClose;
+    const beforeClose = async (payload) => {
+      if (hasUnsavedChanges()) {
+        const confirmed =
+          (await ctx.modal?.confirm?.({
+            title: t('Unsaved changes'),
+            content: t("Are you sure you don't want to save?"),
+            okText: t('Confirm'),
+            cancelText: t('Cancel'),
+          })) ?? true;
+
+        if (!confirmed) {
+          return false;
+        }
+      }
+
+      const result = await previousBeforeClose?.(payload);
+      return result !== false;
+    };
+
+    view.beforeClose = beforeClose;
+
+    return () => {
+      if (view.beforeClose === beforeClose) {
+        view.beforeClose = previousBeforeClose;
+      }
+    };
+  }, [ctx, hasUnsavedChanges, t]);
 
   // 添加新流
   const handleAddFlow = () => {
-    model.flowRegistry.addFlow(uid(), {
+    draftFlowRegistry.addFlow(uid(), {
       title: t('Event flow'),
       steps: {},
     });
@@ -514,7 +648,7 @@ const DynamicFlowsEditor = observer((props: { model: FlowModel }) => {
   );
 
   // 生成折叠面板项
-  const collapseItems = model.flowRegistry.mapFlows((flow) => {
+  const collapseItems = draftFlowRegistry.mapFlows((flow) => {
     return {
       key: flow.key,
       label: renderPanelHeader(flow),
@@ -527,7 +661,7 @@ const DynamicFlowsEditor = observer((props: { model: FlowModel }) => {
       children: (
         <div>
           {/* 事件部分 */}
-          <EventConfigSection flow={flow} model={model} flowEngine={flowEngine} />
+          <EventConfigSection flow={flow} model={model} flowEngine={flowEngine} flowRegistry={draftFlowRegistry} />
 
           {/* 步骤部分 */}
           <div>
@@ -668,13 +802,13 @@ const DynamicFlowsEditor = observer((props: { model: FlowModel }) => {
           flexShrink: 0,
         }}
       >
-        <Button onClick={() => ctx.view.destroy()}>{t('Cancel')}</Button>
+        <Button onClick={() => ctx.view.close()}>{t('Cancel')}</Button>
         <Button
           type="primary"
           loading={submitLoading}
           onClick={async () => {
             setSubmitLoading(true);
-            const invalid = model.flowRegistry
+            const invalid = draftFlowRegistry
               .mapFlows((flow) => {
                 if (!isFlowOnObject(flow.on)) return;
                 normalizeFlowOnPhase(flow.on);
@@ -693,7 +827,15 @@ const DynamicFlowsEditor = observer((props: { model: FlowModel }) => {
               setSubmitLoading(false);
               return;
             }
-            await model.flowRegistry.save();
+            const previousFlows = serializeFlowRegistry(model.flowRegistry);
+            replaceFlowRegistry(model.flowRegistry, serializeFlowRegistry(draftFlowRegistry));
+            try {
+              await model.flowRegistry.save();
+            } catch (error) {
+              replaceFlowRegistry(model.flowRegistry, previousFlows);
+              setSubmitLoading(false);
+              throw error;
+            }
             // 保存事件流定义后，失效 beforeRender 缓存并触发一次重跑，确保改动立刻生效
             const beforeRenderFlows = model.flowRegistry
               .mapFlows((flow) => {

--- a/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
+++ b/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
@@ -26,8 +26,9 @@ import {
   GLOBAL_EMBED_CONTAINER_ID,
   EMBED_REPLACING_DATA_KEY,
   shouldHideEventInSettings,
-  observable,
-  FlowDefinitionOptions,
+  DetachedFlowRegistry,
+  replaceFlowRegistry,
+  serializeFlowRegistry,
 } from '@nocobase/flow-engine';
 import { Collapse, Input, Button, Space, Tooltip, Empty, Dropdown, Select } from 'antd';
 import { uid } from '@formily/shared';
@@ -35,91 +36,6 @@ import { useUpdate } from 'ahooks';
 import _ from 'lodash';
 
 type FlowOnObject = Exclude<FlowDefinition['on'], string | undefined>;
-type SerializedFlowRegistry = Record<string, Omit<FlowDefinitionOptions, 'key'> & { key?: string }>;
-type EditableFlowRegistry = {
-  addFlow(flowKey: string, flowOptions: Omit<FlowDefinitionOptions, 'key'> & { key?: string }): FlowDefinition;
-  addFlows(flows: SerializedFlowRegistry): void;
-  removeFlow(flowKey: string): void;
-  getFlows(): Map<string, FlowDefinition>;
-  mapFlows<T = any>(callback: (flow: FlowDefinition) => T): T[];
-  hasFlow(flowKey: string): boolean;
-  getFlow(flowKey: string): FlowDefinition | undefined;
-};
-
-class DraftFlowRegistry implements EditableFlowRegistry {
-  private flows = observable.shallow(new Map<string, FlowDefinition>());
-
-  constructor(flows: SerializedFlowRegistry) {
-    this.addFlows(flows);
-  }
-
-  addFlows(flows: SerializedFlowRegistry) {
-    for (const [flowKey, flowOptions] of Object.entries(flows || {})) {
-      this.addFlow(flowKey, flowOptions);
-    }
-  }
-
-  addFlow(flowKey: string, flowOptions: Omit<FlowDefinitionOptions, 'key'> & { key?: string }) {
-    const flow = new FlowDefinition(
-      {
-        ..._.cloneDeep(flowOptions),
-        key: flowKey,
-      },
-      this as any,
-    );
-    this.flows.set(flowKey, flow);
-    return flow;
-  }
-
-  removeFlow(flowKey: string) {
-    this.flows.delete(flowKey);
-  }
-
-  getFlows() {
-    return this.flows;
-  }
-
-  mapFlows<T = any>(callback: (flow: FlowDefinition) => T): T[] {
-    return [...this.flows.values()].map(callback);
-  }
-
-  hasFlow(flowKey: string) {
-    return this.flows.has(flowKey);
-  }
-
-  getFlow(flowKey: string) {
-    return this.flows.get(flowKey);
-  }
-
-  saveFlow(): void {}
-
-  destroyFlow(flowKey: string) {
-    this.removeFlow(flowKey);
-  }
-
-  moveStep(flowKey: string, sourceStepKey: string, targetStepKey: string) {
-    const flow = this.getFlow(flowKey);
-    if (!flow) {
-      throw new Error(`Flow '${flowKey}' not found`);
-    }
-    flow.moveStep(sourceStepKey, targetStepKey);
-  }
-}
-
-function serializeFlowRegistry(registry: Pick<EditableFlowRegistry, 'getFlows'>): SerializedFlowRegistry {
-  const flows: SerializedFlowRegistry = {};
-  for (const [key, flow] of registry.getFlows()) {
-    flows[key] = _.cloneDeep(flow.toData());
-  }
-  return flows;
-}
-
-function replaceFlowRegistry(registry: EditableFlowRegistry, flows: SerializedFlowRegistry) {
-  for (const key of Array.from(registry.getFlows().keys())) {
-    registry.removeFlow(key);
-  }
-  registry.addFlows(flows);
-}
 
 function isFlowOnObject(on: FlowDefinition['on']): on is FlowOnObject {
   return !!on && typeof on === 'object';
@@ -284,7 +200,7 @@ const EventConfigSection = observer(
     flow: FlowDefinition;
     model: FlowModel;
     flowEngine: any;
-    flowRegistry: EditableFlowRegistry;
+    flowRegistry: Pick<DetachedFlowRegistry, 'hasFlow'>;
   }) => {
     const ctx = useFlowContext<FlowEngineContext>();
     const t = model.translate.bind(model);
@@ -543,7 +459,7 @@ const DynamicFlowsEditor = observer((props: { model: FlowModel }) => {
   const flowEngine = model.flowEngine;
   const initialFlows = React.useMemo(() => serializeFlowRegistry(model.flowRegistry), [model]);
   const initialFlowsRef = React.useRef(initialFlows);
-  const [draftFlowRegistry] = React.useState(() => new DraftFlowRegistry(initialFlows));
+  const [draftFlowRegistry] = React.useState(() => new DetachedFlowRegistry(initialFlows));
   const [submitLoading, setSubmitLoading] = React.useState(false);
   const t = React.useMemo(() => model.translate.bind(model), [model]);
   const hasUnsavedChanges = React.useCallback(() => {

--- a/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
+++ b/packages/core/client/src/flow/components/DynamicFlowsIcon.tsx
@@ -36,6 +36,9 @@ import { useUpdate } from 'ahooks';
 import _ from 'lodash';
 
 type FlowOnObject = Exclude<FlowDefinition['on'], string | undefined>;
+type FlowRegistryAvailability = {
+  hasFlow(flowKey: string): boolean;
+};
 
 function isFlowOnObject(on: FlowDefinition['on']): on is FlowOnObject {
   return !!on && typeof on === 'object';
@@ -200,7 +203,7 @@ const EventConfigSection = observer(
     flow: FlowDefinition;
     model: FlowModel;
     flowEngine: any;
-    flowRegistry: Pick<DetachedFlowRegistry, 'hasFlow'>;
+    flowRegistry: FlowRegistryAvailability;
   }) => {
     const ctx = useFlowContext<FlowEngineContext>();
     const t = model.translate.bind(model);

--- a/packages/core/client/src/flow/components/__tests__/DynamicFlowsIcon.test.tsx
+++ b/packages/core/client/src/flow/components/__tests__/DynamicFlowsIcon.test.tsx
@@ -30,13 +30,20 @@ vi.mock('antd', async (importOriginal) => {
   const actual = await importOriginal<typeof import('antd')>();
   return {
     ...actual,
-    Button: ({ children, onClick, ...props }: any) => (
+    Button: ({ children, onClick, icon: _icon, loading: _loading, ...props }: any) => (
       <button type="button" onClick={onClick} {...props}>
         {children}
       </button>
     ),
     Collapse: ({ items }: any) => (
-      <div data-testid="collapse">{items?.map((item: any) => <div key={item.key}>{item.children}</div>)}</div>
+      <div data-testid="collapse">
+        {items?.map((item: any) => (
+          <div key={item.key}>
+            {item.label}
+            {item.children}
+          </div>
+        ))}
+      </div>
     ),
     Dropdown: ({ children }: any) => <div>{children}</div>,
     Empty: ({ description }: any) => <div>{description}</div>,
@@ -245,6 +252,20 @@ describe('DynamicFlowsIcon', () => {
     expect(view.destroy).toHaveBeenCalledTimes(1);
     expect(model.flowRegistry.getFlows().size).toBe(1);
     expect(model.flowRegistry.hasFlow('flow1')).toBe(true);
+  });
+
+  it('discards existing event flow edits after confirmed cancel', async () => {
+    const model = createModel();
+    mockState.flowContextValue.modal.confirm.mockResolvedValue(true);
+    const { view } = await openDynamicFlowsEditor(model);
+
+    const titleInput = screen.getByPlaceholderText('Enter flow title');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, 'Changed flow');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(view.destroy).toHaveBeenCalledTimes(1);
+    expect(model.flowRegistry.getFlow('flow1')?.title).toBe('Event flow');
   });
 
   it('saves draft event flows into the real registry', async () => {

--- a/packages/core/client/src/flow/components/__tests__/DynamicFlowsIcon.test.tsx
+++ b/packages/core/client/src/flow/components/__tests__/DynamicFlowsIcon.test.tsx
@@ -9,8 +9,8 @@
 
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, userEvent, waitFor } from '@nocobase/test/client';
-import { FlowEngine, FlowModel, GLOBAL_EMBED_CONTAINER_ID } from '@nocobase/flow-engine';
+import { render, screen, userEvent, waitFor } from '@nocobase/test/client';
+import { ActionScene, FlowEngine, FlowModel, GLOBAL_EMBED_CONTAINER_ID } from '@nocobase/flow-engine';
 import { DynamicFlowsIcon } from '../DynamicFlowsIcon';
 
 const mockState = vi.hoisted(() => ({
@@ -71,9 +71,14 @@ const openDynamicFlowsEditor = async (model: FlowModel) => {
   expect(embedCall?.content).toBeTruthy();
 
   render(embedCall.content);
+
+  return {
+    embedCall,
+    view: mockState.flowContextValue.view,
+  };
 };
 
-const createModel = (options: { preventClose?: boolean; hiddenClose?: boolean } = {}) => {
+const createModel = (options: { preventClose?: boolean; hiddenClose?: boolean; saveStepParams?: any } = {}) => {
   const engine = new FlowEngine();
   engine.translate = vi.fn((key: string) => key) as any;
   engine.flowSettings.renderStepForm = vi.fn(() => null) as any;
@@ -92,6 +97,14 @@ const createModel = (options: { preventClose?: boolean; hiddenClose?: boolean } 
     click: {
       name: 'click',
       title: 'Click',
+      handler: vi.fn(),
+    },
+  });
+  LocalTestModel.registerActions({
+    notify: {
+      name: 'notify',
+      title: 'Notify',
+      scene: ActionScene.DYNAMIC_EVENT_FLOW,
       handler: vi.fn(),
     },
   });
@@ -122,17 +135,38 @@ const createModel = (options: { preventClose?: boolean; hiddenClose?: boolean } 
       destroy: vi.fn(),
     },
   });
+  model.context.defineProperty('message', {
+    value: {
+      error: vi.fn(),
+      success: vi.fn(),
+    },
+  });
+  vi.spyOn(model, 'saveStepParams').mockImplementation(options.saveStepParams || vi.fn(async () => undefined));
 
   return model;
 };
+
+const createView = () => ({
+  close: vi.fn(async function (this: any) {
+    const allowed = await this.beforeClose?.({});
+    if (allowed === false) {
+      return false;
+    }
+    this.destroy();
+    return true;
+  }),
+  destroy: vi.fn(),
+  beforeClose: undefined as any,
+});
 
 describe('DynamicFlowsIcon', () => {
   beforeEach(() => {
     mockState.capturedSelectProps.length = 0;
     mockState.flowContextValue = {
-      view: {
-        destroy: vi.fn(),
+      modal: {
+        confirm: vi.fn(),
       },
+      view: createView(),
     };
     document.body.innerHTML = `<div id="${GLOBAL_EMBED_CONTAINER_ID}"></div>`;
   });
@@ -170,5 +204,60 @@ describe('DynamicFlowsIcon', () => {
       const eventValues = getTriggerEventOptionValues();
       expect(eventValues).toEqual(expect.arrayContaining(['close', 'click']));
     });
+  });
+
+  it('keeps added event flows in draft until saved', async () => {
+    const model = createModel();
+
+    await openDynamicFlowsEditor(model);
+    await userEvent.click(screen.getByRole('button', { name: 'Add event flow' }));
+
+    expect(model.flowRegistry.getFlows().size).toBe(1);
+    expect(model.flowRegistry.hasFlow('flow1')).toBe(true);
+  });
+
+  it('blocks cancel when draft has unsaved changes and confirmation is rejected', async () => {
+    const model = createModel();
+    mockState.flowContextValue.modal.confirm.mockResolvedValue(false);
+    const { view } = await openDynamicFlowsEditor(model);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add event flow' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockState.flowContextValue.modal.confirm).toHaveBeenCalledWith({
+      title: 'Unsaved changes',
+      content: "Are you sure you don't want to save?",
+      okText: 'Confirm',
+      cancelText: 'Cancel',
+    });
+    expect(view.destroy).not.toHaveBeenCalled();
+    expect(model.flowRegistry.getFlows().size).toBe(1);
+  });
+
+  it('discards draft changes after confirmed cancel', async () => {
+    const model = createModel();
+    mockState.flowContextValue.modal.confirm.mockResolvedValue(true);
+    const { view } = await openDynamicFlowsEditor(model);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add event flow' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(view.destroy).toHaveBeenCalledTimes(1);
+    expect(model.flowRegistry.getFlows().size).toBe(1);
+    expect(model.flowRegistry.hasFlow('flow1')).toBe(true);
+  });
+
+  it('saves draft event flows into the real registry', async () => {
+    const saveStepParams = vi.fn(async () => undefined);
+    const model = createModel({ saveStepParams });
+    const { view } = await openDynamicFlowsEditor(model);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add event flow' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(saveStepParams).toHaveBeenCalledTimes(1);
+    expect(model.flowRegistry.getFlows().size).toBe(2);
+    expect(view.destroy).toHaveBeenCalledTimes(1);
+    expect(model.context.message.success).toHaveBeenCalledWith('Configuration saved');
   });
 });

--- a/packages/core/client/src/flow/components/__tests__/DynamicFlowsIcon.test.tsx
+++ b/packages/core/client/src/flow/components/__tests__/DynamicFlowsIcon.test.tsx
@@ -45,7 +45,16 @@ vi.mock('antd', async (importOriginal) => {
         ))}
       </div>
     ),
-    Dropdown: ({ children }: any) => <div>{children}</div>,
+    Dropdown: ({ children, menu }: any) => (
+      <div>
+        {children}
+        {menu?.items?.map((item: any) => (
+          <button key={item.key} type="button" onClick={item.onClick}>
+            {item.label}
+          </button>
+        ))}
+      </div>
+    ),
     Empty: ({ description }: any) => <div>{description}</div>,
     Input: (props: any) => <input {...props} />,
     Select: (props: any) => {
@@ -77,11 +86,12 @@ const openDynamicFlowsEditor = async (model: FlowModel) => {
   const embedCall = (model.context.viewer.embed as any).mock.calls.at(-1)?.[0];
   expect(embedCall?.content).toBeTruthy();
 
-  render(embedCall.content);
+  const editor = render(embedCall.content);
 
   return {
     embedCall,
     view: mockState.flowContextValue.view,
+    editor,
   };
 };
 
@@ -153,18 +163,35 @@ const createModel = (options: { preventClose?: boolean; hiddenClose?: boolean; s
   return model;
 };
 
-const createView = () => ({
-  close: vi.fn(async function (this: any) {
-    const allowed = await this.beforeClose?.({});
-    if (allowed === false) {
-      return false;
-    }
-    this.destroy();
-    return true;
-  }),
-  destroy: vi.fn(),
-  beforeClose: undefined as any,
-});
+const createView = () => {
+  let destroyed = false;
+  let closingPromise: Promise<boolean | void> | undefined;
+  const view = {
+    close: vi.fn(function () {
+      if (destroyed) {
+        return Promise.resolve(true);
+      }
+      if (closingPromise) {
+        return closingPromise;
+      }
+      closingPromise = (async () => {
+        const allowed = await view.beforeClose?.({});
+        if (allowed === false) {
+          closingPromise = undefined;
+          return false;
+        }
+        view.destroy();
+        return true;
+      })();
+      return closingPromise;
+    }),
+    destroy: vi.fn(() => {
+      destroyed = true;
+    }),
+    beforeClose: undefined as any,
+  };
+  return view;
+};
 
 describe('DynamicFlowsIcon', () => {
   beforeEach(() => {
@@ -241,6 +268,25 @@ describe('DynamicFlowsIcon', () => {
     expect(model.flowRegistry.getFlows().size).toBe(1);
   });
 
+  it('runs only one unsaved confirmation while cancel is pending', async () => {
+    const model = createModel();
+    let resolveConfirm: (value: boolean) => void;
+    mockState.flowContextValue.modal.confirm.mockImplementation(
+      () => new Promise<boolean>((resolve) => (resolveConfirm = resolve)),
+    );
+    const { view } = await openDynamicFlowsEditor(model);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add event flow' }));
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelButton);
+    await userEvent.click(cancelButton);
+
+    expect(mockState.flowContextValue.modal.confirm).toHaveBeenCalledTimes(1);
+
+    resolveConfirm(true);
+    await waitFor(() => expect(view.destroy).toHaveBeenCalledTimes(1));
+  });
+
   it('discards draft changes after confirmed cancel', async () => {
     const model = createModel();
     mockState.flowContextValue.modal.confirm.mockResolvedValue(true);
@@ -266,6 +312,37 @@ describe('DynamicFlowsIcon', () => {
 
     expect(view.destroy).toHaveBeenCalledTimes(1);
     expect(model.flowRegistry.getFlow('flow1')?.title).toBe('Event flow');
+  });
+
+  it('discards added draft steps after confirmed cancel', async () => {
+    const model = createModel();
+    mockState.flowContextValue.modal.confirm.mockResolvedValue(true);
+    const { view } = await openDynamicFlowsEditor(model);
+
+    expect(model.flowRegistry.getFlow('flow1')?.getSteps().size).toBe(0);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Notify' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(view.destroy).toHaveBeenCalledTimes(1);
+    expect(model.flowRegistry.getFlow('flow1')?.getSteps().size).toBe(0);
+  });
+
+  it('does not keep discarded draft changes after reopening the editor', async () => {
+    const model = createModel();
+    mockState.flowContextValue.modal.confirm.mockResolvedValue(true);
+
+    const firstEditor = await openDynamicFlowsEditor(model);
+    await userEvent.click(screen.getByRole('button', { name: 'Add event flow' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    firstEditor.editor.unmount();
+
+    mockState.capturedSelectProps.length = 0;
+    mockState.flowContextValue.view = createView();
+    const secondEditor = await openDynamicFlowsEditor(model);
+
+    expect(secondEditor.editor.container.querySelectorAll('input[placeholder="Enter flow title"]')).toHaveLength(1);
+    expect(model.flowRegistry.getFlows().size).toBe(1);
   });
 
   it('saves draft event flows into the real registry', async () => {

--- a/packages/core/flow-engine/src/flow-registry/DetachedFlowRegistry.ts
+++ b/packages/core/flow-engine/src/flow-registry/DetachedFlowRegistry.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import _ from 'lodash';
+import { FlowDefinition } from '../FlowDefinition';
+import { FlowDefinitionOptions } from '../types';
+import { BaseFlowRegistry, IFlowRepository } from './BaseFlowRegistry';
+
+export type FlowRegistryData = Record<string, Omit<FlowDefinitionOptions, 'key'> & { key?: string }>;
+
+export class DetachedFlowRegistry extends BaseFlowRegistry {
+  constructor(flows: FlowRegistryData = {}) {
+    super();
+    this.addFlows(_.cloneDeep(flows));
+  }
+
+  saveFlow(_flow: FlowDefinition): void {}
+
+  destroyFlow(flowKey: string): void {
+    this.removeFlow(flowKey);
+  }
+}
+
+export function serializeFlowRegistry(registry: Pick<IFlowRepository, 'getFlows'>): FlowRegistryData {
+  const flows: FlowRegistryData = {};
+  for (const [key, flow] of registry.getFlows()) {
+    flows[key] = _.cloneDeep(flow.toData());
+  }
+  return flows;
+}
+
+export function replaceFlowRegistry(
+  registry: Pick<IFlowRepository, 'getFlows' | 'removeFlow' | 'addFlows'>,
+  flows: FlowRegistryData,
+) {
+  for (const key of Array.from(registry.getFlows().keys())) {
+    registry.removeFlow(key);
+  }
+  registry.addFlows(_.cloneDeep(flows));
+}

--- a/packages/core/flow-engine/src/flow-registry/__tests__/detachedFlowRegistry.test.ts
+++ b/packages/core/flow-engine/src/flow-registry/__tests__/detachedFlowRegistry.test.ts
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { DetachedFlowRegistry, replaceFlowRegistry, serializeFlowRegistry } from '../DetachedFlowRegistry';
+
+describe('DetachedFlowRegistry', () => {
+  test('keeps flow edits detached and can replace another registry', () => {
+    const source = {
+      flow1: {
+        title: 'Flow 1',
+        steps: {
+          step1: { title: 'Step 1' } as any,
+        },
+      },
+    };
+    const registry = new DetachedFlowRegistry(source);
+
+    source.flow1.title = 'Changed outside';
+    expect(registry.getFlow('flow1')?.title).toBe('Flow 1');
+
+    const flow = registry.getFlow('flow1');
+    expect(flow).toBeDefined();
+    if (!flow) {
+      throw new Error('flow1 should exist');
+    }
+    flow.title = 'Draft title';
+    const serialized = serializeFlowRegistry(registry);
+    serialized.flow1.title = 'Changed serialized';
+    expect(registry.getFlow('flow1')?.title).toBe('Draft title');
+
+    const target = new DetachedFlowRegistry({ stale: { title: 'Stale', steps: {} } });
+    replaceFlowRegistry(target, serializeFlowRegistry(registry));
+
+    expect(target.hasFlow('stale')).toBe(false);
+    expect(target.getFlow('flow1')?.title).toBe('Draft title');
+
+    target.destroyFlow('flow1');
+    expect(target.hasFlow('flow1')).toBe(false);
+  });
+});

--- a/packages/core/flow-engine/src/flow-registry/index.ts
+++ b/packages/core/flow-engine/src/flow-registry/index.ts
@@ -10,3 +10,4 @@
 export * from './BaseFlowRegistry';
 export * from './InstanceFlowRegistry';
 export * from './GlobalFlowRegistry';
+export * from './DetachedFlowRegistry';

--- a/packages/core/flow-engine/src/index.ts
+++ b/packages/core/flow-engine/src/index.ts
@@ -57,5 +57,7 @@ export {
 } from './views/viewEvents';
 
 export * from './FlowDefinition';
+export { DetachedFlowRegistry, replaceFlowRegistry, serializeFlowRegistry } from './flow-registry';
+export type { FlowRegistryData } from './flow-registry';
 export { createViewScopedEngine } from './ViewScopedFlowEngine';
 export { createBlockScopedEngine } from './BlockScopedFlowEngine';

--- a/packages/core/flow-engine/src/views/FlowView.tsx
+++ b/packages/core/flow-engine/src/views/FlowView.tsx
@@ -96,7 +96,9 @@ export class FlowViewer {
         onClose?.(...args);
         releaseZIndex();
       };
-      others.onOpenCancelled = releaseZIndex;
+      if (type === 'embed') {
+        others.onOpenCancelled = releaseZIndex;
+      }
       // embed 不能设置过高的 zIndex，会遮挡菜单的折叠按钮图表
       if (type !== 'embed') {
         others.zIndex = _zIndex ?? this.getNextZIndex();

--- a/packages/core/flow-engine/src/views/FlowView.tsx
+++ b/packages/core/flow-engine/src/views/FlowView.tsx
@@ -84,11 +84,19 @@ export class FlowViewer {
     if (this.types[type]) {
       zIndex += 1;
       const onClose = others.onClose;
+      let zIndexReleased = false;
+      const releaseZIndex = () => {
+        if (!zIndexReleased) {
+          zIndexReleased = true;
+          zIndex -= 1;
+        }
+      };
       const _zIndex = others.zIndex;
       others.onClose = (...args) => {
         onClose?.(...args);
-        zIndex -= 1;
+        releaseZIndex();
       };
+      others.onOpenCancelled = releaseZIndex;
       // embed 不能设置过高的 zIndex，会遮挡菜单的折叠按钮图表
       if (type !== 'embed') {
         others.zIndex = _zIndex ?? this.getNextZIndex();

--- a/packages/core/flow-engine/src/views/PageComponent.tsx
+++ b/packages/core/flow-engine/src/views/PageComponent.tsx
@@ -24,8 +24,10 @@ export const PageComponent = forwardRef((props: any, ref) => {
     title: _title,
     styles = {},
     zIndex = 4, // 这个默认值是为了防止表格的阴影显示到子页面上面
+    onClose,
   } = mergedProps;
   const closedRef = useRef(false);
+  const closingRef = useRef(false);
   const flowEngine = useFlowEngine();
   const [footer, setFooter] = useState(() => _footer);
   const [header, setHeader] = useState(_header);
@@ -86,10 +88,17 @@ export const PageComponent = forwardRef((props: any, ref) => {
             type="text"
             size="small"
             icon={<CloseOutlined />}
-            onClick={() => {
-              if (!closedRef.current) {
-                closedRef.current = true;
-                props.onClose?.();
+            onClick={async () => {
+              if (!closedRef.current && !closingRef.current) {
+                closingRef.current = true;
+                try {
+                  const closed = await onClose?.();
+                  if (closed !== false) {
+                    closedRef.current = true;
+                  }
+                } finally {
+                  closingRef.current = false;
+                }
               }
             }}
             style={{
@@ -111,7 +120,7 @@ export const PageComponent = forwardRef((props: any, ref) => {
         {extra && <div>{extra}</div>}
       </div>
     );
-  }, [header, _title, flowEngine.context.themeToken, styles.header, props.onClose]);
+  }, [header, _title, flowEngine.context.themeToken, styles.header, onClose]);
 
   // Footer 组件
   const FooterComponent = useMemo(() => {

--- a/packages/core/flow-engine/src/views/PageComponent.tsx
+++ b/packages/core/flow-engine/src/views/PageComponent.tsx
@@ -27,7 +27,6 @@ export const PageComponent = forwardRef((props: any, ref) => {
     onClose,
   } = mergedProps;
   const closedRef = useRef(false);
-  const closingRef = useRef(false);
   const flowEngine = useFlowEngine();
   const [footer, setFooter] = useState(() => _footer);
   const [header, setHeader] = useState(_header);
@@ -89,15 +88,10 @@ export const PageComponent = forwardRef((props: any, ref) => {
             size="small"
             icon={<CloseOutlined />}
             onClick={async () => {
-              if (!closedRef.current && !closingRef.current) {
-                closingRef.current = true;
-                try {
-                  const closed = await onClose?.();
-                  if (closed !== false) {
-                    closedRef.current = true;
-                  }
-                } finally {
-                  closingRef.current = false;
+              if (!closedRef.current) {
+                const closed = await onClose?.();
+                if (closed !== false) {
+                  closedRef.current = true;
                 }
               }
             }}

--- a/packages/core/flow-engine/src/views/__tests__/FlowView.usePage.test.tsx
+++ b/packages/core/flow-engine/src/views/__tests__/FlowView.usePage.test.tsx
@@ -185,6 +185,57 @@ describe('FlowViewer zIndex with usePage', () => {
     document.body.removeChild(target);
   });
 
+  it('keeps active global embed view when replacement beforeClose blocks closing', async () => {
+    let getViewer: () => FlowViewer;
+    const beforeClose = vi.fn().mockResolvedValue(false);
+
+    const target = document.createElement('div');
+    target.id = GLOBAL_EMBED_CONTAINER_ID;
+    document.body.appendChild(target);
+
+    const { unmount } = render(
+      <Wrapper
+        onReady={(fn) => {
+          getViewer = fn;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getViewer).toBeDefined());
+    const initialZIndex = getViewer().getNextZIndex();
+
+    let page1: any;
+    await act(async () => {
+      page1 = getViewer().embed({
+        target,
+        content: (currentPage) => {
+          currentPage.beforeClose = beforeClose;
+          return <div data-testid="page1">Page 1</div>;
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('page1')).toBeInTheDocument());
+    expect(getViewer().getNextZIndex()).toBe(initialZIndex + 1);
+
+    await act(async () => {
+      const page2 = getViewer().embed({ target, content: <div data-testid="page2">Page 2</div> });
+      await page2;
+    });
+
+    expect(beforeClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('page1')).toBeInTheDocument();
+    expect(screen.queryByTestId('page2')).not.toBeInTheDocument();
+    expect(getViewer().getNextZIndex()).toBe(initialZIndex + 1);
+
+    await act(async () => {
+      page1.destroy();
+    });
+
+    unmount();
+    document.body.removeChild(target);
+  });
+
   it('keeps the embed close button usable after beforeClose blocks closing', async () => {
     let getViewer: () => FlowViewer;
     const beforeClose = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);

--- a/packages/core/flow-engine/src/views/__tests__/FlowView.usePage.test.tsx
+++ b/packages/core/flow-engine/src/views/__tests__/FlowView.usePage.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { render, act, waitFor, screen } from '@testing-library/react';
 import { FlowEngine } from '../../flowEngine';
 import { FlowEngineProvider } from '../../provider';
@@ -167,20 +167,65 @@ describe('FlowViewer zIndex with usePage', () => {
     );
 
     await waitFor(() => expect(api).toBeDefined());
+    const pageApi = api as NonNullable<typeof api>;
 
     await act(async () => {
-      api!.open({ target, content: <div data-testid="page1">Page 1</div> }, engine.context);
+      pageApi.open({ target, content: <div data-testid="page1">Page 1</div> }, engine.context);
     });
     await waitFor(() => expect(screen.getByTestId('page1')).toBeInTheDocument());
 
     // Opening page2 into the global embed container should destroy page1 (replace behavior).
     await act(async () => {
-      api!.open({ target, content: <div data-testid="page2">Page 2</div> }, engine.context);
+      pageApi.open({ target, content: <div data-testid="page2">Page 2</div> }, engine.context);
     });
     await waitFor(() => expect(screen.getByTestId('page2')).toBeInTheDocument());
     expect(screen.queryByTestId('page1')).not.toBeInTheDocument();
 
     unmount();
     document.body.removeChild(target);
+  });
+
+  it('keeps the embed close button usable after beforeClose blocks closing', async () => {
+    let getViewer: () => FlowViewer;
+    const beforeClose = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const { unmount } = render(
+      <Wrapper
+        onReady={(fn) => {
+          getViewer = fn;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getViewer).toBeDefined());
+
+    await act(async () => {
+      getViewer().embed({
+        title: 'Draft editor',
+        content: (currentPage) => {
+          currentPage.beforeClose = beforeClose;
+          return <div data-testid="draft-editor">Draft editor</div>;
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('draft-editor')).toBeInTheDocument());
+    const closeButton = screen.getByRole('button');
+
+    await act(async () => {
+      closeButton.click();
+    });
+
+    expect(beforeClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('draft-editor')).toBeInTheDocument();
+
+    await act(async () => {
+      closeButton.click();
+    });
+
+    expect(beforeClose).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(screen.queryByTestId('draft-editor')).not.toBeInTheDocument());
+
+    unmount();
   });
 });

--- a/packages/core/flow-engine/src/views/__tests__/FlowView.usePage.test.tsx
+++ b/packages/core/flow-engine/src/views/__tests__/FlowView.usePage.test.tsx
@@ -236,6 +236,150 @@ describe('FlowViewer zIndex with usePage', () => {
     document.body.removeChild(target);
   });
 
+  it('opens the replacement view after async beforeClose allows global embed replacement', async () => {
+    let getViewer: () => FlowViewer;
+    const beforeClose = vi.fn().mockResolvedValue(true);
+
+    const target = document.createElement('div');
+    target.id = GLOBAL_EMBED_CONTAINER_ID;
+    document.body.appendChild(target);
+
+    const { unmount } = render(
+      <Wrapper
+        onReady={(fn) => {
+          getViewer = fn;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getViewer).toBeDefined());
+
+    await act(async () => {
+      getViewer().embed({
+        target,
+        content: (currentPage) => {
+          currentPage.beforeClose = beforeClose;
+          return <div data-testid="page1">Page 1</div>;
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('page1')).toBeInTheDocument());
+
+    await act(async () => {
+      getViewer().embed({ target, content: <div data-testid="page2">Page 2</div> });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('page2')).toBeInTheDocument());
+    expect(beforeClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('page1')).not.toBeInTheDocument();
+
+    unmount();
+    document.body.removeChild(target);
+  });
+
+  it('runs a pending close only once and allows retry when beforeClose rejects', async () => {
+    let getViewer: () => FlowViewer;
+    let resolveFirstClose: (value: boolean) => void;
+    const beforeClose = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<boolean>((resolve) => (resolveFirstClose = resolve)))
+      .mockResolvedValueOnce(true);
+
+    const { unmount } = render(
+      <Wrapper
+        onReady={(fn) => {
+          getViewer = fn;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getViewer).toBeDefined());
+
+    let page: any;
+    await act(async () => {
+      page = getViewer().embed({
+        content: (currentPage) => {
+          currentPage.beforeClose = beforeClose;
+          return <div data-testid="draft-editor">Draft editor</div>;
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('draft-editor')).toBeInTheDocument());
+
+    const firstClose = page.close();
+    const secondClose = page.close();
+    expect(firstClose).toBe(secondClose);
+    expect(beforeClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstClose(false);
+      await firstClose;
+    });
+
+    expect(screen.getByTestId('draft-editor')).toBeInTheDocument();
+
+    await act(async () => {
+      await page.close();
+    });
+
+    expect(beforeClose).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(screen.queryByTestId('draft-editor')).not.toBeInTheDocument());
+
+    unmount();
+  });
+
+  it('keeps only the latest pending global embed replacement', async () => {
+    let getViewer: () => FlowViewer;
+    let resolveBeforeClose: (value: boolean) => void;
+    const beforeClose = vi.fn(() => new Promise<boolean>((resolve) => (resolveBeforeClose = resolve)));
+
+    const target = document.createElement('div');
+    target.id = GLOBAL_EMBED_CONTAINER_ID;
+    document.body.appendChild(target);
+
+    const { unmount } = render(
+      <Wrapper
+        onReady={(fn) => {
+          getViewer = fn;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getViewer).toBeDefined());
+    const initialZIndex = getViewer().getNextZIndex();
+
+    await act(async () => {
+      getViewer().embed({
+        target,
+        content: (currentPage) => {
+          currentPage.beforeClose = beforeClose;
+          return <div data-testid="page1">Page 1</div>;
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('page1')).toBeInTheDocument());
+
+    const page2 = getViewer().embed({ target, content: <div data-testid="page2">Page 2</div> });
+    const page3 = getViewer().embed({ target, content: <div data-testid="page3">Page 3</div> });
+
+    await act(async () => {
+      resolveBeforeClose(true);
+      await page2;
+    });
+
+    expect(beforeClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('page1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('page2')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('page3')).toBeInTheDocument());
+    expect(getViewer().getNextZIndex()).toBe(initialZIndex + 1);
+
+    unmount();
+    document.body.removeChild(target);
+  });
+
   it('keeps the embed close button usable after beforeClose blocks closing', async () => {
     let getViewer: () => FlowViewer;
     const beforeClose = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);

--- a/packages/core/flow-engine/src/views/usePage.tsx
+++ b/packages/core/flow-engine/src/views/usePage.tsx
@@ -219,7 +219,7 @@ export function usePage() {
             hidden={config.inputArgs?.hidden?.value}
             {...restConfig}
             onClose={() => {
-              currentPage.close(config.result);
+              return currentPage.close(config.result);
             }}
           >
             {pageContent}

--- a/packages/core/flow-engine/src/views/usePage.tsx
+++ b/packages/core/flow-engine/src/views/usePage.tsx
@@ -33,6 +33,14 @@ type GlobalEmbedActiveView = {
   destroy: (result?: any) => void;
 };
 
+type PendingGlobalEmbedActions = {
+  beforeClose?: any;
+  destroyed?: { result?: any };
+  update?: any;
+  footer?: React.ReactNode;
+  header?: { title?: React.ReactNode; extra?: React.ReactNode };
+};
+
 function isPromiseLike<T = any>(value: unknown): value is PromiseLike<T> {
   return !!value && typeof (value as PromiseLike<T>).then === 'function';
 }
@@ -60,12 +68,26 @@ function createPendingGlobalEmbedView(
   preventClose: boolean,
 ) {
   let openedPage: any;
-  let pendingBeforeClose: any;
+  const pendingActions: PendingGlobalEmbedActions = {};
 
   const readyPromise = openedPromise.then(({ page }) => {
     openedPage = page;
-    if (openedPage && pendingBeforeClose) {
-      openedPage.beforeClose = pendingBeforeClose;
+    if (openedPage) {
+      if ('beforeClose' in pendingActions) {
+        openedPage.beforeClose = pendingActions.beforeClose;
+      }
+      if ('update' in pendingActions) {
+        openedPage.update(pendingActions.update);
+      }
+      if ('footer' in pendingActions) {
+        openedPage.setFooter(pendingActions.footer);
+      }
+      if ('header' in pendingActions) {
+        openedPage.setHeader(pendingActions.header);
+      }
+      if (pendingActions.destroyed) {
+        openedPage.destroy(pendingActions.destroyed.result);
+      }
     }
     return { page };
   });
@@ -79,28 +101,44 @@ function createPendingGlobalEmbedView(
       Header: null,
       Footer: null,
       get beforeClose() {
-        return openedPage?.beforeClose ?? pendingBeforeClose;
+        return openedPage?.beforeClose ?? pendingActions.beforeClose;
       },
       set beforeClose(value) {
         if (openedPage) {
           openedPage.beforeClose = value;
         } else {
-          pendingBeforeClose = value;
+          pendingActions.beforeClose = value;
         }
       },
       close: (result?: any, force?: boolean) =>
         readyPromise.then(({ page }) => (page ? page.close(result, force) : false)),
       destroy: (result?: any) => {
-        openedPage?.destroy(result);
+        if (openedPage) {
+          openedPage.destroy(result);
+        } else {
+          pendingActions.destroyed = { result };
+        }
       },
       update: (newConfig: any) => {
-        openedPage?.update(newConfig);
+        if (openedPage) {
+          openedPage.update(newConfig);
+        } else {
+          pendingActions.update = { ...pendingActions.update, ...newConfig };
+        }
       },
       setFooter: (footer: React.ReactNode) => {
-        openedPage?.setFooter(footer);
+        if (openedPage) {
+          openedPage.setFooter(footer);
+        } else {
+          pendingActions.footer = footer;
+        }
       },
       setHeader: (header: { title?: React.ReactNode; extra?: React.ReactNode }) => {
-        openedPage?.setHeader(header);
+        if (openedPage) {
+          openedPage.setHeader(header);
+        } else {
+          pendingActions.header = header;
+        }
       },
     },
   );
@@ -118,6 +156,7 @@ const PageElementsHolder = React.memo(
 export function usePage() {
   const holderRef = React.useRef(null);
   const globalEmbedActiveRef = React.useRef<null | GlobalEmbedActiveView>(null);
+  const globalEmbedReplacementTokenRef = React.useRef(0);
 
   const open = (config, flowContext) => {
     const {
@@ -126,6 +165,7 @@ export function usePage() {
       preventClose,
       inheritContext = true,
       inputArgs: viewInputArgs = {},
+      onOpenCancelled,
       ...restConfig
     } = config;
     const isGlobalEmbedContainer = target instanceof HTMLElement && target.id === GLOBAL_EMBED_CONTAINER_ID;
@@ -186,12 +226,16 @@ export function usePage() {
       }
 
       // 构造 currentPage 实例
+      let destroyed = false;
+      let closingPromise: Promise<boolean | void> | undefined;
       const currentPage = {
         type: 'embed' as const,
         inputArgs: viewInputArgs,
         preventClose: !!config.preventClose,
         beforeClose: undefined,
         destroy: (result?: any) => {
+          if (destroyed) return;
+          destroyed = true;
           config.onClose?.();
           resolvePromise?.(result);
           pageRef.current?.destroy();
@@ -216,24 +260,47 @@ export function usePage() {
           scopedEngine.unlinkFromStack();
         },
         update: (newConfig) => pageRef.current?.update(newConfig),
-        close: async (result?: any, force?: boolean) => {
-          if (preventClose && !force) {
-            return false;
+        close: (result?: any, force?: boolean) => {
+          if (destroyed) {
+            return Promise.resolve(true);
+          }
+          if (closingPromise) {
+            return closingPromise;
           }
 
-          const shouldClose = await runViewBeforeClose(currentPage, { result, force });
-          if (!shouldClose) {
-            return false;
-          }
+          closingPromise = (async () => {
+            try {
+              if (preventClose && !force) {
+                closingPromise = undefined;
+                return false;
+              }
 
-          if (config.triggerByRouter && config.inputArgs?.navigation?.back) {
-            // 交由路由系统来销毁当前视图
-            config.inputArgs.navigation.back();
-            return true;
-          }
+              const shouldClose = await runViewBeforeClose(currentPage, { result, force });
+              if (destroyed) {
+                return true;
+              }
+              if (!shouldClose) {
+                closingPromise = undefined;
+                return false;
+              }
 
-          currentPage.destroy(result);
-          return true;
+              if (config.triggerByRouter && config.inputArgs?.navigation?.back) {
+                // 交由路由系统来销毁当前视图
+                config.inputArgs.navigation.back();
+                return true;
+              }
+
+              currentPage.destroy(result);
+              return true;
+            } catch (error) {
+              if (!destroyed) {
+                closingPromise = undefined;
+              }
+              throw error;
+            }
+          })();
+
+          return closingPromise;
         },
         Header: HeaderComponent,
         Footer: FooterComponent,
@@ -324,11 +391,13 @@ export function usePage() {
 
     // Global embed container uses "replace" behavior. The previous view still owns beforeClose.
     if (isGlobalEmbedContainer && globalEmbedActiveRef.current) {
+      const replacementToken = (globalEmbedReplacementTokenRef.current += 1);
+      const cancelOpen = () => onOpenCancelled?.();
       let closeResult: Promise<boolean | void> | boolean | void;
       try {
         closeResult = closeReplacingGlobalEmbed(target, globalEmbedActiveRef.current);
       } catch (error) {
-        config.onOpenCancelled?.();
+        cancelOpen();
         throw error;
       }
 
@@ -336,14 +405,14 @@ export function usePage() {
         return createPendingGlobalEmbedView(
           Promise.resolve(closeResult).then(
             (closed) => {
-              if (closed === false) {
-                config.onOpenCancelled?.();
+              if (closed === false || replacementToken !== globalEmbedReplacementTokenRef.current) {
+                cancelOpen();
                 return { page: null };
               }
               return { page: openCurrentPage() };
             },
             (error) => {
-              config.onOpenCancelled?.();
+              cancelOpen();
               throw error;
             },
           ),
@@ -353,7 +422,7 @@ export function usePage() {
       }
 
       if (closeResult === false) {
-        config.onOpenCancelled?.();
+        cancelOpen();
         return createPendingGlobalEmbedView(Promise.resolve({ page: null }), viewInputArgs, !!config.preventClose);
       }
     }

--- a/packages/core/flow-engine/src/views/usePage.tsx
+++ b/packages/core/flow-engine/src/views/usePage.tsx
@@ -28,6 +28,84 @@ export const GLOBAL_EMBED_CONTAINER_ID = 'nocobase-embed-container';
 /** Dataset key used to signal embed replacement in progress (skip style reset on close) */
 export const EMBED_REPLACING_DATA_KEY = 'nocobaseEmbedReplacing';
 
+type GlobalEmbedActiveView = {
+  close: (result?: any, force?: boolean) => Promise<boolean | void> | boolean | void;
+  destroy: (result?: any) => void;
+};
+
+function isPromiseLike<T = any>(value: unknown): value is PromiseLike<T> {
+  return !!value && typeof (value as PromiseLike<T>).then === 'function';
+}
+
+function closeReplacingGlobalEmbed(target: HTMLElement, activeView: GlobalEmbedActiveView) {
+  target.dataset[EMBED_REPLACING_DATA_KEY] = '1';
+  try {
+    const closeResult = activeView.close();
+    if (isPromiseLike(closeResult)) {
+      return Promise.resolve(closeResult).finally(() => {
+        delete target.dataset[EMBED_REPLACING_DATA_KEY];
+      });
+    }
+    delete target.dataset[EMBED_REPLACING_DATA_KEY];
+    return closeResult;
+  } catch (error) {
+    delete target.dataset[EMBED_REPLACING_DATA_KEY];
+    throw error;
+  }
+}
+
+function createPendingGlobalEmbedView(
+  openedPromise: Promise<{ page: any | null }>,
+  inputArgs: any,
+  preventClose: boolean,
+) {
+  let openedPage: any;
+  let pendingBeforeClose: any;
+
+  const readyPromise = openedPromise.then(({ page }) => {
+    openedPage = page;
+    if (openedPage && pendingBeforeClose) {
+      openedPage.beforeClose = pendingBeforeClose;
+    }
+    return { page };
+  });
+
+  return Object.assign(
+    readyPromise.then(({ page }) => (page ? page : false)),
+    {
+      type: 'embed' as const,
+      inputArgs,
+      preventClose,
+      Header: null,
+      Footer: null,
+      get beforeClose() {
+        return openedPage?.beforeClose ?? pendingBeforeClose;
+      },
+      set beforeClose(value) {
+        if (openedPage) {
+          openedPage.beforeClose = value;
+        } else {
+          pendingBeforeClose = value;
+        }
+      },
+      close: (result?: any, force?: boolean) =>
+        readyPromise.then(({ page }) => (page ? page.close(result, force) : false)),
+      destroy: (result?: any) => {
+        openedPage?.destroy(result);
+      },
+      update: (newConfig: any) => {
+        openedPage?.update(newConfig);
+      },
+      setFooter: (footer: React.ReactNode) => {
+        openedPage?.setFooter(footer);
+      },
+      setHeader: (header: { title?: React.ReactNode; extra?: React.ReactNode }) => {
+        openedPage?.setHeader(header);
+      },
+    },
+  );
+}
+
 // 稳定的 Holder 组件，避免在父组件重渲染时更换组件类型导致卸载， 否则切换主题时会丢失所有页面内容
 const PageElementsHolder = React.memo(
   React.forwardRef((props: any, ref: any) => {
@@ -39,50 +117,9 @@ const PageElementsHolder = React.memo(
 
 export function usePage() {
   const holderRef = React.useRef(null);
-  const globalEmbedActiveRef = React.useRef<null | { destroy: () => void }>(null);
+  const globalEmbedActiveRef = React.useRef<null | GlobalEmbedActiveView>(null);
 
   const open = (config, flowContext) => {
-    const parentEngine = flowContext?.engine;
-    uuid += 1;
-    const pageRef = React.createRef<{
-      destroy: () => void;
-      update: (config: any) => void;
-      setFooter: (footer: React.ReactNode) => void;
-      setHeader: (header: { title?: React.ReactNode; extra?: React.ReactNode }) => void;
-    }>();
-
-    let closeFunc: (() => void) | undefined;
-    let resolvePromise: (value?: any) => void;
-    const promise = new Promise((resolve) => {
-      resolvePromise = resolve;
-    });
-
-    // Footer 组件实现
-    const FooterComponent: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-      React.useEffect(() => {
-        pageRef.current?.setFooter(children);
-
-        return () => {
-          pageRef.current?.setFooter(null);
-        };
-      }, [children]);
-
-      return null; // Footer 组件本身不渲染内容
-    };
-
-    // Header 组件实现
-    const HeaderComponent: React.FC<{ title?: React.ReactNode; extra?: React.ReactNode }> = (props) => {
-      React.useEffect(() => {
-        pageRef.current?.setHeader(props);
-
-        return () => {
-          pageRef.current?.setHeader(null);
-        };
-      }, [props]);
-
-      return null; // Header 组件本身不渲染内容
-    };
-
     const {
       target,
       content,
@@ -93,164 +130,235 @@ export function usePage() {
     } = config;
     const isGlobalEmbedContainer = target instanceof HTMLElement && target.id === GLOBAL_EMBED_CONTAINER_ID;
 
-    // Global embed container uses "replace" behavior: opening a new view destroys the previous one.
+    const openCurrentPage = () => {
+      const parentEngine = flowContext?.engine;
+      uuid += 1;
+      const pageRef = React.createRef<{
+        destroy: () => void;
+        update: (config: any) => void;
+        setFooter: (footer: React.ReactNode) => void;
+        setHeader: (header: { title?: React.ReactNode; extra?: React.ReactNode }) => void;
+      }>();
+
+      let closeFunc: (() => void) | undefined;
+      let resolvePromise: (value?: any) => void;
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      // Footer 组件实现
+      const FooterComponent: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+        React.useEffect(() => {
+          pageRef.current?.setFooter(children);
+
+          return () => {
+            pageRef.current?.setFooter(null);
+          };
+        }, [children]);
+
+        return null; // Footer 组件本身不渲染内容
+      };
+
+      // Header 组件实现
+      const HeaderComponent: React.FC<{ title?: React.ReactNode; extra?: React.ReactNode }> = (props) => {
+        React.useEffect(() => {
+          pageRef.current?.setHeader(props);
+
+          return () => {
+            pageRef.current?.setHeader(null);
+          };
+        }, [props]);
+
+        return null; // Header 组件本身不渲染内容
+      };
+
+      const ctx = new FlowContext();
+      // 为当前视图创建作用域引擎（隔离实例与缓存）
+      const scopedEngine = createViewScopedEngine(flowContext.engine);
+      const openerEngine = resolveOpenerEngine(parentEngine, scopedEngine);
+
+      ctx.defineProperty('engine', { value: scopedEngine });
+      ctx.addDelegate(scopedEngine.context);
+      if (inheritContext) {
+        ctx.addDelegate(flowContext);
+      } else {
+        ctx.addDelegate(flowContext.engine.context);
+      }
+
+      // 构造 currentPage 实例
+      const currentPage = {
+        type: 'embed' as const,
+        inputArgs: viewInputArgs,
+        preventClose: !!config.preventClose,
+        beforeClose: undefined,
+        destroy: (result?: any) => {
+          config.onClose?.();
+          resolvePromise?.(result);
+          pageRef.current?.destroy();
+          closeFunc?.();
+
+          if (isGlobalEmbedContainer && globalEmbedActiveRef.current === currentPage) {
+            globalEmbedActiveRef.current = null;
+          }
+
+          // Notify opener view that it becomes active again.
+          const isReplacing =
+            isGlobalEmbedContainer &&
+            target instanceof HTMLElement &&
+            target.dataset?.[EMBED_REPLACING_DATA_KEY] === '1';
+          if (!isReplacing) {
+            const openerEmitter = openerEngine?.emitter;
+            bumpViewActivatedVersion(openerEmitter);
+            openerEmitter?.emit?.(VIEW_ACTIVATED_EVENT, { type: 'embed', viewUid: currentPage?.inputArgs?.viewUid });
+          }
+
+          // 关闭时修正 previous/next 指针
+          scopedEngine.unlinkFromStack();
+        },
+        update: (newConfig) => pageRef.current?.update(newConfig),
+        close: async (result?: any, force?: boolean) => {
+          if (preventClose && !force) {
+            return false;
+          }
+
+          const shouldClose = await runViewBeforeClose(currentPage, { result, force });
+          if (!shouldClose) {
+            return false;
+          }
+
+          if (config.triggerByRouter && config.inputArgs?.navigation?.back) {
+            // 交由路由系统来销毁当前视图
+            config.inputArgs.navigation.back();
+            return true;
+          }
+
+          currentPage.destroy(result);
+          return true;
+        },
+        Header: HeaderComponent,
+        Footer: FooterComponent,
+        setFooter: (footer: React.ReactNode) => {
+          pageRef.current?.setFooter(footer);
+        },
+        setHeader: (header: { title?: React.ReactNode; extra?: React.ReactNode }) => {
+          pageRef.current?.setHeader(header);
+        },
+        navigation: config.inputArgs?.navigation,
+        get record() {
+          // 当视图正在查看与父 record 同一条记录时，复用父记录深拷贝；否则走服务端解析
+          return getViewRecordFromParent(flowContext, ctx);
+        },
+      };
+
+      ctx.defineProperty('view', {
+        get: () => currentPage,
+        // 仅当访问关联字段或前端无本地记录数据时，才交给服务端解析
+        resolveOnServer: createViewRecordResolveOnServer(ctx, () => getViewRecordFromParent(flowContext, ctx)),
+      });
+      // embed 视图不注册 destroyView，afterSuccess 关闭弹窗时自然跳过
+      // 顶层 popup 变量：弹窗记录/数据源/上级弹窗链（去重封装）
+      registerPopupVariable(ctx, currentPage);
+
+      const PageWithContext = observer(
+        () => {
+          // eslint-disable-next-line react-hooks/rules-of-hooks
+          const mountedRef = React.useRef(false);
+          // 支持 content 为函数，传递 currentPage
+          // eslint-disable-next-line react-hooks/rules-of-hooks
+          const pageContent = React.useMemo(
+            () => (typeof content === 'function' ? content(currentPage, ctx) : content),
+            [],
+          );
+          // 响应themeToken的响应式更新
+          void ctx.themeToken;
+          // eslint-disable-next-line react-hooks/rules-of-hooks
+          React.useEffect(() => {
+            config.onOpen?.(currentPage, ctx);
+          }, []);
+
+          if (config.inputArgs?.hidden?.value && !mountedRef.current) {
+            return null;
+          }
+
+          mountedRef.current = true;
+
+          return (
+            <PageComponent
+              ref={pageRef}
+              hidden={config.inputArgs?.hidden?.value}
+              {...restConfig}
+              onClose={() => {
+                return currentPage.close(config.result);
+              }}
+            >
+              {pageContent}
+            </PageComponent>
+          );
+        },
+        {
+          displayName: 'PageWithContext',
+        },
+      );
+
+      const key = viewInputArgs?.viewUid || `page-${uuid}`;
+      const page = (
+        <FlowEngineProvider key={key} engine={scopedEngine}>
+          <FlowViewContextProvider context={ctx}>
+            <PageWithContext />
+          </FlowViewContextProvider>
+        </FlowEngineProvider>
+      );
+
+      if (target && target instanceof HTMLElement) {
+        closeFunc = holderRef.current?.patchElement(ReactDOM.createPortal(page, target, key));
+      } else {
+        closeFunc = holderRef.current?.patchElement(page);
+      }
+
+      if (isGlobalEmbedContainer) {
+        globalEmbedActiveRef.current = currentPage;
+      }
+
+      return Object.assign(promise, currentPage);
+    };
+
+    // Global embed container uses "replace" behavior. The previous view still owns beforeClose.
     if (isGlobalEmbedContainer && globalEmbedActiveRef.current) {
+      let closeResult: Promise<boolean | void> | boolean | void;
       try {
-        // Avoid style "reset flicker" when replacing: tell embed wrappers to skip resetting container styles.
-        target.dataset[EMBED_REPLACING_DATA_KEY] = '1';
-        globalEmbedActiveRef.current.destroy();
-      } finally {
-        delete target.dataset[EMBED_REPLACING_DATA_KEY];
-        globalEmbedActiveRef.current = null;
+        closeResult = closeReplacingGlobalEmbed(target, globalEmbedActiveRef.current);
+      } catch (error) {
+        config.onOpenCancelled?.();
+        throw error;
+      }
+
+      if (isPromiseLike(closeResult)) {
+        return createPendingGlobalEmbedView(
+          Promise.resolve(closeResult).then(
+            (closed) => {
+              if (closed === false) {
+                config.onOpenCancelled?.();
+                return { page: null };
+              }
+              return { page: openCurrentPage() };
+            },
+            (error) => {
+              config.onOpenCancelled?.();
+              throw error;
+            },
+          ),
+          viewInputArgs,
+          !!config.preventClose,
+        );
+      }
+
+      if (closeResult === false) {
+        config.onOpenCancelled?.();
+        return createPendingGlobalEmbedView(Promise.resolve({ page: null }), viewInputArgs, !!config.preventClose);
       }
     }
 
-    const ctx = new FlowContext();
-    // 为当前视图创建作用域引擎（隔离实例与缓存）
-    const scopedEngine = createViewScopedEngine(flowContext.engine);
-    const openerEngine = resolveOpenerEngine(parentEngine, scopedEngine);
-
-    ctx.defineProperty('engine', { value: scopedEngine });
-    ctx.addDelegate(scopedEngine.context);
-    if (inheritContext) {
-      ctx.addDelegate(flowContext);
-    } else {
-      ctx.addDelegate(flowContext.engine.context);
-    }
-
-    // 构造 currentPage 实例
-    const currentPage = {
-      type: 'embed' as const,
-      inputArgs: viewInputArgs,
-      preventClose: !!config.preventClose,
-      beforeClose: undefined,
-      destroy: (result?: any) => {
-        config.onClose?.();
-        resolvePromise?.(result);
-        pageRef.current?.destroy();
-        closeFunc?.();
-
-        if (isGlobalEmbedContainer) {
-          globalEmbedActiveRef.current = null;
-        }
-
-        // Notify opener view that it becomes active again.
-        const isReplacing =
-          isGlobalEmbedContainer && target instanceof HTMLElement && target.dataset?.[EMBED_REPLACING_DATA_KEY] === '1';
-        if (!isReplacing) {
-          const openerEmitter = openerEngine?.emitter;
-          bumpViewActivatedVersion(openerEmitter);
-          openerEmitter?.emit?.(VIEW_ACTIVATED_EVENT, { type: 'embed', viewUid: currentPage?.inputArgs?.viewUid });
-        }
-
-        // 关闭时修正 previous/next 指针
-        scopedEngine.unlinkFromStack();
-      },
-      update: (newConfig) => pageRef.current?.update(newConfig),
-      close: async (result?: any, force?: boolean) => {
-        if (preventClose && !force) {
-          return false;
-        }
-
-        const shouldClose = await runViewBeforeClose(currentPage, { result, force });
-        if (!shouldClose) {
-          return false;
-        }
-
-        if (config.triggerByRouter && config.inputArgs?.navigation?.back) {
-          // 交由路由系统来销毁当前视图
-          config.inputArgs.navigation.back();
-          return true;
-        }
-
-        currentPage.destroy(result);
-        return true;
-      },
-      Header: HeaderComponent,
-      Footer: FooterComponent,
-      setFooter: (footer: React.ReactNode) => {
-        pageRef.current?.setFooter(footer);
-      },
-      setHeader: (header: { title?: React.ReactNode; extra?: React.ReactNode }) => {
-        pageRef.current?.setHeader(header);
-      },
-      navigation: config.inputArgs?.navigation,
-      get record() {
-        // 当视图正在查看与父 record 同一条记录时，复用父记录深拷贝；否则走服务端解析
-        return getViewRecordFromParent(flowContext, ctx);
-      },
-    };
-
-    ctx.defineProperty('view', {
-      get: () => currentPage,
-      // 仅当访问关联字段或前端无本地记录数据时，才交给服务端解析
-      resolveOnServer: createViewRecordResolveOnServer(ctx, () => getViewRecordFromParent(flowContext, ctx)),
-    });
-    // embed 视图不注册 destroyView，afterSuccess 关闭弹窗时自然跳过
-    // 顶层 popup 变量：弹窗记录/数据源/上级弹窗链（去重封装）
-    registerPopupVariable(ctx, currentPage);
-
-    const PageWithContext = observer(
-      () => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const mountedRef = React.useRef(false);
-        // 支持 content 为函数，传递 currentPage
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const pageContent = React.useMemo(
-          () => (typeof content === 'function' ? content(currentPage, ctx) : content),
-          [],
-        );
-        // 响应themeToken的响应式更新
-        void ctx.themeToken;
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        React.useEffect(() => {
-          config.onOpen?.(currentPage, ctx);
-        }, []);
-
-        if (config.inputArgs?.hidden?.value && !mountedRef.current) {
-          return null;
-        }
-
-        mountedRef.current = true;
-
-        return (
-          <PageComponent
-            ref={pageRef}
-            hidden={config.inputArgs?.hidden?.value}
-            {...restConfig}
-            onClose={() => {
-              return currentPage.close(config.result);
-            }}
-          >
-            {pageContent}
-          </PageComponent>
-        );
-      },
-      {
-        displayName: 'PageWithContext',
-      },
-    );
-
-    const key = viewInputArgs?.viewUid || `page-${uuid}`;
-    const page = (
-      <FlowEngineProvider key={key} engine={scopedEngine}>
-        <FlowViewContextProvider context={ctx}>
-          <PageWithContext />
-        </FlowViewContextProvider>
-      </FlowEngineProvider>
-    );
-
-    if (target && target instanceof HTMLElement) {
-      closeFunc = holderRef.current?.patchElement(ReactDOM.createPortal(page, target, key));
-    } else {
-      closeFunc = holderRef.current?.patchElement(page);
-    }
-
-    if (isGlobalEmbedContainer) {
-      globalEmbedActiveRef.current = { destroy: currentPage.destroy };
-    }
-
-    return Object.assign(promise, currentPage);
+    return openCurrentPage();
   };
 
   const api = React.useMemo(() => ({ open }), []);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added an unsaved changes confirm message when closing the event flow configuration page with unsaved data present. |
| 🇨🇳 Chinese | 关闭事件流配置页面时如果存在未保存的数据则显示未保存的提示信息。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
