### PR TITLE
fix: restore sub-table display-only relation fields

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/pattern.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/pattern.test.ts
@@ -187,4 +187,138 @@ describe('pattern action', () => {
 
     getDisplayBindingSpy.mockRestore();
   });
+
+  it('falls back to the target collection title field for association display only mode', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+    });
+
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'form-item-association',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'field-association',
+          props: {},
+        },
+      },
+    });
+    const collectionField = {
+      targetCollectionTitleFieldName: 'name',
+      isAssociationField: () => true,
+    };
+    parent.collectionField = collectionField;
+
+    await pattern.beforeParamsSave?.(
+      {
+        model: parent,
+        collectionField,
+      } as any,
+      { pattern: 'readPretty' },
+      { pattern: 'editable' },
+    );
+
+    expect(parent.props).toMatchObject({
+      pattern: 'readPretty',
+      disabled: false,
+      titleField: 'name',
+    });
+    expect(parent.getStepParams('editItemSettings', 'titleField')).toEqual({
+      titleField: 'name',
+    });
+  });
+
+  it('passes the association title field to the rebuilt display field model', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+      DummyDisplayFieldModel,
+    });
+
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'form-item-association-rebuild',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'field-association-rebuild',
+          props: {},
+        },
+      },
+    });
+    const targetTitleField = { name: 'name' };
+    const collectionField = {
+      targetCollectionTitleFieldName: 'name',
+      targetCollection: {
+        getField: vi.fn(() => targetTitleField),
+      },
+      isAssociationField: () => true,
+    };
+    parent.collectionField = collectionField;
+    const getDisplayBindingSpy = vi.spyOn(DetailsItemModel, 'getDefaultBindingByField').mockReturnValue({
+      modelName: 'DummyDisplayFieldModel',
+      defaultProps: { display: true },
+    } as any);
+
+    await pattern.afterParamsSave?.(
+      {
+        model: parent,
+        collectionField,
+        engine,
+      } as any,
+      { pattern: 'readPretty' },
+      { pattern: 'editable' },
+    );
+
+    expect(parent.subModels.field).toBeInstanceOf(DummyDisplayFieldModel);
+    expect(parent.subModels.field?.props).toMatchObject({
+      display: true,
+      titleField: 'name',
+    });
+
+    getDisplayBindingSpy.mockRestore();
+  });
+
+  it('refreshes the parent model after leaving display only mode', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      DummyFormItemModel,
+      FieldModel,
+      DummyDisplayFieldModel,
+    });
+
+    const host = engine.createModel<FlowModel>({
+      use: FlowModel,
+      uid: 'sub-table-host',
+    });
+    const parent = engine.createModel<DummyFormItemModel>({
+      use: DummyFormItemModel,
+      uid: 'sub-table-column',
+      subModels: {
+        field: {
+          use: FieldModel,
+          uid: 'sub-table-column-field',
+          stepParams: {
+            fieldBinding: {
+              use: 'DummyDisplayFieldModel',
+            },
+          },
+        },
+      },
+    });
+    parent.setParent(host);
+    const hostSetPropsSpy = vi.spyOn(host, 'setProps');
+
+    await pattern.afterParamsSave?.(makeCtx(parent), { pattern: 'editable' }, { pattern: 'readPretty' });
+
+    expect(parent.subModels.field).toBeInstanceOf(FieldModel);
+    expect(parent.subModels.field?.uid).toBe('sub-table-column-field');
+    expect(hostSetPropsSpy).toHaveBeenCalledWith({
+      __patternRefreshKey: expect.any(String),
+    });
+  });
 });

--- a/packages/core/client/src/flow/actions/pattern.tsx
+++ b/packages/core/client/src/flow/actions/pattern.tsx
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { uid } from '@formily/shared';
 import { defineAction, tExpr } from '@nocobase/flow-engine';
 import { DetailsItemModel } from '../models/blocks/details/DetailsItemModel';
 import { getFieldBindingUse, rebuildFieldSubModel } from '../internal/utils/rebuildFieldSubModel';
@@ -19,12 +20,36 @@ type PatternAwareFieldModel = {
   scheduleApplyJsSettings?: () => void;
 };
 
+function resolveAssociationTitleField(ctx: any) {
+  return (
+    ctx.model.subModels?.field?.props?.fieldNames?.label ||
+    ctx.model.props.titleField ||
+    ctx.collectionField?.targetCollectionTitleFieldName
+  );
+}
+
 function shouldPreserveFieldModelOnPatternChange(ctx: any) {
   const fieldModel = ctx.model.subModels.field;
   const fieldUse = getFieldBindingUse(fieldModel) ?? fieldModel?.use;
   const ModelClass = typeof fieldUse === 'string' ? ctx.engine.getModelClass(fieldUse) : fieldUse;
 
   return ((ModelClass?.meta as PatternAwareFieldModelMeta | undefined)?.preserveOnPatternChange ?? false) === true;
+}
+
+async function refreshPatternRuntime(ctx: any) {
+  ctx.model.invalidateFlowCache?.('beforeRender', true);
+  await ctx.model.rerender?.();
+
+  const parent = ctx.model.parent;
+  if (!parent) {
+    return;
+  }
+
+  parent.invalidateFlowCache?.('beforeRender', true);
+  parent.setProps?.({
+    __patternRefreshKey: uid(),
+  });
+  await parent.rerender?.();
 }
 
 export const pattern = defineAction({
@@ -76,17 +101,25 @@ export const pattern = defineAction({
       if (params.pattern !== previousParams.pattern) {
         (ctx.model.subModels.field as PatternAwareFieldModel | undefined)?.scheduleApplyJsSettings?.();
       }
+      await refreshPatternRuntime(ctx);
       return;
     }
 
     const targetCollection = ctx.collectionField.targetCollection;
-    const targetCollectionTitleField = targetCollection?.getField(
-      ctx.model.subModels.field.props?.fieldNames?.label || ctx.model.props.titleField,
-    );
+    const associationTitleField = resolveAssociationTitleField(ctx);
+    const targetCollectionTitleField = targetCollection?.getField(associationTitleField);
     const { model } = ctx;
     const resolveDefaultProps = (binding, field = ctx.collectionField) => {
       if (!binding) return undefined;
-      return typeof binding.defaultProps === 'function' ? binding.defaultProps(ctx, field) : binding.defaultProps;
+      const defaultProps =
+        typeof binding.defaultProps === 'function' ? binding.defaultProps(ctx, field) : binding.defaultProps;
+      if (!ctx.collectionField?.isAssociationField?.() || !associationTitleField) {
+        return defaultProps;
+      }
+      return {
+        ...(defaultProps || {}),
+        titleField: associationTitleField,
+      };
     };
     if (params.pattern === 'readPretty') {
       const binding = DetailsItemModel.getDefaultBindingByField(ctx, ctx.collectionField, {
@@ -111,17 +144,19 @@ export const pattern = defineAction({
         });
       }
     }
+    await refreshPatternRuntime(ctx);
   },
   async beforeParamsSave(ctx, params, previousParams) {
     if (params.pattern === 'readPretty') {
+      const titleField = resolveAssociationTitleField(ctx);
       ctx.model.setProps({
         pattern: 'readPretty',
         disabled: false,
-        titleField: (ctx.model.subModels?.field as any)?.props.fieldNames?.label || ctx.model.props.titleField,
+        titleField,
       });
       if (ctx.collectionField.isAssociationField())
         await ctx.model.setStepParams('editItemSettings', 'titleField', {
-          titleField: (ctx.model.subModels.field as any).props?.fieldNames?.label || ctx.model.props.titleField,
+          titleField,
         });
     } else {
       ctx.model.setProps({

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
@@ -641,9 +641,15 @@ export class SubTableColumnModel<
         this.props.pattern,
         this.props.readPretty,
         this.props.titleField,
+        this.props.__displayFieldRefreshKey,
         fieldModel?.uid,
         fieldModel?.use,
         fieldModel?.constructor?.name,
+        fieldModel?.props?.clickToOpen,
+        fieldModel?.props?.displayStyle,
+        fieldModel?.props?.overflowMode,
+        fieldModel?.props?.titleField,
+        fieldModel?.props?.fieldNames?.label,
       ]
         .filter((item) => item !== undefined && item !== null)
         .join(':');

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/SubTableColumnModel.tsx
@@ -32,9 +32,11 @@ import { ErrorBoundary } from 'react-error-boundary';
 import React, { useRef, useMemo, useEffect } from 'react';
 import { SubTableFieldModel } from '.';
 import { FieldModel } from '../../../base/FieldModel';
+import { DetailsItemModel } from '../../../blocks/details/DetailsItemModel';
 import { FieldDeletePlaceholder, CustomWidth } from '../../../blocks/table/TableColumnModel';
 import { buildDynamicNamePath } from '../../../blocks/form/dynamicNamePath';
 import { getSubTableRowIdentity } from './rowIdentity';
+import { getFieldBindingUse, rebuildFieldSubModel } from '../../../../internal/utils/rebuildFieldSubModel';
 
 export const SUB_TABLE_COLUMN_FIELD_COMPONENT_CONTEXT = 'subTableColumn';
 
@@ -218,6 +220,41 @@ function shouldCommitImmediately(value: any) {
   return false;
 }
 
+export function isSubTableColumnReadPretty(parent: any) {
+  return !!parent?.props?.readPretty || parent?.props?.pattern === 'readPretty';
+}
+
+export function isSubTableColumnConfiguredReadPretty(parent: any) {
+  return (
+    isSubTableColumnReadPretty(parent) ||
+    parent?.getStepParams?.('subTableColumnSettings', 'pattern')?.pattern === 'readPretty'
+  );
+}
+
+export function getSubTableColumnTitleField(parent: any) {
+  return (
+    parent?.props?.titleField ||
+    parent?.subModels?.field?.props?.titleField ||
+    parent?.subModels?.field?.props?.fieldNames?.label ||
+    parent?.collectionField?.targetCollectionTitleFieldName
+  );
+}
+
+export function getSubTableColumnReadPrettyFieldProps(parent: any, value: any) {
+  const fieldProps: Record<string, any> = { value };
+  const titleField = getSubTableColumnTitleField(parent);
+  const fieldNames = parent?.props?.fieldNames || parent?.subModels?.field?.props?.fieldNames;
+
+  if (titleField) {
+    fieldProps.titleField = titleField;
+  }
+  if (fieldNames) {
+    fieldProps.fieldNames = fieldNames;
+  }
+
+  return fieldProps;
+}
+
 const FieldModelRendererOptimize = React.memo((props: any) => {
   const { model, onChange, value, commitOnChange, ...rest } = props;
   const pendingValueRef = React.useRef<any>(props?.value);
@@ -337,8 +374,8 @@ const MemoCell: React.FC<CellProps> = React.memo(
             });
           }
 
-          if (parent.props.readPretty) {
-            fork.setProps({ value });
+          if (isSubTableColumnReadPretty(parent)) {
+            fork.setProps(getSubTableColumnReadPrettyFieldProps(parent, value));
             return <React.Fragment key={id}>{fork.render()}</React.Fragment>;
           }
 
@@ -598,6 +635,18 @@ export class SubTableColumnModel<
         (this.parent as any)?.collection?.filterTargetKey ?? (this.parent as any)?.context?.collection?.filterTargetKey;
       const rowIdentity = getSubTableRowIdentity(record, filterTargetKey) ?? `row:${String(rowIdx)}`;
       const rowForkKey = `row:${baseIndexKey}:${rowIdentity}:${String(rowIdx)}`;
+      const fieldModel: any = this.subModels.field;
+      const cellModeKey = [
+        rowForkKey,
+        this.props.pattern,
+        this.props.readPretty,
+        this.props.titleField,
+        fieldModel?.uid,
+        fieldModel?.use,
+        fieldModel?.constructor?.name,
+      ]
+        .filter((item) => item !== undefined && item !== null)
+        .join(':');
       const rowFork: any = (() => {
         const fork = this.createFork({}, rowForkKey);
         fork.context.defineProperty('subTableRowFork', {
@@ -651,7 +700,7 @@ export class SubTableColumnModel<
           parentFieldIndex={baseArr}
           parentItem={parentItem}
           rowFork={rowFork}
-          memoKey={rowForkKey}
+          memoKey={cellModeKey}
           width={this.props.width}
           commitOnChange={this.hasFormulaColumn}
         />
@@ -683,6 +732,7 @@ SubTableColumnModel.registerFlow({
         ctx.model.setProps(collectionField.getComponentProps());
         ctx.model.setProps('title', collectionField.title);
         ctx.model.setProps('dataIndex', collectionField.name);
+        await ctx.model.applySubModelsBeforeRenderFlows('field');
         const currentBlockModel = ctx.model.context.blockModel;
         // 避免强依赖 EditFormModel（减少循环依赖风险）：仅在存在该能力时调用
         currentBlockModel?.addAppends?.(ctx.model.fieldPath);
@@ -895,6 +945,91 @@ SubTableColumnModel.registerFlow({
     model: {
       use: 'fieldComponent',
       title: tExpr('Field component'),
+    },
+    fieldNames: {
+      use: 'titleField',
+      title: tExpr('Title field'),
+      hideInSettings(ctx) {
+        return (
+          !ctx.collectionField ||
+          !ctx.collectionField.isAssociationField() ||
+          !isSubTableColumnConfiguredReadPretty(ctx.model) ||
+          (ctx.model.subModels.field as any)?.disableTitleField
+        );
+      },
+      defaultParams(ctx) {
+        return {
+          label: getSubTableColumnTitleField(ctx.model),
+        };
+      },
+      beforeParamsSave: async (ctx, params, previousParams) => {
+        if (!ctx.collectionField || !ctx.collectionField.isAssociationField()) {
+          return null;
+        }
+        if (!isSubTableColumnConfiguredReadPretty(ctx.model)) {
+          return null;
+        }
+        if (!params.label || params.label === previousParams.label) {
+          return null;
+        }
+
+        const targetCollection = ctx.collectionField.targetCollection;
+        const targetCollectionField = targetCollection?.getField(params.label);
+        if (!targetCollectionField) {
+          return null;
+        }
+
+        const binding = DetailsItemModel.getDefaultBindingByField(ctx, targetCollectionField);
+        const fieldModel: any = ctx.model.subModels.field;
+        const currentUse = getFieldBindingUse(fieldModel) || fieldModel?.use;
+        const targetUse = binding?.modelName || currentUse;
+        const fieldSettingsInit = {
+          dataSourceKey: ctx.model.collectionField.dataSourceKey,
+          collectionName: targetCollection.name,
+          fieldPath: params.label,
+        };
+        const defaultProps =
+          typeof binding?.defaultProps === 'function'
+            ? binding.defaultProps(ctx, targetCollectionField)
+            : binding?.defaultProps;
+
+        ctx.model.setProps({
+          titleField: params.label,
+          ...targetCollectionField.getComponentProps?.(),
+        });
+
+        if (targetUse && targetUse !== currentUse) {
+          await rebuildFieldSubModel({
+            parentModel: ctx.model as any,
+            targetUse,
+            defaultProps: {
+              ...(defaultProps || {}),
+              titleField: params.label,
+            },
+            fieldSettingsInit,
+          });
+        } else if (fieldModel) {
+          fieldModel.setProps({
+            ...(defaultProps || {}),
+            titleField: params.label,
+          });
+          fieldModel.setStepParams('fieldSettings', 'init', fieldSettingsInit);
+          await fieldModel.dispatchEvent('beforeRender', undefined, { useCache: false });
+        }
+      },
+      handler(ctx, params) {
+        if (
+          !ctx.collectionField ||
+          !ctx.collectionField.isAssociationField() ||
+          !isSubTableColumnConfiguredReadPretty(ctx.model)
+        ) {
+          return null;
+        }
+        ctx.model.setProps({
+          titleField: params.label,
+          ...ctx.collectionField.targetCollection?.getField(params.label)?.getComponentProps?.(),
+        });
+      },
     },
     pattern: {
       use: 'pattern',

--- a/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/__tests__/SubTableColumnModel.rowRecord.test.ts
+++ b/packages/core/client/src/flow/models/fields/AssociationFieldModel/SubTableFieldModel/__tests__/SubTableColumnModel.rowRecord.test.ts
@@ -8,7 +8,18 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { getLatestSubTableRowRecord, buildRowPathFromFieldIndex } from '../SubTableColumnModel';
+import { FlowEngine } from '@nocobase/flow-engine';
+import { DisplayTitleFieldModel } from '../../../DisplayTitleFieldModel';
+import { titleField } from '../../../../../actions/titleField';
+import {
+  SubTableColumnModel,
+  getLatestSubTableRowRecord,
+  buildRowPathFromFieldIndex,
+  isSubTableColumnConfiguredReadPretty,
+  getSubTableColumnTitleField,
+  getSubTableColumnReadPrettyFieldProps,
+  isSubTableColumnReadPretty,
+} from '../SubTableColumnModel';
 
 describe('SubTableColumnModel row record helpers', () => {
   it('builds the row path from fieldIndex entries', () => {
@@ -38,5 +49,163 @@ describe('SubTableColumnModel row record helpers', () => {
     const fallback = { uid: 'stale-role', __is_new__: false };
 
     expect(getLatestSubTableRowRecord(form, ['roles:0'], fallback)).toBe(fallback);
+  });
+
+  it('treats a display-only column pattern as read-pretty mode', () => {
+    expect(isSubTableColumnReadPretty({ props: { pattern: 'readPretty' } })).toBe(true);
+    expect(isSubTableColumnReadPretty({ props: { readPretty: true } })).toBe(true);
+    expect(isSubTableColumnReadPretty({ props: { pattern: 'editable' } })).toBe(false);
+  });
+
+  it('treats a saved display-only column pattern as read-pretty during beforeRender restore', () => {
+    expect(
+      isSubTableColumnConfiguredReadPretty({
+        props: {},
+        getStepParams: vi.fn(() => ({ pattern: 'readPretty' })),
+      }),
+    ).toBe(true);
+  });
+
+  it('passes the association title field to read-pretty cell field models', () => {
+    const relationValue = { id: 1, name: 'Alice' };
+    expect(
+      getSubTableColumnReadPrettyFieldProps(
+        {
+          props: {},
+          collectionField: {
+            targetCollectionTitleFieldName: 'name',
+          },
+        },
+        relationValue,
+      ),
+    ).toEqual({
+      value: relationValue,
+      titleField: 'name',
+    });
+  });
+
+  it('resolves the saved title field before the target collection default', () => {
+    expect(
+      getSubTableColumnTitleField({
+        props: { titleField: 'nickname' },
+        subModels: {
+          field: {
+            props: {
+              titleField: 'name',
+            },
+          },
+        },
+        collectionField: {
+          targetCollectionTitleFieldName: 'title',
+        },
+      }),
+    ).toBe('nickname');
+  });
+
+  it('applies the configured title field to a display-only association column', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ SubTableColumnModel, DisplayTitleFieldModel });
+    engine.registerActions({ titleField });
+
+    const rolesField = {
+      name: 'roles',
+      title: 'Roles',
+      collection: { name: 'users' },
+      targetCollectionTitleFieldName: 'name',
+      targetCollection: {
+        name: 'roles',
+        getField: vi.fn((name: string) => ({
+          name,
+          getComponentProps: () => ({ componentField: name }),
+        })),
+      },
+      isAssociationField: () => true,
+      getComponentProps: () => ({}),
+    };
+
+    const column = engine.createModel<SubTableColumnModel>({
+      use: SubTableColumnModel,
+      uid: 'roles-display-column-title-field',
+      stepParams: {
+        fieldSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'users',
+            fieldPath: 'roles',
+          },
+        },
+        subTableColumnSettings: {
+          pattern: {
+            pattern: 'readPretty',
+          },
+          fieldNames: {
+            label: 'nickname',
+          },
+        },
+      },
+    });
+    column.context.defineProperty('collectionField', { value: rolesField });
+    column.context.defineProperty('blockModel', { value: { addAppends: vi.fn() } });
+    column.setSubModel('field', {
+      use: DisplayTitleFieldModel,
+      uid: 'roles-display-field-title-field',
+    });
+
+    await column.dispatchEvent('beforeRender');
+
+    expect(column.props.titleField).toBe('nickname');
+    expect(column.props.componentField).toBe('nickname');
+  });
+
+  it('applies saved display field settings to the inner field during column beforeRender', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ SubTableColumnModel, DisplayTitleFieldModel });
+
+    const rolesCollection = {
+      name: 'roles',
+      filterTargetKey: 'id',
+    };
+    const rolesField = {
+      name: 'roles',
+      title: 'Roles',
+      collection: { name: 'users' },
+      targetCollection: rolesCollection,
+      isAssociationField: () => true,
+      getComponentProps: () => ({ titleField: 'name' }),
+    };
+
+    const column = engine.createModel<SubTableColumnModel>({
+      use: SubTableColumnModel,
+      uid: 'roles-title-column',
+      stepParams: {
+        fieldSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'users',
+            fieldPath: 'roles',
+          },
+        },
+      },
+    });
+    column.context.defineProperty('collectionField', { value: rolesField });
+    column.context.defineProperty('blockModel', { value: { addAppends: vi.fn() } });
+
+    const field = column.setSubModel('field', {
+      use: DisplayTitleFieldModel,
+      uid: 'roles-title-display',
+      stepParams: {
+        displayFieldSettings: {
+          clickToOpen: {
+            clickToOpen: true,
+          },
+        },
+      },
+    }) as DisplayTitleFieldModel;
+
+    expect(field.props.clickToOpen).toBeUndefined();
+
+    await column.dispatchEvent('beforeRender');
+
+    expect(field.props.clickToOpen).toBe(true);
   });
 });

--- a/packages/core/client/src/flow/models/fields/ClickableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/ClickableFieldModel.tsx
@@ -37,9 +37,19 @@ const hasAssociationPathName = (parent: unknown): parent is { associationPathNam
 
 const hasUsableSourceId = (sourceId: unknown) => sourceId !== undefined && sourceId !== null && String(sourceId) !== '';
 
+function getParentAssociationField(model: FieldModel): CollectionField | null {
+  const parentCollectionField =
+    (model.parent as any)?.context?.collectionField || (model.parent as any)?.collectionField;
+  return parentCollectionField?.isAssociationField?.() ? parentCollectionField : null;
+}
+
 export class ClickableFieldModel extends FieldModel {
   get collectionField(): CollectionField {
-    return this.context.collectionField;
+    const collectionField = this.context.collectionField;
+    if (collectionField?.isAssociationField?.()) {
+      return collectionField;
+    }
+    return getParentAssociationField(this) || collectionField;
   }
 
   /**

--- a/packages/core/client/src/flow/models/fields/ClickableFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/ClickableFieldModel.tsx
@@ -8,6 +8,7 @@
  */
 
 import { CollectionField, tExpr } from '@nocobase/flow-engine';
+import { uid } from '@formily/shared';
 import { Tag } from 'antd';
 import { castArray, get } from 'lodash';
 import React from 'react';
@@ -42,6 +43,36 @@ function getParentAssociationField(model: FieldModel): CollectionField | null {
   const parentCollectionField =
     (model.parent as any)?.context?.collectionField || (model.parent as any)?.collectionField;
   return parentCollectionField?.isAssociationField?.() ? parentCollectionField : null;
+}
+
+export function applyClickToOpenProps(ctx: any, params: any) {
+  const collectionField = ctx.collectionField?.isAssociationField?.()
+    ? ctx.collectionField
+    : ctx.model?.parent?.context?.collectionField || ctx.collectionField;
+  ctx.model.setProps({
+    clickToOpen: params.clickToOpen,
+    ...(collectionField?.getComponentProps?.() || {}),
+  });
+}
+
+export async function refreshClickToOpenRuntime(ctx: any) {
+  ctx.model.invalidateFlowCache?.('beforeRender', true);
+  await ctx.model.rerender?.();
+
+  const parent = ctx.model.parent;
+  if (!parent) {
+    return;
+  }
+  parent.invalidateFlowCache?.('beforeRender', true);
+  parent.setProps?.({
+    __displayFieldRefreshKey: uid(),
+  });
+  await parent.rerender?.();
+}
+
+export async function applyClickToOpenSetting(ctx: any, params: any) {
+  applyClickToOpenProps(ctx, params);
+  await refreshClickToOpenRuntime(ctx);
 }
 
 export class ClickableFieldModel extends FieldModel {
@@ -303,8 +334,11 @@ ClickableFieldModel.registerFlow({
       hideInSettings(ctx) {
         return ctx.disableFieldClickToOpen;
       },
+      async afterParamsSave(ctx, params) {
+        await applyClickToOpenSetting(ctx, params);
+      },
       handler(ctx, params) {
-        ctx.model.setProps({ clickToOpen: params.clickToOpen, ...ctx.collectionField.getComponentProps() });
+        applyClickToOpenProps(ctx, params);
       },
     },
   },

--- a/packages/core/client/src/flow/models/fields/DisplayTitleFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/DisplayTitleFieldModel.tsx
@@ -13,7 +13,7 @@ import { castArray } from 'lodash';
 import { css } from '@emotion/css';
 import React from 'react';
 import { openViewFlow } from '../../flows/openViewFlow';
-import { ClickableFieldModel } from './ClickableFieldModel';
+import { applyClickToOpenProps, applyClickToOpenSetting, ClickableFieldModel } from './ClickableFieldModel';
 
 function isParentAssociationField(ctx: any) {
   return !!ctx.model?.parent?.context?.collectionField?.isAssociationField?.();
@@ -98,11 +98,11 @@ DisplayTitleFieldModel.registerFlow({
       hideInSettings(ctx) {
         return ctx.disableFieldClickToOpen;
       },
+      async afterParamsSave(ctx, params) {
+        await applyClickToOpenSetting(ctx, params);
+      },
       handler(ctx, params) {
-        ctx.model.setProps({
-          clickToOpen: params.clickToOpen,
-          ...(ctx.collectionField?.getComponentProps?.() || {}),
-        });
+        applyClickToOpenProps(ctx, params);
       },
     },
   },

--- a/packages/core/client/src/flow/models/fields/DisplayTitleFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/DisplayTitleFieldModel.tsx
@@ -12,11 +12,20 @@ import { Typography } from 'antd';
 import { castArray } from 'lodash';
 import { css } from '@emotion/css';
 import React from 'react';
-import { FieldModel } from '../base';
+import { openViewFlow } from '../../flows/openViewFlow';
+import { ClickableFieldModel } from './ClickableFieldModel';
 
-export class DisplayTitleFieldModel extends FieldModel {
+function isParentAssociationField(ctx: any) {
+  return !!ctx.model?.parent?.context?.collectionField?.isAssociationField?.();
+}
+
+export class DisplayTitleFieldModel extends ClickableFieldModel {
   get collectionField(): CollectionField {
-    return this.context.collectionField;
+    const collectionField = this.context.collectionField;
+    if (collectionField?.isAssociationField?.()) {
+      return collectionField;
+    }
+    return (this.parent as any)?.context?.collectionField || collectionField;
   }
 
   renderComponent(value) {
@@ -53,13 +62,13 @@ export class DisplayTitleFieldModel extends FieldModel {
     };
     if (titleField) {
       const result = castArray(value).flatMap((v, idx) => {
-        const result = this.renderComponent(v?.[titleField]);
-        const node = v?.[titleField] ? result : 'N/A';
-        return idx === 0 ? [node] : [<span key={`sep-${idx}`}>, </span>, node];
+        const node = this.renderInDisplayStyle(v?.[titleField], v, Array.isArray(value));
+        const keyedNode = React.isValidElement(node) ? React.cloneElement(node, { key: `item-${idx}` }) : node;
+        return idx === 0 ? [keyedNode] : [<span key={`sep-${idx}`}>, </span>, keyedNode];
       });
       return <Typography.Text {...typographyProps}>{result}</Typography.Text>;
     } else {
-      const textContent = <Typography.Text {...typographyProps}>{this.renderComponent(value)}</Typography.Text>;
+      const textContent = <Typography.Text {...typographyProps}>{this.renderInDisplayStyle(value)}</Typography.Text>;
       return textContent;
     }
   }
@@ -73,5 +82,29 @@ DisplayTitleFieldModel.registerFlow({
     overflowMode: {
       use: 'overflowMode',
     },
+    clickToOpen: {
+      title: tExpr('Enable click-to-open'),
+      uiMode: { type: 'switch', key: 'clickToOpen' },
+      defaultParams: (ctx) => {
+        if (ctx.disableFieldClickToOpen) {
+          return {
+            clickToOpen: false,
+          };
+        }
+        return {
+          clickToOpen: ctx.collectionField?.isAssociationField?.() || isParentAssociationField(ctx),
+        };
+      },
+      hideInSettings(ctx) {
+        return ctx.disableFieldClickToOpen;
+      },
+      handler(ctx, params) {
+        ctx.model.setProps({
+          clickToOpen: params.clickToOpen,
+          ...(ctx.collectionField?.getComponentProps?.() || {}),
+        });
+      },
+    },
   },
 });
+DisplayTitleFieldModel.registerFlow(openViewFlow);

--- a/packages/core/client/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts
+++ b/packages/core/client/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts
@@ -236,4 +236,53 @@ describe('ClickableFieldModel', () => {
     expect(screen.getByText('S-001')).toBeInTheDocument();
     expect(screen.queryByText('Sales')).not.toBeInTheDocument();
   });
+
+  it('refreshes the parent column when title display click-to-open changes', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ DisplayTitleFieldModel });
+
+    const rolesField = {
+      name: 'roles',
+      target: 'roles',
+      collection: { name: 'users' },
+      targetCollection: { name: 'roles' },
+      isAssociationField: () => true,
+      getComponentProps: () => ({ titleField: 'name' }),
+    };
+    const titleField = {
+      name: 'title',
+      collection: { name: 'roles' },
+      isAssociationField: () => false,
+    };
+
+    const parent = engine.createModel<FlowModel>({
+      use: FlowModel,
+      uid: 'roles-title-column-refresh',
+    });
+    parent.context.defineProperty('collectionField', { value: rolesField });
+    const parentSetProps = vi.spyOn(parent, 'setProps');
+    const parentRerender = vi.spyOn(parent, 'rerender').mockResolvedValue(undefined);
+
+    const model = engine.createModel<DisplayTitleFieldModel>({
+      use: DisplayTitleFieldModel,
+      uid: 'roles-title-display-refresh',
+    });
+    model.setParent(parent);
+    model.context.defineProperty('collectionField', { value: titleField });
+    const modelRerender = vi.spyOn(model, 'rerender').mockResolvedValue(undefined);
+
+    const clickToOpenStep = model.getFlow('displayFieldSettings').steps.clickToOpen;
+
+    await clickToOpenStep.afterParamsSave(model.context as any, { clickToOpen: true }, { clickToOpen: false });
+
+    expect(model.props).toMatchObject({
+      clickToOpen: true,
+      titleField: 'name',
+    });
+    expect(modelRerender).toHaveBeenCalled();
+    expect(parentSetProps).toHaveBeenCalledWith({
+      __displayFieldRefreshKey: expect.any(String),
+    });
+    expect(parentRerender).toHaveBeenCalled();
+  });
 });

--- a/packages/core/client/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts
+++ b/packages/core/client/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts
@@ -8,8 +8,11 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { FlowEngine } from '@nocobase/flow-engine';
+import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ClickableFieldModel } from '../ClickableFieldModel';
+import { DisplayTitleFieldModel } from '../DisplayTitleFieldModel';
 
 function createRolesFieldModel(sourceRecord: Record<string, any>) {
   const engine = new FlowEngine();
@@ -81,6 +84,133 @@ describe('ClickableFieldModel', () => {
         associationName: 'users.roles',
         sourceId: 1,
       },
+      { debounce: true },
+    );
+  });
+
+  it('uses the parent association field when the display model is bound to the title field', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ ClickableFieldModel });
+
+    const usersCollection = {
+      name: 'users',
+      filterTargetKey: 'id',
+    };
+    const rolesCollection = {
+      name: 'roles',
+      filterTargetKey: 'name',
+    };
+    const rolesField = {
+      name: 'roles',
+      target: 'roles',
+      targetKey: 'name',
+      type: 'belongsToMany',
+      interface: 'm2m',
+      collection: usersCollection,
+      targetCollection: rolesCollection,
+      isAssociationField: () => true,
+    };
+    const titleField = {
+      name: 'title',
+      collection: rolesCollection,
+      isAssociationField: () => false,
+    };
+
+    const parent = engine.createModel<FlowModel>({
+      use: FlowModel,
+      uid: 'roles-column',
+    });
+    parent.context.defineProperty('collectionField', { value: rolesField });
+
+    const model = engine.createModel<ClickableFieldModel>({
+      use: ClickableFieldModel,
+      uid: 'roles-title-display',
+    });
+    model.setParent(parent);
+    model.context.defineProperty('collectionField', { value: titleField });
+    model.context.defineProperty('blockModel', { value: { collection: usersCollection } });
+    model.context.defineProperty('record', { value: { id: 1 } });
+    const dispatchEvent = vi.spyOn(model, 'dispatchEvent').mockResolvedValue([]);
+    const event = { type: 'click' };
+
+    model.onClick(event, { name: 'admin', title: 'Admin' });
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      'click',
+      {
+        event,
+        filterByTk: 'admin',
+        collectionName: 'users',
+        associationName: 'users.roles',
+        sourceId: 1,
+      },
+      { debounce: true },
+    );
+  });
+
+  it('renders title display values as links when click-to-open is enabled', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ DisplayTitleFieldModel });
+
+    const usersCollection = {
+      name: 'users',
+      filterTargetKey: 'id',
+    };
+    const rolesCollection = {
+      name: 'roles',
+      filterTargetKey: 'name',
+    };
+    const rolesField = {
+      name: 'roles',
+      target: 'roles',
+      targetKey: 'name',
+      type: 'belongsToMany',
+      interface: 'm2m',
+      collection: usersCollection,
+      targetCollection: rolesCollection,
+      isAssociationField: () => true,
+    };
+    const titleField = {
+      name: 'title',
+      collection: rolesCollection,
+      isAssociationField: () => false,
+    };
+
+    const parent = engine.createModel<FlowModel>({
+      use: FlowModel,
+      uid: 'roles-title-column',
+    });
+    parent.context.defineProperty('collectionField', { value: rolesField });
+
+    const model = engine.createModel<DisplayTitleFieldModel>({
+      use: DisplayTitleFieldModel,
+      uid: 'roles-title-display-link',
+      props: {
+        clickToOpen: true,
+        titleField: 'name',
+        value: { name: 'admin', title: 'Admin' },
+      },
+    });
+    model.setParent(parent);
+    model.context.defineProperty('collectionField', { value: titleField });
+    model.context.defineProperty('blockModel', { value: { collection: usersCollection } });
+    model.context.defineProperty('record', { value: { id: 1 } });
+    const dispatchEvent = vi.spyOn(model, 'dispatchEvent').mockResolvedValue([]);
+
+    render(React.createElement(React.Fragment, null, model.render()));
+    const link = screen.getByText('admin').closest('a');
+    expect(link).toBeTruthy();
+
+    fireEvent.click(link);
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      'click',
+      expect.objectContaining({
+        filterByTk: 'admin',
+        collectionName: 'users',
+        associationName: 'users.roles',
+        sourceId: 1,
+      }),
       { debounce: true },
     );
   });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix relation fields inside one-to-many sub-tables losing their display-only, title field, and click-to-open behavior after switching modes or refreshing the page.

### Description
This PR fixes v2 sub-table relation fields in edit forms when the column is switched to Display only.

Key changes:
- Preserve and restore association title field selection when switching to Display only.
- Re-run inner field beforeRender flows for sub-table columns so saved display settings are applied after refresh.
- Support Title field settings for display-only relation columns in sub-tables.
- Allow display title field models to render click-to-open links using the parent association field.
- Refresh parent runtime state when switching display mode so editable/display-only changes take effect without a full page refresh.
- Add regression tests for pattern switching, title field restoration, read-pretty sub-table cells, and click-to-open display titles.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed display-only relation fields in sub-tables not showing or not clickable after refresh. |
| 🇨🇳 Chinese | 修复子表格中关系字段设置为仅展示后刷新不显示或不可点击的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
