### PR TITLE
fix(client-v2): keep page behind dialog

### DIFF
--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -599,7 +599,12 @@ export class ApplicationModel extends FlowModel {
     if (!this.app.maintained) {
       return this.app.renderComponent('AppMaintaining', { app: this.app, error: this.app.error });
     }
-    return this.app.renderComponent('AppMaintainingDialog', { app: this.app, error: this.app.error });
+    return (
+      <>
+        {this.renderContent()}
+        {this.app.renderComponent('AppMaintainingDialog', { app: this.app, error: this.app.error })}
+      </>
+    );
   }
 
   renderError() {

--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -586,25 +586,26 @@ export class ApplicationModel extends FlowModel {
   }
 
   render() {
-    if (this.app.maintaining) {
-      return this.renderMaintaining();
+    if (this.app.maintaining && !this.app.maintained) {
+      return <>{this.renderMaintaining()}</>;
     }
-    if (this.app.error) {
-      return this.renderError();
-    }
-    return this.renderContent();
-  }
-
-  renderMaintaining() {
-    if (!this.app.maintained) {
-      return this.app.renderComponent('AppMaintaining', { app: this.app, error: this.app.error });
+    if (this.app.error && !this.app.maintaining) {
+      return <>{this.renderError()}</>;
     }
     return (
       <>
         {this.renderContent()}
-        {this.app.renderComponent('AppMaintainingDialog', { app: this.app, error: this.app.error })}
+        {this.app.maintaining && this.app.maintained ? this.renderMaintainingDialog() : null}
       </>
     );
+  }
+
+  renderMaintaining() {
+    return this.app.renderComponent('AppMaintaining', { app: this.app, error: this.app.error });
+  }
+
+  renderMaintainingDialog() {
+    return this.app.renderComponent('AppMaintainingDialog', { app: this.app, error: this.app.error });
   }
 
   renderError() {

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -254,6 +254,22 @@ describe('app', () => {
     expect(screen.getByText('maintaining dialog message')).toBeInTheDocument();
   });
 
+  it('should keep current content behind maintained dialog state', async () => {
+    class PluginHelloClient extends Plugin {
+      async load() {
+        this.router.add('root', { path: '/', Component: () => <div>Current page content</div> });
+      }
+    }
+    const app = createMockClient({ plugins: [PluginHelloClient] });
+    app.maintained = true;
+    app.maintaining = true;
+    app.error = { code: 'APP_COMMANDING', command: { name: 'pm.enable' }, message: 'starting sub applications...' };
+    await renderApp(app);
+    expect(screen.getByText('Current page content')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Enabling plugin')).toBeInTheDocument();
+  });
+
   it('should handle long loading state gracefully', async () => {
     class PluginHelloClient extends Plugin {
       async load() {

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -9,7 +9,7 @@
 
 import { Application, createMockClient, NocoBaseBuildInPlugin, Plugin } from '@nocobase/client-v2';
 import { useFlowEngineContext } from '@nocobase/flow-engine';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
@@ -255,17 +255,28 @@ describe('app', () => {
   });
 
   it('should keep current content behind maintained dialog state', async () => {
+    const CurrentPage = () => {
+      const [count, setCount] = React.useState(0);
+      return <button onClick={() => setCount((value) => value + 1)}>Current page count: {count}</button>;
+    };
+
     class PluginHelloClient extends Plugin {
       async load() {
-        this.router.add('root', { path: '/', Component: () => <div>Current page content</div> });
+        this.router.add('root', { path: '/', Component: CurrentPage });
       }
     }
     const app = createMockClient({ plugins: [PluginHelloClient] });
-    app.maintained = true;
-    app.maintaining = true;
-    app.error = { code: 'APP_COMMANDING', command: { name: 'pm.enable' }, message: 'starting sub applications...' };
     await renderApp(app);
-    expect(screen.getByText('Current page content')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Current page count: 0' }));
+    expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
+
+    act(() => {
+      app.maintained = true;
+      app.maintaining = true;
+      app.error = { code: 'APP_COMMANDING', command: { name: 'pm.enable' }, message: 'starting sub applications...' };
+    });
+
+    expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Enabling plugin')).toBeInTheDocument();
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
启用插件时会出现维护中的弹窗。此前在 v2 页面中，这个弹窗显示后，背后的当前页面会变成空白，用户无法确认自己仍停留在原来的插件管理页面。

### Description 
调整 v2 应用已加载后的维护中弹窗展示方式：弹窗出现时继续保留当前页面内容，只在其上方展示维护中的对话框。

同时补充测试，覆盖应用已加载后进入维护状态时，当前页面内容仍然保留、维护弹窗正常显示的场景。

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the page turns blank behind the plugin enabling dialog |
| 🇨🇳 Chinese | 修复启用插件弹窗后方页面变空白的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
