### PR TITLE
fix(client): preserve system settings values

### DIFF
--- a/packages/core/client/src/system-settings/SystemSettingsShortcut.tsx
+++ b/packages/core/client/src/system-settings/SystemSettingsShortcut.tsx
@@ -43,6 +43,29 @@ const useSystemSettingsValues = (options) => {
   });
 };
 
+type SystemSettingsMutationData = {
+  data?: Record<string, unknown>;
+};
+
+export const getSystemSettingsMutationData = (
+  response: { data?: SystemSettingsMutationData } | undefined,
+  currentData: SystemSettingsMutationData | undefined,
+  values: Record<string, unknown>,
+) => {
+  const responseData = response?.data;
+
+  if (responseData && Object.prototype.hasOwnProperty.call(responseData, 'data')) {
+    return responseData;
+  }
+
+  return {
+    data: {
+      ...currentData?.data,
+      ...values,
+    },
+  };
+};
+
 const useSaveSystemSettingsValues = () => {
   const { setVisible } = useActionContext();
   const form = useForm();
@@ -53,16 +76,13 @@ const useSaveSystemSettingsValues = () => {
     async run() {
       await form.submit();
       const values = cloneDeep(form.values);
-      mutate({
-        data: {
-          ...data?.data,
-          ...values,
-        },
-      });
-      await api.request({
+      const response = await api.request({
         url: 'systemSettings:put',
         method: 'post',
         data: values,
+      });
+      mutate({
+        data: getSystemSettingsMutationData(response, data, values),
       });
       message.success(t('Saved successfully'));
       const lang = values.enabledLanguages?.[0] || 'en-US';

--- a/packages/core/client/src/system-settings/__tests__/SystemSettingsShortcut.test.ts
+++ b/packages/core/client/src/system-settings/__tests__/SystemSettingsShortcut.test.ts
@@ -1,0 +1,57 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getSystemSettingsMutationData } from '../SystemSettingsShortcut';
+
+describe('SystemSettingsShortcut', () => {
+  it('should keep the system settings cache wrapped after submit', () => {
+    const response = {
+      data: {
+        data: {
+          raw_title: 'NocoBase',
+          logo: { id: 1 },
+          enabledLanguages: ['zh-CN', 'en-US'],
+        },
+      },
+    };
+
+    expect(
+      getSystemSettingsMutationData(response, undefined, {
+        raw_title: 'Updated',
+        enabledLanguages: [],
+      }),
+    ).toEqual(response.data);
+  });
+
+  it('should wrap fallback values when the response is empty', () => {
+    expect(
+      getSystemSettingsMutationData(
+        { data: {} },
+        {
+          data: {
+            raw_title: 'NocoBase',
+            logo: { id: 1 },
+            enabledLanguages: ['en-US'],
+          },
+        },
+        {
+          enabledLanguages: ['zh-CN', 'en-US'],
+        },
+      ),
+    ).toEqual({
+      data: {
+        raw_title: 'NocoBase',
+        logo: { id: 1 },
+        enabledLanguages: ['zh-CN', 'en-US'],
+      },
+    });
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
系统设置页面点击提交后，页面上的系统名称、Logo 和启用语言会被清空。刷新页面后这些设置又会恢复，导致用户误以为设置没有正确保存。

### Description 
提交系统设置成功后，使用接口返回的数据更新页面状态，避免页面短暂显示为空。

同时补充测试，确保提交后的系统设置数据仍保持页面需要的结构，防止再次出现提交后字段被清空的问题。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where system settings appear empty after submitting |
| 🇨🇳 Chinese | 修复系统设置提交后页面显示为空的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |     |
| 🇨🇳 Chinese |     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
