### PR TITLE
fix(plugin-action-import): fix date issues

### DIFF
--- a/packages/core/database/src/__tests__/interfaces/datetime-interface.test.ts
+++ b/packages/core/database/src/__tests__/interfaces/datetime-interface.test.ts
@@ -74,4 +74,17 @@ describe('Date time interface', () => {
     expect(await interfaceInstance.toValue('42510')).toBe('2016-05-20T00:00:00.000Z');
     expect(await interfaceInstance.toValue('2016-05-20T00:00:00.000Z')).toBe('2016-05-20T00:00:00.000Z');
   });
+
+  it('should honor request timezone when parsing date-only strings and excel serials', async () => {
+    const interfaceInstance = new DatetimeInterface();
+    const ctx = {
+      get(key: string) {
+        return key === 'X-Timezone' ? '+08:00' : undefined;
+      },
+    };
+
+    expect(await interfaceInstance.toValue('2025-05-12', ctx)).toBe('2025-05-11T16:00:00.000Z');
+    // TODO(refactor): Excel value parsing should not be placed in the datetime interface, and should be handled separately. This is a temporary test to ensure that the current implementation continues to work as expected.
+    expect(await interfaceInstance.toValue(45789, ctx)).toBe('2025-05-11T16:00:00.000Z');
+  });
 });

--- a/packages/core/database/src/__tests__/interfaces/time-interface.test.ts
+++ b/packages/core/database/src/__tests__/interfaces/time-interface.test.ts
@@ -9,7 +9,6 @@
 
 import { Database, createMockDatabase } from '@nocobase/database';
 import dayjs from 'dayjs';
-import record from 'packages/core/client/src/schema-component/antd/table-v2/demos/new-demos/record';
 import { TimeInterface } from '../../interfaces/time-interface';
 
 describe('TimeInterface', () => {
@@ -59,6 +58,14 @@ describe('TimeInterface', () => {
       const interfaceInstance = new TimeInterface();
       const value = await interfaceInstance.toValue(time);
       expect(value).toEqual(time);
+    });
+
+    it('should parse excel time serial', async () => {
+      const interfaceInstance = new TimeInterface();
+
+      expect(await interfaceInstance.toValue(0.5084722222222222)).toEqual('12:12:12');
+      expect(await interfaceInstance.toValue(45789.50847222222)).toEqual('12:12:12');
+      expect(await interfaceInstance.toValue(0)).toEqual('00:00:00');
     });
   });
 });

--- a/packages/core/database/src/interfaces/date-interface.ts
+++ b/packages/core/database/src/interfaces/date-interface.ts
@@ -1,6 +1,49 @@
-import { DatetimeInterface } from './datetime-interface';
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { DatetimeInterface, getTimeZoneOffsetMinutes, resolveTimeZoneFromCtx } from './datetime-interface';
+
+function pad2(value: number) {
+  return String(value).padStart(2, '0');
+}
+
+function formatDateOnlyFromDate(date: Date, timezone: string | number | null) {
+  const offsetMinutes = getTimeZoneOffsetMinutes(timezone);
+
+  if (offsetMinutes == null) {
+    return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  }
+
+  const shifted = new Date(date.getTime() + offsetMinutes * 60 * 1000);
+  return `${shifted.getUTCFullYear()}-${pad2(shifted.getUTCMonth() + 1)}-${pad2(shifted.getUTCDate())}`;
+}
 
 export class DateInterface extends DatetimeInterface {
+  async toValue(value: any, ctx?: any): Promise<any> {
+    const normalized = await super.toValue(value, ctx);
+
+    if (!normalized) {
+      return normalized;
+    }
+
+    if (typeof normalized === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+      return normalized;
+    }
+
+    const date = normalized instanceof Date ? normalized : new Date(normalized);
+    if (Number.isNaN(date.getTime())) {
+      return normalized;
+    }
+
+    return formatDateOnlyFromDate(date, resolveTimeZoneFromCtx(ctx));
+  }
+
   toString(value: any, ctx?: any): any {
     return value;
   }

--- a/packages/core/database/src/interfaces/datetime-interface.ts
+++ b/packages/core/database/src/interfaces/datetime-interface.ts
@@ -22,12 +22,110 @@ function isNumeric(str: any) {
   return !isNaN(str as any) && !isNaN(parseFloat(str));
 }
 
-function resolveTimeZoneFromCtx(ctx) {
-  if (ctx?.get && ctx?.get('X-Timezone')) {
-    return ctx.get('X-Timezone');
+export function getTimeZoneOffsetMinutes(timezone: string | number | null | undefined) {
+  if (typeof timezone === 'number' && Number.isFinite(timezone)) {
+    return timezone;
   }
 
-  return 0;
+  if (typeof timezone !== 'string') {
+    return null;
+  }
+
+  const normalized = timezone.trim().toUpperCase();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized === 'Z' || normalized === 'UTC') {
+    return 0;
+  }
+
+  const match = normalized.match(/^([+-])(\d{2})(?::?(\d{2}))?$/);
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, hours, minutes = '00'] = match;
+  const totalMinutes = Number(hours) * 60 + Number(minutes);
+  return sign === '+' ? totalMinutes : -totalMinutes;
+}
+
+export function resolveTimeZoneFromCtx(ctx) {
+  let timezone;
+
+  if (typeof ctx?.get === 'function') {
+    timezone = ctx.get('X-Timezone') || ctx.get('x-timezone');
+  } else if (typeof ctx?.request?.get === 'function') {
+    timezone = ctx.request.get('X-Timezone') || ctx.request.get('x-timezone');
+  }
+
+  timezone =
+    timezone ||
+    ctx?.request?.headers?.['x-timezone'] ||
+    ctx?.request?.headers?.['X-Timezone'] ||
+    ctx?.request?.header?.['x-timezone'] ||
+    ctx?.request?.header?.['X-Timezone'] ||
+    ctx?.req?.headers?.['x-timezone'] ||
+    ctx?.req?.headers?.['X-Timezone'];
+
+  if (timezone !== undefined && timezone !== null && timezone !== '') {
+    return timezone;
+  }
+
+  return null;
+}
+
+function toISOWithTimezone(
+  dateInfo: {
+    year: string;
+    month: string;
+    day: string;
+    hour?: string;
+    minute?: string;
+    second?: string;
+  },
+  timezone: string | number | null,
+) {
+  const offsetMinutes = getTimeZoneOffsetMinutes(timezone);
+  if (offsetMinutes == null) {
+    return null;
+  }
+
+  const utcMillis =
+    Date.UTC(
+      Number(dateInfo.year),
+      Number(dateInfo.month) - 1,
+      Number(dateInfo.day),
+      Number(dateInfo.hour || '00'),
+      Number(dateInfo.minute || '00'),
+      Number(dateInfo.second || '00'),
+      0,
+    ) -
+    offsetMinutes * 60 * 1000;
+
+  return new Date(utcMillis).toISOString();
+}
+
+function excelSerialToISO(value: number | string, timezone: string | number | null) {
+  const wallClockUtcDate = getJsDateFromExcel(value);
+  const offsetMinutes = getTimeZoneOffsetMinutes(timezone);
+  if (offsetMinutes == null) {
+    return wallClockUtcDate.toISOString();
+  }
+
+  const utcMillis =
+    Date.UTC(
+      wallClockUtcDate.getUTCFullYear(),
+      wallClockUtcDate.getUTCMonth(),
+      wallClockUtcDate.getUTCDate(),
+      wallClockUtcDate.getUTCHours(),
+      wallClockUtcDate.getUTCMinutes(),
+      wallClockUtcDate.getUTCSeconds(),
+      wallClockUtcDate.getUTCMilliseconds(),
+    ) -
+    offsetMinutes * 60 * 1000;
+
+  return new Date(utcMillis).toISOString();
 }
 
 export class DatetimeInterface extends BaseInterface {
@@ -48,14 +146,23 @@ export class DatetimeInterface extends BaseInterface {
     return null;
   }
 
-  protected formatDateTimeToISO(dateInfo: {
-    year: string;
-    month: string;
-    day: string;
-    hour?: string;
-    minute?: string;
-    second?: string;
-  }) {
+  protected formatDateTimeToISO(
+    dateInfo: {
+      year: string;
+      month: string;
+      day: string;
+      hour?: string;
+      minute?: string;
+      second?: string;
+    },
+    ctx?: any,
+  ) {
+    const timezone = resolveTimeZoneFromCtx(ctx);
+    const timezoneAwareISO = toISOWithTimezone(dateInfo, timezone);
+    if (timezoneAwareISO) {
+      return timezoneAwareISO;
+    }
+
     const { year, month, day, hour = '00', minute = '00', second = '00' } = dateInfo;
     const m = dayjs(`${year}-${month}-${day} ${hour}:${minute}:${second}.000`);
     return m.toISOString();
@@ -77,7 +184,7 @@ export class DatetimeInterface extends BaseInterface {
     if (typeof value === 'string') {
       const dateInfo = this.parseDateString(value);
       if (dateInfo) {
-        return this.formatDateTimeToISO(dateInfo);
+        return this.formatDateTimeToISO(dateInfo, ctx);
       }
     }
 
@@ -86,7 +193,7 @@ export class DatetimeInterface extends BaseInterface {
     } else if (isDate(value)) {
       return value;
     } else if (isNumeric(value)) {
-      return getJsDateFromExcel(value).toISOString();
+      return excelSerialToISO(value, resolveTimeZoneFromCtx(ctx));
     } else if (typeof value === 'string') {
       return value;
     }
@@ -95,7 +202,7 @@ export class DatetimeInterface extends BaseInterface {
   }
 
   toString(value: any, ctx?: any) {
-    const utcOffset = resolveTimeZoneFromCtx(ctx);
+    const utcOffset = resolveTimeZoneFromCtx(ctx) ?? 0;
     const props = this.options?.uiSchema?.['x-component-props'] ?? {};
     const format = getDefaultFormat(props);
     const m = str2moment(value, { ...props, utcOffset });

--- a/packages/core/database/src/interfaces/datetime-no-tz-interface.ts
+++ b/packages/core/database/src/interfaces/datetime-no-tz-interface.ts
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { DatetimeInterface } from './datetime-interface';
 import dayjs from 'dayjs';
 import { getJsDateFromExcel } from 'excel-date-to-js';
@@ -11,6 +20,10 @@ function isNumeric(str: any) {
   if (typeof str === 'number') return true;
   if (typeof str != 'string') return false;
   return !isNaN(str as any) && !isNaN(parseFloat(str));
+}
+
+function pad2(value: number) {
+  return String(value).padStart(2, '0');
 }
 
 export class DatetimeNoTzInterface extends DatetimeInterface {
@@ -27,6 +40,18 @@ export class DatetimeNoTzInterface extends DatetimeInterface {
       return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
     }
     return `${year}-${month}-${day}`;
+  }
+
+  protected formatExcelSerialToString(value: number | string) {
+    const date = getJsDateFromExcel(value);
+    return this.formatDateTimeToString({
+      year: String(date.getUTCFullYear()),
+      month: pad2(date.getUTCMonth() + 1),
+      day: pad2(date.getUTCDate()),
+      hour: pad2(date.getUTCHours()),
+      minute: pad2(date.getUTCMinutes()),
+      second: pad2(date.getUTCSeconds()),
+    });
   }
 
   async toValue(value: any, ctx: any = {}): Promise<any> {
@@ -46,8 +71,7 @@ export class DatetimeNoTzInterface extends DatetimeInterface {
     } else if (isDate(value)) {
       return value;
     } else if (isNumeric(value)) {
-      const date = getJsDateFromExcel(value);
-      return date.toISOString();
+      return this.formatExcelSerialToString(value);
     } else if (typeof value === 'string') {
       return value;
     }

--- a/packages/core/database/src/interfaces/time-interface.ts
+++ b/packages/core/database/src/interfaces/time-interface.ts
@@ -11,8 +11,30 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { BaseInterface } from './base-interface';
 dayjs.extend(utc);
+
+function isNumeric(value: any): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function formatExcelTimeSerial(value: number) {
+  const normalized = ((value % 1) + 1) % 1;
+  const totalSeconds = Math.round(normalized * 24 * 60 * 60) % (24 * 60 * 60);
+  const hours = Math.floor(totalSeconds / 3600)
+    .toString()
+    .padStart(2, '0');
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+}
+
 export class TimeInterface extends BaseInterface {
   toValue(value: any, ctx?: any) {
+    if (isNumeric(value)) {
+      return formatExcelTimeSerial(value);
+    }
+
     if (this.validate(value)) {
       const result = dayjs(value).format('HH:mm:ss');
       return result;

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
@@ -352,6 +352,10 @@ describe('basic importer', () => {
             defaultTitle: '日期时间',
           },
           {
+            dataIndex: ['datetimeNoTz'],
+            defaultTitle: '日期时间（不含时区）',
+          },
+          {
             dataIndex: ['unixTimestamp'],
             defaultTitle: 'Unix时间戳秒',
           },
@@ -365,10 +369,11 @@ describe('basic importer', () => {
         const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
         const worksheet = template.Sheets[template.SheetNames[0]];
 
-        XLSX.utils.sheet_add_aoa(worksheet, [[name, 45789, 45789, 45789]], { origin: 'A2' });
+        XLSX.utils.sheet_add_aoa(worksheet, [[name, 45789, 45789, 45789, 45789]], { origin: 'A2' });
         worksheet['B2'].z = 'yyyy-mm-dd';
         worksheet['C2'].z = 'yyyy-mm-dd';
         worksheet['D2'].z = 'yyyy-mm-dd';
+        worksheet['E2'].z = 'yyyy-mm-dd';
 
         const buffer = XLSX.write(template, { type: 'buffer', bookType: 'xlsx' });
         const workbook = readImportWorkbook(buffer, 10);
@@ -716,8 +721,120 @@ describe('basic importer', () => {
         const user = await runExcelDateImport(testCase);
 
         expect(user['dateOnly']).toBe('2025-05-12');
+        expect(user['datetimeNoTz']).toBe('2025-05-12 00:00:00');
         expect(moment(user['datetime']).toISOString()).toEqual(testCase.expectedDateTime);
         expect(moment(user['unixTimestamp']).toISOString()).toEqual(testCase.expectedDateTime);
+      }
+    });
+
+    it('should honor request timezone when importing excel date cells through HTTP action', async () => {
+      const httpApp = await createMockServer({
+        name: `import-http-${Date.now()}`,
+        plugins: ['error-handler', 'action-import'],
+      });
+      let filePath: string;
+
+      try {
+        const HttpUser = httpApp.db.collection({
+          name: 'http_import_users',
+          fields: [
+            { type: 'string', name: 'name' },
+            {
+              type: 'datetime',
+              name: 'datetime',
+              interface: 'datetime',
+            },
+            {
+              type: 'datetimeNoTz',
+              name: 'datetimeNoTz',
+              interface: 'datetimeNoTz',
+              uiSchema: {
+                'x-component-props': {
+                  picker: 'date',
+                  dateFormat: 'YYYY-MM-DD',
+                  showTime: true,
+                  timeFormat: 'HH:mm:ss',
+                },
+              },
+            },
+            {
+              type: 'unixTimestamp',
+              name: 'unixTimestamp',
+              interface: 'unixTimestamp',
+              uiSchema: {
+                'x-component-props': {
+                  picker: 'date',
+                  dateFormat: 'YYYY-MM-DD',
+                  showTime: true,
+                  timeFormat: 'HH:mm:ss',
+                },
+              },
+            },
+          ],
+        });
+        await httpApp.db.sync();
+
+        const columns = [
+          {
+            dataIndex: ['name'],
+            defaultTitle: '姓名',
+          },
+          {
+            dataIndex: ['datetime'],
+            defaultTitle: '日期时间',
+          },
+          {
+            dataIndex: ['datetimeNoTz'],
+            defaultTitle: '日期时间（不含时区）',
+          },
+          {
+            dataIndex: ['unixTimestamp'],
+            defaultTitle: 'Unix时间戳秒',
+          },
+        ];
+
+        const templateCreator = new TemplateCreator({
+          collection: HttpUser,
+          columns,
+        });
+
+        const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
+        const worksheet = template.Sheets[template.SheetNames[0]];
+        XLSX.utils.sheet_add_aoa(worksheet, [['http-test', 45789, 45789, 45789]], { origin: 'A2' });
+        worksheet['B2'].z = 'yyyy-mm-dd';
+        worksheet['C2'].z = 'yyyy-mm-dd';
+        worksheet['D2'].z = 'yyyy-mm-dd';
+
+        filePath = path.join(process.cwd(), `tmp-import-date-${Date.now()}.xlsx`);
+        fs.writeFileSync(filePath, XLSX.write(template, { type: 'buffer', bookType: 'xlsx' }));
+
+        const res = await httpApp
+          .agent()
+          .set('X-Timezone', '+08:00')
+          .resource('http_import_users')
+          .importXlsx({
+            file: filePath,
+            values: {
+              columns: JSON.stringify(columns),
+            },
+          });
+
+        expect(res.status).toBe(200);
+
+        const user = await HttpUser.repository.findOne({
+          filter: {
+            name: 'http-test',
+          },
+        });
+
+        expect(moment(user.get('datetime')).toISOString()).toEqual('2025-05-11T16:00:00.000Z');
+        expect(user.get('datetimeNoTz')).toBe('2025-05-12 00:00:00');
+        expect(moment(user.get('unixTimestamp')).toISOString()).toEqual('2025-05-11T16:00:00.000Z');
+      } finally {
+        await httpApp.destroy();
+        if (filePath) {
+          fs.rmSync(filePath, { force: true });
+        }
       }
     });
   });

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
@@ -331,6 +331,93 @@ describe('basic importer', () => {
       await app.db.sync();
     });
 
+    async function runExcelDateImport(options: { serverTimeZone: string; requestTimeZone?: string }) {
+      const previousTz = process.env.TZ;
+      const name = `test-${options.serverTimeZone}-${options.requestTimeZone ?? 'none'}`;
+
+      try {
+        process.env.TZ = options.serverTimeZone;
+
+        const columns = [
+          {
+            dataIndex: ['name'],
+            defaultTitle: '姓名',
+          },
+          {
+            dataIndex: ['dateOnly'],
+            defaultTitle: '日期',
+          },
+          {
+            dataIndex: ['datetime'],
+            defaultTitle: '日期时间',
+          },
+          {
+            dataIndex: ['unixTimestamp'],
+            defaultTitle: 'Unix时间戳秒',
+          },
+        ];
+
+        const templateCreator = new TemplateCreator({
+          collection: User,
+          columns,
+        });
+
+        const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
+        const worksheet = template.Sheets[template.SheetNames[0]];
+
+        XLSX.utils.sheet_add_aoa(worksheet, [[name, 45789, 45789, 45789]], { origin: 'A2' });
+        worksheet['B2'].z = 'yyyy-mm-dd';
+        worksheet['C2'].z = 'yyyy-mm-dd';
+        worksheet['D2'].z = 'yyyy-mm-dd';
+
+        const buffer = XLSX.write(template, { type: 'buffer', bookType: 'xlsx' });
+        const workbook = readImportWorkbook(buffer, 10);
+
+        const importer = new XlsxImporter({
+          collectionManager: app.mainDataSource.collectionManager,
+          collection: User,
+          columns,
+          workbook,
+        });
+
+        await importer.run(
+          options.requestTimeZone
+            ? {
+                context: {
+                  request: {
+                    get(key: string) {
+                      return key.toLowerCase() === 'x-timezone' ? options.requestTimeZone : undefined;
+                    },
+                    headers: {
+                      'x-timezone': options.requestTimeZone,
+                    },
+                  },
+                  req: {
+                    headers: {
+                      'x-timezone': options.requestTimeZone,
+                    },
+                  },
+                },
+              }
+            : {},
+        );
+
+        const user = await User.repository.findOne({
+          filter: {
+            name,
+          },
+        });
+
+        return user.toJSON();
+      } finally {
+        if (previousTz == null) {
+          delete process.env.TZ;
+        } else {
+          process.env.TZ = previousTz;
+        }
+      }
+    }
+
     it('should import with dateOnly', async () => {
       const columns = [
         {
@@ -542,6 +629,96 @@ describe('basic importer', () => {
 
       const users = (await User.repository.find()).map((user) => user.toJSON());
       expect(moment(users[0]['datetime']).toISOString()).toEqual('2111-11-12T00:00:00.000Z');
+    });
+
+    it('should honor request timezone for tz-aware excel date cells while keeping dateOnly stable', async () => {
+      const columns = [
+        {
+          dataIndex: ['name'],
+          defaultTitle: '姓名',
+        },
+        {
+          dataIndex: ['dateOnly'],
+          defaultTitle: '日期',
+        },
+        {
+          dataIndex: ['datetime'],
+          defaultTitle: '日期时间',
+        },
+        {
+          dataIndex: ['unixTimestamp'],
+          defaultTitle: 'Unix时间戳秒',
+        },
+      ];
+
+      const templateCreator = new TemplateCreator({
+        collection: User,
+        columns,
+      });
+
+      const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
+      const worksheet = template.Sheets[template.SheetNames[0]];
+
+      XLSX.utils.sheet_add_aoa(worksheet, [['test', 45789, 45789, 45789]], { origin: 'A2' });
+      worksheet['B2'].z = 'yyyy-mm-dd';
+      worksheet['C2'].z = 'yyyy-mm-dd';
+      worksheet['D2'].z = 'yyyy-mm-dd';
+
+      const buffer = XLSX.write(template, { type: 'buffer', bookType: 'xlsx' });
+      const workbook = readImportWorkbook(buffer, 10);
+
+      const importer = new XlsxImporter({
+        collectionManager: app.mainDataSource.collectionManager,
+        collection: User,
+        columns,
+        workbook,
+      });
+
+      await importer.run({
+        context: {
+          get(key: string) {
+            return key === 'X-Timezone' ? '+08:00' : undefined;
+          },
+        },
+      });
+
+      const users = (await User.repository.find()).map((user) => user.toJSON());
+      expect(users[0]['dateOnly']).toBe('2025-05-12');
+      expect(moment(users[0]['datetime']).toISOString()).toEqual('2025-05-11T16:00:00.000Z');
+      expect(moment(users[0]['unixTimestamp']).toISOString()).toEqual('2025-05-11T16:00:00.000Z');
+    });
+
+    it('should cover the sync import timezone matrix for excel date cells', async () => {
+      const cases = [
+        {
+          serverTimeZone: 'UTC',
+          requestTimeZone: undefined,
+          expectedDateTime: '2025-05-12T00:00:00.000Z',
+        },
+        {
+          serverTimeZone: 'UTC',
+          requestTimeZone: '+08:00',
+          expectedDateTime: '2025-05-11T16:00:00.000Z',
+        },
+        {
+          serverTimeZone: 'Asia/Shanghai',
+          requestTimeZone: undefined,
+          expectedDateTime: '2025-05-12T00:00:00.000Z',
+        },
+        {
+          serverTimeZone: 'Asia/Shanghai',
+          requestTimeZone: '+08:00',
+          expectedDateTime: '2025-05-11T16:00:00.000Z',
+        },
+      ];
+
+      for (const testCase of cases) {
+        const user = await runExcelDateImport(testCase);
+
+        expect(user['dateOnly']).toBe('2025-05-12');
+        expect(moment(user['datetime']).toISOString()).toEqual(testCase.expectedDateTime);
+        expect(moment(user['unixTimestamp']).toISOString()).toEqual(testCase.expectedDateTime);
+      }
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
@@ -10,6 +10,7 @@
 import { createMockServer, MockServer } from '@nocobase/test';
 import { TemplateCreator } from '../services/template-creator';
 import { XlsxImporter } from '../services/xlsx-importer';
+import { readImportWorkbook } from '../actions/import-xlsx';
 import * as XLSX from 'xlsx';
 import * as process from 'node:process';
 import * as path from 'node:path';
@@ -374,6 +375,45 @@ describe('basic importer', () => {
       expect(users[0]['dateOnly']).toBe('2111-11-12');
       expect(users[1]['dateOnly']).toBe('2021-10-18');
       expect(users[2]['dateOnly']).toBe('2024-11-12');
+    });
+
+    it('should keep dateOnly value stable after xlsx round-trip in non-UTC timezone', async () => {
+      const columns = [
+        {
+          dataIndex: ['name'],
+          defaultTitle: '姓名',
+        },
+        {
+          dataIndex: ['dateOnly'],
+          defaultTitle: '日期',
+        },
+      ];
+
+      const templateCreator = new TemplateCreator({
+        collection: User,
+        columns,
+      });
+
+      const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
+      const worksheet = template.Sheets[template.SheetNames[0]];
+
+      XLSX.utils.sheet_add_aoa(worksheet, [['test', 45789]], { origin: 'A2' });
+      worksheet['B2'].z = 'm/d/yy';
+
+      const buffer = XLSX.write(template, { type: 'buffer', bookType: 'xlsx' });
+      const workbook = readImportWorkbook(buffer, 10);
+
+      const importer = new XlsxImporter({
+        collectionManager: app.mainDataSource.collectionManager,
+        collection: User,
+        columns,
+        workbook,
+      });
+
+      await importer.run();
+
+      const users = (await User.repository.find()).map((user) => user.toJSON());
+      expect(users[0]['dateOnly']).toBe('2025-05-12');
     });
 
     it.skipIf(process.env['DB_DIALECT'] === 'sqlite')('should import with datetimeNoTz', async () => {
@@ -2286,6 +2326,7 @@ describe('basic importer', () => {
         {
           type: 'time',
           name: 'brithtime',
+          interface: 'time',
         },
       ],
     });
@@ -2306,9 +2347,11 @@ describe('basic importer', () => {
 
     const worksheet = template.Sheets[template.SheetNames[0]];
 
-    XLSX.utils.sheet_add_aoa(worksheet, [['12:12:12']], {
-      origin: 'A3',
-    });
+    XLSX.utils.sheet_add_aoa(worksheet, [[0.5084722222222222]], { origin: 'A3' });
+    worksheet['A3'].z = 'h:mm:ss';
+
+    const buffer = XLSX.write(template, { type: 'buffer', bookType: 'xlsx' });
+    const workbook = readImportWorkbook(buffer, 10);
 
     const importer = new XlsxImporter({
       collectionManager: app.mainDataSource.collectionManager,
@@ -2320,12 +2363,13 @@ describe('basic importer', () => {
           defaultTitle: '出生时间',
         },
       ],
-      workbook: template,
+      workbook,
     });
 
     await importer.run();
-    const count = await TimeCollection.repository.count();
-    expect(count).toBe(1);
+    const records = await TimeCollection.repository.find();
+    expect(records).toHaveLength(1);
+    expect(records[0].get('brithtime')).toBe('12:12:12');
   });
 
   it('should throw error when import textarea field, value is date', async () => {

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/actions/import-xlsx.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/actions/import-xlsx.ts
@@ -18,6 +18,17 @@ const IMPORT_LIMIT_COUNT = 2000;
 
 const mutex = new Mutex();
 
+export function readImportWorkbook(buffer: Buffer, sheetRows: number) {
+  return XLSX.read(buffer, {
+    type: 'buffer',
+    sheetRows,
+    // Keep Excel date cells as serial numbers. SheetJS `cellDates: true` converts
+    // them to local-time Date objects through a timezone-sensitive path, which can
+    // shift date-only values in non-UTC environments (for example Asia/Shanghai).
+    cellDates: false,
+  });
+}
+
 async function importXlsxAction(ctx: Context, next: Next) {
   let columns = (ctx.request.body as any).columns as any[];
   if (typeof columns === 'string') {
@@ -33,11 +44,7 @@ async function importXlsxAction(ctx: Context, next: Next) {
     readLimit += 1;
   }
 
-  const workbook = XLSX.read(ctx.file.buffer, {
-    type: 'buffer',
-    sheetRows: readLimit,
-    cellDates: true,
-  });
+  const workbook = readImportWorkbook(ctx.file.buffer, readLimit);
 
   const repository = ctx.getCurrentRepository() as Repository;
   const dataSource = ctx.dataSource as DataSource;

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/services/xlsx-importer.ts
@@ -383,10 +383,9 @@ export class XlsxImporter extends EventEmitter {
 
       const interfaceInstance = new InterfaceClass(field.options);
 
-      const ctx: any = {
-        transaction: options.transaction,
-        field,
-      };
+      const ctx: any = options.context ? Object.create(options.context) : {};
+      ctx.transaction = options.transaction;
+      ctx.field = field;
 
       if (column.dataIndex.length > 1) {
         ctx.associationField = field;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix the issue where imported record on date-like fields shows wrong date.

### Description 

When import "2025-05-12" from excel file, will get "2025-05-11 15:59:17".

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where imported record on date-like fields shows wrong date |
| 🇨🇳 Chinese | 修复导入日期类字段后展示错误的时间的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
