### PR TITLE
fix(create-app): normalize app dev client paths

### DIFF
--- a/packages/core/app/client/rsbuild.config.ts
+++ b/packages/core/app/client/rsbuild.config.ts
@@ -20,7 +20,7 @@ import { generatePlugins, getRsbuildAlias } from '@nocobase/devtools/rsbuildConf
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
-const devtoolsPackageJson = require('../../devtools/package.json') as { version?: string };
+const devtoolsPackageJson = require('@nocobase/devtools/package.json') as { version?: string };
 const appVersion = devtoolsPackageJson.version || '';
 const APP_PUBLIC_PATH_TEMPLATE = '{{env.APP_PUBLIC_PATH}}';
 

--- a/packages/core/cli-v1/src/util.js
+++ b/packages/core/cli-v1/src/util.js
@@ -227,6 +227,38 @@ exports.getVersion = async () => {
   return versions[versions.length - 1];
 };
 
+function normalizeAppDevClientRsbuildConfig(appDevDir) {
+  const configPath = resolve(appDevDir, 'client/rsbuild.config.ts');
+  if (!existsSync(configPath)) {
+    return;
+  }
+  const content = fs.readFileSync(configPath, 'utf-8');
+  const normalized = content.replace(
+    "require('../../devtools/package.json')",
+    "require('@nocobase/devtools/package.json')",
+  );
+  if (normalized !== content) {
+    fs.writeFileSync(configPath, normalized, 'utf-8');
+  }
+}
+
+function normalizeAppDevClientV2Tsconfig(appDevDir) {
+  const tsconfigPath = resolve(appDevDir, 'client-v2/tsconfig.json');
+  if (!existsSync(tsconfigPath)) {
+    return;
+  }
+  const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, 'utf-8'));
+  tsconfig.extends = '../../../tsconfig.json';
+  tsconfig.compilerOptions = tsconfig.compilerOptions || {};
+  tsconfig.compilerOptions.baseUrl = '../../../';
+  fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`, 'utf-8');
+}
+
+function normalizeAppDevFiles(appDevDir) {
+  normalizeAppDevClientRsbuildConfig(appDevDir);
+  normalizeAppDevClientV2Tsconfig(appDevDir);
+}
+
 exports.generateAppDir = function generateAppDir() {
   const appPkgPath = dirname(dirname(require.resolve('@nocobase/app/src/index.ts')));
   const appDevDir = resolve(process.cwd(), './storage/.app-dev');
@@ -238,6 +270,7 @@ exports.generateAppDir = function generateAppDir() {
         force: true,
       });
     }
+    normalizeAppDevFiles(appDevDir);
     process.env.APP_PACKAGE_ROOT = appDevDir;
   } else {
     process.env.APP_PACKAGE_ROOT = appPkgPath;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Apps created by `create-nocobase-app` can fail during `yarn dev` because `.app-dev` keeps monorepo-relative client paths after `@nocobase/app` is copied into standalone app storage.

### Description
- Resolve the classic client Rsbuild config's devtools package version through `@nocobase/devtools/package.json`.
- Normalize cached `.app-dev` client files during standalone app startup so existing apps do not need to manually clear `storage/.app-dev`.
- Point the copied `client-v2/tsconfig.json` back to the standalone app root while preserving monorepo source config behavior.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed development startup failures in apps created with create-nocobase-app caused by app-dev client path resolution. |
| 🇨🇳 Chinese | 修复通过 create-nocobase-app 创建的应用在开发启动时因 app-dev 客户端路径解析错误导致构建失败的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
