### PR TITLE
fix: disable quick edit for association fields in table

### DIFF
--- a/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/TableColumnModel.tsx
@@ -445,6 +445,9 @@ TableColumnModel.registerFlow({
     quickEdit: {
       title: tExpr('Enable quick edit'),
       uiMode: { type: 'switch', key: 'editable' },
+      hideInSettings(ctx) {
+        return !!ctx.model.associationPathName;
+      },
       defaultParams(ctx) {
         if (ctx.model.collectionField.readonly || ctx.model.associationPathName) {
           return {
@@ -456,7 +459,7 @@ TableColumnModel.registerFlow({
         };
       },
       handler(ctx, params) {
-        ctx.model.setProps('editable', params.editable);
+        ctx.model.setProps('editable', ctx.model.associationPathName ? false : params.editable);
       },
     },
     model: {

--- a/packages/core/client/src/flow/models/blocks/table/__tests__/TableColumnModel.test.tsx
+++ b/packages/core/client/src/flow/models/blocks/table/__tests__/TableColumnModel.test.tsx
@@ -12,6 +12,42 @@ import { describe, expect, it, vi } from 'vitest';
 import { TableColumnModel } from '../TableColumnModel';
 
 describe('TableColumnModel sorter settings', () => {
+  it('hides quick edit setting for relation path columns added from association groups', async () => {
+    const engine = new FlowEngine();
+    const model = new TableColumnModel({ uid: 'table-column-relation-path-quick-edit', flowEngine: engine } as any);
+    const quickEditStep = model.getFlow('tableColumnSettings')?.steps?.quickEdit as any;
+
+    const hidden = await quickEditStep.hideInSettings({
+      model: {
+        associationPathName: 'department',
+      },
+    });
+
+    expect(hidden).toBe(true);
+  });
+
+  it('keeps quick edit disabled for relation path columns even when params enable it', () => {
+    const engine = new FlowEngine();
+    const model = new TableColumnModel({
+      uid: 'table-column-relation-path-disable-quick-edit',
+      flowEngine: engine,
+    } as any);
+    const quickEditStep = model.getFlow('tableColumnSettings')?.steps?.quickEdit as any;
+    const setProps = vi.fn();
+
+    quickEditStep.handler(
+      {
+        model: {
+          associationPathName: 'department',
+          setProps,
+        },
+      },
+      { editable: true },
+    );
+
+    expect(setProps).toHaveBeenCalledWith('editable', false);
+  });
+
   it('hides sortable setting for association fields', async () => {
     const engine = new FlowEngine();
     const model = new TableColumnModel({ uid: 'table-column-association-sorter', flowEngine: engine } as any);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix prevent opening quick edit for association fields in table       |
| 🇨🇳 Chinese |    修复表格中关联字段显示快捷编辑允许打开编辑弹窗的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
