### PR TITLE
fix: multiple select fields in v2 data blocks should display option l…

### DIFF
--- a/packages/core/client/src/flow/models/fields/DisplayEnumFieldModel.tsx
+++ b/packages/core/client/src/flow/models/fields/DisplayEnumFieldModel.tsx
@@ -48,6 +48,13 @@ export class DisplayEnumFieldModel extends ClickableFieldModel {
     return value === null || value === undefined || value === '';
   }
 
+  private isEmptyEnumValue(value: any) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
+    return this.isEmpty(value);
+  }
+
   public renderComponent(value) {
     const { options = [], dataSource } = this.props;
     const currentOptions = getCurrentOptions(value, dataSource || options, fieldNames);
@@ -60,6 +67,43 @@ export class DisplayEnumFieldModel extends ClickableFieldModel {
         {this.translate(option[fieldNames.label])}
       </Tag>
     ));
+  }
+
+  /**
+   * Keep array values for multipleSelect/checkboxGroup.
+   * ClickableFieldModel will normalize arrays to joined strings, which breaks option label mapping.
+   */
+  renderInDisplayStyle(value, record?, isToMany?, wrap?) {
+    const { clickToOpen = false, ...restProps } = this.props;
+    void wrap;
+
+    const result = this.renderComponent(value);
+    const display = record ? (this.isEmptyEnumValue(value) ? 'N/A' : result) : result;
+
+    const commonStyle = {
+      cursor: clickToOpen ? 'pointer' : 'default',
+      alignItems: 'center',
+      gap: 4,
+      display: isToMany && 'inline-block',
+    };
+
+    const handleClick = (e) => {
+      clickToOpen && this.onClick(e, record);
+    };
+
+    if (clickToOpen) {
+      return (
+        <a {...restProps} style={commonStyle} onClick={handleClick}>
+          {display}
+        </a>
+      );
+    }
+
+    return (
+      <span {...restProps} style={commonStyle} className={restProps.className}>
+        {display}
+      </span>
+    );
   }
 }
 DisplayEnumFieldModel.define({

--- a/packages/core/client/src/flow/models/fields/__tests__/DisplayEnumFieldModel.test.tsx
+++ b/packages/core/client/src/flow/models/fields/__tests__/DisplayEnumFieldModel.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { FlowEngine } from '@nocobase/flow-engine';
+import { render, screen } from '@testing-library/react';
+import { DisplayEnumFieldModel } from '../DisplayEnumFieldModel';
+
+describe('DisplayEnumFieldModel', () => {
+  it('renders labels for multiple values (multipleSelect/checkboxGroup)', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ DisplayEnumFieldModel });
+
+    const model = engine.createModel<DisplayEnumFieldModel>({
+      use: DisplayEnumFieldModel,
+      uid: 'display-enum-multiple-values',
+    });
+
+    model.setProps({
+      value: ['a', 'b'],
+      options: [
+        { label: 'Option A', value: 'a' },
+        { label: 'Option B', value: 'b' },
+      ],
+    });
+
+    render(model.render());
+
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+    expect(screen.queryByText('a, b')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
…abels instead of values

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix multiple select fields in v2 data blocks should display option labels instead of values       |
| 🇨🇳 Chinese |    修复 v2 数据区块多选字段显示选项值而非选项标签的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
