### PR TITLE
fix(client-v2): keep empty menu groups

### DIFF
--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
@@ -628,10 +628,6 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
           )
           .filter(Boolean) || [];
 
-      if (isV2AdminRuntime(this.context.app) && children.length === 0) {
-        return null;
-      }
-
       if (options.designable && depth === 0) {
         children.push(getAdminLayoutMenuInitializerButton('schema-initializer-Menu-side', this, route));
       }

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/AdminLayoutMenuModels.test.ts
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/AdminLayoutMenuModels.test.ts
@@ -311,7 +311,7 @@ describe('AdminLayoutModel menu items', () => {
     expect(route.children[1]._model).toBe(adminLayoutModel.subModels.menuItems?.[1]);
   });
 
-  it('should filter legacy page menu routes in v2 admin layout', () => {
+  it('should filter legacy page menu routes but keep empty groups in v2 admin layout', () => {
     const adminLayoutModel = engine.createModel<AdminLayoutModel>({
       uid: 'admin-layout-model',
       use: AdminLayoutModel,
@@ -369,22 +369,30 @@ describe('AdminLayoutModel menu items', () => {
       t: (title) => title,
     });
 
-    expect(route.children).toHaveLength(2);
+    expect(route.children).toHaveLength(3);
     expect(route.children[0]).toMatchObject({
+      path: '/admin/2',
+      redirect: '/admin/2',
+      _runtimePath: null,
+      _navigationMode: 'spa',
+      _isLegacy: false,
+    });
+    expect(route.children[0].routes).toBeUndefined();
+    expect(route.children[1]).toMatchObject({
       path: '/admin/3',
       redirect: '/admin/nested-flow-page',
       _runtimePath: '/apps/demo/v2/admin/nested-flow-page',
       _navigationMode: 'spa',
       _isLegacy: false,
     });
-    expect(route.children[0].routes).toHaveLength(1);
-    expect(route.children[0].routes?.[0]).toMatchObject({
+    expect(route.children[1].routes).toHaveLength(1);
+    expect(route.children[1].routes?.[0]).toMatchObject({
       path: '/admin/nested-flow-page',
       _runtimePath: '/apps/demo/v2/admin/nested-flow-page',
       _navigationMode: 'spa',
       _isLegacy: false,
     });
-    expect(route.children[1]).toMatchObject({
+    expect(route.children[2]).toMatchObject({
       path: '/admin/__admin_layout__/link/4',
     });
   });

--- a/packages/core/client-v2/src/flow/models/base/PageModel/RootPageModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/PageModel/RootPageModel.tsx
@@ -162,7 +162,7 @@ RootPageModel.registerFlow({
         const route = ctx.routeRepository.getRouteBySchemaUid(ctx.model.parentId);
         ctx.model.setProps('routeId', route?.id);
         const routes: NocoBaseDesktopRoute[] = _.castArray(route?.children);
-        for (const route of routes.sort((a, b) => a.sort - b.sort).filter(Boolean)) {
+        for (const route of routes.filter(Boolean).sort((a, b) => (a.sort || 0) - (b.sort || 0))) {
           // 过滤掉隐藏的路由
           if (route.hideInMenu) {
             continue;

--- a/packages/core/client-v2/src/flow/models/base/PageModel/RootPageModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/PageModel/RootPageModel.tsx
@@ -162,7 +162,7 @@ RootPageModel.registerFlow({
         const route = ctx.routeRepository.getRouteBySchemaUid(ctx.model.parentId);
         ctx.model.setProps('routeId', route?.id);
         const routes: NocoBaseDesktopRoute[] = _.castArray(route?.children);
-        for (const route of routes.sort((a, b) => a.sort - b.sort)) {
+        for (const route of routes.sort((a, b) => a.sort - b.sort).filter(Boolean)) {
           // 过滤掉隐藏的路由
           if (route.hideInMenu) {
             continue;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 布局中，v1 页面菜单会被过滤掉。如果一个分组里原本只有 v1 页面，过滤后这个分组会变为空。之前空分组也会被隐藏，导致用户无法在这个分组里继续新增新的 v2 页面。

### Description 
本次调整后，v2 布局仍会过滤掉 v1 页面菜单，但不会隐藏过滤后为空的分组。这样用户可以保留原有分组结构，并在分组中继续新增 v2 页面。

同时更新了菜单模型测试，覆盖“过滤 v1 页面但保留空分组”的场景。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Keep empty groups after filtering v1 menus in the v2 layout |
| 🇨🇳 Chinese | v2 布局中过滤 v1 菜单后保留空分组 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
