### PR TITLE
fix: issue where the title field option list is empty for association…

### DIFF
--- a/packages/core/client-v2/src/flow/actions/__tests__/titleField.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/titleField.test.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { titleField } from '../titleField';
+
+describe('titleField action', () => {
+  it('builds options from target field interface metadata', () => {
+    const titleableField = {
+      name: 'nickname',
+      title: 'Nickname',
+      getInterfaceOptions: vi.fn(() => ({ titleUsable: true })),
+    };
+    const nonTitleableField = {
+      name: 'profile',
+      title: 'Profile',
+      getInterfaceOptions: vi.fn(() => ({ titleUsable: false })),
+    };
+    const missingContextManager = {
+      collectionFieldInterfaceManager: {
+        getFieldInterface: vi.fn(() => undefined),
+      },
+    };
+
+    const uiMode = (titleField as any).uiMode({
+      dataSourceManager: missingContextManager,
+      collectionField: {
+        targetCollection: {
+          getFields: () => [titleableField, nonTitleableField],
+        },
+      },
+    });
+
+    expect(uiMode.props.options).toEqual([{ value: 'nickname', label: 'Nickname' }]);
+    expect(titleableField.getInterfaceOptions).toHaveBeenCalled();
+    expect(nonTitleableField.getInterfaceOptions).toHaveBeenCalled();
+    expect(missingContextManager.collectionFieldInterfaceManager.getFieldInterface).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/client-v2/src/flow/actions/titleField.tsx
+++ b/packages/core/client-v2/src/flow/actions/titleField.tsx
@@ -43,7 +43,9 @@ export const titleField = defineAction({
     const options = targetFields
       .filter((field) =>
         isTitleFieldInterface(
-          getFlowFieldInterfaceOptions(field.options?.interface || field.interface, dataSourceManager),
+          typeof field.getInterfaceOptions === 'function'
+            ? field.getInterfaceOptions()
+            : getFlowFieldInterfaceOptions(field.options?.interface || field.interface, dataSourceManager),
         ),
       )
       .map((field) => ({


### PR DESCRIPTION
… fields

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix issue where the title field option list is empty for relation fields in table blocks   |
| 🇨🇳 Chinese |       修复表格中关系字段标题字段选项列表为空的问题    |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
