### PR TITLE
fix(calendar): limit popup height

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/global.style.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client/calendar/global.style.ts
@@ -13,6 +13,8 @@ const GlobalStyle = createGlobalStyle`
   .rbc-overlay {
     position: absolute;
     z-index: 50;
+    max-height: ${({ theme }) => `min(360px, calc(100vh - ${theme.marginXL * 2}px))`};
+    overflow-y: auto;
     margin-top: 5px;
     border-radius: ${({ theme }) => `${theme.borderRadius}px`};
     background-color: ${({ theme }) => theme.colorBgElevated};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
日历区块在某一天有大量日程时，点击 “more items” 展开后，弹出层会被内容撑得很高，导致部分日程显示到可视区域之外，用户无法完整查看。

### Description 
限制日历展开层的最大高度，并在日程数量较多时让展开层内部滚动。这样弹出层会保持在当前页面可视区域内，同时仍然可以查看全部隐藏日程。

已在本地连接测试环境复现并回归：大量日程展开后，弹出层位置保持可见，内容可以滚动到底部查看。

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where calendar more items cannot be fully displayed |
| 🇨🇳 Chinese | 修复日历展开更多日程时显示不全的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
