### PR TITLE
fix: can't resolve current popup record in action model

### DIFF
--- a/packages/core/client/src/flow/components/code-editor/__tests__/useCodeRunner.test.tsx
+++ b/packages/core/client/src/flow/components/code-editor/__tests__/useCodeRunner.test.tsx
@@ -14,6 +14,7 @@ import { render, waitFor } from '@testing-library/react';
 import { App, ConfigProvider } from 'antd';
 import { useCodeRunner } from '../hooks/useCodeRunner';
 import {
+  FlowContext,
   FlowEngine,
   FlowModel,
   FlowEngineProvider,
@@ -21,6 +22,7 @@ import {
   ElementProxy,
   createSafeWindow,
   createSafeDocument,
+  createViewScopedEngine,
 } from '@nocobase/flow-engine';
 import { JSEditableFieldModel } from '../../../models/fields/JSEditableFieldModel';
 
@@ -29,6 +31,20 @@ class DummyJsAutoModel extends FlowModel {
   render() {
     return <span data-testid={`dummy-${this.uid}`} ref={this.context.ref as any} />;
   }
+}
+
+function registerRunJsPreviewFlow(model: FlowModel) {
+  model.registerFlow('jsSettings', {
+    steps: {
+      runJs: {
+        useRawParams: true,
+        async handler(ctx) {
+          const code = ctx?.inputArgs?.preview?.code || '';
+          return ctx.runjs(code, undefined, { preprocessTemplates: true });
+        },
+      },
+    },
+  });
 }
 
 describe('useCodeRunner (beforeRender)', () => {
@@ -190,6 +206,71 @@ describe('useCodeRunner (beforeRender)', () => {
       const nodes = Array.from(document.querySelectorAll('[data-testid="dummy-m2"]')) as HTMLElement[];
       expect(nodes.some((el) => el.getAttribute('data-preview') === 'FORKED')).toBe(true);
     });
+  });
+
+  it('keeps popup context when a top scoped engine has another model with the same uid', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ DummyJsAutoModel });
+    const model = engine.createModel<DummyJsAutoModel>({ use: 'DummyJsAutoModel', uid: 'same-popup-uid' });
+    model.context.defineProperty('popup', {
+      value: {
+        uid: 'popup-view',
+        record: { username: 'alice' },
+      },
+    });
+    registerRunJsPreviewFlow(model);
+
+    const scopedEngine = createViewScopedEngine(engine);
+    const topModel = scopedEngine.createModel<DummyJsAutoModel>({ use: 'DummyJsAutoModel', uid: 'same-popup-uid' });
+    registerRunJsPreviewFlow(topModel);
+
+    const { result } = renderHook(() => useCodeRunner(model.context, 'v1'));
+    let runResult: any;
+    await act(async () => {
+      runResult = await result.current.run(`
+const currentUsername = await ctx.getVar('ctx.popup.record.username');
+console.log(currentUsername);
+return currentUsername;
+`);
+    });
+
+    expect(runResult?.success).toBe(true);
+    expect(runResult?.value).toBe('alice');
+    expect(result.current.logs.some((l) => l.level === 'log' && l.msg.includes('alice'))).toBe(true);
+  });
+
+  it('runs direct event-flow previews against the popup-bound model context when the settings view has no popup', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ DummyJsAutoModel });
+    const model = engine.createModel<DummyJsAutoModel>({ use: 'DummyJsAutoModel', uid: 'direct-popup-uid' });
+    model.context.defineProperty('popup', {
+      value: {
+        uid: 'popup-view',
+        record: { username: 'alice' },
+      },
+    });
+
+    const scopedEngine = createViewScopedEngine(engine);
+    scopedEngine.createModel<DummyJsAutoModel>({ use: 'DummyJsAutoModel', uid: 'direct-popup-uid' });
+
+    const settingsCtx = new FlowContext();
+    settingsCtx.defineProperty('engine', { value: scopedEngine });
+    settingsCtx.defineProperty('popup', { value: undefined });
+    settingsCtx.addDelegate(model.context);
+
+    const { result } = renderHook(() => useCodeRunner(settingsCtx as any, 'v1'));
+    let runResult: any;
+    await act(async () => {
+      runResult = await result.current.run(`
+const currentUsername = await ctx.getVar('ctx.popup.record.username');
+console.log(currentUsername);
+return currentUsername;
+`);
+    });
+
+    expect(runResult?.success).toBe(true);
+    expect(runResult?.value).toBe('alice');
+    expect(result.current.logs.some((l) => l.level === 'log' && l.msg.includes('alice'))).toBe(true);
   });
 
   it('compiles JSX in preview and renders antd Input without syntax error', async () => {

--- a/packages/core/client/src/flow/components/code-editor/hooks/useCodeRunner.ts
+++ b/packages/core/client/src/flow/components/code-editor/hooks/useCodeRunner.ts
@@ -112,6 +112,31 @@ function createLoggerWrapperFactory(append: (level: RunLog['level'], args: any[]
   return wrap;
 }
 
+function hasPopupViewMarkers(view: any): boolean {
+  const inputArgs = view?.inputArgs || {};
+  const openerUids = inputArgs?.openerUids;
+  const viewStack = view?.navigation?.viewStack;
+
+  return (Array.isArray(openerUids) && openerUids.length > 0) || (Array.isArray(viewStack) && viewStack.length >= 2);
+}
+
+async function hasPreviewPopupContext(ctx: any): Promise<boolean> {
+  if (!ctx) return false;
+
+  try {
+    const popup = await ctx.popup;
+    if (popup) return true;
+  } catch (_) {
+    // ignore unavailable popup getters
+  }
+
+  try {
+    return hasPopupViewMarkers(await ctx.view);
+  } catch (_) {
+    return false;
+  }
+}
+
 export function useCodeRunner(hostCtx: FlowModelContext, version = 'v1') {
   const [logs, setLogs] = useState<RunLog[]>([]);
   const [running, setRunning] = useState(false);
@@ -131,7 +156,14 @@ export function useCodeRunner(hostCtx: FlowModelContext, version = 'v1') {
         const model = hostCtx?.model;
         if (!model) throw new Error('No model in FlowContext');
         const engine = hostCtx.engine;
-        const runtimeModel = engine.getModel(model.uid, true) || model;
+        const globalRuntimeModel = engine.getModel(model.uid, true) || model;
+        const [hostHasPopupContext, modelHasPopupContext] = await Promise.all([
+          hasPreviewPopupContext(hostCtx),
+          hasPreviewPopupContext(model.context),
+        ]);
+        const shouldPreservePopupModel = hostHasPopupContext || modelHasPopupContext;
+        const runtimeModel = shouldPreservePopupModel ? model : globalRuntimeModel;
+        const directRunCtx = hostHasPopupContext ? hostCtx : modelHasPopupContext ? model.context : hostCtx;
 
         const nativeConsole: Record<RunLog['level'], (...args: any[]) => void> = {
           log: (...args) => console.log(...args),
@@ -255,7 +287,7 @@ export function useCodeRunner(hostCtx: FlowModelContext, version = 'v1') {
           if (!flow) {
             // 无可用流程（典型场景：联动规则里的 RunJS 预览），直接在当前上下文执行代码
             const navigator = createSafeNavigator();
-            await hostCtx.runjs(
+            await directRunCtx.runjs(
               code,
               { window: createSafeWindow({ navigator }), document: createSafeDocument(), navigator },
               { version },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where current popup record variables could not be resolved in action button event flows. |
| 🇨🇳 Chinese | 修复无法在操作按钮事件流中解析当前弹窗记录变量的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
