### PR TITLE
fix(plugin-workflow-javascript): bundle quickjs runtime package

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/build.config.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/build.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig } from '@nocobase/build';
+import fs from 'fs/promises';
+import path from 'path';
+
+function getPackageRoot(packageName: string) {
+  let resolved = '';
+  try {
+    resolved = require.resolve(`${packageName}/package.json`, { paths: [__dirname] });
+  } catch (_error) {
+    resolved = require.resolve(packageName, { paths: [__dirname] });
+  }
+
+  const marker = `${path.sep}node_modules${path.sep}${packageName.split('/').join(path.sep)}${path.sep}`;
+  const markerIndex = resolved.lastIndexOf(marker);
+  if (markerIndex < 0) {
+    throw new Error(`Cannot resolve package root for ${packageName} from ${resolved}`);
+  }
+
+  return resolved.slice(0, markerIndex + marker.length - 1);
+}
+
+async function copyRuntimePackage(packageName: string, copied: Set<string>, log: (msg: string) => void) {
+  if (copied.has(packageName)) {
+    return;
+  }
+
+  copied.add(packageName);
+
+  const source = getPackageRoot(packageName);
+  const packageJson = require(path.join(source, 'package.json'));
+  const target = path.resolve(__dirname, 'dist/node_modules', packageName);
+
+  log(`copying ${packageName} to dist/node_modules`);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.cp(source, target, {
+    recursive: true,
+    force: true,
+    dereference: false,
+    verbatimSymlinks: true,
+  });
+
+  const dependencies = Object.keys(packageJson.dependencies || {});
+  for (const dependency of dependencies) {
+    await copyRuntimePackage(dependency, copied, log);
+  }
+}
+
+export default defineConfig({
+  afterBuild: async (log) => {
+    await copyRuntimePackage('quickjs-emscripten', new Set<string>(), log);
+  },
+});

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/QuickJs.js
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/QuickJs.js
@@ -8,7 +8,19 @@
  */
 
 const { parentPort, workerData } = require('node:worker_threads');
-const { getQuickJS } = require('quickjs-emscripten');
+const path = require('node:path');
+
+function loadQuickJS() {
+  const bundledPath = path.join(__dirname, '..', 'node_modules', 'quickjs-emscripten');
+  try {
+    return require(bundledPath);
+  } catch (error) {
+    const packageName = 'quickjs-emscripten';
+    return require(packageName);
+  }
+}
+
+const { getQuickJS } = loadQuickJS();
 
 const MEMORY_LIMIT_BYTES = 128 * 1024 * 1024;
 const MAX_STACK_SIZE_BYTES = 1024 * 1024;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow JavaScript nodes use QuickJS by default. In production Docker images, the plugin can fail at runtime when loading `quickjs-emscripten` because the package is not available in the expected bundled runtime layout.

### Description
This PR keeps the QuickJS runtime package in the workflow JavaScript plugin's `dist/node_modules` with its original package structure.

- Adds a plugin build config that copies `quickjs-emscripten` and its runtime dependencies after build.
- Updates the QuickJS worker to prefer the plugin-local bundled runtime package and fall back to normal resolution for development.

Risk is limited to the workflow JavaScript QuickJS runtime loading path.

Testing:
- Ran `yarn build @nocobase/plugin-workflow-javascript --no-dts`.
- Verified the built `dist/server/QuickJs.js` worker can execute a script and return the expected result.

### Related issues
Task 4125

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow JavaScript QuickJS runtime package loading in production builds. |
| 🇨🇳 Chinese | 修复生产构建中工作流 JavaScript 节点 QuickJS 运行时包加载失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
