### PR TITLE
fix(database): avoid persisting current schema on field sync

### DIFF
--- a/packages/core/server/src/main-data-source.ts
+++ b/packages/core/server/src/main-data-source.ts
@@ -158,8 +158,13 @@ export class MainDataSource extends SequelizeDataSource {
       ctx.log.error(err);
     }
     const toLoadCollections = this.mergeWithLoadedCollections(collections, loadedCollections);
+    const currentSchema = db.options.schema || 'public';
 
     for (const values of toLoadCollections) {
+      if (values.schema === currentSchema) {
+        delete values.schema;
+      }
+
       const existsFields = loadedCollections[values.tableName].fields;
       const deletedFields = existsFields.filter((field: any) => !values.fields.find((f) => f.name === field.name));
 

--- a/packages/core/server/src/main-data-source.ts
+++ b/packages/core/server/src/main-data-source.ts
@@ -158,7 +158,7 @@ export class MainDataSource extends SequelizeDataSource {
       ctx.log.error(err);
     }
     const toLoadCollections = this.mergeWithLoadedCollections(collections, loadedCollections);
-    const currentSchema = db.options.schema || 'public';
+    const currentSchema = process.env.COLLECTION_MANAGER_SCHEMA || db.options.schema || 'public';
 
     for (const values of toLoadCollections) {
       if (values.schema === currentSchema) {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -277,11 +277,7 @@ describe('db2cm test', () => {
     let collectionName: string;
 
     beforeEach(async () => {
-      app = await createApp({
-        database: {
-          schema: `s_${uid(6)}`,
-        },
-      });
+      app = await createApp();
       db = app.db;
       collectionName = `t_${uid(6)}`;
     });

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -277,6 +277,8 @@ describe('db2cm test', () => {
     let collectionName: string;
 
     beforeEach(async () => {
+      vi.stubEnv('COLLECTION_MANAGER_SCHEMA', 'public');
+
       app = await createApp({
         database: {
           schema: `s_${uid(6)}`,
@@ -289,6 +291,7 @@ describe('db2cm test', () => {
     afterEach(async () => {
       await db.clean({ drop: true });
       await app.destroy();
+      vi.unstubAllEnvs();
     });
 
     it('should not persist current database schema into collection options when syncing fields', async () => {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -274,66 +274,68 @@ describe('db2cm test', () => {
   });
 
   describe.runIf(process.env.DB_DIALECT === 'postgres')('sync fields with database schema', () => {
-    it('should not persist current database schema into collection options when syncing fields', async () => {
-      const schema = `s_${uid(6)}`;
-      const collectionName = `t_${uid(6)}`;
+    let collectionName: string;
 
+    beforeEach(async () => {
       app = await createApp({
         database: {
-          schema,
+          schema: `s_${uid(6)}`,
         },
       });
       db = app.db;
+      collectionName = `t_${uid(6)}`;
+    });
 
-      try {
-        await app
-          .agent()
-          .resource('collections')
-          .create({
-            values: {
-              name: collectionName,
-              fields: [
-                {
-                  type: 'string',
-                  name: 'title',
-                },
-              ],
-            },
-          });
+    afterEach(async () => {
+      await db.clean({ drop: true });
+      await app.destroy();
+    });
 
-        let collectionRecord = await db.getRepository('collections').findOne({
-          filter: {
+    it('should not persist current database schema into collection options when syncing fields', async () => {
+      await app
+        .agent()
+        .resource('collections')
+        .create({
+          values: {
             name: collectionName,
+            fields: [
+              {
+                type: 'string',
+                name: 'title',
+              },
+            ],
           },
         });
-        expect(collectionRecord.get('schema')).toBeUndefined();
 
-        const collection = db.getCollection(collectionName);
-        await db.sequelize.getQueryInterface().addColumn(collection.getTableNameWithSchema(), 'description', {
-          type: DataTypes.TEXT,
-          allowNull: true,
-        });
+      let collectionRecord = await db.getRepository('collections').findOne({
+        filter: {
+          name: collectionName,
+        },
+      });
+      expect(collectionRecord.get('schema')).toBeUndefined();
 
-        const response = await app
-          .agent()
-          .resource('mainDataSource')
-          .syncFields({
-            values: {
-              collections: [collectionName],
-            },
-          });
-        expect(response.status).toBe(200);
+      const collection = db.getCollection(collectionName);
+      await db.sequelize.getQueryInterface().addColumn(collection.getTableNameWithSchema(), 'description', {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      });
 
-        collectionRecord = await db.getRepository('collections').findOne({
-          filter: {
-            name: collectionName,
+      const response = await app
+        .agent()
+        .resource('mainDataSource')
+        .syncFields({
+          values: {
+            collections: [collectionName],
           },
         });
-        expect(collectionRecord.get('schema')).toBeUndefined();
-      } finally {
-        await db.clean({ drop: true });
-        await app.destroy();
-      }
+      expect(response.status).toBe(200);
+
+      collectionRecord = await db.getRepository('collections').findOne({
+        filter: {
+          name: collectionName,
+        },
+      });
+      expect(collectionRecord.get('schema')).toBeUndefined();
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -277,8 +277,6 @@ describe('db2cm test', () => {
     let collectionName: string;
 
     beforeEach(async () => {
-      vi.stubEnv('COLLECTION_MANAGER_SCHEMA', 'public');
-
       app = await createApp({
         database: {
           schema: `s_${uid(6)}`,
@@ -291,7 +289,6 @@ describe('db2cm test', () => {
     afterEach(async () => {
       await db.clean({ drop: true });
       await app.destroy();
-      vi.unstubAllEnvs();
     });
 
     it('should not persist current database schema into collection options when syncing fields', async () => {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -10,6 +10,7 @@
 import Database, { createMockDatabase } from '@nocobase/database';
 import { MainDataSource, Plugin } from '@nocobase/server';
 import { createApp } from '.';
+import { uid } from '@nocobase/utils';
 import { DataTypes, QueryTypes, Sequelize } from 'sequelize';
 
 describe('db2cm test', () => {
@@ -269,6 +270,70 @@ describe('db2cm test', () => {
 
       const tablesAfterLoad = await mainDataSource.readTables();
       expect(tablesAfterLoad.some((table) => table.name === 'a1')).toBe(false);
+    });
+  });
+
+  describe.runIf(process.env.DB_DIALECT === 'postgres')('sync fields with database schema', () => {
+    it('should not persist current database schema into collection options when syncing fields', async () => {
+      const schema = `s_${uid(6)}`;
+      const collectionName = `t_${uid(6)}`;
+
+      app = await createApp({
+        database: {
+          schema,
+        },
+      });
+      db = app.db;
+
+      try {
+        await app
+          .agent()
+          .resource('collections')
+          .create({
+            values: {
+              name: collectionName,
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                },
+              ],
+            },
+          });
+
+        let collectionRecord = await db.getRepository('collections').findOne({
+          filter: {
+            name: collectionName,
+          },
+        });
+        expect(collectionRecord.get('schema')).toBeUndefined();
+
+        const collection = db.getCollection(collectionName);
+        await db.sequelize.getQueryInterface().addColumn(collection.getTableNameWithSchema(), 'description', {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        });
+
+        const response = await app
+          .agent()
+          .resource('mainDataSource')
+          .syncFields({
+            values: {
+              collections: [collectionName],
+            },
+          });
+        expect(response.status).toBe(200);
+
+        collectionRecord = await db.getRepository('collections').findOne({
+          filter: {
+            name: collectionName,
+          },
+        });
+        expect(collectionRecord.get('schema')).toBeUndefined();
+      } finally {
+        await db.clean({ drop: true });
+        await app.destroy();
+      }
     });
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Synchronizing fields from the database could persist the current PostgreSQL schema into collection options. Backups restored into another environment may then depend on the original schema name and fail to work correctly.

### Description 
This change removes the current database schema from collection values before field sync writes metadata back to the collections table. Schemas that do not match the current database schema are left unchanged.

A PostgreSQL regression test covers syncing fields in a non-public schema and verifies that the current schema is not persisted in collection options.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where field options are written into the schema after syncing fields |
| 🇨🇳 Chinese | 修复同步字段后，字段选项会写入 schema 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
