### PR TITLE
fix: field menu of sub form

### DIFF
--- a/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
+++ b/packages/core/client/src/flow/models/blocks/form/FormItemModel.tsx
@@ -24,6 +24,7 @@ import { EditFormModel } from './EditFormModel';
 import _ from 'lodash';
 import { Tooltip } from 'antd';
 import { coerceForToOneField } from '../../../internal/utils/associationValueCoercion';
+import { getFormItemFieldPathCandidates } from '../../../internal/utils/modelUtils';
 import { buildDynamicNamePath } from './dynamicNamePath';
 
 const interfacesOfUnsupportedDefaultValue = [
@@ -57,10 +58,9 @@ export class FormItemModel<T extends DefaultStructure = DefaultStructure> extend
           key: fullName,
           label: field.title,
           // 同步刷新 JS 字段菜单的切换状态（兼容旧路径与新路径）
-          refreshTargets: ['FormItemModel/FormJSFieldItemModel'],
+          refreshTargets: ['FormJSFieldItemModel', 'FormItemModel/FormJSFieldItemModel'],
           toggleable: (subModel) => {
-            const fieldPath = subModel.getStepParams('fieldSettings', 'init')?.fieldPath;
-            return fieldPath === fullName;
+            return getFormItemFieldPathCandidates(subModel).some((fieldPath) => fieldPath === fullName);
           },
           useModel: 'FormItemModel',
           createModelOptions: () => ({

--- a/packages/core/client/src/flow/models/blocks/form/__tests__/FormItemModel.defineChildren.test.ts
+++ b/packages/core/client/src/flow/models/blocks/form/__tests__/FormItemModel.defineChildren.test.ts
@@ -1,0 +1,108 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { FlowEngine, type FlowModelContext, type SubModelItem } from '@nocobase/flow-engine';
+// Import from the aggregate to preserve the model initialization order used by adjacent tests.
+import { FormItemModel, FormJSFieldItemModel, InputFieldModel, JSEditableFieldModel } from '../../../..';
+
+function createFormMenuContext(prefixFieldPath = 'roles') {
+  const engine = new FlowEngine();
+  engine.registerModels({
+    FormItemModel,
+    FormJSFieldItemModel,
+    InputFieldModel,
+    JSEditableFieldModel,
+  });
+
+  const dataSource = engine.dataSourceManager.getDataSource('main');
+  dataSource.addCollection({
+    name: 'users',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number', title: 'ID' },
+      { name: 'roles', type: 'hasMany', interface: 'o2m', target: 'roles', title: 'Roles' },
+    ],
+  });
+  dataSource.addCollection({
+    name: 'roles',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number', title: 'ID' },
+      { name: 'name', type: 'string', interface: 'input', title: 'Name' },
+    ],
+  });
+
+  const blockModel = engine.createModel({ use: 'FlowModel', uid: 'users-form-block' });
+  (blockModel as any).collection = dataSource.getCollection('users');
+
+  const gridModel = engine.createModel({ use: 'FlowModel', uid: 'users-form-grid' });
+  gridModel.context.defineProperty('blockModel', { value: blockModel });
+  gridModel.context.defineProperty('collection', { value: dataSource.getCollection('roles') });
+  gridModel.context.defineProperty('prefixFieldPath', { value: prefixFieldPath });
+
+  return gridModel.context as FlowModelContext;
+}
+
+async function resolveCreateOptions(item: SubModelItem, ctx: FlowModelContext) {
+  return typeof item.createModelOptions === 'function' ? await item.createModelOptions(ctx) : item.createModelOptions;
+}
+
+function createModelLike(createOptions: any) {
+  return {
+    getStepParams: (flowKey: string, stepKey: string) => createOptions?.stepParams?.[flowKey]?.[stepKey],
+  } as any;
+}
+
+describe('FormItemModel defineChildren', () => {
+  it('refreshes the JS field submenu when a normal subform field is toggled', () => {
+    const ctx = createFormMenuContext();
+    const formItems = FormItemModel.defineChildren(ctx) as SubModelItem[];
+    const nameItem = formItems.find((item) => item.key === 'roles.name');
+
+    expect(nameItem?.refreshTargets).toEqual(['FormJSFieldItemModel', 'FormItemModel/FormJSFieldItemModel']);
+  });
+
+  it('recognizes JS subform fields that store associationPathName and fieldPath separately', async () => {
+    const ctx = createFormMenuContext();
+    const formItems = FormItemModel.defineChildren(ctx) as SubModelItem[];
+    const jsItems = (await FormJSFieldItemModel.defineChildren(ctx)) as SubModelItem[];
+    const normalNameItem = formItems.find((item) => item.key === 'roles.name');
+    const jsNameItem = jsItems.find((item) => item.key === 'roles.name');
+
+    expect(normalNameItem).toBeTruthy();
+    expect(jsNameItem).toBeTruthy();
+
+    const jsCreateOptions = await resolveCreateOptions(jsNameItem, ctx);
+    expect(jsCreateOptions?.stepParams?.fieldSettings?.init).toMatchObject({
+      associationPathName: 'roles',
+      fieldPath: 'name',
+    });
+
+    expect((normalNameItem?.toggleable as (model: any) => boolean)(createModelLike(jsCreateOptions))).toBe(true);
+  });
+
+  it('lets the JS subform menu recognize normal fields that store the full fieldPath', async () => {
+    const ctx = createFormMenuContext();
+    const formItems = FormItemModel.defineChildren(ctx) as SubModelItem[];
+    const jsItems = (await FormJSFieldItemModel.defineChildren(ctx)) as SubModelItem[];
+    const normalNameItem = formItems.find((item) => item.key === 'roles.name');
+    const jsNameItem = jsItems.find((item) => item.key === 'roles.name');
+
+    expect(normalNameItem).toBeTruthy();
+    expect(jsNameItem).toBeTruthy();
+
+    const normalCreateOptions = await resolveCreateOptions(normalNameItem, ctx);
+    expect(normalCreateOptions?.stepParams?.fieldSettings?.init).toMatchObject({
+      fieldPath: 'roles.name',
+    });
+
+    expect((jsNameItem?.toggleable as (model: any) => boolean)(createModelLike(normalCreateOptions))).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect JS Field menu state in subforms. |
| 🇨🇳 Chinese | 修复子表单里 JS Field 菜单状态不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
