### PR TITLE
fix(plugin-action-bulk-update): reset loading on update failure

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/BulkUpdateActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/BulkUpdateActionModel.tsx
@@ -212,27 +212,33 @@ BulkUpdateActionModel.registerFlow({
           ctx.model.setProps({
             loading: true,
           });
-          await ctx.api
-            .resource(collection, null, {
-              'x-data-source': ctx.collection?.dataSourceKey,
-            })
-            .update({ filter, values: assignedValues });
-          ctx.model.setProps({
-            loading: false,
-          });
+          try {
+            await ctx.api
+              .resource(collection, null, {
+                'x-data-source': ctx.collection?.dataSourceKey,
+              })
+              .update({ filter, values: assignedValues });
+          } finally {
+            ctx.model.setProps({
+              loading: false,
+            });
+          }
         } else {
           // 整表（无筛选条件时需要 forceUpdate 通过校验）
           ctx.model.setProps({
             loading: true,
           });
-          await ctx.api
-            .resource(collection, null, {
-              'x-data-source': ctx.collection?.dataSourceKey,
-            })
-            .update({ values: assignedValues, forceUpdate: true });
-          ctx.model.setProps({
-            loading: false,
-          });
+          try {
+            await ctx.api
+              .resource(collection, null, {
+                'x-data-source': ctx.collection?.dataSourceKey,
+              })
+              .update({ values: assignedValues, forceUpdate: true });
+          } finally {
+            ctx.model.setProps({
+              loading: false,
+            });
+          }
         }
 
         ctx.blockModel?.resource?.refresh?.();

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/__tests__/BulkUpdateActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client/__tests__/BulkUpdateActionModel.test.ts
@@ -1,0 +1,71 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { BulkUpdateActionModel } from '../BulkUpdateActionModel';
+
+describe('BulkUpdateActionModel apply action', () => {
+  it('resets loading when selected records update fails', async () => {
+    const engine = new FlowEngine();
+    const model = new BulkUpdateActionModel({ uid: 'bulk-update-action', flowEngine: engine } as any);
+    const updateError = new Error('update failed');
+    const update = vi.fn().mockRejectedValue(updateError);
+    const setProps = vi.fn();
+    const refresh = vi.fn();
+
+    const ctx: any = {
+      model: {
+        getStepParams: vi.fn((_flowKey: string, stepKey: string) => {
+          if (stepKey === 'confirm') {
+            return { enable: false };
+          }
+          if (stepKey === 'updateMode') {
+            return { value: 'selected' };
+          }
+          return undefined;
+        }),
+        setProps,
+      },
+      runAction: vi.fn(async () => {}),
+      collection: {
+        name: 'users',
+        dataSourceKey: 'main',
+        filterTargetKey: 'id',
+        getPrimaryKey: () => 'id',
+        getFilterByTK: (record: any) => record.id,
+      },
+      blockModel: {
+        resource: {
+          getSelectedRows: () => [{ id: 1 }],
+          refresh,
+        },
+      },
+      api: {
+        resource: vi.fn(() => ({ update })),
+      },
+      message: {
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+      },
+      t: (value: string) => value,
+    };
+
+    const handler = model.getFlow('apply')?.getStep('apply')?.serialize().handler;
+
+    await expect(handler(ctx, { assignedValues: { nickname: 'Nick' } })).rejects.toThrow(updateError);
+
+    expect(update).toHaveBeenCalled();
+    expect(setProps).toHaveBeenNthCalledWith(1, { loading: true });
+    expect(setProps).toHaveBeenNthCalledWith(2, { loading: false });
+    expect(refresh).not.toHaveBeenCalled();
+    expect(ctx.message.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       fix bulk-update action reset loading state after update failure    |
| 🇨🇳 Chinese |   修复批量更新插件在更新失败后未重置 loading 状态的问题        |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
