### PR TITLE
fix(client-v2): show page-size changer by default in Table

### DIFF
--- a/packages/core/client-v2/src/components/form/table/Table.tsx
+++ b/packages/core/client-v2/src/components/form/table/Table.tsx
@@ -25,6 +25,21 @@ import { readRowKey, snapshotSourceRow, type RowKey, type RowSnapshot } from './
 type RowSelectionRenderCellResult<RecordType> = React.ReactNode | RenderedCell<RecordType>;
 
 /**
+ * Default initial page size for `Table`. Exposed so consumers can seed their
+ * controlled `pageSize` state with the same value the component would use if
+ * they relied purely on the built-in pagination defaults.
+ */
+export const DEFAULT_PAGE_SIZE = 50;
+
+/**
+ * Default `pageSizeOptions` injected into the pagination config. Matches the
+ * v1 settings-page table so users see the same choices across versions.
+ * Consumers can override by passing their own `pageSizeOptions` in
+ * `pagination`.
+ */
+export const PAGE_SIZE_OPTIONS: readonly number[] = [5, 10, 20, 50, 100, 200];
+
+/**
  * antd's `rowSelection.renderCell` can return either a `ReactNode` or a
  * `RenderedCell` (the `{ children, props }` shape used to drive colSpan /
  * rowSpan). `SelectionCell` only paints inside an existing selection cell —
@@ -105,8 +120,25 @@ export function Table<RecordType extends object = any>(props: TableProps<RecordT
     dataSource,
     rowSelection,
     className,
+    pagination,
     ...rest
   } = props;
+
+  // Apply opinionated pagination defaults (showSizeChanger + a v1-aligned set
+  // of pageSizeOptions). `pagination === false` is preserved verbatim so
+  // callers can still disable pagination outright; for any other value (object
+  // or undefined) we spread caller-provided keys last so explicit overrides
+  // win.
+  const mergedPagination = useMemo<AntdTableProps<RecordType>['pagination']>(() => {
+    if (pagination === false) {
+      return false;
+    }
+    return {
+      showSizeChanger: true,
+      pageSizeOptions: [...PAGE_SIZE_OPTIONS],
+      ...(pagination ?? {}),
+    };
+  }, [pagination]);
 
   const showHandleInSelection = isDraggable && showSortHandle && !!rowSelection;
   const showStandaloneHandleColumn = isDraggable && showSortHandle && !rowSelection;
@@ -214,6 +246,7 @@ export function Table<RecordType extends object = any>(props: TableProps<RecordT
       components={tableComponents}
       rowSelection={augmentedRowSelection}
       className={tableClassName}
+      pagination={mergedPagination}
     />
   );
 

--- a/packages/core/client-v2/src/components/form/table/__tests__/Table.pagination.test.tsx
+++ b/packages/core/client-v2/src/components/form/table/__tests__/Table.pagination.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS, Table } from '../Table';
+
+type Row = { id: number; name: string };
+
+const columns = [{ title: 'Name', dataIndex: 'name' as const }];
+
+function makeRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, index) => ({ id: index + 1, name: `row-${index + 1}` }));
+}
+
+describe('Table pagination defaults', () => {
+  it('exports DEFAULT_PAGE_SIZE=50 and the v1-aligned PAGE_SIZE_OPTIONS list', () => {
+    expect(DEFAULT_PAGE_SIZE).toBe(50);
+    expect([...PAGE_SIZE_OPTIONS]).toEqual([5, 10, 20, 50, 100, 200]);
+  });
+
+  it('shows the page-size changer by default when pagination is enabled', () => {
+    const { container } = render(
+      <Table<Row>
+        rowKey="id"
+        columns={columns}
+        dataSource={makeRows(120)}
+        pagination={{ current: 1, pageSize: 50, total: 120 }}
+      />,
+    );
+    expect(container.querySelector('.ant-pagination-options-size-changer')).not.toBeNull();
+  });
+
+  it('shows the page-size changer when caller omits pagination entirely', () => {
+    const { container } = render(<Table<Row> rowKey="id" columns={columns} dataSource={makeRows(120)} />);
+    expect(container.querySelector('.ant-pagination-options-size-changer')).not.toBeNull();
+  });
+
+  it('renders no pagination at all when caller passes pagination={false}', () => {
+    const { container } = render(
+      <Table<Row> rowKey="id" columns={columns} dataSource={makeRows(120)} pagination={false} />,
+    );
+    expect(container.querySelector('.ant-pagination')).toBeNull();
+  });
+
+  it('lets caller-provided showSizeChanger=false override the default', () => {
+    const { container } = render(
+      <Table<Row>
+        rowKey="id"
+        columns={columns}
+        dataSource={makeRows(120)}
+        pagination={{ current: 1, pageSize: 50, total: 120, showSizeChanger: false }}
+      />,
+    );
+    expect(container.querySelector('.ant-pagination-options-size-changer')).toBeNull();
+  });
+
+  it('preserves caller-controlled current page when caller passes a pagination object', () => {
+    const { container } = render(
+      <Table<Row>
+        rowKey="id"
+        columns={columns}
+        dataSource={makeRows(120)}
+        pagination={{ current: 2, pageSize: 50, total: 120 }}
+      />,
+    );
+    // antd marks the active page with `.ant-pagination-item-active` and the
+    // page number lives inside an <a> child — checking the rendered text is
+    // the most stable assertion across antd versions.
+    const active = container.querySelector('.ant-pagination-item-active');
+    expect(active?.textContent).toBe('2');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/pages/AuthenticatorsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/pages/AuthenticatorsPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { CheckOutlined, DeleteOutlined, DownOutlined, PlusOutlined } from '@ant-design/icons';
-import { DrawerFormLayout, Table } from '@nocobase/client-v2';
+import { DEFAULT_PAGE_SIZE, DrawerFormLayout, Table } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
 import { useMemoizedFn, useRequest } from 'ahooks';
 import { App, Button, Card, Checkbox, Dropdown, Form, Input, Select, Space, Spin, Tag, theme } from 'antd';
@@ -30,8 +30,6 @@ type AuthenticatorRecord = {
 };
 
 type AuthTypeOption = { name: string; title?: string };
-
-const PAGE_SIZE = 50;
 
 function createAuthenticatorName() {
   return `s_${Math.random().toString(36).slice(2, 12)}`;
@@ -202,22 +200,35 @@ export default function AuthenticatorsPage() {
   const resource = useAuthenticatorsResource();
   const plugin = ctx.app.pm.get(PluginAuthClientV2);
   const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const { data: authTypes } = useAuthTypesFromServer();
   const { data, loading, refresh } = useRequest(
     async () => {
       const response = await resource.list({
         page,
-        pageSize: PAGE_SIZE,
+        pageSize,
         sort: ['sort'],
         appends: [],
       });
       return normalizeListResponse(response);
     },
     {
-      refreshDeps: [page],
+      refreshDeps: [page, pageSize],
     },
   );
+
+  // antd's pagination `onChange(nextPage, nextPageSize)` fires for both
+  // current-page changes and page-size changes. When pageSize changes we reset
+  // to page 1 so the user is never landed on an out-of-range page.
+  const handlePaginationChange = useMemoizedFn((nextPage: number, nextPageSize: number) => {
+    if (nextPageSize !== pageSize) {
+      setPageSize(nextPageSize);
+      setPage(1);
+      return;
+    }
+    setPage(nextPage);
+  });
 
   const authTypeOptions = useMemo<AuthTypeOption[]>(() => authTypes || [], [authTypes]);
 
@@ -367,10 +378,9 @@ export default function AuthenticatorsPage() {
         }}
         pagination={{
           current: page,
-          pageSize: PAGE_SIZE,
+          pageSize,
           total: data?.total || 0,
-          showSizeChanger: false,
-          onChange: setPage,
+          onChange: handlePaginationChange,
         }}
       />
     </Card>

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/pages/FileStoragePage.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/pages/FileStoragePage.tsx
@@ -9,9 +9,9 @@
 
 import { CheckOutlined, DeleteOutlined, DownOutlined, PlusOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
-import { DrawerFormLayout, Table } from '@nocobase/client-v2';
+import { DEFAULT_PAGE_SIZE, DrawerFormLayout, Table } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
-import { useRequest } from 'ahooks';
+import { useMemoizedFn, useRequest } from 'ahooks';
 import { App, Button, Card, Dropdown, Form, Input, Space, Spin, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { cloneDeep } from 'lodash';
@@ -27,8 +27,6 @@ type StorageRecord = {
   default?: boolean;
   [key: string]: any;
 };
-
-const PAGE_SIZE = 50;
 
 function useStorageFormClassName() {
   const { token } = theme.useToken();
@@ -148,21 +146,34 @@ export default function FileStoragePage() {
   const fileManagerPlugin = ctx.app.pm.get(PluginFileManagerClientV2);
   const storageTypes = useMemo(() => [...fileManagerPlugin.storageTypes.values()], [fileManagerPlugin]);
   const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const { data, loading, refresh } = useRequest(
     async () => {
       const response = await resource.list({
         page,
-        pageSize: PAGE_SIZE,
+        pageSize,
         sort: ['id'],
         appends: [],
       });
       return normalizeListResponse(response);
     },
     {
-      refreshDeps: [page],
+      refreshDeps: [page, pageSize],
     },
   );
+
+  // antd pagination `onChange(nextPage, nextPageSize)` fires for both
+  // page-number changes and page-size changes. When pageSize changes we reset
+  // back to page 1 so the user isn't stranded on an out-of-range page.
+  const handlePaginationChange = useMemoizedFn((nextPage: number, nextPageSize: number) => {
+    if (nextPageSize !== pageSize) {
+      setPageSize(nextPageSize);
+      setPage(1);
+      return;
+    }
+    setPage(nextPage);
+  });
 
   const openForm = useCallback(
     (mode: 'create' | 'edit', storageType: StorageType, record?: StorageRecord) => {
@@ -281,10 +292,9 @@ export default function FileStoragePage() {
         }}
         pagination={{
           current: page,
-          pageSize: PAGE_SIZE,
+          pageSize,
           total: data?.total || 0,
-          showSizeChanger: false,
-          onChange: setPage,
+          onChange: handlePaginationChange,
         }}
       />
     </Card>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v2 公共 `Table` 组件之前默认不展示分页数量选择器,只渲染当前页码,与 v1 Table 行为不一致,导致使用 `Table` 的页面用户无法切换每页显示条数。

### Description
- `Table`(`@nocobase/client-v2`)在 `pagination` prop 上默认注入 `showSizeChanger: true` 和 `pageSizeOptions: [5, 10, 20, 50, 100, 200]`,与 v1 Table 对齐
- 调用方可显式传入 `showSizeChanger` / `pageSizeOptions` 覆盖默认值;`pagination={false}` 完全关闭分页的语义保留
- 新增导出 `DEFAULT_PAGE_SIZE`(50)和 `PAGE_SIZE_OPTIONS`,供调用方初始化受控分页 state
- 跟随清理两处历史用 `showSizeChanger: false` 抑制默认行为的调用点
- 新增 6 个单测覆盖默认合并、override 优先级、`pagination={false}` 透传等用例

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The shared v2 Table component now shows the page-size selector by default, matching v1 behavior. |
| 🇨🇳 Chinese | v2 公共 Table 组件默认展示分页数量选择器,行为对齐 v1。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
