### PR TITLE
fix(plugin-auth): harden ws:message:auth:token handler against unhandled rejections

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/ws-auth-token-handler.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/ws-auth-token-handler.test.ts
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { MockServer, createMockServer } from '@nocobase/test';
+
+// Regression coverage for the `ws:message:auth:token` handler in
+// plugin-auth's server entry. The handler is registered with `app.on`, which
+// is Node's sync EventEmitter — any rejection thrown inside the async
+// listener becomes an unhandled promise rejection and (under Node's default
+// policy) crashes the process. These cases exercise the failure paths that
+// were known to crash before the handler grew defensive try/catch coverage.
+
+type RemoveTagPayload = { clientId: string; tagKey: string };
+
+function nextRemoveTag(app: MockServer): Promise<RemoveTagPayload> {
+  return new Promise((resolve) => {
+    app.once('ws:removeTag', resolve);
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)),
+  ]);
+}
+
+describe('ws:message:auth:token handler', () => {
+  let app: MockServer;
+
+  beforeEach(async () => {
+    app = await createMockServer({
+      plugins: ['field-sort', 'users', 'auth'],
+    });
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+  });
+
+  it('removes the userId tag when the payload has no token', async () => {
+    const removeTag = nextRemoveTag(app);
+    app.emit('ws:message:auth:token', {
+      clientId: 'client-no-token',
+      payload: { token: '' },
+    });
+    const result = await withTimeout(removeTag, 2000, 'ws:removeTag for empty token');
+    expect(result.clientId).toBe('client-no-token');
+    expect(result.tagKey).toBe('userId');
+  });
+
+  it('removes the userId tag when the authenticator name is not registered in the DB', async () => {
+    // No authenticator row was seeded with this name, so `authManager.get`
+    // throws `Authenticator [no-such-authenticator] is not found.`. Before
+    // the fix this rejection escaped the async listener and crashed Node.
+    const removeTag = nextRemoveTag(app);
+    app.emit('ws:message:auth:token', {
+      clientId: 'client-bad-authenticator',
+      payload: { token: 'irrelevant', authenticator: 'no-such-authenticator' },
+    });
+    const result = await withTimeout(removeTag, 2000, 'ws:removeTag for missing authenticator');
+    expect(result.clientId).toBe('client-bad-authenticator');
+    expect(result.tagKey).toBe('userId');
+  });
+
+  it('removes the userId tag when the authenticator references an unregistered authType', async () => {
+    // Seed an authenticator whose `authType` (`CAS`) no plugin in this app
+    // has registered — this is the production-observed shape: a DB row left
+    // over from when an auth plugin was previously enabled. Resolving it
+    // throws `AuthType [CAS] is not found.` from AuthManager.
+    await app.db.getRepository('authenticators').create({
+      values: {
+        name: 'stranded-cas',
+        authType: 'CAS',
+        enabled: true,
+        options: {},
+      },
+    });
+
+    const removeTag = nextRemoveTag(app);
+    app.emit('ws:message:auth:token', {
+      clientId: 'client-unregistered-authtype',
+      payload: { token: 'irrelevant', authenticator: 'stranded-cas' },
+    });
+    const result = await withTimeout(removeTag, 2000, 'ws:removeTag for unregistered authType');
+    expect(result.clientId).toBe('client-unregistered-authtype');
+    expect(result.tagKey).toBe('userId');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-auth/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/plugin.ts
@@ -150,18 +150,39 @@ export class PluginAuthServer extends Plugin {
         return;
       }
 
-      const auth = await this.app.authManager.get(payload.authenticator || 'basic', {
-        getBearerToken: () => payload.token,
-        app: this.app,
-        db: this.app.db,
-        cache: this.app.cache,
-        logger: this.app.logger,
-        log: this.app.log,
-        throw: (...args) => {
-          throw new Error(...args);
-        },
-        t: this.app.i18n.t,
-      } as any);
+      // `app.emit` is Node's sync EventEmitter, so any rejection thrown
+      // inside this async listener becomes an unhandled promise rejection —
+      // under Node 22's default policy that crashes the entire process.
+      // Resolving the authenticator can fail for legitimate runtime reasons
+      // (the auth-type plugin is disabled or still loading during boot, the
+      // authenticator row was deleted, etc.); none of those should take the
+      // server down. Wrap the lookup, log, drop the connection's userId tag
+      // so the client is treated as unauthenticated, and return.
+      let auth;
+      try {
+        auth = await this.app.authManager.get(payload.authenticator || 'basic', {
+          getBearerToken: () => payload.token,
+          app: this.app,
+          db: this.app.db,
+          cache: this.app.cache,
+          logger: this.app.logger,
+          log: this.app.log,
+          throw: (...args) => {
+            throw new Error(...args);
+          },
+          t: this.app.i18n.t,
+        } as any);
+      } catch (error) {
+        this.app.logger.warn('ws:message:auth:token authenticator resolve failed', {
+          authenticator: payload.authenticator,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.app.emit(`ws:removeTag`, {
+          clientId,
+          tagKey: 'userId',
+        });
+        return;
+      }
 
       let user: Model;
       try {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
`plugin-auth` 的 WS handler `ws:message:auth:token` 里调用 `this.app.authManager.get(...)` 时没有 try/catch。该 handler 通过 `app.emit`(Node 原生 `EventEmitter`)被同步触发,async listener 抛出的异常会变成 unhandledRejection,在 Node 22 默认策略下直接 crash 整个服务进程。

触发场景包括:authenticator 记录引用的 authType 对应插件未启用或未注册(典型如 CAS/SAML 插件被禁用、启动期相关插件尚未 `load()` 完成、authenticator 记录已删除但浏览器 token 仍在)。已在 dev `yarn dev` 启动期偶现观察到此 crash —— 浏览器在服务重启窗口里用旧 CAS token 重连 WS 即可复现。

### Description
- `packages/plugins/@nocobase/plugin-auth/src/server/plugin.ts`:把 `authManager.get(...)` 调用放进 try/catch
- 解析失败时:`logger.warn` 记录 authenticator 名和错误信息,emit `ws:removeTag` 清掉该连接的 userId tag(等价视为未认证状态),`return`,不向上抛
- 后续 `checkToken` 原有的 try/catch 维持不变
- 新增 `__tests__/ws-auth-token-handler.test.ts`,3 个用例覆盖:空 token、authenticator 记录不存在、authenticator 记录存在但 authType 未注册(即生产观测到的 CAS 场景)
- 不动 `plugin-auth-cas` 或其他 SSO 插件 —— 这是 plugin-auth 缺少防御性边界处理的问题,跟具体 auth 类型无关

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent the server from crashing when a WebSocket auth token references an authenticator whose auth type plugin is unloaded or missing. |
| 🇨🇳 Chinese | 修复 WebSocket 鉴权 token 关联到未加载或缺失的 authType 时,服务进程崩溃的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
