### PR TITLE
fix(client-v2): register dnd-kit global dependencies

### DIFF
--- a/packages/core/client-v2/package.json
+++ b/packages/core/client-v2/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
+    "@dnd-kit/core": "^6.0.0",
+    "@dnd-kit/sortable": "^7.0.0",
     "@emotion/css": "^11.7.1",
     "@formily/antd-v5": "1.2.3",
     "@formily/react": "^2.2.27",

--- a/packages/core/client-v2/src/__tests__/globalDeps.test.ts
+++ b/packages/core/client-v2/src/__tests__/globalDeps.test.ts
@@ -26,6 +26,8 @@ describe('client-v2 defineGlobalDeps', () => {
     expect(define).toHaveBeenCalledWith('@nocobase/client-v2', expect.any(Function));
     expect(define).toHaveBeenCalledWith('@nocobase/flow-engine', expect.any(Function));
     expect(define).toHaveBeenCalledWith('@nocobase/evaluators/client', expect.any(Function));
+    expect(define).toHaveBeenCalledWith('@dnd-kit/core', expect.any(Function));
+    expect(define).toHaveBeenCalledWith('@dnd-kit/sortable', expect.any(Function));
     expect(define).toHaveBeenCalledWith('ahooks', expect.any(Function));
     expect(define).toHaveBeenCalledWith('dayjs', expect.any(Function));
     expect(define).toHaveBeenCalledWith('lodash', expect.any(Function));

--- a/packages/core/client-v2/src/utils/globalDeps.ts
+++ b/packages/core/client-v2/src/utils/globalDeps.ts
@@ -33,7 +33,8 @@ import * as ReactRouter from 'react-router';
 import * as ReactRouterDom from 'react-router-dom';
 import jsxRuntime from 'react/jsx-runtime';
 import * as nocobaseClientV2 from '../index';
-
+import * as dndKitCore from '@dnd-kit/core';
+import * as dndKitSortable from '@dnd-kit/sortable';
 import type { RequireJS } from './requirejs';
 
 /**
@@ -74,6 +75,9 @@ export function defineGlobalDeps(requirejs: RequireJS) {
   requirejs.define('@nocobase/flow-engine', () => nocobaseFlowEngine);
   requirejs.define('@nocobase/evaluators', () => nocobaseEvaluators);
   requirejs.define('@nocobase/evaluators/client', () => nocobaseEvaluators);
+
+  requirejs.define('@dnd-kit/core', () => dndKitCore);
+  requirejs.define('@dnd-kit/sortable', () => dndKitSortable);
 
   // utils
   requirejs.define('ahooks', () => ahooks);

--- a/packages/plugins/@nocobase/plugin-kanban/package.json
+++ b/packages/plugins/@nocobase/plugin-kanban/package.json
@@ -19,6 +19,8 @@
     "@nocobase/test": "2.x"
   },
   "devDependencies": {
+    "@dnd-kit/core": "^6.0.0",
+    "@dnd-kit/sortable": "^7.0.0",
     "react-intersection-observer": "^9.8.1"
   },
   "gitHead": "d0b4efe4be55f8c79a98a331d99d9f8cf99021a1",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The Kanban plugin v2 client imports `@dnd-kit/core` and `@dnd-kit/sortable`, but these packages are externalized for remote plugin builds. Without host-side RequireJS definitions, loading `@nocobase/plugin-kanban/client-v2` can fail with a script error for `@dnd-kit/core`.

### Description
This PR registers `@dnd-kit/core` and `@dnd-kit/sortable` in client-v2 global dependencies, adds regression assertions for the registrations, and declares the dnd-kit packages in both client-v2 and plugin-kanban package manifests.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the Kanban plugin v2 route failing to load because dnd-kit dependencies were not provided by the client. |
| 🇨🇳 Chinese | 修复看板插件 v2 路由因客户端未提供 dnd-kit 依赖而加载失败的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary