### PR TITLE
fix(calendar): show pointer cursor in more events overlay

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/global.style.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/global.style.ts
@@ -22,6 +22,9 @@ const GlobalStyle = createGlobalStyle`
   .rbc-overlay > * + * {
     margin-top: ${({ theme }) => `${theme.lineWidth}px`};
   }
+  .rbc-overlay .rbc-event {
+    cursor: pointer;
+  }
   .rbc-overlay-header {
     font-weight: ${({ theme }) => theme.fontWeightStrong};
     font-size: ${({ theme }) => `${theme.fontSize}px`};


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When a calendar cell contains many events, users can open the more-events overlay. Event items inside that overlay are clickable, but hovering them did not show the pointer cursor.

### Description 
Added cursor styling for `.rbc-overlay .rbc-event` in the Calendar v2 global styles so events inside the more-events overlay behave consistently with regular calendar events.

Tested with:
- `yarn eslint packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/global.style.ts`
- `yarn test:client packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/__tests__/CalendarBlock.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the cursor style for event items in the calendar more-events overlay |
| 🇨🇳 Chinese | 修复日历更多事项面板中事项 hover 时未显示手型光标的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
