### PR TITLE
refactor(client-v2): move json logic to base app

### DIFF
--- a/packages/core/client-v2/package.json
+++ b/packages/core/client-v2/package.json
@@ -30,6 +30,7 @@
     "@nocobase/flow-engine": "2.1.0-beta.34",
     "@nocobase/sdk": "2.1.0-beta.34",
     "@nocobase/shared": "2.1.0-beta.34",
+    "@nocobase/utils": "2.1.0-beta.34",
     "ahooks": "^3.7.2",
     "antd": "5.24.2",
     "antd-style": "3.7.1",

--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -40,6 +40,7 @@ import type {
   RouterOptions,
 } from './RouterManager';
 import { WebSocketClient, type WebSocketClientOptions } from './WebSocketClient';
+import { getOperators } from './json-logic/globalOperators';
 import { compose, normalizeContainer } from './utils';
 import { defineGlobalDeps } from './utils/globalDeps';
 import { getRequireJs } from './utils/requirejs';
@@ -56,6 +57,11 @@ type AnyComponent = RenderableComponentType<any>;
 type AuthTokenPayload = {
   token: string;
   authenticator: string | null;
+};
+export type JsonLogic = {
+  apply: (logic: any, data?: any) => any;
+  addOperation: (name: string, fn?: any) => void;
+  rmOperation: (name: string) => void;
 };
 
 const LEADING_SLASHES_REGEXP = /^\/+/;
@@ -123,6 +129,7 @@ export abstract class BaseApplication<
   public favicon!: string;
   public flowEngine: FlowEngine;
   public dataSourceManager: any;
+  public jsonLogic!: JsonLogic;
   public context: FlowEngineContext & {
     routeRepository: RouteRepository;
     appInfo: Promise<Record<string, any>>;
@@ -220,6 +227,7 @@ export abstract class BaseApplication<
 
   protected afterManagersInitialized() {
     this.aiManager = new AIManager(this);
+    this.jsonLogic = getOperators();
   }
 
   protected configureContext() {

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -48,6 +48,14 @@ describe('app', () => {
       expect(app.getHref('/test')).toBe('/test');
     });
 
+    it('should initialize shared jsonLogic operators', () => {
+      const app = new Application({ router });
+
+      expect(app.jsonLogic.apply({ $eq: [1, '1'] })).toBe(true);
+      app.jsonLogic.addOperation('$testAlwaysTrue', () => true);
+      expect(app.jsonLogic.apply({ $testAlwaysTrue: [] })).toBe(true);
+    });
+
     it('should apply the provided favicon immediately', () => {
       const app = new Application({ router });
 

--- a/packages/core/client-v2/src/json-logic/globalOperators.js
+++ b/packages/core/client-v2/src/json-logic/globalOperators.js
@@ -7,8 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-/* globals define,module */
-
 /*
 Using a Universal Module Loader that should be browser, require, and AMD friendly
 http://ricostacruz.com/cheatsheets/umdjs.html
@@ -18,7 +16,6 @@ import { getDayRangeByParams } from '@nocobase/utils/client';
 
 export function getOperators() {
   'use strict';
-  /* globals console:false */
 
   if (!Array.isArray) {
     Array.isArray = function (arg) {
@@ -568,14 +565,14 @@ export function getOperators() {
     // The operation is called with "data" bound to its "this" and "values" passed as arguments.
     // Structured commands like % or > can name formal arguments while flexible commands (like missing or merge) can operate on the pseudo-array arguments
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
-    if (operations.hasOwnProperty(op) && typeof operations[op] === 'function') {
+    if (Object.prototype.hasOwnProperty.call(operations, op) && typeof operations[op] === 'function') {
       return operations[op].apply(data, values);
     } else if (op.indexOf('.') > 0) {
       // Contains a dot, and not in the 0th position
       var sub_ops = String(op).split('.');
       var operation = operations;
       for (i = 0; i < sub_ops.length; i++) {
-        if (!operation.hasOwnProperty(sub_ops[i])) {
+        if (!Object.prototype.hasOwnProperty.call(operation, sub_ops[i])) {
           throw new Error('Unrecognized operation ' + op + ' (failed at ' + sub_ops.slice(0, i + 1).join('.') + ')');
         }
         // Descending into operations

--- a/packages/core/client/src/application/Application.tsx
+++ b/packages/core/client/src/application/Application.tsx
@@ -71,13 +71,7 @@ import {
 } from './schema-initializer/components/SchemaInitializerSwitch';
 import { SchemaSettings, SchemaSettingsItemType, SchemaSettingsManager } from './schema-settings';
 
-import { getOperators } from './globalOperators';
 import { useAclSnippets } from './hooks/useAclSnippets';
-
-type JsonLogic = {
-  addOperation: (name: string, fn?: any) => void;
-  rmOperation: (name: string) => void;
-};
 
 /**
  * Reference: https://ant.design/components/cascader-cn#option
@@ -126,7 +120,6 @@ export class Application extends BaseApplication<
   public declare dataSourceManager: DataSourceManager;
   public globalVars: Record<string, any> = {};
   public globalVarCtxs: Record<string, any> = {};
-  public declare jsonLogic: JsonLogic;
   loading = true;
   hasLoadError = false;
   locales = null;
@@ -208,11 +201,6 @@ export class Application extends BaseApplication<
     this.loading = true;
     this.hasLoadError = false;
     this.locales = null;
-  }
-
-  protected afterManagersInitialized() {
-    super.afterManagersInitialized();
-    this.jsonLogic = getOperators();
   }
 
   protected addCustomProviders() {

--- a/packages/core/client/src/application/__tests__/Application.test.tsx
+++ b/packages/core/client/src/application/__tests__/Application.test.tsx
@@ -50,6 +50,7 @@ describe('Application', () => {
     expect(app.providers).toBeDefined();
     expect(app.router).toBeDefined();
     expect(app.scopes).toBeDefined();
+    expect(app.jsonLogic.apply({ $eq: [1, '1'] })).toBe(true);
     expect(app.providers.length).toBeGreaterThan(1);
     expect(Object.keys(app.components).length).toBeGreaterThan(1);
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
v2 页面中的联动规则也需要使用应用级的条件判断能力。此前这部分能力只在旧的 client 应用里初始化，v2 独立运行时无法直接获得同一套判断能力。

### Description
本次调整将条件判断能力放到 v1 和 v2 共用的应用基础层中，让两个应用入口都能使用同一套规则判断能力。

同时补充了 v1 和 v2 两侧的测试，确认应用初始化后都可以正常使用这套能力。

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Migrate jsonLogic from Application v1 to BaseApplication |
| 🇨🇳 Chinese | 将 Application v1 中的 jsonLogic 迁移到 BaseApplication |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
