### PR TITLE
fix: stale flow models when switch flow settings

### DIFF
--- a/packages/core/flow-engine/src/__tests__/viewScopedFlowEngine.test.ts
+++ b/packages/core/flow-engine/src/__tests__/viewScopedFlowEngine.test.ts
@@ -18,6 +18,33 @@ import { APIClient as SDKApiClient } from '@nocobase/sdk';
 import { FlowEngine } from '../flowEngine';
 import { createViewScopedEngine } from '../ViewScopedFlowEngine';
 import { FlowModel } from '../models';
+import type { IFlowModelRepository } from '../types';
+
+const clone = <T>(value: T): T => (value == null ? value : JSON.parse(JSON.stringify(value)));
+
+class DirtyPageRepository implements IFlowModelRepository<FlowModel> {
+  public findOneCalls = 0;
+  public data: Record<string, any> | null = null;
+
+  async findOne(): Promise<Record<string, any> | null> {
+    this.findOneCalls += 1;
+    return clone(this.data);
+  }
+
+  async save(model: FlowModel): Promise<Record<string, any>> {
+    return model.serialize();
+  }
+
+  async destroy(): Promise<boolean> {
+    return true;
+  }
+
+  async move(): Promise<void> {}
+
+  async duplicate(): Promise<Record<string, any> | null> {
+    return null;
+  }
+}
 
 describe('ViewScopedFlowEngine', () => {
   it('shares global actions/events and model classes with parent', async () => {
@@ -306,5 +333,166 @@ describe('ViewScopedFlowEngine', () => {
     // hydrateModelFromPreviousEngines should return a hydrated model (not null)
     expect(result).not.toBeNull();
     expect(result?.uid).toBe('child-normal');
+  });
+
+  it('reloads a dirty loaded page from repository and replaces stale parent reference', async () => {
+    const root = new FlowEngine();
+    const repository = new DirtyPageRepository();
+    root.setModelRepository(repository);
+
+    class ParentModel extends FlowModel {}
+    class PageModel extends FlowModel {}
+    class BlockModel extends FlowModel {}
+    root.registerModels({ ParentModel, PageModel, BlockModel });
+
+    const parent = root.createModel<ParentModel>({ use: 'ParentModel', uid: 'popup-action' });
+    const oldScoped = createViewScopedEngine(root);
+    const stalePage = oldScoped.createModel<PageModel>({
+      use: 'PageModel',
+      uid: 'popup-page',
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      subModels: {
+        items: [{ use: 'BlockModel', uid: 'stale-block' }],
+      },
+    });
+    parent.setSubModel('page', stalePage);
+    oldScoped.unlinkFromStack();
+
+    repository.data = {
+      use: 'PageModel',
+      uid: 'popup-page',
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      subModels: {
+        items: [{ use: 'BlockModel', uid: 'fresh-block' }],
+      },
+    };
+
+    root.flowSettings.enable();
+    await root.saveModel(stalePage);
+    root.flowSettings.disable();
+    repository.findOneCalls = 0;
+
+    const runtimeScoped = createViewScopedEngine(root);
+    const loaded = await runtimeScoped.loadOrCreateModel<PageModel>({
+      async: true,
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'PageModel',
+    });
+
+    expect(repository.findOneCalls).toBe(1);
+    expect(loaded).not.toBe(stalePage);
+    expect((parent.subModels as any).page).toBe(loaded);
+    expect(loaded?.mapSubModels('items' as any, (item) => item.uid)).toEqual(['fresh-block']);
+
+    repository.findOneCalls = 0;
+    const nextRuntimeScoped = createViewScopedEngine(root);
+    const loadedAgain = await nextRuntimeScoped.loadOrCreateModel<PageModel>({
+      async: true,
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'PageModel',
+    });
+
+    expect(repository.findOneCalls).toBe(0);
+    expect(loadedAgain?.uid).toBe('popup-page');
+  });
+
+  it('force replaces a dirty loaded page by subKey when repository returns a new uid', async () => {
+    const root = new FlowEngine();
+    const repository = new DirtyPageRepository();
+    root.setModelRepository(repository);
+
+    class ParentModel extends FlowModel {}
+    class PageModel extends FlowModel {}
+    class BlockModel extends FlowModel {}
+    root.registerModels({ ParentModel, PageModel, BlockModel });
+
+    const parent = root.createModel<ParentModel>({ use: 'ParentModel', uid: 'popup-action-replaced' });
+    const oldScoped = createViewScopedEngine(root);
+    const stalePage = oldScoped.createModel<PageModel>({
+      use: 'PageModel',
+      uid: 'old-popup-page',
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      subModels: {
+        items: [{ use: 'BlockModel', uid: 'old-popup-block' }],
+      },
+    });
+    const staleBlock = stalePage.findSubModel('items' as any, (item) => item.uid === 'old-popup-block') as FlowModel;
+    parent.setSubModel('page', stalePage);
+    oldScoped.unlinkFromStack();
+
+    repository.data = {
+      use: 'PageModel',
+      uid: 'new-popup-page',
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      subModels: {
+        items: [{ use: 'BlockModel', uid: 'new-popup-block' }],
+      },
+    };
+
+    root.flowSettings.enable();
+    await staleBlock.saveStepParams();
+    root.flowSettings.disable();
+
+    const runtimeScoped = createViewScopedEngine(root);
+    const loaded = await runtimeScoped.loadOrCreateModel<PageModel>({
+      async: true,
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'PageModel',
+    });
+
+    expect(loaded?.uid).toBe('new-popup-page');
+    expect((parent.subModels as any).page).toBe(loaded);
+    expect(oldScoped.getModel('old-popup-page')).toBeUndefined();
+    expect(oldScoped.getModel('old-popup-block')).toBeUndefined();
+  });
+
+  it('does not bypass loaded page cache after a non-config save', async () => {
+    const root = new FlowEngine();
+    const repository = new DirtyPageRepository();
+    root.setModelRepository(repository);
+
+    class ParentModel extends FlowModel {}
+    class PageModel extends FlowModel {}
+    root.registerModels({ ParentModel, PageModel });
+
+    const parent = root.createModel<ParentModel>({ use: 'ParentModel', uid: 'normal-parent' });
+    const stalePage = root.createModel<PageModel>({
+      use: 'PageModel',
+      uid: 'normal-page',
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+    });
+    parent.setSubModel('page', stalePage);
+
+    root.flowSettings.disable();
+    await root.saveModel(stalePage);
+    repository.findOneCalls = 0;
+
+    const runtimeScoped = createViewScopedEngine(root);
+    const loaded = await runtimeScoped.loadOrCreateModel<PageModel>({
+      async: true,
+      parentId: parent.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'PageModel',
+    });
+
+    expect(repository.findOneCalls).toBe(0);
+    expect(loaded?.uid).toBe('normal-page');
   });
 });

--- a/packages/core/flow-engine/src/__tests__/viewScopedFlowEngine.test.ts
+++ b/packages/core/flow-engine/src/__tests__/viewScopedFlowEngine.test.ts
@@ -357,6 +357,7 @@ describe('ViewScopedFlowEngine', () => {
         items: [{ use: 'BlockModel', uid: 'stale-block' }],
       },
     });
+    const staleBlock = stalePage.findSubModel('items' as any, (item) => item.uid === 'stale-block') as FlowModel;
     parent.setSubModel('page', stalePage);
     oldScoped.unlinkFromStack();
 
@@ -372,7 +373,7 @@ describe('ViewScopedFlowEngine', () => {
     };
 
     root.flowSettings.enable();
-    await root.saveModel(stalePage);
+    await staleBlock.saveStepParams();
     root.flowSettings.disable();
     repository.findOneCalls = 0;
 
@@ -402,62 +403,6 @@ describe('ViewScopedFlowEngine', () => {
 
     expect(repository.findOneCalls).toBe(0);
     expect(loadedAgain?.uid).toBe('popup-page');
-  });
-
-  it('force replaces a dirty loaded page by subKey when repository returns a new uid', async () => {
-    const root = new FlowEngine();
-    const repository = new DirtyPageRepository();
-    root.setModelRepository(repository);
-
-    class ParentModel extends FlowModel {}
-    class PageModel extends FlowModel {}
-    class BlockModel extends FlowModel {}
-    root.registerModels({ ParentModel, PageModel, BlockModel });
-
-    const parent = root.createModel<ParentModel>({ use: 'ParentModel', uid: 'popup-action-replaced' });
-    const oldScoped = createViewScopedEngine(root);
-    const stalePage = oldScoped.createModel<PageModel>({
-      use: 'PageModel',
-      uid: 'old-popup-page',
-      parentId: parent.uid,
-      subKey: 'page',
-      subType: 'object',
-      subModels: {
-        items: [{ use: 'BlockModel', uid: 'old-popup-block' }],
-      },
-    });
-    const staleBlock = stalePage.findSubModel('items' as any, (item) => item.uid === 'old-popup-block') as FlowModel;
-    parent.setSubModel('page', stalePage);
-    oldScoped.unlinkFromStack();
-
-    repository.data = {
-      use: 'PageModel',
-      uid: 'new-popup-page',
-      parentId: parent.uid,
-      subKey: 'page',
-      subType: 'object',
-      subModels: {
-        items: [{ use: 'BlockModel', uid: 'new-popup-block' }],
-      },
-    };
-
-    root.flowSettings.enable();
-    await staleBlock.saveStepParams();
-    root.flowSettings.disable();
-
-    const runtimeScoped = createViewScopedEngine(root);
-    const loaded = await runtimeScoped.loadOrCreateModel<PageModel>({
-      async: true,
-      parentId: parent.uid,
-      subKey: 'page',
-      subType: 'object',
-      use: 'PageModel',
-    });
-
-    expect(loaded?.uid).toBe('new-popup-page');
-    expect((parent.subModels as any).page).toBe(loaded);
-    expect(oldScoped.getModel('old-popup-page')).toBeUndefined();
-    expect(oldScoped.getModel('old-popup-block')).toBeUndefined();
   });
 
   it('does not bypass loaded page cache after a non-config save', async () => {

--- a/packages/core/flow-engine/src/flowEngine.ts
+++ b/packages/core/flow-engine/src/flowEngine.ts
@@ -104,6 +104,16 @@ export class FlowEngine {
   private _savingModels = new Map<string, Promise<any>>();
 
   /**
+   * Page model loads that must bypass in-memory parent/subKey hydration once.
+   *
+   * This is intentionally narrow: configuration-mode writes inside a popup
+   * mark that popup's loaded `subModels.page` tree dirty, so the next runtime
+   * open reloads it from the repository instead of reusing a stale view-scoped
+   * model tree.
+   */
+  private _dirtyLoadedPageKeys = new Set<string>();
+
+  /**
    * Flow engine context object.
    * @private
    */
@@ -244,6 +254,66 @@ export class FlowEngine {
     const resName = String(resourceName || '');
     if (!resName) return 0;
     return this._dataSourceDirtyVersions.get(dsKey)?.get(resName) || 0;
+  }
+
+  private getLoadedPageKey(options?: { parentId?: string; subKey?: string }): string | undefined {
+    const parentId = options?.parentId;
+    const subKey = options?.subKey;
+    if (!parentId || subKey !== 'page') {
+      return undefined;
+    }
+    return `${parentId}::${subKey}`;
+  }
+
+  private getLoadedPageKeyFromModel(model?: FlowModel | null): string | undefined {
+    let current = model;
+    while (current) {
+      if (current.subKey === 'page' && current.parent?.uid) {
+        return this.getLoadedPageKey({ parentId: current.parent.uid, subKey: current.subKey });
+      }
+      current = current.parent as FlowModel | undefined;
+    }
+    return undefined;
+  }
+
+  private isFlowSettingsEnabledForModel(model?: FlowModel | null): boolean {
+    try {
+      return !!model?.context?.flowSettingsEnabled;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private getLoadedPageDirtyKeyForModel(model?: FlowModel | null): string | undefined {
+    if (!this.isFlowSettingsEnabledForModel(model)) {
+      return undefined;
+    }
+    return this.getLoadedPageKeyFromModel(model);
+  }
+
+  private markLoadedPageDirtyKey(key?: string): void {
+    if (key) {
+      this._dirtyLoadedPageKeys.add(key);
+    }
+  }
+
+  private shouldBypassLoadedPageCache(options?: { parentId?: string; subKey?: string }): boolean {
+    const key = this.getLoadedPageKey(options);
+    if (!key || !this._dirtyLoadedPageKeys.has(key)) {
+      return false;
+    }
+    try {
+      return !this.context.flowSettingsEnabled;
+    } catch (error) {
+      return true;
+    }
+  }
+
+  private clearLoadedPageDirty(options?: { parentId?: string; subKey?: string }): void {
+    const key = this.getLoadedPageKey(options);
+    if (key) {
+      this._dirtyLoadedPageKeys.delete(key);
+    }
   }
 
   /** 在目标模型生命周期达成时执行操作（仅在 View 引擎本地存储计划） */
@@ -937,7 +1007,8 @@ export class FlowEngine {
   async loadModel<T extends FlowModel = FlowModel>(options): Promise<T | null> {
     if (!this.ensureModelRepository()) return;
     const refresh = !!options?.refresh;
-    if (!refresh) {
+    const bypassLoadedPageCache = this.shouldBypassLoadedPageCache(options);
+    if (!refresh && !bypassLoadedPageCache) {
       const model = this.findModelByParentId(options.parentId, options.subKey);
       if (model) {
         return model as T;
@@ -948,14 +1019,24 @@ export class FlowEngine {
       }
     }
     const data = await this._modelRepository.findOne(options);
-    if (!data?.uid) return null;
-    if (refresh) {
+    if (!data?.uid) {
+      if (bypassLoadedPageCache) {
+        this.clearLoadedPageDirty(options);
+      }
+      return null;
+    }
+    if (refresh || bypassLoadedPageCache) {
       const existing = this.getModel(data.uid);
       if (existing) {
         this.removeModelWithSubModels(existing.uid);
       }
     }
-    return this.createModel<T>(data as any);
+    const model = this.createModel<T>(data as any);
+    if (bypassLoadedPageCache) {
+      this.mountLoadedModelToParent(model, true);
+      this.clearLoadedPageDirty(options);
+    }
+    return model;
   }
 
   /**
@@ -979,6 +1060,40 @@ export class FlowEngine {
     }
   }
 
+  private removeLoadedModelTree(model?: FlowModel | null): void {
+    if (!model?.uid || !model.flowEngine) {
+      return;
+    }
+    if (model.flowEngine.getModel(model.uid) === model) {
+      model.flowEngine.removeModelWithSubModels(model.uid);
+    }
+  }
+
+  private mountLoadedModelToParent<T extends FlowModel = FlowModel>(model: T | null, forceReplace = false): T | null {
+    if (!model?.parent || !model.subKey) {
+      return model;
+    }
+
+    const mounted = (model.parent.subModels as any)?.[model.subKey];
+    const existing =
+      forceReplace && model.subType !== 'array' && mounted && !Array.isArray(mounted)
+        ? (mounted as FlowModel)
+        : model.parent.findSubModel(model.subKey, (m) => m.uid === model.uid);
+    if (existing) {
+      if (!forceReplace || existing === model) {
+        return model;
+      }
+      this.removeLoadedModelTree(existing);
+    }
+
+    if (model.subType === 'array') {
+      model.parent.addSubModel(model.subKey, model);
+    } else {
+      model.parent.setSubModel(model.subKey, model);
+    }
+    return model;
+  }
+
   /**
    * Load or create a model instance.
    * @template T FlowModel subclass type, defaults to FlowModel.
@@ -995,22 +1110,31 @@ export class FlowEngine {
   ): Promise<T | null> {
     if (!this.ensureModelRepository()) return;
     const { uid, parentId, subKey } = options;
-    if (uid && this._modelInstances.has(uid)) {
+    const bypassLoadedPageCache = this.shouldBypassLoadedPageCache(options);
+    if (uid && !bypassLoadedPageCache && this._modelInstances.has(uid)) {
       return this._modelInstances.get(uid) as T;
     }
-    const m = this.findModelByParentId<T>(parentId, subKey);
-    if (m) {
-      return m;
-    }
+    if (!bypassLoadedPageCache) {
+      const m = this.findModelByParentId<T>(parentId, subKey);
+      if (m) {
+        return m;
+      }
 
-    const hydrated = this.hydrateModelFromPreviousEngines<T>(options, extra);
-    if (hydrated) {
-      return hydrated;
+      const hydrated = this.hydrateModelFromPreviousEngines<T>(options, extra);
+      if (hydrated) {
+        return hydrated;
+      }
     }
 
     const data = await this._modelRepository.findOne(options);
     let model: T | null = null;
     if (data?.uid) {
+      if (bypassLoadedPageCache) {
+        const existing = this.getModel(data.uid);
+        if (existing) {
+          this.removeModelWithSubModels(existing.uid);
+        }
+      }
       model = this.createModel<T>(data as any, extra);
     } else {
       model = this.createModel<T>(options, extra);
@@ -1018,18 +1142,9 @@ export class FlowEngine {
         await model.save();
       }
     }
-    if (model.parent) {
-      const subModel = model.parent.findSubModel(model.subKey, (m) => {
-        return m.uid === model.uid;
-      });
-      if (subModel) {
-        return model;
-      }
-      if (model.subType === 'array') {
-        model.parent.addSubModel(model.subKey, model);
-      } else {
-        model.parent.setSubModel(model.subKey, model);
-      }
+    this.mountLoadedModelToParent(model, bypassLoadedPageCache);
+    if (bypassLoadedPageCache) {
+      this.clearLoadedPageDirty(options);
     }
     return model;
   }
@@ -1049,6 +1164,7 @@ export class FlowEngine {
     if (!this.ensureModelRepository()) return;
 
     const modelUid = model.uid;
+    const dirtyLoadedPageKey = this.getLoadedPageDirtyKeyForModel(model);
 
     // 如果这个 model 正在保存中，返回现有的保存 Promise
     if (this._savingModels.has(modelUid)) {
@@ -1062,6 +1178,7 @@ export class FlowEngine {
 
     try {
       const result = await savePromise;
+      this.markLoadedPageDirtyKey(dirtyLoadedPageKey);
       return result;
     } finally {
       // 无论成功还是失败，都要清除保存状态
@@ -1098,11 +1215,16 @@ export class FlowEngine {
    * @returns {Promise<boolean>} Whether destroyed successfully
    */
   async destroyModel(uid: string) {
-    if (this.ensureModelRepository()) {
+    const modelInstance = this._modelInstances.get(uid) as FlowModel;
+    const dirtyLoadedPageKey = this.getLoadedPageDirtyKeyForModel(modelInstance);
+    const hasModelRepository = this.ensureModelRepository();
+    if (hasModelRepository) {
       await this._modelRepository.destroy(uid);
     }
 
-    const modelInstance = this._modelInstances.get(uid) as FlowModel;
+    if (hasModelRepository) {
+      this.markLoadedPageDirtyKey(dirtyLoadedPageKey);
+    }
     const parent = modelInstance?.parent;
     const result = this.removeModel(uid);
     parent && parent.emitter.emit('onSubModelDestroyed', modelInstance);
@@ -1217,6 +1339,7 @@ export class FlowEngine {
       console.warn(`FlowEngine: Cannot move model. Source or target model not found.`);
       return;
     }
+    const dirtyLoadedPageKey = this.getLoadedPageDirtyKeyForModel(sourceModel);
     const move = (sourceModel: FlowModel, targetModel: FlowModel) => {
       if (!sourceModel.parent || !targetModel.parent || sourceModel.parent !== targetModel.parent) {
         console.error('FlowModel.moveTo: Both models must have the same parent to perform move operation.');
@@ -1264,6 +1387,7 @@ export class FlowEngine {
     if (options?.persist !== false && this.ensureModelRepository()) {
       const position = sourceModel.sortIndex - targetModel.sortIndex > 0 ? 'after' : 'before';
       await this._modelRepository.move(sourceId, targetId, position);
+      this.markLoadedPageDirtyKey(dirtyLoadedPageKey);
     }
     // 触发事件以通知其他部分模型已移动
     sourceModel.parent.emitter.emit('onSubModelMoved', { source: sourceModel, target: targetModel });

--- a/packages/core/flow-engine/src/flowEngine.ts
+++ b/packages/core/flow-engine/src/flowEngine.ts
@@ -20,6 +20,7 @@ import { APIResource, FlowResource, MultiRecordResource, SingleRecordResource, S
 import { Emitter } from './emitter';
 import ModelOperationScheduler from './scheduler/ModelOperationScheduler';
 import type { ScheduleOptions, ScheduledCancel } from './scheduler/ModelOperationScheduler';
+import { createLoadedPageCache } from './utils/loadedPageCache';
 import type {
   ActionDefinition,
   ApplyFlowCacheEntry,
@@ -103,15 +104,7 @@ export class FlowEngine {
    */
   private _savingModels = new Map<string, Promise<any>>();
 
-  /**
-   * Page model loads that must bypass in-memory parent/subKey hydration once.
-   *
-   * This is intentionally narrow: configuration-mode writes inside a popup
-   * mark that popup's loaded `subModels.page` tree dirty, so the next runtime
-   * open reloads it from the repository instead of reusing a stale view-scoped
-   * model tree.
-   */
-  private _dirtyLoadedPageKeys = new Set<string>();
+  private _loadedPageCache = createLoadedPageCache();
 
   /**
    * Flow engine context object.
@@ -254,66 +247,6 @@ export class FlowEngine {
     const resName = String(resourceName || '');
     if (!resName) return 0;
     return this._dataSourceDirtyVersions.get(dsKey)?.get(resName) || 0;
-  }
-
-  private getLoadedPageKey(options?: { parentId?: string; subKey?: string }): string | undefined {
-    const parentId = options?.parentId;
-    const subKey = options?.subKey;
-    if (!parentId || subKey !== 'page') {
-      return undefined;
-    }
-    return `${parentId}::${subKey}`;
-  }
-
-  private getLoadedPageKeyFromModel(model?: FlowModel | null): string | undefined {
-    let current = model;
-    while (current) {
-      if (current.subKey === 'page' && current.parent?.uid) {
-        return this.getLoadedPageKey({ parentId: current.parent.uid, subKey: current.subKey });
-      }
-      current = current.parent as FlowModel | undefined;
-    }
-    return undefined;
-  }
-
-  private isFlowSettingsEnabledForModel(model?: FlowModel | null): boolean {
-    try {
-      return !!model?.context?.flowSettingsEnabled;
-    } catch (error) {
-      return false;
-    }
-  }
-
-  private getLoadedPageDirtyKeyForModel(model?: FlowModel | null): string | undefined {
-    if (!this.isFlowSettingsEnabledForModel(model)) {
-      return undefined;
-    }
-    return this.getLoadedPageKeyFromModel(model);
-  }
-
-  private markLoadedPageDirtyKey(key?: string): void {
-    if (key) {
-      this._dirtyLoadedPageKeys.add(key);
-    }
-  }
-
-  private shouldBypassLoadedPageCache(options?: { parentId?: string; subKey?: string }): boolean {
-    const key = this.getLoadedPageKey(options);
-    if (!key || !this._dirtyLoadedPageKeys.has(key)) {
-      return false;
-    }
-    try {
-      return !this.context.flowSettingsEnabled;
-    } catch (error) {
-      return true;
-    }
-  }
-
-  private clearLoadedPageDirty(options?: { parentId?: string; subKey?: string }): void {
-    const key = this.getLoadedPageKey(options);
-    if (key) {
-      this._dirtyLoadedPageKeys.delete(key);
-    }
   }
 
   /** 在目标模型生命周期达成时执行操作（仅在 View 引擎本地存储计划） */
@@ -1007,7 +940,7 @@ export class FlowEngine {
   async loadModel<T extends FlowModel = FlowModel>(options): Promise<T | null> {
     if (!this.ensureModelRepository()) return;
     const refresh = !!options?.refresh;
-    const bypassLoadedPageCache = this.shouldBypassLoadedPageCache(options);
+    const bypassLoadedPageCache = this._loadedPageCache.shouldBypass(options, () => this.context.flowSettingsEnabled);
     if (!refresh && !bypassLoadedPageCache) {
       const model = this.findModelByParentId(options.parentId, options.subKey);
       if (model) {
@@ -1021,7 +954,7 @@ export class FlowEngine {
     const data = await this._modelRepository.findOne(options);
     if (!data?.uid) {
       if (bypassLoadedPageCache) {
-        this.clearLoadedPageDirty(options);
+        this._loadedPageCache.clear(options);
       }
       return null;
     }
@@ -1033,8 +966,8 @@ export class FlowEngine {
     }
     const model = this.createModel<T>(data as any);
     if (bypassLoadedPageCache) {
-      this.mountLoadedModelToParent(model, true);
-      this.clearLoadedPageDirty(options);
+      this._loadedPageCache.mountModelToParent(model, true);
+      this._loadedPageCache.clear(options);
     }
     return model;
   }
@@ -1060,40 +993,6 @@ export class FlowEngine {
     }
   }
 
-  private removeLoadedModelTree(model?: FlowModel | null): void {
-    if (!model?.uid || !model.flowEngine) {
-      return;
-    }
-    if (model.flowEngine.getModel(model.uid) === model) {
-      model.flowEngine.removeModelWithSubModels(model.uid);
-    }
-  }
-
-  private mountLoadedModelToParent<T extends FlowModel = FlowModel>(model: T | null, forceReplace = false): T | null {
-    if (!model?.parent || !model.subKey) {
-      return model;
-    }
-
-    const mounted = (model.parent.subModels as any)?.[model.subKey];
-    const existing =
-      forceReplace && model.subType !== 'array' && mounted && !Array.isArray(mounted)
-        ? (mounted as FlowModel)
-        : model.parent.findSubModel(model.subKey, (m) => m.uid === model.uid);
-    if (existing) {
-      if (!forceReplace || existing === model) {
-        return model;
-      }
-      this.removeLoadedModelTree(existing);
-    }
-
-    if (model.subType === 'array') {
-      model.parent.addSubModel(model.subKey, model);
-    } else {
-      model.parent.setSubModel(model.subKey, model);
-    }
-    return model;
-  }
-
   /**
    * Load or create a model instance.
    * @template T FlowModel subclass type, defaults to FlowModel.
@@ -1110,7 +1009,7 @@ export class FlowEngine {
   ): Promise<T | null> {
     if (!this.ensureModelRepository()) return;
     const { uid, parentId, subKey } = options;
-    const bypassLoadedPageCache = this.shouldBypassLoadedPageCache(options);
+    const bypassLoadedPageCache = this._loadedPageCache.shouldBypass(options, () => this.context.flowSettingsEnabled);
     if (uid && !bypassLoadedPageCache && this._modelInstances.has(uid)) {
       return this._modelInstances.get(uid) as T;
     }
@@ -1142,9 +1041,9 @@ export class FlowEngine {
         await model.save();
       }
     }
-    this.mountLoadedModelToParent(model, bypassLoadedPageCache);
+    this._loadedPageCache.mountModelToParent(model, bypassLoadedPageCache);
     if (bypassLoadedPageCache) {
-      this.clearLoadedPageDirty(options);
+      this._loadedPageCache.clear(options);
     }
     return model;
   }
@@ -1164,7 +1063,7 @@ export class FlowEngine {
     if (!this.ensureModelRepository()) return;
 
     const modelUid = model.uid;
-    const dirtyLoadedPageKey = this.getLoadedPageDirtyKeyForModel(model);
+    const dirtyLoadedPageKey = this._loadedPageCache.getDirtyKeyForModel(model);
 
     // 如果这个 model 正在保存中，返回现有的保存 Promise
     if (this._savingModels.has(modelUid)) {
@@ -1178,7 +1077,7 @@ export class FlowEngine {
 
     try {
       const result = await savePromise;
-      this.markLoadedPageDirtyKey(dirtyLoadedPageKey);
+      this._loadedPageCache.markDirty(dirtyLoadedPageKey);
       return result;
     } finally {
       // 无论成功还是失败，都要清除保存状态
@@ -1216,14 +1115,14 @@ export class FlowEngine {
    */
   async destroyModel(uid: string) {
     const modelInstance = this._modelInstances.get(uid) as FlowModel;
-    const dirtyLoadedPageKey = this.getLoadedPageDirtyKeyForModel(modelInstance);
+    const dirtyLoadedPageKey = this._loadedPageCache.getDirtyKeyForModel(modelInstance);
     const hasModelRepository = this.ensureModelRepository();
     if (hasModelRepository) {
       await this._modelRepository.destroy(uid);
     }
 
     if (hasModelRepository) {
-      this.markLoadedPageDirtyKey(dirtyLoadedPageKey);
+      this._loadedPageCache.markDirty(dirtyLoadedPageKey);
     }
     const parent = modelInstance?.parent;
     const result = this.removeModel(uid);
@@ -1339,7 +1238,7 @@ export class FlowEngine {
       console.warn(`FlowEngine: Cannot move model. Source or target model not found.`);
       return;
     }
-    const dirtyLoadedPageKey = this.getLoadedPageDirtyKeyForModel(sourceModel);
+    const dirtyLoadedPageKey = this._loadedPageCache.getDirtyKeyForModel(sourceModel);
     const move = (sourceModel: FlowModel, targetModel: FlowModel) => {
       if (!sourceModel.parent || !targetModel.parent || sourceModel.parent !== targetModel.parent) {
         console.error('FlowModel.moveTo: Both models must have the same parent to perform move operation.');
@@ -1387,7 +1286,7 @@ export class FlowEngine {
     if (options?.persist !== false && this.ensureModelRepository()) {
       const position = sourceModel.sortIndex - targetModel.sortIndex > 0 ? 'after' : 'before';
       await this._modelRepository.move(sourceId, targetId, position);
-      this.markLoadedPageDirtyKey(dirtyLoadedPageKey);
+      this._loadedPageCache.markDirty(dirtyLoadedPageKey);
     }
     // 触发事件以通知其他部分模型已移动
     sourceModel.parent.emitter.emit('onSubModelMoved', { source: sourceModel, target: targetModel });

--- a/packages/core/flow-engine/src/utils/loadedPageCache.ts
+++ b/packages/core/flow-engine/src/utils/loadedPageCache.ts
@@ -1,0 +1,117 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { FlowModel } from '../models';
+
+type LoadedPageOptions = {
+  parentId?: string;
+  subKey?: string;
+};
+
+const getLoadedPageKey = (options?: LoadedPageOptions): string | undefined => {
+  const parentId = options?.parentId;
+  const subKey = options?.subKey;
+  if (!parentId || subKey !== 'page') {
+    return undefined;
+  }
+  return `${parentId}::${subKey}`;
+};
+
+const getLoadedPageKeyFromModel = (model?: FlowModel | null): string | undefined => {
+  let current = model;
+  while (current) {
+    if (current.subKey === 'page' && current.parent?.uid) {
+      return getLoadedPageKey({ parentId: current.parent.uid, subKey: current.subKey });
+    }
+    current = current.parent as FlowModel | undefined;
+  }
+  return undefined;
+};
+
+const isFlowSettingsEnabledForModel = (model?: FlowModel | null): boolean => {
+  try {
+    return !!model?.context?.flowSettingsEnabled;
+  } catch (error) {
+    return false;
+  }
+};
+
+const removeLoadedModelTree = (model?: FlowModel | null): void => {
+  if (!model?.uid || !model.flowEngine) {
+    return;
+  }
+  if (model.flowEngine.getModel(model.uid) === model) {
+    model.flowEngine.removeModelWithSubModels(model.uid);
+  }
+};
+
+const mountLoadedModelToParent = <T extends FlowModel = FlowModel>(model: T | null, forceReplace = false): T | null => {
+  if (!model?.parent || !model.subKey) {
+    return model;
+  }
+
+  const mounted = (model.parent.subModels as any)?.[model.subKey];
+  const existing =
+    forceReplace && model.subType !== 'array' && mounted && !Array.isArray(mounted)
+      ? (mounted as FlowModel)
+      : model.parent.findSubModel(model.subKey, (m) => m.uid === model.uid);
+  if (existing) {
+    if (!forceReplace || existing === model) {
+      return model;
+    }
+    removeLoadedModelTree(existing);
+  }
+
+  if (model.subType === 'array') {
+    model.parent.addSubModel(model.subKey, model);
+  } else {
+    model.parent.setSubModel(model.subKey, model);
+  }
+  return model;
+};
+
+export const createLoadedPageCache = () => {
+  const dirtyKeys = new Set<string>();
+
+  return {
+    getDirtyKeyForModel(model?: FlowModel | null): string | undefined {
+      if (!isFlowSettingsEnabledForModel(model)) {
+        return undefined;
+      }
+      return getLoadedPageKeyFromModel(model);
+    },
+
+    markDirty(key?: string): void {
+      if (key) {
+        dirtyKeys.add(key);
+      }
+    },
+
+    shouldBypass(options?: LoadedPageOptions, isFlowSettingsEnabled?: () => boolean): boolean {
+      const key = getLoadedPageKey(options);
+      if (!key || !dirtyKeys.has(key)) {
+        return false;
+      }
+      try {
+        return !isFlowSettingsEnabled?.();
+      } catch (error) {
+        return true;
+      }
+    },
+
+    clear(options?: LoadedPageOptions): void {
+      const key = getLoadedPageKey(options);
+      if (key) {
+        dirtyKeys.delete(key);
+      }
+    },
+
+    mountModelToParent: mountLoadedModelToParent,
+  };
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the popup displayed outdated UI data after toggling the UI configuration mode switch. |
| 🇨🇳 Chinese | 修复切换 UI 配置模式开关后弹窗内部存在旧 UI 数据的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
