### PR TITLE
fix(client): keep empty column width

### DIFF
--- a/packages/core/client/src/flow/models/base/GridModel.tsx
+++ b/packages/core/client/src/flow/models/base/GridModel.tsx
@@ -835,6 +835,7 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
    * 运行态按可见 block 过滤行/列，避免“整行都是 hidden block”但依然保留行间距占位。
    * - 配置态（flowSettingsEnabled）保持原始 rows/sizes 以便拖拽和布局编辑。
    * - 运行态仅在判断为“整列/整行都不可见”时做过滤，不写回 props/stepParams，布局元数据保持不变。
+   * - 空列是拖拽缩窄后保存的布局占位，运行态需要保留其宽度，但 Grid 渲染层不会渲染其内容。
    */
   private getVisibleLayout() {
     const rawLayout = this.normalizeLayoutFromSource();
@@ -862,46 +863,52 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     }
 
     const modelByUid = new Map(items.map((m: FlowModel) => [m.uid, m]));
+    type VisibleCellEntry = {
+      cell: GridLayoutV2['rows'][number]['cells'][number];
+      size: number;
+      hasVisibleContent: boolean;
+    };
 
     const filterRows = (rows: GridLayoutV2['rows']): GridLayoutV2['rows'] => {
       return rows
         .map((row) => {
-          const cells: GridLayoutV2['rows'][number]['cells'] = [];
-          const keptSizes: number[] = [];
-
-          row.cells.forEach((cell, index) => {
-            const sourceSize = row.sizes?.[index];
-            const keepSize = Number.isFinite(sourceSize) && sourceSize > 0 ? sourceSize : 1;
-            if (cell.rows) {
-              const childRows = filterRows(cell.rows);
-              if (childRows.length) {
-                cells.push({ ...cell, rows: childRows });
-                keptSizes.push(keepSize);
+          const cellsWithSizes = row.cells
+            .map((cell, index) => {
+              const sourceSize = row.sizes?.[index];
+              const keepSize = Number.isFinite(sourceSize) && sourceSize > 0 ? sourceSize : 1;
+              if (cell.rows) {
+                const childRows = filterRows(cell.rows);
+                if (childRows.length) {
+                  return { cell: { ...cell, rows: childRows }, size: keepSize, hasVisibleContent: true };
+                }
+                return null;
               }
-              return;
-            }
 
-            const cellItems = (cell.items || []).filter((uid) => {
-              if (uid === EMPTY_COLUMN_UID) {
-                return false;
+              const cellItems = (cell.items || []).filter((uid) => {
+                if (uid === EMPTY_COLUMN_UID) {
+                  return true;
+                }
+                return modelByUid.get(uid)?.hidden !== true;
+              });
+              const hasVisibleContent = cellItems.some((uid) => {
+                if (uid === EMPTY_COLUMN_UID) return false;
+                const model = modelByUid.get(uid);
+                return !model || !model.hidden;
+              });
+              const hasEmptyPlaceholder = cellItems.includes(EMPTY_COLUMN_UID);
+              if (hasVisibleContent || hasEmptyPlaceholder) {
+                return { cell: { ...cell, items: cellItems }, size: keepSize, hasVisibleContent };
               }
-              return modelByUid.get(uid)?.hidden !== true;
-            });
-            const hasVisibleItem = cellItems.some((uid) => {
-              const model = modelByUid.get(uid);
-              return !model || !model.hidden;
-            });
-            if (hasVisibleItem) {
-              cells.push({ ...cell, items: cellItems });
-              keptSizes.push(keepSize);
-            }
-          });
+              return null;
+            })
+            .filter(Boolean) as VisibleCellEntry[];
+          const hasVisibleContent = cellsWithSizes.some((entry) => entry.hasVisibleContent);
 
-          return cells.length
+          return hasVisibleContent
             ? {
                 ...row,
-                cells,
-                sizes: keptSizes,
+                cells: cellsWithSizes.map((entry) => entry.cell),
+                sizes: cellsWithSizes.map((entry) => entry.size),
               }
             : null;
         })

--- a/packages/core/client/src/flow/models/base/GridModel.tsx
+++ b/packages/core/client/src/flow/models/base/GridModel.tsx
@@ -345,6 +345,58 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     return rowElement?.parentElement?.clientWidth || fallbackWidth;
   }
 
+  private prunePlaceholderOnlyRows(layout: GridLayoutV2): GridLayoutV2 {
+    type RowCellEntry = {
+      cell: GridCellV2;
+      size: number;
+      hasRealItem: boolean;
+    };
+
+    const pruneRows = (rows: GridRowV2[]): GridRowV2[] => {
+      return rows
+        .map((row) => {
+          const cellsWithSizes = row.cells
+            .map((cell, index) => {
+              const size = row.sizes?.[index] ?? 1;
+              if (cell.rows?.length) {
+                const childRows = pruneRows(cell.rows);
+                if (childRows.length) {
+                  return { cell: { ...cell, rows: childRows }, size, hasRealItem: true };
+                }
+                return null;
+              }
+
+              const items = cell.items || [];
+              const hasRealItem = items.some((uid) => uid !== EMPTY_COLUMN_UID);
+              const hasEmptyPlaceholder = items.includes(EMPTY_COLUMN_UID);
+              if (hasRealItem || hasEmptyPlaceholder) {
+                return { cell, size, hasRealItem };
+              }
+              return null;
+            })
+            .filter(Boolean) as RowCellEntry[];
+
+          if (!cellsWithSizes.some((entry) => entry.hasRealItem)) {
+            return null;
+          }
+
+          return {
+            ...row,
+            cells: cellsWithSizes.map((entry) => entry.cell),
+            sizes: cellsWithSizes.map((entry) => entry.size),
+          };
+        })
+        .filter(Boolean) as GridRowV2[];
+    };
+
+    return normalizeGridLayout({
+      layout: { ...layout, rows: pruneRows(layout.rows || []) },
+      itemUids: this.getItemUids(),
+      gridUid: this.uid,
+      logger: console,
+    });
+  }
+
   private resizeGridLayout({
     direction,
     resizeDistance,
@@ -414,7 +466,9 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     this.emitter.on('onSubModelDestroyed', (model: FlowModel) => {
       const modelUid = model.uid;
       this.resetRows(true);
-      this.setGridStepLayout(this.props.layout);
+      const layout = this.prunePlaceholderOnlyRows(this.props.layout);
+      this.setGridStepLayout(layout);
+      this.syncLayoutProps(layout);
 
       // 删除筛选配置
       this.context.filterManager?.removeFilterConfig({ targetId: modelUid });
@@ -858,10 +912,6 @@ export class GridModel<T extends { subModels: { items: FlowModel[] } } = Default
     }
 
     const items = this.subModels?.items || [];
-    if (!items.length) {
-      return { layout: baseLayout, rows: baseProjection.rows, sizes: baseProjection.sizes };
-    }
-
     const modelByUid = new Map(items.map((m: FlowModel) => [m.uid, m]));
     type VisibleCellEntry = {
       cell: GridLayoutV2['rows'][number]['cells'][number];

--- a/packages/core/client/src/flow/models/base/__tests__/GridModel.visibleLayout.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/GridModel.visibleLayout.test.ts
@@ -228,7 +228,7 @@ describe('GridModel.getVisibleLayout (hidden items filtering)', () => {
     expect(sizes.row1).toEqual([10, 14]);
   });
 
-  it('ignores EMPTY_COLUMN uid in runtime mode without crashing', () => {
+  it('preserves EMPTY_COLUMN placeholder width in runtime mode', () => {
     engine.flowSettings.disable();
 
     const visible = engine.createModel({ use: 'FlowModel', uid: 'v' });
@@ -237,11 +237,18 @@ describe('GridModel.getVisibleLayout (hidden items filtering)', () => {
       use: 'GridModel',
       uid: 'grid-8',
       props: {
-        rows: {
-          row1: [[EMPTY_COLUMN_UID, 'ghost', 'v'], ['ghost-2']],
-        },
-        sizes: {
-          row1: [8, 16],
+        layout: {
+          version: 2,
+          rows: [
+            {
+              id: 'row1',
+              cells: [
+                { id: 'cell1', items: ['v'] },
+                { id: 'cell2', items: [EMPTY_COLUMN_UID] },
+              ],
+              sizes: [8, 16],
+            },
+          ],
         },
       },
       structure: {} as any,
@@ -250,8 +257,38 @@ describe('GridModel.getVisibleLayout (hidden items filtering)', () => {
     (model as any).subModels = { items: [visible] };
 
     const { rows, sizes } = (model as any).getVisibleLayout();
-    // 新布局归一化会移除不在 subModels.items 中的 uid，EMPTY_COLUMN_UID 也不会在运行态显示
-    expect(rows.row1).toEqual([['v']]);
-    expect(sizes.row1).toEqual([24]);
+    // 空列是拖拽缩窄区块后的布局占位；运行态也要保留其宽度，避免剩余区块被拉满整行。
+    expect(rows.row1).toEqual([['v'], [EMPTY_COLUMN_UID]]);
+    expect(sizes.row1).toEqual([8, 16]);
+  });
+
+  it('removes rows that only contain EMPTY_COLUMN placeholders in runtime mode', () => {
+    engine.flowSettings.disable();
+
+    const model = engine.createModel<GridModel>({
+      use: 'GridModel',
+      uid: 'grid-9',
+      props: {
+        layout: {
+          version: 2,
+          rows: [
+            {
+              id: 'row1',
+              cells: [{ id: 'cell1', items: [EMPTY_COLUMN_UID] }],
+              sizes: [24],
+            },
+          ],
+        },
+      },
+      structure: {} as any,
+    });
+
+    const hidden = engine.createModel({ use: 'FlowModel', uid: 'h' }) as any;
+    hidden.hidden = true;
+    (model as any).subModels = { items: [hidden] };
+
+    const { rows, sizes } = (model as any).getVisibleLayout();
+    expect(rows).toEqual({});
+    expect(sizes).toEqual({});
   });
 });

--- a/packages/core/client/src/flow/models/base/__tests__/GridModel.visibleLayout.test.ts
+++ b/packages/core/client/src/flow/models/base/__tests__/GridModel.visibleLayout.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { EMPTY_COLUMN_UID, FlowEngine } from '@nocobase/flow-engine';
-import { GridModel } from '../GridModel';
+import { GRID_FLOW_KEY, GRID_STEP, GridModel } from '../GridModel';
 
 describe('GridModel.getVisibleLayout (hidden items filtering)', () => {
   let engine: FlowEngine;
@@ -262,7 +262,7 @@ describe('GridModel.getVisibleLayout (hidden items filtering)', () => {
     expect(sizes.row1).toEqual([8, 16]);
   });
 
-  it('removes rows that only contain EMPTY_COLUMN placeholders in runtime mode', () => {
+  it('removes rows that only contain EMPTY_COLUMN placeholders in runtime mode when there are no items', () => {
     engine.flowSettings.disable();
 
     const model = engine.createModel<GridModel>({
@@ -283,12 +283,47 @@ describe('GridModel.getVisibleLayout (hidden items filtering)', () => {
       structure: {} as any,
     });
 
-    const hidden = engine.createModel({ use: 'FlowModel', uid: 'h' }) as any;
-    hidden.hidden = true;
-    (model as any).subModels = { items: [hidden] };
+    (model as any).subModels = { items: [] };
 
     const { rows, sizes } = (model as any).getVisibleLayout();
     expect(rows).toEqual({});
     expect(sizes).toEqual({});
+  });
+
+  it('removes the placeholder-only row after the last real item in the row is deleted', () => {
+    engine.flowSettings.disable();
+
+    const visible = engine.createModel({ use: 'FlowModel', uid: 'v' });
+    const layout = {
+      version: 2 as const,
+      rows: [
+        {
+          id: 'row1',
+          cells: [
+            { id: 'cell1', items: ['v'] },
+            { id: 'cell2', items: [EMPTY_COLUMN_UID] },
+          ],
+          sizes: [8, 16],
+        },
+      ],
+    };
+    const model = engine.createModel<GridModel>({
+      use: 'GridModel',
+      uid: 'grid-10',
+      props: { layout },
+      structure: {} as any,
+    });
+    (model as any).subModels = { items: [visible] };
+    model.setStepParams(GRID_FLOW_KEY, GRID_STEP, { layout });
+    model.syncLayoutProps(model.getGridLayout());
+    model.onMount();
+
+    (model as any).subModels = { items: [] };
+    model.emitter.emit('onSubModelDestroyed', visible);
+
+    expect(model.props.rows).toEqual({});
+    expect(model.props.sizes).toEqual({});
+    expect(model.props.layout.rows).toEqual([]);
+    expect(model.getStepParams(GRID_FLOW_KEY, GRID_STEP).layout.rows).toEqual([]);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 页面中，将一个区块拖拽缩窄后，退出编辑模式时区块会重新占满整行；再次进入编辑模式后，才会恢复为拖拽后的宽度。这会让用户在普通浏览模式下看到的页面布局与配置时保存的布局不一致。

### Description 
修复运行态页面布局对空白列的处理逻辑。空白列用于记录用户拖拽缩窄区块后留下的占位宽度，现在普通浏览模式也会保留这部分宽度，避免剩余区块被拉满整行。

同时补充了相关测试，确保只有包含实际内容的行才会保留空白列，单独的空白列不会在页面上撑出多余空行。

测试建议：
- 在 v2 页面中进入编辑模式，将一行中单个区块拖拽缩窄。
- 退出编辑模式，确认区块仍保持缩窄后的宽度。
- 再次进入编辑模式，确认布局与普通浏览模式一致。

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where narrowed v2 blocks become full width after leaving edit mode |
| 🇨🇳 Chinese | 修复 v2 区块退出编辑模式后缩窄宽度丢失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
