### PR TITLE
fix(l10n): use cached resources for built-in references

### DIFF
--- a/packages/plugins/@nocobase/plugin-localization/src/server/__tests__/localization-ai-translate.test.ts
+++ b/packages/plugins/@nocobase/plugin-localization/src/server/__tests__/localization-ai-translate.test.ts
@@ -1,0 +1,52 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { pickBuiltInResourceReference } from '../tasks/localization-ai-translate';
+
+describe('localization AI translate', () => {
+  test('should pick built-in reference translations from local resources', () => {
+    const resources = new Map([['zh-CN', new Map([['1', '翻译']])]]);
+
+    const reference = pickBuiltInResourceReference(
+      {
+        id: 1,
+        module: 'resources.@nocobase/plugin-ai',
+        text: 'Translate',
+      },
+      resources,
+      {
+        primary: 'zh-CN',
+      },
+    );
+
+    expect(reference).toEqual({ locale: 'zh-CN', translation: '翻译' });
+  });
+
+  test('should fallback to the next built-in reference language', () => {
+    const resources = new Map([
+      ['zh-CN', new Map()],
+      ['ja-JP', new Map([['1', '翻訳']])],
+    ]);
+
+    const reference = pickBuiltInResourceReference(
+      {
+        id: 1,
+        module: 'resources.ai',
+        text: 'Translate',
+      },
+      resources,
+      {
+        primary: 'zh-CN',
+        fallback: 'ja-JP',
+      },
+    );
+
+    expect(reference).toEqual({ locale: 'ja-JP', translation: '翻訳' });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-localization/src/server/tasks/localization-ai-translate.ts
+++ b/packages/plugins/@nocobase/plugin-localization/src/server/tasks/localization-ai-translate.ts
@@ -11,7 +11,13 @@ import { CancelError, TaskType } from '@nocobase/plugin-async-task-manager';
 import PluginAIServer from '@nocobase/plugin-ai';
 import type { ModelRef } from '@nocobase/plugin-ai';
 import { HumanMessage } from '@langchain/core/messages';
-import { buildFindTextsOptions, isBuiltInText, normalizeTextRecord } from '../translation-scope';
+import {
+  buildFindTextsOptions,
+  getModuleName,
+  isBuiltInText,
+  normalizeModuleName,
+  normalizeTextRecord,
+} from '../translation-scope';
 import type { LocalizationTextRecord, TranslationScope } from '../translation-scope';
 
 export const LOCALIZATION_AI_TRANSLATE_TASK_TYPE = 'localization:ai-translate';
@@ -31,6 +37,20 @@ const getTranslationWorkerCount = () => {
     return value;
   }
   return DEFAULT_TRANSLATION_WORKER_COUNT;
+};
+
+export const pickBuiltInResourceReference = (
+  row: LocalizationTextRecord,
+  references: Map<string, Map<string, string>>,
+  locales: ReferenceLocaleConfig,
+) => {
+  for (const locale of [locales.primary, locales.fallback].filter(isString)) {
+    const translation = references.get(locale)?.get(String(row.id));
+    if (translation) {
+      return { locale, translation };
+    }
+  }
+  return {};
 };
 
 type TranslationMode = 'full' | 'incremental' | 'selected';
@@ -246,8 +266,37 @@ export class LocalizationAITranslateTask extends TaskType {
   private async getReferenceMaps(textIds: Array<string | number>, locales: string[]) {
     const result = new Map<string, Map<string, string>>();
     await Promise.all(
-      locales.map(async (locale) => {
+      Array.from(new Set(locales)).map(async (locale) => {
         result.set(locale, await this.getLocaleReferences(textIds, locale));
+      }),
+    );
+    return result;
+  }
+
+  private async getBuiltInReferenceMaps(rows: LocalizationTextRecord[], locales: string[]) {
+    const result = new Map<string, Map<string, string>>();
+    if (!rows.length) {
+      return result;
+    }
+    await Promise.all(
+      Array.from(new Set(locales)).map(async (locale) => {
+        const resources = await this.app.localeManager.getCacheResources(locale);
+        const references = new Map<string, string>();
+        for (const row of rows) {
+          const moduleName = getModuleName(row);
+          if (!moduleName) {
+            continue;
+          }
+          const modules = Array.from(new Set([normalizeModuleName(moduleName), moduleName]));
+          for (const module of modules) {
+            const translation = resources?.[module]?.[row.text];
+            if (translation) {
+              references.set(String(row.id), translation);
+              break;
+            }
+          }
+        }
+        result.set(locale, references);
       }),
     );
     return result;
@@ -294,10 +343,10 @@ export class LocalizationAITranslateTask extends TaskType {
     referenceLocales: Required<TranslationReferenceLocales>,
     chunkIndex: number,
   ) {
-    const builtInTextIds = batch.filter((item) => item.isBuiltIn).map((item) => item.row.id);
+    const builtInRows = batch.filter((item) => item.isBuiltIn).map((item) => item.row);
     const customTextIds = batch.filter((item) => !item.isBuiltIn).map((item) => item.row.id);
-    const builtInReferences = await this.getReferenceMaps(
-      builtInTextIds,
+    const builtInReferences = await this.getBuiltInReferenceMaps(
+      builtInRows,
       [referenceLocales.builtIn.primary, referenceLocales.builtIn.fallback].filter(isString),
     );
     const customReferences = await this.getReferenceMaps(
@@ -307,7 +356,9 @@ export class LocalizationAITranslateTask extends TaskType {
 
     return batch.map(({ row, isBuiltIn }) => {
       const references = isBuiltIn ? referenceLocales.builtIn : referenceLocales.custom;
-      const reference = this.pickDbReference(row, isBuiltIn ? builtInReferences : customReferences, references);
+      const reference = isBuiltIn
+        ? pickBuiltInResourceReference(row, builtInReferences, references)
+        : this.pickDbReference(row, customReferences, references);
       return {
         row,
         chunkIndex,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI localization translation used database translation records for built-in entry reference translations. Built-in references should follow the cached localization resources for the selected reference language so existing resource overrides are respected consistently.

### Description 
Built-in localization entries now resolve reference translations from cached locale resources by module and source text, while custom entries continue to use database translations by text ID. This keeps built-in reference lookup aligned with runtime localization resources and avoids querying built-in references through the translation table.

Added focused tests for built-in reference selection and fallback language handling.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed built-in localization reference translations for AI translation tasks |
| 🇨🇳 Chinese | 修复 AI 翻译任务中内建词条参考翻译的取值问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary