### PR TITLE
fix(plugin-workflow): add loading for manual execute action

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -102,25 +102,32 @@ function useExecuteConfirmAction() {
   const navigate = useNavigateNoUpdate();
   const { message: messageApi } = App.useApp();
   const executed = useWorkflowExecuted();
+  const [loading, setLoading] = useState(false);
   return {
+    loading,
     async run() {
-      const { autoRevision, ...values } = form.values;
-      // Not executed, could choose to create new version (by default)
-      // Executed, stay in current version, and refresh
-      await form.submit();
-      const {
-        data: { data },
-      } = await resource.execute({
-        filterByTk: workflow.id,
-        values,
-        ...(!executed && autoRevision ? { autoRevision: 1 } : {}),
-      });
-      form.reset();
-      ctx.setFormValueChanged(false);
-      ctx.setVisible(false);
-      messageApi?.open(getExecutedStatusMessage(data.execution));
-      if (data.newVersionId) {
-        navigate(getWorkflowDetailPath(data.newVersionId));
+      setLoading(true);
+      try {
+        const { autoRevision, ...values } = form.values;
+        // Not executed, could choose to create new version (by default)
+        // Executed, stay in current version, and refresh
+        await form.submit();
+        const {
+          data: { data },
+        } = await resource.execute({
+          filterByTk: workflow.id,
+          values,
+          ...(!executed && autoRevision ? { autoRevision: 1 } : {}),
+        });
+        form.reset();
+        ctx.setFormValueChanged(false);
+        ctx.setVisible(false);
+        messageApi?.open(getExecutedStatusMessage(data.execution));
+        if (data.newVersionId) {
+          navigate(getWorkflowDetailPath(data.newVersionId));
+        }
+      } finally {
+        setLoading(false);
       }
     },
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When manually executing a workflow, the execute action did not expose a loading state while the form submit and workflow execution request were in progress. This could leave users without clear feedback and made repeated clicks possible during the async operation.

### Description
Add a loading state to the manual execute confirm action in the workflow canvas.

Key changes:
- Return `loading` from `useExecuteConfirmAction()`.
- Set loading before submitting/executing the workflow.
- Reset loading in `finally` so it is cleared after success or failure.

Potential risks:
- Low. The change is scoped to the client-side manual execute action state.

Testing suggestions:
- Manually execute a workflow and verify the action enters loading state while the request is pending.
- Verify loading is cleared after success, validation failure, or request failure.

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add loading state for manual workflow execution. |
| 🇨🇳 Chinese | 为手动执行工作流增加加载状态。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
