### PR TITLE
fix(ai): buffer streamed chat events

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatMessageActions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatMessageActions.ts
@@ -239,6 +239,7 @@ export const useChatMessageActions = () => {
       const decoder = new TextDecoder();
       let result = '';
       let error = false;
+      let streamBuffer = '';
 
       type MessagesStore = {
         addMessage: (msg: Message) => void;
@@ -515,8 +516,10 @@ export const useChatMessageActions = () => {
             break;
           }
 
-          const chunk = decoder.decode(value, { stream: true });
-          const lines = chunk.split('\n').filter(Boolean);
+          streamBuffer += decoder.decode(value, { stream: true });
+          const parts = streamBuffer.split(/\r?\n/);
+          streamBuffer = parts.pop() ?? '';
+          const lines = parts.filter(Boolean);
 
           for (const line of lines) {
             try {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Large streamed AI tool events can be split across browser stream chunks. When a split occurs, the client may try to parse an incomplete SSE line and drop the event.

### Description 
Buffer streamed chat response text until complete SSE lines are available before parsing.

Potential risk is low. This keeps the existing per-line event handling behavior and only preserves incomplete trailing lines for the next stream chunk.

Testing suggestions:
- Generate an AI business report with large tool call arguments and verify the tool event is processed during streaming.
- Verify normal chat content and reasoning still render incrementally.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI tool call cards not appearing immediately when streamed tool events are split |
| 🇨🇳 Chinese | 修复工具调用流式事件被拆分时，AI 工具调用卡片无法即时显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
