### PR TITLE
chore: add team-shared AGENTS.md and CLAUDE.md with personal local rules support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,6 @@ vitest.config.mts.timestamp-*
 .claudeignore
 python/
 git-repos.json
-CLAUDE.md
-AGENTS.md
+CLAUDE.local.md
+AGENTS.local.md
 openspec/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS
+
+This file holds the team-shared rules for AI coding agents working in this repository. It is the single source of truth — `CLAUDE.md` is a one-line bridge (`@AGENTS.md`) so Claude Code reads the same content.
+
+## Personal Local Rules
+
+If a file `AGENTS.local.md` exists in this repository root, read it once at the start of the session and treat its contents as additional personal rules that extend (but never override) the team rules in this file.
+
+## Project Structure
+
+- New plugins live under `packages/plugins/@nocobase/plugin-<name>/`. Reuse the existing plugin scaffold; do not invent a new layout.
+- This repo has two client runtimes: legacy v1 (`src/client/`, `@nocobase/client`, `SchemaComponent`) and v2 (`src/client-v2/`, `@nocobase/client-v2`, `FlowEngine` / `FlowModel`). Confirm which runtime the file under edit belongs to before writing code. Import direction is one-way: v1 client may import from v2 (`@nocobase/client-v2`), but v2 client must never import from v1 (`@nocobase/client`).
+
+## Code Style Rules
+
+- Do not use `void someAsyncCall()` style fire-and-forget invocation. Prefer direct invocation such as `someAsyncCall()` and structure surrounding code accordingly.
+- Avoid `any` in TypeScript. Reach for a specific type, a generic, or `unknown` with a narrowing guard instead. Replace `as any` with a named type or a type guard. When touching existing code that uses `any`, narrow it to a concrete type whenever feasible.
+- For frontend components and pages, prefer Ant Design v5 components and follow its conventions. Reference https://ant.design/llms.txt for antd's LLM-friendly documentation when needed.
+- For frontend components and pages, follow accessibility (a11y) best practices — add appropriate ARIA attributes, use semantic HTML, and ensure keyboard navigation works.
+- Do not use async IIFE patterns in event handlers (for example: `runAsyncTask((async () => { ... })())`). Extract the async logic into a named async function or call it directly.
+- Do not introduce new abstractions, error-handling layers, or feature flags beyond what the task requires. Three similar lines is better than a premature abstraction.
+
+## Database & Migrations
+
+- Any change to database tables, columns, or indexes must ship with a migration under the plugin's `src/server/migrations/`. Import column types from `DataTypes`; do not reuse type names from neighboring migrations without verifying they still apply.
+
+## Internationalization (i18n)
+
+- User-facing strings (UI labels, messages, errors shown to end users) must go through the project's i18n layer (`t()` / `useTranslation()`); do not hardcode them. Add keys for both `en-US` and `zh-CN` when introducing new strings.
+
+## Pre-Commit Workflow
+
+- Run `yarn eslint --fix` on touched files before reporting work as done. Resolve type errors and lint warnings rather than disabling them.
+
+## Commit Conventions
+
+- Commit messages follow Conventional Commits, prefixed with the affected scope: `fix(plugin-workflow): ...`, `feat(client): ...`, `chore: ...`, `docs: ...`.
+
+## Testing Rules
+
+- Run single test file: `yarn test <path-to-test-file> --run --reporter=verbose`
+  - Example: `yarn test packages/core/flow-engine/src/__tests__/flow-engine.test.ts --run --reporter=verbose`
+- Always run related test files after modifying source code to ensure no regressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ If a file `AGENTS.local.md` exists in this repository root, read it once at the 
 
 - New plugins live under `packages/plugins/@nocobase/plugin-<name>/`. Reuse the existing plugin scaffold; do not invent a new layout.
 - This repo has two client runtimes: legacy v1 (`src/client/`, `@nocobase/client`, `SchemaComponent`) and v2 (`src/client-v2/`, `@nocobase/client-v2`, `FlowEngine` / `FlowModel`). Confirm which runtime the file under edit belongs to before writing code. Import direction is one-way: v1 client may import from v2 (`@nocobase/client-v2`), but v2 client must never import from v1 (`@nocobase/client`).
+- Pro (not open source) plugins live in individual repositories under `packages/plugins` or `packages/pro-plugins` (for example, `@nocobase/plugin-workflow-approval`), but used not as submodules. When working on a pro plugin, clone its repo separately under `packages/plugins/` or `packages/pro-plugins/` and treat it as a standalone project with git.
 
 ## Code Style Rules
 
@@ -23,6 +24,16 @@ If a file `AGENTS.local.md` exists in this repository root, read it once at the 
 ## Database & Migrations
 
 - Any change to database tables, columns, or indexes must ship with a migration under the plugin's `src/server/migrations/`. Import column types from `DataTypes`; do not reuse type names from neighboring migrations without verifying they still apply.
+- New collections (tables), columns, indexes will be automatically synced to database when running the command `yarn nocobase upgrade` (will also run in docker container when start). So no need to create migration files in these cases.
+
+## Testing Rules
+
+- Run single test file: `yarn test <path-to-test-file>`
+  - Client example: `yarn test packages/core/flow-engine/src/__tests__/flow-engine.test.ts --run --reporter=verbose`
+  - Server example: `yarn test packages/core/server/src/__tests__/Application.test.ts`
+- Always run related test files after modifying source code to ensure no regressions.
+- Co-locate unit and integration tests in `__tests__` directories, naming files `*.test.ts` or `*.spec.ts`.
+- Do NOT run server tests parallelly; they may interfere with each other. Use `yarn test` to run them sequentially.
 
 ## Internationalization (i18n)
 
@@ -35,9 +46,3 @@ If a file `AGENTS.local.md` exists in this repository root, read it once at the 
 ## Commit Conventions
 
 - Commit messages follow Conventional Commits, prefixed with the affected scope: `fix(plugin-workflow): ...`, `feat(client): ...`, `chore: ...`, `docs: ...`.
-
-## Testing Rules
-
-- Run single test file: `yarn test <path-to-test-file> --run --reporter=verbose`
-  - Example: `yarn test packages/core/flow-engine/src/__tests__/flow-engine.test.ts --run --reporter=verbose`
-- Always run related test files after modifying source code to ensure no regressions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
 @AGENTS.md
+
+This file is a bridge — treat `AGENTS.md` as the source of truth. When asked to read, update, or add rules to `CLAUDE.md`, read from and write to `AGENTS.md` instead.


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation

The NocoBase repo already had `AGENTS.md` and `CLAUDE.md` at the root, but both were gitignored — they were effectively private to whoever created them locally. That meant the team's coding conventions for AI coding agents (Claude Code, Codex, etc.) were invisible to teammates and to agents running on other machines.

We want one shared source of truth that travels with the repo, plus a clear opt-in slot for each developer's personal additions without committing them.

### Description

- Commit a team-shared `AGENTS.md` at the repo root with sections covering Project Structure, Code Style Rules, Database & Migrations, i18n, Pre-Commit Workflow, Commit Conventions, and Testing Rules.
- Commit `CLAUDE.md` as a one-line `@AGENTS.md` bridge so Claude Code reads the same content as Codex and other AGENTS.md-aware agents.
- Update `.gitignore`: stop ignoring `AGENTS.md` / `CLAUDE.md`; start ignoring `AGENTS.local.md` / `CLAUDE.local.md` so each developer can drop in personal rules that extend (but never override) the team rules.
- `AGENTS.md` includes a "Personal Local Rules" section instructing the agent to read `AGENTS.local.md` at session start if present, providing a project-level personal layer for agents that lack a native one.

### Showcase

<!-- N/A — repo metadata only. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add team-shared `AGENTS.md` and `CLAUDE.md` to standardize AI coding agent behavior across the team, with optional gitignored `AGENTS.local.md` / `CLAUDE.local.md` for personal additions. |
| 🇨🇳 Chinese | 新增团队共享的 `AGENTS.md` 与 `CLAUDE.md` 以统一 AI 代码助手行为，同时通过 gitignore 支持个人在 `AGENTS.local.md` / `CLAUDE.local.md` 中追加私有规则。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
