### PR TITLE
fix(client-v2): support custom brand integration

### DIFF
--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -368,11 +368,11 @@ export abstract class BaseApplication<
     });
   }
 
-  updateFavicon(favicon?: string) {
+  updateFavicon(favicon?: string | null) {
     let faviconLinkElement = document.querySelector('link[rel="shortcut icon"]') as HTMLLinkElement;
 
-    if (favicon) {
-      this.favicon = favicon;
+    if (arguments.length > 0) {
+      this.favicon = favicon || '';
     }
 
     const iconHref = this.favicon || '/favicon/favicon.ico';

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -12,6 +12,7 @@ import { useFlowEngineContext } from '@nocobase/flow-engine';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { escapeHTML, getAppVersionHTML } from '../utils';
 
 const waitForAppReady = async () => {
   await waitFor(() => {
@@ -86,6 +87,14 @@ describe('app', () => {
       const favicon = document.querySelector('link[rel="shortcut icon"]') as HTMLLinkElement;
       expect(favicon).toBeInTheDocument();
       expect(favicon.getAttribute('href')).toBe('/favicon/favicon.ico');
+    });
+
+    it('should escape app version html placeholder content', () => {
+      expect(getAppVersionHTML('<script>alert(1)</script>&"')).toBe(
+        '<span class="nb-app-version">v&lt;script&gt;alert(1)&lt;/script&gt;&amp;&quot;</span>',
+      );
+      expect(getAppVersionHTML(undefined)).toBe('');
+      expect(escapeHTML("NocoBase <v2> & 'beta'")).toBe('NocoBase &lt;v2&gt; &amp; &#39;beta&#39;');
     });
 
     it('should reject invalid component objects but keep valid exotic components', () => {

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -66,6 +66,28 @@ describe('app', () => {
       expect(favicon.getAttribute('href')).toBe('/custom-favicon.ico');
     });
 
+    it('should reset favicon to default when favicon is cleared', () => {
+      const app = new Application({ router });
+
+      app.updateFavicon('/custom-favicon.ico');
+      app.updateFavicon(null);
+
+      const favicon = document.querySelector('link[rel="shortcut icon"]') as HTMLLinkElement;
+      expect(favicon).toBeInTheDocument();
+      expect(favicon.getAttribute('href')).toBe('/favicon/favicon.ico');
+    });
+
+    it('should reset favicon to default when favicon is explicitly undefined', () => {
+      const app = new Application({ router });
+
+      app.updateFavicon('/custom-favicon.ico');
+      app.updateFavicon(undefined);
+
+      const favicon = document.querySelector('link[rel="shortcut icon"]') as HTMLLinkElement;
+      expect(favicon).toBeInTheDocument();
+      expect(favicon.getAttribute('href')).toBe('/favicon/favicon.ico');
+    });
+
     it('should reject invalid component objects but keep valid exotic components', () => {
       const app = new Application({ router });
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/core/client-v2/src/css-variable/CSSVariableProvider.tsx
+++ b/packages/core/client-v2/src/css-variable/CSSVariableProvider.tsx
@@ -10,7 +10,8 @@
 import { TinyColor } from '@ctrl/tinycolor';
 import { useEffect } from 'react';
 import { theme } from 'antd';
-import { type CustomToken, defaultTheme } from '../theme';
+import { defaultTheme } from '../theme';
+import type { CustomToken } from '../theme';
 
 interface Result extends ReturnType<typeof theme.useToken> {
   token: CustomToken;
@@ -42,6 +43,10 @@ export const CSSVariableProvider = ({ children }) => {
     document.body.style.setProperty('--colorWarningBg', token.colorWarningBg);
     document.body.style.setProperty('--colorWarningBorder', token.colorWarningBorder);
     document.body.style.setProperty('--colorText', token.colorText);
+    document.body.style.setProperty('--colorTextDescription', token.colorTextDescription);
+    document.body.style.setProperty('--colorBgTextHover', token.colorBgTextHover);
+    document.body.style.setProperty('--colorSplit', token.colorSplit);
+    document.body.style.setProperty('--borderRadiusOuter', `${token.borderRadiusOuter}px`);
     document.body.style.setProperty('--colorTextHeaderMenu', token.colorTextHeaderMenu);
     document.body.style.setProperty('--colorPrimaryText', token.colorPrimaryText);
     document.body.style.setProperty('--colorPrimaryTextActive', token.colorPrimaryTextActive);
@@ -81,9 +86,13 @@ export const CSSVariableProvider = ({ children }) => {
     token.colorPrimaryTextActive,
     token.colorPrimaryTextHover,
     token.colorSettings,
+    token.colorBgTextHover,
+    token.colorSplit,
     token.colorText,
+    token.colorTextDescription,
     token.colorWarningBg,
     token.colorWarningBorder,
+    token.borderRadiusOuter,
     token.controlHeightLG,
     token.marginLG,
     token.marginSM,

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/HelpLite.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/HelpLite.tsx
@@ -9,44 +9,18 @@
 
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
-import { observer, useFlowEngine } from '@nocobase/flow-engine';
+import { observer } from '@nocobase/flow-engine';
 import { parseHTML } from '@nocobase/utils/client';
 import { Dropdown, Menu, Popover, theme as antdTheme } from 'antd';
 import type { MenuItemType, MenuDividerType } from 'antd/es/menu/interface';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlugin } from '../../../flow-compat';
+import { useCurrentAppInfo } from '../../../hooks';
 import type { CustomToken } from '../../../theme';
+import { getAppVersionHTML } from '../../../utils';
 
 type SettingsMenuItemType = MenuItemType | MenuDividerType;
-
-/**
- * 读取当前应用信息，避免继续依赖旧的 CurrentAppInfoProvider。
- */
-function useCurrentAppInfoLite() {
-  const flowEngine = useFlowEngine();
-  const [data, setData] = useState<any>();
-
-  useEffect(() => {
-    let active = true;
-
-    Promise.resolve(flowEngine.context.appInfo)
-      .then((info) => {
-        if (active) {
-          setData(info);
-        }
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [flowEngine]);
-
-  return data;
-}
 
 const helpClassName = css`
   display: inline-block;
@@ -60,7 +34,7 @@ const helpClassName = css`
 
 const SettingsMenu: React.FC = () => {
   const { t } = useTranslation();
-  const appInfo = useCurrentAppInfoLite();
+  const appInfo = useCurrentAppInfo();
   const { token } = antdTheme.useToken();
   const isSimplifiedChinese = appInfo?.lang === 'zh-CN';
 
@@ -136,7 +110,7 @@ export const HelpLite = observer(
     const { token } = antdTheme.useToken();
     const customToken = token as CustomToken;
     const customBrandPlugin: any = usePlugin('@nocobase/plugin-custom-brand');
-    const appInfo = useCurrentAppInfoLite();
+    const appInfo = useCurrentAppInfo();
 
     const icon = (
       <span
@@ -156,7 +130,7 @@ export const HelpLite = observer(
     );
 
     if (customBrandPlugin?.options?.options?.about) {
-      const appVersion = appInfo?.version ? `<span class="nb-app-version">v${appInfo.version}</span>` : '';
+      const appVersion = getAppVersionHTML(appInfo?.version);
       const content = parseHTML(customBrandPlugin.options.options.about, { appVersion });
 
       return (

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/HelpLite.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/HelpLite.tsx
@@ -156,7 +156,7 @@ export const HelpLite = observer(
     );
 
     if (customBrandPlugin?.options?.options?.about) {
-      const appVersion = `<span class="nb-app-version">v${appInfo?.version}</span>`;
+      const appVersion = appInfo?.version ? `<span class="nb-app-version">v${appInfo.version}</span>` : '';
       const content = parseHTML(customBrandPlugin.options.options.about, { appVersion });
 
       return (

--- a/packages/core/client-v2/src/hooks/index.ts
+++ b/packages/core/client-v2/src/hooks/index.ts
@@ -8,5 +8,7 @@
  */
 
 export * from './useApp';
+export * from './useCurrentAppInfo';
 export * from './usePlugin';
 export * from './useRouter';
+export { escapeHTML, getAppVersionHTML } from '../utils/appVersionHTML';

--- a/packages/core/client-v2/src/hooks/useCurrentAppInfo.ts
+++ b/packages/core/client-v2/src/hooks/useCurrentAppInfo.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowEngineContext } from '@nocobase/flow-engine';
+import { useEffect, useState } from 'react';
+
+export function useCurrentAppInfo<TAppInfo extends Record<string, any> = Record<string, any>>() {
+  const ctx = useFlowEngineContext();
+  const [data, setData] = useState<TAppInfo>();
+
+  useEffect(() => {
+    let active = true;
+
+    Promise.resolve(ctx.appInfo)
+      .then((info) => {
+        if (active) {
+          setData((info || {}) as TAppInfo);
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [ctx]);
+
+  return data;
+}

--- a/packages/core/client-v2/src/utils/appVersionHTML.ts
+++ b/packages/core/client-v2/src/utils/appVersionHTML.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+const htmlEscapeMap: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeHTML(value: string) {
+  return value.replace(/[&<>"']/g, (matched) => htmlEscapeMap[matched]);
+}
+
+export function getAppVersionHTML(version: unknown) {
+  if (version === null || typeof version === 'undefined' || version === '') {
+    return '';
+  }
+
+  return `<span class="nb-app-version">v${escapeHTML(String(version))}</span>`;
+}

--- a/packages/core/client-v2/src/utils/index.tsx
+++ b/packages/core/client-v2/src/utils/index.tsx
@@ -10,6 +10,8 @@
 import React, { ComponentType, FC } from 'react';
 import { BlankComponent } from '../components';
 
+export * from './appVersionHTML';
+
 export function normalizeContainer(container: Element | ShadowRoot | string): Element | null {
   if (!container) {
     console.warn(`Failed to mount app: mount target should not be null or undefined.`);

--- a/packages/core/client/src/css-variable/CSSVariableProvider.tsx
+++ b/packages/core/client/src/css-variable/CSSVariableProvider.tsx
@@ -42,6 +42,10 @@ export const CSSVariableProvider = ({ children }) => {
     document.body.style.setProperty('--colorWarningBg', token.colorWarningBg);
     document.body.style.setProperty('--colorWarningBorder', token.colorWarningBorder);
     document.body.style.setProperty('--colorText', token.colorText);
+    document.body.style.setProperty('--colorTextDescription', token.colorTextDescription);
+    document.body.style.setProperty('--colorBgTextHover', token.colorBgTextHover);
+    document.body.style.setProperty('--colorSplit', token.colorSplit);
+    document.body.style.setProperty('--borderRadiusOuter', `${token.borderRadiusOuter}px`);
     document.body.style.setProperty('--colorTextHeaderMenu', token.colorTextHeaderMenu);
     document.body.style.setProperty('--colorPrimaryText', token.colorPrimaryText);
     document.body.style.setProperty('--colorPrimaryTextActive', token.colorPrimaryTextActive);
@@ -81,9 +85,13 @@ export const CSSVariableProvider = ({ children }) => {
     token.colorPrimaryTextActive,
     token.colorPrimaryTextHover,
     token.colorSettings,
+    token.colorBgTextHover,
+    token.colorSplit,
     token.colorText,
+    token.colorTextDescription,
     token.colorWarningBg,
     token.colorWarningBorder,
+    token.borderRadiusOuter,
     token.controlHeightLG,
     token.marginLG,
     token.marginSM,

--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/__tests__/PoweredByLite.test.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/__tests__/PoweredByLite.test.tsx
@@ -96,4 +96,28 @@ describe('PoweredByLite', () => {
     expect(container.querySelector('.nb-brand')).not.toHaveTextContent('undefined');
     expect(container.querySelector('.nb-app-version')).not.toBeInTheDocument();
   });
+
+  it('should escape custom-brand appVersion placeholder', async () => {
+    const { container } = await renderPoweredByLite(
+      [
+        [
+          MockCustomBrandPlugin,
+          {
+            packageName: '@nocobase/plugin-custom-brand',
+            options: {
+              brand: '<span>Custom Brand</span>{{appVersion}}',
+            },
+          },
+        ],
+      ],
+      {
+        version: '<script>alert(1)</script>&"',
+      },
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('.nb-app-version')).toHaveTextContent('v<script>alert(1)</script>&"');
+    });
+    expect(container.querySelector('.nb-brand script')).not.toBeInTheDocument();
+  });
 });

--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/__tests__/PoweredByLite.test.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/__tests__/PoweredByLite.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createMockClient, Plugin } from '@nocobase/client-v2';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import PoweredByLite from '../components/PoweredByLite';
+
+class PoweredByLiteRoutePlugin extends Plugin {
+  async load() {
+    this.router.add('root', {
+      path: '/',
+      Component: PoweredByLite,
+    });
+  }
+}
+
+class MockCustomBrandPlugin extends Plugin {}
+
+const renderPoweredByLite = async (plugins: any[] = [], appInfoData: Record<string, any> = { version: '1.2.3' }) => {
+  const app = createMockClient({
+    plugins: [PoweredByLiteRoutePlugin as any, ...plugins],
+  });
+
+  app.apiMock.onGet('app:getInfo').reply(200, {
+    data: appInfoData,
+  });
+
+  const Root = app.getRootComponent();
+  const result = render(<Root />);
+
+  await waitFor(() => {
+    expect(document.querySelector('.ant-spin-spinning')).not.toBeInTheDocument();
+  });
+
+  return result;
+};
+
+describe('PoweredByLite', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should render the default brand when custom-brand is not installed', async () => {
+    const { container } = await renderPoweredByLite();
+
+    expect(screen.getByRole('link', { name: 'NocoBase' })).toHaveAttribute('href', 'https://www.nocobase.com');
+    expect(container).toHaveTextContent('Powered by NocoBase');
+    expect(container.querySelector('.nb-brand')).not.toBeInTheDocument();
+  });
+
+  it('should render custom-brand HTML and replace appVersion', async () => {
+    const { container } = await renderPoweredByLite([
+      [
+        MockCustomBrandPlugin,
+        {
+          packageName: '@nocobase/plugin-custom-brand',
+          options: {
+            brand: '<span>Custom Brand</span>{{appVersion}}',
+          },
+        },
+      ],
+    ]);
+
+    await waitFor(() => {
+      expect(container.querySelector('.nb-brand')).toHaveTextContent('Custom Brandv1.2.3');
+    });
+    expect(container.querySelector('.nb-app-version')).toHaveTextContent('v1.2.3');
+    expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+  });
+
+  it('should not render undefined appVersion when app version is unavailable', async () => {
+    const { container } = await renderPoweredByLite(
+      [
+        [
+          MockCustomBrandPlugin,
+          {
+            packageName: '@nocobase/plugin-custom-brand',
+            options: {
+              brand: '<span>Custom Brand</span>{{appVersion}}',
+            },
+          },
+        ],
+      ],
+      {},
+    );
+
+    expect(container.querySelector('.nb-brand')).toHaveTextContent('Custom Brand');
+    expect(container.querySelector('.nb-brand')).not.toHaveTextContent('undefined');
+    expect(container.querySelector('.nb-app-version')).not.toBeInTheDocument();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/components/PoweredByLite.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/components/PoweredByLite.tsx
@@ -7,14 +7,58 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { useApp, usePlugin } from '@nocobase/client-v2';
+import { parseHTML } from '@nocobase/utils/client';
 import React from 'react';
 import { theme as antdTheme } from 'antd';
 import { useTranslation } from 'react-i18next';
 
+function useCurrentAppInfoLite() {
+  const app = useApp();
+  const [data, setData] = React.useState<any>();
+
+  React.useEffect(() => {
+    let active = true;
+
+    Promise.resolve(app.flowEngine.context.appInfo)
+      .then((info) => {
+        if (active) {
+          setData(info);
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [app]);
+
+  return data;
+}
+
 export default function PoweredByLite() {
   const { token } = antdTheme.useToken();
   const { i18n } = useTranslation();
+  const customBrandPlugin: any = usePlugin('@nocobase/plugin-custom-brand');
+  const appInfo = useCurrentAppInfoLite();
   const homePage = i18n.language === 'zh-CN' ? 'https://www.nocobase.com/cn/' : 'https://www.nocobase.com';
+  const customBrand = customBrandPlugin?.options?.options?.brand;
+
+  if (customBrand) {
+    const appVersion = appInfo?.version ? `<span class="nb-app-version">v${appInfo.version}</span>` : '';
+
+    return (
+      <div
+        className="nb-brand"
+        style={{ color: token.colorTextDescription }}
+        dangerouslySetInnerHTML={{
+          __html: parseHTML(customBrand, { appVersion }),
+        }}
+      />
+    );
+  }
 
   return (
     <div style={{ color: token.colorTextDescription }}>

--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/components/PoweredByLite.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/components/PoweredByLite.tsx
@@ -7,47 +7,22 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { useApp, usePlugin } from '@nocobase/client-v2';
+import { getAppVersionHTML, useCurrentAppInfo, usePlugin } from '@nocobase/client-v2';
 import { parseHTML } from '@nocobase/utils/client';
 import React from 'react';
 import { theme as antdTheme } from 'antd';
 import { useTranslation } from 'react-i18next';
 
-function useCurrentAppInfoLite() {
-  const app = useApp();
-  const [data, setData] = React.useState<any>();
-
-  React.useEffect(() => {
-    let active = true;
-
-    Promise.resolve(app.flowEngine.context.appInfo)
-      .then((info) => {
-        if (active) {
-          setData(info);
-        }
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [app]);
-
-  return data;
-}
-
 export default function PoweredByLite() {
   const { token } = antdTheme.useToken();
   const { i18n } = useTranslation();
   const customBrandPlugin: any = usePlugin('@nocobase/plugin-custom-brand');
-  const appInfo = useCurrentAppInfoLite();
+  const appInfo = useCurrentAppInfo();
   const homePage = i18n.language === 'zh-CN' ? 'https://www.nocobase.com/cn/' : 'https://www.nocobase.com';
   const customBrand = customBrandPlugin?.options?.options?.brand;
 
   if (customBrand) {
-    const appVersion = appInfo?.version ? `<span class="nb-app-version">v${appInfo.version}</span>` : '';
+    const appVersion = getAppVersionHTML(appInfo?.version);
 
     return (
       <div

--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/components/PoweredByLite.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/components/PoweredByLite.tsx
@@ -52,7 +52,6 @@ export default function PoweredByLite() {
     return (
       <div
         className="nb-brand"
-        style={{ color: token.colorTextDescription }}
         dangerouslySetInnerHTML={{
           __html: parseHTML(customBrand, { appVersion }),
         }}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
自定义品牌插件迁移到 v2 后，登录页和帮助入口需要继续显示自定义品牌内容，并且清空网站图标后应立即恢复默认图标。

### Description 
本次调整让 v2 登录页支持读取自定义品牌内容，并在应用版本信息未加载时避免显示异常文本。同时补充网站图标的清空语义，显式传入空值时会恢复默认图标。

已补充相关单元测试，覆盖自定义品牌登录页展示、应用版本兜底和网站图标清空。

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Custom brand settings now work correctly in the v2 client |
| 🇨🇳 Chinese | 自定义品牌设置现在可以在 v2 客户端中正常生效 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
