### PR TITLE
fix: align dnd-kit global deps registration

### DIFF
--- a/packages/core/client-v2/src/utils/globalDeps.ts
+++ b/packages/core/client-v2/src/utils/globalDeps.ts
@@ -92,8 +92,8 @@ export function defineGlobalDeps(requirejs: RequireJS) {
   defineGlobalDep(requirejs, '@nocobase/evaluators', nocobaseEvaluators);
   defineGlobalDep(requirejs, '@nocobase/evaluators/client', nocobaseEvaluators);
 
-  requirejs.define('@dnd-kit/core', () => dndKitCore);
-  requirejs.define('@dnd-kit/sortable', () => dndKitSortable);
+  defineGlobalDep(requirejs, '@dnd-kit/core', dndKitCore);
+  defineGlobalDep(requirejs, '@dnd-kit/sortable', dndKitSortable);
 
   // utils
   defineGlobalDep(requirejs, 'ahooks', ahooks);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The dnd-kit shared dependencies in client-v2 were registered directly with `requirejs.define`, unlike the other shared dependencies. This bypassed the common dev-mode dependency exposure path.

### Description 
This PR aligns `@dnd-kit/core` and `@dnd-kit/sortable` with the rest of the client-v2 shared dependency registration by routing them through `defineGlobalDep`.

Tested with:

`yarn vitest run packages/core/client-v2/src/__tests__/globalDeps.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed inconsistent dnd-kit dependency registration. |
| 🇨🇳 Chinese | 修复 dnd-kit 依赖注册不一致的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
