### PR TITLE
fix(client): preserve dev plugin named exports

### DIFF
--- a/packages/core/client-v2/src/__tests__/remotePlugins.test.ts
+++ b/packages/core/client-v2/src/__tests__/remotePlugins.test.ts
@@ -32,6 +32,61 @@ describe('client-v2 remotePlugins', () => {
     expect(mockDefine).toHaveBeenCalledWith('@nocobase/demo/client-v2', expect.any(Function));
   });
 
+  it('should preserve named exports from dev plugin modules', () => {
+    class DemoPlugin extends Plugin {}
+    class DemoActionModel {}
+
+    const mockDefine: any = vi.fn();
+    window.define = mockDefine;
+
+    const pluginModule = {
+      default: DemoPlugin,
+      DemoActionModel,
+    };
+    defineDevPlugins({
+      '@nocobase/demo': pluginModule,
+    });
+
+    const moduleFactory = mockDefine.mock.calls[0]?.[1];
+    expect(mockDefine).toHaveBeenCalledWith('@nocobase/demo/client-v2', expect.any(Function));
+    expect(moduleFactory()).toBe(pluginModule);
+    expect(window.__nocobase_app_dev_plugins__['@nocobase/demo/client-v2']).toBe(pluginModule);
+  });
+
+  it('should expose named exports from devDynamicImport modules to RequireJS consumers', async () => {
+    class DemoPlugin extends Plugin {}
+    class DemoActionModel {}
+
+    const requirejs: any = {
+      requirejs: vi.fn(),
+    };
+    requirejs.requirejs.config = vi.fn();
+
+    const mockDefine: any = vi.fn();
+    window.define = mockDefine;
+
+    const plugins = await getPlugins({
+      requirejs,
+      pluginData: [
+        {
+          name: '@nocobase/demo',
+          packageName: '@nocobase/demo',
+          url: 'https://demo.com/dist/client-v2/index.js',
+        },
+      ] as any,
+      devDynamicImport: vi.fn().mockResolvedValue({ default: DemoPlugin, DemoActionModel }) as any,
+    });
+
+    const moduleFactory = mockDefine.mock.calls.find((call) => call[0] === '@nocobase/demo/client-v2')?.[1];
+
+    expect(plugins).toEqual([['@nocobase/demo', DemoPlugin]]);
+    expect(moduleFactory()).toEqual({ default: DemoPlugin, DemoActionModel });
+    expect(window.__nocobase_app_dev_plugins__['@nocobase/demo/client-v2']).toEqual({
+      default: DemoPlugin,
+      DemoActionModel,
+    });
+  });
+
   it('should not define /client aliases when loading v2 plugins', async () => {
     class DemoPlugin extends Plugin {}
 

--- a/packages/core/client-v2/src/utils/remotePlugins.ts
+++ b/packages/core/client-v2/src/utils/remotePlugins.ts
@@ -31,9 +31,11 @@ function defineAppDevPluginModule(moduleId: string, pluginModule: RemotePluginMo
 /**
  * @internal
  */
-export function defineDevPlugins(plugins: Record<string, PluginClass>) {
-  Object.entries(plugins).forEach(([packageName, plugin]) => {
-    window.define(getClientV2ModuleId(packageName), () => plugin);
+export function defineDevPlugins(plugins: Record<string, RemotePluginModule>) {
+  Object.entries(plugins).forEach(([packageName, pluginModule]) => {
+    const moduleId = getClientV2ModuleId(packageName);
+    window.define(moduleId, () => pluginModule);
+    defineAppDevPluginModule(moduleId, pluginModule);
   });
 }
 
@@ -188,15 +190,18 @@ export async function getPlugins(options: GetPluginsOption): Promise<Array<[stri
   const res: Array<[string, PluginClass]> = [];
 
   const resolveDevPlugins: Record<string, PluginClass> = {};
+  const resolveDevPluginModules: Record<string, RemotePluginModule> = {};
   if (devDynamicImport) {
     for await (const plugin of pluginData) {
-      const pluginModule = await devDynamicImport(plugin.packageName);
+      const pluginModule: RemotePluginModule | null = await devDynamicImport(plugin.packageName);
       if (pluginModule) {
-        res.push([plugin.name, pluginModule.default]);
-        resolveDevPlugins[plugin.packageName] = pluginModule.default;
+        const pluginClass = getPluginClass(pluginModule);
+        res.push([plugin.name, pluginClass]);
+        resolveDevPlugins[plugin.packageName] = pluginClass;
+        resolveDevPluginModules[plugin.packageName] = pluginModule;
       }
     }
-    defineDevPlugins(resolveDevPlugins);
+    defineDevPlugins(resolveDevPluginModules);
   }
 
   const remotePlugins = pluginData.filter((item) => !resolveDevPlugins[item.packageName]);

--- a/packages/core/client/src/application/__tests__/utils/remotePlugins.test.ts
+++ b/packages/core/client/src/application/__tests__/utils/remotePlugins.test.ts
@@ -56,6 +56,26 @@ describe('remotePlugins', () => {
 
       defineDevPlugins(plugins);
     });
+
+    it('should preserve named exports from dev plugin modules', () => {
+      class DemoPlugin extends Plugin {}
+      class DemoActionModel {}
+      const plugins = {
+        '@nocobase/demo': {
+          default: DemoPlugin,
+          DemoActionModel,
+        },
+      };
+      const define: any = function (packageName: string, load: any) {
+        expect(packageName).toEqual('@nocobase/demo/client');
+        expect(load()).toEqual(plugins['@nocobase/demo']);
+      };
+      window.define = define;
+
+      defineDevPlugins(plugins);
+
+      expect(window.__nocobase_app_dev_plugins__['@nocobase/demo/client']).toBe(plugins['@nocobase/demo']);
+    });
   });
 
   describe('definePluginClient()', () => {
@@ -325,6 +345,42 @@ describe('remotePlugins', () => {
       expect(remoteFn).toBeCalledTimes(0);
       expect(mockDefine).toBeCalledTimes(2);
       expect(requirejs.requirejs.config).toBeCalledTimes(0);
+    });
+
+    it('should expose named exports from devDynamicImport modules to RequireJS consumers', async () => {
+      class DemoPlugin extends Plugin {}
+      class DemoActionModel {}
+
+      const requirejs: any = {
+        requirejs: vi.fn(),
+      };
+      requirejs.requirejs.config = vi.fn();
+
+      const mockDefine: any = vi.fn();
+      window.define = mockDefine;
+
+      const plugins = await getPlugins({
+        requirejs,
+        pluginData: [
+          {
+            name: '@nocobase/demo',
+            packageName: '@nocobase/demo',
+            url: 'https://demo.com',
+          },
+        ] as any,
+        devDynamicImport: (() => {
+          return Promise.resolve({ default: DemoPlugin, DemoActionModel });
+        }) as any,
+      });
+
+      const moduleFactory = mockDefine.mock.calls.find((call) => call[0] === '@nocobase/demo/client')?.[1];
+
+      expect(plugins).toEqual([['@nocobase/demo', DemoPlugin]]);
+      expect(moduleFactory()).toEqual({ default: DemoPlugin, DemoActionModel });
+      expect(window.__nocobase_app_dev_plugins__['@nocobase/demo/client']).toEqual({
+        default: DemoPlugin,
+        DemoActionModel,
+      });
     });
 
     it('If there is devDynamicImport and devDynamicImport returns partial, remote API will be requested', async () => {

--- a/packages/core/client/src/application/utils/remotePlugins.ts
+++ b/packages/core/client/src/application/utils/remotePlugins.ts
@@ -31,9 +31,11 @@ function defineAppDevPluginModule(moduleId: string, pluginModule: RemotePluginMo
 /**
  * @internal
  */
-export function defineDevPlugins(plugins: Record<string, PluginClass<any>>) {
-  Object.entries(plugins).forEach(([packageName, plugin]) => {
-    window.define(getClientModuleId(packageName), () => plugin);
+export function defineDevPlugins(plugins: Record<string, RemotePluginModule>) {
+  Object.entries(plugins).forEach(([packageName, pluginModule]) => {
+    const moduleId = getClientModuleId(packageName);
+    window.define(moduleId, () => pluginModule);
+    defineAppDevPluginModule(moduleId, pluginModule);
   });
 }
 
@@ -224,15 +226,18 @@ export async function getPlugins(options: GetPluginsOption): Promise<Array<[stri
   const res: Array<[string, PluginClass<any>]> = [];
 
   const resolveDevPlugins: Record<string, PluginClass<any>> = {};
+  const resolveDevPluginModules: Record<string, RemotePluginModule> = {};
   if (devDynamicImport) {
     for await (const plugin of pluginData) {
-      const pluginModule = await devDynamicImport(plugin.packageName);
+      const pluginModule: RemotePluginModule | null = await devDynamicImport(plugin.packageName);
       if (pluginModule) {
-        res.push([plugin.name, pluginModule.default]);
-        resolveDevPlugins[plugin.packageName] = pluginModule.default;
+        const pluginClass = getPluginClass(pluginModule);
+        res.push([plugin.name, pluginClass]);
+        resolveDevPlugins[plugin.packageName] = pluginClass;
+        resolveDevPluginModules[plugin.packageName] = pluginModule;
       }
     }
-    defineDevPlugins(resolveDevPlugins);
+    defineDevPlugins(resolveDevPluginModules);
   }
 
   const remotePlugins = pluginData.filter((item) => !resolveDevPlugins[item.packageName]);

--- a/packages/core/devtools/common.js
+++ b/packages/core/devtools/common.js
@@ -172,7 +172,7 @@ export default function devDynamicImport(packageName: string): Promise<any> {
             this.packagesPath,
             join(dirname(pluginPackageJsonPath), 'src', this.options.clientSourceDir),
           ).replaceAll(sep, '/');
-          exportStatement = `export { default } from '${pluginSrcClientPath}';`;
+          exportStatement = `export { default } from '${pluginSrcClientPath}';\nexport * from '${pluginSrcClientPath}';`;
         } else {
           exportStatement = `export { default } from '${pluginPackageJson.name}/${this.options.clientModuleName}';`;
         }

--- a/packages/core/test/src/__tests__/devtools/common.test.ts
+++ b/packages/core/test/src/__tests__/devtools/common.test.ts
@@ -70,6 +70,7 @@ describe('IndexGenerator', () => {
 
     const manifest = fs.readFileSync(path.join(outputPath, 'packages', 'nocobase_plugin_acl.ts'), 'utf8');
     expect(manifest).toContain('src/client-v2');
+    expect(manifest).toContain("export * from '../../../../../../plugins/@nocobase/plugin-acl/src/client-v2';");
   });
 
   it('should keep client manifests using client.js and src/client', () => {
@@ -101,6 +102,7 @@ describe('IndexGenerator', () => {
 
     const manifest = fs.readFileSync(path.join(outputPath, 'packages', 'nocobase_plugin_v1_only.ts'), 'utf8');
     expect(manifest).toContain('src/client');
+    expect(manifest).toContain("export * from '../../../../../../plugins/@nocobase/plugin-v1-only/src/client';");
     expect(manifest).not.toContain('src/client-v2');
   });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Source plugins loaded through `devDynamicImport` only exposed their default plugin class to the RequireJS compatibility layer. Built storage plugins can depend on named exports from those source plugin client modules, which caused mixed dev/static plugin loading to fail when the named exports were missing.

### Description 
- Preserve named exports when generating local source plugin wrapper modules.
- Register the full dev plugin module with RequireJS while still using the default export as the plugin class.
- Add regression coverage for named exports from dev plugin modules in both client lanes.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed dev mode loading for built storage plugins that depend on named exports from local source plugins. |
| 🇨🇳 Chinese | 修复开发模式下已构建 storage 插件依赖本地源码插件命名导出时加载失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
