### PR TITLE
fix(workflow-manual): persist manual task draft result

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/form.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/form.test.ts
@@ -462,6 +462,11 @@ describe('workflow > instructions > manual', () => {
         f1: { number: 1 },
         f2: { number: 2 },
       });
+      const savedTask = await UserJobModel.findByPk(pendingJobs[0].get('id'));
+      expect(savedTask.result).toMatchObject({
+        f1: { number: 1 },
+        f2: { number: 2 },
+      });
 
       const res3 = await userAgents[0].resource('workflowManualTasks').submit({
         filterByTk: pendingJobs[0].get('id'),

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/actions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/actions.ts
@@ -85,9 +85,10 @@ export async function submit(context: Context, next) {
   task.set({
     status: actionItem.status,
     result: actionItem.status
-      ? { [formKey]: Object.assign(values.result[formKey], presetValues), _: actionKey }
-      : Object.assign(task.result ?? {}, values.result),
+      ? { [formKey]: { ...values.result[formKey], ...presetValues }, _: actionKey }
+      : { ...(task.result ?? {}), ...values.result },
   });
+  task.changed('result', true);
 
   const handler = instruction.formTypes.get(forms[formKey].type);
   if (handler && task.status) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Manual workflow tasks could be saved temporarily without persisting the submitted form values. After reopening the pending todo, the fields filled during "Save temporarily" were missing.

### Description 
This PR updates the manual task submit action to persist draft results reliably:

- avoid mutating the existing JSONB `result` object in place when saving a pending manual task
- explicitly mark the `result` field as changed before saving
- keep action preset values overriding submitted values for final submissions
- add a regression assertion that reloads the manual task from the database after multiple temporary saves

Potential risk is low and scoped to manual workflow task submission.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/form.test.ts -t "save all forms, only reserve submitted ones"`
- `yarn test packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/form.test.ts -t "submitted values should be overrided by action assigned"`

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed temporary saves for manual workflow tasks not persisting submitted form values. |
| 🇨🇳 Chinese | 修复工作流人工任务暂存后未持久化已填写表单内容的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
