### PR TITLE
fix(build): keep server obfuscation node-compatible

### DIFF
--- a/packages/core/build/src/utils/__tests__/obfuscationResult.test.ts
+++ b/packages/core/build/src/utils/__tests__/obfuscationResult.test.ts
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { obfuscate } from '../obfuscationResult';
+
+describe('obfuscate', () => {
+  it('keeps server output compatible with Node.js when string code generation is disabled', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nocobase-obfuscate-'));
+    const filePath = path.join(tmpDir, 'server.js');
+
+    try {
+      fs.writeFileSync(
+        filePath,
+        `
+module.exports = function getValue() {
+  console.log('server log');
+  return 1;
+};
+`,
+        'utf8',
+      );
+
+      obfuscate(filePath);
+
+      const obfuscatedCode = fs.readFileSync(filePath, 'utf8');
+
+      expect(obfuscatedCode).not.toMatch(/\bwindow\b/);
+
+      execFileSync(
+        process.execPath,
+        [
+          '--disallow-code-generation-from-strings',
+          '-e',
+          `const getValue = require(${JSON.stringify(filePath)}); if (getValue() !== 1) process.exit(1);`,
+        ],
+        { stdio: 'pipe' },
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/build/src/utils/obfuscationResult.ts
+++ b/packages/core/build/src/utils/obfuscationResult.ts
@@ -18,7 +18,7 @@ export const obfuscate = (filePath: string) => {
     deadCodeInjection: false,
     debugProtection: false,
     debugProtectionInterval: 0,
-    disableConsoleOutput: true,
+    disableConsoleOutput: false,
     identifierNamesGenerator: 'hexadecimal',
     log: false,
     numbersToExpressions: false,
@@ -37,7 +37,8 @@ export const obfuscate = (filePath: string) => {
     stringArrayWrappersParametersMaxCount: 2,
     stringArrayWrappersType: 'variable',
     stringArrayThreshold: 0.75,
-    unicodeEscapeSequence: false
+    target: 'node',
+    unicodeEscapeSequence: false,
   });
   fs.writeFileSync(filePath, obfuscationResult.getObfuscatedCode(), 'utf8');
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Plugin server obfuscation output could include a `window` fallback from the obfuscator console-output helper, which crashes in Node.js when string code generation is disabled.

### Description 
- Configure server obfuscation for the Node.js target.
- Disable the obfuscator console-output helper for server bundles to avoid injecting browser globals.
- Add a regression test that verifies obfuscated server output does not contain `window` and can load under `--disallow-code-generation-from-strings`.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed plugin server obfuscation output to avoid browser globals in Node.js runtime bundles. |
| 🇨🇳 Chinese | 修复插件服务端混淆产物在 Node.js 运行时注入浏览器全局变量的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
