### PR TITLE
fix(client): sync document language with app locale

### DIFF
--- a/packages/core/app/client-v2/index.html
+++ b/packages/core/app/client-v2/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />

--- a/packages/core/app/client/index.html
+++ b/packages/core/app/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 
 <head>
   <meta charset="UTF-8" />

--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -169,6 +169,18 @@ export abstract class BaseApplication<
     return this.wsAuthorized;
   }
 
+  public setDocumentLanguage(language?: string | null) {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    if (language) {
+      document.documentElement.lang = language;
+    } else {
+      document.documentElement.removeAttribute('lang');
+    }
+  }
+
   constructor(protected options: TOptions = {} as TOptions) {
     this.initRequireJs();
     this.defineObservableState();
@@ -205,6 +217,7 @@ export abstract class BaseApplication<
     this.addRoutes();
     this.i18n.on('languageChanged', (lng) => {
       this.apiClient.auth.locale = lng;
+      this.setDocumentLanguage(lng);
     });
     this.initListeners();
     this.afterManagersInitialized();

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -33,6 +33,7 @@ describe('app', () => {
 
     afterEach(() => {
       document.querySelectorAll('link[rel="shortcut icon"]').forEach((node) => node.remove());
+      document.documentElement.removeAttribute('lang');
       vi.restoreAllMocks();
     });
 
@@ -87,6 +88,14 @@ describe('app', () => {
       const favicon = document.querySelector('link[rel="shortcut icon"]') as HTMLLinkElement;
       expect(favicon).toBeInTheDocument();
       expect(favicon.getAttribute('href')).toBe('/favicon/favicon.ico');
+    });
+
+    it('should sync document language when app language changes', async () => {
+      const app = new Application({ router });
+
+      await app.i18n.changeLanguage('ja-JP');
+
+      expect(document.documentElement.lang).toBe('ja-JP');
     });
 
     it('should escape app version html placeholder content', () => {

--- a/packages/core/client-v2/src/nocobase-buildin-plugin/plugins/LocalePlugin.ts
+++ b/packages/core/client-v2/src/nocobase-buildin-plugin/plugins/LocalePlugin.ts
@@ -39,6 +39,7 @@ export class LocalePlugin extends Plugin {
 
       if (data.lang) {
         api.auth.setLocale(data.lang);
+        this.app.setDocumentLanguage(data.lang);
         this.app.i18n.changeLanguage(data.lang);
       }
 

--- a/packages/core/client/src/nocobase-buildin-plugin/plugins/LocalePlugin.ts
+++ b/packages/core/client/src/nocobase-buildin-plugin/plugins/LocalePlugin.ts
@@ -33,6 +33,7 @@ export class LocalePlugin extends Plugin {
       this.app.use(App, { component: false });
       if (data?.data?.lang) {
         api.auth.setLocale(data?.data?.lang);
+        this.app.setDocumentLanguage(data?.data?.lang);
         this.app.i18n.changeLanguage(data?.data?.lang);
       }
       Object.keys(data?.data?.resources || {}).forEach((key) => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The app HTML templates hardcoded `lang="en"`, so browsers could still identify pages as English even when the application language was set to Japanese. This caused browser translation prompts to appear for users whose pages already followed the selected app language.

### Description 
- Remove the hardcoded `lang="en"` attribute from the v1 and v2 app HTML templates.
- Sync `document.documentElement.lang` whenever the application i18n language changes.
- Set the document language immediately after `app:getLang` resolves in both v1 and v2 locale plugins.
- Add regression coverage for document language synchronization.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed browser language metadata so the app page follows the selected application language instead of being marked as English. |
| 🇨🇳 Chinese | 修复页面语言元信息，使应用页面跟随当前应用语言，而不是固定标记为英文。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
