### PR TITLE
fix(build): copy text assets during server builds

### DIFF
--- a/packages/core/build/src/__tests__/buildCjs.test.ts
+++ b/packages/core/build/src/__tests__/buildCjs.test.ts
@@ -1,0 +1,49 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { buildCjs } from '../buildCjs';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fs.remove(dir)));
+  tempDirs.length = 0;
+});
+
+async function createTempPackageDir() {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'nocobase-build-cjs-'));
+  tempDirs.push(cwd);
+  return cwd;
+}
+
+describe('buildCjs', () => {
+  test('copies text assets without converting them to JavaScript modules', async () => {
+    const cwd = await createTempPackageDir();
+
+    await fs.outputFile(path.join(cwd, 'src/index.ts'), 'export const name = "test";');
+    await fs.outputFile(path.join(cwd, 'src/migrations/t.txt'), '123');
+
+    await buildCjs(
+      cwd,
+      {
+        modifyTsupConfig: (config) => config,
+      },
+      false,
+      () => {},
+    );
+
+    await expect(fs.readFile(path.join(cwd, 'lib/migrations/t.txt'), 'utf8')).resolves.toBe('123');
+    await expect(fs.pathExists(path.join(cwd, 'lib/migrations/t.js'))).resolves.toBe(false);
+  });
+});

--- a/packages/core/build/src/buildCjs.ts
+++ b/packages/core/build/src/buildCjs.ts
@@ -14,31 +14,36 @@ import chalk from 'chalk';
 import { globExcludeFiles, EsbuildSupportExts } from './constant';
 import { PkgLog, UserConfig } from './utils';
 
-export function buildCjs(cwd: string, userConfig: UserConfig, sourcemap: boolean = false, log: PkgLog) {
+export function buildCjs(cwd: string, userConfig: UserConfig, sourcemap = false, log: PkgLog) {
   log('build cjs');
 
   const entry = fg.globSync(['src/**', ...globExcludeFiles], { cwd, absolute: true });
   const outDir = path.join(cwd, 'lib');
-  const otherExts = Array.from(new Set(entry.map((item) => path.extname(item)).filter((item) => !EsbuildSupportExts.includes(item))));
+  const otherExts = Array.from(
+    new Set(entry.map((item) => path.extname(item)).filter((item) => !EsbuildSupportExts.includes(item))),
+  );
   if (otherExts.length) {
     log('%s will not be processed, only be copied to the lib directory.', chalk.yellow(otherExts.join(',')));
   }
-  return build(userConfig.modifyTsupConfig({
-    entry,
-    splitting: false,
-    clean: true,
-    bundle: false,
-    silent: true,
-    sourcemap,
-    treeshake: false,
-    target: 'node16',
-    keepNames: true,
-    outDir,
-    loader: {
-      ...otherExts.reduce((prev, cur) => ({ ...prev, [cur]: 'copy' }), {}),
-      '.json': 'copy',
-    },
-    format: 'cjs',
-    skipNodeModulesBundle: true,
-  }));
+  return build(
+    userConfig.modifyTsupConfig({
+      entry,
+      splitting: false,
+      clean: true,
+      bundle: false,
+      silent: true,
+      sourcemap,
+      treeshake: false,
+      target: 'node16',
+      keepNames: true,
+      outDir,
+      loader: {
+        ...otherExts.reduce((prev, cur) => ({ ...prev, [cur]: 'copy' }), {}),
+        '.json': 'copy',
+        '.txt': 'copy',
+      },
+      format: 'cjs',
+      skipNodeModulesBundle: true,
+    }),
+  );
 }

--- a/packages/core/build/src/buildPlugin.ts
+++ b/packages/core/build/src/buildPlugin.ts
@@ -312,7 +312,7 @@ export async function buildServerDeps(cwd: string, serverFiles: string[], log: P
   const includePackages = getIncludePackages(sourcePackages, external, pluginPrefix);
   const excludePackages = getExcludePackages(sourcePackages, external, pluginPrefix);
 
-  let tips = [];
+  const tips = [];
   if (includePackages.length) {
     tips.push(
       `These packages ${chalk.yellow(includePackages.join(', '))} will be ${chalk.italic(
@@ -431,6 +431,7 @@ export async function buildPluginServer(cwd: string, userConfig: UserConfig, sou
       loader: {
         ...otherExts.reduce((prev, cur) => ({ ...prev, [cur]: 'copy' }), {}),
         '.json': 'copy',
+        '.txt': 'copy',
       },
     }),
   );
@@ -487,6 +488,7 @@ export async function buildProPluginServer(cwd: string, userConfig: UserConfig, 
       loader: {
         ...otherExts.reduce((prev, cur) => ({ ...prev, [cur]: 'copy' }), {}),
         '.json': 'copy',
+        '.txt': 'copy',
       },
     }),
   );
@@ -541,6 +543,7 @@ export async function buildProPluginServer(cwd: string, userConfig: UserConfig, 
       loader: {
         ...otherExts.reduce((prev, cur) => ({ ...prev, [cur]: 'copy' }), {}),
         '.json': 'copy',
+        '.txt': 'copy',
       },
 
       ...externalOptions,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Server-side builds currently include `src/**` as tsup entries. Because `.txt` is treated as an esbuild-supported extension, text assets can be converted into JavaScript modules instead of remaining asset files.

### Description 
- Configure core CJS builds to copy `.txt` assets explicitly, preserving file names such as `lib/migrations/t.txt`.
- Apply the same `.txt` copy behavior to plugin server and pro plugin server builds.
- Add regression coverage to ensure `.txt` assets are copied without generating `.js` modules.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Text assets in server builds are now copied as files instead of being converted into JavaScript modules. |
| 🇨🇳 Chinese | 服务端构建中的文本资源现在会作为文件复制，不再被转换成 JavaScript 模块。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |     |
| 🇨🇳 Chinese |     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
