### PR TITLE
fix(plugin-file-manager): render PDF previews safely

### DIFF
--- a/packages/core/client/src/schema-component/antd/upload/Upload.tsx
+++ b/packages/core/client/src/schema-component/antd/upload/Upload.tsx
@@ -186,7 +186,7 @@ attachmentFileTypes.add({
   },
 });
 
-const iframePreviewSupportedTypes = ['application/pdf', 'audio/*', 'image/*', 'video/*', 'text/plain'];
+const iframePreviewSupportedTypes = ['audio/*', 'image/*', 'video/*', 'text/plain'];
 
 function IframePreviewer({ index, list, onSwitchIndex }) {
   const { t } = useTranslation();

--- a/packages/core/server/src/__tests__/gateway/static-file-security.test.ts
+++ b/packages/core/server/src/__tests__/gateway/static-file-security.test.ts
@@ -13,6 +13,7 @@ import { getStorageUploadSecurityHeaders, hasActiveContentExtension } from '../.
 describe('static file security', () => {
   it('should detect active content file extensions', () => {
     expect(hasActiveContentExtension('/storage/uploads/a.html')).toBe(true);
+    expect(hasActiveContentExtension('/storage/uploads/a.pdf')).toBe(true);
     expect(hasActiveContentExtension('/storage/uploads/a.SVG')).toBe(true);
     expect(hasActiveContentExtension('/storage/uploads/a.svgz?download=1')).toBe(true);
     expect(hasActiveContentExtension('/storage/uploads/a.txt')).toBe(false);
@@ -25,6 +26,11 @@ describe('static file security', () => {
     });
 
     expect(getStorageUploadSecurityHeaders('/storage/uploads/a.pdf')).toEqual({
+      'Content-Disposition': 'attachment',
+      'X-Content-Type-Options': 'nosniff',
+    });
+
+    expect(getStorageUploadSecurityHeaders('/storage/uploads/a.txt')).toEqual({
       'X-Content-Type-Options': 'nosniff',
     });
   });

--- a/packages/core/server/src/gateway/static-file-security.ts
+++ b/packages/core/server/src/gateway/static-file-security.ts
@@ -9,7 +9,7 @@
 
 import path from 'node:path';
 
-const ACTIVE_CONTENT_EXTENSIONS = new Set(['.htm', '.html', '.svg', '.svgz', '.xhtml']);
+const ACTIVE_CONTENT_EXTENSIONS = new Set(['.htm', '.html', '.pdf', '.svg', '.svgz', '.xhtml']);
 
 function stripQueryAndHash(pathname = '') {
   return pathname.split('?')[0].split('#')[0];

--- a/packages/plugins/@nocobase/plugin-file-manager/package.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/package.json
@@ -40,7 +40,8 @@
     "url-join": "4.0.1"
   },
   "dependencies": {
-    "file-type": "^21.0.0"
+    "file-type": "^21.0.0",
+    "pdfjs-dist": "^5.3.31"
   },
   "peerDependencies": {
     "@nocobase/actions": "2.x",

--- a/packages/plugins/@nocobase/plugin-file-manager/package.json
+++ b/packages/plugins/@nocobase/plugin-file-manager/package.json
@@ -27,6 +27,7 @@
     "antd": "5.x",
     "axios": "^1.7.0",
     "cos-nodejs-sdk-v5": "^2.11.14",
+    "file-type": "^21.0.0",
     "koa-static": "^5.0.0",
     "mime-match": "^1.0.2",
     "mime-types": "^3.0.1",
@@ -34,14 +35,11 @@
     "multer": "^1.4.5-lts.2",
     "multer-s3": "^3.0.1",
     "multistream": "^4.1.0",
+    "pdfjs-dist": "^5.3.31",
     "react": "^18.2.0",
     "react-i18next": "^11.15.1",
     "supertest": "^6.1.6",
     "url-join": "4.0.1"
-  },
-  "dependencies": {
-    "file-type": "^21.0.0",
-    "pdfjs-dist": "^5.3.31"
   },
   "peerDependencies": {
     "@nocobase/actions": "2.x",

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/index.tsx
@@ -7,7 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Plugin, useCollection } from '@nocobase/client';
+import React from 'react';
+import { attachmentFileTypes, Plugin, useCollection } from '@nocobase/client';
 import { STORAGE_TYPE_ALI_OSS, STORAGE_TYPE_LOCAL, STORAGE_TYPE_S3, STORAGE_TYPE_TX_COS } from '../constants';
 import { FileManagerProvider } from './FileManagerProvider';
 import { FileSizeField } from './FileSizeField';
@@ -19,8 +20,51 @@ import { NAMESPACE } from './locale';
 import { DisplayPreviewFieldModel } from './models/DisplayPreviewFieldModel';
 import { UploadFieldModel } from './models/UploadFieldModel';
 import { UploadActionModel } from './models/UploadActionModel';
+import { FilePreviewRenderer, getDownloadFileName, getFileUrl, isPdfFile } from './previewer/filePreviewTypes';
 import { storageTypes } from './schemas/storageTypes';
 import { FileCollectionTemplate } from './templates';
+
+function AttachmentPdfPreviewer({ index, list, onSwitchIndex }) {
+  const file = list[index];
+  const onDownload = React.useCallback(
+    (targetFile?: any) => {
+      const target = targetFile || file;
+      const url = getFileUrl(target);
+      if (!url) {
+        return;
+      }
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = getDownloadFileName(target, url);
+      link.rel = 'noopener noreferrer';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    },
+    [file],
+  );
+
+  if (!file) {
+    return null;
+  }
+
+  return (
+    <FilePreviewRenderer
+      open={index != null}
+      file={file}
+      index={index}
+      list={list}
+      onOpenChange={(open) => {
+        if (!open) {
+          onSwitchIndex(null);
+        }
+      }}
+      onClose={() => onSwitchIndex(null)}
+      onSwitchIndex={onSwitchIndex}
+      onDownload={onDownload}
+    />
+  );
+}
 
 export class PluginFileManagerClient extends Plugin {
   // refer by plugin-field-attachment-url
@@ -40,6 +84,11 @@ export class PluginFileManagerClient extends Plugin {
     });
     Object.values(storageTypes).forEach((storageType) => {
       this.registerStorageType(storageType.name, storageType);
+    });
+
+    attachmentFileTypes.add({
+      match: isPdfFile,
+      Previewer: AttachmentPdfPreviewer,
     });
 
     const tableActionInitializers = this.app.schemaInitializerManager.get('table:configureActions');

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getDownloadFileName, getPreviewThumbnailUrl, isActiveContentFile } from '../filePreviewTypes';
+import { getDownloadFileName, getFileName, getPreviewThumbnailUrl, isActiveContentFile } from '../filePreviewTypes';
 
 describe('getDownloadFileName', () => {
   afterEach(() => {
@@ -46,8 +46,15 @@ describe('getDownloadFileName', () => {
     ).toBe('1700000000000_contract.pdf');
   });
 
+  it('应解码 URL 中的中文文件名', () => {
+    expect(getFileName({ url: 'https://example.com/files/%E6%B5%8B%E8%AF%95.pdf?token=1' })).toBe('测试.pdf');
+  });
+
   it('应识别主动内容文件类型', () => {
     expect(isActiveContentFile({ mimetype: 'image/svg+xml', url: 'https://example.com/files/logo.svg' })).toBe(true);
+    expect(isActiveContentFile({ mimetype: 'application/pdf', url: 'https://example.com/files/report.pdf' })).toBe(
+      true,
+    );
     expect(isActiveContentFile({ filename: 'index.html', url: 'https://example.com/files/index.html' })).toBe(true);
     expect(isActiveContentFile({ mimetype: 'image/png', url: 'https://example.com/files/avatar.png' })).toBe(false);
   });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/filePreviewTypes.tsx
@@ -22,6 +22,7 @@ import {
 import { Alert, Button, Image, Modal, Space, Spin } from 'antd';
 import { matchMimetype } from '@nocobase/client';
 import { useTranslation } from 'react-i18next';
+import type { PDFDocumentLoadingTask, PDFDocumentProxy, PDFWorker, RenderTask } from 'pdfjs-dist';
 
 export interface FilePreviewerProps {
   file: any;
@@ -346,92 +347,226 @@ let pdfjsPromise: Promise<PdfJs> | null = null;
 
 const loadPdfJs = async () => {
   if (!pdfjsPromise) {
-    pdfjsPromise = import('pdfjs-dist/build/pdf.mjs').then((pdfjs) => {
-      pdfjs.GlobalWorkerOptions.workerSrc ||= new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).href;
-      return pdfjs;
-    });
+    pdfjsPromise = import('pdfjs-dist/build/pdf.mjs');
   }
   return pdfjsPromise;
 };
 
-const PdfPreviewer = ({ file, onDownload }: FilePreviewerProps) => {
+const PDF_SCALE = 1.4;
+
+interface PdfMeta {
+  numPages: number;
+  // First page dimensions, used as the placeholder size for every page so the
+  // scrollbar reserves a roughly correct full height before pages are rendered.
+  width: number;
+  height: number;
+}
+
+interface PdfSession {
+  cancelled: boolean;
+  pdfjs?: PdfJs;
+  worker?: PDFWorker;
+  abortController: AbortController;
+  // The full file is fetched once into memory; metadata and page 1 use this
+  // document, and every other page gets its own document built from the bytes.
+  metaPdf?: PDFDocumentProxy;
+  data?: Uint8Array;
+  rendered: Set<number>;
+  inFlight: Set<number>;
+  loadingTasks: PDFDocumentLoadingTask[];
+  renderTasks: RenderTask[];
+  observer?: IntersectionObserver;
+}
+
+const PdfPreviewer = ({ file }: FilePreviewerProps) => {
   const { t } = useTranslation();
   const src = getFileUrl(file);
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const [loading, setLoading] = React.useState(true);
+  const pageElsRef = React.useRef<Map<number, HTMLDivElement>>(new Map());
+  const sessionRef = React.useRef<PdfSession | null>(null);
+  const [meta, setMeta] = React.useState<PdfMeta | null>(null);
   const [error, setError] = React.useState(false);
 
+  // Load metadata over a streaming document and paint the first page as soon as
+  // its bytes arrive. Rendering of the remaining pages happens lazily below.
   React.useEffect(() => {
-    if (!src || !containerRef.current) {
+    if (!src) {
       return;
     }
 
-    let cancelled = false;
-    const container = containerRef.current;
-    const canvases: HTMLCanvasElement[] = [];
-    let loadingTask: any;
-    let loadedPdf: any;
-    container.innerHTML = '';
-    setLoading(true);
+    const session: PdfSession = {
+      cancelled: false,
+      abortController: new AbortController(),
+      rendered: new Set(),
+      inFlight: new Set(),
+      loadingTasks: [],
+      renderTasks: [],
+    };
+    sessionRef.current = session;
+    setMeta(null);
     setError(false);
 
-    const render = async () => {
+    const init = async () => {
       const pdfjs = await loadPdfJs();
+      if (session.cancelled) {
+        return;
+      }
+      session.pdfjs = pdfjs;
+      // Fetch the whole file once into memory. pdf.js's own URL loader proved
+      // unreliable in this app (range/credentials handling), so we control the
+      // request here and feed the bytes to in-memory documents below.
       const url = new URL(src, location.href);
-      loadingTask = pdfjs.getDocument({
-        url: src,
-        withCredentials: url.origin === location.origin,
+      const response = await fetch(url, {
+        credentials: url.origin === location.origin ? 'include' : 'omit',
+        signal: session.abortController.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to load PDF: ${response.status}`);
+      }
+      const data = new Uint8Array(await response.arrayBuffer());
+      if (session.cancelled) {
+        return;
+      }
+      session.data = data;
+      session.worker = pdfjs.PDFWorker.create({
+        port: new Worker(new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url), { type: 'module' }),
+      });
+      // Security hardening: no eval-based font hinting, no XFA scripting
+      // (annotations are disabled per render call). getDocument detaches the
+      // buffer it receives, so hand it a copy and keep `data` for later pages.
+      const metaTask = pdfjs.getDocument({
+        data: data.slice(0),
         isEvalSupported: false,
         enableXfa: false,
+        useWasm: false,
+        worker: session.worker,
       });
-      const pdf = await loadingTask.promise;
-      loadedPdf = pdf;
+      session.loadingTasks.push(metaTask);
+      const metaPdf = await metaTask.promise;
+      if (session.cancelled) {
+        return;
+      }
+      session.metaPdf = metaPdf;
+      const viewport = (await metaPdf.getPage(1)).getViewport({ scale: PDF_SCALE });
+      if (session.cancelled) {
+        return;
+      }
+      setMeta({ numPages: metaPdf.numPages, width: viewport.width, height: viewport.height });
+    };
 
-      for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
-        if (cancelled) {
-          break;
+    init().catch(() => {
+      if (!session.cancelled) {
+        setError(true);
+      }
+    });
+
+    return () => {
+      session.cancelled = true;
+      session.abortController.abort();
+      session.observer?.disconnect();
+      session.renderTasks.forEach((task) => task.cancel?.());
+      session.loadingTasks.forEach((task) => task.destroy?.());
+      session.worker?.destroy?.();
+    };
+  }, [src]);
+
+  // Lazily render pages as their placeholders scroll into view.
+  React.useEffect(() => {
+    const session = sessionRef.current;
+    if (!meta || !session?.pdfjs || !session.metaPdf) {
+      return;
+    }
+    const { pdfjs, metaPdf } = session;
+
+    const renderPage = async (pageNumber: number) => {
+      if (session.cancelled || session.rendered.has(pageNumber) || session.inFlight.has(pageNumber)) {
+        return;
+      }
+      const wrapper = pageElsRef.current.get(pageNumber);
+      if (!wrapper) {
+        return;
+      }
+      session.inFlight.add(pageNumber);
+      // Page 1 reuses the already-loaded streaming document; rendering only that
+      // one page on it keeps the document from promoting any image to pdf.js's
+      // cross-page global cache (the path that breaks later pages). Every other
+      // page renders in its own short-lived document built from the full bytes,
+      // for the same isolation reason. getDocument detaches the buffer it is
+      // given, so each document receives its own copy.
+      let task: PDFDocumentLoadingTask | undefined;
+      try {
+        let pdf: PDFDocumentProxy;
+        if (pageNumber === 1 || !session.data) {
+          pdf = metaPdf;
+        } else {
+          task = pdfjs.getDocument({
+            data: session.data.slice(0),
+            isEvalSupported: false,
+            enableXfa: false,
+            useWasm: false,
+            worker: session.worker,
+          });
+          session.loadingTasks.push(task);
+          pdf = await task.promise;
+        }
+        if (session.cancelled) {
+          return;
         }
         const page = await pdf.getPage(pageNumber);
-        const viewport = page.getViewport({ scale: 1.4 });
-        const canvas = document.createElement('canvas');
-        const context = canvas.getContext('2d');
+        const viewport = page.getViewport({ scale: PDF_SCALE });
+        const context = document.createElement('canvas').getContext('2d');
         if (!context) {
-          continue;
+          return;
         }
+        const canvas = context.canvas;
         canvas.width = viewport.width;
         canvas.height = viewport.height;
         canvas.style.display = 'block';
-        canvas.style.maxWidth = '100%';
+        canvas.style.width = '100%';
         canvas.style.height = 'auto';
-        canvas.style.margin = pageNumber === 1 ? '0 auto 16px' : '16px auto';
-        canvases.push(canvas);
-        container.appendChild(canvas);
-        await page.render({ canvasContext: context, viewport }).promise.catch((error) => {
-          throw error;
+        // The real page governs the wrapper height now; drop the placeholder ratio.
+        wrapper.style.aspectRatio = '';
+        wrapper.replaceChildren(canvas);
+        const renderTask = page.render({
+          canvas,
+          canvasContext: context,
+          viewport,
+          annotationMode: pdfjs.AnnotationMode.DISABLE,
         });
+        session.renderTasks.push(renderTask);
+        await renderTask.promise;
+        if (session.cancelled) {
+          return;
+        }
+        session.rendered.add(pageNumber);
+        session.observer?.unobserve(wrapper);
+      } catch (renderError) {
+        // Leave the placeholder in place; scrolling back can retry the page.
+      } finally {
+        task?.destroy();
+        session.inFlight.delete(pageNumber);
       }
     };
 
-    const rendering = render()
-      .catch(() => {
-        if (!cancelled) {
-          setError(true);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            renderPage(Number((entry.target as HTMLElement).dataset.page));
+          }
         }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      });
-    void rendering;
+      },
+      { rootMargin: '300px 0px' },
+    );
+    session.observer = observer;
+    pageElsRef.current.forEach((el) => observer.observe(el));
 
     return () => {
-      cancelled = true;
-      loadingTask?.destroy?.();
-      loadedPdf?.destroy?.();
-      canvases.forEach((canvas) => canvas.remove());
+      observer.disconnect();
+      if (session.observer === observer) {
+        session.observer = undefined;
+      }
     };
-  }, [src]);
+  }, [meta]);
 
   if (!src) {
     return null;
@@ -439,11 +574,6 @@ const PdfPreviewer = ({ file, onDownload }: FilePreviewerProps) => {
 
   return (
     <div style={{ width: '100%', minHeight: '100%', padding: 16 }}>
-      {loading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: 48 }}>
-          <Spin />
-        </div>
-      ) : null}
       {error ? (
         <Alert
           type="warning"
@@ -451,7 +581,34 @@ const PdfPreviewer = ({ file, onDownload }: FilePreviewerProps) => {
           message={t('File type is not supported for previewing, please download it to preview.')}
         />
       ) : null}
-      <div ref={containerRef} />
+      {!meta && !error ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 48 }}>
+          <Spin />
+        </div>
+      ) : null}
+      {meta
+        ? Array.from({ length: meta.numPages }, (_, index) => index + 1).map((pageNumber) => (
+            <div
+              key={pageNumber}
+              data-page={pageNumber}
+              ref={(el) => {
+                if (el) {
+                  pageElsRef.current.set(pageNumber, el);
+                } else {
+                  pageElsRef.current.delete(pageNumber);
+                }
+              }}
+              style={{
+                width: '100%',
+                maxWidth: meta.width,
+                margin: '0 auto 16px',
+                aspectRatio: `${meta.width} / ${meta.height}`,
+                background: '#fff',
+                border: '1px solid #f0f0f0',
+              }}
+            />
+          ))
+        : null}
     </div>
   );
 };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/filePreviewTypes.tsx
@@ -19,10 +19,9 @@ import {
   ZoomInOutlined,
   ZoomOutOutlined,
 } from '@ant-design/icons';
-import { Alert, Image, Modal, Space } from 'antd';
+import { Alert, Button, Image, Modal, Space, Spin } from 'antd';
 import { matchMimetype } from '@nocobase/client';
-import { Trans, useTranslation } from 'react-i18next';
-import { NAMESPACE } from '../locale';
+import { useTranslation } from 'react-i18next';
 
 export interface FilePreviewerProps {
   file: any;
@@ -115,8 +114,8 @@ const FALLBACK_ICON_MAP: Record<string, string> = {
   default: '/file-placeholder/unknown-200-200.png',
 };
 
-const ACTIVE_CONTENT_MIMETYPES = new Set(['application/xhtml+xml', 'image/svg+xml', 'text/html']);
-const ACTIVE_CONTENT_EXTENSIONS = new Set(['htm', 'html', 'svg', 'svgz', 'xhtml']);
+const ACTIVE_CONTENT_MIMETYPES = new Set(['application/pdf', 'application/xhtml+xml', 'image/svg+xml', 'text/html']);
+const ACTIVE_CONTENT_EXTENSIONS = new Set(['htm', 'html', 'pdf', 'svg', 'svgz', 'xhtml']);
 
 const stripQueryAndHash = (url: string) => url.split('?')[0].split('#')[0];
 
@@ -135,7 +134,12 @@ const getNameFromUrl = (url?: string) => {
   }
   const clean = stripQueryAndHash(url);
   const index = clean.lastIndexOf('/');
-  return index !== -1 ? clean.slice(index + 1) : clean;
+  const name = index !== -1 ? clean.slice(index + 1) : clean;
+  try {
+    return decodeURIComponent(name);
+  } catch (error) {
+    return name;
+  }
 };
 
 export const getFileExt = (file: any, url?: string) => {
@@ -161,8 +165,16 @@ export const isActiveContentFile = (file: any, url?: string) => {
   return ACTIVE_CONTENT_EXTENSIONS.has(ext);
 };
 
+export const isPdfFile = (file: any, url?: string) => {
+  const mimetype = file?.mimetype || file?.type;
+  if (typeof mimetype === 'string' && mimetype.toLowerCase() === 'application/pdf') {
+    return true;
+  }
+  return getFileExt(file, url) === 'pdf';
+};
+
 export const getFileName = (file: any, url?: string) => {
-  const nameFromUrl = getNameFromUrl(url);
+  const nameFromUrl = getNameFromUrl(url || getFileUrl(file));
   if (!file || typeof file === 'string') {
     return nameFromUrl;
   }
@@ -328,6 +340,122 @@ const IframePreviewer = ({ file }: FilePreviewerProps) => {
   return <iframe src={src} width="100%" height="100%" style={{ border: 'none' }} />;
 };
 
+type PdfJs = typeof import('pdfjs-dist/build/pdf.mjs');
+
+let pdfjsPromise: Promise<PdfJs> | null = null;
+
+const loadPdfJs = async () => {
+  if (!pdfjsPromise) {
+    pdfjsPromise = import('pdfjs-dist/build/pdf.mjs').then((pdfjs) => {
+      pdfjs.GlobalWorkerOptions.workerSrc ||= new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).href;
+      return pdfjs;
+    });
+  }
+  return pdfjsPromise;
+};
+
+const PdfPreviewer = ({ file, onDownload }: FilePreviewerProps) => {
+  const { t } = useTranslation();
+  const src = getFileUrl(file);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!src || !containerRef.current) {
+      return;
+    }
+
+    let cancelled = false;
+    const container = containerRef.current;
+    const canvases: HTMLCanvasElement[] = [];
+    let loadingTask: any;
+    let loadedPdf: any;
+    container.innerHTML = '';
+    setLoading(true);
+    setError(false);
+
+    const render = async () => {
+      const pdfjs = await loadPdfJs();
+      const url = new URL(src, location.href);
+      loadingTask = pdfjs.getDocument({
+        url: src,
+        withCredentials: url.origin === location.origin,
+        isEvalSupported: false,
+        enableXfa: false,
+      });
+      const pdf = await loadingTask.promise;
+      loadedPdf = pdf;
+
+      for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+        if (cancelled) {
+          break;
+        }
+        const page = await pdf.getPage(pageNumber);
+        const viewport = page.getViewport({ scale: 1.4 });
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+        if (!context) {
+          continue;
+        }
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        canvas.style.display = 'block';
+        canvas.style.maxWidth = '100%';
+        canvas.style.height = 'auto';
+        canvas.style.margin = pageNumber === 1 ? '0 auto 16px' : '16px auto';
+        canvases.push(canvas);
+        container.appendChild(canvas);
+        await page.render({ canvasContext: context, viewport }).promise.catch((error) => {
+          throw error;
+        });
+      }
+    };
+
+    const rendering = render()
+      .catch(() => {
+        if (!cancelled) {
+          setError(true);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    void rendering;
+
+    return () => {
+      cancelled = true;
+      loadingTask?.destroy?.();
+      loadedPdf?.destroy?.();
+      canvases.forEach((canvas) => canvas.remove());
+    };
+  }, [src]);
+
+  if (!src) {
+    return null;
+  }
+
+  return (
+    <div style={{ width: '100%', minHeight: '100%', padding: 16 }}>
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 48 }}>
+          <Spin />
+        </div>
+      ) : null}
+      {error ? (
+        <Alert
+          type="warning"
+          showIcon
+          message={t('File type is not supported for previewing, please download it to preview.')}
+        />
+      ) : null}
+      <div ref={containerRef} />
+    </div>
+  );
+};
+
 const AudioPreviewer = ({ file }: FilePreviewerProps) => {
   const { t } = useTranslation();
   const src = getFileUrl(file);
@@ -358,22 +486,10 @@ const VideoPreviewer = ({ file }: FilePreviewerProps) => {
 
 const UnsupportedPreviewer = (props: FilePreviewerProps) => {
   const { t } = useTranslation();
-  const { file } = props;
   return (
     <Alert
       type="warning"
-      description={
-        <Trans ns={NAMESPACE}>
-          {'File type is not supported for previewing, please '}
-          {props.onDownload ? (
-            <a onClick={() => props.onDownload?.(file)} style={{ textDecoration: 'underline', cursor: 'pointer' }}>
-              {'download it to preview'}
-            </a>
-          ) : (
-            <span>{'download it to preview'}</span>
-          )}
-        </Trans>
-      }
+      description={t('File type is not supported for previewing, please download it to preview.')}
       showIcon
     />
   );
@@ -398,7 +514,7 @@ filePreviewTypes.add({
 
 filePreviewTypes.add({
   match(file) {
-    return ['text/plain', 'application/pdf', 'application/json'].some((type) => matchMimetype(file, type));
+    return ['text/plain', 'application/json'].some((type) => matchMimetype(file, type));
   },
   Previewer: wrapWithModalPreviewer(IframePreviewer),
 });
@@ -422,6 +538,13 @@ filePreviewTypes.add({
     return isActiveContentFile(file, getFileUrl(file));
   },
   Previewer: wrapWithModalPreviewer(UnsupportedPreviewer),
+});
+
+filePreviewTypes.add({
+  match(file) {
+    return isPdfFile(file, getFileUrl(file));
+  },
+  Previewer: wrapWithModalPreviewer(PdfPreviewer),
 });
 
 export const FilePreviewRenderer = (props: FilePreviewerProps) => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
PDF files can contain embedded JavaScript. The previous online preview path rendered uploaded PDF files directly in browser iframes, allowing the browser PDF viewer to process the original file inline.

### Description
This PR changes PDF preview handling to avoid iframe-based rendering of raw uploaded PDFs:

- Adds a PDF.js canvas-based previewer for file-manager previews.
- Registers the same safe PDF previewer for the shared upload attachment preview path.
- Removes `application/pdf` from the generic iframe preview allowlist.
- Forces uploaded `.pdf` files served by the built-in static file server to use `Content-Disposition: attachment` as a defense-in-depth fallback.
- Decodes URL-derived filenames so preview modal titles display Chinese filenames correctly.
- Keeps unsupported-file preview alerts text-only because the outer modal already provides the download action.

Potential risks:

- PDF preview now depends on fetching the PDF with PDF.js. Cross-origin object storage must allow the browser to fetch the file for preview; otherwise the UI falls back to the unsupported preview warning and the user can still download from the modal footer.
- PDF.js is dynamically imported, so it should not affect the initial client bundle. The first PDF preview loads the async PDF.js chunks.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts`
- `yarn test packages/core/client/src/schema-component/antd/upload/__tests__/upload.test.tsx`
- `yarn test packages/core/server/src/__tests__/gateway/static-file-security.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Safely render PDF previews with PDF.js instead of iframe-based raw PDF rendering. |
| 🇨🇳 Chinese | 使用 PDF.js 安全渲染 PDF 预览，避免通过 iframe 直接加载原始 PDF。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
