### PR TITLE
feat(plugin-workflow): add execution rerun action

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -19,7 +19,14 @@ import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import type PluginWorkflowServer from './Plugin';
 import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
-type Pending = { execution: ExecutionModel; job?: JobModel; loaded?: boolean; rerun?: ProcessorRerunOptions };
+type Pending = {
+  execution: ExecutionModel;
+  job?: JobModel;
+  loaded?: boolean;
+  rerun?: ProcessorRerunOptions;
+};
+
+type RunOptions = { dispatch?: boolean };
 
 type CachedEvent = [WorkflowModel, any, EventOptions];
 
@@ -138,7 +145,7 @@ export default class Dispatcher {
           try {
             const execution = await this.createExecution(...event);
             // NOTE: cache first execution for most cases
-            if (!execution?.dispatched) {
+            if (!execution.dispatched) {
               if (this.plugin.serving() && !this.executing && !this.pending.length) {
                 logger.info(`local pending list is empty, adding execution (${execution.id}) to pending list`);
                 this.pending.push({ execution });
@@ -170,7 +177,7 @@ export default class Dispatcher {
     })();
   }
 
-  public async resume(job) {
+  public async resume(job: JobModel) {
     let { execution } = job;
     if (!execution) {
       execution = await job.getExecution();
@@ -232,8 +239,9 @@ export default class Dispatcher {
     this.executing = (async () => {
       let next: [ExecutionModel, JobModel?, ProcessorRerunOptions?] | null = null;
       let execution: ExecutionModel | null = null;
+      let pending: Pending | null = null;
       if (this.pending.length) {
-        const pending = this.pending.shift() as Pending;
+        pending = this.pending.shift() as Pending;
         execution = pending.loaded ? pending.execution : await this.acquirePendingExecution(pending.execution);
         if (execution) {
           next = [execution, pending.job, pending.rerun];
@@ -258,6 +266,9 @@ export default class Dispatcher {
           await this.process(next[0], next[1], { rerun: next[2] });
         } catch (error) {
           this.plugin.getLogger(next[0].workflowId).error(`execution (${next[0].id}) process failed`, { error });
+          if (pending && this.isLockAcquireError(error)) {
+            this.pending.unshift({ ...pending, execution: next[0], loaded: true });
+          }
         }
       }
       setImmediate(() => {
@@ -271,7 +282,7 @@ export default class Dispatcher {
     })();
   }
 
-  public async run(pending: Pending, options: { dispatch?: boolean } = {}): Promise<void> {
+  public async run(pending: Pending, options: RunOptions = {}): Promise<void> {
     this.pending.push(pending);
 
     if (options.dispatch !== false) {
@@ -307,7 +318,7 @@ export default class Dispatcher {
       return false;
     }
 
-    const { stack } = options;
+    const { stack = [] } = options;
     let valid = true;
     if (stack?.length > 0) {
       const existed = await workflow.countExecutions({
@@ -333,9 +344,9 @@ export default class Dispatcher {
 
   private async createExecution(
     workflow: WorkflowModel,
-    context,
+    context: object,
     options: EventOptions,
-  ): Promise<ExecutionModel | null> {
+  ): Promise<ExecutionModel> {
     const { deferred } = options;
     const transaction = await this.plugin.useDataSourceTransaction('main', options.transaction, true);
     const sameTransaction = options.transaction === transaction;
@@ -345,7 +356,7 @@ export default class Dispatcher {
         await transaction.commit();
       }
       options.onTriggerFail?.(workflow, context, options);
-      return Promise.reject(new Error('event is not valid'));
+      throw new Error('event is not valid');
     }
 
     let execution: ExecutionModel;
@@ -400,7 +411,7 @@ export default class Dispatcher {
     const logger = this.plugin.getLogger(execution.workflowId);
     const isolationLevel =
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
-    let fetched = execution;
+    let fetched: ExecutionModel | null = execution;
     try {
       await this.plugin.db.sequelize.transaction({ isolationLevel }, async (transaction) => {
         const ExecutionModelClass = this.plugin.db.getModel('executions');
@@ -470,38 +481,44 @@ export default class Dispatcher {
     return `workflow:execution:${executionId}`;
   }
 
+  private isLockAcquireError(error: unknown) {
+    return error instanceof Error && error.constructor.name === 'LockAcquireError';
+  }
+
   private async process(
     execution: ExecutionModel,
-    job?: JobModel,
+    job: JobModel | null = null,
     options: Transactionable & { rerun?: ProcessorRerunOptions } = {},
   ): Promise<Processor> {
     const { rerun, ...processorOptions } = options;
     const logger = this.plugin.getLogger(execution.workflowId);
-    const lock = await this.plugin.app.lockManager.tryAcquire(this.getExecutionLockKey(execution.id));
+    const run = async () => {
+      if (!execution.dispatched) {
+        const transaction = await this.plugin.useDataSourceTransaction('main', processorOptions.transaction);
+        await execution.update({ dispatched: true, status: EXECUTION_STATUS.STARTED }, { transaction });
+        logger.info(`execution (${execution.id}) from pending list updated to started`);
+      }
+      const processor = this.plugin.createProcessor(execution, processorOptions);
+
+      logger.info(`execution (${execution.id}) ${rerun ? 'rerunning' : job ? 'resuming' : 'starting'}...`);
+
+      try {
+        await (rerun ? processor.rerun(rerun) : job ? processor.resume(job) : processor.start());
+        logger.info(`execution (${execution.id}) finished with status: ${execution.status}`);
+        logger.debug(`execution (${execution.id}) details:`, { execution });
+        if (execution.status && execution.workflow?.options?.deleteExecutionOnStatus?.includes(execution.status)) {
+          await execution.destroy({ transaction: processor.mainTransaction });
+        }
+      } catch (err) {
+        logger.error(`execution (${execution.id}) error: ${err.message}`, err);
+      }
+
+      return processor;
+    };
+
+    const lock = await this.plugin.app.lockManager.tryAcquire(this.getExecutionLockKey(execution.id), 60_000);
     try {
-      return await lock.runExclusive(async () => {
-        if (!execution.dispatched) {
-          const transaction = await this.plugin.useDataSourceTransaction('main', processorOptions.transaction);
-          await execution.update({ dispatched: true, status: EXECUTION_STATUS.STARTED }, { transaction });
-          logger.info(`execution (${execution.id}) from pending list updated to started`);
-        }
-        const processor = this.plugin.createProcessor(execution, processorOptions);
-
-        logger.info(`execution (${execution.id}) ${rerun ? 'rerunning' : job ? 'resuming' : 'starting'}...`);
-
-        try {
-          await (rerun ? processor.rerun(rerun) : job ? processor.resume(job) : processor.start());
-          logger.info(`execution (${execution.id}) finished with status: ${execution.status}`);
-          logger.debug(`execution (${execution.id}) details:`, { execution });
-          if (execution.status && execution.workflow.options?.deleteExecutionOnStatus?.includes(execution.status)) {
-            await execution.destroy({ transaction: processor.mainTransaction });
-          }
-        } catch (err) {
-          logger.error(`execution (${execution.id}) error: ${err.message}`, err);
-        }
-
-        return processor;
-      }, 60_000);
+      return await lock.runExclusive(run, 60_000);
     } catch (error) {
       logger.error(`execution (${execution.id}) could not acquire process lock`, { error });
       throw error;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -13,13 +13,13 @@ import { Transaction, Transactionable } from 'sequelize';
 
 import type { QueueEventOptions } from '@nocobase/server';
 
-import Processor from './Processor';
+import Processor, { ProcessorRerunOptions } from './Processor';
 import { EXECUTION_STATUS } from './constants';
 import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import type PluginWorkflowServer from './Plugin';
 import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
-type Pending = { execution: ExecutionModel; job?: JobModel; loaded?: boolean };
+type Pending = { execution: ExecutionModel; job?: JobModel; loaded?: boolean; rerun?: ProcessorRerunOptions };
 
 type CachedEvent = [WorkflowModel, any, EventOptions];
 
@@ -230,13 +230,13 @@ export default class Dispatcher {
     }
 
     this.executing = (async () => {
-      let next: [ExecutionModel, JobModel?] | null = null;
+      let next: [ExecutionModel, JobModel?, ProcessorRerunOptions?] | null = null;
       let execution: ExecutionModel | null = null;
       if (this.pending.length) {
         const pending = this.pending.shift() as Pending;
         execution = pending.loaded ? pending.execution : await this.acquirePendingExecution(pending.execution);
         if (execution) {
-          next = [execution, pending.job];
+          next = [execution, pending.job, pending.rerun];
           this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
         }
       } else {
@@ -254,7 +254,11 @@ export default class Dispatcher {
         }
       }
       if (next) {
-        await this.process(...next);
+        try {
+          await this.process(next[0], next[1], { rerun: next[2] });
+        } catch (error) {
+          this.plugin.getLogger(next[0].workflowId).error(`execution (${next[0].id}) process failed`, { error });
+        }
       }
       setImmediate(() => {
         this.executing = null;
@@ -267,10 +271,12 @@ export default class Dispatcher {
     })();
   }
 
-  public async run(pending: Pending): Promise<void> {
+  public async run(pending: Pending, options: { dispatch?: boolean } = {}): Promise<void> {
     this.pending.push(pending);
 
-    this.dispatch();
+    if (options.dispatch !== false) {
+      this.dispatch();
+    }
   }
 
   private async triggerSync(
@@ -460,28 +466,45 @@ export default class Dispatcher {
     return fetched;
   }
 
-  private async process(execution: ExecutionModel, job?: JobModel, options: Transactionable = {}): Promise<Processor> {
+  private getExecutionLockKey(executionId: number | string) {
+    return `workflow:execution:${executionId}`;
+  }
+
+  private async process(
+    execution: ExecutionModel,
+    job?: JobModel,
+    options: Transactionable & { rerun?: ProcessorRerunOptions } = {},
+  ): Promise<Processor> {
+    const { rerun, ...processorOptions } = options;
     const logger = this.plugin.getLogger(execution.workflowId);
-    if (!execution.dispatched) {
-      const transaction = await this.plugin.useDataSourceTransaction('main', options.transaction);
-      await execution.update({ dispatched: true, status: EXECUTION_STATUS.STARTED }, { transaction });
-      logger.info(`execution (${execution.id}) from pending list updated to started`);
-    }
-    const processor = this.plugin.createProcessor(execution, options);
-
-    logger.info(`execution (${execution.id}) ${job ? 'resuming' : 'starting'}...`);
-
+    const lock = await this.plugin.app.lockManager.tryAcquire(this.getExecutionLockKey(execution.id));
     try {
-      await (job ? processor.resume(job) : processor.start());
-      logger.info(`execution (${execution.id}) finished with status: ${execution.status}`);
-      logger.debug(`execution (${execution.id}) details:`, { execution });
-      if (execution.status && execution.workflow.options?.deleteExecutionOnStatus?.includes(execution.status)) {
-        await execution.destroy({ transaction: processor.mainTransaction });
-      }
-    } catch (err) {
-      logger.error(`execution (${execution.id}) error: ${err.message}`, err);
-    }
+      return await lock.runExclusive(async () => {
+        if (!execution.dispatched) {
+          const transaction = await this.plugin.useDataSourceTransaction('main', processorOptions.transaction);
+          await execution.update({ dispatched: true, status: EXECUTION_STATUS.STARTED }, { transaction });
+          logger.info(`execution (${execution.id}) from pending list updated to started`);
+        }
+        const processor = this.plugin.createProcessor(execution, processorOptions);
 
-    return processor;
+        logger.info(`execution (${execution.id}) ${rerun ? 'rerunning' : job ? 'resuming' : 'starting'}...`);
+
+        try {
+          await (rerun ? processor.rerun(rerun) : job ? processor.resume(job) : processor.start());
+          logger.info(`execution (${execution.id}) finished with status: ${execution.status}`);
+          logger.debug(`execution (${execution.id}) details:`, { execution });
+          if (execution.status && execution.workflow.options?.deleteExecutionOnStatus?.includes(execution.status)) {
+            await execution.destroy({ transaction: processor.mainTransaction });
+          }
+        } catch (err) {
+          logger.error(`execution (${execution.id}) error: ${err.message}`, err);
+        }
+
+        return processor;
+      }, 60_000);
+    } catch (error) {
+      logger.error(`execution (${execution.id}) could not acquire process lock`, { error });
+      throw error;
+    }
   }
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -459,8 +459,15 @@ export default class PluginWorkflowServer extends Plugin {
     return this.dispatcher.trigger(workflow, context, options);
   }
 
-  public async run(pending: Parameters<Dispatcher['run']>[0]): Promise<void> {
-    return this.dispatcher.run(pending);
+  public async run(
+    pending: Parameters<Dispatcher['run']>[0],
+    options?: Parameters<Dispatcher['run']>[1],
+  ): Promise<void> {
+    return this.dispatcher.run(pending, options);
+  }
+
+  public dispatch() {
+    return this.dispatcher.dispatch();
   }
 
   public async resume(job) {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -18,6 +18,20 @@ import { EXECUTION_STATUS, JOB_STATUS } from './constants';
 import { Runner } from './instructions';
 import type { ExecutionModel, FlowNodeModel, JobModel } from './types';
 
+export type ProcessorRunOptions = {
+  rerun?: true;
+};
+
+export type ProcessorRerunOptions = {
+  nodeId?: string | number;
+  overwrite?: boolean;
+};
+
+type RerunContext = {
+  overwrite: boolean;
+  targetJob?: JobModel;
+};
+
 export interface ProcessorOptions extends Transactionable {
   plugin: Plugin;
   [key: string]: any;
@@ -60,6 +74,7 @@ export default class Processor {
   private jobsMapByNodeKey: { [key: string]: JobModel } = {};
   private jobResultsMapByNodeKey: { [key: string]: any } = {};
   private jobsToSave: Map<string, JobModel> = new Map();
+  private rerunContext: RerunContext | null = null;
 
   /**
    * @experimental
@@ -118,6 +133,9 @@ export default class Processor {
     if (!execution.workflow) {
       execution.workflow =
         plugin.enabledCache.get(execution.workflowId) || (await execution.getWorkflow({ transaction }));
+    }
+    if (!execution.workflow) {
+      throw new Error(`workflow (#${execution.workflowId}) not found for execution (#${execution.id})`);
     }
 
     const nodes = execution.workflow.nodes || (await execution.workflow.getNodes({ transaction }));
@@ -178,12 +196,77 @@ export default class Processor {
     await this.recall(node, job);
   }
 
-  private async exec(instruction: Runner, node: FlowNodeModel, prevJob) {
+  public resolveRerun(options: ProcessorRerunOptions = {}) {
+    const node = this.getRerunNode(options.nodeId);
+    const targetJob = this.jobsMapByNodeKey[node.key];
+
+    if (options.nodeId != null && !targetJob) {
+      throw new Error(`job of node (#${node.id}) not found in execution (#${this.execution.id})`);
+    }
+
+    if (options.nodeId == null && options.overwrite && !targetJob) {
+      throw new Error(`job of head node (#${node.id}) not found in execution (#${this.execution.id})`);
+    }
+
+    const input = this.getRerunInput(node);
+    return { node, input, targetJob };
+  }
+
+  public async rerun(options: ProcessorRerunOptions = {}) {
+    const { execution } = this;
+    if (execution.status !== EXECUTION_STATUS.STARTED) {
+      throw new Error(`execution (#${execution.id}) is not started`);
+    }
+
+    await this.prepare();
+    const { node, input, targetJob } = this.resolveRerun(options);
+    this.rerunContext = {
+      overwrite: options.overwrite === true,
+      targetJob,
+    };
+
+    try {
+      return await this.run(node, input, { rerun: true });
+    } finally {
+      this.rerunContext = null;
+    }
+  }
+
+  private getRerunNode(nodeId?: string | number) {
+    if (nodeId != null) {
+      const node = this.nodesMap.get(nodeId) || this.nodes.find((item) => String(item.id) === String(nodeId));
+      if (!node) {
+        throw new Error(`node (#${nodeId}) not found in workflow (#${this.execution.workflowId})`);
+      }
+      return node;
+    }
+
+    const head = this.nodes.find((item) => !item.upstream);
+    if (!head) {
+      throw new Error(`head node not found in workflow (#${this.execution.workflowId})`);
+    }
+    return head;
+  }
+
+  private getRerunInput(node: FlowNodeModel) {
+    if (!node.upstream) {
+      return { result: this.execution.context };
+    }
+
+    const upstreamJob = this.jobsMapByNodeKey[node.upstream.key];
+    if (!upstreamJob) {
+      throw new Error(`upstream job of node (#${node.id}) not found in execution (#${this.execution.id})`);
+    }
+
+    return upstreamJob;
+  }
+
+  private async exec(instruction: Runner, node: FlowNodeModel, prevJob, options?: ProcessorRunOptions) {
     let job;
     try {
       // call instruction to get result and status
       this.logger.debug(`config of node`, { data: node.config, workflowId: node.workflowId });
-      job = await instruction(node, prevJob, this);
+      job = await instruction(node, prevJob, this, options);
       if (job === null) {
         return this.exit();
       }
@@ -238,7 +321,7 @@ export default class Processor {
     return this.end(node, savedJob);
   }
 
-  public async run(node, input?) {
+  public async run(node, input?, options?: ProcessorRunOptions) {
     const { instructions } = this.options.plugin;
     const instruction = instructions.get(node.type);
     if (!instruction) {
@@ -251,7 +334,7 @@ export default class Processor {
     this.logger.info(`execution (${this.execution.id}) run instruction [${node.type}] for node (${node.id})`, {
       workflowId: node.workflowId,
     });
-    return this.exec(instruction.run.bind(instruction), node, input);
+    return this.exec(instruction.run.bind(instruction), node, input, options);
   }
 
   // parent node should take over the control
@@ -363,6 +446,18 @@ export default class Processor {
     if (payload instanceof model) {
       job = payload;
       job.set('updatedAt', new Date());
+    } else if (
+      this.rerunContext?.overwrite &&
+      this.rerunContext.targetJob &&
+      this.rerunContext.targetJob.nodeId === payload.nodeId
+    ) {
+      job = this.rerunContext.targetJob;
+      job.set({
+        status: payload.status,
+        result: Object.prototype.hasOwnProperty.call(payload, 'result') ? payload.result : null,
+        meta: Object.prototype.hasOwnProperty.call(payload, 'meta') ? payload.meta : null,
+        updatedAt: new Date(),
+      });
     } else {
       job = model.build(
         {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/executions.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/executions.test.ts
@@ -168,4 +168,164 @@ describe('workflow > actions > executions', () => {
       expect(jobs[0].status).toBe(JOB_STATUS.ABORTED);
     });
   });
+
+  describe('rerun', () => {
+    async function prepareStartedExecution() {
+      const n1 = await workflow.createNode({
+        type: 'echo',
+      });
+      const n2 = await workflow.createNode({
+        type: 'pending',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(execution.status).toBe(EXECUTION_STATUS.STARTED);
+      expect(jobs.length).toBe(2);
+      return { execution, n1, n2 };
+    }
+
+    it('only root could rerun executions', async () => {
+      const { execution } = await prepareStartedExecution();
+
+      const res1 = await userAgents[0].resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(res1.status).toBe(403);
+
+      const res2 = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(res2.status).toBe(202);
+    });
+
+    it('execution not exists could not be rerun', async () => {
+      const { status } = await agent.resource('executions').rerun({
+        filterByTk: -1,
+      });
+
+      expect(status).toBe(404);
+    });
+
+    it('only started execution could be rerun', async () => {
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
+
+      const res1 = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(res1.status).toBe(409);
+
+      const queued = await workflow.createExecution({
+        status: EXECUTION_STATUS.QUEUEING,
+        context: {},
+        key: workflow.key,
+      });
+      const res2 = await agent.resource('executions').rerun({
+        filterByTk: queued.id,
+      });
+      expect(res2.status).toBe(409);
+    });
+
+    it('rerun without overwrite creates new jobs from head node', async () => {
+      const { execution, n1, n2 } = await prepareStartedExecution();
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(res.status).toBe(202);
+      await sleep(500);
+
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.filter((job) => job.nodeId === n1.id).length).toBe(2);
+      expect(jobs.filter((job) => job.nodeId === n2.id).length).toBe(2);
+    });
+
+    it('rerun with nodeId starts from the specified node', async () => {
+      const { execution, n1, n2 } = await prepareStartedExecution();
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          nodeId: n2.id,
+        },
+      });
+      expect(res.status).toBe(202);
+      await sleep(500);
+
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      expect(jobs.filter((job) => job.nodeId === n1.id).length).toBe(1);
+      expect(jobs.filter((job) => job.nodeId === n2.id).length).toBe(2);
+    });
+
+    it('rerun with overwrite updates target latest job', async () => {
+      const { execution, n1, n2 } = await prepareStartedExecution();
+      const [firstJob] = await execution.getJobs({ where: { nodeId: n1.id } });
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          nodeId: n1.id,
+          overwrite: true,
+        },
+      });
+      expect(res.status).toBe(202);
+      await sleep(500);
+
+      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      const headJobs = jobs.filter((job) => job.nodeId === n1.id);
+      expect(headJobs.length).toBe(1);
+      expect(headJobs[0].id).toBe(firstJob.id);
+      expect(jobs.filter((job) => job.nodeId === n2.id).length).toBe(2);
+    });
+
+    it('rerun fails when node does not exist', async () => {
+      const { execution } = await prepareStartedExecution();
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          nodeId: -1,
+        },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rerun fails when workflow revision does not exist', async () => {
+      const { execution } = await prepareStartedExecution();
+      await workflow.destroy();
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rerun fails when target node has no latest job', async () => {
+      const n1 = await workflow.createNode({
+        type: 'echo',
+      });
+      const execution = await workflow.createExecution({
+        status: EXECUTION_STATUS.STARTED,
+        context: {},
+        key: workflow.key,
+      });
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          nodeId: n1.id,
+        },
+      });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/executions.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/executions.test.ts
@@ -11,6 +11,7 @@ import { MockServer } from '@nocobase/test';
 import Database from '@nocobase/database';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { EXECUTION_STATUS, JOB_STATUS } from '../../constants';
+import PluginWorkflowServer from '../../Plugin';
 
 describe('workflow > actions > executions', () => {
   let app: MockServer;
@@ -190,6 +191,42 @@ describe('workflow > actions > executions', () => {
       return { execution, n1, n2 };
     }
 
+    async function prepareLongRunningStartedExecution() {
+      const n1 = await workflow.createNode({
+        type: 'timeConsume',
+        config: {
+          duration: 1000,
+        },
+      });
+      const n2 = await workflow.createNode({
+        type: 'pending',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(1200);
+
+      const [execution] = await workflow.getExecutions();
+      const [pendingJob] = await execution.getJobs({ where: { nodeId: n2.id } });
+      expect(execution.status).toBe(EXECUTION_STATUS.STARTED);
+      expect(pendingJob.status).toBe(JOB_STATUS.PENDING);
+      return { execution, pendingJob };
+    }
+
+    async function createJob(execution, node, values = {}) {
+      const workflowPlugin = app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
+      const JobModel = db.getModel('jobs');
+      return JobModel.create({
+        id: workflowPlugin.snowflake.getUniqueID().toString(),
+        executionId: execution.id,
+        nodeId: node.id,
+        nodeKey: node.key,
+        status: JOB_STATUS.RESOLVED,
+        ...values,
+      });
+    }
+
     it('only root could rerun executions', async () => {
       const { execution } = await prepareStartedExecution();
 
@@ -269,6 +306,15 @@ describe('workflow > actions > executions', () => {
     it('rerun with overwrite updates target latest job', async () => {
       const { execution, n1, n2 } = await prepareStartedExecution();
       const [firstJob] = await execution.getJobs({ where: { nodeId: n1.id } });
+      await firstJob.update({
+        status: JOB_STATUS.ERROR,
+        result: {
+          old: true,
+        },
+        meta: {
+          old: true,
+        },
+      });
 
       const res = await agent.resource('executions').rerun({
         filterByTk: execution.id,
@@ -284,7 +330,48 @@ describe('workflow > actions > executions', () => {
       const headJobs = jobs.filter((job) => job.nodeId === n1.id);
       expect(headJobs.length).toBe(1);
       expect(headJobs[0].id).toBe(firstJob.id);
+      expect(headJobs[0].status).toBe(JOB_STATUS.RESOLVED);
+      expect(headJobs[0].result).toEqual(expect.objectContaining({ data: expect.objectContaining({ title: 't1' }) }));
+      expect(headJobs[0].meta).toBeNull();
       expect(jobs.filter((job) => job.nodeId === n2.id).length).toBe(2);
+    });
+
+    it('rerun uses the latest upstream job as input', async () => {
+      const n1 = await workflow.createNode({
+        type: 'echo',
+      });
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+      const n3 = await workflow.createNode({
+        type: 'pending',
+        upstreamId: n2.id,
+      });
+      await n1.setDownstream(n2);
+      await n2.setDownstream(n3);
+
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      await createJob(execution, n1, {
+        result: {
+          source: 'latest',
+        },
+      });
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          nodeId: n2.id,
+        },
+      });
+      expect(res.status).toBe(202);
+      await sleep(500);
+
+      const jobs = await execution.getJobs({ where: { nodeId: n2.id }, order: [['id', 'ASC']] });
+      expect(jobs[jobs.length - 1].result).toEqual({ source: 'latest' });
     });
 
     it('rerun fails when node does not exist', async () => {
@@ -326,6 +413,101 @@ describe('workflow > actions > executions', () => {
         },
       });
       expect(res.status).toBe(400);
+    });
+
+    it('rerun fails when target node has no latest upstream job', async () => {
+      const n1 = await workflow.createNode({
+        type: 'echo',
+      });
+      const n2 = await workflow.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+      const execution = await workflow.createExecution({
+        status: EXECUTION_STATUS.STARTED,
+        context: {},
+        key: workflow.key,
+      });
+      await createJob(execution, n2);
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          nodeId: n2.id,
+        },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rerun fails when overwrite from head has no latest job', async () => {
+      await workflow.createNode({
+        type: 'echo',
+      });
+      const execution = await workflow.createExecution({
+        status: EXECUTION_STATUS.STARTED,
+        context: {},
+        key: workflow.key,
+      });
+
+      const res = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+        values: {
+          overwrite: true,
+        },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('processing rerun blocks cancel', async () => {
+      const { execution } = await prepareLongRunningStartedExecution();
+
+      const rerunRes = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(rerunRes.status).toBe(202);
+      await sleep(100);
+
+      const cancelRes = await agent.resource('executions').cancel({
+        filterByTk: execution.id,
+      });
+      expect(cancelRes.status).toBe(409);
+      await sleep(1200);
+    });
+
+    it('processing rerun blocks resume', async () => {
+      const { execution, pendingJob } = await prepareLongRunningStartedExecution();
+
+      const rerunRes = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(rerunRes.status).toBe(202);
+      await sleep(100);
+
+      const resumeRes = await agent.resource('jobs').resume({
+        filterByTk: pendingJob.id,
+        values: {
+          status: JOB_STATUS.RESOLVED,
+        },
+      });
+      expect(resumeRes.status).toBe(409);
+      await sleep(1200);
+    });
+
+    it('processing rerun blocks duplicate rerun', async () => {
+      const { execution } = await prepareLongRunningStartedExecution();
+
+      const rerunRes = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(rerunRes.status).toBe(202);
+      await sleep(100);
+
+      const duplicateRes = await agent.resource('executions').rerun({
+        filterByTk: execution.id,
+      });
+      expect(duplicateRes.status).toBe(409);
+      await sleep(1200);
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
@@ -106,18 +106,19 @@ export async function rerun(context: Context, next) {
         nodeId,
         overwrite: overwrite === true,
       });
-      await workflowPlugin.run(
-        {
-          execution,
-          loaded: true,
-          rerun: {
-            nodeId,
-            overwrite: overwrite === true,
-          },
-        },
-        { dispatch: false },
-      );
     }, 60_000);
+    await workflowPlugin.run(
+      {
+        execution,
+        loaded: true,
+        rerun: {
+          nodeId,
+          overwrite: overwrite === true,
+        },
+      },
+      { dispatch: false },
+    );
+    workflowPlugin.dispatch();
   } catch (error) {
     if (isLockAcquireError(error)) {
       return context.throw(409, 'Execution is being processed');
@@ -127,8 +128,6 @@ export async function rerun(context: Context, next) {
     }
     throw error;
   }
-
-  workflowPlugin.dispatch();
 
   context.body = execution;
   context.status = 202;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
@@ -9,7 +9,16 @@
 
 import actions, { Context } from '@nocobase/actions';
 import { Op } from '@nocobase/database';
+import PluginWorkflowServer from '../Plugin';
 import { EXECUTION_STATUS, JOB_STATUS } from '../constants';
+
+function getExecutionLockKey(executionId: number | string) {
+  return `workflow:execution:${executionId}`;
+}
+
+function isLockAcquireError(error: unknown) {
+  return error instanceof Error && error.constructor.name === 'LockAcquireError';
+}
 
 export async function destroy(context: Context, next) {
   context.action.mergeParams({
@@ -38,27 +47,90 @@ export async function cancel(context: Context, next) {
     return context.throw(400);
   }
 
-  await context.db.sequelize.transaction(async (transaction) => {
-    await execution.update(
-      {
-        status: EXECUTION_STATUS.ABORTED,
-      },
-      { transaction },
-    );
+  try {
+    const lock = await context.app.lockManager.tryAcquire(getExecutionLockKey(execution.id));
+    await lock.runExclusive(async () => {
+      await context.db.sequelize.transaction(async (transaction) => {
+        await execution.update(
+          {
+            status: EXECUTION_STATUS.ABORTED,
+          },
+          { transaction },
+        );
 
-    const pendingJobs = execution.jobs.filter((job) => job.status === JOB_STATUS.PENDING);
-    await JobRepo.update({
-      values: {
-        status: JOB_STATUS.ABORTED,
-      },
-      filter: {
-        id: pendingJobs.map((job) => job.id),
-      },
-      individualHooks: false,
-      transaction,
-    });
-  });
+        const pendingJobs = execution.jobs.filter((job) => job.status === JOB_STATUS.PENDING);
+        await JobRepo.update({
+          values: {
+            status: JOB_STATUS.ABORTED,
+          },
+          filter: {
+            id: pendingJobs.map((job) => job.id),
+          },
+          individualHooks: false,
+          transaction,
+        });
+      });
+    }, 60_000);
+  } catch (error) {
+    if (isLockAcquireError(error)) {
+      return context.throw(409, 'Execution is being processed');
+    }
+    throw error;
+  }
 
   context.body = execution;
+  await next();
+}
+
+export async function rerun(context: Context, next) {
+  const workflowPlugin = context.app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
+  const { filterByTk, values = {} } = context.action.params;
+  const { nodeId, overwrite } = values;
+  const ExecutionRepo = context.db.getRepository('executions');
+  const execution = await ExecutionRepo.findOne({
+    filterByTk,
+  });
+  if (!execution) {
+    return context.throw(404);
+  }
+  if (execution.status !== EXECUTION_STATUS.STARTED) {
+    return context.throw(409, 'Only started executions can be rerun');
+  }
+
+  try {
+    const lock = await context.app.lockManager.tryAcquire(getExecutionLockKey(execution.id));
+    await lock.runExclusive(async () => {
+      const processor = workflowPlugin.createProcessor(execution);
+      await processor.prepare();
+      processor.resolveRerun({
+        nodeId,
+        overwrite: overwrite === true,
+      });
+      await workflowPlugin.run(
+        {
+          execution,
+          loaded: true,
+          rerun: {
+            nodeId,
+            overwrite: overwrite === true,
+          },
+        },
+        { dispatch: false },
+      );
+    }, 60_000);
+  } catch (error) {
+    if (isLockAcquireError(error)) {
+      return context.throw(409, 'Execution is being processed');
+    }
+    if (error instanceof Error) {
+      return context.throw(400, error.message);
+    }
+    throw error;
+  }
+
+  workflowPlugin.dispatch();
+
+  context.body = execution;
+  context.status = 202;
   await next();
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
@@ -7,10 +7,11 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import actions, { Context } from '@nocobase/actions';
+import actions, { Context, Next } from '@nocobase/actions';
 import { Op } from '@nocobase/database';
 import PluginWorkflowServer from '../Plugin';
 import { EXECUTION_STATUS, JOB_STATUS } from '../constants';
+import { JobModel } from '../types';
 
 function getExecutionLockKey(executionId: number | string) {
   return `workflow:execution:${executionId}`;
@@ -20,7 +21,7 @@ function isLockAcquireError(error: unknown) {
   return error instanceof Error && error.constructor.name === 'LockAcquireError';
 }
 
-export async function destroy(context: Context, next) {
+export async function destroy(context: Context, next: Next) {
   context.action.mergeParams({
     filter: {
       status: {
@@ -32,7 +33,7 @@ export async function destroy(context: Context, next) {
   await actions.destroy(context, next);
 }
 
-export async function cancel(context: Context, next) {
+export async function cancel(context: Context, next: Next) {
   const { filterByTk } = context.action.params;
   const ExecutionRepo = context.db.getRepository('executions');
   const JobRepo = context.db.getRepository('jobs');
@@ -58,13 +59,13 @@ export async function cancel(context: Context, next) {
           { transaction },
         );
 
-        const pendingJobs = execution.jobs.filter((job) => job.status === JOB_STATUS.PENDING);
+        const pendingJobs = execution.jobs.filter((job: JobModel) => job.status === JOB_STATUS.PENDING);
         await JobRepo.update({
           values: {
             status: JOB_STATUS.ABORTED,
           },
           filter: {
-            id: pendingJobs.map((job) => job.id),
+            id: pendingJobs.map((job: JobModel) => job.id),
           },
           individualHooks: false,
           transaction,
@@ -82,7 +83,7 @@ export async function cancel(context: Context, next) {
   await next();
 }
 
-export async function rerun(context: Context, next) {
+export async function rerun(context: Context, next: Next) {
   const workflowPlugin = context.app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
   const { filterByTk, values = {} } = context.action.params;
   const { nodeId, overwrite } = values;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/jobs.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/jobs.ts
@@ -10,6 +10,14 @@
 import { utils } from '@nocobase/actions';
 import PluginWorkflowServer from '../Plugin';
 
+function getExecutionLockKey(executionId: number | string) {
+  return `workflow:execution:${executionId}`;
+}
+
+function isLockAcquireError(error: unknown) {
+  return error instanceof Error && error.constructor.name === 'LockAcquireError';
+}
+
 export async function resume(context, next) {
   const repository = utils.getRepositoryFromParams(context);
   const workflowPlugin = context.app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
@@ -20,8 +28,21 @@ export async function resume(context, next) {
   if (!job) {
     return context.throw(404, 'Job not found');
   }
+  if (!job.execution) {
+    job.execution = await job.getExecution();
+  }
   workflowPlugin.getLogger(job.workflowId).warn(`Resuming job #${job.id}...`);
-  await job.update(values);
+  try {
+    const lock = await context.app.lockManager.tryAcquire(getExecutionLockKey(job.execution.id));
+    await lock.runExclusive(async () => {
+      await job.update(values);
+    }, 60_000);
+  } catch (error) {
+    if (isLockAcquireError(error)) {
+      return context.throw(409, 'Execution is being processed');
+    }
+    throw error;
+  }
 
   context.body = job;
   context.status = 202;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/instructions/index.ts
@@ -30,7 +30,12 @@ export interface IJob {
  */
 export type InstructionResult = IJob | Promise<IJob> | Promise<void> | Promise<null> | null | void;
 
-export type Runner = (node: FlowNodeModel, input: any, processor: Processor) => InstructionResult;
+export type Runner = (
+  node: FlowNodeModel,
+  input: any,
+  processor: Processor,
+  options?: { rerun?: true },
+) => InstructionResult;
 
 export type InstructionInterface = {
   run: Runner;
@@ -48,7 +53,7 @@ export type InstructionInterface = {
 export abstract class Instruction implements InstructionInterface {
   constructor(public workflow: Plugin) {}
 
-  abstract run(node: FlowNodeModel, input: any, processor: Processor): InstructionResult;
+  abstract run(node: FlowNodeModel, input: any, processor: Processor, options?: { rerun?: true }): InstructionResult;
 }
 
 export default Instruction;


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Provide an administrator repair API for abnormal started workflow executions, allowing a workflow execution to re-enter from the head node or a specified node by running the node normally instead of resuming a pending job.

### Description
- Adds `executions:rerun` with `nodeId` and `overwrite` support.
- Adds `Processor.rerun()` and rerun input reconstruction from execution context or the upstream latest job.
- Supports overwrite rerun by updating the target node's latest job instead of creating a new target job.
- Adds execution-level locking for dispatcher processing, `jobs:resume`, `executions:cancel`, and `executions:rerun`.
- Keeps rerun/resume/cancel mutual exclusion close to actual dispatcher processing so lock TTL does not include local pending queue wait time.
- Extends instruction runner options with `{ rerun: true }`.
- Adds executions action coverage for permissions, status validation, default rerun, node rerun, overwrite rerun, validation failures, rerun input reconstruction, and processing-time mutual exclusion.

Potential risks:
- Rerun intentionally re-executes node side effects and does not clean historical downstream jobs or old pending jobs.
- `overwrite` only updates the target node latest job and does not rebuild a strict historical timeline.

### Testing
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts` passed before rebasing to `main`.
- Cherry-pick commit hooks ran `eslint --fix` successfully for the touched files.
- `TZ=Asia/Shanghai yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/executions.test.ts` could not run in this workspace because `yarn test` invokes missing binary `nocobase`.
- `TZ=Asia/Shanghai yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/jobs.test.ts` could not run in this workspace because `yarn test` invokes missing binary `nocobase`.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added an administrator API to rerun started workflow executions from the head or a specified node. |
| 🇨🇳 Chinese | 新增管理员 API，用于从头节点或指定节点重新执行已开始的工作流执行。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not provided |
| 🇨🇳 Chinese | Not provided |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
