### PR TITLE
fix(client): sync mobile date picker popup value

### DIFF
--- a/packages/core/client/src/flow/models/fields/mobile-components/MobileDatePicker.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/MobileDatePicker.tsx
@@ -9,10 +9,25 @@
 
 import { useFlowModelContext } from '@nocobase/flow-engine';
 import { dayjs } from '@nocobase/utils/client';
+import type { Dayjs } from 'dayjs';
 import { DatePicker } from 'antd';
 import { DatePicker as AntdMobileDatePicker } from 'antd-mobile';
 import React from 'react';
 import { useCallback, useState } from 'react';
+
+type DateValue = string | number | Date | Dayjs | null | undefined;
+
+function toNativeDate(value: DateValue): Date | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  const parsed = dayjs.isDayjs(value) ? value : dayjs(value);
+  return parsed.isValid() ? parsed.toDate() : null;
+}
 
 export const MobileDatePicker = (props) => {
   const {
@@ -56,9 +71,9 @@ export const MobileDatePicker = (props) => {
         return data;
     }
   }, []);
-  // Convert dayjs min/max to native Date for Antd Mobile Picker
-  const minDate = min ? (min as any).toDate() : new Date(1950, 0, 1);
-  const maxDate = max ? (max as any).toDate() : new Date(2050, 11, 31);
+  const mobileValue = toNativeDate(value);
+  const minDate = toNativeDate(min) ?? new Date(1950, 0, 1);
+  const maxDate = toNativeDate(max) ?? new Date(2050, 11, 31);
 
   return (
     <>
@@ -78,6 +93,7 @@ export const MobileDatePicker = (props) => {
         cancelText={t('Cancel')}
         confirmText={t('Confirm')}
         visible={visible}
+        value={mobileValue}
         title={<a onClick={handleClear}>{t('Clear')}</a>}
         onClose={() => {
           setVisible(false);

--- a/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileDatePicker.test.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileDatePicker.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@nocobase/test/client';
+import { dayjs } from '@nocobase/utils/client';
+import { MobileDatePicker } from '../MobileDatePicker';
+
+type MockDatePickerProps = Record<string, unknown> & {
+  value?: unknown;
+  visible?: boolean;
+};
+
+const mockState = vi.hoisted(
+  (): {
+    antdDatePickerProps?: MockDatePickerProps;
+    mobileDatePickerProps?: MockDatePickerProps;
+  } => ({
+    antdDatePickerProps: undefined,
+    mobileDatePickerProps: undefined,
+  }),
+);
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<typeof import('@nocobase/flow-engine')>('@nocobase/flow-engine');
+  return {
+    ...actual,
+    useFlowModelContext: () => ({
+      t: (value: string) => value,
+    }),
+  };
+});
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+  return {
+    ...actual,
+    DatePicker: (props: MockDatePickerProps) => {
+      mockState.antdDatePickerProps = props;
+      return <div data-testid="antd-date-picker" />;
+    },
+  };
+});
+
+vi.mock('antd-mobile', () => ({
+  DatePicker: (props: MockDatePickerProps) => {
+    mockState.mobileDatePickerProps = props;
+    return props.visible ? <div data-testid="mobile-date-picker" /> : null;
+  },
+}));
+
+describe('MobileDatePicker', () => {
+  beforeEach(() => {
+    mockState.antdDatePickerProps = undefined;
+    mockState.mobileDatePickerProps = undefined;
+  });
+
+  it('uses the form value as the mobile popup value', () => {
+    render(
+      <MobileDatePicker
+        value={dayjs('2037-03-06 12:34:56')}
+        showTime
+        picker="date"
+        timeFormat="HH:mm:ss"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByTestId('antd-date-picker').parentElement as HTMLElement;
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    const popupValue = mockState.mobileDatePickerProps?.value;
+    expect(screen.getByTestId('mobile-date-picker')).toBeInTheDocument();
+    expect(popupValue).toBeInstanceOf(Date);
+    if (!(popupValue instanceof Date)) {
+      throw new Error('Expected popup value to be a Date');
+    }
+    expect(popupValue.getFullYear()).toBe(2037);
+    expect(popupValue.getMonth()).toBe(2);
+    expect(popupValue.getDate()).toBe(6);
+    expect(popupValue.getHours()).toBe(12);
+    expect(popupValue.getMinutes()).toBe(34);
+    expect(popupValue.getSeconds()).toBe(56);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix sync mobile date picker popup value      |
| 🇨🇳 Chinese |    修复 v2 移动端日期弹窗使用当前时间而不是表单值的问题       |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
