### PR TITLE
fix(client): keep tabs after route switch

### DIFF
--- a/packages/core/client/src/flow/FlowPage.tsx
+++ b/packages/core/client/src/flow/FlowPage.tsx
@@ -139,17 +139,24 @@ export const FlowRoute = () => {
     routeModel.context.defineProperty('currentRoute', {
       get: () => currentRoute,
     });
-    // Also expose currentRoute on engine context so view-scoped engines
-    // can still read it for default title fallback.
-    flowEngine.context.defineProperty('currentRoute', {
-      get: () => currentRoute,
-    });
     routeModel.context.defineProperty('refreshDesktopRoutes', {
       get: () => refresh,
     });
   }, [routeModel, currentRoute, refresh, flowEngine]);
 
   useEffect(() => {
+    if (!active) {
+      return;
+    }
+    // Also expose currentRoute on engine context so view-scoped engines
+    // can still read it for default title fallback.
+    flowEngine.context.defineProperty('currentRoute', {
+      get: () => currentRoute,
+    });
+  }, [active, currentRoute, flowEngine]);
+
+  useEffect(() => {
+    const viewState = viewStateRef.current;
     const dispose = reaction(
       () => flowEngine.context.route,
       (newRoute) => {
@@ -310,7 +317,7 @@ export const FlowRoute = () => {
       dispose?.();
       prevViewListRef.current.forEach((viewItem) => {
         flowEngine.removeModelWithSubModels(viewItem.params.viewUid);
-        viewStateRef.current[getKey(viewItem)]?.destroy();
+        viewState[getKey(viewItem)]?.destroy();
       });
     };
   }, [flowEngine, isMobileLayout, routeModel]);

--- a/packages/core/client/src/flow/__tests__/FlowRoute.test.tsx
+++ b/packages/core/client/src/flow/__tests__/FlowRoute.test.tsx
@@ -20,12 +20,18 @@ import { getOpenViewStepParams } from '../flows/openViewFlow';
 import { FlowRoute } from '../FlowPage';
 import { RouteModel } from '../models/base/RouteModel';
 
+const routeSwitchMock = vi.hoisted(() => ({
+  active: true,
+  currentRoute: { name: 'testRoute' } as Record<string, unknown>,
+  refresh: () => undefined,
+}));
+
 // mock 路由相关 hooks
 vi.mock('../../route-switch', () => ({
-  useCurrentRoute: () => ({ name: 'testRoute' }),
-  useKeepAlive: () => ({ active: true }),
+  useCurrentRoute: () => routeSwitchMock.currentRoute,
+  useKeepAlive: () => ({ active: routeSwitchMock.active }),
   useMobileLayout: () => ({ isMobileLayout: true }),
-  useAllAccessDesktopRoutes: () => ({ refresh: vi.fn() }),
+  useAllAccessDesktopRoutes: () => ({ refresh: routeSwitchMock.refresh }),
 }));
 
 vi.mock('../resolveViewParamsToViewList', () => ({
@@ -53,6 +59,9 @@ const mockGetOpenViewStepParams = vi.mocked(getOpenViewStepParams);
 describe('FlowRoute', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    routeSwitchMock.active = true;
+    routeSwitchMock.currentRoute = { name: 'testRoute' };
+    routeSwitchMock.refresh = vi.fn();
     mockResolveViewParamsToViewList.mockReturnValue([]);
     mockGetViewDiffAndUpdateHidden.mockReturnValue({ viewsToClose: [], viewsToOpen: [] });
     mockGetOpenViewStepParams.mockReturnValue({} as any);
@@ -238,6 +247,48 @@ describe('FlowRoute', () => {
       filterByTk: 'member',
       sourceId: '1',
       triggerByRouter: true,
+    });
+  });
+
+  it('refreshes engine currentRoute when a cached route becomes active again', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ RouteModel });
+    const routeName = 'test-route';
+    const cachedRoute = { id: 'route-a', enableTabs: true };
+    const otherRoute = { id: 'route-b', enableTabs: false };
+    routeSwitchMock.currentRoute = cachedRoute;
+    engine.context.defineProperty('route', {
+      value: {
+        params: { name: routeName },
+        pathname: '/admin/test-view',
+      },
+    });
+
+    const renderFlowRoute = () => (
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={[`/flow/${routeName}`]}>
+          <Routes>
+            <Route path="/flow/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>
+    );
+
+    const { rerender } = render(renderFlowRoute());
+
+    await waitFor(() => {
+      expect(engine.context.currentRoute).toBe(cachedRoute);
+    });
+
+    routeSwitchMock.active = false;
+    rerender(renderFlowRoute());
+    engine.context.defineProperty('currentRoute', { value: otherRoute });
+
+    routeSwitchMock.active = true;
+    rerender(renderFlowRoute());
+
+    await waitFor(() => {
+      expect(engine.context.currentRoute).toBe(cachedRoute);
     });
   });
 });

--- a/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
+++ b/packages/core/client/src/flow/models/base/PageModel/PageModel.tsx
@@ -39,6 +39,15 @@ type PageModelStructure = {
   };
 };
 
+type CurrentRouteWithTabs = {
+  id?: string | number | null;
+  enableTabs?: boolean;
+};
+
+type PageModelContextWithRoute = {
+  currentRoute?: CurrentRouteWithTabs | null;
+};
+
 export class PageModel extends FlowModel<PageModelStructure> {
   tabBarExtraContent: { left?: ReactNode; right?: ReactNode } = {};
   private viewActivatedListener?: (_payload?: unknown) => void;
@@ -52,9 +61,15 @@ export class PageModel extends FlowModel<PageModelStructure> {
    * 根页面标签页开关以路由表为准，避免 flow model 里的旧配置覆盖路由管理设置。
    */
   private getEnableTabs(): boolean {
-    const routeEnableTabs = (this.context as any)?.currentRoute?.enableTabs;
-    if (this.props.routeId != null && typeof routeEnableTabs === 'boolean') {
-      return routeEnableTabs;
+    const currentRoute = (this.context as PageModelContextWithRoute).currentRoute;
+    const routeId = this.props.routeId;
+    if (
+      routeId != null &&
+      currentRoute?.id != null &&
+      String(currentRoute.id) === String(routeId) &&
+      typeof currentRoute.enableTabs === 'boolean'
+    ) {
+      return currentRoute.enableTabs;
     }
     return !!this.props.enableTabs;
   }

--- a/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
+++ b/packages/core/client/src/flow/models/base/PageModel/__tests__/PageModel.test.ts
@@ -455,6 +455,7 @@ describe('PageModel', () => {
       } as any;
       (pageModel as any).context = {
         currentRoute: {
+          id: 'route-1',
           enableTabs: false,
         },
       };
@@ -479,6 +480,7 @@ describe('PageModel', () => {
       } as any;
       (pageModel as any).context = {
         currentRoute: {
+          id: 'route-1',
           enableTabs: true,
         },
       };
@@ -494,6 +496,59 @@ describe('PageModel', () => {
         backgroundColor: 'var(--colorBgLayout)',
         paddingBottom: 0,
       });
+    });
+
+    it('should ignore stale desktop route enableTabs=false from another route', () => {
+      pageModel.props = {
+        routeId: 'route-1',
+        displayTitle: true,
+        enableTabs: true,
+        title: 'Title',
+        headerStyle: { backgroundColor: 'var(--colorBgLayout)' },
+      } as any;
+      (pageModel as any).context = {
+        currentRoute: {
+          id: 'route-2',
+          enableTabs: false,
+        },
+      };
+      pageModel.renderTabs = vi.fn(() => null);
+      pageModel.renderFirstTab = vi.fn(() => null);
+
+      const result = pageModel.render() as any;
+      const header = result.props.children[0];
+
+      expect(pageModel.renderTabs).toHaveBeenCalled();
+      expect(pageModel.renderFirstTab).not.toHaveBeenCalled();
+      expect(header.props.style).toMatchObject({
+        backgroundColor: 'var(--colorBgLayout)',
+        paddingBottom: 0,
+      });
+    });
+
+    it('should ignore stale desktop route enableTabs=true from another route', () => {
+      pageModel.props = {
+        routeId: 'route-1',
+        displayTitle: true,
+        enableTabs: false,
+        title: 'Title',
+        headerStyle: { backgroundColor: 'var(--colorBgLayout)' },
+      } as any;
+      (pageModel as any).context = {
+        currentRoute: {
+          id: 'route-2',
+          enableTabs: true,
+        },
+      };
+      pageModel.renderTabs = vi.fn(() => null);
+      pageModel.renderFirstTab = vi.fn(() => null);
+
+      const result = pageModel.render() as any;
+      const header = result.props.children[0];
+
+      expect(pageModel.renderTabs).not.toHaveBeenCalled();
+      expect(pageModel.renderFirstTab).toHaveBeenCalled();
+      expect(header.props.style).toEqual({ backgroundColor: 'var(--colorBgLayout)' });
     });
   });
 
@@ -630,6 +685,7 @@ describe('PageModel', () => {
     it('should use page documentTitle when desktop route disables tabs even if flow model enables tabs', async () => {
       pageModel.props = { routeId: 'route-1', enableTabs: true, title: 'Route page title' } as any;
       (pageModel as any).context.currentRoute = {
+        id: 'route-1',
         enableTabs: false,
       };
       (pageModel as any).stepParams = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 页面中，从带有标签页的页面切换到其他菜单后，再切回原页面，页面标签页可能会消失，只剩下页面标题和内容区域。

### Description
修复缓存页面重新显示时当前路由信息没有及时更新的问题，确保切回页面后仍按该页面自己的设置显示标签页。

同时增加了相关测试，覆盖缓存页面重新激活时的路由信息刷新，以及页面只使用匹配当前路由的标签页设置，避免后续再次出现同类问题。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix page tabs disappearing after switching menus |
| 🇨🇳 Chinese | 修复切换菜单后页面标签页消失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
