### PR TITLE
fix(plugin-file-manager): preserve unicode filenames

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
@@ -24,6 +24,7 @@ import {
 import { AttachmentModel, StorageType } from '../storages';
 
 const MOCK_REPAIR_STORAGE_TYPE = 'mock-repair-storage';
+const describeLocalRepair = process.platform === 'win32' ? describe.skip : describe;
 
 class MockRepairStorage extends StorageType {
   static sourceKeys = new Set<string>();
@@ -303,7 +304,7 @@ describe('file manager > utils', () => {
     });
   });
 
-  describe('repairAttachmentFilenames', () => {
+  describeLocalRepair('repairAttachmentFilenames with local storage', () => {
     let documentRoot: string;
 
     beforeEach(async () => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
@@ -13,6 +13,55 @@ import PluginFileManagerServer from '../server';
 import { STORAGE_TYPE_LOCAL } from '../../constants';
 
 import { cloudFilenameGetter, getFileKey } from '../utils';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  getRepairedAttachmentValues,
+  repairAttachmentFilenames,
+  replaceInvisibleChars,
+} from '../commands/repair-filenames';
+import { AttachmentModel, StorageType } from '../storages';
+
+const MOCK_REPAIR_STORAGE_TYPE = 'mock-repair-storage';
+
+class MockRepairStorage extends StorageType {
+  static sourceKeys = new Set<string>();
+  static targetKeys = new Set<string>();
+  static existsCalls: string[] = [];
+  static copied: Array<{ source: string; target: string }> = [];
+  static deleted: string[] = [];
+
+  static reset() {
+    this.sourceKeys = new Set();
+    this.targetKeys = new Set();
+    this.existsCalls = [];
+    this.copied = [];
+    this.deleted = [];
+  }
+
+  make() {
+    return {} as never;
+  }
+
+  async exists(record: AttachmentModel) {
+    const key = this.getFileKey(record);
+    MockRepairStorage.existsCalls.push(key);
+    return MockRepairStorage.sourceKeys.has(key) || MockRepairStorage.targetKeys.has(key);
+  }
+
+  async copy(source: AttachmentModel, target: AttachmentModel) {
+    MockRepairStorage.copied.push({
+      source: this.getFileKey(source),
+      target: this.getFileKey(target),
+    });
+  }
+
+  async delete(records: AttachmentModel[]) {
+    MockRepairStorage.deleted.push(...records.map((record) => this.getFileKey(record)));
+    return [records.length, []] as [number, AttachmentModel[]];
+  }
+}
 
 describe('file manager > utils', () => {
   let app;
@@ -21,6 +70,7 @@ describe('file manager > utils', () => {
   let plugin: PluginFileManagerServer;
   let StorageRepo;
   let AttachmentRepo;
+  let FileRepo;
   let local;
 
   beforeEach(async () => {
@@ -30,6 +80,7 @@ describe('file manager > utils', () => {
     plugin = app.pm.get(PluginFileManagerServer) as PluginFileManagerServer;
 
     AttachmentRepo = db.getCollection('attachments').repository;
+    FileRepo = db.getCollection('files').repository;
     StorageRepo = db.getCollection('storages').repository;
     local = await StorageRepo.findOne({
       filter: {
@@ -103,6 +154,285 @@ describe('file manager > utils', () => {
       const storage = { path: 'uploads' };
       const filename = await getFilename(storage, asciiFilename);
       expect(filename).toMatch(/^uploads\/report-[0-9a-z]{6}\.txt$/);
+    });
+  });
+
+  describe('repair filename helpers', () => {
+    it('replaces C0 and C1 invisible characters only', () => {
+      expect(replaceInvisibleChars('a\u0000b\u001Ac\u007Fd\u0085e')).toBe('a-b-c-d-e');
+      expect(replaceInvisibleChars('1 场景_用户[普通表]-jypc1s.xlsx')).toBe('1 场景_用户[普通表]-jypc1s.xlsx');
+    });
+
+    it('returns repaired path and filename values', () => {
+      expect(
+        getRepairedAttachmentValues({
+          path: 'reports\u001A',
+          filename: 'file\u001A.xlsx',
+        }),
+      ).toEqual({
+        path: 'reports-',
+        filename: 'file-.xlsx',
+      });
+    });
+  });
+
+  describe('repairAttachmentFilenames with storage interface', () => {
+    let mockStorage;
+
+    beforeEach(async () => {
+      MockRepairStorage.reset();
+      plugin.registerStorageType(MOCK_REPAIR_STORAGE_TYPE, MockRepairStorage);
+      mockStorage = await StorageRepo.create({
+        values: {
+          title: 'Mock repair storage',
+          name: 'mock-repair-storage',
+          type: MOCK_REPAIR_STORAGE_TYPE,
+          baseUrl: '/mock',
+          options: {},
+        },
+      });
+      await plugin.loadStorages();
+    });
+
+    it('dry-runs through exists without copy, delete, or db updates', async () => {
+      const oldPath = 'mock\u001A';
+      const oldFilename = 'dry\u001A.xlsx';
+      const oldKey = `${oldPath}/${oldFilename}`;
+      MockRepairStorage.sourceKeys.add(oldKey);
+      const attachment = await AttachmentRepo.create({
+        values: {
+          title: 'test',
+          filename: oldFilename,
+          extname: '.xlsx',
+          path: oldPath,
+          storageId: mockStorage.get('id'),
+        },
+      });
+
+      const result = await repairAttachmentFilenames(app, plugin, { batchSize: 10 });
+
+      expect(result.candidates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: attachment.get('id'),
+            oldKey,
+            newKey: 'mock-/dry-.xlsx',
+            sourceExists: true,
+            targetExists: false,
+            status: 'pending',
+          }),
+        ]),
+      );
+      expect(MockRepairStorage.existsCalls).toEqual([oldKey, 'mock-/dry-.xlsx']);
+      expect(MockRepairStorage.copied).toEqual([]);
+      expect(MockRepairStorage.deleted).toEqual([]);
+
+      const unchanged = await AttachmentRepo.findOne({ filterByTk: attachment.get('id') });
+      expect(unchanged.get('path')).toBe(oldPath);
+      expect(unchanged.get('filename')).toBe(oldFilename);
+    });
+
+    it('applies copy, db update, url rewrite, and delete through the storage interface', async () => {
+      const oldPath = 'mock\u001A';
+      const oldFilename = 'apply\u001A.xlsx';
+      const oldKey = `${oldPath}/${oldFilename}`;
+      const newKey = 'mock-/apply-.xlsx';
+      MockRepairStorage.sourceKeys.add(oldKey);
+      const attachment = await AttachmentRepo.create({
+        values: {
+          title: 'test',
+          filename: oldFilename,
+          extname: '.xlsx',
+          path: oldPath,
+          url: `/mock/${encodeURIComponent(oldPath)}/${encodeURIComponent(oldFilename)}`,
+          storageId: mockStorage.get('id'),
+        },
+      });
+
+      const result = await repairAttachmentFilenames(app, plugin, { apply: true, batchSize: 10 });
+
+      expect(result.repaired).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: attachment.get('id'),
+            oldKey,
+            newKey,
+            status: 'repaired',
+          }),
+        ]),
+      );
+      expect(MockRepairStorage.copied).toEqual([{ source: oldKey, target: newKey }]);
+      expect(MockRepairStorage.deleted).toEqual([oldKey]);
+
+      const updated = await AttachmentRepo.findOne({ filterByTk: attachment.get('id') });
+      expect(updated.get('path')).toBe('mock-');
+      expect(updated.get('filename')).toBe('apply-.xlsx');
+      expect(updated.get('url')).toBe('/mock/mock-/apply-.xlsx');
+    });
+
+    it('skips records when the repaired target already exists', async () => {
+      const oldPath = 'mock\u001A';
+      const oldFilename = 'exists\u001A.xlsx';
+      const oldKey = `${oldPath}/${oldFilename}`;
+      const newKey = 'mock-/exists-.xlsx';
+      MockRepairStorage.sourceKeys.add(oldKey);
+      MockRepairStorage.targetKeys.add(newKey);
+      const attachment = await AttachmentRepo.create({
+        values: {
+          title: 'test',
+          filename: oldFilename,
+          extname: '.xlsx',
+          path: oldPath,
+          storageId: mockStorage.get('id'),
+        },
+      });
+
+      const result = await repairAttachmentFilenames(app, plugin, { apply: true, batchSize: 10 });
+
+      expect(result.skipped).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: attachment.get('id'),
+            reason: 'target_exists',
+            status: 'skipped',
+          }),
+        ]),
+      );
+      expect(MockRepairStorage.copied).toEqual([]);
+      expect(MockRepairStorage.deleted).toEqual([]);
+    });
+  });
+
+  describe('repairAttachmentFilenames', () => {
+    let documentRoot: string;
+
+    beforeEach(async () => {
+      documentRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nocobase-file-repair-'));
+      await local.update({
+        options: {
+          ...local.get('options'),
+          documentRoot,
+        },
+      });
+      await plugin.loadStorages();
+    });
+
+    afterEach(async () => {
+      await fs.rm(documentRoot, { recursive: true, force: true });
+    });
+
+    it('dry-runs and repairs file records with invisible chars in path and filename', async () => {
+      const oldPath = 'reports\u001A';
+      const oldFilename = '1 -o_(7[n\u001Ah]-jypc1s.xlsx';
+      const newPath = 'reports-';
+      const newFilename = '1 -o_(7[n-h]-jypc1s.xlsx';
+      const fileOldPath = 'files\u001A';
+      const fileOldFilename = 'file\u001A.xlsx';
+      const fileNewPath = 'files-';
+      const fileNewFilename = 'file-.xlsx';
+      await fs.mkdir(path.join(documentRoot, oldPath), { recursive: true });
+      await fs.writeFile(path.join(documentRoot, oldPath, oldFilename), 'test');
+      await fs.mkdir(path.join(documentRoot, fileOldPath), { recursive: true });
+      await fs.writeFile(path.join(documentRoot, fileOldPath, fileOldFilename), 'test');
+      const attachment = await AttachmentRepo.create({
+        values: {
+          title: 'test',
+          filename: oldFilename,
+          extname: '.xlsx',
+          path: oldPath,
+          storageId: local.get('id'),
+        },
+      });
+      const file = await FileRepo.create({
+        values: {
+          title: 'test',
+          filename: fileOldFilename,
+          extname: '.xlsx',
+          path: fileOldPath,
+          storageId: local.get('id'),
+        },
+      });
+
+      const dryRun = await repairAttachmentFilenames(app, plugin, { batchSize: 10 });
+      expect(dryRun.dryRun).toBe(true);
+      expect(dryRun.candidates).toHaveLength(2);
+      expect(dryRun.candidates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            collectionName: 'attachments',
+            id: attachment.get('id'),
+            oldKey: `${oldPath}/${oldFilename}`,
+            newKey: `${newPath}/${newFilename}`,
+            sourceExists: true,
+            targetExists: false,
+            status: 'pending',
+          }),
+          expect.objectContaining({
+            collectionName: 'files',
+            id: file.get('id'),
+            oldKey: `${fileOldPath}/${fileOldFilename}`,
+            newKey: `${fileNewPath}/${fileNewFilename}`,
+            sourceExists: true,
+            targetExists: false,
+            status: 'pending',
+          }),
+        ]),
+      );
+      await expect(fs.stat(path.join(documentRoot, oldPath, oldFilename))).resolves.toBeTruthy();
+      await expect(fs.stat(path.join(documentRoot, fileOldPath, fileOldFilename))).resolves.toBeTruthy();
+
+      const applied = await repairAttachmentFilenames(app, plugin, { apply: true, batchSize: 10 });
+      expect(applied.repaired).toHaveLength(2);
+      expect(applied.repaired).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            collectionName: 'attachments',
+            id: attachment.get('id'),
+            status: 'repaired',
+          }),
+          expect.objectContaining({
+            collectionName: 'files',
+            id: file.get('id'),
+            status: 'repaired',
+          }),
+        ]),
+      );
+      await expect(fs.stat(path.join(documentRoot, newPath, newFilename))).resolves.toBeTruthy();
+      await expect(fs.stat(path.join(documentRoot, fileNewPath, fileNewFilename))).resolves.toBeTruthy();
+      await expect(fs.stat(path.join(documentRoot, oldPath, oldFilename))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(path.join(documentRoot, fileOldPath, fileOldFilename))).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+
+      const updated = await AttachmentRepo.findOne({ filterByTk: attachment.get('id') });
+      expect(updated.get('path')).toBe(newPath);
+      expect(updated.get('filename')).toBe(newFilename);
+      const updatedFile = await FileRepo.findOne({ filterByTk: file.get('id') });
+      expect(updatedFile.get('path')).toBe(fileNewPath);
+      expect(updatedFile.get('filename')).toBe(fileNewFilename);
+    });
+
+    it('supports limit across file collections', async () => {
+      const oldPath = 'reports\u001A';
+      const oldFilename = 'limited\u001A.xlsx';
+      await fs.mkdir(path.join(documentRoot, oldPath), { recursive: true });
+      await fs.writeFile(path.join(documentRoot, oldPath, oldFilename), 'test');
+      const attachment = await AttachmentRepo.create({
+        values: {
+          title: 'test',
+          filename: oldFilename,
+          extname: '.xlsx',
+          path: oldPath,
+          storageId: local.get('id'),
+        },
+      });
+
+      const dryRun = await repairAttachmentFilenames(app, plugin, { batchSize: 10, limit: 1 });
+      expect(dryRun.scanned).toBe(1);
+      expect(dryRun.candidates[0]).toMatchObject({
+        id: attachment.get('id'),
+        collectionName: 'attachments',
+      });
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
@@ -68,6 +68,12 @@ describe('file manager > utils', () => {
       expect(filename).toBe(`uploads/${testFilename}`);
     });
 
+    it('keeps unicode filename without binary-decoding it again', async () => {
+      const storage = { renameMode: 'none', path: '' };
+      const filename = await getFilename(storage, '1 场景_用户[普通表]-jypc1s.xlsx');
+      expect(filename).toBe('1 场景_用户[普通表]-jypc1s.xlsx');
+    });
+
     it('decodes binary-encoded filename', async () => {
       const storage = { renameMode: 'none', path: '' };
       const originalname = Buffer.from(testFilename, 'utf8').toString('binary');
@@ -79,6 +85,12 @@ describe('file manager > utils', () => {
       const storage = { renameMode: 'none', path: 'uploads' };
       const filename = await getFilename(storage, asciiFilename);
       expect(filename).toBe(`uploads/${asciiFilename}`);
+    });
+
+    it('replaces control characters in filename', async () => {
+      const storage = { renameMode: 'none', path: '' };
+      const filename = await getFilename(storage, '1 -o_(7[n\u001Ah].xlsx');
+      expect(filename).toBe('1 -o_(7[n-h].xlsx');
     });
 
     it('uses random name when renameMode is random', async () => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/commands/repair-filenames.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/commands/repair-filenames.ts
@@ -1,0 +1,350 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Application } from '@nocobase/server';
+import type { Model } from '@nocobase/database';
+import type { CollectionRepository } from '@nocobase/plugin-data-source-main';
+import { Op } from 'sequelize';
+import { getFileKey } from '../utils';
+import { AttachmentModel, StorageClassType, StorageModel } from '../storages';
+
+export type RepairFilenameStatus = 'pending' | 'repaired' | 'skipped' | 'failed';
+
+export interface RepairFilenameItem {
+  collectionName: string;
+  id: number | string;
+  storageId: number | string;
+  storageType: string;
+  oldPath: string;
+  oldFilename: string;
+  newPath: string;
+  newFilename: string;
+  oldKey: string;
+  newKey: string;
+  sourceExists?: boolean;
+  targetExists?: boolean;
+  status: RepairFilenameStatus;
+  reason?: string;
+}
+
+export interface RepairFilenamesOptions {
+  apply?: boolean;
+  batchSize?: number;
+  limit?: number;
+}
+
+export interface RepairFilenamesResult {
+  dryRun: boolean;
+  scanned: number;
+  candidates: RepairFilenameItem[];
+  repaired: RepairFilenameItem[];
+  skipped: RepairFilenameItem[];
+  failed: RepairFilenameItem[];
+}
+
+interface FileManagerLike {
+  storageTypes: {
+    get(type: string): StorageClassType | undefined;
+  };
+  loadStorages(): Promise<void>;
+  storagesCache: Map<number | string, StorageModel>;
+}
+
+function containsInvisibleChars(value?: string | null) {
+  return Array.from(value || '').some((char) => {
+    const code = char.charCodeAt(0);
+    return code <= 31 || (code >= 127 && code <= 159);
+  });
+}
+
+export function replaceInvisibleChars(value?: string | null) {
+  return Array.from(value || '')
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159) ? '-' : char;
+    })
+    .join('');
+}
+
+export function getRepairedAttachmentValues(record: Pick<AttachmentModel, 'path' | 'filename'>) {
+  return {
+    path: replaceInvisibleChars(record.path),
+    filename: replaceInvisibleChars(record.filename),
+  };
+}
+
+function updateUrlValue(url: string | null | undefined, oldKey: string, newKey: string) {
+  if (!url) {
+    return url;
+  }
+  const encodedOldKey = oldKey
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  const encodedNewKey = newKey
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return url.split(oldKey).join(newKey).split(encodedOldKey).join(encodedNewKey);
+}
+
+function formatItem(item: RepairFilenameItem) {
+  return {
+    collectionName: item.collectionName,
+    id: item.id,
+    storageId: item.storageId,
+    storageType: item.storageType,
+    oldKey: item.oldKey,
+    newKey: item.newKey,
+    sourceExists: item.sourceExists,
+    targetExists: item.targetExists,
+    status: item.status,
+    reason: item.reason,
+  };
+}
+
+async function getFileCollectionNames(app: Application) {
+  const repository = (app.db.getRepository('collections') ||
+    app.db.getCollection('collections')?.repository) as CollectionRepository;
+  if (repository) {
+    const collections: Model[] = await repository.find({
+      filter: {
+        'options.template': 'file',
+      },
+    });
+    return Array.from(new Set(['attachments', ...collections.map((collection) => collection.get('name') as string)]));
+  }
+  return Array.from(
+    new Set([
+      'attachments',
+      ...Array.from(app.db.collections.values())
+        .filter((collection) => collection.options.template === 'file')
+        .map((collection) => collection.name),
+    ]),
+  );
+}
+
+async function loadFileCollections(app: Application) {
+  const collection = app.db.getCollection('collections');
+  if (!collection) {
+    return;
+  }
+  const repository = collection.repository as CollectionRepository;
+  // Keep this aligned with core repair/db:sync commands so file collections
+  // persisted in the collections table are available in app.db.collections.
+  await repository.setApp?.(app);
+  await repository.load?.();
+}
+
+async function repairCollectionAttachmentFilenames({
+  app,
+  fileManager,
+  collectionName,
+  result,
+  apply,
+  batchSize,
+  limit,
+}: {
+  app: Application;
+  fileManager: FileManagerLike;
+  collectionName: string;
+  result: RepairFilenamesResult;
+  apply: boolean;
+  batchSize: number;
+  limit: number;
+}) {
+  const collection = app.db.getCollection(collectionName);
+  if (!collection) {
+    return;
+  }
+  const Model = collection.model;
+
+  let lastId: number | string | null = null;
+  while (result.scanned < limit) {
+    const rows = await Model.findAll({
+      attributes: ['id', 'path', 'filename', 'storageId', 'url'],
+      where: lastId ? { id: { [Op.gt]: lastId } } : undefined,
+      order: [['id', 'ASC']],
+      limit: Math.min(batchSize, limit - result.scanned),
+    });
+    if (!rows.length) {
+      break;
+    }
+
+    for (const row of rows) {
+      result.scanned += 1;
+      lastId = row.get('id') as number | string;
+
+      const record = row.toJSON() as AttachmentModel;
+      if (!containsInvisibleChars(record.path) && !containsInvisibleChars(record.filename)) {
+        continue;
+      }
+
+      const storage = fileManager.storagesCache.get(record.storageId);
+      const { path: newPath, filename: newFilename } = getRepairedAttachmentValues(record);
+      const oldKey = getFileKey(record);
+      const newRecord = { ...record, path: newPath, filename: newFilename };
+      const newKey = getFileKey(newRecord);
+      const item: RepairFilenameItem = {
+        collectionName,
+        id: lastId,
+        storageId: record.storageId,
+        storageType: storage?.type || '',
+        oldPath: record.path || '',
+        oldFilename: record.filename,
+        newPath,
+        newFilename,
+        oldKey,
+        newKey,
+        status: 'pending',
+      };
+      result.candidates.push(item);
+
+      if (!storage) {
+        item.status = 'skipped';
+        item.reason = 'storage_not_found';
+        result.skipped.push(item);
+        continue;
+      }
+      if (oldKey === newKey) {
+        item.status = 'skipped';
+        item.reason = 'unchanged';
+        result.skipped.push(item);
+        continue;
+      }
+
+      try {
+        const StorageClass = fileManager.storageTypes.get(storage.type);
+        if (!StorageClass) {
+          item.status = 'skipped';
+          item.reason = 'storage_type_not_found';
+          result.skipped.push(item);
+          continue;
+        }
+        const storageInstance = new StorageClass(storage);
+        item.sourceExists = await storageInstance.exists(record);
+        if (!item.sourceExists) {
+          item.status = 'skipped';
+          item.reason = 'source_not_found';
+          result.skipped.push(item);
+          continue;
+        }
+
+        item.targetExists = await storageInstance.exists(newRecord);
+        if (item.targetExists) {
+          item.status = 'skipped';
+          item.reason = 'target_exists';
+          result.skipped.push(item);
+          continue;
+        }
+
+        if (apply) {
+          await storageInstance.copy(record, newRecord);
+          await row.update({
+            path: newPath,
+            filename: newFilename,
+            url: updateUrlValue(record.url, oldKey, newKey),
+          });
+          try {
+            const [deleted] = await storageInstance.delete([record]);
+            if (!deleted) {
+              item.reason = 'delete_old_failed';
+            }
+          } catch (error) {
+            item.reason = `delete_old_failed: ${(error as Error).message}`;
+          }
+          item.status = 'repaired';
+          result.repaired.push(item);
+        }
+      } catch (error) {
+        item.status = 'failed';
+        item.reason = (error as Error).message;
+        result.failed.push(item);
+      }
+    }
+  }
+}
+
+export async function repairAttachmentFilenames(
+  app: Application,
+  fileManager: FileManagerLike,
+  options: RepairFilenamesOptions = {},
+): Promise<RepairFilenamesResult> {
+  const apply = !!options.apply;
+  const batchSize = options.batchSize || 500;
+  const limit = options.limit || Number.POSITIVE_INFINITY;
+  const result: RepairFilenamesResult = {
+    dryRun: !apply,
+    scanned: 0,
+    candidates: [],
+    repaired: [],
+    skipped: [],
+    failed: [],
+  };
+
+  if (!fileManager.storagesCache.size) {
+    await fileManager.loadStorages();
+  }
+  await loadFileCollections(app);
+
+  for (const collectionName of await getFileCollectionNames(app)) {
+    if (result.scanned >= limit) {
+      break;
+    }
+    await repairCollectionAttachmentFilenames({
+      app,
+      fileManager,
+      collectionName,
+      result,
+      apply,
+      batchSize,
+      limit,
+    });
+  }
+
+  return result;
+}
+
+export function registerRepairFilenamesCommand(app: Application) {
+  const command = (app.findCommand('file-manager') || app.command('file-manager')) as ReturnType<
+    Application['command']
+  >;
+  command
+    .command('repair-filenames')
+    .preload()
+    .option('--apply', 'rename objects and update attachment records')
+    .option('--batch-size [batchSize]', 'batch size for scanning attachments')
+    .option('--limit [limit]', 'maximum number of attachment records to scan')
+    .action(async (options) => {
+      const fileManager = app.pm.get('file-manager') as unknown as FileManagerLike;
+      const result = await repairAttachmentFilenames(app, fileManager, {
+        apply: !!options.apply,
+        batchSize: options.batchSize ? Number(options.batchSize) : undefined,
+        limit: options.limit ? Number(options.limit) : undefined,
+      });
+
+      console.log(
+        JSON.stringify(
+          {
+            dryRun: result.dryRun,
+            scanned: result.scanned,
+            candidates: result.candidates.length,
+            repaired: result.repaired.length,
+            skipped: result.skipped.length,
+            failed: result.failed.length,
+          },
+          null,
+          2,
+        ),
+      );
+      if (result.candidates.length) {
+        console.table(result.candidates.map(formatItem));
+      }
+    });
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
@@ -12,7 +12,7 @@ import { basename } from 'path';
 import match from 'mime-match';
 
 import { Collection, Model, Transactionable } from '@nocobase/database';
-import { Plugin } from '@nocobase/server';
+import { Application, Plugin } from '@nocobase/server';
 import { Registry } from '@nocobase/utils';
 import { Readable } from 'stream';
 import { STORAGE_TYPE_ALI_OSS, STORAGE_TYPE_LOCAL, STORAGE_TYPE_S3, STORAGE_TYPE_TX_COS } from '../constants';
@@ -24,6 +24,7 @@ import StorageTypeLocal from './storages/local';
 import StorageTypeS3 from './storages/s3';
 import StorageTypeTxCos from './storages/tx-cos';
 import { encodeURL } from './utils';
+import { registerRepairFilenamesCommand } from './commands/repair-filenames';
 
 export type * from './storages';
 
@@ -55,6 +56,10 @@ export type UploadFileOptions = {
 export class PluginFileManagerServer extends Plugin {
   storageTypes = new Registry<StorageClassType>();
   storagesCache = new Map<number | string, StorageModel>();
+
+  static async staticImport() {
+    Application.addCommand(registerRepairFilenamesCommand);
+  }
 
   afterDestroy = async (record: Model, options) => {
     const { collection } = record.constructor as typeof Model;

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/ali-oss.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/ali-oss.ts
@@ -76,14 +76,16 @@ class AliYunOssStorage {
       .catch(cb);
   }
 
-  _removeFile(req, file, cb) {
+  async _removeFile(req, file, cb) {
     if (!this.client) {
       return cb(ERROR_NO_CLIENT);
     }
-    this.client
-      .delete(file.filename)
-      .then((result) => cb(null, result))
-      .catch(cb);
+    try {
+      const result = await this.client.delete(file.filename);
+      cb(null, result);
+    } catch (error) {
+      cb(error);
+    }
   }
 }
 
@@ -109,6 +111,25 @@ export default class extends StorageType {
       filename: cloudFilenameGetter(this.storage),
     });
   }
+
+  async exists(record: AttachmentModel): Promise<boolean> {
+    const { client } = this.make();
+    try {
+      await client.head(getFileKey(record));
+      return true;
+    } catch (error) {
+      if (['NoSuchKey', 'NotFoundError'].includes((error as Error).name)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async copy(source: AttachmentModel, target: AttachmentModel): Promise<void> {
+    const { client } = this.make();
+    await client.copy(getFileKey(target), getFileKey(source));
+  }
+
   async delete(records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {
     const { client } = this.make();
     const { deleted } = await client.deleteMulti(records.map(getFileKey));

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/index.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/index.ts
@@ -30,6 +30,7 @@ export interface StorageModel {
 }
 
 export interface AttachmentModel {
+  id?: number;
   title: string;
   filename: string;
   mimetype?: string;
@@ -46,6 +47,14 @@ export abstract class StorageType {
   constructor(public storage: StorageModel) {}
   abstract make(): StorageEngine;
   abstract delete(records: AttachmentModel[]): [number, AttachmentModel[]] | Promise<[number, AttachmentModel[]]>;
+
+  async exists(record: AttachmentModel): Promise<boolean> {
+    throw new Error(`Storage type "${this.storage.type}" does not support object existence checks`);
+  }
+
+  async copy(source: AttachmentModel, target: AttachmentModel): Promise<void> {
+    throw new Error(`Storage type "${this.storage.type}" does not support object copy`);
+  }
 
   getFileKey(record: AttachmentModel) {
     return getFileKey(record);

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/local.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/local.ts
@@ -66,6 +66,26 @@ export default class extends StorageType {
       filename: diskFilenameGetter(this.storage),
     });
   }
+  async exists(record: AttachmentModel): Promise<boolean> {
+    try {
+      await fs.stat(resolveSafePath(getDocumentRoot(this.storage), record.path, record.filename));
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async copy(source: AttachmentModel, target: AttachmentModel): Promise<void> {
+    const documentRoot = getDocumentRoot(this.storage);
+    const sourcePath = resolveSafePath(documentRoot, source.path, source.filename);
+    const targetPath = resolveSafePath(documentRoot, target.path, target.filename);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.copyFile(sourcePath, targetPath);
+  }
+
   async delete(records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {
     const documentRoot = getDocumentRoot(this.storage);
     let count = 0;

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/s3.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/s3.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { DeleteObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { CopyObjectCommand, DeleteObjectCommand, HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import urlJoin from 'url-join';
 import { isURL } from '@nocobase/utils';
@@ -164,6 +164,37 @@ export default class extends StorageType {
     return {
       Deleted,
     };
+  }
+
+  async exists(record: AttachmentModel): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({
+          Bucket: this.storage.options.bucket,
+          Key: this.getFileKey(record),
+        }),
+      );
+      return true;
+    } catch (error) {
+      if (['NotFound', 'NoSuchKey', 'NoSuchBucket'].includes((error as Error).name)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async copy(source: AttachmentModel, target: AttachmentModel): Promise<void> {
+    const sourceKey = this.getFileKey(source);
+    await this.client.send(
+      new CopyObjectCommand({
+        Bucket: this.storage.options.bucket,
+        Key: this.getFileKey(target),
+        CopySource: `${this.storage.options.bucket}/${sourceKey
+          .split('/')
+          .map((segment) => encodeURIComponent(segment))
+          .join('/')}`,
+      }),
+    );
   }
 
   async delete(records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/tx-cos.ts
@@ -150,6 +150,38 @@ export default class extends StorageType {
     });
   }
 
+  async exists(record: AttachmentModel): Promise<boolean> {
+    const { cos } = this.make() as any;
+    try {
+      await promisify(cos.headObject).call(cos, {
+        Region: this.storage.options.Region,
+        Bucket: this.storage.options.Bucket,
+        Key: getFileKey(record),
+      });
+      return true;
+    } catch (error) {
+      if (['NoSuchKey', 'NotFound'].includes((error as Error).name)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async copy(source: AttachmentModel, target: AttachmentModel): Promise<void> {
+    const { cos } = this.make() as any;
+    const sourceKey = getFileKey(source);
+    const copySource = `${this.storage.options.Bucket}.cos.${this.storage.options.Region}.myqcloud.com/${sourceKey
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/')}`;
+    await promisify(cos.putObjectCopy).call(cos, {
+      Region: this.storage.options.Region,
+      Bucket: this.storage.options.Bucket,
+      Key: getFileKey(target),
+      CopySource: copySource,
+    });
+  }
+
   async delete(records: AttachmentModel[]): Promise<[number, AttachmentModel[]]> {
     const { cos } = this.make() as any;
     const { Deleted } = await promisify(cos.deleteMultipleObject).call(cos, {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
@@ -24,14 +24,14 @@ function sanitizeFilename(value: string) {
 }
 
 function normalizeOriginalname(file) {
-  const originalname = file?.originalname;
+  const originalname: string | Buffer | undefined = file?.originalname;
   if (!originalname) {
     return '';
   }
   if (Buffer.isBuffer(originalname)) {
     return originalname.toString('utf8');
   }
-  if (Array.from(originalname).some((char) => char.charCodeAt(0) > 0xff)) {
+  if (Array.from(originalname).some((char: string) => char.charCodeAt(0) > 0xff)) {
     return originalname;
   }
   const decoded = Buffer.from(originalname, 'binary').toString('utf8');

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
@@ -12,6 +12,17 @@ import crypto from 'crypto';
 import path from 'path';
 import urlJoin from 'url-join';
 
+const INVALID_FILENAME_CHARS = new Set(['<', '>', '?', '*', '|', ':', '"', '\\', '/']);
+
+function sanitizeFilename(value: string) {
+  return Array.from(value)
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127 || INVALID_FILENAME_CHARS.has(char) ? '-' : char;
+    })
+    .join('');
+}
+
 function normalizeOriginalname(file) {
   const originalname = file?.originalname;
   if (!originalname) {
@@ -19,6 +30,9 @@ function normalizeOriginalname(file) {
   }
   if (Buffer.isBuffer(originalname)) {
     return originalname.toString('utf8');
+  }
+  if (Array.from(originalname).some((char) => char.charCodeAt(0) > 0xff)) {
+    return originalname;
   }
   const decoded = Buffer.from(originalname, 'binary').toString('utf8');
   if (decoded.includes('\uFFFD')) {
@@ -30,14 +44,14 @@ function normalizeOriginalname(file) {
 export function getFilename(req, file, cb) {
   const originalname = normalizeOriginalname(file);
   // Filename in Windows cannot contain the following characters: < > ? * | : " \ /
-  const baseName = path.basename(originalname.replace(/[<>?*|:"\\/]/g, '-'), path.extname(originalname));
+  const baseName = path.basename(sanitizeFilename(originalname), path.extname(originalname));
   cb(null, `${baseName}-${uid(6)}${path.extname(originalname)}`);
 }
 
 function getOriginalFilename(file) {
   const originalname = normalizeOriginalname(file);
   const extname = path.extname(originalname);
-  const baseName = path.basename(originalname.replace(/[<>?*|:"\\/]/g, '-'), extname);
+  const baseName = path.basename(sanitizeFilename(originalname), extname);
   return `${baseName}${extname}`;
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Office online preview can fail for files whose original names contain Chinese characters. In the S3 Pro direct-upload flow, the browser already sends a Unicode filename, but `cloudFilenameGetter()` tried to decode it as binary/latin1 again. Some Chinese characters were converted into ASCII/control characters, for example `通` could become `0x1A`, producing object keys that S3 can download but Office viewer cannot extract.

Existing affected files may still need manual repair because this code fix only affects newly uploaded files.

### Description 
- Preserve filenames that are already Unicode strings instead of binary-decoding them again.
- Keep compatibility for binary-encoded UTF-8 filenames.
- Sanitize ASCII control characters in generated filenames.
- Add regression tests for normal Unicode filenames and control-character sanitization.
- Add repair command for admins to migrate legacy filenames.

Potential risk: filename normalization changes only for upload-time generated filenames. Existing stored attachment keys are not automatically migrated by this PR.

Testing suggestions:
- Upload and preview an Office file named like `1 场景_用户[普通表]-jypc1s.xlsx`.
- Verify generated object keys no longer contain `%1A` or other control-character escapes.
- For existing records, use the `yarn nocobase file-manager repair-filenames` command to migrate.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Unicode filename normalization during file uploads to avoid generating object keys with control characters. |
| 🇨🇳 Chinese | 修复文件上传时 Unicode 文件名被错误二次解码的问题，避免生成包含控制字符的对象 key。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
