### PR TITLE
fix(client-v2): avoid layout thrashing in plugin manager cards on Windows

### DIFF
--- a/packages/core/client-v2/src/settings-center/plugin-manager/PluginCard.tsx
+++ b/packages/core/client-v2/src/settings-center/plugin-manager/PluginCard.tsx
@@ -250,7 +250,16 @@ export const PluginCard: FC<PluginCardProps> = ({ data }) => {
       >
         <Card.Meta
           description={
-            <Typography.Paragraph type="secondary" ellipsis={{ rows: 2 }} style={{ marginBottom: 0 }}>
+            <Typography.Paragraph
+              type="secondary"
+              className={css`
+                display: -webkit-box;
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 2;
+                overflow: hidden;
+                margin-bottom: 0;
+              `}
+            >
               {description}
             </Typography.Paragraph>
           }


### PR DESCRIPTION
### This is a ...
- [x] Bug fix

### Motivation

On Windows Chrome, the v2 plugin manager page (`/v2/admin/settings/plugin-manager`) is unusably slow:

- Initial load shows a blank screen for **>5s**.
- After typing into the search box and clearing it, the full plugin list takes **>8s** to re-render.

The equivalent v1 page (`/admin/settings/plugin-manager`) is smooth on Windows, and v2 itself is smooth on macOS — so the cards/data are not the issue.

A Chrome performance trace from the affected Windows machine shows the cost is concentrated in style/layout:

- 5.7s window: **2825ms in Layout** (49%), 124 Layout events, 123 of them with `dirtyObjects=35`.
- 14s window (search → clear): **9629ms in Layout** (69%), 383 Layout events, 365 of them with `dirtyObjects=35`. A single `FunctionCall` runs the main thread for 8069ms.

The stack trace points at antd's Typography ellipsis hook.

### Description

- Root cause: `PluginCard.tsx` used `<Typography.Paragraph ellipsis={{ rows: 2 }}>` for the description. antd wraps such elements in `rc-resize-observer` and runs `isEleEllipsis` inside a `useEffect`. That function calls `appendChild` then `getBoundingClientRect()` twice, forcing two synchronous layouts per card on every relevant dependency change. With ~50 cards mounting at once, this becomes hundreds of forced layouts.
- Fix: replace the `ellipsis` prop with plain CSS line-clamp — `display: -webkit-box; -webkit-line-clamp: 2; overflow: hidden` — exactly matching the v1 implementation. Visual output is unchanged (two-line truncation with `…`), but no JS measurement is involved.
- Why Windows is hit harder: each forced layout costs much more there (DirectWrite + DirectComposition), so the same code path that is ~500ms total on macOS adds up to 5–10s on Windows.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve plugin manager page performance by using CSS line-clamp instead of antd Typography ellipsis. |
| 🇨🇳 Chinese | 通过使用 CSS line-clamp 替代 antd Typography 的 ellipsis 测量，优化插件管理页面的性能。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
