### PR TITLE
fix(client): fix header badge width

### DIFF
--- a/packages/core/client/src/plugin-manager/PinnedPluginListProvider.tsx
+++ b/packages/core/client/src/plugin-manager/PinnedPluginListProvider.tsx
@@ -70,6 +70,12 @@ const pinnedPluginListClassName = css`
         line-height: 10px;
         font-size: 8px;
       }
+      > .ant-badge-count-sm {
+        min-width: 12px;
+      }
+      > .ant-badge-multiple-words {
+        padding: 0 4px;
+      }
     }
 
     &:hover {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
默认主题下，顶部导航栏里带数字的图标徽标背景会比数字本身宽很多，显示效果不符合预期；紧凑主题下显示正常。

### Description 
调整顶部导航栏插件入口内的小号数字徽标宽度，让默认主题下的数字背景宽度与紧凑主题保持一致。

影响范围限制在顶部导航栏右侧插件入口，不影响菜单徽标、页签徽标和页面内容里的徽标。

测试建议：切换默认主题和紧凑主题，检查顶部导航栏中的消息和工作流待办数字徽标宽度是否正常。

### Showcase
-

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the badge width in the top navigation bar |
| 🇨🇳 Chinese | 修复顶部导航栏数字徽标背景过宽的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
