### PR TITLE
fix(plugin-workflow-custom-action-trigger): filter workflows by context type

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client/flows.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client/flows.tsx
@@ -17,6 +17,14 @@ import { ContextDataJsonInput } from './components';
 
 const customActionDescription = `{{t('Workflow will be triggered directly once the button clicked, without data saving. Only supports to be bound with "Custom action event".', { ns: "${NAMESPACE}" })}}`;
 
+function matchWorkflowContextType(config?: { type?: number | null } | null, contextType?: number | null) {
+  const configType = config?.type;
+  if (contextType === CONTEXT_TYPE.GLOBAL || contextType == null) {
+    return configType === CONTEXT_TYPE.GLOBAL || configType == null;
+  }
+  return configType === contextType;
+}
+
 export class FormTriggerWorkflowActionModel extends FormActionModel {
   defaultProps: ButtonProps = {
     title: tExpr('Trigger workflow', { ns: NAMESPACE }),
@@ -191,7 +199,7 @@ function CollectionActionWorkflowSelectComponent({ ...props }) {
   const optionFilter = useCallback(
     ({ config }) => {
       const { type } = model.stepParams.customCollectionTriggerWorkflowsActionSettings.setContextType;
-      return (type && config.type === type) || !config.type;
+      return matchWorkflowContextType(config, type);
     },
     [model.stepParams.customCollectionTriggerWorkflowsActionSettings.setContextType],
   );
@@ -378,7 +386,7 @@ function globalTriggerWorkflowUiSchema(ctx) {
     },
     description: `{{t('Only support custom action workflow with context type set to "Custom context".', { ns: "${NAMESPACE}" })}}`,
     optionFilter({ config }) {
-      return !config.type;
+      return matchWorkflowContextType(config, CONTEXT_TYPE.GLOBAL);
     },
     usingContext: false,
   })(ctx);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Custom action table buttons using the multiple records context could bind workflows configured with the custom context type. This happened because `CONTEXT_TYPE.GLOBAL` is `0`, and the client-side option filter treated falsy `config.type` values as globally compatible.

### Description
Use explicit context type matching when filtering custom action workflows:

- Multiple records buttons only list workflows with `config.type === CONTEXT_TYPE.MULTIPLE_RECORDS`.
- Global/custom context buttons continue to list `CONTEXT_TYPE.GLOBAL` workflows and legacy workflows with `null`/`undefined` context type.

Testing suggestions:

- Create one custom action workflow with custom context and one with multiple records context.
- Add a table batch trigger workflow button configured for multiple records.
- Confirm only the multiple records workflow is selectable.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed custom action table buttons with multiple records context incorrectly allowing custom context workflows to be selected. |
| 🇨🇳 Chinese | 修复自定义操作事件表格按钮在多行数据上下文下仍可选择自定义上下文工作流的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
