### PR TITLE
feat(plugin-ai): support global variables in llm base url

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/llm-services/llms-schema.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/llm-services/llms-schema.test.ts
@@ -44,7 +44,7 @@ describe('LLM Schema', () => {
       expect(drawerProperties.options.type).toBe('object');
       expect(drawerProperties['options.baseURL']).toBeDefined();
       expect(drawerProperties['options.baseURL'].type).toBe('string');
-      expect(drawerProperties['options.baseURL']['x-component']).toBe('Input');
+      expect(drawerProperties['options.baseURL']['x-component']).toBe('TextAreaWithGlobalScope');
     });
 
     it('includes LLMTestFlight in create form footer', () => {
@@ -61,6 +61,7 @@ describe('LLM Schema', () => {
       expect(editDrawerProperties.provider['x-component']).toBe('ProviderDisplay');
       expect(editDrawerProperties.enabledModels.type).toBe('object');
       expect(editDrawerProperties.enabledModels['x-component']).toBe('EnabledModelsSelect');
+      expect(editDrawerProperties['options.baseURL']['x-component']).toBe('TextAreaWithGlobalScope');
     });
 
     it('includes LLMTestFlight in edit form footer', () => {

--- a/packages/plugins/@nocobase/plugin-ai/src/client/schemas/llms.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/schemas/llms.ts
@@ -58,7 +58,7 @@ export const createLLMSchema = {
           type: 'string',
           'x-decorator': 'FormItem',
           title: '{{ t("Base URL") }}',
-          'x-component': 'Input',
+          'x-component': 'TextAreaWithGlobalScope',
           'x-component-props': {
             placeholder: '{{ t("Base URL is optional, leave blank to use default (recommended)") }}',
           },
@@ -286,7 +286,7 @@ export const llmsSchema = {
                               type: 'string',
                               'x-decorator': 'FormItem',
                               title: '{{ t("Base URL") }}',
-                              'x-component': 'Input',
+                              'x-component': 'TextAreaWithGlobalScope',
                               'x-component-props': {
                                 placeholder:
                                   '{{ t("Base URL is optional, leave blank to use default (recommended)") }}',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Allow the LLM Base URL field in the schema-based create and edit forms to use global-scope variables, matching other provider settings that already support variable input.

### Description 
Switch the `Base URL` field from `Input` to `TextAreaWithGlobalScope` in both the create drawer and edit form schema for AI LLM services.

Potential risk is low because the change only affects the field renderer in the client schema.

Testing suggestion: create or edit an LLM service, insert a global variable into `Base URL`, and verify the value is accepted and persisted.

Tests were not run in this session.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved the LLM Base URL field so it can use global-scope variables in create and edit forms. |
| 🇨🇳 Chinese | 改进 LLM 的 Base URL 字段，使其在创建和编辑表单中都支持使用全局变量。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
