### PR TITLE
fix(plugin-ai): recover AI shortcut context after referenced block removal

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx
@@ -7,9 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Avatar, Spin, Popover, Card, Tag, Select, Switch, Typography } from 'antd';
-import { FlowModel, tExpr, useFlowSettingsContext, observer } from '@nocobase/flow-engine';
+import { FlowModel, tExpr, useFlowSettingsContext, observer, useFlowContext } from '@nocobase/flow-engine';
 import { avatars } from '../../avatars';
 import { AIEmployee, TriggerTaskOptions, ContextItem as ContextItemType } from '../../types';
 import { useChatBoxActions } from '../../chatbox/hooks/useChatBoxActions';
@@ -56,6 +56,7 @@ const Shortcut: React.FC<ShortcutProps> = ({
   context,
   auto,
 }) => {
+  const ctx = useFlowContext();
   const { size, mask } = style;
   const [focus, setFocus] = useState(false);
   const aiConfigRepository = useAIConfigRepository();
@@ -86,6 +87,29 @@ const Shortcut: React.FC<ShortcutProps> = ({
     });
   }, [aiEmployee, focus, showNotice, mask]);
 
+  const getShortcutContext = useCallback(() => {
+    const workContext = context.workContext ?? [];
+    if (!workContext.length) {
+      return workContext;
+    }
+    const nextWorkContext = workContext.filter((item) => {
+      if (item.type !== 'flow-model') {
+        return true;
+      }
+      return Boolean(ctx.engine.getModel(item.uid));
+    });
+    if (nextWorkContext.every((item) => item.type !== 'flow-model')) {
+      const parent = ctx.model.parent;
+      if (parent) {
+        nextWorkContext.push({
+          type: 'flow-model',
+          uid: parent.uid,
+        });
+      }
+    }
+    return nextWorkContext;
+  }, [ctx, context.workContext]);
+
   if (!aiEmployee) {
     return null;
   }
@@ -108,8 +132,9 @@ const Shortcut: React.FC<ShortcutProps> = ({
           onClick={() => {
             triggerTask({ aiEmployee, tasks, auto });
             if (context?.workContext?.length) {
-              addContextItems(context.workContext);
-              syncContextAttachments(context.workContext);
+              const shortcutContext = getShortcutContext();
+              addContextItems(shortcutContext);
+              syncContextAttachments(shortcutContext);
             }
           }}
         />


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When a referenced table block is deleted, clicking the AI employee shortcut from a table that still references that block can send a stale `flow-model` context and result in an empty block context in the chat session.

### Description
- Filter invalid `flow-model` items out of the shortcut work context before sending it to the AI chatbox.
- Fall back to the current model's parent block when the referenced block has been removed and no valid flow-model context remains.
- Reuse the normalized context for attachment syncing so the shortcut and attachment state stay aligned.
- Self-tested with `yarn eslint --fix packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx`.
- Verified related client tests with `yarn test packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/model.test.ts --run --reporter=verbose`.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI shortcut buttons getting an empty block context after referenced table blocks are removed. |
| 🇨🇳 Chinese | 修复引用表格区块删除后 AI 快捷操作按钮上下文变成一个空区块的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
