### PR TITLE
fix(plugin-workflow): avoid duplicate triggers

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -608,21 +608,24 @@ WorkbenchTriggerWorkflowActionModel.registerFlow({
   },
 });
 
-const triggerWorkflowActionModels: Record<string, ModelConstructor> = {
-  FormTriggerWorkflowActionModel,
-  RecordTriggerWorkflowActionModel,
-  CollectionTriggerWorkflowActionModel,
-  WorkbenchTriggerWorkflowActionModel,
+const triggerWorkflowActionModelsByGroup: Record<string, Record<string, ModelConstructor>> = {
+  CollectionActionGroupModel: {
+    CollectionTriggerWorkflowActionModel,
+  },
+  RecordActionGroupModel: {
+    RecordTriggerWorkflowActionModel,
+  },
+  FormActionGroupModel: {
+    FormTriggerWorkflowActionModel,
+  },
+  ActionPanelGroupActionModel: {
+    WorkbenchTriggerWorkflowActionModel,
+  },
 };
 
 export function registerTriggerWorkflowActionGroups(flowEngine: FlowEngine) {
-  [
-    'CollectionActionGroupModel',
-    'RecordActionGroupModel',
-    'FormActionGroupModel',
-    'ActionPanelGroupActionModel',
-  ].forEach((modelName) => {
+  Object.entries(triggerWorkflowActionModelsByGroup).forEach(([modelName, actionModels]) => {
     const modelClass = flowEngine.getModelClass(modelName) as ActionGroupModelClass | undefined;
-    modelClass?.registerActionModels?.(triggerWorkflowActionModels);
+    modelClass?.registerActionModels?.(actionModels);
   });
 }

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
@@ -1,0 +1,134 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import {
+  ActionGroupModel,
+  CollectionActionGroupModel,
+  FormActionGroupModel,
+  RecordActionGroupModel,
+} from '@nocobase/client-v2';
+import { FlowEngine } from '@nocobase/flow-engine';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CollectionTriggerWorkflowActionModel,
+  FormTriggerWorkflowActionModel,
+  RecordTriggerWorkflowActionModel,
+  registerTriggerWorkflowActionGroups,
+  WorkbenchTriggerWorkflowActionModel,
+} from '../TriggerWorkflowActionModels';
+
+class ActionPanelGroupActionModel extends ActionGroupModel {}
+
+const triggerWorkflowActionModelNames = new Set([
+  'CollectionTriggerWorkflowActionModel',
+  'RecordTriggerWorkflowActionModel',
+  'FormTriggerWorkflowActionModel',
+  'WorkbenchTriggerWorkflowActionModel',
+]);
+
+const actionGroupModelClasses = [
+  CollectionActionGroupModel,
+  RecordActionGroupModel,
+  FormActionGroupModel,
+  ActionPanelGroupActionModel,
+];
+
+let actionGroupModelSnapshots: Array<[any, Map<string, any>]>;
+
+function createEngine() {
+  const flowEngine = new FlowEngine();
+  flowEngine.registerModels({
+    CollectionActionGroupModel,
+    RecordActionGroupModel,
+    FormActionGroupModel,
+    ActionPanelGroupActionModel,
+    FormTriggerWorkflowActionModel,
+    RecordTriggerWorkflowActionModel,
+    CollectionTriggerWorkflowActionModel,
+    WorkbenchTriggerWorkflowActionModel,
+  });
+
+  return flowEngine;
+}
+
+function createCollectionContext(flowEngine: FlowEngine) {
+  const dataSource = flowEngine.dataSourceManager.getDataSource('main');
+  dataSource.addCollection({
+    name: 'posts',
+    filterTargetKey: 'id',
+    availableActions: ['create', 'view', 'update', 'destroy'],
+    fields: [{ name: 'id', type: 'integer', interface: 'number' }],
+  });
+
+  return {
+    engine: flowEngine,
+    dataSourceManager: flowEngine.dataSourceManager,
+    collection: dataSource.getCollection('posts'),
+  } as any;
+}
+
+function restoreActionGroupModels() {
+  for (const [ModelClass, snapshot] of actionGroupModelSnapshots) {
+    ModelClass.currentModels.clear();
+    for (const [name, Model] of snapshot) {
+      ModelClass.currentModels.set(name, Model);
+    }
+  }
+}
+
+function getTriggerWorkflowModelNames(ModelClass: any) {
+  return Array.from(ModelClass.models.keys()).filter((name) => triggerWorkflowActionModelNames.has(name));
+}
+
+async function getTriggerWorkflowItemNames(ModelClass: any, ctx: any) {
+  const items = await ModelClass.defineChildren(ctx);
+  return items.map((item) => item.useModel).filter((name) => triggerWorkflowActionModelNames.has(name));
+}
+
+describe('trigger workflow action model registration', () => {
+  beforeEach(() => {
+    actionGroupModelSnapshots = actionGroupModelClasses.map((ModelClass) => [
+      ModelClass,
+      new Map(ModelClass.currentModels),
+    ]);
+  });
+
+  afterEach(() => {
+    restoreActionGroupModels();
+  });
+
+  it('registers trigger workflow actions only to their matching action groups', () => {
+    const flowEngine = createEngine();
+
+    registerTriggerWorkflowActionGroups(flowEngine);
+
+    expect(getTriggerWorkflowModelNames(CollectionActionGroupModel)).toEqual(['CollectionTriggerWorkflowActionModel']);
+    expect(getTriggerWorkflowModelNames(RecordActionGroupModel)).toEqual(['RecordTriggerWorkflowActionModel']);
+    expect(getTriggerWorkflowModelNames(FormActionGroupModel)).toEqual(['FormTriggerWorkflowActionModel']);
+    expect(getTriggerWorkflowModelNames(ActionPanelGroupActionModel)).toEqual(['WorkbenchTriggerWorkflowActionModel']);
+  });
+
+  it('does not duplicate trigger workflow items in data block action menus', async () => {
+    const flowEngine = createEngine();
+    const ctx = createCollectionContext(flowEngine);
+
+    registerTriggerWorkflowActionGroups(flowEngine);
+
+    expect(await getTriggerWorkflowItemNames(CollectionActionGroupModel, ctx)).toEqual([
+      'CollectionTriggerWorkflowActionModel',
+    ]);
+    expect(await getTriggerWorkflowItemNames(RecordActionGroupModel, ctx)).toEqual([
+      'RecordTriggerWorkflowActionModel',
+    ]);
+    expect(await getTriggerWorkflowItemNames(FormActionGroupModel, ctx)).toEqual(['FormTriggerWorkflowActionModel']);
+    expect(await getTriggerWorkflowItemNames(ActionPanelGroupActionModel, ctx)).toEqual([
+      'WorkbenchTriggerWorkflowActionModel',
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 页面中配置表格、列表等区块操作时，操作菜单里会重复出现多个「Trigger workflow」选项，容易让用户误选，也会影响配置体验。

### Description 
修复 v2 区块操作菜单中「Trigger workflow」重复显示的问题。现在不同位置的操作菜单只会显示适合当前位置的工作流触发操作，表格和列表等区块不会再出现多个同名选项。

已补充测试，覆盖不同操作菜单中工作流触发操作的显示结果。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicate Trigger workflow options in v2 block action menus |
| 🇨🇳 Chinese | 修复 v2 区块操作菜单重复显示触发工作流的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
