### PR TITLE
fix(cli): serve plugin mjs files with javascript mime

### DIFF
--- a/packages/core/cli/nocobase.conf.tpl
+++ b/packages/core/cli/nocobase.conf.tpl
@@ -20,6 +20,9 @@ server {
     client_max_body_size 0;
     access_log /var/log/nginx/nocobase.log apm;
 
+    include /etc/nginx/mime.types;
+    types { application/javascript mjs; }
+
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Some nginx environments do not include a MIME mapping for `.mjs`. Browser module loading rejects `.mjs` files served as `application/octet-stream`, which can break plugin client chunks such as the PDF.js worker used by file-manager PDF previews.

### Description
Update the generated nginx config template to load the standard nginx MIME table and add a server-level `.mjs` mapping to `application/javascript`.

This applies to all `.mjs` files served by the generated NocoBase nginx server while preserving the normal MIME mappings for other static assets.

Testing suggestions:
- Regenerate the nginx config and reload nginx.
- Check an `.mjs` asset with `curl -I` and confirm `Content-Type: application/javascript`.
- Verify PDF preview can load the PDF.js worker in file manager.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix nginx template to serve `.mjs` assets with JavaScript MIME type. |
| 🇨🇳 Chinese | 修复 nginx 模板，使 `.mjs` 静态资源以 JavaScript MIME 类型返回。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary