### PR TITLE
fix(plugin-file-manager): harden local storage paths

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
@@ -8,15 +8,31 @@
  */
 
 import { promises as fs } from 'fs';
+import os from 'os';
 import path from 'path';
 import querystring from 'querystring';
 import { getApp } from '.';
 import { FILE_FIELD_NAME, FILE_SIZE_LIMIT_DEFAULT, STORAGE_TYPE_LOCAL } from '../../constants';
 import PluginFileManagerServer from '../server';
+import { normalizeLocalStoragePath } from '../storages/local';
 
 const { LOCAL_STORAGE_BASE_URL, LOCAL_STORAGE_DEST = 'storage/uploads', APP_PORT = '13000' } = process.env;
 
 const DEFAULT_LOCAL_BASE_URL = LOCAL_STORAGE_BASE_URL || `/storage/uploads`;
+
+describe('local storage path validation', () => {
+  it('should normalize windows path separators', () => {
+    expect(normalizeLocalStoragePath('windows\\path')).toBe('windows/path');
+  });
+
+  it('should reject null byte path', () => {
+    expect(() => normalizeLocalStoragePath('safe\0path')).toThrow('Invalid local storage path');
+  });
+
+  it('should reject non-string path', () => {
+    expect(() => normalizeLocalStoragePath(1)).toThrow('Invalid local storage path');
+  });
+});
 
 describe('action', () => {
   let app;
@@ -477,6 +493,21 @@ describe('action', () => {
         const content = await agent.get(url);
         expect(content.text.includes('Hello world!')).toBe(true);
       });
+
+      it('upload should reject unsafe local storage path at write destination', async () => {
+        const Plugin = app.pm.get(PluginFileManagerServer) as PluginFileManagerServer;
+        const storage = Plugin.storagesCache.get(defaultStorage.id);
+        if (!storage) {
+          throw new Error('Default storage not found');
+        }
+        storage.path = '../outside';
+
+        await expect(
+          Plugin.uploadFile({
+            filePath: path.resolve(__dirname, './files/text.txt'),
+          }),
+        ).rejects.toThrow('Access denied');
+      });
     });
   });
 
@@ -706,6 +737,105 @@ describe('action', () => {
   });
 
   describe('storage actions', () => {
+    it('should reject unsafe local storage documentRoot on create', async () => {
+      const { status } = await agent.resource('storages').create({
+        values: {
+          name: 'unsafe_create',
+          type: STORAGE_TYPE_LOCAL,
+          baseUrl: DEFAULT_LOCAL_BASE_URL,
+          options: {
+            documentRoot: path.resolve(process.cwd(), '..', 'unsafe-local-storage'),
+          },
+        },
+      });
+
+      expect(status).toBe(400);
+    });
+
+    it('should reject unsafe local storage documentRoot on update', async () => {
+      const { status } = await agent.resource('storages').update({
+        filterByTk: defaultStorage.id,
+        values: {
+          options: {
+            documentRoot: '..',
+          },
+        },
+      });
+
+      expect(status).toBe(400);
+
+      const storage = await StorageRepo.findById(defaultStorage.id);
+      expect(storage.options.documentRoot).toBe(LOCAL_STORAGE_DEST);
+    });
+
+    it('should keep trusted existing absolute local storage documentRoot usable', async () => {
+      const documentRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nocobase-local-storage-'));
+
+      try {
+        const storage = await StorageRepo.create({
+          values: {
+            name: 'external_local',
+            type: STORAGE_TYPE_LOCAL,
+            rules: {
+              mimetype: ['text/*'],
+            },
+            path: 'trusted/path',
+            baseUrl: '/external-local',
+            options: {
+              documentRoot,
+            },
+          },
+        });
+
+        db.collection({
+          name: 'externalFiles',
+          fields: [
+            {
+              name: 'file',
+              type: 'belongsTo',
+              target: 'attachments',
+              storage: storage.name,
+            },
+          ],
+        });
+
+        const { body, status } = await agent.resource('attachments').create({
+          attachmentField: 'externalFiles.file',
+          [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
+        });
+
+        expect(status).toBe(200);
+        const content = await fs.readFile(path.join(documentRoot, 'trusted/path', body.data.filename), 'utf8');
+        expect(content.includes('Hello world!')).toBe(true);
+      } finally {
+        await fs.rm(documentRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('should reject unsafe local storage path on create', async () => {
+      const { status } = await agent.resource('storages').create({
+        values: {
+          name: 'unsafe_path_create',
+          type: STORAGE_TYPE_LOCAL,
+          baseUrl: DEFAULT_LOCAL_BASE_URL,
+          path: '../outside',
+        },
+      });
+
+      expect(status).toBe(400);
+    });
+
+    it('should reject unsafe local storage path on update', async () => {
+      const { status } = await agent.resource('storages').update({
+        filterByTk: defaultStorage.id,
+        values: {
+          path: '../outside',
+        },
+      });
+
+      expect(status).toBe(400);
+    });
+
     describe('getBasicInfo', () => {
       it('get default storage', async () => {
         const { body, status } = await agent.resource('storages').getBasicInfo();

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -23,7 +23,12 @@ import {
   STORAGE_TYPE_LOCAL,
 } from '../../constants';
 import { StorageClassType, StorageType } from '../storages';
-import { getDocumentRoot, resolveSafePath } from '../storages/local';
+import {
+  getDocumentRoot,
+  normalizeLocalStoragePath,
+  resolveSafePath,
+  validateLocalStorageConfig,
+} from '../storages/local';
 
 function makeMulterStorage(storage: StorageType) {
   const innerStorage = storage.make();
@@ -192,8 +197,55 @@ async function multipart(ctx: Context, next: Next) {
   await next();
 }
 
+async function validateStorageAction(ctx: Context) {
+  const { actionName, params } = ctx.action;
+  if (!['create', 'update'].includes(actionName)) {
+    return;
+  }
+
+  const values = params.values || {};
+  let storage = values;
+  const hasSubmittedDocumentRoot = Object.prototype.hasOwnProperty.call(values.options || {}, 'documentRoot');
+
+  if (actionName === 'update' && params.filterByTk) {
+    const repository = ctx.db.getRepository('storages');
+    let existing = await repository.findById(params.filterByTk);
+    if (!existing) {
+      existing = await repository.findOne({
+        filter: {
+          name: params.filterByTk,
+        },
+      });
+    }
+    if (existing) {
+      const existingValues = existing.toJSON();
+      storage = {
+        ...existingValues,
+        ...values,
+        options: {
+          ...(existingValues.options || {}),
+          ...(values.options || {}),
+        },
+      };
+    }
+  }
+
+  try {
+    validateLocalStorageConfig(storage, { validateDocumentRoot: hasSubmittedDocumentRoot });
+  } catch (error) {
+    if (['INVALID_LOCAL_STORAGE_PATH', 'PATH_TRAVERSAL'].includes((error as NodeJS.ErrnoException).code)) {
+      return ctx.throw(400, (error as Error).message);
+    }
+    throw error;
+  }
+}
+
 export async function createMiddleware(ctx: Context, next: Next) {
   const { resourceName, actionName } = ctx.action;
+  if (resourceName === 'storages') {
+    await validateStorageAction(ctx);
+  }
+
   const { attachmentField } = ctx.action.params;
   const collection = ctx.db.getCollection(resourceName);
 
@@ -229,10 +281,10 @@ export async function createMiddleware(ctx: Context, next: Next) {
       const filePath = values?.path ?? '';
       const filename = values?.filename ?? '';
       try {
-        resolveSafePath(getDocumentRoot(storage), filePath, filename);
+        resolveSafePath(getDocumentRoot(storage), normalizeLocalStoragePath(filePath), filename);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'PATH_TRAVERSAL') {
-          return ctx.throw(400, error);
+          return ctx.throw(400, (error as Error).message);
         }
         throw error;
       }

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -23,12 +23,7 @@ import {
   STORAGE_TYPE_LOCAL,
 } from '../../constants';
 import { StorageClassType, StorageType } from '../storages';
-import {
-  getDocumentRoot,
-  normalizeLocalStoragePath,
-  resolveSafePath,
-  validateLocalStorageConfig,
-} from '../storages/local';
+import { getDocumentRoot, normalizeLocalStoragePath, resolveSafePath } from '../storages/local';
 
 function makeMulterStorage(storage: StorageType) {
   const innerStorage = storage.make();
@@ -197,55 +192,8 @@ async function multipart(ctx: Context, next: Next) {
   await next();
 }
 
-async function validateStorageAction(ctx: Context) {
-  const { actionName, params } = ctx.action;
-  if (!['create', 'update'].includes(actionName)) {
-    return;
-  }
-
-  const values = params.values || {};
-  let storage = values;
-  const hasSubmittedDocumentRoot = Object.prototype.hasOwnProperty.call(values.options || {}, 'documentRoot');
-
-  if (actionName === 'update' && params.filterByTk) {
-    const repository = ctx.db.getRepository('storages');
-    let existing = await repository.findById(params.filterByTk);
-    if (!existing) {
-      existing = await repository.findOne({
-        filter: {
-          name: params.filterByTk,
-        },
-      });
-    }
-    if (existing) {
-      const existingValues = existing.toJSON();
-      storage = {
-        ...existingValues,
-        ...values,
-        options: {
-          ...(existingValues.options || {}),
-          ...(values.options || {}),
-        },
-      };
-    }
-  }
-
-  try {
-    validateLocalStorageConfig(storage, { validateDocumentRoot: hasSubmittedDocumentRoot });
-  } catch (error) {
-    if (['INVALID_LOCAL_STORAGE_PATH', 'PATH_TRAVERSAL'].includes((error as NodeJS.ErrnoException).code)) {
-      return ctx.throw(400, (error as Error).message);
-    }
-    throw error;
-  }
-}
-
 export async function createMiddleware(ctx: Context, next: Next) {
   const { resourceName, actionName } = ctx.action;
-  if (resourceName === 'storages') {
-    await validateStorageAction(ctx);
-  }
-
   const { attachmentField } = ctx.action.params;
   const collection = ctx.db.getCollection(resourceName);
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/index.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/index.ts
@@ -9,12 +9,19 @@
 
 import actions from '@nocobase/actions';
 import { createMiddleware } from './attachments';
+import { validateStorageMiddleware } from './storage-validation';
 import * as storageActions from './storages';
 
 export default function ({ app }) {
   app.resourcer.define({
     name: 'storages',
     actions: storageActions,
+    middlewares: [
+      {
+        only: ['create', 'update'],
+        handler: validateStorageMiddleware,
+      },
+    ],
   });
   app.resourcer.use(createMiddleware, { tag: 'createMiddleware', after: 'auth' });
   app.resourcer.registerActionHandler('upload', actions.create);

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/storage-validation.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/storage-validation.ts
@@ -43,7 +43,7 @@ export async function validateStorageMiddleware(ctx: Context, next: Next) {
   try {
     validateLocalStorageConfig(storage, { validateDocumentRoot: hasSubmittedDocumentRoot });
   } catch (error) {
-    if (['INVALID_LOCAL_STORAGE_PATH', 'PATH_TRAVERSAL'].includes((error as NodeJS.ErrnoException).code)) {
+    if ((error as NodeJS.ErrnoException).code === 'PATH_TRAVERSAL') {
       return ctx.throw(400, (error as Error).message);
     }
     throw error;

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/storage-validation.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/storage-validation.ts
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Context, Next } from '@nocobase/actions';
+
+import { validateLocalStorageConfig } from '../storages/local';
+
+export async function validateStorageMiddleware(ctx: Context, next: Next) {
+  const { actionName, params } = ctx.action;
+  const values = params.values || {};
+  let storage = values;
+  const hasSubmittedDocumentRoot = Object.prototype.hasOwnProperty.call(values.options || {}, 'documentRoot');
+
+  if (actionName === 'update' && params.filterByTk) {
+    const repository = ctx.db.getRepository('storages');
+    let existing = await repository.findById(params.filterByTk);
+    if (!existing) {
+      existing = await repository.findOne({
+        filter: {
+          name: params.filterByTk,
+        },
+      });
+    }
+    if (existing) {
+      const existingValues = existing.toJSON();
+      storage = {
+        ...existingValues,
+        ...values,
+        options: {
+          ...(existingValues.options || {}),
+          ...(values.options || {}),
+        },
+      };
+    }
+  }
+
+  try {
+    validateLocalStorageConfig(storage, { validateDocumentRoot: hasSubmittedDocumentRoot });
+  } catch (error) {
+    if (['INVALID_LOCAL_STORAGE_PATH', 'PATH_TRAVERSAL'].includes((error as NodeJS.ErrnoException).code)) {
+      return ctx.throw(400, (error as Error).message);
+    }
+    throw error;
+  }
+
+  await next();
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
@@ -20,7 +20,7 @@ import initActions from './actions';
 import { AttachmentInterface } from './interfaces/attachment-interface';
 import { AttachmentModel, GetFileStreamOptions, StorageClassType, StorageModel } from './storages';
 import StorageTypeAliOss from './storages/ali-oss';
-import StorageTypeLocal from './storages/local';
+import StorageTypeLocal, { validateLocalStorageConfig } from './storages/local';
 import StorageTypeS3 from './storages/s3';
 import StorageTypeTxCos from './storages/tx-cos';
 import { encodeURL } from './utils';
@@ -232,6 +232,9 @@ export class PluginFileManagerServer extends Plugin {
     this.storageTypes.register(STORAGE_TYPE_TX_COS, StorageTypeTxCos);
 
     const Storage = this.db.getModel('storages');
+    Storage.beforeSave((m) => {
+      validateLocalStorageConfig(m.toJSON());
+    });
     Storage.afterSave(async (m, { transaction }) => {
       await this.loadStorages({ transaction });
       this.sendSyncMessage({ type: 'reloadStorages' }, { transaction });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/local.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/local.ts
@@ -19,100 +19,50 @@ import { FILE_SIZE_LIMIT_DEFAULT, STORAGE_TYPE_LOCAL } from '../../constants';
 import { diskFilenameGetter } from '../utils';
 
 const DEFAULT_BASE_URL = '/storage/uploads';
-const SAFE_LOCAL_STORAGE_ROOT = 'storage';
-const LOCAL_STORAGE_ALLOWED_ROOTS = 'LOCAL_STORAGE_ALLOWED_ROOTS';
+const DEFAULT_DOCUMENT_ROOT = process.env.LOCAL_STORAGE_DEST || path.join(process.cwd(), 'storage', 'uploads');
 
-function createInvalidLocalStoragePathError(message: string) {
-  const error = new Error(message);
-  (error as NodeJS.ErrnoException).code = 'INVALID_LOCAL_STORAGE_PATH';
+function pathError(message: string) {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = 'PATH_TRAVERSAL';
   return error;
 }
 
-function assertSafeChildPath(basePath: string, targetPath: string, message: string) {
-  const relative = path.relative(basePath, targetPath);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw createInvalidLocalStoragePathError(message);
-  }
+function isInside(base: string, target: string) {
+  const relative = path.relative(base, target);
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
 }
 
 function resolveDocumentRoot(documentRoot: unknown) {
-  if (typeof documentRoot !== 'string' || !documentRoot) {
-    throw createInvalidLocalStoragePathError('Invalid local storage document root');
+  if (typeof documentRoot !== 'string' || !documentRoot || documentRoot.includes('\0')) {
+    throw pathError('Invalid local storage document root');
   }
-  if (documentRoot.includes('\0')) {
-    throw createInvalidLocalStoragePathError('Invalid local storage document root');
-  }
-
   return path.resolve(path.isAbsolute(documentRoot) ? documentRoot : path.join(process.cwd(), documentRoot));
 }
 
-function getDefaultAllowedDocumentRoots() {
-  const roots = [path.resolve(process.cwd(), SAFE_LOCAL_STORAGE_ROOT)];
-
-  if (process.env.LOCAL_STORAGE_DEST) {
-    roots.push(resolveDocumentRoot(process.env.LOCAL_STORAGE_DEST));
-  }
-
-  if (process.env[LOCAL_STORAGE_ALLOWED_ROOTS]) {
-    for (const root of process.env[LOCAL_STORAGE_ALLOWED_ROOTS].split(',')) {
-      const trimmed = root.trim();
-      if (trimmed) {
-        roots.push(resolveDocumentRoot(trimmed));
-      }
+// 受信任的允许根：<cwd>/storage 加上环境变量显式声明的目录
+function allowedRoots() {
+  const roots = [path.resolve(process.cwd(), 'storage')];
+  const extra = [process.env.LOCAL_STORAGE_DEST, ...(process.env.LOCAL_STORAGE_ALLOWED_ROOTS?.split(',') ?? [])];
+  for (const item of extra) {
+    if (item?.trim()) {
+      roots.push(resolveDocumentRoot(item.trim()));
     }
   }
-
   return roots;
-}
-
-export function validateLocalDocumentRoot(documentRoot: unknown, allowedRoots = getDefaultAllowedDocumentRoots()) {
-  const resolvedDocumentRoot = resolveDocumentRoot(documentRoot);
-  if (
-    !allowedRoots.some((allowedRoot) => {
-      try {
-        assertSafeChildPath(allowedRoot, resolvedDocumentRoot, 'Invalid local storage document root');
-        return true;
-      } catch (error) {
-        return false;
-      }
-    })
-  ) {
-    throw createInvalidLocalStoragePathError('Invalid local storage document root');
-  }
-  return resolvedDocumentRoot;
 }
 
 export function normalizeLocalStoragePath(storagePath?: unknown) {
   if (storagePath == null || storagePath === '') {
     return '';
   }
-  if (typeof storagePath !== 'string') {
-    throw createInvalidLocalStoragePathError('Invalid local storage path');
-  }
-  if (storagePath.includes('\0')) {
-    throw createInvalidLocalStoragePathError('Invalid local storage path');
+  if (typeof storagePath !== 'string' || storagePath.includes('\0')) {
+    throw pathError('Invalid local storage path');
   }
   return storagePath.replace(/\\/g, '/').replace(/^\/+/, '');
 }
 
-export function validateLocalStorageConfig(
-  storage: Pick<StorageType['storage'], 'type' | 'options' | 'path'>,
-  options: { validateDocumentRoot?: boolean } = {},
-) {
-  if (storage.type !== STORAGE_TYPE_LOCAL) {
-    return;
-  }
-  const { documentRoot = process.env.LOCAL_STORAGE_DEST || path.join(process.cwd(), 'storage', 'uploads') } =
-    storage.options || {};
-  const resolvedDocumentRoot = options.validateDocumentRoot
-    ? validateLocalDocumentRoot(documentRoot)
-    : resolveDocumentRoot(documentRoot);
-  resolveSafePath(resolvedDocumentRoot, normalizeLocalStoragePath(storage.path));
-}
-
 export function getDocumentRoot(storage): string {
-  const { documentRoot = process.env.LOCAL_STORAGE_DEST || path.join(process.cwd(), 'storage', 'uploads') } =
-    storage.options || {};
+  const { documentRoot = DEFAULT_DOCUMENT_ROOT } = storage.options || {};
   // TODO(feature): 后面考虑以字符串模板的方式使用，可注入 req/action 相关变量，以便于区分文件夹
   return resolveDocumentRoot(documentRoot);
 }
@@ -120,13 +70,25 @@ export function getDocumentRoot(storage): string {
 export function resolveSafePath(documentRoot: string, filePath?: string, filename?: string) {
   const root = path.resolve(documentRoot);
   const target = path.resolve(root, filePath || '', filename || '');
-  const relative = path.relative(root, target);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    const error = new Error('Access denied');
-    (error as NodeJS.ErrnoException).code = 'PATH_TRAVERSAL';
-    throw error;
+  if (!isInside(root, target)) {
+    throw pathError('Access denied');
   }
   return target;
+}
+
+export function validateLocalStorageConfig(
+  storage: Pick<StorageType['storage'], 'type' | 'options' | 'path'>,
+  { validateDocumentRoot = false } = {},
+) {
+  if (storage.type !== STORAGE_TYPE_LOCAL) {
+    return;
+  }
+  const root = getDocumentRoot(storage);
+  // 仅对用户提交的 documentRoot 走白名单校验；env/已存值视为可信
+  if (validateDocumentRoot && !allowedRoots().some((allowed) => isInside(allowed, root))) {
+    throw pathError('Invalid local storage document root');
+  }
+  resolveSafePath(root, normalizeLocalStoragePath(storage.path));
 }
 
 export default class extends StorageType {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/local.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/storages/local.ts
@@ -19,12 +19,102 @@ import { FILE_SIZE_LIMIT_DEFAULT, STORAGE_TYPE_LOCAL } from '../../constants';
 import { diskFilenameGetter } from '../utils';
 
 const DEFAULT_BASE_URL = '/storage/uploads';
+const SAFE_LOCAL_STORAGE_ROOT = 'storage';
+const LOCAL_STORAGE_ALLOWED_ROOTS = 'LOCAL_STORAGE_ALLOWED_ROOTS';
+
+function createInvalidLocalStoragePathError(message: string) {
+  const error = new Error(message);
+  (error as NodeJS.ErrnoException).code = 'INVALID_LOCAL_STORAGE_PATH';
+  return error;
+}
+
+function assertSafeChildPath(basePath: string, targetPath: string, message: string) {
+  const relative = path.relative(basePath, targetPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw createInvalidLocalStoragePathError(message);
+  }
+}
+
+function resolveDocumentRoot(documentRoot: unknown) {
+  if (typeof documentRoot !== 'string' || !documentRoot) {
+    throw createInvalidLocalStoragePathError('Invalid local storage document root');
+  }
+  if (documentRoot.includes('\0')) {
+    throw createInvalidLocalStoragePathError('Invalid local storage document root');
+  }
+
+  return path.resolve(path.isAbsolute(documentRoot) ? documentRoot : path.join(process.cwd(), documentRoot));
+}
+
+function getDefaultAllowedDocumentRoots() {
+  const roots = [path.resolve(process.cwd(), SAFE_LOCAL_STORAGE_ROOT)];
+
+  if (process.env.LOCAL_STORAGE_DEST) {
+    roots.push(resolveDocumentRoot(process.env.LOCAL_STORAGE_DEST));
+  }
+
+  if (process.env[LOCAL_STORAGE_ALLOWED_ROOTS]) {
+    for (const root of process.env[LOCAL_STORAGE_ALLOWED_ROOTS].split(',')) {
+      const trimmed = root.trim();
+      if (trimmed) {
+        roots.push(resolveDocumentRoot(trimmed));
+      }
+    }
+  }
+
+  return roots;
+}
+
+export function validateLocalDocumentRoot(documentRoot: unknown, allowedRoots = getDefaultAllowedDocumentRoots()) {
+  const resolvedDocumentRoot = resolveDocumentRoot(documentRoot);
+  if (
+    !allowedRoots.some((allowedRoot) => {
+      try {
+        assertSafeChildPath(allowedRoot, resolvedDocumentRoot, 'Invalid local storage document root');
+        return true;
+      } catch (error) {
+        return false;
+      }
+    })
+  ) {
+    throw createInvalidLocalStoragePathError('Invalid local storage document root');
+  }
+  return resolvedDocumentRoot;
+}
+
+export function normalizeLocalStoragePath(storagePath?: unknown) {
+  if (storagePath == null || storagePath === '') {
+    return '';
+  }
+  if (typeof storagePath !== 'string') {
+    throw createInvalidLocalStoragePathError('Invalid local storage path');
+  }
+  if (storagePath.includes('\0')) {
+    throw createInvalidLocalStoragePathError('Invalid local storage path');
+  }
+  return storagePath.replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+export function validateLocalStorageConfig(
+  storage: Pick<StorageType['storage'], 'type' | 'options' | 'path'>,
+  options: { validateDocumentRoot?: boolean } = {},
+) {
+  if (storage.type !== STORAGE_TYPE_LOCAL) {
+    return;
+  }
+  const { documentRoot = process.env.LOCAL_STORAGE_DEST || path.join(process.cwd(), 'storage', 'uploads') } =
+    storage.options || {};
+  const resolvedDocumentRoot = options.validateDocumentRoot
+    ? validateLocalDocumentRoot(documentRoot)
+    : resolveDocumentRoot(documentRoot);
+  resolveSafePath(resolvedDocumentRoot, normalizeLocalStoragePath(storage.path));
+}
 
 export function getDocumentRoot(storage): string {
   const { documentRoot = process.env.LOCAL_STORAGE_DEST || path.join(process.cwd(), 'storage', 'uploads') } =
     storage.options || {};
   // TODO(feature): 后面考虑以字符串模板的方式使用，可注入 req/action 相关变量，以便于区分文件夹
-  return path.resolve(path.isAbsolute(documentRoot) ? documentRoot : path.join(process.cwd(), documentRoot));
+  return resolveDocumentRoot(documentRoot);
 }
 
 export function resolveSafePath(documentRoot: string, filePath?: string, filename?: string) {
@@ -59,7 +149,7 @@ export default class extends StorageType {
   make() {
     return multer.diskStorage({
       destination: (req, file, cb) => {
-        const destPath = path.join(getDocumentRoot(this.storage), this.storage.path || '');
+        const destPath = resolveSafePath(getDocumentRoot(this.storage), normalizeLocalStoragePath(this.storage.path));
         const mkdirp = require('mkdirp');
         mkdirp(destPath, (err: Error | null) => cb(err, destPath));
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Local file storage accepted user-controlled storage paths that could escape the configured document root in create/update and upload flows. The fix needs to block path traversal while preserving trusted existing deployments that use absolute external document roots, such as mounted volumes or NFS paths.

### Description
- Validate local storage `documentRoot` only when it is submitted through storage create/update APIs, using `<cwd>/storage`, `LOCAL_STORAGE_DEST`, and `LOCAL_STORAGE_ALLOWED_ROOTS` as allowed roots.
- Preserve backward compatibility for trusted existing/runtime `documentRoot` values, including absolute paths outside the repository storage directory.
- Normalize and validate local storage `path`, including Windows separators, null bytes, and non-string values.
- Use safe path resolution for local upload destinations and attachment create/update validation.
- Add tests for unsafe absolute document roots, unsafe storage paths, trusted external absolute document roots, upload write destinations, Windows separators, null bytes, and non-string path values.

Potential risk: symlink traversal is not fully hardened in this change because the path checks are lexical and do not resolve filesystem realpaths. That remains a separate hardening item if attackers can create symlinks inside the local storage root.

### Related issues
GHSA-ghvf-qf6h-g8x5

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed local file storage path validation to prevent unsafe paths from escaping the configured storage root. |
| 🇨🇳 Chinese | 修复本地文件存储路径校验，阻止不安全路径逃逸出配置的存储根目录。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

