### PR TITLE
fix(plugin-notification-in-app-message): validate channel timestamp filter

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/__tests__/server.test.ts
@@ -259,6 +259,154 @@ describe('inapp message channels', () => {
       expect(res.body.data.length).toBe(1);
       expect(res.body.data[0].name).toBe(targetChannel.name);
     });
+
+    test('filter channel by latest message receive timestamp', async () => {
+      const channels = await channelsRepo.create({
+        values: [
+          {
+            title: 'old_channel',
+            notificationType: 'in-app-message',
+          },
+          {
+            title: 'new_channel',
+            notificationType: 'in-app-message',
+          },
+        ],
+      });
+      const oldChannel = channels.find((channel) => channel.title === 'old_channel');
+      const newChannel = channels.find((channel) => channel.title === 'new_channel');
+      const now = Date.now();
+
+      await messagesRepo.create({
+        values: [
+          {
+            channelName: oldChannel.name,
+            userId: currUserId,
+            status: 'unread',
+            title: 'old message',
+            content: 'old content',
+            receiveTimestamp: now - 1000,
+          },
+          {
+            channelName: newChannel.name,
+            userId: currUserId,
+            status: 'unread',
+            title: 'new message',
+            content: 'new content',
+            receiveTimestamp: now,
+          },
+        ],
+      });
+
+      const res = await currUserAgent.resource('myInAppChannels').list({
+        filter: {
+          latestMsgReceiveTimestamp: {
+            $lt: now,
+          },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].name).toBe(oldChannel.name);
+    });
+
+    test('should accept numeric string latest message receive timestamp filter', async () => {
+      const channels = await channelsRepo.create({
+        values: [
+          {
+            title: 'old_channel',
+            notificationType: 'in-app-message',
+          },
+          {
+            title: 'new_channel',
+            notificationType: 'in-app-message',
+          },
+        ],
+      });
+      const oldChannel = channels.find((channel) => channel.title === 'old_channel');
+      const newChannel = channels.find((channel) => channel.title === 'new_channel');
+      const now = Date.now();
+
+      await messagesRepo.create({
+        values: [
+          {
+            channelName: oldChannel.name,
+            userId: currUserId,
+            status: 'unread',
+            title: 'old message',
+            content: 'old content',
+            receiveTimestamp: now - 1000,
+          },
+          {
+            channelName: newChannel.name,
+            userId: currUserId,
+            status: 'unread',
+            title: 'new message',
+            content: 'new content',
+            receiveTimestamp: now,
+          },
+        ],
+      });
+
+      const res = await currUserAgent.resource('myInAppChannels').list({
+        filter: {
+          latestMsgReceiveTimestamp: {
+            $lt: String(now),
+          },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].name).toBe(oldChannel.name);
+    });
+
+    test('should accept zero latest message receive timestamp filter', async () => {
+      const channels = await channelsRepo.create({
+        values: {
+          title: 'channel',
+          notificationType: 'in-app-message',
+        },
+      });
+
+      await messagesRepo.create({
+        values: {
+          channelName: channels.name,
+          userId: currUserId,
+          status: 'unread',
+          title: 'message',
+          content: 'content',
+          receiveTimestamp: Date.now(),
+        },
+      });
+
+      const res = await currUserAgent.resource('myInAppChannels').list({
+        filter: {
+          latestMsgReceiveTimestamp: {
+            $lt: 0,
+          },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(0);
+    });
+
+    test.each(['0) OR 1=1 --', { value: Date.now() }, 'Infinity', ''])(
+      'should reject invalid latest message receive timestamp filter: %s',
+      async (latestMsgReceiveTimestamp) => {
+        const res = await currUserAgent.resource('myInAppChannels').list({
+          filter: {
+            latestMsgReceiveTimestamp: {
+              $lt: latestMsgReceiveTimestamp,
+            },
+          },
+        });
+
+        expect(res.status).toBe(400);
+      },
+    );
     // test('channel last receive timestamp filter', () => {
     //   const currentTS = Date.now();
     // });

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/defineMyInAppChannels.ts
@@ -12,6 +12,35 @@ import { Op, Sequelize } from 'sequelize';
 import { ChannelsCollectionDefinition as ChannelsDefinition } from '@nocobase/plugin-notification-manager';
 import { InAppMessagesDefinition as MessagesDefinition } from '../types';
 
+function parseLatestMsgReceiveTimestampLt(filter: unknown) {
+  const latestMsgReceiveTimestamp =
+    typeof filter === 'object' && filter !== null
+      ? (filter as { latestMsgReceiveTimestamp?: unknown }).latestMsgReceiveTimestamp
+      : null;
+  if (
+    typeof latestMsgReceiveTimestamp !== 'object' ||
+    latestMsgReceiveTimestamp === null ||
+    !Object.prototype.hasOwnProperty.call(latestMsgReceiveTimestamp, '$lt')
+  ) {
+    return null;
+  }
+
+  const value = (latestMsgReceiveTimestamp as { $lt?: unknown }).$lt;
+  if (typeof value === 'string' && value.trim() === '') {
+    throw new Error('Invalid latest message receive timestamp filter');
+  }
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    throw new Error('Invalid latest message receive timestamp filter');
+  }
+
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error('Invalid latest message receive timestamp filter');
+  }
+
+  return timestamp;
+}
+
 export default function defineMyInAppChannels(app: Application) {
   app.resourceManager.define({
     name: 'myInAppChannels',
@@ -19,6 +48,12 @@ export default function defineMyInAppChannels(app: Application) {
       list: {
         handler: async (ctx) => {
           const { filter = {}, limit = 30 } = ctx.action?.params ?? {};
+          let latestMsgReceiveTimestampLt: number | null;
+          try {
+            latestMsgReceiveTimestampLt = parseLatestMsgReceiveTimestampLt(filter);
+          } catch (error) {
+            return ctx.throw(400, (error as Error).message);
+          }
           const messagesCollection = app.db.getCollection(MessagesDefinition.name);
           const messagesTableName = messagesCollection.getRealTableName(true);
           const channelsCollection = app.db.getCollection(ChannelsDefinition.name);
@@ -59,9 +94,10 @@ export default function defineMyInAppChannels(app: Application) {
                                 ORDER BY messages.${messagesFieldName.receiveTimestamp} DESC
                                 LIMIT 1
                             )`;
-          const latestMsgReceiveTSFilter = filter?.latestMsgReceiveTimestamp?.$lt
-            ? Sequelize.literal(`${latestMsgReceiveTimestampSQL} < ${filter.latestMsgReceiveTimestamp.$lt}`)
-            : null;
+          const latestMsgReceiveTSFilter =
+            latestMsgReceiveTimestampLt !== null
+              ? Sequelize.where(Sequelize.literal(latestMsgReceiveTimestampSQL), Op.lt, latestMsgReceiveTimestampLt)
+              : null;
           const channelIdFilter = filter?.id ? { id: filter.id } : null;
           const channelNameFilter = filter?.name ? { name: filter.name } : null;
           const statusMap = {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
`myInAppChannels:list` accepted `filter.latestMsgReceiveTimestamp.$lt` from user input and interpolated it directly into a `Sequelize.literal()` SQL fragment. Authenticated users could therefore inject SQL through this filter, and default deployments may expose the endpoint to anonymously registered users.

### Description
- Parse `latestMsgReceiveTimestamp.$lt` before building the channel query.
- Accept only finite numeric values, including numeric strings used by query parameters.
- Reject invalid values such as SQL payloads, objects, `Infinity`, and empty strings with a 400 response before reaching SQL construction.
- Replace direct literal interpolation of the user value with `Sequelize.where(Sequelize.literal(...), Op.lt, parsedNumber)`.
- Add tests for valid numeric filters, numeric strings, zero, and invalid payloads.

### Related issues
GHSA-p849-8hwh-84j9

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed SQL injection risk in the in-app notification channel timestamp filter. |
| 🇨🇳 Chinese | 修复站内消息频道时间戳过滤条件中的 SQL 注入风险。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

