### PR TITLE
fix(plugin-acl): preserve union default role members

### DIFF
--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/setCurrentRole.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/setCurrentRole.test.ts
@@ -11,6 +11,8 @@ import Database from '@nocobase/database';
 import UsersPlugin from '@nocobase/plugin-users';
 import { createMockServer, MockServer } from '@nocobase/test';
 import { vi } from 'vitest';
+import { UNION_ROLE_KEY } from '../constants';
+import { SystemRoleMode } from '../enum';
 import { setCurrentRole } from '../middlewares/setCurrentRole';
 import { prepareApp } from './prepare';
 
@@ -65,6 +67,45 @@ describe('role', () => {
     };
     await setCurrentRole(ctx, () => {});
     expect(ctx.state.currentRole).toBe('root');
+  });
+
+  it('should keep all roles when the default role is union and X-Role is empty', async () => {
+    await db.getRepository('roles').create({
+      values: {
+        name: 'r1',
+      },
+    });
+    const user = await db.getRepository('users').create({
+      values: {
+        name: 'u1',
+        roles: ['member', 'r1'],
+      },
+    });
+    await db.getRepository('systemSettings').update({
+      filter: { id: 1 },
+      values: {
+        roleMode: SystemRoleMode.allowUseUnion,
+      },
+    });
+    await db.getRepository('rolesUsers').create({
+      values: {
+        userId: user.id,
+        roleName: UNION_ROLE_KEY,
+        default: true,
+      },
+    });
+    ctx.state.currentUser = user;
+    ctx.get = function (name) {
+      if (name === 'X-Role') {
+        return '';
+      }
+    };
+
+    await setCurrentRole(ctx, () => {});
+
+    expect(ctx.state.currentRole).toBe(UNION_ROLE_KEY);
+    expect(ctx.state.currentRoles).toEqual(expect.arrayContaining(['member', 'r1']));
+    expect(ctx.state.currentRoles).toHaveLength(2);
   });
 
   it('should throw error', async () => {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/setCurrentRole.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/middlewares/setCurrentRole.ts
@@ -92,7 +92,7 @@ export async function setCurrentRole(ctx: Context, next) {
     role = defaultRoleModel?.roleName || userRoles[0]?.name;
   }
   ctx.state.currentRole = role;
-  ctx.state.currentRoles = role === UNION_ROLE_KEY ? [userRoles[0]?.name] : [role];
+  ctx.state.currentRoles = role === UNION_ROLE_KEY ? userRoles.map((role) => role.name) : [role];
   if (!ctx.state.currentRoles.length) {
     return ctx.throw(401, {
       code: 'ROLE_NOT_FOUND_ERR',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When union role is configured as a user's default role, the first authenticated request may not include the `X-Role` header yet. In that path, the server should keep all roles that belong to the union role instead of reducing the permission context to the first role.

### Description 
- Preserves all user roles when the default role resolves to `__union__` without an incoming `X-Role` header.
- Adds a regression test for the first-login/default-union-role path.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incomplete permissions on first login when union role is the default |
| 🇨🇳 Chinese | 修复联合角色作为默认角色时首次登录权限不完整的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
