### PR TITLE
fix(database): support numeric password values

### DIFF
--- a/packages/core/database/src/__tests__/fields/password-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/password-field.test.ts
@@ -61,4 +61,25 @@ describe('password field', () => {
     const user = await User.model.findOne({ where: { name: 'zhangsan' } });
     expect(await pwd.verify('123456', user.password)).toBeTruthy();
   });
+
+  it('should hash numeric password values', async () => {
+    const User = db.collection({
+      name: 'users',
+      fields: [
+        { type: 'string', name: 'name' },
+        { type: 'password', name: 'password' },
+      ],
+    });
+    await db.sync();
+
+    const user = await User.repository.create({
+      values: {
+        name: 'zhangsan',
+        password: 123456,
+      },
+    });
+
+    const pwd = User.getField<PasswordField>('password');
+    expect(await pwd.verify('123456', user.password)).toBeTruthy();
+  });
 });

--- a/packages/core/database/src/fields/password-field.ts
+++ b/packages/core/database/src/fields/password-field.ts
@@ -24,30 +24,33 @@ export interface PasswordFieldOptions extends BaseColumnFieldOptions {
   randomBytesSize?: number;
 }
 
+type PasswordValue = string | number;
+
 export class PasswordField extends Field {
   get dataType() {
     return DataTypes.STRING;
   }
 
-  async verify(password: string, hash: string) {
-    password = password || '';
+  async verify(password: PasswordValue, hash: string) {
+    const passwordString = password === null || password === undefined ? '' : String(password);
     hash = hash || '';
     const { length = 64, randomBytesSize = 8 } = this.options;
     return new Promise((resolve, reject) => {
       const salt = hash.substring(0, randomBytesSize * 2);
       const key = hash.substring(randomBytesSize * 2);
-      crypto.scrypt(password, salt, length / 2 - randomBytesSize, (err, derivedKey) => {
+      crypto.scrypt(passwordString, salt, length / 2 - randomBytesSize, (err, derivedKey) => {
         if (err) reject(err);
         resolve(key == derivedKey.toString('hex'));
       });
     });
   }
 
-  async hash(password: string) {
+  async hash(password: PasswordValue) {
+    const passwordString = String(password);
     const { length = 64, randomBytesSize = 8 } = this.options;
     return new Promise((resolve, reject) => {
       const salt = crypto.randomBytes(randomBytesSize).toString('hex');
-      crypto.scrypt(password, salt, length / 2 - randomBytesSize, (err, derivedKey) => {
+      crypto.scrypt(passwordString, salt, length / 2 - randomBytesSize, (err, derivedKey) => {
         if (err) reject(err);
         resolve(salt + derivedKey.toString('hex'));
       });
@@ -56,18 +59,20 @@ export class PasswordField extends Field {
 
   init() {
     const { name } = this.options;
+    const fieldName = name as string;
     this.listener = async (instances: Model[]) => {
       instances = Array.isArray(instances) ? instances : [instances];
       for (const instance of instances) {
-        if (!instance.changed(name as any)) {
+        if (!instance.changed(fieldName)) {
           continue;
         }
-        const value = instance.get(name) as string;
-        if (value) {
-          const hash = await this.hash(value);
-          instance.set(name, hash);
+        const value = instance.get(fieldName);
+        if (value !== null && value !== undefined && value !== '') {
+          const password = typeof value === 'number' ? value : String(value);
+          const hash = await this.hash(password);
+          instance.set(fieldName, hash);
         } else {
-          instance.set(name, instance.previous(name));
+          instance.set(fieldName, instance.previous(fieldName));
         }
       }
     };

--- a/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
@@ -2717,7 +2717,7 @@ describe('basic importer', () => {
     await expect(importer.run()).rejects.toThrow();
   });
 
-  it('should import password field, insert data is encrypt', async () => {
+  it('should import numeric password field values as strings', async () => {
     const User = app.db.collection({
       name: 'users',
       fields: [
@@ -2743,7 +2743,7 @@ describe('basic importer', () => {
     const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
     const worksheet = template.Sheets[template.SheetNames[0]];
 
-    XLSX.utils.sheet_add_aoa(worksheet, [['zhangsan', '123456']], {
+    XLSX.utils.sheet_add_aoa(worksheet, [['zhangsan', 123456]], {
       origin: 'A2',
     });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Importing numeric values into password fields could fail because password hashing expected string input.

### Description 
- Accept numeric password values when hashing or verifying password fields.
- Add a database password-field regression test for numeric password values.
- Cover numeric password values in the XLSX import password-field regression test.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where importing numeric password values could fail |
| 🇨🇳 Chinese | 修复导入纯数字密码值可能失败的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
