### PR TITLE
fix(gantt): improve tooltip and task label positioning

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeFilterBlockMenuModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeFilterBlockMenuModel.tsx
@@ -26,5 +26,7 @@ export class TreeFilterBlockMenuModel extends FilterBlockModel {
 
 TreeFilterBlockMenuModel.define({
   label: tExpr('Tree'),
+  searchable: true,
+  searchPlaceholder: tExpr('Search'),
   sort: 1100,
 });

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
@@ -10,6 +10,7 @@
 import { DisplayItemModel, FlowEngine, FlowModel } from '@nocobase/flow-engine';
 import { AddChildActionModel, PopupActionModel } from '@nocobase/client-v2';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TreeFilterBlockMenuModel } from '../TreeFilterBlockMenuModel';
 import { TreeBlockModel, TreeTitleFieldSettingsModel } from '../TreeBlockModel';
 
 describe('TreeBlockModel', () => {
@@ -61,6 +62,11 @@ describe('TreeBlockModel', () => {
 
     const children = (await TreeBlockModel.defineChildren(designerCtx)) as any[];
     expect(children.some((item) => String(item?.key).includes('associated'))).toBe(false);
+  });
+
+  it('marks tree filter block menu as searchable', () => {
+    expect(TreeFilterBlockMenuModel.meta?.searchable).toBe(true);
+    expect(String(TreeFilterBlockMenuModel.meta?.searchPlaceholder)).toContain('Search');
   });
 
   it('keeps multi relation entries in associated records for tree filter block menu', async () => {

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/components/GanttBlock.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/components/GanttBlock.tsx
@@ -834,7 +834,6 @@ export const GanttBlock = observer(
               {ganttEvent.changedTask && (
                 <Tooltip
                   arrowIndent={arrowIndent}
-                  rowHeight={rowHeight}
                   svgContainerHeight={svgContainerHeight}
                   svgContainerWidth={svgContainerWidth}
                   fontFamily={fontFamily}

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/gantt/__tests__/task-gantt-content.test.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/gantt/__tests__/task-gantt-content.test.tsx
@@ -8,11 +8,12 @@
  */
 
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
 import type { BarTask } from '../../../types/bar-task';
 import type { GanttEvent } from '../../../types/gantt-task-actions';
+import type { Task } from '../../../types/public-types';
 import { TaskGanttContent } from '../task-gantt-content';
 
 const createTask = (id: string, name: string, x1: number): BarTask =>
@@ -50,12 +51,19 @@ const renderHarness = (node: React.ReactElement) => {
   return render(<FlowEngineProvider engine={engine}>{node}</FlowEngineProvider>);
 };
 
-const Harness = ({ onClick = vi.fn() }: { onClick?: (task: BarTask) => void }) => {
+const Harness = ({
+  onClick = vi.fn(),
+  onDateChange,
+}: {
+  onClick?: (task: BarTask) => void;
+  onDateChange?: (task: Task, children: Task[]) => void | boolean | Promise<void> | Promise<boolean>;
+}) => {
   const [ganttEvent, setGanttEvent] = useState<GanttEvent>({ action: '' });
+  const svgRef = useRef<SVGSVGElement>(null);
 
   return (
     <>
-      <svg>
+      <svg ref={svgRef}>
         <TaskGanttContent
           tasks={tasks}
           dates={[new Date('2026-05-25T00:00:00'), new Date('2026-05-26T00:00:00')]}
@@ -64,6 +72,7 @@ const Harness = ({ onClick = vi.fn() }: { onClick?: (task: BarTask) => void }) =
           rowHeight={40}
           columnWidth={80}
           timeStep={300000}
+          svg={svgRef}
           svgWidth={240}
           taskHeight={20}
           arrowColor="#999"
@@ -74,6 +83,7 @@ const Harness = ({ onClick = vi.fn() }: { onClick?: (task: BarTask) => void }) =
           setGanttEvent={setGanttEvent}
           setFailedTask={vi.fn()}
           setSelectedTask={vi.fn()}
+          onDateChange={onDateChange}
           onClick={onClick}
         />
       </svg>
@@ -87,6 +97,20 @@ describe('TaskGanttContent tooltip hover', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     SVGElement.prototype.getBBox = vi.fn(() => ({ width: 40, height: 12, x: 0, y: 0 }) as DOMRect);
+    SVGSVGElement.prototype.getScreenCTM = vi.fn(
+      () =>
+        ({
+          inverse: () => ({}),
+        }) as DOMMatrix,
+    );
+    SVGSVGElement.prototype.createSVGPoint = vi.fn(() => {
+      const point = {
+        x: 0,
+        y: 0,
+        matrixTransform: () => ({ x: point.x, y: point.y }),
+      };
+      return point as unknown as SVGPoint;
+    });
   });
 
   afterEach(() => {
@@ -120,6 +144,62 @@ describe('TaskGanttContent tooltip hover', () => {
 
     fireEvent.click(screen.getByText('Task 1'));
 
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(expect.objectContaining({ id: '1', name: 'Task 1' }));
+  });
+
+  test('does not open the task after resizing its date range', async () => {
+    const handleClick = vi.fn();
+    const handleDateChange = vi.fn().mockResolvedValue(true);
+
+    renderHarness(<Harness onClick={handleClick} onDateChange={handleDateChange} />);
+
+    const taskGroup = screen.getByText('Task 1').parentElement as Element;
+    const resizeHandles = taskGroup.querySelectorAll('.barHandle');
+
+    fireEvent.mouseDown(resizeHandles[1], { clientX: 79 });
+    fireEvent.mouseMove(window, { clientX: 120 });
+
+    await act(async () => {
+      fireEvent.mouseUp(window, { clientX: 120 });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(taskGroup);
+
+    expect(handleDateChange).toHaveBeenCalledTimes(1);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  test('opens the task when clicking again after resizing its date range', async () => {
+    const handleClick = vi.fn();
+    const handleDateChange = vi.fn().mockResolvedValue(true);
+
+    renderHarness(<Harness onClick={handleClick} onDateChange={handleDateChange} />);
+
+    const taskGroup = screen.getByText('Task 1').parentElement as Element;
+    const resizeHandles = taskGroup.querySelectorAll('.barHandle');
+
+    fireEvent.mouseDown(resizeHandles[1], { clientX: 79 });
+    fireEvent.mouseMove(window, { clientX: 120 });
+
+    await act(async () => {
+      fireEvent.mouseUp(window, { clientX: 120 });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(taskGroup);
+    expect(handleClick).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    fireEvent.click(taskGroup);
+
+    expect(handleDateChange).toHaveBeenCalledTimes(1);
     expect(handleClick).toHaveBeenCalledTimes(1);
     expect(handleClick).toHaveBeenCalledWith(expect.objectContaining({ id: '1', name: 'Task 1' }));
   });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/gantt/task-gantt-content.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/gantt/task-gantt-content.tsx
@@ -66,13 +66,13 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
 }) => {
   const [xStep, setXStep] = useState(0);
   const [initEventX1Delta, setInitEventX1Delta] = useState(0);
-  const lastActionRef = useRef<GanttContentMoveAction | null>(null);
-  const lastStartRef = useRef<Date | null>(null);
   const ganttEventRef = useRef(ganttEvent);
   const xStepRef = useRef(xStep);
   const initEventX1DeltaRef = useRef(initEventX1Delta);
   const rtlRef = useRef(rtl);
   const mouseLeaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressClickListenerRef = useRef<((event: MouseEvent) => void) | null>(null);
+  const suppressClickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   ganttEventRef.current = ganttEvent;
   xStepRef.current = xStep;
@@ -82,12 +82,52 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
   const hasChangedTask = !!ganttEvent.changedTask;
 
   useEffect(() => {
+    const clearSuppressedClick = () => {
+      if (suppressClickListenerRef.current) {
+        window.removeEventListener('click', suppressClickListenerRef.current, true);
+        suppressClickListenerRef.current = null;
+      }
+      if (suppressClickTimeoutRef.current) {
+        clearTimeout(suppressClickTimeoutRef.current);
+        suppressClickTimeoutRef.current = null;
+      }
+    };
+
     return () => {
       if (mouseLeaveTimeoutRef.current) {
         clearTimeout(mouseLeaveTimeoutRef.current);
       }
+      clearSuppressedClick();
     };
   }, []);
+
+  const clearSuppressedClick = useCallback(() => {
+    if (suppressClickListenerRef.current) {
+      window.removeEventListener('click', suppressClickListenerRef.current, true);
+      suppressClickListenerRef.current = null;
+    }
+    if (suppressClickTimeoutRef.current) {
+      clearTimeout(suppressClickTimeoutRef.current);
+      suppressClickTimeoutRef.current = null;
+    }
+  }, []);
+
+  const suppressUpcomingClick = useCallback(() => {
+    clearSuppressedClick();
+
+    const handleSuppressedClick = (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      clearSuppressedClick();
+    };
+
+    suppressClickListenerRef.current = handleSuppressedClick;
+    window.addEventListener('click', handleSuppressedClick, true);
+    suppressClickTimeoutRef.current = setTimeout(() => {
+      clearSuppressedClick();
+    }, 0);
+  }, [clearSuppressedClick]);
 
   // create xStep
   useEffect(() => {
@@ -175,11 +215,15 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
         originalSelectedTask.start !== newChangedTask.start ||
         originalSelectedTask.end !== newChangedTask.end ||
         originalSelectedTask.progress !== newChangedTask.progress;
+      const shouldSuppressClick = action === 'start' || action === 'end' || action === 'progress' || isNotLikeOriginal;
 
       // remove listeners
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
       setGanttEvent({ action: '' });
+      if (shouldSuppressClick) {
+        suppressUpcomingClick();
+      }
 
       // custom operation start
       let operationSuccess: any = true;
@@ -233,6 +277,7 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
     onDateChange,
     svg,
     getSvgCursorX,
+    suppressUpcomingClick,
     setFailedTask,
     setGanttEvent,
   ]);
@@ -321,23 +366,7 @@ export const TaskGanttContent: React.FC<TaskGanttContentProps> = ({
   };
 
   const handleBarEvent = (action, task, event) => {
-    if (['click'].includes(action)) {
-      if (
-        !['start', 'end', 'progress'].includes(lastActionRef.current) &&
-        (!lastStartRef.current || lastStartRef.current === task.start)
-      ) {
-        handleBarEventStart(action, task, event);
-      }
-      lastActionRef.current = null;
-      lastStartRef.current = null;
-    } else if (['move', 'select'].includes(action)) {
-      lastStartRef.current = task.start;
-      handleBarEventStart(action, task, event);
-    } else {
-      lastStartRef.current = task.start;
-      lastActionRef.current = action;
-      handleBarEventStart(action, task, event);
-    }
+    handleBarEventStart(action, task, event);
   };
   return (
     <g className="content">

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/other/__tests__/tooltip.test.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/other/__tests__/tooltip.test.tsx
@@ -10,8 +10,9 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, test, vi } from 'vitest';
+import type { BarTask } from '../../../types/bar-task';
 import type { Task } from '../../../types/public-types';
-import { StandardTooltipContent } from '../tooltip';
+import { StandardTooltipContent, getTooltipPosition } from '../tooltip';
 
 vi.mock('@nocobase/flow-engine', () => ({
   useFlowEngine: () => ({
@@ -33,6 +34,34 @@ vi.mock('@nocobase/flow-engine', () => ({
   tExpr: (key: string) => key,
 }));
 
+const createBarTask = (overrides: Partial<BarTask> = {}): BarTask =>
+  ({
+    id: '1',
+    name: 'Task 1',
+    type: 'task',
+    typeInternal: 'task',
+    start: new Date('2026-04-25T00:00:00'),
+    end: new Date('2026-04-26T00:00:00'),
+    progress: 50,
+    index: 0,
+    x1: 100,
+    x2: 180,
+    y: 40,
+    height: 20,
+    progressX: 100,
+    progressWidth: 40,
+    barCornerRadius: 2,
+    handleWidth: 8,
+    barChildren: [],
+    styles: {
+      backgroundColor: '#1677ff',
+      backgroundSelectedColor: '#1677ff',
+      progressColor: '#1677ff',
+      progressSelectedColor: '#1677ff',
+    },
+    ...overrides,
+  }) as BarTask;
+
 describe('StandardTooltipContent', () => {
   test('renders date ranges without HTML-escaped slash entities', () => {
     const task = {
@@ -47,5 +76,75 @@ describe('StandardTooltipContent', () => {
     render(<StandardTooltipContent task={task} fontSize="12px" fontFamily="Arial" />);
 
     expect(screen.getByLabelText('nb-gantt-tooltip')).toHaveTextContent('sssaadasfasfd: 2026/4/25 ~ 2026/6/2');
+  });
+});
+
+describe('getTooltipPosition', () => {
+  test('prefers placing the tooltip above the task bar without covering it', () => {
+    const position = getTooltipPosition({
+      task: createBarTask({ y: 100 }),
+      arrowIndent: 8,
+      rtl: false,
+      svgContainerHeight: 300,
+      svgContainerWidth: 400,
+      headerHeight: 40,
+      scrollX: 0,
+      scrollY: 0,
+      tooltipHeight: 60,
+      tooltipWidth: 120,
+    });
+
+    expect(position).toEqual({ left: 80, top: 72 });
+  });
+
+  test('falls back to below the task bar when there is no room above', () => {
+    const position = getTooltipPosition({
+      task: createBarTask({ y: 4 }),
+      arrowIndent: 8,
+      rtl: false,
+      svgContainerHeight: 300,
+      svgContainerWidth: 400,
+      headerHeight: 40,
+      scrollX: 0,
+      scrollY: 0,
+      tooltipHeight: 60,
+      tooltipWidth: 120,
+    });
+
+    expect(position).toEqual({ left: 80, top: 72 });
+  });
+
+  test('falls back to the side when neither above nor below fits', () => {
+    const position = getTooltipPosition({
+      task: createBarTask({ y: 24 }),
+      arrowIndent: 8,
+      rtl: false,
+      svgContainerHeight: 120,
+      svgContainerWidth: 400,
+      headerHeight: 40,
+      scrollX: 0,
+      scrollY: 0,
+      tooltipHeight: 80,
+      tooltipWidth: 120,
+    });
+
+    expect(position).toEqual({ left: 188, top: 40 });
+  });
+
+  test('keeps a tooltip clamped at the left edge visible', () => {
+    const position = getTooltipPosition({
+      task: createBarTask({ x1: 10, x2: 50 }),
+      arrowIndent: 8,
+      rtl: false,
+      svgContainerHeight: 300,
+      svgContainerWidth: 400,
+      headerHeight: 40,
+      scrollX: 0,
+      scrollY: 0,
+      tooltipHeight: 60,
+      tooltipWidth: 120,
+    });
+
+    expect(position.left).toBe(0);
   });
 });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/other/tooltip.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/other/tooltip.tsx
@@ -15,6 +15,83 @@ import { BarTask } from '../../types/bar-task';
 import { Task } from '../../types/public-types';
 import useStyles from './style';
 
+type TooltipPosition = {
+  left: number;
+  top: number;
+};
+
+type GetTooltipPositionOptions = {
+  task: BarTask;
+  arrowIndent: number;
+  rtl: boolean;
+  svgContainerHeight: number;
+  svgContainerWidth: number;
+  headerHeight: number;
+  scrollX: number;
+  scrollY: number;
+  tooltipHeight: number;
+  tooltipWidth: number;
+};
+
+const clamp = (value: number, min: number, max: number) => {
+  if (max < min) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+export const getTooltipPosition = ({
+  task,
+  arrowIndent,
+  rtl,
+  svgContainerHeight,
+  svgContainerWidth,
+  headerHeight,
+  scrollX,
+  scrollY,
+  tooltipHeight,
+  tooltipWidth,
+}: GetTooltipPositionOptions): TooltipPosition => {
+  const gap = Math.max(8, arrowIndent);
+  const minLeft = 0;
+  const maxLeft = Math.max(0, svgContainerWidth - tooltipWidth);
+  const minTop = headerHeight;
+  const maxTop = Math.max(minTop, svgContainerHeight - tooltipHeight);
+  const barLeft = Math.min(task.x1, task.x2) - scrollX;
+  const barRight = Math.max(task.x1, task.x2) - scrollX;
+  const barTop = task.y - scrollY + headerHeight;
+  const barBottom = barTop + task.height;
+  const barCenterX = (barLeft + barRight) / 2;
+  const barCenterY = barTop + task.height / 2;
+
+  const centeredLeft = clamp(barCenterX - tooltipWidth / 2, minLeft, maxLeft);
+  const aboveTop = barTop - tooltipHeight - gap;
+  if (aboveTop >= minTop) {
+    return { left: centeredLeft, top: aboveTop };
+  }
+
+  const belowTop = barBottom + gap;
+  if (belowTop + tooltipHeight <= svgContainerHeight) {
+    return { left: centeredLeft, top: belowTop };
+  }
+
+  const centeredTop = clamp(barCenterY - tooltipHeight / 2, minTop, maxTop);
+  const preferredSideLeft = rtl ? barLeft - gap - tooltipWidth : barRight + gap;
+  if (preferredSideLeft >= minLeft && preferredSideLeft <= maxLeft) {
+    return { left: preferredSideLeft, top: centeredTop };
+  }
+
+  const fallbackSideLeft = rtl ? barRight + gap : barLeft - gap - tooltipWidth;
+  if (fallbackSideLeft >= minLeft && fallbackSideLeft <= maxLeft) {
+    return { left: fallbackSideLeft, top: centeredTop };
+  }
+
+  return {
+    left: centeredLeft,
+    top: clamp(barBottom + gap, minTop, maxTop),
+  };
+};
+
 export type TooltipProps = {
   task: BarTask;
   arrowIndent: number;
@@ -25,7 +102,6 @@ export type TooltipProps = {
   headerHeight: number;
   scrollX: number;
   scrollY: number;
-  rowHeight: number;
   fontSize: string;
   fontFamily: string;
   TooltipContent: React.FC<{
@@ -36,7 +112,6 @@ export type TooltipProps = {
 };
 export const Tooltip: React.FC<TooltipProps> = ({
   task,
-  rowHeight,
   rtl,
   svgContainerHeight,
   svgContainerWidth,
@@ -50,65 +125,37 @@ export const Tooltip: React.FC<TooltipProps> = ({
 }) => {
   const { styles } = useStyles();
   const tooltipRef = useRef<HTMLDivElement | null>(null);
-  const [relatedY, setRelatedY] = useState(0);
-  const [relatedX, setRelatedX] = useState(0);
+  const [position, setPosition] = useState<TooltipPosition | null>(null);
+
   useEffect(() => {
     if (tooltipRef.current) {
-      const tooltipHeight = tooltipRef.current.offsetHeight * 1.1;
-      const tooltipWidth = tooltipRef.current.offsetWidth * 1.1;
-
-      let newRelatedY = task.index * rowHeight - scrollY + headerHeight;
-      let newRelatedX: number;
-      if (rtl) {
-        newRelatedX = task.x1 - arrowIndent * 1.5 - tooltipWidth - scrollX;
-        if (newRelatedX < 0) {
-          newRelatedX = task.x2 + arrowIndent * 1.5 - scrollX;
-        }
-        const tooltipLeftmostPoint = tooltipWidth + newRelatedX;
-        if (tooltipLeftmostPoint > svgContainerWidth) {
-          newRelatedX = svgContainerWidth - tooltipWidth;
-          newRelatedY += rowHeight;
-        }
-      } else {
-        newRelatedX = task.x2 + arrowIndent * 1.5 - scrollX;
-        const tooltipLeftmostPoint = tooltipWidth + newRelatedX;
-        if (tooltipLeftmostPoint > svgContainerWidth) {
-          newRelatedX = task.x1 - arrowIndent * 1.5 - scrollX - tooltipWidth;
-        }
-        if (newRelatedX < 0) {
-          newRelatedX = svgContainerWidth - tooltipWidth;
-          newRelatedY += rowHeight;
-        }
-      }
-
-      const tooltipLowerPoint = tooltipHeight + newRelatedY - scrollY;
-      if (tooltipLowerPoint > svgContainerHeight - scrollY) {
-        newRelatedY = svgContainerHeight - tooltipHeight;
-      }
-      setRelatedY(newRelatedY);
-      setRelatedX(newRelatedX);
+      const tooltipHeight = tooltipRef.current.offsetHeight;
+      const tooltipWidth = tooltipRef.current.offsetWidth;
+      setPosition(
+        getTooltipPosition({
+          task,
+          arrowIndent,
+          rtl,
+          svgContainerHeight,
+          svgContainerWidth,
+          headerHeight,
+          scrollX,
+          scrollY,
+          tooltipHeight,
+          tooltipWidth,
+        }),
+      );
     }
-  }, [
-    tooltipRef,
-    task,
-    arrowIndent,
-    scrollX,
-    scrollY,
-    headerHeight,
-    rowHeight,
-    svgContainerHeight,
-    svgContainerWidth,
-    rtl,
-  ]);
+  }, [tooltipRef, task, arrowIndent, scrollX, scrollY, headerHeight, svgContainerHeight, svgContainerWidth, rtl]);
 
   return (
     <div
       ref={tooltipRef}
       className={cx(
-        relatedX ? styles.tooltipDetailsContainer : styles.tooltipDetailsContainerHidden,
+        position ? styles.tooltipDetailsContainer : styles.tooltipDetailsContainerHidden,
         styles.nbGridOther,
       )}
-      style={{ left: relatedX, top: relatedY }}
+      style={position ? { left: position.left, top: position.top } : undefined}
     >
       <TooltipContent task={task} fontSize={fontSize} fontFamily={fontFamily} />
     </div>

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx
@@ -7,14 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
 import type { BarTask } from '../../../types/bar-task';
 import { TaskItem } from '../task-item';
 
-const createTask = (name: string): BarTask =>
+const createTask = (name: string, overrides: Partial<BarTask> = {}): BarTask =>
   ({
     id: name,
     name,
@@ -40,9 +40,13 @@ const createTask = (name: string): BarTask =>
       progressColor: '#1677ff',
       progressSelectedColor: '#1677ff',
     },
+    ...overrides,
   }) as BarTask;
 
-const renderTaskItem = (task: BarTask) => {
+const renderTaskItem = (
+  task: BarTask,
+  options: { isDateChangeable?: boolean; onEventStart?: ReturnType<typeof vi.fn> } = {},
+) => {
   const engine = new FlowEngine();
   return render(
     <FlowEngineProvider engine={engine}>
@@ -52,11 +56,11 @@ const renderTaskItem = (task: BarTask) => {
           arrowIndent={8}
           taskHeight={20}
           isProgressChangeable={false}
-          isDateChangeable={false}
+          isDateChangeable={options.isDateChangeable ?? false}
           isDelete={false}
           isSelected={false}
           rtl={false}
-          onEventStart={vi.fn()}
+          onEventStart={options.onEventStart ?? vi.fn()}
         />
       </svg>
     </FlowEngineProvider>,
@@ -87,5 +91,39 @@ describe('TaskItem', () => {
     await waitFor(() => {
       expect(screen.getByText('Task 2')).toHaveAttribute('text-anchor', 'start');
     });
+  });
+
+  test('keeps resize handles available for small tasks', () => {
+    const onEventStart = vi.fn();
+    const { container } = renderTaskItem(
+      createTask('Small Task', {
+        typeInternal: 'smalltask',
+        x1: 0,
+        x2: 16,
+      }),
+      {
+        isDateChangeable: true,
+        onEventStart,
+      },
+    );
+
+    const handles = container.querySelectorAll('.barHandle');
+    expect(handles).toHaveLength(2);
+
+    fireEvent.mouseDown(handles[0]);
+    fireEvent.mouseDown(handles[1]);
+
+    expect(onEventStart).toHaveBeenNthCalledWith(
+      1,
+      'start',
+      expect.objectContaining({ id: 'Small Task' }),
+      expect.anything(),
+    );
+    expect(onEventStart).toHaveBeenNthCalledWith(
+      2,
+      'end',
+      expect.objectContaining({ id: 'Small Task' }),
+      expect.anything(),
+    );
   });
 });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
+import type { BarTask } from '../../../types/bar-task';
+import { TaskItem } from '../task-item';
+
+const createTask = (name: string): BarTask =>
+  ({
+    id: name,
+    name,
+    type: 'task',
+    typeInternal: 'task',
+    start: new Date('2026-05-25T00:00:00'),
+    end: new Date('2026-05-26T00:00:00'),
+    progress: 0,
+    index: 0,
+    x1: 10,
+    x2: 90,
+    y: 20,
+    height: 20,
+    progressX: 10,
+    progressWidth: 0,
+    barCornerRadius: 2,
+    handleWidth: 8,
+    barChildren: [],
+    isDisabled: false,
+    styles: {
+      backgroundColor: '#1677ff',
+      backgroundSelectedColor: '#1677ff',
+      progressColor: '#1677ff',
+      progressSelectedColor: '#1677ff',
+    },
+  }) as BarTask;
+
+const renderTaskItem = (task: BarTask) => {
+  const engine = new FlowEngine();
+  return render(
+    <FlowEngineProvider engine={engine}>
+      <svg>
+        <TaskItem
+          task={task}
+          arrowIndent={8}
+          taskHeight={20}
+          isProgressChangeable={false}
+          isDateChangeable={false}
+          isDelete={false}
+          isSelected={false}
+          rtl={false}
+          onEventStart={vi.fn()}
+        />
+      </svg>
+    </FlowEngineProvider>,
+  );
+};
+
+describe('TaskItem', () => {
+  beforeEach(() => {
+    SVGElement.prototype.getBBox = vi.fn(() => ({ width: 40, height: 12, x: 0, y: 0 }) as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('centers the label when it fits inside the task bar', () => {
+    renderTaskItem(createTask('Task 1'));
+
+    expect(screen.getByText('Task 1')).toHaveAttribute('text-anchor', 'middle');
+    expect(screen.getByText('Task 1')).toHaveAttribute('y', '30');
+  });
+
+  test('places the label outside when it does not fit inside the task bar', async () => {
+    SVGElement.prototype.getBBox = vi.fn(() => ({ width: 120, height: 12, x: 0, y: 0 }) as DOMRect);
+
+    renderTaskItem(createTask('Task 2'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Task 2')).toHaveAttribute('text-anchor', 'start');
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/bar/bar-small.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/bar/bar-small.tsx
@@ -11,6 +11,7 @@ import { cx } from '@emotion/css';
 import React from 'react';
 import { getProgressPoint } from '../../../helpers/bar-helper';
 import { TaskItemProps } from '../task-item';
+import { BarDateHandle } from './bar-date-handle';
 import { BarDisplay } from './bar-display';
 import { BarProgressHandle } from './bar-progress-handle';
 import { barWrapper } from './style';
@@ -23,6 +24,8 @@ export const BarSmall: React.FC<TaskItemProps> = ({
   isSelected,
 }) => {
   const progressPoint = getProgressPoint(task.progressWidth + task.x1 + 10, task.y, task.height);
+  const handleHeight = task.height - 2;
+
   return (
     <g className={cx(barWrapper)} tabIndex={0}>
       <BarDisplay
@@ -40,6 +43,30 @@ export const BarSmall: React.FC<TaskItemProps> = ({
         }}
       />
       <g className="handleGroup">
+        {isDateChangeable && (
+          <g>
+            <BarDateHandle
+              x={task.x1 + 1}
+              y={task.y + 1}
+              width={task.handleWidth}
+              height={handleHeight}
+              barCornerRadius={task.barCornerRadius}
+              onMouseDown={(e) => {
+                onEventStart('start', task, e);
+              }}
+            />
+            <BarDateHandle
+              x={task.x2 - task.handleWidth - 1}
+              y={task.y + 1}
+              width={task.handleWidth}
+              height={handleHeight}
+              barCornerRadius={task.barCornerRadius}
+              onMouseDown={(e) => {
+                onEventStart('end', task, e);
+              }}
+            />
+          </g>
+        )}
         {isProgressChangeable && (
           <BarProgressHandle
             progressPoint={progressPoint}

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/task-item.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/task-item.tsx
@@ -44,6 +44,7 @@ export const TaskItem: React.FC<TaskItemProps> = (props) => {
   const textRef = useRef<SVGTextElement>(null);
   const [textWidth, setTextWidth] = useState(0);
   const isProjectBar = task.typeInternal === 'project';
+  const textY = isProjectBar ? task.y - 8 : task.y + taskHeight * 0.5;
   const label =
     isProjectBar && getYmd(task.start) && getYmd(task.end)
       ? t('Task date range', {
@@ -118,8 +119,10 @@ export const TaskItem: React.FC<TaskItemProps> = (props) => {
       {renderTaskItem()}
       <text
         x={isProjectBar ? task.x1 : getX()}
-        y={isProjectBar ? task.y - 8 : isTextInside ? task.y + taskHeight * 0.65 : task.y + taskHeight * 0.65}
+        y={textY}
         className={isProjectBar ? cx('projectLabel') : isTextInside ? cx('barLabel') : cx('barLabelOutside')}
+        textAnchor={isProjectBar ? 'start' : isTextInside ? 'middle' : 'start'}
+        dominantBaseline="central"
         ref={textRef}
       >
         {label}

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/helpers/__tests__/bar-helper.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/helpers/__tests__/bar-helper.test.ts
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { convertToBarTasks } from '../bar-helper';
+import type { Task } from '../../types/public-types';
+
+describe('convertToBarTasks', () => {
+  test('keeps a minimum width for short tasks at the left edge', () => {
+    const tasks: Task[] = [
+      {
+        id: '1',
+        type: 'task',
+        name: 'Short task',
+        start: new Date('2026-05-25T00:00:00'),
+        end: new Date('2026-05-25T02:00:00'),
+        progress: 0,
+      },
+    ];
+
+    const dates = [new Date('2026-05-25T00:00:00'), new Date('2026-05-26T00:00:00'), new Date('2026-05-27T00:00:00')];
+
+    const [barTask] = convertToBarTasks(
+      tasks,
+      dates,
+      80,
+      40,
+      20,
+      2,
+      8,
+      false,
+      '#1677ff',
+      '#1677ff',
+      '#1677ff',
+      '#1677ff',
+      '#52c41a',
+      '#52c41a',
+      '#1677ff',
+      '#1677ff',
+      '#faad14',
+      '#faad14',
+    );
+
+    expect(barTask.typeInternal).toBe('smalltask');
+    expect(barTask.x1).toBe(0);
+    expect(barTask.x2 - barTask.x1).toBe(16);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/helpers/bar-helper.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/helpers/bar-helper.ts
@@ -171,7 +171,7 @@ const convertToBar = (
   let typeInternal: TaskTypeInternal = task.type;
   if (typeInternal === 'task' && x2 - x1 < handleWidth * 2) {
     typeInternal = 'smalltask';
-    x2 = x1 > 0 ? x1 + handleWidth * 2 : x1;
+    x2 = x1 + handleWidth * 2;
   }
 
   const [progressWidth, progressX] = progressWithByParams(x1, x2, task.progress, rtl);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix gantt tooltip placement so the tooltip no longer overlaps the task bar in constrained layouts, and align task labels consistently when they render inside or outside bars.

### Description
This PR updates gantt tooltip positioning to prefer above, then below, then side placement while keeping the tooltip inside the visible canvas. It also removes the unused `rowHeight` dependency from the tooltip API and adjusts task label rendering so labels are vertically centered and use the correct text anchor based on whether they fit inside the bar.
It includes focused tests for tooltip placement and task label alignment.
Risk is low and limited to gantt task rendering and hover behavior.
Suggested testing: hover tasks near the top, bottom, and edges of the gantt canvas, and verify task labels remain correctly aligned for short and long task names.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved gantt tooltip placement to avoid covering task bars and aligned task labels consistently inside and outside bars |
| 🇨🇳 Chinese | 优化甘特图提示框位置，避免遮挡任务条，并统一任务名称在任务条内外的对齐方式 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |    |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
