### PR TITLE
fix(client): normalize cascade m2o value

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
@@ -14,8 +14,8 @@ import { uid } from '@formily/shared';
 import { Select as AntdSelect, Input, Space, Spin, Tag } from 'antd';
 import dayjs from 'dayjs';
 import { css } from '@emotion/css';
-import { debounce } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { debounce, isEqual } from 'lodash';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAPIClient, useCollectionManager_deprecated } from '../../../';
 import { mergeFilter } from '../../../filter-provider/utils';
@@ -38,6 +38,7 @@ const CascadeSelect = connect((props) => {
   const [selectedOptions, setSelectedOptions] = useState<{ key: string; children: any; value?: any }[]>([
     { key: undefined, children: [], value: null },
   ]);
+  const selectedOptionsRef = useRef(selectedOptions);
 
   const [options, setOptions] = useState(data);
   const [loading, setLoading] = useState(false);
@@ -57,29 +58,45 @@ const CascadeSelect = connect((props) => {
       return getInterface(targetField.interface)?.filterable?.operators[0].value || '$includes';
     }
     return '$includes';
-  }, [targetField]);
+  }, [getInterface, targetField]);
   const field: any = useField();
 
   useEffect(() => {
-    if (value) {
-      const values = Array.isArray(value)
-        ? extractLastNonNullValueObjects(value?.filter((v) => v.value), true)
-        : transformNestedData(value);
-      const options = values?.map?.((v) => {
-        return {
-          key: v.parentId,
-          children: [],
-          value: v,
-        };
-      });
-      setSelectedOptions(options);
-    }
-  }, []);
+    selectedOptionsRef.current = selectedOptions;
+  }, [selectedOptions]);
+
   useEffect(() => {
-    if (!value) {
+    if (value) {
+      if (collectionField.interface === 'm2o' && !Array.isArray(value)) {
+        const selectedValue = normalizeToOneCascadeValue(selectedOptionsRef.current);
+        if (isEqual(selectedValue, value)) {
+          return;
+        }
+      }
+      if (Array.isArray(value)) {
+        const cascadeOptions = value
+          ?.filter((v) => v && (v.value || v.children))
+          .map((v) => ({
+            key: v.key,
+            children: v.children || [],
+            value: v.value,
+          }));
+        setSelectedOptions(cascadeOptions?.length ? cascadeOptions : [{ key: undefined, children: [], value: null }]);
+      } else {
+        const values = transformNestedData(value);
+        const options = values?.map?.((v) => {
+          return {
+            key: v.parentId,
+            children: [],
+            value: v,
+          };
+        });
+        setSelectedOptions(options);
+      }
+    } else {
       setSelectedOptions([{ key: undefined, children: [], value: null }]);
     }
-  }, [value]);
+  }, [collectionField.interface, value]);
   const mapOptionsToTags = useCallback(
     (options) => {
       try {
@@ -133,7 +150,7 @@ const CascadeSelect = connect((props) => {
         return options;
       }
     },
-    [targetField?.uiSchema, fieldNames],
+    [compile, fieldNames, mapOptions, targetField],
   );
   const handleGetOptions = async (filter) => {
     const response = await resource.list({
@@ -145,6 +162,16 @@ const CascadeSelect = connect((props) => {
     return response?.data?.data;
   };
 
+  const getAssociationValue = (options) => {
+    if (options.length === 1 && !options[0].value) {
+      return null;
+    }
+    if (collectionField.interface === 'm2o') {
+      return normalizeToOneCascadeValue(options);
+    }
+    return options;
+  };
+
   const handleSelect = async (value, option, index) => {
     const data = await handleGetOptions({ parentId: option?.id });
     const options = [...selectedOptions];
@@ -154,18 +181,15 @@ const CascadeSelect = connect((props) => {
       options[index + 1] = { key: option?.id, children: data?.length > 0 ? data : null };
     }
     setSelectedOptions(options);
+    const associationValue = getAssociationValue(options);
     if (['o2m', 'm2m'].includes(collectionField.interface)) {
       const fieldValue = Array.isArray(associationField.fieldValue) ? associationField.fieldValue : [];
       fieldValue[field.index] = option;
       associationField.fieldValue = fieldValue;
     } else {
-      associationField.value = option;
+      associationField.value = associationValue;
     }
-    if (options.length === 1 && !options[0].value) {
-      onChange?.(null);
-    } else {
-      onChange?.(options);
-    }
+    onChange?.(associationValue);
   };
 
   const onDropdownVisibleChange = async (visible, selectedValue, index) => {
@@ -181,7 +205,11 @@ const CascadeSelect = connect((props) => {
         options[index] = { ...options[index], value: selectedValue?.value };
         options[index + 1] = { key: selectedValue?.value?.id, children: data?.length > 0 ? data : null };
         setSelectedOptions(options);
-        onChange?.(options);
+        const associationValue = getAssociationValue(options);
+        if (!['o2m', 'm2m'].includes(collectionField.interface)) {
+          associationField.value = associationValue;
+        }
+        onChange?.(associationValue);
       }
     }
   };
@@ -251,26 +279,38 @@ export const InternalCascadeSelect = observer(
     const form = useForm();
     const fieldSchema = useFieldSchema();
     const { loading, data: formData } = useDataBlockRequest() || {};
-    const initialValue = useMemo(() => formData?.data?.[fieldSchema.name], [loading]);
-    const associationDataFlag = !formData || fieldSchema.name in (formData?.data || {});
-    const handleFormValuesChange = debounce((form) => {
-      if (collectionField.interface === 'm2o') {
-        // 对 m2o 类型字段，提取最后一个非 null 值
-        const value = extractLastNonNullValueObjects(form.values?.[fieldSchema.name]);
-        setTimeout(() => {
-          form.setValuesIn(fieldSchema.name, value);
-          field.value = value;
-        });
-      } else {
-        // 对 select_array 类型字段，过滤掉空对象
-        const value = extractLastNonNullValueObjects(form.values?.select_array || []).filter(
-          (v) => v && Object.keys(v).length > 0,
-        );
-        setTimeout(() => {
-          field.value = value;
-        });
-      }
-    }, 300);
+    const fieldValue = field.value !== undefined ? field.value : props.value;
+    const requestValue = formData?.data?.[fieldSchema.name];
+    const initialValue = useMemo(() => {
+      const value = requestValue !== undefined ? requestValue : fieldValue;
+      return collectionField.interface === 'm2o' ? normalizeToOneCascadeValue(value) : value;
+    }, [collectionField.interface, fieldValue, requestValue]);
+    const associationDataFlag =
+      !formData ||
+      fieldSchema.name in (formData?.data || {}) ||
+      (collectionField.interface === 'm2o' && fieldValue !== undefined);
+    const handleFormValuesChange = useMemo(
+      () =>
+        debounce((form) => {
+          if (collectionField.interface === 'm2o') {
+            // 对 m2o 类型字段，提取最后一个非 null 值
+            const value = normalizeToOneCascadeValue(form.values?.[fieldSchema.name]);
+            setTimeout(() => {
+              field.value = value;
+            });
+          } else {
+            // 对 select_array 类型字段，过滤掉空对象
+            const value = extractLastNonNullValueObjects(form.values?.select_array || []).filter(
+              (v) => v && Object.keys(v).length > 0,
+            );
+            setTimeout(() => {
+              field.value = value;
+            });
+          }
+        }, 300),
+      [collectionField.interface, field, fieldSchema.name],
+    );
+    const currentFieldValue = form.values?.[fieldSchema.name];
 
     useEffect(() => {
       const id = uid();
@@ -285,11 +325,23 @@ export const InternalCascadeSelect = observer(
         // 清除防抖定时器
         handleFormValuesChange.cancel();
       };
-    }, []);
+    }, [handleFormValuesChange, selectForm]);
 
     useEffect(() => {
-      if (!form.values?.[fieldSchema.name]) {
-        if (selectForm && selectForm.values.select_array && !form.values?.[fieldSchema.name]) {
+      if (collectionField.interface !== 'm2o') {
+        return;
+      }
+      const value = initialValue ?? null;
+      if (isEqual(normalizeToOneCascadeValue(selectForm.values?.[fieldSchema.name]), value)) {
+        return;
+      }
+      selectForm.setInitialValues({ [fieldSchema.name]: value });
+      selectForm.setValuesIn(fieldSchema.name, value);
+    }, [collectionField.interface, fieldSchema.name, initialValue, selectForm]);
+
+    useEffect(() => {
+      if (!currentFieldValue) {
+        if (selectForm && selectForm.values.select_array && !currentFieldValue) {
           selectForm.setValuesIn('select_array', undefined);
           setTimeout(() => {
             selectForm.setValuesIn('select_array', [{}]);
@@ -298,7 +350,7 @@ export const InternalCascadeSelect = observer(
           selectForm.setValuesIn(fieldSchema.name, null);
         }
       }
-    }, [form.values?.[fieldSchema.name]]);
+    }, [currentFieldValue, fieldSchema.name, selectForm]);
 
     const toValue = () => {
       if (Array.isArray(initialValue) && initialValue.length > 0) {
@@ -433,6 +485,14 @@ function extractLastNonNullValueObjects(data, flag?) {
     }
   }
   return result;
+}
+
+function normalizeToOneCascadeValue(value) {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const result = extractLastNonNullValueObjects(value);
+  return Array.isArray(result) && result.length === 0 ? null : result;
 }
 
 export function transformNestedData(inputData) {

--- a/packages/core/client/src/schema-component/antd/association-field/__tests__/InternalCascadeSelect.test.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/__tests__/InternalCascadeSelect.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FormItem } from '@formily/antd-v5';
+import { createForm } from '@formily/core';
+import { createSchemaField, FormProvider, useField, useFieldSchema } from '@formily/react';
+import { render, screen, userEvent, waitFor } from '@nocobase/test/client';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { InternalCascadeSelect } from '../InternalCascadeSelect';
+
+const mocks = vi.hoisted(() => ({
+  associationFieldContext: undefined,
+  dataBlockRequest: { loading: false, data: { data: {} } },
+  resourceList: vi.fn(),
+}));
+
+vi.mock('../hooks', () => ({
+  default: () => ({ params: {} }),
+  useAssociationFieldContext: () => mocks.associationFieldContext,
+}));
+
+vi.mock('../../../', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useAPIClient: () => ({
+      resource: () => ({
+        list: mocks.resourceList,
+      }),
+    }),
+    useCollectionManager_deprecated: () => ({
+      getCollectionJoinField: () => null,
+      getInterface: () => ({ filterable: { operators: [{ value: '$includes' }] } }),
+    }),
+  };
+});
+
+vi.mock('../../../data-source', () => ({
+  useDataBlockRequest: () => mocks.dataBlockRequest,
+}));
+
+const collectionField = {
+  interface: 'm2o',
+  target: 'orgs',
+};
+
+const orgValue = {
+  id: 3,
+  parentId: 2,
+  parent: {
+    id: 2,
+    parentId: 1,
+    parent: {
+      id: 1,
+      parentId: null,
+    },
+  },
+};
+
+const TestCascadeSelect = (props) => {
+  const field = useField();
+  const fieldSchema = useFieldSchema();
+
+  mocks.associationFieldContext = {
+    options: collectionField,
+    field,
+    fieldSchema,
+    currentMode: 'CascadeSelect',
+  };
+
+  return <InternalCascadeSelect {...props} />;
+};
+
+const SchemaField = createSchemaField({
+  components: {
+    FormItem,
+    TestCascadeSelect,
+  },
+});
+
+const schema = {
+  type: 'object',
+  properties: {
+    org_m2o_tree: {
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'TestCascadeSelect',
+      'x-component-props': {
+        fieldNames: {
+          value: 'id',
+          label: 'id',
+        },
+        mode: 'CascadeSelect',
+      },
+    },
+  },
+};
+
+describe('InternalCascadeSelect', () => {
+  beforeEach(() => {
+    mocks.associationFieldContext = undefined;
+    mocks.dataBlockRequest = { loading: false, data: { data: {} } };
+    mocks.resourceList.mockReset();
+    mocks.resourceList.mockResolvedValue({
+      data: {
+        data: [],
+      },
+    });
+  });
+
+  it('syncs m2o value from the outer form when request data does not include the field yet', async () => {
+    const form = createForm();
+
+    render(
+      <FormProvider form={form}>
+        <SchemaField schema={schema} />
+      </FormProvider>,
+    );
+
+    form.setValuesIn('org_m2o_tree', orgValue);
+
+    await waitFor(() => {
+      expect(screen.getByText('1', { selector: '.ant-select-selection-item' })).toBeInTheDocument();
+      expect(screen.getByText('2', { selector: '.ant-select-selection-item' })).toBeInTheDocument();
+      expect(screen.getByText('3', { selector: '.ant-select-selection-item' })).toBeInTheDocument();
+    });
+  });
+
+  it('keeps m2o form value as the selected record instead of the cascade path array', async () => {
+    mocks.dataBlockRequest = { loading: false, data: { data: { org_m2o_tree: null } } };
+    mocks.resourceList.mockResolvedValue({
+      data: {
+        data: [
+          { id: 1, parentId: null },
+          { id: 2, parentId: null },
+        ],
+      },
+    });
+    const form = createForm();
+
+    render(
+      <FormProvider form={form}>
+        <SchemaField schema={schema} />
+      </FormProvider>,
+    );
+
+    await userEvent.click(document.querySelector('.ant-select-selector'));
+    await userEvent.click(await screen.findByText('2', { selector: '.ant-select-item-option-content' }));
+
+    await waitFor(() => {
+      expect(Array.isArray(form.values.org_m2o_tree)).toBe(false);
+      expect(form.values.org_m2o_tree).toMatchObject({ id: 2, parentId: null });
+    });
+  });
+
+  it('keeps the next cascade level available after selecting an m2o parent option', async () => {
+    mocks.dataBlockRequest = { loading: false, data: { data: { org_m2o_tree: null } } };
+    mocks.resourceList.mockImplementation(({ filter }) => {
+      const parentFilter = Array.isArray(filter?.$and)
+        ? filter.$and.find((item) => item && Object.prototype.hasOwnProperty.call(item, 'parentId'))
+        : filter;
+      const parentId = parentFilter?.parentId;
+      const data =
+        parentId === undefined ? [{ id: 1, parentId: null }] : parentId === 1 ? [{ id: 2, parentId: 1 }] : [];
+
+      return Promise.resolve({
+        data: {
+          data,
+        },
+      });
+    });
+    const form = createForm();
+
+    render(
+      <FormProvider form={form}>
+        <SchemaField schema={schema} />
+      </FormProvider>,
+    );
+
+    await userEvent.click(document.querySelector('.ant-select-selector'));
+    await userEvent.click(await screen.findByText('1', { selector: '.ant-select-item-option-content' }));
+
+    expect(Array.isArray(form.values.org_m2o_tree)).toBe(false);
+    expect(form.values.org_m2o_tree).toMatchObject({ id: 1, parentId: null });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.ant-select-selector')).toHaveLength(2);
+    });
+
+    await userEvent.click(document.querySelectorAll('.ant-select-selector')[1]);
+    await userEvent.click(await screen.findByText('2', { selector: '.ant-select-item-option-content' }));
+
+    await waitFor(() => {
+      expect(Array.isArray(form.values.org_m2o_tree)).toBe(false);
+      expect(form.values.org_m2o_tree).toMatchObject({ id: 2, parentId: 1 });
+    });
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v1 编辑表单使用引用模板时，树形关系字段 `org_m2o_tree` 虽然页面上有值，但提交时可能被当成数组保存，导致保存失败。用户在修改该字段后立即提交，也会遇到同样的报错。

### Description
本次修复让 `org_m2o_tree` 这类单选树形关系字段在表单里始终按最终选中的记录保存，同时保留页面上逐级选择的交互。

同时补充了相关测试，覆盖引用模板表单初始值同步、修改后提交值保持为单条记录，以及选择父级后仍能继续选择下一级的场景。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error when saving a tree relation field in a referenced form template |
| 🇨🇳 Chinese | 修复引用表单模板中保存树形关系字段时报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
