### PR TITLE
fix(flow-engine): preserve field search input

### DIFF
--- a/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
+++ b/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
@@ -463,6 +463,7 @@ const createSearchItem = (
   },
   activateSearchSubmenu: (key: string) => void,
   deactivateSearchSubmenu: (key: string) => void,
+  shouldActivateSearchSubmenu: boolean,
 ) => ({
   key: `${searchKey}-search`,
   type: 'group' as const,
@@ -480,28 +481,34 @@ const createSearchItem = (
         onChange={(e) => {
           e.stopPropagation();
           const value = e.target.value;
-          activateSearchSubmenu(searchKey);
+          if (shouldActivateSearchSubmenu) {
+            activateSearchSubmenu(searchKey);
+          }
           if ((e.nativeEvent as any)?.isComposing || searchHandlers.isComposing(searchKey)) {
             searchHandlers.updateInputValue(searchKey, value);
             return;
           }
-          if (!value) {
+          if (!value && shouldActivateSearchSubmenu) {
             deactivateSearchSubmenu(searchKey);
           }
           searchHandlers.updateSearchValue(searchKey, value);
         }}
         onCompositionStart={(e) => {
           e.stopPropagation();
-          activateSearchSubmenu(searchKey);
+          if (shouldActivateSearchSubmenu) {
+            activateSearchSubmenu(searchKey);
+          }
           searchHandlers.startComposition(searchKey);
         }}
         onCompositionEnd={(e) => {
           e.stopPropagation();
           const value = e.currentTarget.value;
-          if (value) {
-            activateSearchSubmenu(searchKey);
-          } else {
-            deactivateSearchSubmenu(searchKey);
+          if (shouldActivateSearchSubmenu) {
+            if (value) {
+              activateSearchSubmenu(searchKey);
+            } else {
+              deactivateSearchSubmenu(searchKey);
+            }
           }
           searchHandlers.endComposition(searchKey, value);
         }}
@@ -737,6 +744,7 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
     const searchKey = keyPath;
     const currentSearchValue = searchValues[searchKey] || '';
     const currentInputValue = inputValues[searchKey] ?? currentSearchValue;
+    const shouldActivateSearchSubmenu = !(item.type === 'group' && path.length === 0);
 
     // 递归过滤：当 child 为分组时，会继续向下过滤其 children；
     // 仅保留自身匹配或存在匹配子项的分组。
@@ -770,6 +778,7 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
       searchHandlers,
       activateSearchSubmenu,
       deactivateSearchSubmenu,
+      shouldActivateSearchSubmenu,
     );
     const dividerItem = { key: `${keyPath}-search-divider`, type: 'divider' as const };
 

--- a/packages/core/flow-engine/src/components/subModel/__tests__/AddSubModelButton.test.tsx
+++ b/packages/core/flow-engine/src/components/subModel/__tests__/AddSubModelButton.test.tsx
@@ -556,6 +556,57 @@ describe('transformItems - searchable flags', () => {
     await waitFor(() => expect(screen.getByText('Field 1')).toBeInTheDocument());
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
+
+  it('keeps root group search value when hovering a sibling submenu', async () => {
+    const engine = new FlowEngine();
+    await engine.flowSettings.forceEnable();
+    class Parent extends FlowModel {}
+    engine.registerModels({ Parent });
+    const parent = engine.createModel<FlowModel>({ use: 'Parent' });
+
+    const items = [
+      {
+        key: 'fields',
+        label: '',
+        type: 'group' as const,
+        searchable: true,
+        searchPlaceholder: 'Search fields',
+        children: [
+          { key: 'nickname', label: 'Nickname', createModelOptions: { use: 'Parent' } },
+          { key: 'email', label: 'Email', createModelOptions: { use: 'Parent' } },
+        ],
+      },
+      {
+        key: 'association-fields',
+        label: 'Display association fields',
+        children: [{ key: 'author', label: 'Author', createModelOptions: { use: 'Parent' } }],
+      },
+    ];
+
+    const user = userEvent.setup();
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>
+            <AddSubModelButton model={parent} subModelKey="items" items={items as any}>
+              Open
+            </AddSubModelButton>
+          </App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    await user.click(screen.getByText('Open'));
+    const searchInput = await screen.findByPlaceholderText('Search fields');
+    await user.type(searchInput, 'nick');
+    await waitFor(() => expect(screen.queryByText('Email')).not.toBeInTheDocument());
+
+    await user.hover(screen.getByText('Display association fields'));
+
+    await waitFor(() => expect(screen.getByText('Author')).toBeInTheDocument());
+    expect(searchInput).toHaveValue('nick');
+    expect(screen.getByText('Nickname')).toBeInTheDocument();
+  });
 });
 
 describe('transformItems - hide', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 页面配置字段时，用户在字段搜索框中输入关键词后，如果鼠标移到“显示关联表的字段”这一组，搜索框里的内容会被清空。这样会打断连续查找字段的操作，也容易让用户误以为搜索结果丢失。

### Description 
本次修复后，用户在“显示字段”搜索框中输入的内容会在移入“显示关联表的字段”时保留，字段列表仍按当前关键词展示。

同时补充了一个前端测试，覆盖“输入字段搜索词后移入关联字段分组，搜索框内容不被清空”的场景。建议在字段配置菜单中手动输入关键词，并将鼠标移到“显示关联表的字段”分组进行复测。

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where field search is cleared when hovering over association fields |
| 🇨🇳 Chinese | 修复鼠标移到关联字段分组时字段搜索内容被清空的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
