### PR TITLE
fix(client): sync hidden restore across same target

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.hiddenSync.restore.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.hiddenSync.restore.test.ts
@@ -1,0 +1,100 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { actionLinkageRules } from '../linkageRules';
+
+function createRule(actions: any[]) {
+  return {
+    key: 'r1',
+    title: 'r1',
+    enable: true,
+    condition: { logic: '$and', items: [] },
+    actions,
+  };
+}
+
+describe('linkageRules hidden state propagation', () => {
+  it('restores hidden state to same-target models when reverting to original props', async () => {
+    const blockModel = { uid: 'block-1' };
+
+    const hostModel: any = {
+      uid: 'host',
+      hidden: false,
+      context: { blockModel },
+      __allModels: [],
+      setProps: vi.fn(),
+      getFlow: vi.fn(() => ({})),
+      getStepParams: vi.fn((_flowKey: string, stepKey: string) => {
+        if (stepKey === 'init') return { fieldPath: 'org_m2o' };
+        return undefined;
+      }),
+      translate: (s: string) => s,
+    };
+
+    const sameTargetModel: any = {
+      uid: 'same-target',
+      hidden: false,
+      context: { blockModel },
+      setProps: vi.fn(),
+      getStepParams: vi.fn((_flowKey: string, stepKey: string) => {
+        if (stepKey === 'init') return { fieldPath: 'org_m2o' };
+        return undefined;
+      }),
+      translate: (s: string) => s,
+    };
+
+    const engine = {
+      forEachModel: (visitor: (m: any) => void) => {
+        [hostModel, sameTargetModel].forEach(visitor);
+      },
+    };
+
+    const ctx: any = {
+      flowKey: 'buttonSettings',
+      model: hostModel,
+      engine,
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      resolveJsonTemplate: vi.fn(async (value: any) => value),
+      getAction: (name: string) => {
+        if (name !== 'linkageSetActionProps') return undefined;
+        return {
+          handler: async (_ctx: any, params: any) => {
+            params.setProps(hostModel, {
+              hiddenModel: params.value === 'hidden',
+              disabled: false,
+              hiddenText: false,
+            });
+          },
+        };
+      },
+    };
+
+    await actionLinkageRules.handler(ctx, {
+      value: [
+        createRule([
+          {
+            name: 'linkageSetActionProps',
+            params: { value: 'hidden' },
+          },
+        ]),
+      ],
+    });
+    expect(hostModel.hidden).toBe(true);
+    expect(sameTargetModel.hidden).toBe(true);
+
+    await actionLinkageRules.handler(ctx, { value: [] });
+    expect(hostModel.hidden).toBe(false);
+    expect(sameTargetModel.hidden).toBe(false);
+  });
+});

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -2063,13 +2063,14 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
   mergedByUid.forEach((model: any, uid) => {
     const patchProps = mergedPropsByUid.get(uid) || {};
     const newProps = { ...model.__originalProps, ...patchProps };
-    const hasHiddenModelPatch = Object.prototype.hasOwnProperty.call(patchProps, 'hiddenModel');
+    const prevHidden = !!model.hidden;
+    const nextHidden = !!newProps.hiddenModel;
 
     model.setProps(_.omit(newProps, ['hiddenModel', 'value', 'hiddenText']));
     syncFieldOptionsToForks(model, patchProps);
-    model.hidden = !!newProps.hiddenModel;
-    if (hasHiddenModelPatch) {
-      hiddenStatePatches.push({ model, hidden: model.hidden });
+    model.hidden = nextHidden;
+    if (prevHidden !== nextHidden) {
+      hiddenStatePatches.push({ model, hidden: nextHidden });
     }
 
     if (newProps.required === true) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |（linkage rule） fix fields becoming readonly when shown after being hidden       |
| 🇨🇳 Chinese |  修复v2 表单切换字段显示状态后字段变为只读的问题   |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
