### PR TITLE
Fix license settings page hanging on pkg login check

### DIFF
--- a/packages/plugins/@nocobase/plugin-license/src/server/utils/pkg.ts
+++ b/packages/plugins/@nocobase/plugin-license/src/server/utils/pkg.ts
@@ -52,6 +52,7 @@ export async function testPkgConnection() {
 
 export async function testPkgLogin(keyData: KeyData | Record<string, any>) {
   try {
+    const timeout = 10000;
     const NOCOBASE_PKG_URL = getNocoBasePkgUrl();
     const { accessKeyId, accessKeySecret } = keyData || {};
     if (!accessKeyId || !accessKeySecret) {
@@ -60,6 +61,7 @@ export async function testPkgLogin(keyData: KeyData | Record<string, any>) {
     const credentials = { username: accessKeyId, password: accessKeySecret };
     const res1 = await axios.post(`${NOCOBASE_PKG_URL}-/verdaccio/sec/login`, credentials, {
       responseType: 'json',
+      timeout,
     });
     const token = res1.data.token;
     if (!token) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The license settings page could hang for a long time when the pkg service login check was slow or unreachable.

### Description
This change adds a 10 second timeout to the pkg login check used during license validation.
It prevents the license settings page from blocking on a long network stall when `pkg.nocobase.com` is slow or inaccessible.

Potential risk is low because the existing behavior already treated login failures as a non-fatal `false` result.

Testing suggestion:
- Open license settings with blocked or slow access to the pkg service and confirm the page returns promptly instead of hanging for more than two minutes.

### Related issues
- [nocobase/nocobase#9650](https://github.com/nocobase/nocobase/pull/9650)

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| English | Fixed the license settings page hanging for a long time when the pkg login check is slow or unreachable |
| Chinese | 修复许可证设置页面在 pkg 登录检查缓慢或不可达时长时间卡住的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| English |  <!-- [Title](link) -->    |
| Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
