### PR TITLE
Fix map field detail rendering for text and map modes

### DIFF
--- a/packages/plugins/@nocobase/plugin-map/src/client/models/fieldModels/DisplayMapFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/models/fieldModels/DisplayMapFieldModel.tsx
@@ -10,6 +10,8 @@
 import React from 'react';
 import { DisplayTitleFieldModel, TableColumnModel } from '@nocobase/client';
 import { tExpr } from '@nocobase/flow-engine';
+import { Typography } from 'antd';
+import { css } from '@emotion/css';
 import { MapComponent } from '../MapComponent';
 import { NAMESPACE } from '../../locale';
 
@@ -24,6 +26,42 @@ export const PointReadPretty = (props) => {
 export class DisplayMapFieldModel extends DisplayTitleFieldModel {
   getMapFieldType() {
     return null;
+  }
+
+  render(): any {
+    const { value, displayStyle, overflowMode, width } = this.props;
+
+    if (displayStyle === 'map') {
+      return this.renderComponent(value);
+    }
+
+    return (
+      <Typography.Text
+        ellipsis={
+          overflowMode === 'ellipsis'
+            ? {
+                tooltip: {
+                  rootClassName: css`
+                    .ant-tooltip-inner {
+                      color: #000;
+                      max-height: 500px;
+                      overflow-y: auto;
+                      padding: 10px;
+                    }
+                  `,
+                  color: '#fff',
+                },
+              }
+            : false
+        }
+        style={{
+          whiteSpace: overflowMode === 'wrap' ? 'normal' : 'nowrap',
+          width: width || 'auto',
+        }}
+      >
+        {this.renderComponent(value)}
+      </Typography.Text>
+    );
   }
 
   public renderComponent(value) {

--- a/packages/plugins/@nocobase/plugin-map/src/client/models/fieldModels/__tests__/DisplayMapFieldModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client/models/fieldModels/__tests__/DisplayMapFieldModel.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { DisplayPointFieldModel } from '../DisplayPointFieldModel';
+
+vi.mock('../../MapComponent', () => ({
+  MapComponent: (props) => <div data-testid="map-component">{JSON.stringify(props.value)}</div>,
+}));
+
+describe('DisplayMapFieldModel', () => {
+  function createModel(props: Record<string, any>) {
+    const engine = new FlowEngine();
+    engine.registerModels({ DisplayPointFieldModel });
+
+    const model = engine.createModel<DisplayPointFieldModel>({
+      use: DisplayPointFieldModel,
+      uid: `display-point-${props.displayStyle || 'text'}`,
+      props,
+    });
+
+    model.context.defineProperty('collectionField', {
+      value: {
+        uiSchema: {
+          'x-component-props': {
+            mapType: 'amap',
+          },
+        },
+      },
+    });
+
+    return model;
+  }
+
+  it('renders point values as text without converting the coordinate array to an empty string', () => {
+    const model = createModel({
+      displayStyle: 'text',
+      value: [116.397, 39.907],
+    });
+
+    render(<>{model.render()}</>);
+
+    expect(screen.getByText('116.397,39.907')).toBeInTheDocument();
+  });
+
+  it('passes the raw point value to the map component in map mode', () => {
+    const value = [116.397, 39.907];
+    const model = createModel({
+      displayStyle: 'map',
+      value,
+    });
+
+    render(<>{model.render()}</>);
+
+    expect(screen.getByTestId('map-component')).toHaveTextContent(JSON.stringify(value));
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Map field values in detail views were being normalized by the generic display-title pipeline before they reached the map-specific renderer. For point fields, this converted the raw coordinate array into a string, which caused text mode to render blank values and map mode to pass an invalid marker position to AMap.

### Description
- preserve raw map field values in detail displays instead of sending them through the generic display-value normalization flow
- keep point fields readable in text mode and keep map mode passing the original coordinate array to the map renderer
- add a regression test that covers both text mode and map mode for point detail fields

Potential risk:
- the change affects shared detail rendering for all map field types, so map detail displays should be smoke-tested across point, line, polygon, and circle fields

Testing suggestions:
- open a detail view with a point field and verify text mode shows coordinates
- switch the same field to map mode and verify the map renders without a `LngLat(NaN, NaN)` error

### Related issues
- Ticket 365550823342080

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| English | Fixed detail views so map fields keep their original values when switching between text and map display modes |
| Chinese | 修复详情页地图字段在文本和地图显示模式切换时原始值被错误转换，导致显示异常的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| English |  <!-- [Title](link) -->    |
| Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
