### PR TITLE
fix(ai): avoid ctx.get errors in AI employee workflow node

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -236,17 +236,21 @@ export abstract class LLMProvider {
   }
 
   protected async loadDocument(ctx: Context, attachment: any): Promise<any> {
-    const referer = ctx.get('referer') || '';
-    const ua = ctx.get('user-agent') || '';
     const safeFilename = attachment.filename ? path.basename(attachment.filename) : 'document';
-    const parsed = await this.documentLoader.load(attachment, {
-      requestOptions: {
-        headers: {
-          Referer: referer,
-          'User-Agent': ua,
-        },
-      },
-    });
+
+    const loaderOptions =
+      typeof ctx.get === 'function'
+        ? {
+            requestOptions: {
+              headers: {
+                Referer: ctx.get('referer') || '',
+                'User-Agent': ctx.get('user-agent') || '',
+              },
+            },
+          }
+        : undefined;
+
+    const parsed = await this.documentLoader.load(attachment, loaderOptions);
     if (!parsed.supported) {
       return {
         placement: 'system',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI employee workflow nodes can receive a workflow runtime context that does not expose `ctx.get()`. The existing attachment loading path unconditionally called `ctx.get`, which can throw before document parsing starts.

### Description
This PR guards the request header lookup used by `loadDocument()` so the document loader only reads `Referer` and `User-Agent` when the workflow context actually provides `ctx.get`.

The change keeps the existing request headers for HTTP contexts and avoids runtime failures for workflow contexts that do not implement that API.

Risk is low and limited to attachment loading in the AI provider path.

Tests were not run in this branch.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed `ctx.get` errors in AI employee workflow nodes |
| 🇨🇳 Chinese | 修复工作流 AI 员工节点调用`ctx.get`报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |    |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
