### PR TITLE
fix(client): wait for collection metadata

### DIFF
--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminDynamicPage.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminDynamicPage.tsx
@@ -9,11 +9,14 @@
 
 import { type FlowEngine, useFlowEngine } from '@nocobase/flow-engine';
 import { FlowRoute, getAdminLayoutModel, type LayoutRouteLike } from '@nocobase/client-v2';
+import { Spin } from 'antd';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { CurrentPageUidContext, useCurrentPageUid } from '../../../application/CustomRouterContextProvider';
 import { AppNotFound } from '../../../common/AppNotFound';
+import { useRemoteCollectionManagerLoading } from '../../../collection-manager/CollectionManagerProvider';
 import { RemoteSchemaComponent } from '../../../schema-component';
+import { LOADING_DELAY } from '../../../variables/constants';
 import { KeepAlive, useKeepAlive } from './KeepAlive';
 import { CurrentRouteProvider, useAllAccessDesktopRoutes } from './route-runtime';
 import { NocoBaseDesktopRoute, NocoBaseDesktopRouteType } from './route-types';
@@ -84,13 +87,23 @@ const getLegacyAdminLayoutModel = (flowEngine: FlowEngine) => {
   return getAdminLayoutModel(flowEngine, { required: true });
 };
 
+const LegacyFlowRoute = (props: { pageUid: string; active?: boolean }) => {
+  const collectionManagerLoading = useRemoteCollectionManagerLoading();
+
+  if (collectionManagerLoading) {
+    return <Spin style={{ width: '100%', marginTop: 20 }} delay={LOADING_DELAY} />;
+  }
+
+  return <FlowRoute {...props} getLayoutModel={getLegacyAdminLayoutModel} />;
+};
+
 const AdminPageContent = (props: { uid: string; allAccessRoutes: NocoBaseDesktopRoute[] }) => {
   const { uid, allAccessRoutes } = props;
   const { active } = useKeepAlive();
   const route = findRouteBySchemaUid(uid, allAccessRoutes);
 
   if (route?.type === NocoBaseDesktopRouteType.flowPage) {
-    return <FlowRoute pageUid={uid} active={active} getLayoutModel={getLegacyAdminLayoutModel} />;
+    return <LegacyFlowRoute pageUid={uid} active={active} />;
   }
 
   return <RemoteSchemaComponent uid={uid} />;

--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/AdminDynamicPage.test.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/AdminDynamicPage.test.tsx
@@ -21,12 +21,24 @@ const { useAllAccessDesktopRoutesMock } = vi.hoisted(() => ({
   useAllAccessDesktopRoutesMock: vi.fn(),
 }));
 
+const { useRemoteCollectionManagerLoadingMock } = vi.hoisted(() => ({
+  useRemoteCollectionManagerLoadingMock: vi.fn(),
+}));
+
 vi.mock('@nocobase/client-v2', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@nocobase/client-v2')>();
   const ReactModule = await import('react');
   return {
     ...actual,
     FlowRoute: ({ pageUid }) => ReactModule.createElement('div', { 'data-testid': 'flow-route', 'data-uid': pageUid }),
+  };
+});
+
+vi.mock('../../../../collection-manager/CollectionManagerProvider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../collection-manager/CollectionManagerProvider')>();
+  return {
+    ...actual,
+    useRemoteCollectionManagerLoading: () => useRemoteCollectionManagerLoadingMock(),
   };
 });
 
@@ -102,10 +114,12 @@ describe('AdminDynamicPage', () => {
     useAllAccessDesktopRoutesMock.mockReturnValue({
       allAccessRoutes: [{ schemaUid: 'flow-page-1', type: NocoBaseDesktopRouteType.flowPage }],
     });
+    useRemoteCollectionManagerLoadingMock.mockReturnValue(false);
   });
 
   afterEach(() => {
     useAllAccessDesktopRoutesMock.mockReset();
+    useRemoteCollectionManagerLoadingMock.mockReset();
   });
 
   it('should sync legacy admin route into admin layout model', async () => {
@@ -235,6 +249,32 @@ describe('AdminDynamicPage', () => {
 
     expect(await screen.findByTestId('flow-route')).toHaveAttribute('data-uid', 'flow-page-1');
     expect(screen.getByTestId('keep-alive')).toHaveAttribute('data-uid', 'flow-page-1');
+    expect(screen.queryByTestId('remote-schema')).toBeNull();
+  });
+
+  it('should wait for collection metadata before rendering flow pages in legacy admin route', () => {
+    useRemoteCollectionManagerLoadingMock.mockReturnValue(true);
+
+    const { container } = render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/flow-page-1/view/detail']}>
+          <Routes>
+            <Route
+              path="/admin/:name/view/*"
+              element={
+                <CurrentPageUidProvider>
+                  <AdminDynamicPage />
+                </CurrentPageUidProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    expect(screen.getByTestId('keep-alive')).toHaveAttribute('data-uid', 'flow-page-1');
+    expect(container.querySelector('.ant-spin')).toBeTruthy();
+    expect(screen.queryByTestId('flow-route')).toBeNull();
     expect(screen.queryByTestId('remote-schema')).toBeNull();
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
刷新页面时，部分区块在集合信息尚未加载完成的情况下可能提前渲染，导致页面偶现“数据表可能已被删除”的错误提示。实际数据表仍然存在，用户需要再次刷新或等待页面恢复，影响页面访问体验。

### Description 
本次调整让旧版管理端路由中的 v2 页面在集合信息加载完成后再渲染区块内容，避免刷新过程中把尚未加载到的集合误判为不存在。

同时补充了对应的单元测试，覆盖集合信息加载期间不会提前渲染页面区块的场景。

潜在风险较低，改动仅影响旧版管理端路由中 v2 页面的加载时机。

### Showcase
不涉及界面样式变更。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where blocks may incorrectly show as deleted after refreshing the page |
| 🇨🇳 Chinese | 修复刷新页面后区块偶现误提示数据表已删除的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
