### PR TITLE
fix(client): sync mobile relation selections

### DIFF
--- a/packages/core/client/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
@@ -21,7 +21,6 @@ import {
   type LazySelectProps,
   type PopupScrollEvent,
 } from '../AssociationFieldModel/recordSelectShared';
-import _ from 'lodash';
 
 const labelClassName = css`
   div {
@@ -45,7 +44,7 @@ function getValueKey(fieldNames: LazySelectProps['fieldNames']) {
 function deriveRecordsFromValue(
   value: LazySelectProps['value'],
   valueKey: string,
-  optionMap: Map<any, AssociationOption>,
+  optionMap: Map<unknown, AssociationOption>,
   isMultiple: boolean,
   valueMode: LazySelectProps['valueMode'] = 'record',
 ) {
@@ -98,7 +97,7 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
   const valueKey = getValueKey(fieldNames);
   const realOptions = resolveOptions(options, value, isMultiple);
   const optionMap = useMemo(() => {
-    const map = new Map<any, AssociationOption>();
+    const map = new Map<unknown, AssociationOption>();
     for (const item of realOptions) {
       map.set(item?.[valueKey], item);
     }
@@ -154,39 +153,32 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
   }, [onDropdownVisibleChange]);
 
   const handleConfirm = useCallback(() => {
-    if (valueMode === 'value') {
-      if (isMultiple) {
-        const values = selectedRecords
-          .map((item) => item?.[valueKey])
-          .filter((item) => item !== undefined && item !== null);
-        onChange(values as any);
-      } else {
-        onChange(selectedRecords?.[0]?.[valueKey]);
-      }
-      handleClose();
-      return;
-    }
-    onChange(selectedRecords);
     handleClose();
-  }, [handleClose, isMultiple, onChange, selectedRecords, valueKey, valueMode]);
+  }, [handleClose]);
 
   const handleListChange = useCallback(
     (vals: (string | number)[]) => {
       if (isMultiple) {
-        setSelectedRecords((prev) => {
-          const prevMap = new Map<any, AssociationOption>();
-          for (const item of prev) {
-            prevMap.set(item?.[valueKey], item);
+        const selectedMap = new Map<unknown, AssociationOption>();
+        for (const item of selectedRecords) {
+          selectedMap.set(item?.[valueKey], item);
+        }
+        const nextRecords: AssociationOption[] = [];
+        for (const id of vals) {
+          const nextItem = optionMap.get(id) ?? selectedMap.get(id);
+          if (nextItem) {
+            nextRecords.push(nextItem);
           }
-          const result: AssociationOption[] = [];
-          for (const id of vals) {
-            const nextItem = optionMap.get(id) ?? prevMap.get(id);
-            if (nextItem) {
-              result.push(nextItem);
-            }
-          }
-          return result;
-        });
+        }
+        setSelectedRecords(nextRecords);
+        if (valueMode === 'value') {
+          const values = nextRecords
+            .map((item) => item?.[valueKey])
+            .filter((item): item is string | number => item !== undefined && item !== null);
+          onChange(values as string[] | number[]);
+        } else {
+          onChange(nextRecords);
+        }
         return;
       }
       const selectedId = vals[0];
@@ -200,7 +192,7 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
       }
       handleClose();
     },
-    [handleClose, isMultiple, onChange, optionMap, valueKey, valueMode],
+    [handleClose, isMultiple, onChange, optionMap, selectedRecords, valueKey, valueMode],
   );
 
   const handleScroll = useCallback(

--- a/packages/core/client/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
@@ -175,7 +175,11 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
           const values = nextRecords
             .map((item) => item?.[valueKey])
             .filter((item): item is string | number => item !== undefined && item !== null);
-          onChange(values as string[] | number[]);
+          if (values.every((item) => typeof item === 'number')) {
+            onChange(values as number[]);
+          } else {
+            onChange(values.map(String));
+          }
         } else {
           onChange(nextRecords);
         }

--- a/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileLazySelect.test.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileLazySelect.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@nocobase/test/client';
+import { MobileLazySelect } from '../MobileLazySelect';
+
+const OPTIONS = [
+  { id: 1, name: 'Org A' },
+  { id: 2, name: 'Org B' },
+];
+
+const mockState = vi.hoisted(() => ({
+  checklistProps: undefined as any,
+}));
+
+function resetMockState() {
+  mockState.checklistProps = undefined;
+}
+
+function renderSelect(props: Record<string, any> = {}) {
+  const onChange = props.onChange ?? vi.fn();
+
+  render(
+    <MobileLazySelect
+      fieldNames={{ value: 'id', label: 'name' }}
+      multiple
+      allowMultiple
+      value={[]}
+      options={OPTIONS}
+      onChange={onChange}
+      {...props}
+    />,
+  );
+
+  return { onChange };
+}
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<any>('@nocobase/flow-engine');
+  return {
+    ...actual,
+    useFlowModel: () => ({
+      context: {
+        collectionField: {
+          targetCollection: undefined,
+        },
+      },
+      subModels: {},
+    }),
+    useFlowModelContext: () => ({
+      t: (value: string) => value,
+    }),
+  };
+});
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<any>('antd');
+  return {
+    ...actual,
+    Select: (props: any) => (
+      <button type="button" data-testid="select-trigger" onClick={props.onClick}>
+        Select
+      </button>
+    ),
+  };
+});
+
+vi.mock('antd-mobile', () => {
+  const MockCheckList: any = (props: any) => {
+    mockState.checklistProps = props;
+    return <div data-testid="checklist">{props.children}</div>;
+  };
+
+  MockCheckList.Item = ({ value, children }: any) => <div data-testid={`item-${value}`}>{children}</div>;
+
+  return {
+    Button: (props: any) => (
+      <button type="button" data-testid="confirm" onClick={props.onClick}>
+        {props.children}
+      </button>
+    ),
+    Popup: (props: any) => (props.visible ? <div data-testid="popup">{props.children}</div> : null),
+    SearchBar: ({ value, onChange }: any) => (
+      <input data-testid="search" value={value ?? ''} onChange={(e) => onChange?.(e.target.value)} />
+    ),
+    CheckList: MockCheckList,
+    SpinLoading: () => <div data-testid="loading" />,
+  };
+});
+
+describe('MobileLazySelect', () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  it('commits association records immediately when selecting in multiple mode', () => {
+    const { onChange } = renderSelect();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('select-trigger'));
+    });
+
+    act(() => {
+      mockState.checklistProps?.onChange?.([1, 2]);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(OPTIONS);
+  });
+
+  it('commits target key values immediately in value mode', () => {
+    const { onChange } = renderSelect({ valueMode: 'value' });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('select-trigger'));
+    });
+
+    act(() => {
+      mockState.checklistProps?.onChange?.([1, 2]);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('does not recommit multiple selections when confirming', () => {
+    const { onChange } = renderSelect();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('select-trigger'));
+    });
+
+    act(() => {
+      mockState.checklistProps?.onChange?.([1, 2]);
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId('confirm'));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In mobile layout or browser device simulation, many-to-many association selections in the mobile relation dropdown were only stored in the popup's local selection state until the user clicked Confirm. If the form was submitted after selecting records but before the form value had been synchronized, the submitted form values could still be empty.

### Description
This PR updates the mobile relation dropdown so multiple association selections are written back to the form immediately when the checklist selection changes. The Confirm button now only closes the popup, avoiding duplicate form change events.

Tests were added for immediate record/value commits and avoiding duplicate commits on Confirm.

Potential risk: mobile multiple-selection behavior changes from deferred commit to immediate commit. This matches desktop association select behavior and ensures form submissions read the latest selected values.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed mobile relation dropdowns so many-to-many selections are included when submitting a form. |
| 🇨🇳 Chinese | 修复移动端关联下拉多选后提交表单未包含所选多对多关联数据的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary

### Notes
ESLint was run manually and passed. The targeted test could not be executed in this worktree because local dependencies are not installed and the `nocobase`/`lint-staged` binaries are unavailable.