### PR TITLE
fix(client): keep mobile relation selection

### DIFF
--- a/packages/core/client/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
@@ -10,7 +10,7 @@
 import { useFlowModelContext } from '@nocobase/flow-engine';
 import { Select } from 'antd';
 import type { CSSProperties } from 'react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, CheckList, Popup, SearchBar, SpinLoading } from 'antd-mobile';
 import { css } from '@emotion/css';
 import {
@@ -51,7 +51,7 @@ function deriveRecordsFromValue(
 ) {
   if (isMultiple) {
     if (Array.isArray(value)) {
-      return (value.filter(Boolean) as any[]).map((item) => {
+      return (value.filter((item) => item !== null && item !== undefined) as any[]).map((item) => {
         if (valueMode === 'value') {
           return optionMap.get(item) ?? { [valueKey]: item };
         }
@@ -113,11 +113,13 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
   );
 
   const [selectedRecords, setSelectedRecords] = useState<AssociationOption[]>(() => derivedRecords);
+  const wasVisibleRef = useRef(visible);
 
   useEffect(() => {
-    if (visible) {
+    if (visible && !wasVisibleRef.current) {
       setSelectedRecords(derivedRecords);
     }
+    wasVisibleRef.current = visible;
   }, [derivedRecords, visible]);
 
   useEffect(() => {

--- a/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
@@ -10,11 +10,17 @@
 import React from 'react';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { act, fireEvent, render, screen } from '@nocobase/test/client';
+import { MobileLazySelect } from '../MobileLazySelect';
 import { MobileSelect } from '../MobileSelect';
 
 const DEFAULT_OPTIONS = [
   { label: 'Option A', value: 'a' },
   { label: 'Option B', value: 'b' },
+];
+
+const RELATION_OPTIONS = [
+  { uuid: '05f6a3b4-bfb7-7943-578a-3819e2687a7e' },
+  { uuid: 'c7d99828-a1de-9e70-4c2d-b0139abdf02e' },
 ];
 
 const mockState = vi.hoisted(() => ({
@@ -41,6 +47,13 @@ function clickTrigger() {
 
 function openPopup() {
   clickTrigger();
+  expect(screen.getByTestId('popup')).toBeInTheDocument();
+}
+
+function openLazyPopup() {
+  act(() => {
+    mockState.selectProps?.onClick?.();
+  });
   expect(screen.getByTestId('popup')).toBeInTheDocument();
 }
 
@@ -73,12 +86,36 @@ function renderMobileSelect(props: Record<string, any> = {}) {
   return { onChange, onChangeComplete };
 }
 
+function renderMobileLazySelect(props: Record<string, any> = {}) {
+  const onChange = props.onChange ?? vi.fn();
+
+  render(
+    <MobileLazySelect
+      fieldNames={{ label: 'uuid', value: 'uuid' }}
+      value={[]}
+      multiple
+      allowMultiple
+      options={RELATION_OPTIONS}
+      onChange={onChange}
+      {...props}
+    />,
+  );
+
+  return { onChange };
+}
+
 vi.mock('@nocobase/flow-engine', async () => {
   const actual = await vi.importActual<any>('@nocobase/flow-engine');
   return {
     ...actual,
     useFlowModelContext: () => ({
       t: (value: string) => value,
+    }),
+    useFlowModel: () => ({
+      context: {
+        collectionField: {},
+      },
+      subModels: {},
     }),
   };
 });
@@ -238,5 +275,26 @@ describe('MobileSelect in SubForm/SubTable containers', () => {
     expect(onCommit).toHaveBeenCalledTimes(2);
     expect(onCommit).toHaveBeenNthCalledWith(1, ['a', 'b']);
     expect(onCommit).toHaveBeenNthCalledWith(2, ['a', 'b']);
+  });
+});
+
+describe('MobileLazySelect', () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  it('keeps pending relation records selected until confirm', () => {
+    const { onChange } = renderMobileLazySelect();
+
+    openLazyPopup();
+    expect(mockState.checklistProps?.value).toEqual([]);
+
+    selectValues(['c7d99828-a1de-9e70-4c2d-b0139abdf02e']);
+    expect(mockState.checklistProps?.value).toEqual(['c7d99828-a1de-9e70-4c2d-b0139abdf02e']);
+
+    confirmSelection();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([RELATION_OPTIONS[1]]);
   });
 });

--- a/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
+++ b/packages/core/client/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
@@ -88,20 +88,26 @@ function renderMobileSelect(props: Record<string, any> = {}) {
 
 function renderMobileLazySelect(props: Record<string, any> = {}) {
   const onChange = props.onChange ?? vi.fn();
-
-  render(
+  const renderComponent = (nextProps: Record<string, any> = {}) => (
     <MobileLazySelect
       fieldNames={{ label: 'uuid', value: 'uuid' }}
       value={[]}
       multiple
       allowMultiple
       options={RELATION_OPTIONS}
-      onChange={onChange}
       {...props}
-    />,
+      {...nextProps}
+      onChange={onChange}
+    />
   );
 
-  return { onChange };
+  const result = render(renderComponent());
+
+  return {
+    ...result,
+    onChange,
+    rerender: (nextProps: Record<string, any> = {}) => result.rerender(renderComponent(nextProps)),
+  };
 }
 
 vi.mock('@nocobase/flow-engine', async () => {
@@ -284,12 +290,18 @@ describe('MobileLazySelect', () => {
   });
 
   it('keeps pending relation records selected until confirm', () => {
-    const { onChange } = renderMobileLazySelect();
+    const { onChange, rerender } = renderMobileLazySelect();
 
     openLazyPopup();
     expect(mockState.checklistProps?.value).toEqual([]);
 
     selectValues(['c7d99828-a1de-9e70-4c2d-b0139abdf02e']);
+    expect(mockState.checklistProps?.value).toEqual(['c7d99828-a1de-9e70-4c2d-b0139abdf02e']);
+
+    rerender({
+      options: RELATION_OPTIONS.map((item) => ({ ...item })),
+    });
+
     expect(mockState.checklistProps?.value).toEqual(['c7d99828-a1de-9e70-4c2d-b0139abdf02e']);
 
     confirmSelection();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在移动端表单中，关系字段打开选择列表后，选择数据并点击确认，字段仍然显示为空。用户无法确认自己刚刚选择的数据是否生效。

### Description 
修复移动端关系字段选择器在弹层打开期间重置待选数据的问题。现在用户选择关系数据后，确认前会保留当前选择，点击确认后字段会正常显示选中的记录。

已补充对应单测，覆盖移动端多选关系字段选择后再确认的场景。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where selected relation field data is not displayed on mobile |
| 🇨🇳 Chinese | 修复移动端关系字段选择数据后不显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
