### PR TITLE
fix(client): save menu linkage rules

### DIFF
--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
@@ -55,6 +55,15 @@ const insertPositionToMethod = {
   afterEnd: 'insertAfter',
 } as const;
 
+const omitMenuRuntimeProps = (props: Record<string, unknown> = {}) => {
+  const persistableProps = { ...props };
+  delete persistableProps.item;
+  delete persistableProps.dom;
+  delete persistableProps.options;
+  delete persistableProps.renderType;
+  return persistableProps;
+};
+
 export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStructure> {
   private creationPersisted = false;
   private persistedStateHydrated = false;
@@ -259,6 +268,12 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
     const currentFlowCount = this.flowRegistry.getFlows().size;
     const initialFlowCount = Object.keys((this as any)._options?.flowRegistry || {}).length;
     return currentFlowCount > 0 || initialFlowCount > 0;
+  }
+
+  serialize(): ReturnType<FlowModel['serialize']> {
+    const data = super.serialize();
+    data.props = omitMenuRuntimeProps(data.props);
+    return data;
   }
 
   setHidden(value: boolean) {

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
@@ -696,7 +696,6 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
 AdminLayoutMenuItemModel.registerFlow({
   key: 'menuCreation',
   title: 'Add menu item',
-  manual: true,
   steps: {
     basic: {
       title: 'Add menu item',
@@ -713,7 +712,6 @@ AdminLayoutMenuItemModel.registerFlow({
 AdminLayoutMenuItemModel.registerFlow({
   key: 'menuSettings',
   title: 'Menu settings',
-  manual: true,
   steps: {
     edit: {
       title: 'Edit',

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutMenuModels.tsx
@@ -696,6 +696,7 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
 AdminLayoutMenuItemModel.registerFlow({
   key: 'menuCreation',
   title: 'Add menu item',
+  manual: true,
   steps: {
     basic: {
       title: 'Add menu item',

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/AdminLayoutMenuModels.test.ts
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/__tests__/AdminLayoutMenuModels.test.ts
@@ -950,6 +950,73 @@ describe('AdminLayoutModel menu items', () => {
     });
   });
 
+  it('should save menu linkage rules without serializing runtime render props', async () => {
+    type SerializedFlowModel = Record<string, unknown> & {
+      props?: Record<string, unknown>;
+      subModels?: unknown;
+    };
+    const save = vi.fn(
+      async (targetModel: { serialize: () => SerializedFlowModel }, options?: { onlyStepParams?: boolean }) => {
+        const data = targetModel.serialize();
+        if (options?.onlyStepParams) {
+          delete data.subModels;
+        }
+
+        expect(data.props?.item).toBeUndefined();
+        expect(data.props?.dom).toBeUndefined();
+        expect(data.props?.options).toBeUndefined();
+        expect(data.props?.renderType).toBeUndefined();
+        expect(() => JSON.stringify(data)).not.toThrow();
+        return data;
+      },
+    );
+    const updateRoute = vi.fn().mockResolvedValue(undefined);
+    engine.setModelRepository({ save } as Parameters<FlowEngine['setModelRepository']>[0]);
+    engine.context.routeRepository.updateRoute = updateRoute;
+
+    const route = createRoute();
+    const model = engine.createModel<AdminLayoutMenuItemModel>({
+      uid: 'menu-item-linkage-runtime-props',
+      use: AdminLayoutMenuItemModel,
+      props: {
+        route,
+      },
+    });
+    const item = {
+      name: 'Page 1',
+      path: '/admin/page-1',
+      _route: route,
+      _model: model,
+    };
+
+    model.setProps({
+      item,
+      dom: React.createElement('span', null, 'Page 1'),
+      renderType: 'item',
+      options: { collapsed: false },
+    });
+    model.setStepParams('menuSettings', 'linkageRules', {
+      value: [
+        {
+          key: 'r1',
+          title: 'Hide menu item',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [{ key: 'a1', name: 'linkageSetMenuItemProps', params: { value: 'hidden' } }],
+        },
+      ],
+    });
+
+    await model.saveStepParams();
+
+    expect(save).toHaveBeenCalledWith(model, { onlyStepParams: true });
+    expect(updateRoute).toHaveBeenCalledWith(1, {
+      options: {
+        hasPersistedMenuInstanceFlow: true,
+      },
+    });
+  });
+
   it('should clear persisted menu linkage rules when no persisted state remains', async () => {
     const saveModel = vi.spyOn(engine, 'saveModel').mockResolvedValue(undefined as any);
     const destroy = vi.fn().mockResolvedValue(true);

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
@@ -679,7 +679,6 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
 AdminLayoutMenuItemModel.registerFlow({
   key: 'menuCreation',
   title: 'Add menu item',
-  manual: true,
   steps: {
     basic: {
       title: 'Add menu item',
@@ -696,7 +695,6 @@ AdminLayoutMenuItemModel.registerFlow({
 AdminLayoutMenuItemModel.registerFlow({
   key: 'menuSettings',
   title: 'Menu settings',
-  manual: true,
   steps: {
     edit: {
       title: 'Edit',

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
@@ -53,6 +53,15 @@ const insertPositionToMethod = {
   afterEnd: 'insertAfter',
 } as const;
 
+const omitMenuRuntimeProps = (props: Record<string, unknown> = {}) => {
+  const persistableProps = { ...props };
+  delete persistableProps.item;
+  delete persistableProps.dom;
+  delete persistableProps.options;
+  delete persistableProps.renderType;
+  return persistableProps;
+};
+
 export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStructure> {
   private creationPersisted = false;
   private persistedStateHydrated = false;
@@ -274,6 +283,12 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
     const currentFlowCount = this.flowRegistry.getFlows().size;
     const initialFlowCount = Object.keys((this as any)._options?.flowRegistry || {}).length;
     return currentFlowCount > 0 || initialFlowCount > 0;
+  }
+
+  serialize(): ReturnType<FlowModel['serialize']> {
+    const data = super.serialize();
+    data.props = omitMenuRuntimeProps(data.props);
+    return data;
   }
 
   setHidden(value: boolean) {

--- a/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/AdminLayoutMenuModels.tsx
@@ -679,6 +679,7 @@ export class AdminLayoutMenuItemModel extends FlowModel<AdminLayoutMenuItemStruc
 AdminLayoutMenuItemModel.registerFlow({
   key: 'menuCreation',
   title: 'Add menu item',
+  manual: true,
   steps: {
     basic: {
       title: 'Add menu item',

--- a/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-menu-models-legacy.test.tsx
+++ b/packages/core/client/src/route-switch/antd/admin-layout/__tests__/admin-layout-menu-models-legacy.test.tsx
@@ -477,6 +477,73 @@ describe('AdminLayoutMenuItemModel legacy behavior', () => {
     });
   });
 
+  it('should save menu linkage rules without serializing runtime render props in client v1', async () => {
+    type SerializedFlowModel = Record<string, unknown> & {
+      props?: Record<string, unknown>;
+      subModels?: unknown;
+    };
+    const save = vi.fn(
+      async (targetModel: { serialize: () => SerializedFlowModel }, options?: { onlyStepParams?: boolean }) => {
+        const data = targetModel.serialize();
+        if (options?.onlyStepParams) {
+          delete data.subModels;
+        }
+
+        expect(data.props?.item).toBeUndefined();
+        expect(data.props?.dom).toBeUndefined();
+        expect(data.props?.options).toBeUndefined();
+        expect(data.props?.renderType).toBeUndefined();
+        expect(() => JSON.stringify(data)).not.toThrow();
+        return data;
+      },
+    );
+    const updateRoute = vi.fn().mockResolvedValue(undefined);
+    engine.setModelRepository({ save } as Parameters<FlowEngine['setModelRepository']>[0]);
+    engine.context.routeRepository.updateRoute = updateRoute;
+
+    const route = createRoute();
+    const model = engine.createModel<AdminLayoutMenuItemModel>({
+      uid: 'legacy-menu-item-linkage-runtime-props',
+      use: AdminLayoutMenuItemModel,
+      props: {
+        route,
+      },
+    });
+    const item = {
+      name: 'Page 1',
+      path: '/admin/page-1',
+      _route: route,
+      _model: model,
+    };
+
+    model.setProps({
+      item,
+      dom: React.createElement('span', null, 'Page 1'),
+      renderType: 'item',
+      options: { collapsed: false },
+    });
+    model.setStepParams('menuSettings', 'linkageRules', {
+      value: [
+        {
+          key: 'r1',
+          title: 'Hide menu item',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [{ key: 'a1', name: 'linkageSetMenuItemProps', params: { value: 'hidden' } }],
+        },
+      ],
+    });
+
+    await model.saveStepParams();
+
+    expect(save).toHaveBeenCalledWith(model, { onlyStepParams: true });
+    expect(updateRoute).toHaveBeenCalledWith(1, {
+      options: {
+        hasPersistedMenuInstanceFlow: true,
+      },
+    });
+  });
+
   it('should clear persisted menu linkage rules when no persisted state remains in client v1', async () => {
     const saveModel = vi.spyOn(engine, 'saveModel').mockResolvedValue(undefined as any);
     const destroy = vi.fn().mockResolvedValue(true);

--- a/packages/core/flow-engine/src/executor/FlowExecutor.ts
+++ b/packages/core/flow-engine/src/executor/FlowExecutor.ts
@@ -158,9 +158,6 @@ export class FlowExecutor {
         const stepDefaultParams = await resolveDefaultParams(step.defaultParams, runtimeCtx);
         combinedParams = { ...stepDefaultParams };
       } else {
-        flowContext.logger.warn(
-          `BaseModel.applyFlow: Step '${stepKey}' in flow '${flowKey}' has neither 'use' nor 'handler'. Skipping.`,
-        );
         continue;
       }
 

--- a/packages/core/flow-engine/src/executor/__tests__/flowExecutor.test.ts
+++ b/packages/core/flow-engine/src/executor/__tests__/flowExecutor.test.ts
@@ -81,7 +81,7 @@ describe('FlowExecutor', () => {
     expect(result.step2).toBe('step2-ok');
   });
 
-  it('runFlow warns and skips steps without use or handler', async () => {
+  it('runFlow silently skips steps without use or handler', async () => {
     const flows = {
       referenceSettings: {
         steps: {
@@ -98,9 +98,7 @@ describe('FlowExecutor', () => {
       const result = await engine.executor.runFlow(model, 'referenceSettings');
 
       expect(result).toEqual({});
-      expect(loggerWarnSpy).toHaveBeenCalledWith(
-        "BaseModel.applyFlow: Step 'target' in flow 'referenceSettings' has neither 'use' nor 'handler'. Skipping.",
-      );
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
       expect(loggerErrorSpy).not.toHaveBeenCalled();
     } finally {
       loggerChildSpy.mockRestore();

--- a/packages/core/flow-engine/src/models/__tests__/flowModel.test.ts
+++ b/packages/core/flow-engine/src/models/__tests__/flowModel.test.ts
@@ -550,34 +550,6 @@ describe('FlowModel', () => {
 
         loggerSpy.mockRestore();
       });
-
-      test('should warn and skip step when use and handler are both missing', async () => {
-        const warnSpy = vi.spyOn(model.context.logger, 'warn').mockImplementation(() => {});
-        const errorSpy = vi.spyOn(model.context.logger, 'error').mockImplementation(() => {});
-
-        TestFlowModel.registerFlow({
-          key: 'settingsOnlyFlow',
-          steps: {
-            edit: {
-              title: 'Edit',
-              uiSchema: {},
-            },
-          },
-        });
-
-        const result = await model.applyFlow('settingsOnlyFlow');
-
-        expect(result).toEqual({});
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining("Step 'edit' in flow 'settingsOnlyFlow' has neither 'use' nor 'handler'"),
-        );
-        expect(errorSpy).not.toHaveBeenCalledWith(
-          expect.stringContaining("Step 'edit' in flow 'settingsOnlyFlow' has neither 'use' nor 'handler'"),
-        );
-
-        warnSpy.mockRestore();
-        errorSpy.mockRestore();
-      });
     });
 
     describe('beforeRender flows', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
配置顶部菜单或左侧菜单的菜单联动规则时，新增规则后点击保存会报错，导致规则无法正常保存。

### Description
本次修复避免菜单项保存联动规则时把页面渲染过程中临时使用的数据一起提交到后端。

这些临时数据只用于页面显示，不应该进入保存内容。修复后，顶部菜单和左侧菜单都可以正常新增、保存和清空菜单联动规则。

已补充 v1 和 v2 两套菜单模型测试，覆盖菜单联动规则保存时不会携带运行时渲染数据的场景。

### Showcase
无 UI 样式变更。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix menu linkage rule save errors |
| 🇨🇳 Chinese | 修复菜单联动规则保存报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
