### PR TITLE
fix(plugin-ai): guard llm provider base urls

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts
@@ -1,0 +1,104 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, afterEach } from 'vitest';
+import type { Application } from '@nocobase/server';
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import { EmbeddingProvider, LLMProvider } from '../provider';
+
+class TestLLMProvider extends LLMProvider {
+  get baseURL(): string {
+    return 'https://api.example.com/v1';
+  }
+
+  createModel() {
+    return {};
+  }
+
+  getResolvedURL() {
+    return this.getResolvedBaseURL();
+  }
+
+  buildURL(pathname: string) {
+    return this.buildRequestURL(pathname);
+  }
+}
+
+class TestEmbeddingProvider extends EmbeddingProvider {
+  protected getDefaultUrl(): string {
+    return 'https://api.example.com/v1';
+  }
+
+  createEmbedding(): EmbeddingsInterface {
+    return {} as EmbeddingsInterface;
+  }
+
+  getResolvedURL() {
+    return this.baseURL;
+  }
+}
+
+function createApp(renderedValue?: Record<string, unknown>): Application {
+  return {
+    environment: {
+      renderJsonTemplate: () => renderedValue ?? {},
+    },
+  } as unknown as Application;
+}
+
+const originalWhitelist = process.env.SERVER_REQUEST_WHITELIST;
+
+describe('LLM provider baseURL guard', () => {
+  afterEach(() => {
+    process.env.SERVER_REQUEST_WHITELIST = originalWhitelist;
+  });
+
+  it('normalizes rendered baseURL and preserves nested paths when building request URLs', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    const provider = new TestLLMProvider({
+      app: createApp({ baseURL: 'https://api.example.com/v1/' }),
+    });
+
+    expect(provider.serviceOptions.baseURL).toBe('https://api.example.com/v1');
+    expect(provider.buildURL('models')).toBe('https://api.example.com/v1/models');
+  });
+
+  it('validates provider default baseURL against the global whitelist', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    const provider = new TestLLMProvider({
+      app: createApp(),
+    });
+
+    expect(provider.getResolvedURL()).toBe('https://api.example.com/v1');
+  });
+
+  it('rejects rendered baseURL values blocked by the global whitelist', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    expect(
+      () =>
+        new TestLLMProvider({
+          app: createApp({ baseURL: 'http://169.254.169.254/latest/meta-data/' }),
+        }),
+    ).toThrow(/blocked/i);
+  });
+
+  it('applies the same normalization to embedding providers', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    const provider = new TestEmbeddingProvider({
+      app: createApp({ baseURL: 'https://api.example.com/v1/' }),
+      modelOptions: { model: 'text-embedding-3-small' },
+    });
+
+    expect(provider.getResolvedURL()).toBe('https://api.example.com/v1');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/anthropic.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/anthropic.ts
@@ -10,7 +10,7 @@
 import { LLMProvider, ParsedAttachmentResult } from './provider';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { PluginFileManagerServer } from '@nocobase/plugin-file-manager';
-import axios from 'axios';
+import { serverRequest } from '@nocobase/utils';
 import { encodeFile, stripToolCallTags } from '../utils';
 import { Model } from '@nocobase/database';
 import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
@@ -31,7 +31,7 @@ export class AnthropicProvider extends LLMProvider {
   }
 
   createModel() {
-    const { apiKey, baseURL } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const sanitizedModelOptions = { ...(this.modelOptions || {}) };
     const model = sanitizedModelOptions.model;
 
@@ -68,7 +68,7 @@ export class AnthropicProvider extends LLMProvider {
       apiKey,
       ...sanitizedModelOptions,
       model,
-      anthropicApiUrl: baseURL || this.baseURL,
+      anthropicApiUrl: this.getResolvedBaseURL(),
       verbose: false,
     });
   }
@@ -80,18 +80,22 @@ export class AnthropicProvider extends LLMProvider {
   }> {
     const options = this.serviceOptions || {};
     const apiKey = options.apiKey;
-    let baseURL = options.baseURL || this.baseURL;
-    if (!baseURL) {
+    let url: string;
+    try {
+      url = this.buildRequestURL('v1/models');
+    } catch (e) {
+      return { code: 400, errMsg: e instanceof Error ? e.message : String(e) };
+    }
+    if (!url) {
       return { code: 400, errMsg: 'baseURL is required' };
     }
     if (!apiKey) {
       return { code: 400, errMsg: 'API Key required' };
     }
-    if (baseURL && baseURL.endsWith('/')) {
-      baseURL = baseURL.slice(0, -1);
-    }
     try {
-      const res = await axios.get(`${baseURL}/v1/models`, {
+      const res = await serverRequest({
+        method: 'GET',
+        url,
         headers: {
           'x-api-key': apiKey,
           'anthropic-version': '2023-06-01',

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -30,7 +30,7 @@ export class DashscopeProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
 
@@ -63,7 +63,7 @@ export class DashscopeProvider extends LLMProvider {
       ...this.modelOptions,
       modelKwargs,
       configuration: {
-        baseURL: baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       },
       verbose: false,
     });
@@ -122,7 +122,7 @@ export class DashscopeEmbeddingProvider extends EmbeddingProvider {
   createEmbedding(): EmbeddingsInterface {
     return new OpenAIEmbeddings({
       configuration: {
-        baseURL: this.baseURL ?? '',
+        baseURL: this.baseURL,
         apiKey: this.apiKey,
       },
       model: this.model,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
@@ -71,7 +71,7 @@ export class DeepSeekProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat } = this.modelOptions || {};
 
     const modelKwargs: Record<string, any> = {};
@@ -88,7 +88,7 @@ export class DeepSeekProvider extends LLMProvider {
       ...this.modelOptions,
       modelKwargs,
       configuration: {
-        baseURL: baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       },
       verbose: false,
     });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/google-genai.ts
@@ -9,7 +9,7 @@
 
 import { ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings } from '@langchain/google-genai';
 import { EmbeddingProvider, LLMProvider, ParsedAttachmentResult } from './provider';
-import axios from 'axios';
+import { serverRequest } from '@nocobase/utils';
 import { Model } from '@nocobase/database';
 import { encodeFile } from '../utils';
 import { AttachmentModel, PluginFileManagerServer } from '@nocobase/plugin-file-manager';
@@ -29,7 +29,7 @@ export class GoogleGenAIProvider extends LLMProvider {
   }
 
   createModel() {
-    const { apiKey, baseURL } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { model, responseFormat } = this.modelOptions || {};
 
     return new ChatGoogleGenerativeAI({
@@ -37,7 +37,7 @@ export class GoogleGenAIProvider extends LLMProvider {
       ...this.modelOptions,
       model,
       json: responseFormat === 'json',
-      baseUrl: baseURL ?? this.baseURL,
+      baseUrl: this.getResolvedBaseURL(),
     });
   }
 
@@ -48,18 +48,23 @@ export class GoogleGenAIProvider extends LLMProvider {
   }> {
     const options = this.serviceOptions || {};
     const apiKey = options.apiKey;
-    let baseURL = options.baseURL || this.baseURL;
-    if (!baseURL) {
+    let url: string;
+    try {
+      url = this.buildRequestURL(`v1beta/models?key=${encodeURIComponent(apiKey ?? '')}`);
+    } catch (e) {
+      return { code: 400, errMsg: e instanceof Error ? e.message : String(e) };
+    }
+    if (!url) {
       return { code: 400, errMsg: 'baseURL is required' };
     }
     if (!apiKey) {
       return { code: 400, errMsg: 'API Key required' };
     }
-    if (baseURL && baseURL.endsWith('/')) {
-      baseURL = baseURL.slice(0, -1);
-    }
     try {
-      const res = await axios.get(`${baseURL}/v1beta/models?key=${apiKey}`);
+      const res = await serverRequest({
+        method: 'GET',
+        url,
+      });
       return {
         models: res?.data?.models.map((model) => ({
           id: model.name,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
@@ -26,7 +26,7 @@ export class KimiProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
     const responseFormatOptions = {
@@ -42,7 +42,7 @@ export class KimiProvider extends LLMProvider {
         response_format: responseFormatOptions,
       },
       configuration: {
-        baseURL: baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       },
     });
   }
@@ -83,7 +83,7 @@ export class KimiProvider extends LLMProvider {
     if (!this._documentLoader) {
       const loader = new KimiDocumentLoader(this.aiPlugin.fileManager, {
         apiKey: this.serviceOptions?.apiKey,
-        baseURL: this.serviceOptions?.baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       });
       this._documentLoader = new CachedDocumentLoader(this.aiPlugin, {
         loader,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/mimo.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/mimo.ts
@@ -24,7 +24,7 @@ export class MiMoProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
     const responseFormatOptions = {
@@ -41,7 +41,7 @@ export class MiMoProvider extends LLMProvider {
         response_format: responseFormatOptions,
       },
       configuration: {
-        baseURL: baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       },
       verbose: true,
     });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/ollama.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/ollama.ts
@@ -11,7 +11,7 @@ import { ChatOllama, OllamaEmbeddings } from '@langchain/ollama';
 import { LLMProvider, EmbeddingProvider } from './provider';
 import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
 import { EmbeddingsInterface } from '@langchain/core/embeddings';
-import axios from 'axios';
+import { serverRequest } from '@nocobase/utils';
 
 const OLLAMA_DEFAULT_URL = 'http://localhost:11434';
 
@@ -23,11 +23,10 @@ export class OllamaProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL } = this.serviceOptions || {};
     const { model, temperature, topP, topK, numPredict, ...rest } = this.modelOptions || {};
 
     return new ChatOllama({
-      baseUrl: baseURL || this.baseURL,
+      baseUrl: this.getResolvedBaseURL(),
       model: model || 'mistral-nemo:12b',
       temperature,
       topP,
@@ -45,19 +44,21 @@ export class OllamaProvider extends LLMProvider {
     code?: number;
     errMsg?: string;
   }> {
-    const options = this.serviceOptions || {};
-    let baseURL = options.baseURL || this.baseURL;
-
-    if (!baseURL) {
+    let url: string;
+    try {
+      url = this.buildRequestURL('api/tags');
+    } catch (e) {
+      return { code: 400, errMsg: e instanceof Error ? e.message : String(e) };
+    }
+    if (!url) {
       return { code: 400, errMsg: 'baseURL is required' };
     }
 
-    if (baseURL && baseURL.endsWith('/')) {
-      baseURL = baseURL.slice(0, -1);
-    }
-
     try {
-      const res = await axios.get(`${baseURL}/api/tags`);
+      const res = await serverRequest({
+        method: 'GET',
+        url,
+      });
       const models = res?.data?.models || [];
 
       return {
@@ -68,7 +69,9 @@ export class OllamaProvider extends LLMProvider {
     } catch (e) {
       return {
         code: 500,
-        errMsg: `Failed to fetch Ollama models: ${e.message}. Make sure Ollama is running at ${baseURL}`,
+        errMsg: `Failed to fetch Ollama models: ${
+          e.message
+        }. Make sure Ollama is running at ${this.getResolvedBaseURL()}`,
       };
     }
   }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
@@ -18,7 +18,7 @@ export class OpenAICompletionsProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
     const responseFormatOptions = {
@@ -34,7 +34,7 @@ export class OpenAICompletionsProvider extends LLMProvider {
         response_format: responseFormatOptions,
       },
       configuration: {
-        baseURL: baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       },
     });
   }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/embedding.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/embedding.ts
@@ -19,7 +19,7 @@ export class OpenAiEmbeddingProvider extends EmbeddingProvider {
   createEmbedding(): EmbeddingsInterface {
     return new OpenAIEmbeddings({
       configuration: {
-        baseURL: this.baseURL ?? '',
+        baseURL: this.baseURL,
         apiKey: this.apiKey,
       },
       model: this.model,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/responses.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/responses.ts
@@ -22,7 +22,7 @@ export class OpenAIResponsesProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
     const responseFormatOptions = {
@@ -41,7 +41,7 @@ export class OpenAIResponsesProvider extends LLMProvider {
         },
       },
       configuration: {
-        baseURL: baseURL || this.baseURL,
+        baseURL: this.getResolvedBaseURL(),
       },
       verbose: false,
       useResponsesApi: true,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -11,7 +11,7 @@ import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { Model } from '@nocobase/database';
 import { AttachmentModel, PluginFileManagerServer } from '@nocobase/plugin-file-manager';
 import { Application } from '@nocobase/server';
-import axios from 'axios';
+import { checkUrlAgainstWhitelist, serverRequest } from '@nocobase/utils';
 import { AIChatContext } from '../types/ai-chat-conversation.type';
 import { encodeFile, parseResponseMessage, stripToolCallTags } from '../utils';
 import { EmbeddingsInterface } from '@langchain/core/embeddings';
@@ -37,6 +37,22 @@ export interface LLMProviderOptions {
   modelOptions?: Record<string, any>;
 }
 
+function normalizeBaseURL(baseURL: string): string {
+  checkUrlAgainstWhitelist(baseURL);
+  return new URL(baseURL).toString().replace(/\/$/, '');
+}
+
+function resolveServiceOptions(serviceOptions: Record<string, any> | undefined, app: Application) {
+  const rendered = app.environment.renderJsonTemplate(serviceOptions ?? {});
+  if (rendered?.baseURL != null) {
+    if (typeof rendered.baseURL !== 'string') {
+      throw new Error('baseURL must be a string');
+    }
+    rendered.baseURL = normalizeBaseURL(rendered.baseURL);
+  }
+  return rendered;
+}
+
 export abstract class LLMProvider {
   app: Application;
   serviceOptions: Record<string, any>;
@@ -52,7 +68,7 @@ export abstract class LLMProvider {
   constructor(opts: LLMProviderOptions) {
     const { app, serviceOptions, modelOptions } = opts;
     this.app = app;
-    this.serviceOptions = app.environment.renderJsonTemplate(serviceOptions);
+    this.serviceOptions = resolveServiceOptions(serviceOptions, app);
     if (modelOptions) {
       this.modelOptions = modelOptions;
       this.chatModel = this.createModel();
@@ -99,18 +115,19 @@ export abstract class LLMProvider {
   }> {
     const options = this.serviceOptions || {};
     const apiKey = options.apiKey;
-    let baseURL = options.baseURL || this.baseURL;
-    if (!baseURL) {
-      return { code: 400, errMsg: 'baseURL is required' };
+    let url: string;
+    try {
+      url = this.buildRequestURL('models');
+    } catch (e) {
+      return { code: 400, errMsg: e instanceof Error ? e.message : String(e) };
     }
     if (!apiKey) {
       return { code: 400, errMsg: 'API Key required' };
     }
-    if (baseURL && baseURL.endsWith('/')) {
-      baseURL = baseURL.slice(0, -1);
-    }
     try {
-      const res = await axios.get(`${baseURL}/models`, {
+      const res = await serverRequest({
+        method: 'GET',
+        url,
         headers: {
           Authorization: `Bearer ${apiKey}`,
         },
@@ -304,6 +321,23 @@ export abstract class LLMProvider {
     return this.aiPlugin.documentLoaders.cached;
   }
 
+  protected getResolvedBaseURL(): string {
+    const baseURL = this.serviceOptions?.baseURL ?? this.baseURL;
+    if (!baseURL) {
+      throw new Error('baseURL is required');
+    }
+    if (typeof baseURL !== 'string') {
+      throw new Error('baseURL must be a string');
+    }
+    return normalizeBaseURL(baseURL);
+  }
+
+  protected buildRequestURL(pathname: string): string {
+    const url = new URL(pathname.replace(/^\/+/, ''), `${this.getResolvedBaseURL()}/`).toString();
+    checkUrlAgainstWhitelist(url);
+    return url;
+  }
+
   protected get aiPlugin(): PluginAIServer {
     return this.app.pm.get('ai');
   }
@@ -322,7 +356,7 @@ export abstract class EmbeddingProvider {
   constructor(protected opts: EmbeddingProviderOptions) {
     const { app, serviceOptions, modelOptions } = this.opts;
     this.app = app;
-    this.serviceOptions = app.environment.renderJsonTemplate(serviceOptions ?? {});
+    this.serviceOptions = resolveServiceOptions(serviceOptions, app);
     this.modelOptions = modelOptions;
   }
   abstract createEmbedding(): EmbeddingsInterface;
@@ -341,7 +375,10 @@ export abstract class EmbeddingProvider {
     if (!baseURL) {
       throw new Error('baseURL is required');
     }
-    return baseURL;
+    if (typeof baseURL !== 'string') {
+      throw new Error('baseURL must be a string');
+    }
+    return normalizeBaseURL(baseURL);
   }
 
   protected get model() {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/xai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/xai.ts
@@ -19,7 +19,7 @@ export class XAIProvider extends LLMProvider {
   }
 
   createModel() {
-    const { baseURL, apiKey } = this.serviceOptions || {};
+    const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput, ...restModelOptions } = this.modelOptions || {};
     const { schema } = structuredOutput || {};
 
@@ -35,7 +35,7 @@ export class XAIProvider extends LLMProvider {
     return new ChatXAI({
       apiKey,
       ...restModelOptions,
-      baseURL: baseURL || this.baseURL,
+      baseURL: this.getResolvedBaseURL(),
       modelKwargs: {
         response_format: responseFormatOptions,
       },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Prevent custom or templated AI provider `baseURL` values from bypassing the server request whitelist and producing inconsistent request URLs.

### Description
This PR normalizes rendered LLM provider `baseURL` values before use, validates both default and custom provider URLs against the global server request whitelist, and centralizes request URL construction in shared helper methods.

It also switches model-discovery requests in multiple providers to `serverRequest`, so provider connectivity checks go through the same guarded request path as runtime calls.

Coverage is added for `baseURL` normalization, whitelist enforcement, and nested-path request URL building in provider tests.

Testing note: `yarn test packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts` could not be executed in this environment because the workspace does not have the `nocobase` CLI available on PATH.

### Related issues
N/A

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI provider base URL validation. |
| 🇨🇳 Chinese | 修复 AI 提供商 base URL 校验问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
