### PR TITLE
fix(plugin-workflow): prevent duplicate execution dispatch

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -21,6 +21,8 @@ import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
 const EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
 
+type AcquireRetryLogger = Pick<ReturnType<PluginWorkflowServer['getLogger']>, 'warn'>;
+
 type Pending = {
   execution: ExecutionModel;
   job?: JobModel;
@@ -415,9 +417,8 @@ export default class Dispatcher {
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
     let fetched: ExecutionModel | null = null;
     try {
-      for (let attempt = 1; !fetched && attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
-        let shouldRetry = false;
-        try {
+      await this.acquireWithRetry(
+        async () => {
           await this.plugin.db.sequelize.transaction({ isolationLevel }, async (transaction) => {
             const ExecutionModelClass = this.plugin.db.getModel('executions');
             const [affected] = await ExecutionModelClass.update(
@@ -436,23 +437,14 @@ export default class Dispatcher {
             await execution.reload({ transaction });
             fetched = execution;
           });
-        } catch (error) {
-          if (!this.isConcurrentAcquireError(error)) {
-            throw error;
-          }
-          shouldRetry = true;
-          logger.warn(`acquiring pending execution (${execution.id}) conflicted with another worker, retrying`, {
-            error,
-          });
-        }
-        if (!shouldRetry) {
-          break;
-        }
-        if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
-          logger.warn(`acquiring pending execution (${execution.id}) reached max retry attempts`);
-          break;
-        }
-      }
+          return false;
+        },
+        {
+          logger,
+          conflictMessage: `acquiring pending execution (${execution.id}) conflicted with another worker, retrying`,
+          maxAttemptsMessage: `acquiring pending execution (${execution.id}) reached max retry attempts`,
+        },
+      );
     } catch (error) {
       fetched = null;
       logger.error(`acquiring pending execution failed: ${error.message}`, { error });
@@ -465,9 +457,9 @@ export default class Dispatcher {
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
     let fetched: ExecutionModel | null = null;
     try {
-      for (let attempt = 1; !fetched && attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
-        let shouldRetry = false;
-        try {
+      await this.acquireWithRetry(
+        async () => {
+          let shouldRetry = false;
           await this.plugin.db.sequelize.transaction(
             {
               isolationLevel,
@@ -486,7 +478,6 @@ export default class Dispatcher {
                 return;
               }
 
-              this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
               const ExecutionModelClass = this.plugin.db.getModel('executions');
               const [affected] = await ExecutionModelClass.update(
                 {
@@ -509,34 +500,53 @@ export default class Dispatcher {
                 return;
               }
 
+              this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
               await execution.reload({ transaction });
               execution.workflow = this.plugin.enabledCache.get(execution.workflowId);
               fetched = execution;
             },
           );
-        } catch (error) {
-          if (!this.isConcurrentAcquireError(error)) {
-            throw error;
-          }
-          shouldRetry = true;
-          this.plugin.getLogger('dispatcher').warn(`acquiring execution conflicted with another worker, retrying`, {
-            error,
-          });
-        }
-        if (!shouldRetry) {
-          break;
-        }
-        if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
-          this.plugin
-            .getLogger('dispatcher')
-            .warn(`acquiring execution reached max retry attempts, will retry on next dispatch`);
-          break;
-        }
-      }
+          return shouldRetry;
+        },
+        {
+          logger: this.plugin.getLogger('dispatcher'),
+          conflictMessage: `acquiring execution conflicted with another worker, retrying`,
+          maxAttemptsMessage: `acquiring execution reached max retry attempts, will retry on next dispatch`,
+        },
+      );
     } catch (error) {
       this.plugin.getLogger('dispatcher').error(`fetching execution from db failed: ${error.message}`, { error });
     }
     return fetched;
+  }
+
+  private async acquireWithRetry(
+    acquire: () => Promise<boolean>,
+    options: {
+      logger: AcquireRetryLogger;
+      conflictMessage: string;
+      maxAttemptsMessage: string;
+    },
+  ) {
+    for (let attempt = 1; attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
+      let shouldRetry = false;
+      try {
+        shouldRetry = await acquire();
+      } catch (error) {
+        if (!this.isConcurrentAcquireError(error)) {
+          throw error;
+        }
+        shouldRetry = true;
+        options.logger.warn(options.conflictMessage, { error });
+      }
+      if (!shouldRetry) {
+        break;
+      }
+      if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
+        options.logger.warn(options.maxAttemptsMessage);
+        break;
+      }
+    }
   }
 
   private getExecutionLockKey(executionId: number | string) {
@@ -558,7 +568,7 @@ export default class Dispatcher {
     const code = databaseError.parent?.code || databaseError.original?.code;
     const errno = databaseError.parent?.errno || databaseError.original?.errno;
 
-    return code === '40001' || code === 'ER_LOCK_DEADLOCK' || errno === 1205 || errno === 1213;
+    return code === '40001' || code === '40P01' || code === 'ER_LOCK_DEADLOCK' || errno === 1205 || errno === 1213;
   }
 
   private async process(

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -20,7 +20,6 @@ import type PluginWorkflowServer from './Plugin';
 import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
 const EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
-const EXECUTION_ACQUIRE_RETRY_DELAY_MS = 50;
 
 type Pending = {
   execution: ExecutionModel;
@@ -453,7 +452,6 @@ export default class Dispatcher {
           logger.warn(`acquiring pending execution (${execution.id}) reached max retry attempts`);
           break;
         }
-        await new Promise((resolve) => setTimeout(resolve, EXECUTION_ACQUIRE_RETRY_DELAY_MS * attempt));
       }
     } catch (error) {
       fetched = null;
@@ -534,7 +532,6 @@ export default class Dispatcher {
             .warn(`acquiring execution reached max retry attempts, will retry on next dispatch`);
           break;
         }
-        await new Promise((resolve) => setTimeout(resolve, EXECUTION_ACQUIRE_RETRY_DELAY_MS * attempt));
       }
     } catch (error) {
       this.plugin.getLogger('dispatcher').error(`fetching execution from db failed: ${error.message}`, { error });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -19,8 +19,8 @@ import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import type PluginWorkflowServer from './Plugin';
 import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
-const QUEUEING_EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
-const QUEUEING_EXECUTION_ACQUIRE_RETRY_DELAY_MS = 50;
+const EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
+const EXECUTION_ACQUIRE_RETRY_DELAY_MS = 50;
 
 type Pending = {
   execution: ExecutionModel;
@@ -414,27 +414,49 @@ export default class Dispatcher {
     const logger = this.plugin.getLogger(execution.workflowId);
     const isolationLevel =
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
-    let fetched: ExecutionModel | null = execution;
+    let fetched: ExecutionModel | null = null;
     try {
-      await this.plugin.db.sequelize.transaction({ isolationLevel }, async (transaction) => {
-        const ExecutionModelClass = this.plugin.db.getModel('executions');
-        const [affected] = await ExecutionModelClass.update(
-          { dispatched: true, status: EXECUTION_STATUS.STARTED },
-          {
-            where: {
-              id: execution.id,
-              dispatched: false,
-            },
-            transaction,
-          },
-        );
-        if (!affected) {
-          fetched = null;
-          return;
+      for (let attempt = 1; !fetched && attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
+        let shouldRetry = false;
+        try {
+          await this.plugin.db.sequelize.transaction({ isolationLevel }, async (transaction) => {
+            const ExecutionModelClass = this.plugin.db.getModel('executions');
+            const [affected] = await ExecutionModelClass.update(
+              { dispatched: true, status: EXECUTION_STATUS.STARTED },
+              {
+                where: {
+                  id: execution.id,
+                  dispatched: false,
+                },
+                transaction,
+              },
+            );
+            if (!affected) {
+              return;
+            }
+            await execution.reload({ transaction });
+            fetched = execution;
+          });
+        } catch (error) {
+          if (!this.isConcurrentAcquireError(error)) {
+            throw error;
+          }
+          shouldRetry = true;
+          logger.warn(`acquiring pending execution (${execution.id}) conflicted with another worker, retrying`, {
+            error,
+          });
         }
-        await execution.reload({ transaction });
-      });
+        if (!shouldRetry) {
+          break;
+        }
+        if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
+          logger.warn(`acquiring pending execution (${execution.id}) reached max retry attempts`);
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, EXECUTION_ACQUIRE_RETRY_DELAY_MS * attempt));
+      }
     } catch (error) {
+      fetched = null;
       logger.error(`acquiring pending execution failed: ${error.message}`, { error });
     }
     return fetched;
@@ -445,7 +467,7 @@ export default class Dispatcher {
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
     let fetched: ExecutionModel | null = null;
     try {
-      for (let attempt = 1; !fetched && attempt <= QUEUEING_EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
+      for (let attempt = 1; !fetched && attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
         let shouldRetry = false;
         try {
           await this.plugin.db.sequelize.transaction(
@@ -506,13 +528,13 @@ export default class Dispatcher {
         if (!shouldRetry) {
           break;
         }
-        if (attempt >= QUEUEING_EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
+        if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
           this.plugin
             .getLogger('dispatcher')
             .warn(`acquiring execution reached max retry attempts, will retry on next dispatch`);
           break;
         }
-        await new Promise((resolve) => setTimeout(resolve, QUEUEING_EXECUTION_ACQUIRE_RETRY_DELAY_MS * attempt));
+        await new Promise((resolve) => setTimeout(resolve, EXECUTION_ACQUIRE_RETRY_DELAY_MS * attempt));
       }
     } catch (error) {
       this.plugin.getLogger('dispatcher').error(`fetching execution from db failed: ${error.message}`, { error });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -19,6 +19,9 @@ import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import type PluginWorkflowServer from './Plugin';
 import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
+const QUEUEING_EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
+const QUEUEING_EXECUTION_ACQUIRE_RETRY_DELAY_MS = 50;
+
 type Pending = {
   execution: ExecutionModel;
   job?: JobModel;
@@ -442,7 +445,7 @@ export default class Dispatcher {
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
     let fetched: ExecutionModel | null = null;
     try {
-      while (!fetched) {
+      for (let attempt = 1; !fetched && attempt <= QUEUEING_EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
         let shouldRetry = false;
         try {
           await this.plugin.db.sequelize.transaction(
@@ -503,6 +506,13 @@ export default class Dispatcher {
         if (!shouldRetry) {
           break;
         }
+        if (attempt >= QUEUEING_EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
+          this.plugin
+            .getLogger('dispatcher')
+            .warn(`acquiring execution reached max retry attempts, will retry on next dispatch`);
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, QUEUEING_EXECUTION_ACQUIRE_RETRY_DELAY_MS * attempt));
       }
     } catch (error) {
       this.plugin.getLogger('dispatcher').error(`fetching execution from db failed: ${error.message}`, { error });

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -442,35 +442,68 @@ export default class Dispatcher {
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
     let fetched: ExecutionModel | null = null;
     try {
-      await this.plugin.db.sequelize.transaction(
-        {
-          isolationLevel,
-        },
-        async (transaction) => {
-          const execution = (await this.plugin.db.getRepository('executions').findOne({
-            filter: {
-              dispatched: false,
-              'workflow.enabled': true,
+      while (!fetched) {
+        let shouldRetry = false;
+        try {
+          await this.plugin.db.sequelize.transaction(
+            {
+              isolationLevel,
             },
-            sort: 'id',
-            transaction,
-          })) as ExecutionModel;
-          if (execution) {
-            this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
-            await execution.update(
-              {
-                dispatched: true,
-                status: EXECUTION_STATUS.STARTED,
-              },
-              { transaction },
-            );
-            execution.workflow = this.plugin.enabledCache.get(execution.workflowId);
-            fetched = execution;
-          } else {
-            this.plugin.getLogger('dispatcher').debug(`no execution in db queued to process`);
+            async (transaction) => {
+              const execution = (await this.plugin.db.getRepository('executions').findOne({
+                filter: {
+                  dispatched: false,
+                  'workflow.enabled': true,
+                },
+                sort: 'id',
+                transaction,
+              })) as ExecutionModel;
+              if (!execution) {
+                this.plugin.getLogger('dispatcher').debug(`no execution in db queued to process`);
+                return;
+              }
+
+              this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
+              const ExecutionModelClass = this.plugin.db.getModel('executions');
+              const [affected] = await ExecutionModelClass.update(
+                {
+                  dispatched: true,
+                  status: EXECUTION_STATUS.STARTED,
+                },
+                {
+                  where: {
+                    id: execution.id,
+                    dispatched: false,
+                  },
+                  transaction,
+                },
+              );
+              if (!affected) {
+                shouldRetry = true;
+                this.plugin
+                  .getLogger(execution.workflowId)
+                  .warn(`execution (${execution.id}) was already acquired by another worker, retrying`);
+                return;
+              }
+
+              await execution.reload({ transaction });
+              execution.workflow = this.plugin.enabledCache.get(execution.workflowId);
+              fetched = execution;
+            },
+          );
+        } catch (error) {
+          if (!this.isConcurrentAcquireError(error)) {
+            throw error;
           }
-        },
-      );
+          shouldRetry = true;
+          this.plugin.getLogger('dispatcher').warn(`acquiring execution conflicted with another worker, retrying`, {
+            error,
+          });
+        }
+        if (!shouldRetry) {
+          break;
+        }
+      }
     } catch (error) {
       this.plugin.getLogger('dispatcher').error(`fetching execution from db failed: ${error.message}`, { error });
     }
@@ -483,6 +516,20 @@ export default class Dispatcher {
 
   private isLockAcquireError(error: unknown) {
     return error instanceof Error && error.constructor.name === 'LockAcquireError';
+  }
+
+  private isConcurrentAcquireError(error: unknown) {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+    const databaseError = error as Error & {
+      parent?: { code?: string; errno?: number };
+      original?: { code?: string; errno?: number };
+    };
+    const code = databaseError.parent?.code || databaseError.original?.code;
+    const errno = databaseError.parent?.errno || databaseError.original?.errno;
+
+    return code === '40001' || code === 'ER_LOCK_DEADLOCK' || errno === 1205 || errno === 1213;
   }
 
   private async process(

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -462,7 +462,7 @@ export default class Processor {
       job = model.build(
         {
           ...payload,
-          id: this.options.plugin.snowflake.getUniqueID().toString(),
+          id: this.options.plugin.app.snowflakeIdGenerator.generate().toString(),
           createdAt: new Date(),
           updatedAt: new Date(),
           executionId: this.execution.id,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -462,7 +462,7 @@ export default class Processor {
       job = model.build(
         {
           ...payload,
-          id: this.options.plugin.app.snowflakeIdGenerator.generate().toString(),
+          id: this.options.plugin.snowflake.getUniqueID().toString(),
           createdAt: new Date(),
           updatedAt: new Date(),
           executionId: this.execution.id,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -13,6 +13,7 @@ import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 
 import Plugin, { Processor } from '..';
 import { EXECUTION_STATUS } from '../constants';
+import type { ExecutionModel } from '../types';
 
 describe('workflow > Plugin', () => {
   let app: MockServer;
@@ -248,6 +249,40 @@ describe('workflow > Plugin', () => {
   });
 
   describe('dispatcher', () => {
+    it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
+      'should acquire queueing execution only once under concurrent dispatch',
+      async () => {
+        const w1 = await WorkflowModel.create({
+          enabled: true,
+          type: 'asyncTrigger',
+        });
+
+        const e1 = await w1.createExecution({
+          key: w1.key,
+          context: {},
+          dispatched: false,
+          status: EXECUTION_STATUS.QUEUEING,
+        });
+
+        type QueueingDispatcher = {
+          acquireQueueingExecution(): Promise<ExecutionModel | null>;
+        };
+        const dispatcher = (plugin as unknown as { dispatcher: QueueingDispatcher }).dispatcher;
+
+        const acquired = await Promise.all([
+          dispatcher.acquireQueueingExecution(),
+          dispatcher.acquireQueueingExecution(),
+        ]);
+
+        const acquiredExecutions = acquired.filter((execution): execution is ExecutionModel => Boolean(execution));
+        expect(acquiredExecutions.map((execution) => execution.id)).toEqual([e1.id]);
+
+        await e1.reload();
+        expect(e1.dispatched).toBe(true);
+        expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+      },
+    );
+
     it('multiple triggers in same event', async () => {
       const w1 = await WorkflowModel.create({
         enabled: true,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -250,6 +250,43 @@ describe('workflow > Plugin', () => {
 
   describe('dispatcher', () => {
     it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
+      'should acquire pending execution only once under concurrent dispatch',
+      async () => {
+        const w1 = await WorkflowModel.create({
+          enabled: true,
+          type: 'asyncTrigger',
+        });
+
+        const e1 = await w1.createExecution({
+          key: w1.key,
+          context: {},
+          dispatched: false,
+          status: EXECUTION_STATUS.QUEUEING,
+        });
+        const sameExecution = (await db.getRepository('executions').findOne({
+          filterByTk: e1.id,
+        })) as ExecutionModel;
+
+        type PendingDispatcher = {
+          acquirePendingExecution(execution: ExecutionModel): Promise<ExecutionModel | null>;
+        };
+        const dispatcher = (plugin as unknown as { dispatcher: PendingDispatcher }).dispatcher;
+
+        const acquired = await Promise.all([
+          dispatcher.acquirePendingExecution(e1),
+          dispatcher.acquirePendingExecution(sameExecution),
+        ]);
+
+        const acquiredExecutions = acquired.filter((execution): execution is ExecutionModel => Boolean(execution));
+        expect(acquiredExecutions.map((execution) => execution.id)).toEqual([e1.id]);
+
+        await e1.reload();
+        expect(e1.dispatched).toBe(true);
+        expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+      },
+    );
+
+    it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
       'should acquire queueing execution only once under concurrent dispatch',
       async () => {
         const w1 = await WorkflowModel.create({

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -320,6 +320,16 @@ describe('workflow > Plugin', () => {
       expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
     });
 
+    it('should treat postgres deadlock as concurrent acquire error', () => {
+      type ConcurrentAcquireDispatcher = {
+        isConcurrentAcquireError(error: unknown): boolean;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: ConcurrentAcquireDispatcher }).dispatcher;
+      const error = Object.assign(new Error('deadlock detected'), { parent: { code: '40P01' } });
+
+      expect(dispatcher.isConcurrentAcquireError(error)).toBe(true);
+    });
+
     it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
       'should acquire queueing execution only once under concurrent dispatch',
       async () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -286,6 +286,40 @@ describe('workflow > Plugin', () => {
       },
     );
 
+    it('should not acquire pending execution when acquire transaction fails', async () => {
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+
+      const e1 = await w1.createExecution({
+        key: w1.key,
+        context: {},
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+
+      type PendingDispatcher = {
+        acquirePendingExecution(execution: ExecutionModel): Promise<ExecutionModel | null>;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: PendingDispatcher }).dispatcher;
+      const transaction = db.sequelize.transaction;
+      db.sequelize.transaction = (async () => {
+        throw new Error('simulated transaction failure');
+      }) as typeof db.sequelize.transaction;
+
+      try {
+        const acquired = await dispatcher.acquirePendingExecution(e1);
+        expect(acquired).toBeNull();
+      } finally {
+        db.sequelize.transaction = transaction;
+      }
+
+      await e1.reload();
+      expect(e1.dispatched).toBe(false);
+      expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
+    });
+
     it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
       'should acquire queueing execution only once under concurrent dispatch',
       async () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow executions could be acquired by more than one worker when multiple dispatchers selected the same queued or pending execution before either transaction updated it. This could lead to duplicate workflow processing, duplicate job inserts, and primary key conflicts.

### Description
This PR updates workflow execution acquisition to:

- Atomically mark executions as dispatched using `WHERE id = ? AND dispatched = false` and only process when the conditional update succeeds.
- Return `null` from pending acquisition when acquire fails, so an execution is not processed unless ownership was confirmed.
- Retry acquisition conflicts immediately with a bounded retry loop, including PostgreSQL serialization/deadlock errors and MySQL lock conflicts.
- Keep queueing acquisition retrying after a lost race so another queued execution can be acquired without waiting for the next dispatch tick.
- Move the queueing acquire log until after the conditional update succeeds.
- Add regression tests for pending and queueing concurrent acquisition, pending transaction failure, and PostgreSQL deadlock classification.

Potential risk: acquisition conflicts are logged as retryable warnings instead of terminal acquisition errors.

```json
{
  "level": "debug",
  "message": "Executing (default): INSERT INTO `jobs` (`created_at`,`updated_at`,`id`,`execution_id`,`node_id`,`node_key`,`status`,`result`,`upstream_id`) VALUES ('2026-06-03 13:24:25','2026-06-03 13:24:25','216280568386572288',367924903936002,367516146270229,'r23mwb7du56',1,'[{\\\"subject_chinese_name\\\":\\\"xxxxx\\\",\\\"responsible_email\\\":\\\"a@domain.com;b@domain.com\\\",\\\"branch_slic\\\":\\\"xxx\\\"}]',NULL),('2026-06-03 13:24:25','2026-06-03 13:24:25','216280568390766592',367924903936002,367516146270230,'14dane4sh4j',1,'{\\\"faamm1dinzm\\\":[\\\"a@domain.com;b@domain.com\\\"],\\\"xkboojz6oeg\\\":[\\\"xxxxx\\\"],\\\"9noe51d9r5y\\\":[\\\"xxx\\\"]}',NULL),('2026-06-03 13:24:25','2026-06-03 13:24:25','216280568428515328',367924903936002,367516146270224,'po7fn1ecmgz',1,'{\\\"fieldCount\\\":0,\\\"affectedRows\\\":1,\\\"insertId\\\":0,\\\"info\\\":\\\"Rows matched: 1 Changed: 1 Warnings: 0\\\",\\\"serverStatus\\\":2,\\\"warningStatus\\\":0,\\\"changedRows\\\":1}',NULL),('2026-06-03 13:24:25','2026-06-03 13:24:25','216280568436903936',367924903936002,367516146270234,'3kdbefaw0ko',0,NULL,'216280568428515328'),('2026-06-03 13:24:25','2026-06-03 13:24:25','216280568516595712',367924903936002,367516146270234,'3kdbefaw0ko',-2,'{\\\"message\\\":\\\"Validation error\\\",\\\"name\\\":\\\"SequelizeUniqueConstraintError\\\",\\\"errors\\\":[{\\\"message\\\":\\\"PRIMARY must be unique\\\",\\\"type\\\":\\\"unique violation\\\",\\\"path\\\":\\\"PRIMARY\\\",\\\"value\\\":\\\"216280568436903936\\\",\\\"origin\\\":\\\"DB\\\",\\\"instance\\\":null,\\\"validatorKey\\\":\\\"not_unique\\\",\\\"validatorName\\\":null,\\\"validatorArgs\\\":[]}],\\\"parent\\\":{\\\"code\\\":\\\"ER_DUP_ENTRY\\\",\\\"errno\\\":1062,\\\"sqlState\\\":\\\"23000\\\",\\\"sqlMessage\\\":\\\"Duplicate entry \\'216280568436903936\\' for key \\'jobs.PRIMARY\\'\\\",\\\"sql\\\":\\\"INSERT INTO `jobs` (`created_at`,`updated_at`,`id`,`execution_id`,`node_id`,`node_key`,`status`,`result`,`upstream_id`) VALUES (\\'2026-06-03 13:24:25\\',\\'2026-06-03 13:24:25\\',\\'216280568386572288\\',367924903936002,367516146270229,\\'r23mwb7du56\\',1,\\'[{\\\\\\\\\\\\\\\"subject_chinese_name\\\\\\\\\\\\\\\"...",
  "app": "main",
  "reqId": "2fbac57d-425a-44e1-ad1d-5cada3901a60",
  "timestamp": "2026-06-03 13:24:25"
}
```

Testing:

- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts -t "should treat postgres deadlock as concurrent acquire error"`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts -t "should not acquire pending execution when acquire transaction fails"`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/cluster.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed duplicate workflow execution dispatch under concurrent workers. |
| 🇨🇳 Chinese | 修复多工作节点并发时工作流执行可能被重复调度的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
