### PR TITLE
fix(calendar): restore v2 event color field rendering

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
@@ -19,7 +19,7 @@ import {
   MultiRecordResource,
   observer,
 } from '@nocobase/flow-engine';
-import { Select, Space } from 'antd';
+import { Select, Space, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import React from 'react';
 import { tExpr } from '../locale';
@@ -126,6 +126,15 @@ const applyCalendarFieldNames = (model: CalendarBlockModel, params: Record<strin
       ...(Object.prototype.hasOwnProperty.call(params, 'titleField') ? { title: params.titleField } : {}),
       ...(Object.prototype.hasOwnProperty.call(params, 'start') ? { start: params.start } : {}),
       ...(Object.prototype.hasOwnProperty.call(params, 'end') ? { end: params.end || null } : {}),
+    },
+  });
+};
+
+const applyCalendarColorFieldName = (model: CalendarBlockModel, params: Record<string, any>) => {
+  model.setProps({
+    fieldNames: {
+      ...(model.props?.fieldNames || {}),
+      colorFieldName: params.colorFieldName || undefined,
     },
   });
 };
@@ -257,8 +266,8 @@ export class CalendarBlockModel extends CollectionBlockModel {
     const resource = this.context.createResource(MultiRecordResource);
     resource.addRequestParameter('paginate', false);
 
-    const { start, end } = this.getFieldNames();
-    [start, end].forEach((fieldPath) => {
+    const { title, start, end, colorFieldName } = this.getFieldNames();
+    [title, start, end, colorFieldName].forEach((fieldPath) => {
       if (Array.isArray(fieldPath) && fieldPath.length >= 2) {
         resource.addAppends(fieldPath[0]);
       }
@@ -474,6 +483,7 @@ export class CalendarBlockModel extends CollectionBlockModel {
 const useDefaultGetColor = () => {
   return {
     getBackgroundColor: () => null,
+    getBorderColor: () => null,
     getFontColor: () => null,
     loading: false,
   };
@@ -484,17 +494,17 @@ const CalendarBlockRenderer = observer(
     model,
     fieldNames,
     colorCollectionField,
+    colorFieldInterface,
   }: {
     model: CalendarBlockModel;
     fieldNames: any;
     colorCollectionField: any;
+    colorFieldInterface: any;
   }) => {
     const { styles } = useCalendarActionBarStyle();
-    const colorFieldInterface = colorCollectionField?.interface
-      ? model.calendarPlugin?.getColorFieldInterface?.(colorCollectionField.interface)
-      : null;
+    const { token } = theme.useToken();
     const useGetColor = colorFieldInterface?.useGetColor || useDefaultGetColor;
-    const colorFunctions = useGetColor(colorCollectionField);
+    const colorFunctions = useGetColor(colorCollectionField, { token });
     const isConfigMode = !!model.context.flowSettingsEnabled;
 
     const leftActions = ((model as any).mapSubModels('actions', (action: CalendarActionSubModel) => {
@@ -588,13 +598,21 @@ const CalendarBlockView = observer(({ model }: { model: CalendarBlockModel }) =>
   const fieldNames = model.getFieldNames();
   const colorFieldName = normalizeCalendarFieldPath(fieldNames.colorFieldName);
   const colorCollectionField = colorFieldName ? model.collection?.getField?.(colorFieldName) : null;
+  const colorFieldInterface = colorCollectionField?.interface
+    ? model.calendarPlugin?.getColorFieldInterface?.(colorCollectionField.interface)
+    : null;
 
   return (
     <CalendarBlockRenderer
-      key={colorFieldName || '__calendar-default-color__'}
+      key={[
+        colorFieldName || '__calendar-default-color__',
+        colorCollectionField?.interface || '__calendar-no-color-interface__',
+        colorFieldInterface ? '__calendar-color-resolver__' : '__calendar-default-color-resolver__',
+      ].join(':')}
       model={model}
       fieldNames={fieldNames}
       colorCollectionField={colorCollectionField}
+      colorFieldInterface={colorFieldInterface}
     />
   );
 });
@@ -700,13 +718,10 @@ CalendarBlockModel.registerFlow({
         };
       },
       handler(ctx, params) {
-        const model = ctx.model as CalendarBlockModel;
-        model.setProps({
-          fieldNames: {
-            ...(model.props?.fieldNames || {}),
-            colorFieldName: params.colorFieldName || undefined,
-          },
-        });
+        applyCalendarColorFieldName(ctx.model as CalendarBlockModel, params);
+      },
+      beforeParamsSave(ctx, params) {
+        applyCalendarColorFieldName(ctx.model as CalendarBlockModel, params);
       },
     },
     startDateField: {

--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
@@ -7,8 +7,13 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { FlowEngine } from '@nocobase/flow-engine';
+import { renderHook } from '@testing-library/react';
+import { ConfigProvider, theme } from 'antd';
+import React from 'react';
 import { buildCalendarSlotFormData } from '../actions/CalendarPopupModels';
 import { CalendarBlockModel } from '../CalendarBlockModel';
+import { PluginCalendarClient } from '../../plugin';
 
 describe('calendarPopupModels', () => {
   it('should expose preset field settings before creating a calendar block', () => {
@@ -154,6 +159,126 @@ describe('calendarPopupModels', () => {
       end: undefined,
       colorFieldName: undefined,
     });
+  });
+
+  it('should persist the color field selection before saving settings', () => {
+    const flow: any = (CalendarBlockModel as any).globalFlowRegistry.getFlow('calendarSettings');
+    const step = flow?.steps?.colorField;
+    const model = Object.create(CalendarBlockModel.prototype) as CalendarBlockModel;
+
+    Object.defineProperty(model, 'props', {
+      value: {
+        fieldNames: {
+          title: 'name',
+          start: 'startsAt',
+          end: 'endsAt',
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+    (model as any).setProps = function setProps(next: Record<string, unknown>) {
+      this.props = {
+        ...(this.props || {}),
+        ...next,
+      };
+    };
+
+    step.beforeParamsSave({ model } as any, { colorFieldName: 'status' });
+
+    expect(model.props.fieldNames).toEqual({
+      title: 'name',
+      start: 'startsAt',
+      end: 'endsAt',
+      colorFieldName: 'status',
+    });
+  });
+
+  it('should append associated title and color field paths when creating the resource', () => {
+    const flowEngine = new FlowEngine();
+    flowEngine.registerModels({ CalendarBlockModel });
+    flowEngine.dataSourceManager.getDataSource('main').addCollection({
+      name: 'calendar_events',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'integer' },
+        { name: 'startsAt', type: 'datetime', interface: 'datetime' },
+        { name: 'endsAt', type: 'datetime', interface: 'datetime' },
+        { name: 'owner', type: 'belongsTo', interface: 'm2o', target: 'users' },
+        { name: 'status', type: 'belongsTo', interface: 'm2o', target: 'statuses' },
+      ],
+    });
+
+    const model = flowEngine.createModel<CalendarBlockModel>({
+      use: 'CalendarBlockModel',
+      props: {
+        fieldNames: {
+          title: ['owner', 'nickname'],
+          start: 'startsAt',
+          end: 'endsAt',
+          colorFieldName: ['status', 'color'],
+        },
+      },
+      stepParams: {
+        resourceSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'calendar_events',
+          },
+        },
+      },
+    });
+
+    expect(model.resource.getAppends()).toEqual(['owner', 'status']);
+  });
+
+  it('should resolve default color field background colors to concrete color values', () => {
+    const plugin = new PluginCalendarClient({} as any, {} as any);
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(ConfigProvider, { theme: { token: { blue: '#123456' } } }, children);
+    const { result } = renderHook(
+      () => {
+        const { token } = theme.useToken();
+        const selectColor = plugin.getColorFieldInterface('select').useGetColor(
+          {
+            interface: 'select',
+            uiSchema: {
+              enum: [
+                { label: 'Todo', value: 'todo', color: 'blue' },
+                { label: 'Done', value: 'done', color: '#52c41a' },
+                { label: 'Other', value: 'other', color: 'default' },
+              ],
+            },
+          },
+          { token },
+        );
+        const colorFieldColor = plugin.getColorFieldInterface('color').useGetColor(
+          {
+            interface: 'color',
+          },
+          { token },
+        );
+
+        return {
+          colorFieldColor,
+          selectColor,
+          token,
+        };
+      },
+      { wrapper },
+    );
+
+    expect(result.current.selectColor.getFontColor('todo')).toBe(result.current.token.blue7);
+    expect(result.current.selectColor.getBackgroundColor('todo')).toBe(result.current.token.blue1);
+    expect(result.current.selectColor.getBorderColor?.('todo')).toBe(result.current.token.blue3);
+    expect(result.current.selectColor.getFontColor('done')).toBe(result.current.token.colorTextLightSolid);
+    expect(result.current.selectColor.getBackgroundColor('done')).toBe('#52c41a');
+    expect(result.current.selectColor.getBorderColor?.('done')).toBe('transparent');
+    expect(result.current.selectColor.getFontColor('other')).toBeNull();
+    expect(result.current.selectColor.getBackgroundColor('other')).toBeNull();
+    expect(result.current.selectColor.getBorderColor?.('other')).toBeNull();
+    expect(result.current.colorFieldColor.getFontColor({ hex: '#fa541c' })).toBeNull();
+    expect(result.current.colorFieldColor.getBackgroundColor({ hex: '#fa541c' })).toBe('#fa541c');
   });
 
   it('should hide quick create popup settings when quick create is disabled', () => {

--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/CalendarBlock.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/CalendarBlock.tsx
@@ -252,6 +252,7 @@ type CalendarBlockProps = {
     title: string;
   };
   getBackgroundColor?: (value: string) => string | null;
+  getBorderColor?: (value: string) => string | null;
   getFontColor?: (value: string) => string | null;
   height?: number;
   heightMode?: string;
@@ -496,6 +497,7 @@ export const CalendarBlock = observer((props: CalendarBlockProps) => {
 
     const fontColor = props.getFontColor?.(event.colorFieldValue);
     const backgroundColor = props.getBackgroundColor?.(event.colorFieldValue);
+    const borderColor = props.getBorderColor?.(event.colorFieldValue);
     const style = {} as Record<string, string>;
 
     if (fontColor) {
@@ -503,6 +505,9 @@ export const CalendarBlock = observer((props: CalendarBlockProps) => {
     }
     if (backgroundColor) {
       style.backgroundColor = backgroundColor;
+    }
+    if (borderColor) {
+      style.borderColor = borderColor;
     }
 
     return { style };

--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/plugin.tsx
@@ -17,20 +17,91 @@ const TitleRenderer = ({ value }) => {
 
 interface ColorFunctions {
   loading: boolean;
-  getFontColor: (value: any) => string;
-  getBackgroundColor: (value: any) => string;
+  getFontColor: (value: any) => string | null;
+  getBackgroundColor: (value: any) => string | null;
+  getBorderColor?: (value: any) => string | null;
 }
 
-const useGetColor = (field) => {
+type CalendarColorOptions = {
+  token?: Record<string, any>;
+};
+
+const PRESET_COLOR_NAMES = new Set([
+  'blue',
+  'purple',
+  'cyan',
+  'green',
+  'magenta',
+  'pink',
+  'red',
+  'orange',
+  'yellow',
+  'volcano',
+  'geekblue',
+  'lime',
+  'gold',
+]);
+
+const normalizeColorValue = (value: any) => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    return normalizeColorValue(value.hex || value.hexString || value.color || value.value);
+  }
+
+  const color = String(value);
+  return color;
+};
+
+const getTagColorStyle = (token: Record<string, any> | undefined, value: any) => {
+  const color = normalizeColorValue(value);
+
+  if (!color || color === 'default') {
+    return null;
+  }
+
+  if (PRESET_COLOR_NAMES.has(color)) {
+    return {
+      backgroundColor: token?.[`${color}1`] || null,
+      borderColor: token?.[`${color}3`] || null,
+      fontColor: token?.[`${color}7`] || null,
+    };
+  }
+
+  return {
+    backgroundColor: color,
+    borderColor: 'transparent',
+    fontColor: token?.colorTextLightSolid || '#fff',
+  };
+};
+
+const getEnumOption = (field: any, value: any) => {
+  const enumOptions = Array.isArray(field?.uiSchema?.enum) ? field.uiSchema.enum : [];
+  return enumOptions.find((item: any) => {
+    return String(item?.value ?? item?.name ?? item?.id ?? '') === String(value);
+  });
+};
+
+const useGetColor = (field, options?: CalendarColorOptions) => {
   return {
     loading: false,
     getFontColor(value) {
-      const option = field?.uiSchema?.enum?.find((item) => item.value === value);
-      return option?.color ? `var(--ant-${option.color}-7)` : null;
+      const option = getEnumOption(field, value);
+      return field?.interface === 'color' ? null : getTagColorStyle(options?.token, option?.color)?.fontColor || null;
     },
     getBackgroundColor(value) {
-      const option = field?.uiSchema?.enum?.find((item) => item.value === value);
-      return option?.color ? `var(--ant-${option.color}-1)` : null;
+      const option = getEnumOption(field, value);
+      return field?.interface === 'color'
+        ? normalizeColorValue(value)
+        : getTagColorStyle(options?.token, option?.color)?.backgroundColor || null;
+    },
+    getBorderColor(value) {
+      const option = getEnumOption(field, value);
+      return field?.interface === 'color'
+        ? normalizeColorValue(value)
+        : getTagColorStyle(options?.token, option?.color)?.borderColor || null;
     },
   };
 };
@@ -47,10 +118,11 @@ export class PluginCalendarClient extends Plugin<any, Application> {
   };
 
   colorFieldInterfaces: {
-    [T: string]: { useGetColor: (field: any) => ColorFunctions };
+    [T: string]: { useGetColor: (field: any, options?: CalendarColorOptions) => ColorFunctions };
   } = {
     select: { useGetColor },
     radioGroup: { useGetColor },
+    color: { useGetColor },
   };
 
   dateTimeFieldInterfaces = ['date', 'datetime', 'dateOnly', 'datetimeNoTz', 'unixTimestamp', 'createdAt', 'updatedAt'];
@@ -85,7 +157,10 @@ export class PluginCalendarClient extends Plugin<any, Application> {
     return this.dateTimeFieldInterfaces;
   }
 
-  registerColorFieldInterface(type, option: { useGetColor: (field: any) => ColorFunctions }) {
+  registerColorFieldInterface(
+    type,
+    option: { useGetColor: (field: any, options?: CalendarColorOptions) => ColorFunctions },
+  ) {
     this.colorFieldInterfaces[type] = option;
   }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 calendar block did not persist or render the configured color field correctly under v2 routes, so calendar events could miss their background color.

### Description
This PR fixes v2 calendar color field handling by:
- Persisting the calendar color field selection into `props.fieldNames` before settings are saved.
- Appending associated title and color field paths when creating the calendar resource.
- Resolving event colors from the current antd theme tokens so preset colors match antd Tag behavior.
- Handling custom color values with readable text and transparent borders.
- Applying event border colors together with text and background colors.
- Adding focused regression tests for color field persistence, associated appends, and themed color resolution.

Potential risks:
- The calendar color extension API now accepts an optional token context argument. Existing custom resolvers should continue to work because the argument is optional.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-calendar/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/CalendarBlock.tsx packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/__tests__/CalendarBlock.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/__tests__/CalendarBlock.test.ts --run --reporter=verbose`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed calendar event colors not rendering from the configured color field in v2 pages. |
| 🇨🇳 Chinese | 修复 v2 页面中日历事件未按配置的颜色字段显示颜色的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
