### PR TITLE
fix(plugin-ai): avoid exposing LLM provider errors

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/locale/de-DE.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/de-DE.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM-Dienst",
   "LLM services": "LLM-Dienste",
+  "LLM service test failed. Please check the service configuration.": "Test des LLM-Dienstes fehlgeschlagen. Bitte überprüfen Sie die Dienstkonfiguration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "Eine Obergrenze für die Anzahl der Tokens, die für eine Vervollständigung generiert werden können, einschließlich sichtbarer Ausgabe-Tokens und Reasoning-Tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -132,6 +132,7 @@
   "LLM service": "LLM service",
   "LLM service not configured": "LLM service not configured",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/es-ES.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/es-ES.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/fr-FR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/fr-FR.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/hu-HU.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/hu-HU.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM szolgáltatás",
   "LLM services": "LLM szolgáltatások",
+  "LLM service test failed. Please check the service configuration.": "Az LLM szolgáltatás tesztje sikertelen. Kérjük, ellenőrizze a szolgáltatás konfigurációját.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "A generálható tokenek maximális határa egy befejezéshez, beleértve a látható kimeneti tokeneket és a gondolkodási tokeneket.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/id-ID.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/id-ID.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "Layanan LLM",
   "LLM services": "Layanan LLM",
+  "LLM service test failed. Please check the service configuration.": "Pengujian layanan LLM gagal. Silakan periksa konfigurasi layanan.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "Batas atas jumlah token yang dapat dihasilkan untuk penyelesaian, termasuk token keluaran yang terlihat dan token penalaran.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/it-IT.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/it-IT.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "Servizio LLM",
   "LLM services": "Servizi LLM",
+  "LLM service test failed. Please check the service configuration.": "Test del servizio LLM non riuscito. Controllare la configurazione del servizio.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "Un limite superiore per il numero di token che possono essere generati per un completamento, inclusi i token di output visibili e i token di ragionamento.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/ja-JP.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/ja-JP.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLMサービス",
   "LLM services": "LLMサービス",
+  "LLM service test failed. Please check the service configuration.": "LLMサービスのテストに失敗しました。サービス設定を確認してください。",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "生成可能なトークン数の上限値（可視出力トークンと推論トークンを含む）。入力トークンと出力トークンの総数はモデルのコンテキスト長制限に準拠します。",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/ko-KR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/ko-KR.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM 서비스",
   "LLM services": "LLM 서비스",
+  "LLM service test failed. Please check the service configuration.": "LLM 서비스 테스트에 실패했습니다. 서비스 구성을 확인하세요.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "완료에 대해 생성할 수 있는 토큰 수의 상한값으로, 표시 가능한 출력 토큰과 추론 토큰이 포함됩니다.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/nl-NL.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/nl-NL.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM dienst",
   "LLM services": "LLM diensten",
+  "LLM service test failed. Please check the service configuration.": "Test van de LLM-dienst is mislukt. Controleer de serviceconfiguratie.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "Een bovengrens voor het aantal tokens dat kan worden gegenereerd voor een voltooiing, inclusief zichtbare outputtokens en redeneertokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/pt-BR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/pt-BR.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/ru-RU.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/ru-RU.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "Сервис LLM",
   "LLM services": "Сервисы LLM",
+  "LLM service test failed. Please check the service configuration.": "Проверка сервиса LLM не удалась. Проверьте конфигурацию сервиса.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "Верхняя граница количества токенов, которые могут быть сгенерированы для завершения, включая видимые выходные токены и токены рассуждений.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/tr-TR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/tr-TR.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/uk-UA.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/uk-UA.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/vi-VN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/vi-VN.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM service test failed. Please check the service configuration.",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -133,6 +133,7 @@
   "LLM service": "LLM 服务",
   "LLM service not configured": "LLM 服务未配置",
   "LLM services": "LLM 服务",
+  "LLM service test failed. Please check the service configuration.": "LLM 服务测试失败，请检查服务配置。",
   "Label for task selection buttons when multiple tasks exist": "多个任务可选时，用于让用户选择任务的按钮标题",
   "Limit": "限制",
   "Max completion tokens description": "限制一次请求中模型生成 completion 的最大 token 数。输入 token 和输出 token 的总长度受模型的上下文长度的限制。",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-TW.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-TW.json
@@ -107,6 +107,7 @@
   "KnowledgeBase": "Knowledge Base",
   "LLM service": "LLM service",
   "LLM services": "LLM services",
+  "LLM service test failed. Please check the service configuration.": "LLM 服務測試失敗，請檢查服務設定。",
   "Label for task selection buttons when multiple tasks exist": "Label for task selection buttons when multiple tasks exist",
   "Limit": "Limit",
   "Max completion tokens description": "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",

--- a/packages/plugins/@nocobase/plugin-ai/src/server/resource/ai.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/resource/ai.ts
@@ -7,10 +7,15 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+// @ts-ignore
+import { name as namespace } from '../../../package.json';
 import { ResourceOptions } from '@nocobase/resourcer';
 import { PluginAIServer } from '../plugin';
 import _ from 'lodash';
 import { getRecommendedModels } from '../../common/recommended-models';
+
+const getModelsListFailedMessage = 'Get models list failed, you can enter a model name manually.';
+const testFlightFailedMessage = 'LLM service test failed. Please check the service configuration.';
 
 const aiResource: ResourceOptions = {
   name: 'ai',
@@ -69,10 +74,7 @@ const aiResource: ResourceOptions = {
         const res = await provider.listModels();
         if (res.errMsg) {
           ctx.log.error(res.errMsg);
-          ctx.throw(
-            res.code || 500,
-            `${ctx.t('Get models list failed, you can enter a model name manually.')} ${res.errMsg}`,
-          );
+          ctx.throw(res.code || 500, ctx.t(getModelsListFailedMessage, { ns: namespace }));
         }
         ctx.body = res.models || [];
       }
@@ -97,10 +99,7 @@ const aiResource: ResourceOptions = {
       const res = await providerClient.listModels();
       if (res.errMsg) {
         ctx.log.error(res.errMsg);
-        ctx.throw(
-          res.code || 500,
-          `${ctx.t('Get models list failed, you can enter a model name manually.')} ${res.errMsg}`,
-        );
+        ctx.throw(res.code || 500, ctx.t(getModelsListFailedMessage, { ns: namespace }));
       }
       const models = res.models || [];
       if (model) {
@@ -127,7 +126,12 @@ const aiResource: ResourceOptions = {
           responseFormat: 'text',
         },
       });
-      ctx.body = await providerClient.testFlight();
+      const result = await providerClient.testFlight();
+      if (result.status === 'error') {
+        ctx.log.error(result.message);
+        result.message = ctx.t(testFlightFailedMessage, { ns: namespace });
+      }
+      ctx.body = result;
       return next();
     },
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
LLM provider errors can include request details such as API keys or authorization tokens. These raw errors should not be exposed in frontend messages.

### Description
This PR updates the AI plugin server resource responses so model list failures and test-flight failures return fixed localized messages to the frontend while preserving the original provider error in server logs.

It also adds the new test-flight failure message to the plugin locale files.

Testing performed:
- `git diff --check`
- Parsed all `packages/plugins/@nocobase/plugin-ai/src/locale/*.json` files with `JSON.parse`

Tests not run:
- `yarn eslint --fix ...` because `eslint` is not available in the current checkout
- `yarn test ...` because `nocobase` is not available in the current checkout
- Git hooks were skipped for the commit because `lint-staged` is not available in the current checkout

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hid raw LLM provider errors from frontend messages. |
| 🇨🇳 Chinese | 隐藏前端提示中的原始 LLM 服务商错误。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
