### PR TITLE
fix(plugin-ai): allow workflow AI employee node default model

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/model-options.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/model-options.tsx
@@ -97,12 +97,11 @@ export const ModelOptions: React.FC = () => {
             title: tExpr('Model', { ns: namespace }),
             'x-decorator': 'FormItem',
             'x-decorator-props': {
-              tooltip: tExpr('Select the LLM to be used for the task', {
+              tooltip: tExpr('Leave empty to use AI employee or global default model.', {
                 ns: namespace,
               }),
             },
             'x-component': ModelSelect,
-            required: true,
           },
         },
       }}

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -400,7 +400,7 @@
   "Choose the AI employee for this task": "Choose the AI employee for this task",
   "Operator": "Operator",
   "Complete the task using operator permissions": "Complete the task using operator permissions",
-  "Select the LLM to be used for the task": "Select the LLM to be used for the task",
+  "Leave empty to use AI employee or global default model.": "Leave empty to use AI employee or global default model.",
   "Enter the specific task description": "Enter the specific task description",
   "Attachments": "Attachments",
   "Select the file or image to be sent to the LLM": "Select the file or image to be sent to the LLM",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -406,7 +406,7 @@
   "Choose the AI employee for this task": "为当前任务选择 AI 员工",
   "Operator": "操作者",
   "Complete the task using operator permissions": "用操作者权限完成任务",
-  "Select the LLM to be used for the task": "选择任务要使用的大模型",
+  "Leave empty to use AI employee or global default model.": "留空时使用 AI 员工模型或全局默认模型。",
   "Enter the specific task description": "输入具体任务描述",
   "Attachments": "附件",
   "Select the file or image to be sent to the LLM": "选择发送给大模型的文件或图片",

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/types.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/types.ts
@@ -21,10 +21,10 @@ export type AIEmployeeInstructionConfig = {
     [key: string]: any;
   };
   webSearch?: boolean;
-  model: {
+  model?: {
     llmService: string;
     model: string;
-  };
+  } | null;
   requiresApproval?: RequiresApproval;
   assignees?: string[];
   userId: string;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow AI employee nodes should be able to use the AI employee or global default model when no task-specific model is selected.

### Description 
This PR makes the workflow AI employee node model configuration optional and updates the model field tooltip to explain the fallback behavior.

Potential risk is limited to AI employee workflow node configuration and execution when the model field is omitted.

Suggested testing:
- Configure an AI employee workflow node without selecting a model.
- Verify it runs using the AI employee model or the global default model.
- Verify explicitly selected models still work as before.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Workflow AI employee nodes can use the default model |
| 🇨🇳 Chinese | 工作流 AI 员工节点可使用默认模型 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
