### PR TITLE
fix(plugin-workflow-custom-action-trigger): register workbench trigger action

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/plugin.tsx
@@ -23,6 +23,15 @@ type WorkflowPluginLike = {
 };
 
 export class CustomActionTriggerPlugin extends Plugin {
+  private registerWorkbenchActionGroups = async () => {
+    await this.flowEngine.getModelClassAsync('ActionPanelGroupActionModel');
+    registerTriggerWorkflowActionGroups(this.flowEngine);
+  };
+
+  async beforeLoad() {
+    this.app.eventBus.addEventListener('plugin:block-workbench:loaded', this.registerWorkbenchActionGroups);
+  }
+
   async load() {
     this.flowEngine.registerModels({
       FormTriggerWorkflowActionModel,
@@ -30,16 +39,10 @@ export class CustomActionTriggerPlugin extends Plugin {
       CollectionTriggerWorkflowActionModel,
       WorkbenchTriggerWorkflowActionModel,
     });
-
     const workflow = this.app.pm.get('workflow') as WorkflowPluginLike | undefined;
     workflow?.registerTrigger?.(EVENT_TYPE, CustomActionTrigger);
 
-    const registerActionGroups = () => {
-      registerTriggerWorkflowActionGroups(this.flowEngine);
-    };
-
-    registerActionGroups();
-    this.app.eventBus.addEventListener('plugin:block-workbench:loaded', registerActionGroups);
+    registerTriggerWorkflowActionGroups(this.flowEngine);
   }
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The workbench action panel action menu did not show the workflow trigger action in some plugin loading orders.

### Description
This PR registers the workbench workflow trigger action from the plugin `beforeLoad` phase, so the listener is attached before the workbench plugin emits its loaded event.

When the workbench plugin is loaded, the registration now resolves the lazily loaded `ActionPanelGroupActionModel` with `getModelClassAsync()` before registering `WorkbenchTriggerWorkflowActionModel`. This makes the workflow trigger action available in the action panel button list even when the workbench model is loaded asynchronously.

Tests run:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/plugin.tsx`
- `yarn test packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts --run --reporter=verbose`

Risk is limited to the v2 workflow custom action trigger plugin lifecycle registration path.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the workflow trigger action missing from the workbench action panel button list. |
| 🇨🇳 Chinese | 修复工作台操作面板按钮列表中缺少触发工作流操作的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
