### PR TITLE
fix(collection-sql): block sensitive PostgreSQL metadata queries

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
@@ -50,6 +50,21 @@ describe('sql collection', () => {
     });
     expect(res.status).toBe(400);
     expect(res.body.errors[0].message).toMatch('SQL statements contain dangerous keywords');
+
+    for (const sql of [
+      'select usename, passwd from pg_shadow',
+      'select rolname, rolsuper from pg_roles',
+      'select table_name from information_schema.tables',
+      'select * from (select usename, passwd from pg_shadow) as passwords',
+    ]) {
+      res = await agent.resource('sqlCollection').execute({
+        values: {
+          sql,
+        },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.errors[0].message).toMatch('SQL statements contain dangerous keywords');
+    }
   });
 
   it('sqlCollection:execute', async () => {

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
@@ -22,6 +22,13 @@ export const checkSQL = (sql: string) => {
     'pg_reload_conf',
     'pg_sleep',
     'generate_series',
+    'pg_catalog',
+    'pg_shadow',
+    'pg_authid',
+    'pg_auth_members',
+    'pg_roles',
+    'pg_stat_activity',
+    'information_schema',
 
     // MySQL
     'LOAD_FILE',
@@ -33,7 +40,7 @@ export const checkSQL = (sql: string) => {
     'sqlite3_load_extension',
     'load_extension',
   ];
-  sql = sql.trim().split(';').shift();
+  sql = sql.trim().split(';').shift() || '';
   if (!/^select/i.test(sql) && !/^with([\s\S]+)select([\s\S]+)/i.test(sql)) {
     throw new Error('Only supports SELECT statements or WITH clauses');
   }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
SQL Collection should not allow querying sensitive PostgreSQL system catalogs through user-supplied SELECT statements.

### Description 
Extends SQL Collection validation to block sensitive PostgreSQL catalog and metadata identifiers, including role, password, session activity, and information schema access.

Potential risk: this may reject existing SQL collections that directly query PostgreSQL metadata tables.

Testing suggestions: run the SQL Collection server action tests and verify normal collection SELECT queries still work.

### Related issues
GHSA-v8vm-cqh8-q87q

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Blocked SQL Collection access to sensitive PostgreSQL metadata |
| 🇨🇳 Chinese | 禁止 SQL 数据表访问敏感的 PostgreSQL 元数据 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
