### PR TITLE
fix(plugin-field-sort): generate unique sort values in bulk create

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts
@@ -2299,6 +2299,63 @@ describe('basic importer', () => {
     expect(users[1].get('email')).toBe('test2@test.com');
   });
 
+  it('should generate different sort values for imported rows', async () => {
+    await app.destroy();
+    app = await createMockServer({
+      plugins: ['field-sort', 'data-source-main', 'error-handler'],
+    });
+
+    const Task = app.db.collection({
+      name: 'tasks',
+      fields: [
+        {
+          type: 'string',
+          name: 'name',
+        },
+        {
+          type: 'sort',
+          name: 'sort',
+        },
+      ],
+    });
+
+    await app.db.sync();
+
+    const columns = [
+      {
+        dataIndex: ['name'],
+        defaultTitle: 'Name',
+      },
+    ];
+
+    const templateCreator = new TemplateCreator({
+      collection: Task,
+      columns,
+    });
+
+    const template = (await templateCreator.run({ returnXLSXWorkbook: true })) as XLSX.WorkBook;
+    const worksheet = template.Sheets[template.SheetNames[0]];
+
+    XLSX.utils.sheet_add_aoa(worksheet, [['task1'], ['task2'], ['task3']], {
+      origin: 'A2',
+    });
+
+    const importer = new XlsxImporter({
+      collectionManager: app.mainDataSource.collectionManager,
+      collection: Task,
+      columns,
+      workbook: template,
+    });
+
+    await importer.run();
+
+    const tasks = await Task.repository.find({
+      sort: ['id'],
+    });
+
+    expect(tasks.map((task) => task.get('sort'))).toEqual([1, 2, 3]);
+  });
+
   describe('template creator', () => {
     it('should create template with explain and field descriptions', async () => {
       const User = app.db.collection({

--- a/packages/plugins/@nocobase/plugin-field-sort/src/server/sort-field.ts
+++ b/packages/plugins/@nocobase/plugin-field-sort/src/server/sort-field.ts
@@ -24,33 +24,42 @@ export class SortField extends Field {
     const { model } = this.context.collection;
 
     instances = Array.isArray(instances) ? instances : [instances];
-    for (const instance of instances) {
-      if (from == 'create' && isNumber(instance.get(name))) {
-        continue;
-      }
-      if (isNumber(instance.get(name)) && instance._previousDataValues[scopeKey] == instance[scopeKey]) {
-        continue;
-      }
+    await (<typeof SortField>this.constructor).lockManager.runExclusive(
+      this.context.collection.name,
+      async () => {
+        const maxCache = new Map<string, number>();
 
-      const where = {};
+        for (const instance of instances) {
+          if (from == 'create' && isNumber(instance.get(name))) {
+            continue;
+          }
+          if (isNumber(instance.get(name)) && instance._previousDataValues[scopeKey] == instance[scopeKey]) {
+            continue;
+          }
 
-      if (scopeKey) {
-        const value = instance.get(scopeKey);
-        if (value !== undefined && value !== null) {
-          where[scopeKey] = value;
-        }
-      }
+          const where = {};
+          let cacheKey = '__default__';
 
-      await (<typeof SortField>this.constructor).lockManager.runExclusive(
-        this.context.collection.name,
-        async () => {
-          const max = await model.max<number, any>(name, { ...options, where });
-          const newValue = (max || 0) + 1;
+          if (scopeKey) {
+            const value = instance.get(scopeKey);
+            if (value !== undefined && value !== null) {
+              where[scopeKey] = value;
+              cacheKey = `${typeof value}:${String(value)}`;
+            }
+          }
+
+          if (!maxCache.has(cacheKey)) {
+            const max = await model.max<number, any>(name, { ...options, where });
+            maxCache.set(cacheKey, max || 0);
+          }
+
+          const newValue = (maxCache.get(cacheKey) ?? 0) + 1;
+          maxCache.set(cacheKey, newValue);
           instance.set(name, newValue);
-        },
-        2000,
-      );
-    }
+        }
+      },
+      2000,
+    );
   };
 
   onScopeChange = async (instance, options) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Imported records with an automatic sort field could receive the same sort value when they were inserted in the same bulk import batch.

### Description 
Updated the sort field bulk-create hook to allocate sort values from an in-memory max value per scope while holding the existing collection lock. This keeps sort values unique within the same bulk-create batch while still respecting explicitly provided sort values.

Risk: bulk-create sort allocation now holds the collection lock for the full batch instead of per row. The number of database max queries is reduced, but concurrent creates for the same collection may wait for the batch allocation to finish.

Testing:
- `yarn test packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts --run --reporter=verbose -t "should generate different sort values for imported rows"`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-field-sort/src/server/sort-field.ts packages/plugins/@nocobase/plugin-action-import/src/server/__tests__/xlsx-importer.test.ts`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed imported records receiving duplicate sort values |
| 🇨🇳 Chinese | 修复导入记录生成重复排序值的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
