### PR TITLE
fix(client): clear hidden field values

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
@@ -9,9 +9,14 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { FlowSettingsContextProvider } from '@nocobase/flow-engine';
+import { FlowEngine, FlowModel, FlowSettingsContextProvider } from '@nocobase/flow-engine';
 import { describe, expect, it, vi } from 'vitest';
-import { fieldLinkageRules, linkageSetFieldProps, subFormLinkageSetFieldProps } from '../linkageRules';
+import {
+  fieldLinkageRules,
+  linkageSetFieldProps,
+  subFormFieldLinkageRules,
+  subFormLinkageSetFieldProps,
+} from '../linkageRules';
 
 const createSubFormFieldModel = ({
   uid,
@@ -334,6 +339,110 @@ describe('subFormLinkageSetFieldProps action', () => {
 
     expect(row0CollectedModel.hidden).toBe(false);
     expect(row1CollectedModel.hidden).toBe(true);
+  });
+
+  it('should clear the current row value when a subform list field is hidden without reserving value', async () => {
+    const setFormValues = vi.fn(async () => undefined);
+    const form = {
+      getFieldValue: vi.fn((path: Array<string | number>) => {
+        if (JSON.stringify(path) === JSON.stringify(['items', 0, 'a'])) {
+          return 'row value';
+        }
+        return undefined;
+      }),
+      setFieldValue: vi.fn(),
+    };
+    const engine = new FlowEngine();
+
+    const rowGridFork = new FlowModel({ uid: 'row-grid-fork', flowEngine: engine }) as any;
+    rowGridFork.hidden = false;
+    rowGridFork.context.defineProperty('fieldKey', { value: ['items:0'] });
+    rowGridFork.context.defineProperty('fieldIndex', { value: ['items:0'] });
+    rowGridFork.context.defineProperty('form', { value: form });
+    rowGridFork.context.defineProperty('setFormValues', { value: setFormValues });
+    rowGridFork.context.defineProperty('app', {
+      value: {
+        jsonLogic: {
+          apply: () => true,
+        },
+      },
+    });
+    rowGridFork.getAction = vi.fn((name: string) => {
+      if (name === 'subFormLinkageSetFieldProps') {
+        return subFormLinkageSetFieldProps;
+      }
+    });
+
+    const targetFieldFork: any = {
+      uid: 'field-a',
+      isFork: true,
+      hidden: false,
+      props: {},
+      context: {
+        fieldIndex: ['items:0'],
+      },
+      getStepParams: vi.fn((flowKey: string, stepKey: string) => {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') {
+          return { fieldPath: 'a' };
+        }
+      }),
+      setProps(key: any, value?: any) {
+        if (typeof key === 'string') {
+          this.props[key] = value;
+        } else {
+          this.props = { ...this.props, ...key };
+        }
+      },
+    };
+
+    const formItemModel: any = {
+      uid: 'field-a',
+      getFork: vi.fn((key: string) => (key === 'items:0:field-a' ? targetFieldFork : undefined)),
+    };
+
+    engine.getModel = vi.fn((uid: string) => (uid === 'field-a' ? formItemModel : undefined)) as any;
+
+    await subFormFieldLinkageRules.handler(
+      {
+        model: {
+          hidden: false,
+          subModels: {
+            grid: {
+              forks: [rowGridFork],
+            },
+          },
+        },
+        flowKey: 'eventSettings',
+      } as any,
+      {
+        value: [
+          {
+            key: 'rule-1',
+            enable: true,
+            condition: { logic: '$and', items: [] },
+            actions: [
+              {
+                name: 'subFormLinkageSetFieldProps',
+                params: {
+                  value: {
+                    fields: ['field-a'],
+                    state: 'hidden',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(form.getFieldValue).toHaveBeenCalledWith(['items', 0, 'a']);
+    expect(targetFieldFork.hidden).toBe(true);
+    expect(setFormValues).toHaveBeenCalledWith(
+      [{ path: ['items', 0, 'a'], value: undefined }],
+      expect.objectContaining({ source: 'linkage' }),
+    );
+    expect(form.setFieldValue).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
@@ -829,13 +829,7 @@ describe('linkageSetFieldProps action', () => {
 
     expect(fieldModel.hidden).toBe(true);
     expect(formValues.name).toBeUndefined();
-    expect(setFormValues).toHaveBeenCalledWith(
-      [
-        { path: ['name'], value: 'assigned' },
-        { path: ['name'], value: undefined },
-      ],
-      expect.objectContaining({ source: 'linkage' }),
-    );
+    expect(setFormValues).not.toHaveBeenCalled();
     expect(form.setFieldValue).not.toHaveBeenCalled();
   });
 

--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
@@ -13,6 +13,7 @@ import { FlowEngine, FlowModel, FlowSettingsContextProvider } from '@nocobase/fl
 import { describe, expect, it, vi } from 'vitest';
 import {
   fieldLinkageRules,
+  linkageAssignField,
   linkageSetFieldProps,
   subFormFieldLinkageRules,
   subFormLinkageSetFieldProps,
@@ -722,6 +723,117 @@ describe('linkageSetFieldProps action', () => {
     expect(fieldModel.hidden).toBe(true);
     expect(setFormValues).toHaveBeenCalledWith(
       [{ path: ['name'], value: undefined }],
+      expect.objectContaining({ source: 'linkage' }),
+    );
+    expect(form.setFieldValue).not.toHaveBeenCalled();
+  });
+
+  it('should keep hidden clear after same-round assignment for the same field', async () => {
+    const formValues: { name?: string } = {};
+    const setFormValues = vi.fn(async (patches: Array<{ path: Array<string | number>; value: string | undefined }>) => {
+      for (const patch of patches) {
+        if (patch.path.length === 1 && patch.path[0] === 'name') {
+          formValues.name = patch.value;
+        }
+      }
+    });
+    const form = {
+      getFieldValue: vi.fn((path: Array<string | number>) => {
+        if (path.length === 1 && path[0] === 'name') {
+          return formValues.name;
+        }
+        return undefined;
+      }),
+      setFieldValue: vi.fn(),
+    };
+    const fieldModel: any = {
+      uid: 'name-field',
+      hidden: false,
+      context: { form },
+      props: {
+        label: 'Name',
+      },
+      getStepParams: vi.fn((flowKey: string, stepKey: string) => {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') {
+          return { fieldPath: 'name' };
+        }
+      }),
+      setProps(key: any, value?: any) {
+        if (typeof key === 'string') {
+          this.props[key] = value;
+        } else {
+          this.props = { ...this.props, ...key };
+        }
+      },
+    };
+    const ctx: any = {
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      model: {
+        context: { form },
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+      setFormValues,
+      getAction: (name: string) => {
+        if (name === 'linkageSetFieldProps') return linkageSetFieldProps;
+        if (name === 'linkageAssignField') return linkageAssignField;
+        return null;
+      },
+      resolveJsonTemplate: vi.fn(async (value) => value),
+    };
+
+    await fieldLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'rule-1',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [
+            {
+              key: 'action-1',
+              name: 'linkageSetFieldProps',
+              params: {
+                value: {
+                  fields: ['name-field'],
+                  state: 'hidden',
+                },
+              },
+            },
+            {
+              key: 'action-2',
+              name: 'linkageAssignField',
+              params: {
+                value: [
+                  {
+                    key: 'assign-1',
+                    enable: true,
+                    targetPath: 'name',
+                    value: 'assigned',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fieldModel.hidden).toBe(true);
+    expect(formValues.name).toBeUndefined();
+    expect(setFormValues).toHaveBeenCalledWith(
+      [
+        { path: ['name'], value: 'assigned' },
+        { path: ['name'], value: undefined },
+      ],
       expect.objectContaining({ source: 'linkage' }),
     );
     expect(form.setFieldValue).not.toHaveBeenCalled();

--- a/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/linkageRules.subFormSetFieldProps.test.ts
@@ -541,6 +541,158 @@ describe('linkageSetFieldProps action', () => {
     expect(form.setFieldValue).not.toHaveBeenCalled();
   });
 
+  it('should clear form value when a field is hidden without reserving value', async () => {
+    const setFormValues = vi.fn(async () => undefined);
+    const form = {
+      getFieldValue: vi.fn(() => '123'),
+      setFieldValue: vi.fn(),
+    };
+    const fieldModel: any = {
+      uid: 'name-field',
+      hidden: false,
+      context: { form },
+      props: {
+        label: 'Name',
+      },
+      getStepParams: vi.fn((flowKey: string, stepKey: string) => {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') {
+          return { fieldPath: 'name' };
+        }
+      }),
+      setProps(key: any, value?: any) {
+        if (typeof key === 'string') {
+          this.props[key] = value;
+        } else {
+          this.props = { ...this.props, ...key };
+        }
+      },
+    };
+    const ctx: any = {
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      model: {
+        context: { form },
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+      setFormValues,
+      getAction: (name: string) => (name === 'linkageSetFieldProps' ? linkageSetFieldProps : null),
+      resolveJsonTemplate: vi.fn(async (value) => value),
+    };
+
+    await fieldLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'rule-1',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [
+            {
+              key: 'action-1',
+              name: 'linkageSetFieldProps',
+              params: {
+                value: {
+                  fields: ['name-field'],
+                  state: 'hidden',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fieldModel.hidden).toBe(true);
+    expect(setFormValues).toHaveBeenCalledWith(
+      [{ path: ['name'], value: undefined }],
+      expect.objectContaining({ source: 'linkage' }),
+    );
+    expect(form.setFieldValue).not.toHaveBeenCalled();
+  });
+
+  it('should not clear form value when a field is hidden with reserved value', async () => {
+    const setFormValues = vi.fn(async () => undefined);
+    const form = {
+      getFieldValue: vi.fn(() => '123'),
+      setFieldValue: vi.fn(),
+    };
+    const fieldModel: any = {
+      uid: 'name-field',
+      hidden: false,
+      context: { form },
+      props: {
+        label: 'Name',
+      },
+      getStepParams: vi.fn((flowKey: string, stepKey: string) => {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') {
+          return { fieldPath: 'name' };
+        }
+      }),
+      setProps(key: any, value?: any) {
+        if (typeof key === 'string') {
+          this.props[key] = value;
+        } else {
+          this.props = { ...this.props, ...key };
+        }
+      },
+    };
+    const ctx: any = {
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      model: {
+        context: { form },
+        subModels: {
+          grid: {
+            subModels: {
+              items: [fieldModel],
+            },
+          },
+        },
+      },
+      setFormValues,
+      getAction: (name: string) => (name === 'linkageSetFieldProps' ? linkageSetFieldProps : null),
+      resolveJsonTemplate: vi.fn(async (value) => value),
+    };
+
+    await fieldLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'rule-1',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [
+            {
+              key: 'action-1',
+              name: 'linkageSetFieldProps',
+              params: {
+                value: {
+                  fields: ['name-field'],
+                  state: 'hiddenReservedValue',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fieldModel.hidden).toBe(false);
+    expect(fieldModel.props.hidden).toBe(true);
+    expect(setFormValues).not.toHaveBeenCalled();
+    expect(form.setFieldValue).not.toHaveBeenCalled();
+  });
+
   it('should keep all options selectable after options were limited once', async () => {
     const fieldComponentModel: any = {
       uid: 'status-field-component',

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -1936,6 +1936,23 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
 
     return out;
   };
+  const getModelTargetPathForHiddenClear = (model: any): string | Array<string | number> | null => {
+    const fieldPathArray = normalizeNamePathForKey(model?.context?.fieldPathArray);
+    const targetPath = getModelTargetPathForPatch(model);
+    if (fieldPathArray) {
+      const targetPathLastString = targetPath
+        ? ([...parsePathString(targetPath)].reverse().find((seg) => typeof seg === 'string') as string | undefined)
+        : undefined;
+      const fieldPathArrayLastString = [...fieldPathArray].reverse().find((seg) => typeof seg === 'string');
+      if (!targetPathLastString || targetPathLastString === fieldPathArrayLastString) {
+        return fieldPathArray;
+      }
+    }
+
+    if (!targetPath) return null;
+
+    return resolveIndexedRelativePath(targetPath, model?.context?.fieldIndex) || targetPath;
+  };
   const getModelTargetPathKeys = (model: any): Set<string> => {
     const keys = new Set<string>();
     const fieldPathArray = normalizeNamePathForKey(model?.context?.fieldPathArray);
@@ -2102,7 +2119,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       Object.prototype.hasOwnProperty.call(patchProps, 'hiddenModel') &&
       patchProps.hiddenModel === true
     ) {
-      const targetPath = getModelTargetPathForPatch(model);
+      const targetPath = getModelTargetPathForHiddenClear(model);
       if (!targetPath) {
         console.warn('[linkageRules] Skip clearing hidden field value due to missing target path', {
           flowKey: ctx.flowKey,

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -1812,6 +1812,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       });
       return;
     }
+    const resolvedPathKey = namePathToPathKey(resolvedPath);
     const whenEmpty = !!(patch as any)?.whenEmpty;
     const value = (patch as any)?.value;
     try {
@@ -1828,7 +1829,10 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
           return;
         }
       }
-      if (_.isEqual(current, value)) {
+      const hasPendingDifferentValue = directValuePatches.some(
+        (item) => namePathToPathKey(item.path) === resolvedPathKey && !_.isEqual(item.value, value),
+      );
+      if (_.isEqual(current, value) && !hasPendingDifferentValue) {
         return;
       }
     } catch {
@@ -2114,6 +2118,22 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       model.setProps('title', '');
     }
 
+    // 只有本轮联动动作显式写入 value 时，才应执行表单赋值。
+    // 普通字段组件也会由 Form.Item/FieldModelRenderer 注入 value；如果从 __originalProps 继承该值，
+    // limitOptions/disabled 等状态联动会误把当前表单值清空。
+    if (Object.prototype.hasOwnProperty.call(patchProps, 'value') && model.context.form) {
+      const targetPath = getModelTargetPathForPatch(model);
+      if (!targetPath) {
+        console.warn('[linkageRules] Skip linkage assignment due to missing target path', {
+          flowKey: ctx.flowKey,
+          modelUid: ctx.model?.uid,
+          targetUid: model?.uid,
+        });
+      } else {
+        addFormValuePatch({ path: targetPath, value: newProps.value });
+      }
+    }
+
     if (
       clearValueOnHiddenModelUids.has(uid) &&
       Object.prototype.hasOwnProperty.call(patchProps, 'hiddenModel') &&
@@ -2128,22 +2148,6 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
         });
       } else {
         addFormValuePatch({ path: targetPath, value: undefined });
-      }
-    }
-
-    // 只有本轮联动动作显式写入 value 时，才应执行表单赋值。
-    // 普通字段组件也会由 Form.Item/FieldModelRenderer 注入 value；如果从 __originalProps 继承该值，
-    // limitOptions/disabled 等状态联动会误把当前表单值清空。
-    if (Object.prototype.hasOwnProperty.call(patchProps, 'value') && model.context.form) {
-      const targetPath = getModelTargetPathForPatch(model);
-      if (!targetPath) {
-        console.warn('[linkageRules] Skip linkage assignment due to missing target path', {
-          flowKey: ctx.flowKey,
-          modelUid: ctx.model?.uid,
-          targetUid: model?.uid,
-        });
-      } else {
-        addFormValuePatch({ path: targetPath, value: newProps.value });
       }
     }
 

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -1812,7 +1812,6 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       });
       return;
     }
-    const resolvedPathKey = namePathToPathKey(resolvedPath);
     const whenEmpty = !!(patch as any)?.whenEmpty;
     const value = (patch as any)?.value;
     try {
@@ -1829,10 +1828,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
           return;
         }
       }
-      const hasPendingDifferentValue = directValuePatches.some(
-        (item) => namePathToPathKey(item.path) === resolvedPathKey && !_.isEqual(item.value, value),
-      );
-      if (_.isEqual(current, value) && !hasPendingDifferentValue) {
+      if (_.isEqual(current, value)) {
         return;
       }
     } catch {
@@ -1844,6 +1840,16 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
       value,
       ...(whenEmpty ? { whenEmpty: true } : {}),
     });
+  };
+  const removePendingFormValuePatches = (path: any) => {
+    const resolvedPath = resolveNamePathForPatch(path);
+    if (!resolvedPath) return;
+    const resolvedPathKey = namePathToPathKey(resolvedPath);
+    for (let i = directValuePatches.length - 1; i >= 0; i--) {
+      if (namePathToPathKey(directValuePatches[i].path) === resolvedPathKey) {
+        directValuePatches.splice(i, 1);
+      }
+    }
   };
 
   const getModelTargetPathForPatch = (model: any): string | null => {
@@ -2147,6 +2153,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
           targetUid: model?.uid,
         });
       } else {
+        removePendingFormValuePatches(targetPath);
         addFormValuePatch({ path: targetPath, value: undefined });
       }
     }

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -1730,6 +1730,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
   const allModels: FlowModel[] = ctx.model.__allModels || (ctx.model.__allModels = []);
   const modelsToApply = new Set<FlowModel>(allModels);
   const patchPropsByModel = new Map<FlowModel, any>();
+  const clearValueOnHiddenModelUids = new Set<string>();
   const directValuePatches: Array<{ path: Array<string | number>; value: any; whenEmpty?: boolean }> = [];
   const rootCollection = getCollectionFromModel((ctx.model as any)?.context?.blockModel ?? ctx.model);
   const isSafeToWriteAssociationSubpath = (namePath: any): boolean => {
@@ -2022,6 +2023,13 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
           ...props,
         });
 
+        if (
+          (action.name === 'linkageSetFieldProps' || action.name === 'subFormLinkageSetFieldProps') &&
+          props?.hiddenModel === true
+        ) {
+          clearValueOnHiddenModelUids.add(model?.uid || String(model));
+        }
+
         if (allModels.indexOf(model) === -1) {
           allModels.push(model);
         }
@@ -2087,6 +2095,23 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
 
     if (newProps.hiddenText) {
       model.setProps('title', '');
+    }
+
+    if (
+      clearValueOnHiddenModelUids.has(uid) &&
+      Object.prototype.hasOwnProperty.call(patchProps, 'hiddenModel') &&
+      patchProps.hiddenModel === true
+    ) {
+      const targetPath = getModelTargetPathForPatch(model);
+      if (!targetPath) {
+        console.warn('[linkageRules] Skip clearing hidden field value due to missing target path', {
+          flowKey: ctx.flowKey,
+          modelUid: ctx.model?.uid,
+          targetUid: model?.uid,
+        });
+      } else {
+        addFormValuePatch({ path: targetPath, value: undefined });
+      }
     }
 
     // 只有本轮联动动作显式写入 value 时，才应执行表单赋值。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 表单中使用字段联动规则时，普通的“隐藏”应当表示字段被隐藏后不再保留当前填写的值。但此前字段被隐藏后，值仍然留在表单中，字段再次显示时旧值会重新出现，容易导致用户误提交不再可见的旧数据。

### Description
本次修复让字段联动规则中的普通“隐藏”在生效时同步清空对应字段值。

同时保留“隐藏（保留值）”的原有语义：字段只从界面上隐藏，但当前值不会被清空。

已补充测试覆盖这两种隐藏方式，避免普通隐藏和保留值隐藏的行为再次混淆。建议重点回归 v2 表单中字段联动的隐藏、隐藏（保留值）以及字段重新显示后的值状态。

### Showcase
无 UI 样式变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where hidden linked fields still kept old values |
| 🇨🇳 Chinese | 修复联动隐藏字段后仍保留旧值的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
