### PR TITLE
fix(data-source-manager): preserve field template namespaces

### DIFF
--- a/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
+++ b/packages/core/client/src/schema-component/antd/association-field/InternalCascadeSelect.tsx
@@ -281,10 +281,12 @@ export const InternalCascadeSelect = observer(
     const { loading, data: formData } = useDataBlockRequest() || {};
     const fieldValue = field.value !== undefined ? field.value : props.value;
     const requestValue = formData?.data?.[fieldSchema.name];
-    const initialValue = useMemo(() => {
-      const value = requestValue !== undefined ? requestValue : fieldValue;
+    const getLatestValue = useCallback(() => {
+      const latestFieldValue = field.value !== undefined ? field.value : props.value;
+      const value = latestFieldValue !== undefined ? latestFieldValue : requestValue;
       return collectionField.interface === 'm2o' ? normalizeToOneCascadeValue(value) : value;
-    }, [collectionField.interface, fieldValue, requestValue]);
+    }, [collectionField.interface, field, props.value, requestValue]);
+    const initialValue = useMemo(() => getLatestValue(), [getLatestValue]);
     const associationDataFlag =
       !formData ||
       fieldSchema.name in (formData?.data || {}) ||
@@ -311,6 +313,7 @@ export const InternalCascadeSelect = observer(
       [collectionField.interface, field, fieldSchema.name],
     );
     const currentFieldValue = form.values?.[fieldSchema.name];
+    const hasCurrentFieldValue = Object.prototype.hasOwnProperty.call(form.values || {}, fieldSchema.name);
 
     useEffect(() => {
       const id = uid();
@@ -331,15 +334,18 @@ export const InternalCascadeSelect = observer(
       if (collectionField.interface !== 'm2o') {
         return;
       }
-      const value = initialValue ?? null;
+      const value = getLatestValue() ?? null;
       if (isEqual(normalizeToOneCascadeValue(selectForm.values?.[fieldSchema.name]), value)) {
         return;
       }
       selectForm.setInitialValues({ [fieldSchema.name]: value });
       selectForm.setValuesIn(fieldSchema.name, value);
-    }, [collectionField.interface, fieldSchema.name, initialValue, selectForm]);
+    }, [collectionField.interface, fieldSchema.name, getLatestValue, selectForm]);
 
     useEffect(() => {
+      if (!hasCurrentFieldValue) {
+        return;
+      }
       if (!currentFieldValue) {
         if (selectForm && selectForm.values.select_array && !currentFieldValue) {
           selectForm.setValuesIn('select_array', undefined);
@@ -350,7 +356,7 @@ export const InternalCascadeSelect = observer(
           selectForm.setValuesIn(fieldSchema.name, null);
         }
       }
-    }, [currentFieldValue, fieldSchema.name, selectForm]);
+    }, [currentFieldValue, fieldSchema.name, hasCurrentFieldValue, selectForm]);
 
     const toValue = () => {
       if (Array.isArray(initialValue) && initialValue.length > 0) {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/locale.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/locale.ts
@@ -20,5 +20,6 @@ export function tExpr(key: string) {
 
 export function useT() {
   const engine = useFlowEngine();
-  return (key: string) => engine.context.t(key, { ns: [NAMESPACE, 'client'] });
+  return (key: string, options?: Record<string, unknown>) =>
+    engine.context.t(key, { ns: [NAMESPACE, 'client'], ...options });
 }

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
@@ -69,7 +69,7 @@ import {
   type CollectionTemplateOptions,
   PluginDataSourceManagerClientV2,
 } from '../../plugin';
-import { compileLegacyTemplate } from '../../utils/compileLegacyTemplate';
+import { compileLegacyTemplate, preferLegacyTemplateTitle } from '../../utils/compileLegacyTemplate';
 import { getCollectionFieldActionUrl } from './collectionFieldApi';
 import FieldsPage from './FieldsPage';
 
@@ -552,7 +552,7 @@ function getPresetFieldName(field: CollectionPresetFieldOptions) {
   return field.name || field.value.name;
 }
 
-function getPresetFieldRows(
+export function getPresetFieldRows(
   presetFields: CollectionPresetFieldOptions[],
   fieldInterfaceManager?: { getFieldInterface?: (name: string) => { title?: React.ReactNode } | undefined },
 ): PresetFieldRow[] {
@@ -560,10 +560,13 @@ function getPresetFieldRows(
     const fieldInterface = field.value.interface
       ? fieldInterfaceManager?.getFieldInterface?.(field.value.interface)
       : undefined;
+    const templateTitle = field.value.uiSchema?.title || fieldInterface?.title;
+    const fieldTitle = field.field || field.value.uiSchema?.title || field.value.name;
+    const interfaceLabel = field.interfaceLabel || fieldInterface?.title || field.value.interface || field.value.type;
     return {
       name: getPresetFieldName(field),
-      field: field.field || field.value.uiSchema?.title || field.value.name,
-      interfaceLabel: field.interfaceLabel || fieldInterface?.title || field.value.interface || field.value.type,
+      field: preferLegacyTemplateTitle(fieldTitle, templateTitle),
+      interfaceLabel: preferLegacyTemplateTitle(interfaceLabel, fieldInterface?.title),
       description: field.description,
     };
   });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
@@ -1,0 +1,48 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { compileLegacyTemplate } from '../../../utils/compileLegacyTemplate';
+import { getPresetFieldRows } from '../CollectionsPage';
+
+describe('getPresetFieldRows', () => {
+  it('uses the preset title template when preset field label is a raw translation key', () => {
+    const rows = getPresetFieldRows(
+      [
+        {
+          name: 'space',
+          field: 'Space',
+          value: {
+            name: 'space',
+            interface: 'space',
+            type: 'belongsTo',
+            uiSchema: {
+              title: '{{t("Space", {"ns":["@nocobase/plugin-multi-space","client"]})}}',
+            },
+          },
+        },
+      ],
+      {
+        getFieldInterface: (name) =>
+          name === 'space'
+            ? {
+                title: '{{t("Space", {"ns":["@nocobase/plugin-multi-space","client"]})}}',
+              }
+            : undefined,
+      },
+    );
+    const t = (key: string, options?: Record<string, unknown>) => {
+      if (key === 'Space' && Array.isArray(options?.ns) && options.ns.includes('@nocobase/plugin-multi-space')) {
+        return '空间';
+      }
+      return key;
+    };
+
+    expect(compileLegacyTemplate(rows[0].field, t)).toBe('空间');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/utils/__tests__/compileLegacyTemplate.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/utils/__tests__/compileLegacyTemplate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { compileLegacyTemplate, preferLegacyTemplateTitle } from '../compileLegacyTemplate';
+
+describe('compileLegacyTemplate', () => {
+  it('passes namespace options from JSON t templates', () => {
+    const t = vi.fn((key: string, options?: Record<string, unknown>) => {
+      if (key === 'Space' && Array.isArray(options?.ns) && options.ns.includes('@nocobase/plugin-multi-space')) {
+        return '空间';
+      }
+      return key;
+    });
+
+    expect(compileLegacyTemplate('{{t("Space", {"ns":["@nocobase/plugin-multi-space","client"]})}}', t)).toBe('空间');
+    expect(t).toHaveBeenCalledWith('Space', { ns: ['@nocobase/plugin-multi-space', 'client'] });
+  });
+
+  it('keeps support for legacy object literal namespace options', () => {
+    const t = vi.fn((key: string, options?: Record<string, unknown>) => {
+      if (key === 'Space' && options?.ns === '@nocobase/plugin-multi-space') {
+        return '空间';
+      }
+      return key;
+    });
+
+    expect(compileLegacyTemplate('{{t("Space", { ns: "@nocobase/plugin-multi-space" })}}', t)).toBe('空间');
+    expect(t).toHaveBeenCalledWith('Space', { ns: '@nocobase/plugin-multi-space' });
+  });
+
+  it('passes namespace options from template fragments', () => {
+    const t = (key: string, options?: Record<string, unknown>) => {
+      if (key === 'Store the space of each record' && Array.isArray(options?.ns)) {
+        return '记录空间';
+      }
+      return key;
+    };
+
+    expect(
+      compileLegacyTemplate(
+        'Description: {{t("Store the space of each record", {"ns":["@nocobase/plugin-multi-space","client"]})}}',
+        t,
+      ),
+    ).toBe('Description: 记录空间');
+  });
+
+  it('prefers a matching namespaced template over a raw title key', () => {
+    expect(preferLegacyTemplateTitle('Space', '{{t("Space", {"ns":["@nocobase/plugin-multi-space","client"]})}}')).toBe(
+      '{{t("Space", {"ns":["@nocobase/plugin-multi-space","client"]})}}',
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/utils/compileLegacyTemplate.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/utils/compileLegacyTemplate.ts
@@ -9,10 +9,59 @@
 
 import type { ReactNode } from 'react';
 
-type TFunction = (key: string) => string;
+type TOptions = Record<string, unknown>;
+type TFunction = (key: string, options?: TOptions) => string;
 
-const LEGACY_T_TEMPLATE = /^\s*\{\{\s*t\s*\(\s*(['"])(.*?)\1(?:\s*,[\s\S]*?)?\)\s*\}\}\s*$/;
-const LEGACY_T_TEMPLATE_FRAGMENT = /\{\{\s*t\s*\(\s*(['"])(.*?)\1(?:\s*,[\s\S]*?)?\)\s*\}\}/g;
+const LEGACY_T_TEMPLATE = /^\s*\{\{\s*t\s*\(\s*(['"])(.*?)\1(?:\s*,\s*([\s\S]*?))?\)\s*\}\}\s*$/;
+const LEGACY_T_TEMPLATE_FRAGMENT = /\{\{\s*t\s*\(\s*(['"])(.*?)\1(?:\s*,\s*([\s\S]*?))?\)\s*\}\}/g;
+
+function parseStringArray(source: string) {
+  const values: string[] = [];
+  source.replace(/(['"])(.*?)\1/g, (_item, _quote, value) => {
+    values.push(value);
+    return '';
+  });
+  return values.length ? values : undefined;
+}
+
+export function getLegacyTemplateKey(value: ReactNode) {
+  return typeof value === 'string' ? value.match(LEGACY_T_TEMPLATE)?.[2] : undefined;
+}
+
+function parseTOptions(source?: string): TOptions | undefined {
+  const value = source?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const options = JSON.parse(value) as unknown;
+    return options && typeof options === 'object' && !Array.isArray(options) ? (options as TOptions) : undefined;
+  } catch {
+    // Keep support for old templates like {{t("Space", { ns: "client" })}}.
+  }
+
+  const options: TOptions = {};
+  const nsArrayMatch = value.match(/(?:^|[{,\s])ns\s*:\s*(\[[\s\S]*?\])/);
+  if (nsArrayMatch?.[1]) {
+    const ns = parseStringArray(nsArrayMatch[1]);
+    if (ns) {
+      options.ns = ns;
+    }
+  } else {
+    const nsStringMatch = value.match(/(?:^|[{,\s])ns\s*:\s*(['"])(.*?)\1/);
+    if (nsStringMatch?.[2]) {
+      options.ns = nsStringMatch[2];
+    }
+  }
+
+  const nsModeMatch = value.match(/(?:^|[{,\s])nsMode\s*:\s*(['"])(.*?)\1/);
+  if (nsModeMatch?.[2]) {
+    options.nsMode = nsModeMatch[2];
+  }
+
+  return Object.keys(options).length ? options : undefined;
+}
 
 export function compileLegacyTemplate(value: ReactNode, t: TFunction): ReactNode {
   if (typeof value !== 'string') {
@@ -20,10 +69,18 @@ export function compileLegacyTemplate(value: ReactNode, t: TFunction): ReactNode
   }
   const match = value.match(LEGACY_T_TEMPLATE);
   if (match?.[2]) {
-    return t(match[2]);
+    return t(match[2], parseTOptions(match[3]));
   }
 
-  return value.replace(LEGACY_T_TEMPLATE_FRAGMENT, (_source, _quote, key) => t(key));
+  return value.replace(LEGACY_T_TEMPLATE_FRAGMENT, (_source, _quote, key, options) => t(key, parseTOptions(options)));
+}
+
+export function preferLegacyTemplateTitle(value: ReactNode, templateTitle?: ReactNode): ReactNode {
+  const templateKey = getLegacyTemplateKey(templateTitle);
+  if (typeof value === 'string' && templateKey === value) {
+    return templateTitle;
+  }
+  return value;
 }
 
 export function compileLegacyTemplateText(value: ReactNode, t: TFunction, fallback = '-'): string {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix v2 data source manager preset field labels losing plugin namespace information when rendering legacy `{{t(...)}}` templates.

### Description
Preserve namespace options from legacy translation templates and prefer matching namespaced template titles over raw translation keys in collection preset field rows.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed multi-space field localization in v2 data source manager. |
| 🇨🇳 Chinese | 修复 v2 数据源管理中多空间字段的本地化显示问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
