### PR TITLE
feat(gantt): add default today positioning setting

### DIFF
--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
@@ -97,6 +97,7 @@ describe('PluginGanttClient model discovery', () => {
         Day: '天',
         Hour: '小时',
         'Event popup settings': '任务弹窗设置',
+        'Scroll to today on first display': '默认定位到今天',
         'Show table': '表格显示',
         'Table width': '表格宽度',
         Today: '今天',
@@ -109,6 +110,7 @@ describe('PluginGanttClient model discovery', () => {
         Day: '天',
         Hour: '小时',
         'Event popup settings': '任务弹窗设置',
+        'Scroll to today on first display': '默认定位到今天',
         'Show table': '表格显示',
         'Table width': '表格宽度',
         Today: '今天',
@@ -485,6 +487,47 @@ describe('GanttBlockModel settings', () => {
     expect(model.getTableWidth()).toBe(360);
 
     expect(step?.hideInSettings?.({ model: { props: { showTable: false } } } as any)).toBe(true);
+  });
+
+  test('keeps initial scroll to today disabled by default and persists the setting', () => {
+    const flowEngine = new FlowEngine();
+    flowEngine.registerModels({ GanttBlockModel });
+
+    const model = flowEngine.createModel<GanttBlockModel>({
+      use: 'GanttBlockModel',
+    });
+    const step = model.getFlow('ganttSettings')?.steps?.scrollToTodayOnFirstRender;
+
+    const defaultParams =
+      typeof step?.defaultParams === 'function' ? step.defaultParams({ model } as any) : step?.defaultParams;
+    expect(defaultParams).toEqual({ scrollToTodayOnFirstRender: false });
+    expect(model.shouldScrollToTodayOnFirstRender()).toBe(false);
+
+    step?.handler?.({ model } as any, { scrollToTodayOnFirstRender: true });
+    expect(model.props?.scrollToTodayOnFirstRender).toBe(true);
+    expect(model.shouldScrollToTodayOnFirstRender()).toBe(true);
+
+    step?.beforeParamsSave?.({ model } as any, { scrollToTodayOnFirstRender: false });
+    expect(model.props?.scrollToTodayOnFirstRender).toBe(false);
+    expect(model.shouldScrollToTodayOnFirstRender()).toBe(false);
+  });
+
+  test('reads the initial scroll to today setting from stored step params', () => {
+    const flowEngine = new FlowEngine();
+    flowEngine.registerModels({ GanttBlockModel });
+
+    const model = flowEngine.createModel<GanttBlockModel>({
+      use: 'GanttBlockModel',
+      stepParams: {
+        ganttSettings: {
+          scrollToTodayOnFirstRender: {
+            scrollToTodayOnFirstRender: true,
+          },
+        },
+      },
+    });
+
+    expect(model.shouldScrollToTodayOnFirstRender()).toBe(true);
   });
 
   test('translates time scale options at settings render time', () => {

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
@@ -455,6 +455,22 @@ export function registerGanttBlockModelSettings(GanttBlockModel: any) {
           getGanttModel(ctx).setProps('enableDragToReschedule', params.enableDragToReschedule !== false);
         },
       },
+      scrollToTodayOnFirstRender: {
+        title: tExpr('Scroll to today on first display'),
+        uiMode: { type: 'switch', key: 'scrollToTodayOnFirstRender' },
+        defaultParams(ctx) {
+          const model = getGanttModel(ctx);
+          return {
+            scrollToTodayOnFirstRender: model.shouldScrollToTodayOnFirstRender(),
+          };
+        },
+        handler(ctx, params) {
+          getGanttModel(ctx).setProps('scrollToTodayOnFirstRender', params.scrollToTodayOnFirstRender === true);
+        },
+        beforeParamsSave(ctx, params) {
+          getGanttModel(ctx).setProps('scrollToTodayOnFirstRender', params.scrollToTodayOnFirstRender === true);
+        },
+      },
       eventPopupSettings: {
         use: 'openView',
         title: tExpr('Event popup settings'),
@@ -491,6 +507,7 @@ export function registerGanttBlockModelSettings(GanttBlockModel: any) {
       use: 'GanttBlockModel',
       props: {
         enableDragToReschedule: true,
+        scrollToTodayOnFirstRender: false,
         showTable: true,
       },
       subModels: {

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
@@ -163,6 +163,13 @@ export class GanttBlockModel extends TableBlockModel {
     );
   }
 
+  shouldScrollToTodayOnFirstRender() {
+    return (
+      (this.props?.scrollToTodayOnFirstRender ??
+        this.getStepParams('ganttSettings', 'scrollToTodayOnFirstRender')?.scrollToTodayOnFirstRender) === true
+    );
+  }
+
   getTreeChildrenFieldName() {
     return (
       this.getCollectionFields().find((field: any) => field?.treeChildren || field?.options?.treeChildren)?.name ||

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/components/GanttBlock.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/components/GanttBlock.tsx
@@ -105,6 +105,7 @@ export const GanttBlock = observer(
     const [failedTask, setFailedTask] = useState<BarTask | null>(null);
     const [scrollY, setScrollY] = useState(0);
     const syncingScrollRef = useRef(false);
+    const scrolledToTodayOnFirstRenderRef = useRef(false);
     const scrollYRef = useRef(0);
     const scrollXRef = useRef(-1);
     const setScrollYValue = useCallback((nextScrollY: number) => {
@@ -164,6 +165,7 @@ export const GanttBlock = observer(
     const fieldNamesProp = model.props?.fieldNames;
     const dragEnabled = model.props?.enableDragToReschedule;
     const showTable = model.props?.showTable !== false;
+    const scrollToTodayOnFirstRender = model.shouldScrollToTodayOnFirstRender();
     const showRowNumbers = model.shouldShowRowNumbers();
     const tableColumns = model.getColumns().filter((column: any) => column?.key !== 'empty');
     const showActionsTable = showTable && tableColumns.length > 0;
@@ -455,6 +457,16 @@ export const GanttBlock = observer(
     ]);
 
     useEffect(() => {
+      if (!scrollToTodayOnFirstRender || scrolledToTodayOnFirstRenderRef.current || loading) {
+        return;
+      }
+
+      if (scrollToDate(new Date())) {
+        scrolledToTodayOnFirstRenderRef.current = true;
+      }
+    }, [dateSetup.viewMode, loading, scrollToDate, scrollToTodayOnFirstRender]);
+
+    useEffect(() => {
       if (
         viewMode === dateSetup.viewMode &&
         ((viewDate && !currentViewDate) || (viewDate && currentViewDate?.valueOf() !== viewDate.valueOf()))
@@ -721,9 +733,9 @@ export const GanttBlock = observer(
     const handleSelectedTask = (taskId: string) => {
       setSelectedTask(displayBarTasks.find((t) => t.id === taskId));
     };
-    const handleTaskClick = (task: Task) => {
+    const handleTaskClick = async (task: Task) => {
       handleSelectedTask(task.id);
-      void model.openEvent((task as any).record);
+      await model.openEvent((task as any).record);
     };
 
     const commitChangedTask = (task: Task) => {

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/en-US.json
@@ -22,6 +22,7 @@
   "Progress field": "Progress field",
   "Quarter of day": "Quarter of day",
   "QuarterYear": "QuarterYear",
+  "Scroll to today on first display": "Scroll to today on first display",
   "Show table": "Show table",
   "Start date field": "Start date field",
   "Table width": "Table width",

--- a/packages/plugins/@nocobase/plugin-gantt/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-gantt/src/locale/zh-CN.json
@@ -22,6 +22,7 @@
   "Progress field": "进度字段",
   "Quarter of day": "一天的四分之一",
   "QuarterYear": "季度",
+  "Scroll to today on first display": "默认定位到今天",
   "Show table": "表格显示",
   "Start date field": "开始日期字段",
   "Table width": "表格宽度",


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Gantt blocks need a configurable way to position the chart at today's date when the block is opened.

### Description
Added a Gantt block setting for focusing on today by default. The setting is disabled by default to preserve existing behavior, is persisted in the v2 Gantt block settings, and only triggers once per block mount after the chart date ticks are ready.

Self-tested with focused Gantt block model tests, touched-file linting, and diff whitespace checks.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added an option for Gantt blocks to focus on today by default when opened |
| 🇨🇳 Chinese | 为甘特图区块新增默认定位到今天的配置项 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
