### PR TITLE
fix(plugin-workflow): prevent duplicate execution dispatch

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -19,6 +19,10 @@ import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import type PluginWorkflowServer from './Plugin';
 import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 
+const EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
+
+type AcquireRetryLogger = Pick<ReturnType<PluginWorkflowServer['getLogger']>, 'warn'>;
+
 type Pending = { execution: ExecutionModel; job?: JobModel; loaded?: boolean };
 
 type CachedEvent = [WorkflowModel, any, EventOptions];
@@ -381,27 +385,38 @@ export default class Dispatcher {
     const logger = this.plugin.getLogger(execution.workflowId);
     const isolationLevel =
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
-    let fetched = execution;
+    let fetched: ExecutionModel | null = null;
     try {
-      await this.plugin.db.sequelize.transaction({ isolationLevel }, async (transaction) => {
-        const ExecutionModelClass = this.plugin.db.getModel('executions');
-        const [affected] = await ExecutionModelClass.update(
-          { dispatched: true, status: EXECUTION_STATUS.STARTED },
-          {
-            where: {
-              id: execution.id,
-              dispatched: false,
-            },
-            transaction,
-          },
-        );
-        if (!affected) {
-          fetched = null;
-          return;
-        }
-        await execution.reload({ transaction });
-      });
+      await this.acquireWithRetry(
+        async () => {
+          await this.plugin.db.sequelize.transaction({ isolationLevel }, async (transaction) => {
+            const ExecutionModelClass = this.plugin.db.getModel('executions');
+            const [affected] = await ExecutionModelClass.update(
+              { dispatched: true, status: EXECUTION_STATUS.STARTED },
+              {
+                where: {
+                  id: execution.id,
+                  dispatched: false,
+                },
+                transaction,
+              },
+            );
+            if (!affected) {
+              return;
+            }
+            await execution.reload({ transaction });
+            fetched = execution;
+          });
+          return false;
+        },
+        {
+          logger,
+          conflictMessage: `acquiring pending execution (${execution.id}) conflicted with another worker, retrying`,
+          maxAttemptsMessage: `acquiring pending execution (${execution.id}) reached max retry attempts`,
+        },
+      );
     } catch (error) {
+      fetched = null;
       logger.error(`acquiring pending execution failed: ${error.message}`, { error });
     }
     return fetched;
@@ -412,39 +427,110 @@ export default class Dispatcher {
       this.plugin.db.options.dialect === 'sqlite' ? [][0] : Transaction.ISOLATION_LEVELS.REPEATABLE_READ;
     let fetched: ExecutionModel | null = null;
     try {
-      await this.plugin.db.sequelize.transaction(
-        {
-          isolationLevel,
-        },
-        async (transaction) => {
-          const execution = (await this.plugin.db.getRepository('executions').findOne({
-            filter: {
-              dispatched: false,
-              'workflow.enabled': true,
+      await this.acquireWithRetry(
+        async () => {
+          let shouldRetry = false;
+          await this.plugin.db.sequelize.transaction(
+            {
+              isolationLevel,
             },
-            sort: 'id',
-            transaction,
-          })) as ExecutionModel;
-          if (execution) {
-            this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
-            await execution.update(
-              {
-                dispatched: true,
-                status: EXECUTION_STATUS.STARTED,
-              },
-              { transaction },
-            );
-            execution.workflow = this.plugin.enabledCache.get(execution.workflowId);
-            fetched = execution;
-          } else {
-            this.plugin.getLogger('dispatcher').debug(`no execution in db queued to process`);
-          }
+            async (transaction) => {
+              const execution = (await this.plugin.db.getRepository('executions').findOne({
+                filter: {
+                  dispatched: false,
+                  'workflow.enabled': true,
+                },
+                sort: 'id',
+                transaction,
+              })) as ExecutionModel;
+              if (!execution) {
+                this.plugin.getLogger('dispatcher').debug(`no execution in db queued to process`);
+                return;
+              }
+
+              const ExecutionModelClass = this.plugin.db.getModel('executions');
+              const [affected] = await ExecutionModelClass.update(
+                {
+                  dispatched: true,
+                  status: EXECUTION_STATUS.STARTED,
+                },
+                {
+                  where: {
+                    id: execution.id,
+                    dispatched: false,
+                  },
+                  transaction,
+                },
+              );
+              if (!affected) {
+                shouldRetry = true;
+                this.plugin
+                  .getLogger(execution.workflowId)
+                  .warn(`execution (${execution.id}) was already acquired by another worker, retrying`);
+                return;
+              }
+
+              this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
+              await execution.reload({ transaction });
+              execution.workflow = this.plugin.enabledCache.get(execution.workflowId);
+              fetched = execution;
+            },
+          );
+          return shouldRetry;
+        },
+        {
+          logger: this.plugin.getLogger('dispatcher'),
+          conflictMessage: `acquiring execution conflicted with another worker, retrying`,
+          maxAttemptsMessage: `acquiring execution reached max retry attempts, will retry on next dispatch`,
         },
       );
     } catch (error) {
       this.plugin.getLogger('dispatcher').error(`fetching execution from db failed: ${error.message}`, { error });
     }
     return fetched;
+  }
+
+  private async acquireWithRetry(
+    acquire: () => Promise<boolean>,
+    options: {
+      logger: AcquireRetryLogger;
+      conflictMessage: string;
+      maxAttemptsMessage: string;
+    },
+  ) {
+    for (let attempt = 1; attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
+      let shouldRetry = false;
+      try {
+        shouldRetry = await acquire();
+      } catch (error) {
+        if (!this.isConcurrentAcquireError(error)) {
+          throw error;
+        }
+        shouldRetry = true;
+        options.logger.warn(options.conflictMessage, { error });
+      }
+      if (!shouldRetry) {
+        break;
+      }
+      if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
+        options.logger.warn(options.maxAttemptsMessage);
+        break;
+      }
+    }
+  }
+
+  private isConcurrentAcquireError(error: unknown) {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+    const databaseError = error as Error & {
+      parent?: { code?: string; errno?: number };
+      original?: { code?: string; errno?: number };
+    };
+    const code = databaseError.parent?.code || databaseError.original?.code;
+    const errno = databaseError.parent?.errno || databaseError.original?.errno;
+
+    return code === '40001' || code === '40P01' || code === 'ER_LOCK_DEADLOCK' || errno === 1205 || errno === 1213;
   }
 
   private async process(execution: ExecutionModel, job?: JobModel, options: Transactionable = {}): Promise<Processor> {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -13,6 +13,7 @@ import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 
 import Plugin, { Processor } from '..';
 import { EXECUTION_STATUS } from '../constants';
+import type { ExecutionModel } from '../types';
 
 describe('workflow > Plugin', () => {
   let app: MockServer;
@@ -248,6 +249,121 @@ describe('workflow > Plugin', () => {
   });
 
   describe('dispatcher', () => {
+    it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
+      'should acquire pending execution only once under concurrent dispatch',
+      async () => {
+        const w1 = await WorkflowModel.create({
+          enabled: true,
+          type: 'asyncTrigger',
+        });
+
+        const e1 = await w1.createExecution({
+          key: w1.key,
+          context: {},
+          dispatched: false,
+          status: EXECUTION_STATUS.QUEUEING,
+        });
+        const sameExecution = (await db.getRepository('executions').findOne({
+          filterByTk: e1.id,
+        })) as ExecutionModel;
+
+        type PendingDispatcher = {
+          acquirePendingExecution(execution: ExecutionModel): Promise<ExecutionModel | null>;
+        };
+        const dispatcher = (plugin as unknown as { dispatcher: PendingDispatcher }).dispatcher;
+
+        const acquired = await Promise.all([
+          dispatcher.acquirePendingExecution(e1),
+          dispatcher.acquirePendingExecution(sameExecution),
+        ]);
+
+        const acquiredExecutions = acquired.filter((execution): execution is ExecutionModel => Boolean(execution));
+        expect(acquiredExecutions.map((execution) => execution.id)).toEqual([e1.id]);
+
+        await e1.reload();
+        expect(e1.dispatched).toBe(true);
+        expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+      },
+    );
+
+    it('should not acquire pending execution when acquire transaction fails', async () => {
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+
+      const e1 = await w1.createExecution({
+        key: w1.key,
+        context: {},
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+
+      type PendingDispatcher = {
+        acquirePendingExecution(execution: ExecutionModel): Promise<ExecutionModel | null>;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: PendingDispatcher }).dispatcher;
+      const transaction = db.sequelize.transaction;
+      db.sequelize.transaction = (async () => {
+        throw new Error('simulated transaction failure');
+      }) as typeof db.sequelize.transaction;
+
+      try {
+        const acquired = await dispatcher.acquirePendingExecution(e1);
+        expect(acquired).toBeNull();
+      } finally {
+        db.sequelize.transaction = transaction;
+      }
+
+      await e1.reload();
+      expect(e1.dispatched).toBe(false);
+      expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
+    });
+
+    it('should treat postgres deadlock as concurrent acquire error', () => {
+      type ConcurrentAcquireDispatcher = {
+        isConcurrentAcquireError(error: unknown): boolean;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: ConcurrentAcquireDispatcher }).dispatcher;
+      const error = Object.assign(new Error('deadlock detected'), { parent: { code: '40P01' } });
+
+      expect(dispatcher.isConcurrentAcquireError(error)).toBe(true);
+    });
+
+    it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
+      'should acquire queueing execution only once under concurrent dispatch',
+      async () => {
+        const w1 = await WorkflowModel.create({
+          enabled: true,
+          type: 'asyncTrigger',
+        });
+
+        const e1 = await w1.createExecution({
+          key: w1.key,
+          context: {},
+          dispatched: false,
+          status: EXECUTION_STATUS.QUEUEING,
+        });
+
+        type QueueingDispatcher = {
+          acquireQueueingExecution(): Promise<ExecutionModel | null>;
+        };
+        const dispatcher = (plugin as unknown as { dispatcher: QueueingDispatcher }).dispatcher;
+
+        const acquired = await Promise.all([
+          dispatcher.acquireQueueingExecution(),
+          dispatcher.acquireQueueingExecution(),
+        ]);
+
+        const acquiredExecutions = acquired.filter((execution): execution is ExecutionModel => Boolean(execution));
+        expect(acquiredExecutions.map((execution) => execution.id)).toEqual([e1.id]);
+
+        await e1.reload();
+        expect(e1.dispatched).toBe(true);
+        expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+      },
+    );
+
     it('multiple triggers in same event', async () => {
       const w1 = await WorkflowModel.create({
         enabled: true,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Backport
Backport #9673 to v1.

### Motivation
Workflow executions could be acquired by more than one worker when multiple dispatchers selected the same queued or pending execution before either transaction updated it. This could lead to duplicate workflow processing, duplicate job inserts, and primary key conflicts.

### Description
This updates workflow execution acquisition to atomically mark executions as dispatched with a conditional update, only process executions after ownership is confirmed, and retry retryable concurrent acquisition conflicts with a bounded loop.

### Testing
- yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
- yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts -t "should treat postgres deadlock as concurrent acquire error"
- yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts -t "should not acquire pending execution when acquire transaction fails"

### Changelog
| Language | Changelog |
| --- | --- |
| English | Fixed duplicate workflow execution dispatch under concurrent workers. |
| Chinese | 修复多工作节点并发时工作流执行可能被重复调度的问题。 |