### PR TITLE
feat(async-task-manager): add client v2 topbar action

### DIFF
--- a/packages/plugins/@nocobase/plugin-async-task-manager/client-v2.d.ts
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/client-v2.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/client-v2';
+export { default } from './dist/client-v2';

--- a/packages/plugins/@nocobase/plugin-async-task-manager/client-v2.js
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/client-v2.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/client-v2/index.js');

--- a/packages/plugins/@nocobase/plugin-async-task-manager/package.json
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/package.json
@@ -10,6 +10,7 @@
   "main": "dist/server/index.js",
   "peerDependencies": {
     "@nocobase/client": "2.x",
+    "@nocobase/client-v2": "2.x",
     "@nocobase/plugin-error-handler": "2.x",
     "@nocobase/server": "2.x",
     "@nocobase/test": "2.x"

--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/index.tsx
@@ -1,0 +1,11 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export { PluginAsyncTaskManagerClientV2 } from './plugin';
+export { default } from './plugin';

--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/locale.ts
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/locale.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr as _tExpr, useFlowEngine } from '@nocobase/flow-engine';
+
+export const NAMESPACE = '@nocobase/plugin-async-task-manager';
+
+export function tExpr(key: string) {
+  return _tExpr(key, { ns: [NAMESPACE, 'client'], nsMode: 'fallback' });
+}
+
+export function useT() {
+  const engine = useFlowEngine();
+  return (key: string, options?: Record<string, unknown>) =>
+    engine.context.t(key, { ns: [NAMESPACE, 'client'], nsMode: 'fallback', ...options });
+}

--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/models/AsyncTasksTopbarActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/models/AsyncTasksTopbarActionModel.tsx
@@ -1,0 +1,432 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ExclamationCircleOutlined, EyeOutlined, StopOutlined, SyncOutlined } from '@ant-design/icons';
+import { Icon, TopbarActionModel, useApp, useMobileLayout } from '@nocobase/client-v2';
+import { observer } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import {
+  Alert,
+  Button,
+  Empty,
+  Modal,
+  Popconfirm,
+  Popover,
+  Progress,
+  Space,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { TASK_STATUS, TASK_STATUS_OPTIONS } from '../../common/constants';
+import type { TaskStatus } from '../../common/types';
+import type { AsyncTaskRecord, PluginAsyncTaskManagerClientV2, TaskOrigin } from '../plugin';
+import { tExpr, useT } from '../locale';
+
+dayjs.extend(relativeTime);
+
+type AsyncTasksListBody = {
+  data?: AsyncTaskRecord[];
+};
+
+type StatusOption = {
+  label: string;
+  color?: string;
+  icon?: string;
+};
+
+type TaskErrorResult = {
+  message?: string;
+  params?: Record<string, unknown>;
+};
+
+const statusOptions = TASK_STATUS_OPTIONS as Record<string, StatusOption>;
+
+function getStatusOption(status: TaskStatus | undefined): StatusOption {
+  const statusKey = String(status ?? TASK_STATUS.PENDING);
+  return statusOptions[statusKey] ?? statusOptions[String(TASK_STATUS.PENDING)];
+}
+
+function isTaskErrorResult(value: unknown): value is TaskErrorResult {
+  return !!value && typeof value === 'object';
+}
+
+function getTaskManagerPlugin(app: ReturnType<typeof useApp>): PluginAsyncTaskManagerClientV2 | undefined {
+  const plugin = app.pm.get('async-task-manager') ?? app.pm.get('@nocobase/plugin-async-task-manager');
+  return plugin as PluginAsyncTaskManagerClientV2 | undefined;
+}
+
+function getTaskOrigin(plugin: PluginAsyncTaskManagerClientV2 | undefined, origin?: string): TaskOrigin | undefined {
+  if (!origin) {
+    return undefined;
+  }
+
+  return plugin?.taskOrigins.get(origin);
+}
+
+const AsyncTasksButton = React.memo(
+  (props: {
+    popoverVisible: boolean;
+    setPopoverVisible: (visible: boolean) => void;
+    tasks: AsyncTaskRecord[];
+    refresh: () => void;
+    loading?: boolean;
+  }) => {
+    const { popoverVisible, setPopoverVisible, tasks, refresh, loading } = props;
+    const app = useApp();
+    const t = useT();
+    const { token } = theme.useToken();
+    const plugin = getTaskManagerPlugin(app);
+    const taskResource = useMemo(() => app.apiClient.resource('asyncTasks'), [app.apiClient]);
+
+    const columns = useMemo<ColumnsType<AsyncTaskRecord>>(
+      () => [
+        {
+          title: t('Created at'),
+          dataIndex: 'createdAt',
+          key: 'createdAt',
+          width: token.controlHeight * 5,
+          render: (createdAt?: string) =>
+            createdAt ? (
+              <Tooltip title={dayjs(createdAt).format('YYYY-MM-DD HH:mm:ss')}>{dayjs(createdAt).fromNow()}</Tooltip>
+            ) : (
+              '-'
+            ),
+        },
+        {
+          title: t('Task'),
+          dataIndex: 'title',
+          key: 'title',
+          ellipsis: true,
+        },
+        {
+          title: t('Status'),
+          dataIndex: 'status',
+          key: 'status',
+          width: token.controlHeight * 5,
+          render: (status: TaskStatus, record) => {
+            const option = getStatusOption(status);
+
+            const renderProgress = () => {
+              const commonStyle = {
+                width: token.controlHeight * 3,
+                margin: 0,
+              };
+
+              switch (status) {
+                case TASK_STATUS.PENDING:
+                case TASK_STATUS.CANCELED:
+                  return <Alert showIcon={false} message={t(option.label)} banner />;
+                case TASK_STATUS.RUNNING:
+                  return (
+                    <Progress
+                      type="line"
+                      size="small"
+                      strokeWidth={token.lineWidthBold}
+                      percent={Number((((record.progressCurrent ?? 0) / (record.progressTotal ?? 1)) * 100).toFixed(2))}
+                      status="active"
+                      style={commonStyle}
+                      format={(percent) => `${(percent ?? 0).toFixed(1)}%`}
+                    />
+                  );
+                case TASK_STATUS.SUCCEEDED:
+                  return (
+                    <Progress
+                      type="line"
+                      size="small"
+                      strokeWidth={token.lineWidthBold}
+                      percent={100}
+                      status="success"
+                      style={commonStyle}
+                      format={() => ''}
+                    />
+                  );
+                case TASK_STATUS.FAILED:
+                  return (
+                    <Progress
+                      type="line"
+                      size="small"
+                      strokeWidth={token.lineWidthBold}
+                      percent={100}
+                      status="exception"
+                      style={commonStyle}
+                      format={() => ''}
+                    />
+                  );
+                default:
+                  return null;
+              }
+            };
+
+            return (
+              <Space align="center" size={token.marginXS}>
+                <span>{renderProgress()}</span>
+                <Tag
+                  color={option.color}
+                  icon={option.icon ? <Icon type={option.icon} /> : null}
+                  style={{
+                    margin: 0,
+                    paddingInline: token.paddingXXS,
+                    height: token.controlHeightSM,
+                    width: token.controlHeightSM,
+                  }}
+                />
+              </Space>
+            );
+          },
+        },
+        {
+          title: t('Actions'),
+          dataIndex: 'result',
+          key: 'actions',
+          width: token.controlHeight * 6,
+          render: (result: unknown, record) => {
+            const actions: React.ReactNode[] = [];
+            const taskOrigin = getTaskOrigin(plugin, record.origin);
+            const ResultComponent = taskOrigin?.Result;
+            const ResultButton = taskOrigin?.ResultButton;
+
+            if (record.cancelable && (record.status === TASK_STATUS.RUNNING || record.status === TASK_STATUS.PENDING)) {
+              actions.push(
+                <Popconfirm
+                  key="cancel"
+                  title={t('Confirm cancel')}
+                  description={t('Confirm to cancel this task?')}
+                  onConfirm={async () => {
+                    await taskResource.stop({
+                      filterByTk: record.id,
+                    });
+                    refresh();
+                  }}
+                  okText={t('Confirm')}
+                  cancelText={t('Cancel')}
+                >
+                  <Button type="link" size="small" icon={<StopOutlined />}>
+                    {t('Stop')}
+                  </Button>
+                </Popconfirm>,
+              );
+            }
+
+            if (record.status === TASK_STATUS.SUCCEEDED && result) {
+              if (ResultButton) {
+                actions.push(<ResultButton key="result-button" task={record} />);
+              } else {
+                actions.push(
+                  <Button
+                    key="view"
+                    type="link"
+                    size="small"
+                    icon={<EyeOutlined />}
+                    onClick={() => {
+                      setPopoverVisible(false);
+                      Modal.info({
+                        title: t('Task result'),
+                        content: ResultComponent ? (
+                          <ResultComponent payload={result} task={record} />
+                        ) : (
+                          <div>
+                            {t('No renderer available for this task type, payload: {{payload}}', {
+                              payload: String(result),
+                            })}
+                          </div>
+                        ),
+                      });
+                    }}
+                  >
+                    {t('View result')}
+                  </Button>,
+                );
+              }
+            }
+
+            if (record.status === TASK_STATUS.FAILED && isTaskErrorResult(result)) {
+              actions.push(
+                <Button
+                  key="error"
+                  type="link"
+                  size="small"
+                  icon={<ExclamationCircleOutlined />}
+                  onClick={() => {
+                    setPopoverVisible(false);
+                    const namespace = taskOrigin?.namespace ?? 'client';
+                    Modal.info({
+                      title: t('Error Details'),
+                      content: (
+                        <Typography.Text>
+                          {t(result.message ?? '', { ...result.params, ns: namespace })}
+                        </Typography.Text>
+                      ),
+                      closable: true,
+                      width: token.screenSM,
+                    });
+                  }}
+                >
+                  {t('Error details')}
+                </Button>,
+              );
+            }
+
+            return <Space size={token.marginSM}>{actions}</Space>;
+          },
+        },
+      ],
+      [plugin, refresh, setPopoverVisible, t, taskResource, token],
+    );
+
+    const content = (
+      <div
+        style={{
+          maxHeight: '70vh',
+          overflow: 'auto',
+          width: tasks.length > 0 ? token.screenLG : token.controlHeight * 6,
+        }}
+      >
+        {tasks.length > 0 ? (
+          <Table<AsyncTaskRecord>
+            loading={loading}
+            columns={columns}
+            dataSource={tasks}
+            size="small"
+            pagination={false}
+            rowKey="id"
+          />
+        ) : (
+          <div style={{ paddingBlock: token.paddingLG, display: 'flex', justifyContent: 'center' }}>
+            <Empty description={t('No tasks')} image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          </div>
+        )}
+      </div>
+    );
+
+    return (
+      <Popover
+        content={content}
+        trigger="click"
+        placement="bottom"
+        open={popoverVisible}
+        onOpenChange={setPopoverVisible}
+      >
+        <Button
+          type="text"
+          onClick={() => {
+            setPopoverVisible(!popoverVisible);
+            if (!popoverVisible) {
+              refresh();
+            }
+          }}
+          icon={<SyncOutlined spin={tasks.some((task) => TASK_STATUS.RUNNING === task.status)} />}
+          data-testid="async-tasks-button"
+        />
+      </Popover>
+    );
+  },
+);
+
+AsyncTasksButton.displayName = 'AsyncTasksButton';
+
+const AsyncTasksTopbarAction = observer(
+  () => {
+    const app = useApp();
+    const { isMobileLayout } = useMobileLayout();
+    const { data, refresh, loading } = useRequest(async (): Promise<AsyncTasksListBody> => {
+      const response = await app.apiClient.resource('asyncTasks').list({
+        sort: '-createdAt',
+      });
+      return (response?.data ?? { data: [] }) as AsyncTasksListBody;
+    });
+
+    const [tasks, setTasks] = useState<AsyncTaskRecord[]>([]);
+    const [popoverVisible, setPopoverVisible] = useState(false);
+
+    useEffect(() => {
+      setTasks(Array.isArray(data?.data) ? data.data : []);
+    }, [data]);
+
+    const handleTaskCreated = useCallback(() => {
+      setPopoverVisible(true);
+      refresh();
+    }, [refresh]);
+
+    const handleTaskProgress = useCallback((event: Event) => {
+      const detail = (event as CustomEvent<AsyncTaskRecord>).detail;
+      if (!detail?.id) {
+        return;
+      }
+
+      setTasks((prevTasks) => {
+        const nextTasks = [...prevTasks];
+        const index = nextTasks.findIndex((task) => task.id === detail.id);
+        if (index === -1) {
+          nextTasks.unshift(detail);
+          return nextTasks;
+        }
+
+        nextTasks.splice(index, 1, detail);
+        return nextTasks;
+      });
+    }, []);
+
+    const handleTaskStatus = useCallback(() => {
+      refresh();
+    }, [refresh]);
+
+    const handleTaskDeleted = useCallback(() => {
+      refresh();
+    }, [refresh]);
+
+    useEffect(() => {
+      app.eventBus.addEventListener('ws:message:async-tasks:created', handleTaskCreated);
+      app.eventBus.addEventListener('ws:message:async-tasks:progress', handleTaskProgress);
+      app.eventBus.addEventListener('ws:message:async-tasks:status', handleTaskStatus);
+      app.eventBus.addEventListener('ws:message:async-tasks:deleted', handleTaskDeleted);
+
+      return () => {
+        app.eventBus.removeEventListener('ws:message:async-tasks:created', handleTaskCreated);
+        app.eventBus.removeEventListener('ws:message:async-tasks:progress', handleTaskProgress);
+        app.eventBus.removeEventListener('ws:message:async-tasks:status', handleTaskStatus);
+        app.eventBus.removeEventListener('ws:message:async-tasks:deleted', handleTaskDeleted);
+      };
+    }, [app.eventBus, handleTaskCreated, handleTaskDeleted, handleTaskProgress, handleTaskStatus]);
+
+    if (isMobileLayout || tasks.length === 0) {
+      return null;
+    }
+
+    return (
+      <AsyncTasksButton
+        tasks={tasks}
+        refresh={refresh}
+        loading={loading}
+        popoverVisible={popoverVisible}
+        setPopoverVisible={setPopoverVisible}
+      />
+    );
+  },
+  { displayName: 'AsyncTasksTopbarAction' },
+);
+
+export class AsyncTasksTopbarActionModel extends TopbarActionModel {
+  sort = 300;
+  actionId = 'async-tasks';
+  testId = 'async-tasks-button';
+  tooltip = tExpr('Async tasks');
+
+  render() {
+    return <AsyncTasksTopbarAction />;
+  }
+}
+
+export default AsyncTasksTopbarActionModel;

--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/plugin.tsx
@@ -1,0 +1,50 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Application } from '@nocobase/client-v2';
+import { Plugin } from '@nocobase/client-v2';
+import { Registry } from '@nocobase/utils/client';
+import React from 'react';
+
+export type AsyncTaskRecord = {
+  id: string;
+  origin?: string;
+  type?: string;
+  title?: string;
+  status?: number | null;
+  result?: unknown;
+  cancelable?: boolean;
+  progressCurrent?: number | null;
+  progressTotal?: number | null;
+  createdAt?: string;
+  params?: Record<string, unknown>;
+};
+
+export type TaskOrigin = {
+  Result?: React.ComponentType<{ payload: unknown; task: AsyncTaskRecord }>;
+  ResultButton?: React.ComponentType<{ task: AsyncTaskRecord }>;
+  namespace?: string;
+};
+
+export class PluginAsyncTaskManagerClientV2 extends Plugin<Record<string, never>, Application> {
+  taskOrigins: Registry<TaskOrigin> = new Registry();
+
+  async load() {
+    this.flowEngine.registerModelLoaders({
+      AsyncTasksTopbarActionModel: {
+        extends: 'TopbarActionModel',
+        loader: () => import('./models/AsyncTasksTopbarActionModel'),
+      },
+    });
+
+    this.app.eventBus.dispatchEvent(new CustomEvent('plugin:async-task-manager:loaded', { detail: this }));
+  }
+}
+
+export default PluginAsyncTaskManagerClientV2;


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Migrate the async task manager client integration to the v2 client runtime.

### Description
- Added a `client-v2` plugin entry and package shims.
- Registered an async task topbar action through v2 `TopbarActionModel`.
- Preserved the existing `taskOrigins` registry for import/export task result renderers.
- Replaced v1 `PinnedPluginListProvider` / `SchemaComponentOptions` usage in the v2 path.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/index.tsx packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/locale.ts packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-async-task-manager/src/client-v2/models/AsyncTasksTopbarActionModel.tsx`
- `git diff --check`
- `yarn nocobase build packages/plugins/@nocobase/plugin-async-task-manager`

### Related issues

### Showcase
Browser screenshot report generated locally at:
`packages/plugins/@nocobase/plugin-async-task-manager/migration-report/README.md`

The local app login was blocked by `Invalid SQL column or table reference` / `Unauthenticated. Please sign in to continue`, so the topbar popover could not be visually verified in that environment.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added v2 client support for the async task manager topbar action. |
| 🇨🇳 Chinese | 为异步任务管理器顶部栏入口增加 v2 客户端支持。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
