### PR TITLE
fix(client-v2): avoid translating plain option labels

### DIFF
--- a/packages/core/client-v2/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client-v2/src/flow/actions/linkageRules.tsx
@@ -46,7 +46,7 @@ import { useAssociationTitleFieldSync } from '../components/useAssociationTitleF
 import _ from 'lodash';
 import { SubFormFieldModel, SubFormListFieldModel } from '../models';
 import { coerceForToOneField } from '../internal/utils/associationValueCoercion';
-import { enumToOptions } from '../internal/utils/enumOptionsUtils';
+import { enumToOptions, translateOptionLabel } from '../internal/utils/enumOptionsUtils';
 import {
   findFormItemModelByFieldPath,
   getCollectionFromModel,
@@ -156,7 +156,7 @@ const getFieldModelOptions = (fieldModel: any, t: (s: string) => string) => {
   if (originalOptions) {
     return originalOptions.map((option: any) =>
       option && typeof option === 'object' && typeof option.label === 'string'
-        ? { ...option, label: t(option.label) }
+        ? { ...option, label: translateOptionLabel(option.label, t) }
         : option,
     );
   }

--- a/packages/core/client-v2/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts
+++ b/packages/core/client-v2/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts
@@ -24,27 +24,28 @@ function mockT(input: string) {
 }
 
 describe('enumOptions utils', () => {
-  it('enumToOptions: converts primitive enum and translates labels', () => {
+  it('enumToOptions: converts primitive enum and translates explicit template labels', () => {
     const uiEnum = ['{{t("Yes")}}', '{{t("No")}}'];
-    const options = enumToOptions(uiEnum as any, mockT)!;
-    expect(options).toHaveLength(2);
-    expect(options[0]).toEqual({ label: '是', value: '{{t("Yes")}}' });
-    expect(options[1]).toEqual({ label: '否', value: '{{t("No")}}' });
+    const options = enumToOptions(uiEnum as any, mockT);
+    expect(options).toEqual([
+      { label: '是', value: '{{t("Yes")}}' },
+      { label: '否', value: '{{t("No")}}' },
+    ]);
   });
 
-  it('enumToOptions: keeps object value and translates object label', () => {
+  it('enumToOptions: keeps object value and translates explicit template object label', () => {
     const uiEnum = [
       { label: '{{t("Yes")}}', value: true },
       { label: '{{t("No")}}', value: false },
     ];
-    const options = enumToOptions(uiEnum as any, mockT)!;
+    const options = enumToOptions(uiEnum as any, mockT);
     expect(options).toEqual([
       { label: '是', value: true },
       { label: '否', value: false },
     ]);
   });
 
-  it('translateOptions: maps given options labels through t()', () => {
+  it('translateOptions: maps only explicit template labels through t()', () => {
     const options = [
       { label: '{{t("Draft")}}', value: 'draft' },
       { label: 'No', value: false },
@@ -52,7 +53,7 @@ describe('enumOptions utils', () => {
     const out = translateOptions(options as any, mockT);
     expect(out).toEqual([
       { label: '草稿', value: 'draft' },
-      { label: '否', value: false },
+      { label: 'No', value: false },
     ]);
   });
 

--- a/packages/core/client-v2/src/flow/internal/utils/enumOptionsUtils.ts
+++ b/packages/core/client-v2/src/flow/internal/utils/enumOptionsUtils.ts
@@ -33,13 +33,21 @@ function normalizeUiSchemaEnumToOptions(uiEnum: UiSchemaEnumItem[] = []): Option
   });
 }
 
-// Map option labels through t() (supports {{t('key')}} template and plain strings)
-export function translateOptions(options: Option[] = [], t: (s: string) => string): Option[] {
-  if (!Array.isArray(options)) return [] as Option[];
-  return options.map((opt) => (typeof opt?.label === 'string' ? { ...opt, label: t(opt.label) } : opt));
+export function isTranslationTemplate(value: unknown): value is string {
+  return typeof value === 'string' && /\{\{\s*t\s*\(/.test(value);
 }
 
-// Build options from uiSchema.enum with translated labels
+export function translateOptionLabel(label: any, t: (s: string) => string): any {
+  return isTranslationTemplate(label) ? t(label) : label;
+}
+
+// Map option labels through t() only when labels explicitly use {{t(...)}} templates.
+export function translateOptions(options: Option[] = [], t: (s: string) => string): Option[] {
+  if (!Array.isArray(options)) return [] as Option[];
+  return options.map((opt) => ({ ...opt, label: translateOptionLabel(opt?.label, t) }));
+}
+
+// Build options from uiSchema.enum with explicitly translated labels
 export function enumToOptions(uiEnum: UiSchemaEnumItem[] | undefined, t: (s: string) => string): Option[] | undefined {
   if (!uiEnum || !Array.isArray(uiEnum) || uiEnum.length === 0) return undefined;
   const normalized = normalizeUiSchemaEnumToOptions(uiEnum);

--- a/packages/core/client-v2/src/flow/models/fields/DisplayEnumFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/DisplayEnumFieldModel.tsx
@@ -13,6 +13,7 @@ import { Tag } from 'antd';
 import React from 'react';
 import { castArray } from 'lodash';
 import { ClickableFieldModel } from './ClickableFieldModel';
+import { translateOptionLabel } from '../../internal/utils/enumOptionsUtils';
 
 interface FieldNames {
   value: string;
@@ -70,7 +71,7 @@ export class DisplayEnumFieldModel extends ClickableFieldModel {
     }
     return currentOptions.map((option) => (
       <Tag key={option[fieldNames.value]} color={option[fieldNames.color]} icon={<Icon type={option['icon']} />}>
-        {this.translate(option[fieldNames.label])}
+        {translateOptionLabel(option[fieldNames.label], this.translate)}
       </Tag>
     ));
   }

--- a/packages/core/client-v2/src/flow/models/fields/SelectFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/SelectFieldModel.tsx
@@ -12,7 +12,7 @@ import { Select, Tag, Tooltip } from 'antd';
 import React from 'react';
 import { FieldModel } from '../base/FieldModel';
 import { MobileSelect } from './mobile-components/MobileSelect';
-import { enumToOptions, getSelectedEnumLabels } from '../../internal/utils/enumOptionsUtils';
+import { enumToOptions, getSelectedEnumLabels, translateOptionLabel } from '../../internal/utils/enumOptionsUtils';
 
 const getOriginalEnumOptions = (model: SelectFieldModel) => {
   const fromEnum = enumToOptions(model.context.collectionField?.uiSchema?.enum, (text) => text) || [];
@@ -29,12 +29,12 @@ export class SelectFieldModel extends FieldModel {
     const options = this.props.options?.map((v) => {
       return {
         ...v,
-        label: this.translate(v.label),
+        label: translateOptionLabel(v.label, this.translate),
       };
     });
     const selectedLabels = getSelectedEnumLabels(this.props.value, fallbackOptions).map((item) => ({
       ...item,
-      label: this.translate(item.label),
+      label: translateOptionLabel(item.label, this.translate),
     }));
     const value = Array.isArray(this.props.value)
       ? selectedLabels

--- a/packages/core/flow-engine/src/data-source/__tests__/index.test.ts
+++ b/packages/core/flow-engine/src/data-source/__tests__/index.test.ts
@@ -50,7 +50,7 @@ describe('DataSource & Collection APIs', () => {
         { name: 'body', type: 'string', interface: 'text' },
       ],
     });
-    const bodyField = ds.getCollection('posts')!.getField('body');
+    const bodyField = ds.getCollection('posts')?.getField('body');
     expect(bodyField?.name).toBe('body');
 
     // remove collection
@@ -109,7 +109,7 @@ describe('DataSource & Collection APIs', () => {
       ],
     });
 
-    const rules = ds.getCollection('posts')!.getField('title')!.getComponentProps().rules;
+    const rules = ds.getCollection('posts')?.getField('title')?.getComponentProps().rules || [];
 
     await expect(rules[0].validator({}, '123')).rejects.toBe('单行文本 长度必须为 18 个字符');
   });

--- a/packages/core/flow-engine/src/data-source/index.ts
+++ b/packages/core/flow-engine/src/data-source/index.ts
@@ -336,6 +336,14 @@ export function getCollectionFieldInterface(
   return undefined;
 }
 
+function shouldTranslateOptionLabel(label: unknown): label is string {
+  return typeof label === 'string' && /\{\{\s*t\s*\(/.test(label);
+}
+
+function translateOptionLabel(flowEngine: FlowEngine, label: unknown, options?: Record<string, any>) {
+  return shouldTranslateOptionLabel(label) ? flowEngine.translate(label, options) : label;
+}
+
 export class DataSource {
   dataSourceManager: DataSourceManager;
   collectionManager: CollectionManager;
@@ -1086,7 +1094,7 @@ export class CollectionField {
         }
         return {
           ...v,
-          label: v.label ? this.flowEngine.translate(v.label, { ns: 'lm-collections' }) : v.label,
+          label: translateOptionLabel(this.flowEngine, v.label, { ns: 'lm-collections' }),
           value: Number(v.value),
         };
       });
@@ -1094,7 +1102,7 @@ export class CollectionField {
     return options.map((v) => {
       return {
         ...v,
-        label: this.flowEngine.translate(v.label, { ns: 'lm-collections' }),
+        label: translateOptionLabel(this.flowEngine, v.label, { ns: 'lm-collections' }),
       };
     });
   }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 local option fields were translating plain option labels through the application i18n layer. Business labels such as `Action`, `Add`, or `medium` could therefore be displayed as translated UI text in Chinese, even when the field configuration intended them to remain literal option labels.

### Description
This PR changes V2 enum option label handling so only explicit `{{t(...)}}` templates are translated. Plain option labels are kept as configured across editable select fields, display enum tags, linkage-rule option limiting, and collection field component props.

Potential compatibility risk: existing configurations that used plain option labels as implicit i18n keys will now display those labels literally. Such labels should use `{{t(...)}}` when translation is intended.

Tested with:
- `yarn eslint --fix packages/core/client-v2/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts packages/core/flow-engine/src/data-source/__tests__/index.test.ts packages/core/client-v2/src/flow/internal/utils/enumOptionsUtils.ts packages/core/client-v2/src/flow/models/fields/SelectFieldModel.tsx packages/core/client-v2/src/flow/models/fields/DisplayEnumFieldModel.tsx packages/core/client-v2/src/flow/actions/linkageRules.tsx packages/core/flow-engine/src/data-source/index.ts`
- `yarn test packages/core/client-v2/src/flow/internal/utils/__tests__/enumOptionsUtils.test.ts --run --reporter=verbose`
- `yarn test packages/core/flow-engine/src/data-source/__tests__/index.test.ts --run --reporter=verbose`

### Related issues

None.

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed V2 option fields incorrectly translating plain option labels in localized environments. |
| 🇨🇳 Chinese | 修复 V2 选项字段在本地化环境下错误翻译普通选项标签的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
