### PR TITLE
feat(plugin-backups): add client v2 migration

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/client-v2.d.ts
+++ b/packages/plugins/@nocobase/plugin-backups/client-v2.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/client-v2';
+export { default } from './dist/client-v2';

--- a/packages/plugins/@nocobase/plugin-backups/client-v2.js
+++ b/packages/plugins/@nocobase/plugin-backups/client-v2.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/client-v2/index.js');

--- a/packages/plugins/@nocobase/plugin-backups/package.json
+++ b/packages/plugins/@nocobase/plugin-backups/package.json
@@ -30,6 +30,7 @@
     "mkdirp": "^1.0.4",
     "object-path": "^0.11.8",
     "react": "^18.2.0",
+    "react-js-cron": "^3.1.0",
     "semver": "^7.5.4",
     "tar": "^7.5.15",
     "yauzl": "^3.2.0"

--- a/packages/plugins/@nocobase/plugin-backups/package.json
+++ b/packages/plugins/@nocobase/plugin-backups/package.json
@@ -37,7 +37,9 @@
   "peerDependencies": {
     "@nocobase/actions": "2.x",
     "@nocobase/client": "2.x",
+    "@nocobase/client-v2": "2.x",
     "@nocobase/database": "2.x",
+    "@nocobase/flow-engine": "2.x",
     "@nocobase/lock-manager": "2.x",
     "@nocobase/plugin-file-manager": "2.x",
     "@nocobase/server": "2.x",

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
@@ -10,7 +10,7 @@
 import { Table, useCurrentAppInfo } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
 import { useRequest } from 'ahooks';
-import { App, Button, Divider, Space, theme } from 'antd';
+import { App, Divider, Space, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import { saveAs } from 'file-saver';
@@ -100,6 +100,7 @@ export const BackupsTable = () => {
       {
         title: t('Backup list'),
         dataIndex: 'name',
+        width: 400,
         onCell: (record) => {
           return record.inProgress
             ? {
@@ -125,7 +126,9 @@ export const BackupsTable = () => {
         title: t('Created at'),
         dataIndex: 'createdAt',
         onCell: hideCellWhenInProgress,
-        render: (value: string | undefined) => (value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-'),
+        render: (value: string | undefined) => {
+          return value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : null;
+        },
       },
       {
         title: t('Actions'),
@@ -134,12 +137,14 @@ export const BackupsTable = () => {
         render: (_: unknown, record) => (
           <Space split={<Divider type="vertical" />}>
             <RestoreFromBackup backup={record} />
-            <Button type="link" size="small" onClick={() => handleDownload(record)}>
+            <a
+              onClick={() => {
+                handleDownload(record);
+              }}
+            >
               {t('Download')}
-            </Button>
-            <Button type="link" size="small" onClick={() => handleDestroy(record)}>
-              {t('Delete')}
-            </Button>
+            </a>
+            <a onClick={() => handleDestroy(record)}>{t('Delete')}</a>
           </Space>
         ),
       },

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
@@ -1,0 +1,151 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Table, useCurrentAppInfo } from '@nocobase/client-v2';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import { App, Button, Divider, Space, theme } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import dayjs from 'dayjs';
+import { saveAs } from 'file-saver';
+import React, { useCallback, useMemo } from 'react';
+import { NAMESPACE } from '../constants';
+import { useBackupsContext } from '../contexts';
+import { useT } from '../locale';
+import { RestoreFromBackup } from './RestoreFromBackup';
+
+export interface BackupFile {
+  name: string;
+  fileSize: string;
+  createdAt: string;
+  inProgress: boolean;
+}
+
+type AppInfo = {
+  name?: string;
+  data?: {
+    name?: string;
+  };
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+export const BackupsTable = () => {
+  const t = useT();
+  const ctx = useFlowContext();
+  const currentAppInfo = useCurrentAppInfo<AppInfo>();
+  const { token } = theme.useToken();
+  const { modal, message } = App.useApp();
+  const { data, loading, refreshAsync: refresh } = useBackupsContext();
+  const { runAsync: destroy } = useRequest<BackupFile[] | undefined, [string]>(
+    async (filterByTk) => {
+      const response = await ctx.api.request<ResourceResponse<BackupFile[]>>({
+        url: `${NAMESPACE}:destroy`,
+        method: 'post',
+        params: { filterByTk },
+      });
+
+      return response.data?.data;
+    },
+    { manual: true },
+  );
+
+  const handleDestroy = useCallback(
+    (fileData: BackupFile) => {
+      modal.confirm({
+        title: t('Delete record'),
+        content: t('Are you sure you want to delete it?'),
+        onOk: async () => {
+          await destroy(fileData.name);
+          await refresh();
+          message.success(t('The deletion was successful.'));
+        },
+      });
+    },
+    [destroy, message, modal, refresh, t],
+  );
+
+  const handleDownload = useCallback(
+    async (fileData: BackupFile) => {
+      const appName = currentAppInfo?.name ?? currentAppInfo?.data?.name;
+      const params: Record<string, string> = {
+        filterByTk: fileData.name,
+      };
+      if (appName) {
+        params.__appName = appName;
+      }
+      const response = await ctx.api.request({
+        url: 'backups:download',
+        method: 'get',
+        params,
+        responseType: 'blob',
+      });
+      const blob = new Blob([response.data]);
+      saveAs(blob, fileData.name);
+    },
+    [ctx.api, currentAppInfo?.data?.name, currentAppInfo?.name],
+  );
+
+  const hideCellWhenInProgress = (record: BackupFile) => (record.inProgress ? { colSpan: 0 } : {});
+  const columns = useMemo<ColumnsType<BackupFile>>(
+    () => [
+      {
+        title: t('Backup list'),
+        dataIndex: 'name',
+        onCell: (record) => {
+          return record.inProgress
+            ? {
+                colSpan: 4,
+              }
+            : {};
+        },
+        render: (name: string, record) =>
+          record.inProgress ? (
+            <span style={{ color: token.colorText }}>
+              {name}({t('Backing up')}...)
+            </span>
+          ) : (
+            <span>{name}</span>
+          ),
+      },
+      {
+        title: t('File size'),
+        dataIndex: 'fileSize',
+        onCell: hideCellWhenInProgress,
+      },
+      {
+        title: t('Created at'),
+        dataIndex: 'createdAt',
+        onCell: hideCellWhenInProgress,
+        render: (value: string | undefined) => (value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-'),
+      },
+      {
+        title: t('Actions'),
+        dataIndex: 'actions',
+        onCell: hideCellWhenInProgress,
+        render: (_: unknown, record) => (
+          <Space split={<Divider type="vertical" />}>
+            <RestoreFromBackup backup={record} />
+            <Button type="link" size="small" onClick={() => handleDownload(record)}>
+              {t('Download')}
+            </Button>
+            <Button type="link" size="small" onClick={() => handleDestroy(record)}>
+              {t('Delete')}
+            </Button>
+          </Space>
+        ),
+      },
+    ],
+    [handleDestroy, handleDownload, t, token.colorText],
+  );
+
+  return <Table<BackupFile> rowKey="name" dataSource={data?.data} loading={loading} columns={columns} />;
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/NewBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/NewBackup.tsx
@@ -1,0 +1,120 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { LoadingOutlined, PlusOutlined } from '@ant-design/icons';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import { App, Button } from 'antd';
+import React, { useEffect, useState } from 'react';
+import { NAMESPACE } from '../constants';
+import { useBackupsContext } from '../contexts';
+import { useT } from '../locale';
+import type { BackupFile } from './BackupsTable';
+
+type BackupTaskStatus = {
+  inProgress: boolean;
+  message?: string;
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+export const NewBackup = () => {
+  const [inProgressBackups, setInProgressBackups] = useState<string[]>([]);
+  const t = useT();
+  const ctx = useFlowContext();
+  const { message, notification, modal } = App.useApp();
+  const { refreshAsync: refresh } = useBackupsContext();
+  const { runAsync: create, loading: creating } = useRequest<BackupFile | undefined, []>(
+    async () => {
+      const response = await ctx.api.request<ResourceResponse<BackupFile>>({
+        url: `${NAMESPACE}:create`,
+        method: 'post',
+      });
+
+      return response.data?.data;
+    },
+    {
+      manual: true,
+      throttleWait: 1000,
+    },
+  );
+  const { runAsync: queryStatus } = useRequest<Record<string, BackupTaskStatus>, [string[]]>(
+    async (names) => {
+      const response = await ctx.api.request<ResourceResponse<Record<string, BackupTaskStatus>>>({
+        url: `${NAMESPACE}:taskStatus`,
+        method: 'get',
+        params: { names },
+      });
+
+      return response.data?.data ?? {};
+    },
+    {
+      manual: true,
+    },
+  );
+
+  useEffect(() => {
+    if (inProgressBackups.length === 0) {
+      return;
+    }
+    const interval = setInterval(async () => {
+      const statusResults = await queryStatus(inProgressBackups);
+      const doneBackup: string[] = [];
+      const errorBackup: string[] = [];
+      for (const [name, status] of Object.entries(statusResults)) {
+        if (!status.inProgress) {
+          if (status.message) {
+            errorBackup.push(name);
+            notification.error({ message: status.message, role: 'alert' });
+          } else {
+            doneBackup.push(name);
+          }
+        }
+      }
+      const completedBackups = [...doneBackup, ...errorBackup];
+      if (doneBackup.length > 0) {
+        message.success(t('NEW_BACKUPS_CREATED', { names: doneBackup.join(', ') }));
+        await refresh();
+      }
+      if (completedBackups.length > 0) {
+        setInProgressBackups((current) => current.filter((name) => !completedBackups.includes(name)));
+      }
+    }, 3000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [inProgressBackups, message, notification, queryStatus, refresh, t]);
+
+  const Icon = creating ? LoadingOutlined : PlusOutlined;
+  const createBackup = async () => {
+    const backup = await create();
+    if (backup?.name) {
+      setInProgressBackups((current) => [...current, backup.name]);
+    }
+    message.success(t('New backup operation started'));
+    await refresh();
+  };
+  const handleBtnClick = async () => {
+    modal.confirm({
+      title: t('New backup'),
+      content: t('Are you sure you want to create new backup?'),
+      onOk: async () => {
+        await createBackup();
+      },
+    });
+  };
+
+  return (
+    <Button icon={<Icon />} disabled={creating} type="primary" onClick={handleBtnClick}>
+      {t('New backup')}
+    </Button>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RefreshBackups.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RefreshBackups.tsx
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { LoadingOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+import React from 'react';
+import { useBackupsContext } from '../contexts';
+import { useT } from '../locale';
+
+export const RefreshBackups = () => {
+  const t = useT();
+  const { refresh, loading } = useBackupsContext();
+  const Icon = loading ? LoadingOutlined : ReloadOutlined;
+
+  return (
+    <Button onClick={refresh} icon={<Icon />} disabled={loading}>
+      {t('Refresh')}
+    </Button>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
@@ -1,0 +1,116 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowContext } from '@nocobase/flow-engine';
+import { Button, Form, Input, Modal } from 'antd';
+import React from 'react';
+import { useBackupAppInfo } from '../hooks/useBackupAppInfo';
+import { useCheckBackupMessage } from '../hooks/useCheckBackupMessage';
+import { useRestoreTask } from '../hooks/useRestoreTask';
+import { useT } from '../locale';
+import type { BackupFile } from './BackupsTable';
+
+type RestoreTaskBody = {
+  task?: string;
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
+  const t = useT();
+  const ctx = useFlowContext();
+  const [isModalVisible, setIsModalVisible] = React.useState(false);
+  const [password, setPassword] = React.useState('');
+  const [progressing, setProgressing] = React.useState(false);
+  const [dbSchema, setDbSchema] = React.useState('');
+  const restoreTaskId = useRestoreTask();
+  const { showCheckBackupMessage } = useCheckBackupMessage();
+  const {
+    database: { schema: currentDbSchema, dialect },
+  } = useBackupAppInfo();
+  const currentDbSchemaTips = currentDbSchema ? `[${currentDbSchema}]` : '';
+
+  const showModal = () => {
+    setIsModalVisible(true);
+  };
+
+  const resetFields = () => {
+    setPassword('');
+    setDbSchema('');
+  };
+
+  const handleOk = async () => {
+    setProgressing(true);
+    try {
+      const response = await ctx.api.request<ResourceResponse<RestoreTaskBody>>({
+        url: 'backups:restore',
+        method: 'post',
+        data: {
+          name: backup.name,
+          password,
+          dbSchema,
+        },
+      });
+      restoreTaskId.current = response.data?.data?.task ?? null;
+      showCheckBackupMessage();
+    } catch (error) {
+      console.error(error);
+    }
+    setProgressing(false);
+    setIsModalVisible(false);
+    resetFields();
+  };
+
+  const handleCancel = () => {
+    setIsModalVisible(false);
+    resetFields();
+  };
+
+  return (
+    <>
+      <Button type="link" size="small" onClick={showModal}>
+        {t('Restore')}
+      </Button>
+      <Modal
+        title={t('Restore')}
+        open={isModalVisible}
+        onCancel={handleCancel}
+        footer={[
+          <Button key="back" onClick={handleCancel}>
+            {t('Cancel')}
+          </Button>,
+          <Button key="submit" type="primary" loading={progressing} onClick={handleOk}>
+            {t('Submit')}
+          </Button>,
+        ]}
+      >
+        <Form layout="vertical" autoComplete="off">
+          {dialect === 'postgres' && (
+            <Form.Item
+              label={<strong>{t('Confirm the application database schema')}</strong>}
+              help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}
+            >
+              <Input autoComplete="new-password" value={dbSchema} onChange={(e) => setDbSchema(e.target.value)} />
+            </Form.Item>
+          )}
+
+          <Form.Item colon label={<strong>{t('Restore password')}</strong>}>
+            <Input.Password
+              value={password}
+              autoComplete="new-password"
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
@@ -1,0 +1,151 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { InboxOutlined, UploadOutlined } from '@ant-design/icons';
+import { useFlowContext } from '@nocobase/flow-engine';
+import type { UploadFile, UploadProps } from 'antd';
+import { App, Button, Form, Input, Modal, Upload } from 'antd';
+import React, { useState } from 'react';
+import { useBackupAppInfo } from '../hooks/useBackupAppInfo';
+import { useCheckBackupMessage } from '../hooks/useCheckBackupMessage';
+import { useRestoreTask } from '../hooks/useRestoreTask';
+import { useT } from '../locale';
+
+type RestoreTaskBody = {
+  task?: string;
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+export const RestoreFromLocal = () => {
+  const t = useT();
+  const ctx = useFlowContext();
+  const { notification } = App.useApp();
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [progressing, setProgressing] = useState(false);
+  const [password, setPassword] = useState('');
+  const [dbSchema, setDbSchema] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [fileList, setFileList] = useState<UploadFile[]>([]);
+  const restoreTaskId = useRestoreTask();
+  const { showCheckBackupMessage } = useCheckBackupMessage();
+  const {
+    database: { schema: currentDbSchema, dialect },
+  } = useBackupAppInfo();
+  const currentDbSchemaTips = currentDbSchema ? `[${currentDbSchema}]` : '';
+
+  const beforeUpload: UploadProps['beforeUpload'] = (selectedFile) => {
+    setFile(selectedFile);
+    setFileList([selectedFile]);
+    return false;
+  };
+
+  const showModal = () => {
+    setIsModalVisible(true);
+  };
+
+  const resetFields = () => {
+    setPassword('');
+    setFile(null);
+    setFileList([]);
+    setDbSchema('');
+  };
+
+  const handleOk = async () => {
+    if (!file) {
+      notification.error({ message: t('Please select a backup file') });
+      return;
+    }
+
+    setProgressing(true);
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('password', password);
+    formData.append('dbSchema', dbSchema);
+    try {
+      const response = await ctx.api.request<ResourceResponse<RestoreTaskBody>>({
+        url: 'backups:upload',
+        method: 'post',
+        data: formData,
+      });
+      restoreTaskId.current = response.data?.data?.task ?? null;
+      showCheckBackupMessage();
+    } catch (error) {
+      console.error(error);
+    }
+    setProgressing(false);
+    setIsModalVisible(false);
+    resetFields();
+  };
+
+  const handleCancel = () => {
+    setIsModalVisible(false);
+    resetFields();
+  };
+
+  const handleRemove = () => {
+    setFileList([]);
+    setFile(null);
+  };
+
+  return (
+    <>
+      <Button icon={<UploadOutlined />} onClick={showModal}>
+        {t('Restore backup from local')}
+      </Button>
+      <Modal
+        title={t('Restore backup from local')}
+        open={isModalVisible}
+        onCancel={handleCancel}
+        footer={[
+          <Button key="back" onClick={handleCancel}>
+            {t('Cancel')}
+          </Button>,
+          <Button key="submit" type="primary" loading={progressing} onClick={handleOk}>
+            {t('Submit')}
+          </Button>,
+        ]}
+      >
+        <Form layout="vertical" autoComplete="off">
+          <Form.Item>
+            <Upload.Dragger
+              onRemove={handleRemove}
+              fileList={fileList}
+              multiple={false}
+              maxCount={1}
+              beforeUpload={beforeUpload}
+            >
+              <p className="ant-upload-drag-icon">
+                <InboxOutlined />
+              </p>
+              <p className="ant-upload-text">{t('Click or drag file to this area to upload')}</p>
+            </Upload.Dragger>
+          </Form.Item>
+          {dialect === 'postgres' && (
+            <Form.Item
+              label={<strong>{t('Confirm the application database schema')}</strong>}
+              help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}
+            >
+              <Input autoComplete="new-password" value={dbSchema} onChange={(e) => setDbSchema(e.target.value)} />
+            </Form.Item>
+          )}
+          <Form.Item colon label={<strong>{t('Restore password')}</strong>}>
+            <Input.Password
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/constants.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export const NAMESPACE = 'backups';
+
+export const BACKUP_RESTORE_RUNTIME_KEY = 'backupRestoreRuntime';
+
+export type BackupRestoreRuntime = {
+  showCheckBackupMessage: () => void;
+  hideCheckBackupMessage: () => void;
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/contexts.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/contexts.ts
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createContext, useContext } from 'react';
+import type { BackupFile } from './components/BackupsTable';
+
+export type BackupsListBody = {
+  data: BackupFile[];
+};
+
+export type BackupsContextValue = {
+  data?: BackupsListBody;
+  loading: boolean;
+  refresh: () => void;
+  refreshAsync: () => Promise<BackupsListBody>;
+};
+
+export const BackupsContext = createContext<BackupsContextValue | null>(null);
+
+export const useBackupsContext = () => {
+  const context = useContext(BackupsContext);
+
+  if (!context) {
+    throw new Error('BackupsContext provider is missing');
+  }
+
+  return context;
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useBackupAppInfo.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useBackupAppInfo.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useMemoizedFn, useRequest } from 'ahooks';
+
+export type BackupAppInfo = {
+  database: {
+    dialect: string;
+    schema?: string;
+  };
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+const EMPTY_BACKUP_APP_INFO: BackupAppInfo = {
+  database: {
+    dialect: '',
+  },
+};
+
+export const useBackupAppInfo = () => {
+  const ctx = useFlowContext();
+  const getBackupAppInfo = useMemoizedFn(async () => {
+    const response = await ctx.api.request<ResourceResponse<BackupAppInfo>>({
+      url: 'backups:appInfo',
+    });
+
+    return response.data?.data ?? EMPTY_BACKUP_APP_INFO;
+  });
+
+  const { data } = useRequest(getBackupAppInfo, {
+    cacheKey: 'backupAppInfo',
+    staleTime: -1,
+  });
+
+  return data ?? EMPTY_BACKUP_APP_INFO;
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useCheckBackupMessage.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useCheckBackupMessage.ts
@@ -1,0 +1,65 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useApp } from '@nocobase/client-v2';
+import { useFlowEngine } from '@nocobase/flow-engine';
+import { useMemoizedFn } from 'ahooks';
+import { BACKUP_RESTORE_RUNTIME_KEY, BackupRestoreRuntime } from '../constants';
+
+type BackupRuntimeApp = {
+  error?: unknown;
+  maintaining?: boolean;
+  setMaintaining?: (maintaining: boolean) => void;
+};
+
+function getRuntime(context: object): BackupRestoreRuntime | undefined {
+  return (context as Record<string, unknown>)[BACKUP_RESTORE_RUNTIME_KEY] as BackupRestoreRuntime | undefined;
+}
+
+export const useCheckBackupMessage = () => {
+  const engine = useFlowEngine();
+  const app = useApp() as BackupRuntimeApp;
+
+  const showCheckBackupMessage = useMemoizedFn(() => {
+    const runtime = getRuntime(engine.context);
+    if (runtime) {
+      runtime.showCheckBackupMessage();
+      return;
+    }
+
+    if (typeof app.setMaintaining === 'function') {
+      app.setMaintaining(true);
+    } else {
+      app.maintaining = true;
+    }
+    app.error = {
+      command: {
+        name: 'APP Restoring',
+      },
+      message: 'checking backup...',
+      code: 'APP_COMMANDING',
+    };
+  });
+
+  const hideCheckBackupMessage = useMemoizedFn(() => {
+    const runtime = getRuntime(engine.context);
+    if (runtime) {
+      runtime.hideCheckBackupMessage();
+      return;
+    }
+
+    if (typeof app.setMaintaining === 'function') {
+      app.setMaintaining(false);
+    } else {
+      app.maintaining = false;
+    }
+  });
+
+  return { showCheckBackupMessage, hideCheckBackupMessage };
+};

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useRestoreTask.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useRestoreTask.ts
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useApp } from '@nocobase/client-v2';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { App } from 'antd';
+import React, { useEffect } from 'react';
+import { NAMESPACE } from '../constants';
+import { useCheckBackupMessage } from './useCheckBackupMessage';
+
+type RestoreStatus = {
+  inProgress: boolean;
+  message?: string;
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+type BackupRuntimeApp = {
+  maintaining?: boolean;
+};
+
+export function useRestoreTask() {
+  const ctx = useFlowContext();
+  const app = useApp() as BackupRuntimeApp;
+  const restoreTaskId = React.useRef<string | null>(null);
+  const { notification } = App.useApp();
+  const { hideCheckBackupMessage } = useCheckBackupMessage();
+
+  useEffect(() => {
+    const checkRestoreTask = async () => {
+      if (!restoreTaskId.current) {
+        return;
+      }
+      try {
+        const response = await ctx.api.request<ResourceResponse<RestoreStatus>>({
+          url: `${NAMESPACE}:restoreStatus`,
+          method: 'get',
+          params: {
+            task: restoreTaskId.current,
+          },
+        });
+        const status = response.data?.data;
+        if (!status) {
+          return;
+        }
+        if (!status.inProgress) {
+          restoreTaskId.current = null;
+        }
+        if (status.message) {
+          hideCheckBackupMessage();
+          notification.error({ message: status.message, role: 'alert' });
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    const interval = setInterval(checkRestoreTask, 3000);
+    return () => clearInterval(interval);
+  }, [app.maintaining, ctx.api, hideCheckBackupMessage, notification]);
+
+  return restoreTaskId;
+}

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/index.tsx
@@ -1,0 +1,10 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export { default } from './plugin';

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/locale.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/locale.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr as flowTExpr, useFlowEngine } from '@nocobase/flow-engine';
+import { NAMESPACE } from './constants';
+
+export function useT() {
+  const engine = useFlowEngine();
+
+  return (key: string, options?: Record<string, unknown>) =>
+    engine.context.t(key, { ns: [NAMESPACE, 'client'], ...options });
+}
+
+export function tExpr(key: string) {
+  return flowTExpr(key, { ns: [NAMESPACE, 'client'] });
+}

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -152,7 +152,7 @@ const BackupSettings = () => {
   const storageOptions = useMemo(
     () =>
       (storagesRequest.data ?? []).map((storage) => ({
-        label: storage.title ?? storage.name ?? String(storage.id),
+        label: storage.title,
         value: storage.id,
       })),
     [storagesRequest.data],
@@ -214,17 +214,7 @@ const BackupSettings = () => {
         </Form.Item>
 
         <Form.Item name="storageId" label={label(t('Sync backups to cloud storage'))}>
-          <Select
-            allowClear
-            loading={storagesRequest.loading}
-            options={storageOptions}
-            style={{ width: '100%' }}
-            onDropdownVisibleChange={(open) => {
-              if (open) {
-                storagesRequest.refresh();
-              }
-            }}
-          />
+          <Select loading={storagesRequest.loading} options={storageOptions} style={{ width: '100%' }} />
         </Form.Item>
 
         <Form.Item name="enableFilesBackup" label={label(t('Backup local storage files'))} valuePropName="checked">

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -11,6 +11,8 @@ import { useFlowContext } from '@nocobase/flow-engine';
 import { useRequest } from 'ahooks';
 import { App, Button, Card, Checkbox, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
 import React, { useMemo, useState } from 'react';
+import { CronProps as ReactJsCronProps, Cron as ReactCron } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
 import { useT } from '../locale';
 
 type BackupSettingsValues = {
@@ -42,9 +44,75 @@ type ResourceResponse<T> = {
 const DEFAULT_FORM_VALUES: BackupSettingsValues = {
   scheduled: false,
   cron: '0 0 * * *',
-  keep: 1,
+  keep: 100,
   enableFilesBackup: false,
 };
+
+type BackupCronProps = Omit<ReactJsCronProps, 'setValue' | 'value'> & {
+  value?: string;
+  onChange?: (value: string) => void;
+};
+
+type WindowWithCronLocale = Window & {
+  cronLocale?: ReactJsCronProps['locale'];
+};
+
+const BACKUP_SETTINGS_CRON_STYLES = `
+  .nb-backup-settings-cron {
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .nb-backup-settings-cron .react-js-cron {
+    padding: 0.5em 0.5em 0 0.5em;
+    border: 1px dashed #ccc;
+  }
+
+  .nb-backup-settings-cron .react-js-cron .react-js-cron-field {
+    flex-shrink: 0;
+    margin-bottom: 0.5em;
+  }
+
+  .nb-backup-settings-cron .react-js-cron .react-js-cron-field > span {
+    flex-shrink: 0;
+    margin: 0 0.5em 0 0;
+  }
+
+  .nb-backup-settings-cron .react-js-cron .react-js-cron-field > .react-js-cron-select {
+    margin: 0 0.5em 0 0;
+  }
+
+  .nb-backup-settings-cron
+    .react-js-cron
+    .react-js-cron-field
+    > .react-js-cron-select
+    .ant-select-selection-overflow {
+    align-items: center;
+    flex: initial;
+  }
+`;
+
+const BackupCron = ({ onChange, value, ...props }: BackupCronProps) => {
+  const cronLocale = (window as WindowWithCronLocale).cronLocale;
+
+  return (
+    <fieldset className="nb-backup-settings-cron">
+      <ReactCron
+        {...props}
+        clearButton={false}
+        locale={cronLocale}
+        value={value ?? DEFAULT_FORM_VALUES.cron ?? ''}
+        setValue={(nextValue) => {
+          onChange?.(nextValue);
+        }}
+      />
+    </fieldset>
+  );
+};
+
+const label = (text: string) => <strong>{text}:</strong>;
 
 const BackupSettings = () => {
   const ctx = useFlowContext();
@@ -112,42 +180,45 @@ const BackupSettings = () => {
   };
 
   return (
-    <Card>
+    <Card bordered={false}>
+      <style>{BACKUP_SETTINGS_CRON_STYLES}</style>
       <Form<BackupSettingsValues>
         form={form}
         layout="vertical"
         initialValues={DEFAULT_FORM_VALUES}
         disabled={settingsRequest.loading}
       >
-        <Form.Item label={t('Automatic backup')}>
-          <Space direction="vertical">
+        <Form.Item label={label(t('Automatic backup'))}>
+          <Space direction="vertical" style={{ width: '100%' }}>
             <Form.Item name="scheduled" valuePropName="checked" noStyle>
               <Checkbox>{t('Run automatic backup on the cron schedule')}</Checkbox>
             </Form.Item>
             <Form.Item
               name="cron"
               rules={[{ required: !!scheduled, message: t('The field value is required') }]}
-              noStyle
+              style={{ marginBottom: 0 }}
             >
-              <Input disabled={!scheduled} placeholder="0 0 * * *" />
+              <BackupCron disabled={!scheduled} />
             </Form.Item>
           </Space>
         </Form.Item>
 
         <Form.Item
           name="keep"
-          label={t('Maximum number of backups')}
-          tooltip={t('The maximum number of backups to keep, older backups are automatically deleted.')}
+          label={label(t('Maximum number of backups'))}
+          extra={t('The maximum number of backups to keep, older backups are automatically deleted.')}
+          required
           rules={[{ required: true, message: t('The field value is required') }]}
         >
-          <InputNumber min={1} />
+          <InputNumber min={1} style={{ width: '100%' }} />
         </Form.Item>
 
-        <Form.Item name="storageId" label={t('Sync backups to cloud storage')}>
+        <Form.Item name="storageId" label={label(t('Sync backups to cloud storage'))}>
           <Select
             allowClear
             loading={storagesRequest.loading}
             options={storageOptions}
+            style={{ width: '100%' }}
             onDropdownVisibleChange={(open) => {
               if (open) {
                 storagesRequest.refresh();
@@ -156,16 +227,16 @@ const BackupSettings = () => {
           />
         </Form.Item>
 
-        <Form.Item name="enableFilesBackup" label={t('Backup local storage files')} valuePropName="checked">
+        <Form.Item name="enableFilesBackup" label={label(t('Backup local storage files'))} valuePropName="checked">
           <Switch />
         </Form.Item>
 
         <Form.Item
           name="encryptionPassword"
-          label={t('Restore password')}
-          tooltip={t('If a restore password is set, it must be entered when restoring the backup.')}
+          label={label(t('Restore password'))}
+          extra={t('If a restore password is set, it must be entered when restoring the backup.')}
         >
-          <Input.Password autoComplete="new-password" />
+          <Input.Password autoComplete="new-password" style={{ width: '100%' }} />
         </Form.Item>
 
         <Form.Item>

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -1,0 +1,181 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import { App, Button, Card, Checkbox, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
+import React, { useMemo, useState } from 'react';
+import { useT } from '../locale';
+
+type BackupSettingsValues = {
+  scheduled?: boolean;
+  cron?: string;
+  keep?: number;
+  storageId?: string | number;
+  enableFilesBackup?: boolean;
+  encryptionPassword?: string;
+};
+
+type BackupSettingsRecord = BackupSettingsValues & {
+  id?: number;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type StorageRecord = {
+  id: string | number;
+  title?: string;
+  name?: string;
+  type?: string;
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+const DEFAULT_FORM_VALUES: BackupSettingsValues = {
+  scheduled: false,
+  cron: '0 0 * * *',
+  keep: 1,
+  enableFilesBackup: false,
+};
+
+const BackupSettings = () => {
+  const ctx = useFlowContext();
+  const t = useT();
+  const { message } = App.useApp();
+  const [form] = Form.useForm<BackupSettingsValues>();
+  const [submitting, setSubmitting] = useState(false);
+  const scheduled = Form.useWatch('scheduled', form);
+
+  const settingsRequest = useRequest<BackupSettingsRecord | undefined, []>(
+    async () => {
+      const response = await ctx.api.request<ResourceResponse<BackupSettingsRecord>>({
+        url: 'backupSettings:get/1',
+      });
+
+      return response.data?.data;
+    },
+    {
+      onSuccess: (values) => {
+        form.setFieldsValue({
+          ...DEFAULT_FORM_VALUES,
+          ...values,
+        });
+      },
+    },
+  );
+
+  const storagesRequest = useRequest<StorageRecord[], []>(async () => {
+    const response = await ctx.api.request<ResourceResponse<StorageRecord[]>>({
+      url: 'storages:list',
+    });
+    const storages = response.data?.data ?? [];
+
+    return storages.filter((storage) => storage.type !== 'local');
+  });
+
+  const storageOptions = useMemo(
+    () =>
+      (storagesRequest.data ?? []).map((storage) => ({
+        label: storage.title ?? storage.name ?? String(storage.id),
+        value: storage.id,
+      })),
+    [storagesRequest.data],
+  );
+
+  const handleSubmit = async () => {
+    const formValues = await form.validateFields();
+    const values = {
+      ...settingsRequest.data,
+      ...formValues,
+    };
+
+    setSubmitting(true);
+    try {
+      await ctx.api.request({
+        url: 'backupSettings:update/1',
+        method: 'post',
+        data: values,
+      });
+      settingsRequest.mutate(values);
+      message.success(t('Saved successfully'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <Form<BackupSettingsValues>
+        form={form}
+        layout="vertical"
+        initialValues={DEFAULT_FORM_VALUES}
+        disabled={settingsRequest.loading}
+      >
+        <Form.Item label={t('Automatic backup')}>
+          <Space direction="vertical">
+            <Form.Item name="scheduled" valuePropName="checked" noStyle>
+              <Checkbox>{t('Run automatic backup on the cron schedule')}</Checkbox>
+            </Form.Item>
+            <Form.Item
+              name="cron"
+              rules={[{ required: !!scheduled, message: t('The field value is required') }]}
+              noStyle
+            >
+              <Input disabled={!scheduled} placeholder="0 0 * * *" />
+            </Form.Item>
+          </Space>
+        </Form.Item>
+
+        <Form.Item
+          name="keep"
+          label={t('Maximum number of backups')}
+          tooltip={t('The maximum number of backups to keep, older backups are automatically deleted.')}
+          rules={[{ required: true, message: t('The field value is required') }]}
+        >
+          <InputNumber min={1} />
+        </Form.Item>
+
+        <Form.Item name="storageId" label={t('Sync backups to cloud storage')}>
+          <Select
+            allowClear
+            loading={storagesRequest.loading}
+            options={storageOptions}
+            onDropdownVisibleChange={(open) => {
+              if (open) {
+                storagesRequest.refresh();
+              }
+            }}
+          />
+        </Form.Item>
+
+        <Form.Item name="enableFilesBackup" label={t('Backup local storage files')} valuePropName="checked">
+          <Switch />
+        </Form.Item>
+
+        <Form.Item
+          name="encryptionPassword"
+          label={t('Restore password')}
+          tooltip={t('If a restore password is set, it must be entered when restoring the backup.')}
+        >
+          <Input.Password autoComplete="new-password" />
+        </Form.Item>
+
+        <Form.Item>
+          <Button type="primary" loading={submitting} onClick={handleSubmit}>
+            {t('Submit')}
+          </Button>
+        </Form.Item>
+      </Form>
+    </Card>
+  );
+};
+
+export default BackupSettings;

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupsManagement.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupsManagement.tsx
@@ -9,7 +9,7 @@
 
 import { useFlowContext } from '@nocobase/flow-engine';
 import { useRequest } from 'ahooks';
-import { Card, Flex, Space, theme } from 'antd';
+import { Card, Space } from 'antd';
 import React from 'react';
 import { BackupsTable } from '../components/BackupsTable';
 import { NewBackup } from '../components/NewBackup';
@@ -22,7 +22,6 @@ const EMPTY_BACKUPS_LIST: BackupsListBody = { data: [] };
 
 const BackupsManagement = () => {
   const ctx = useFlowContext();
-  const { token } = theme.useToken();
   const request = useRequest<BackupsListBody, []>(async () => {
     const response = await ctx.api.request<BackupsListBody>({
       url: `${NAMESPACE}:list`,
@@ -34,14 +33,12 @@ const BackupsManagement = () => {
 
   return (
     <BackupsContext.Provider value={request}>
-      <Card>
-        <Flex justify="flex-end" style={{ marginBottom: token.marginMD }}>
-          <Space>
-            <RefreshBackups />
-            <RestoreFromLocal />
-            <NewBackup />
-          </Space>
-        </Flex>
+      <Card bordered={false}>
+        <Space style={{ float: 'right', marginBottom: 16 }}>
+          <RefreshBackups />
+          <RestoreFromLocal />
+          <NewBackup />
+        </Space>
         <BackupsTable />
       </Card>
     </BackupsContext.Provider>

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupsManagement.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupsManagement.tsx
@@ -1,0 +1,51 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import { Card, Flex, Space, theme } from 'antd';
+import React from 'react';
+import { BackupsTable } from '../components/BackupsTable';
+import { NewBackup } from '../components/NewBackup';
+import { RefreshBackups } from '../components/RefreshBackups';
+import { RestoreFromLocal } from '../components/RestoreFromLocal';
+import { NAMESPACE } from '../constants';
+import { BackupsContext, BackupsListBody } from '../contexts';
+
+const EMPTY_BACKUPS_LIST: BackupsListBody = { data: [] };
+
+const BackupsManagement = () => {
+  const ctx = useFlowContext();
+  const { token } = theme.useToken();
+  const request = useRequest<BackupsListBody, []>(async () => {
+    const response = await ctx.api.request<BackupsListBody>({
+      url: `${NAMESPACE}:list`,
+      method: 'get',
+    });
+
+    return response.data ?? EMPTY_BACKUPS_LIST;
+  });
+
+  return (
+    <BackupsContext.Provider value={request}>
+      <Card>
+        <Flex justify="flex-end" style={{ marginBottom: token.marginMD }}>
+          <Space>
+            <RefreshBackups />
+            <RestoreFromLocal />
+            <NewBackup />
+          </Space>
+        </Flex>
+        <BackupsTable />
+      </Card>
+    </BackupsContext.Provider>
+  );
+};
+
+export default BackupsManagement;

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/plugin.tsx
@@ -1,0 +1,81 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Application } from '@nocobase/client-v2';
+import { Plugin } from '@nocobase/client-v2';
+import { BACKUP_RESTORE_RUNTIME_KEY, BackupRestoreRuntime, NAMESPACE } from './constants';
+
+type BackupRuntimeApp = Application & {
+  error: unknown;
+  maintaining: boolean;
+  setMaintaining?: (maintaining: boolean) => void;
+};
+
+export class PluginBackupsClientV2 extends Plugin<Record<string, never>, Application> {
+  async load() {
+    const title = this.t('Backup manager') as unknown as string;
+
+    this.flowEngine.context.defineProperty(BACKUP_RESTORE_RUNTIME_KEY, {
+      value: this.createBackupRestoreRuntime(),
+    });
+
+    this.pluginSettingsManager.addMenuItem({
+      key: NAMESPACE,
+      title,
+      icon: 'CloudServerOutlined',
+      showTabs: true,
+    });
+
+    this.pluginSettingsManager.addPageTabItem({
+      menuKey: NAMESPACE,
+      key: 'list',
+      title: this.t('Backup list') as unknown as string,
+      aclSnippet: `pm.${NAMESPACE}`,
+      componentLoader: () => import('./pages/BackupsManagement'),
+    });
+
+    this.pluginSettingsManager.addPageTabItem({
+      menuKey: NAMESPACE,
+      key: 'settings',
+      title: this.t('Settings') as unknown as string,
+      aclSnippet: `pm.${NAMESPACE}.settings`,
+      componentLoader: () => import('./pages/BackupSettings'),
+    });
+  }
+
+  private createBackupRestoreRuntime(): BackupRestoreRuntime {
+    const app = this.app as BackupRuntimeApp;
+
+    return {
+      showCheckBackupMessage: () => {
+        if (typeof app.setMaintaining === 'function') {
+          app.setMaintaining(true);
+        } else {
+          app.maintaining = true;
+        }
+        app.error = {
+          command: {
+            name: 'APP Restoring',
+          },
+          message: 'checking backup...',
+          code: 'APP_COMMANDING',
+        };
+      },
+      hideCheckBackupMessage: () => {
+        if (typeof app.setMaintaining === 'function') {
+          app.setMaintaining(false);
+        } else {
+          app.maintaining = false;
+        }
+      },
+    };
+  }
+}
+
+export default PluginBackupsClientV2;

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/plugin.tsx
@@ -36,6 +36,7 @@ export class PluginBackupsClientV2 extends Plugin<Record<string, never>, Applica
       menuKey: NAMESPACE,
       key: 'list',
       title: this.t('Backup list') as unknown as string,
+      icon: 'CloudServerOutlined',
       aclSnippet: `pm.${NAMESPACE}`,
       componentLoader: () => import('./pages/BackupsManagement'),
     });
@@ -44,6 +45,7 @@ export class PluginBackupsClientV2 extends Plugin<Record<string, never>, Applica
       menuKey: NAMESPACE,
       key: 'settings',
       title: this.t('Settings') as unknown as string,
+      icon: 'SettingOutlined',
       aclSnippet: `pm.${NAMESPACE}.settings`,
       componentLoader: () => import('./pages/BackupSettings'),
     });


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Migrate the backup manager plugin client to the NocoBase v2 client runtime while preserving the existing v1 client entry for compatibility.

### Description
This PR adds a `client-v2` entry for `@nocobase/plugin-backups` and implements the backup list, restore actions, new backup action, and backup settings pages with the v2 client runtime.

Key changes:
- Added root `client-v2.js` and `client-v2.d.ts` entries.
- Added `src/client-v2` plugin registration with lazy settings page tabs.
- Rebuilt the backup settings page with React and Ant Design Form instead of `SchemaComponent`.
- Replaced v1 client hooks in the v2 implementation with `@nocobase/client-v2`, `@nocobase/flow-engine`, and `ahooks` APIs.
- Exposed the backup restore runtime through `flowEngine.context.defineProperty`.

Potential risks:
- The v2 settings page uses a plain cron input because the v1 `Cron` component is not exposed by `@nocobase/client-v2`.

Testing suggestions:
- Open the v2 backup manager settings pages.
- Verify backup list refresh, new backup creation, backup download, deletion, restore from backup, restore from local file, and settings save.

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added v2 client runtime support for the backup manager plugin. |
| 🇨🇳 Chinese | 为备份管理器插件新增 v2 客户端运行时支持。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
