### PR TITLE
fix(client-v2): render json display field values

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/DisplayJSONFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/DisplayJSONFieldModel.tsx
@@ -9,7 +9,8 @@
 
 import { css, cx } from '@emotion/css';
 import { DisplayItemModel } from '@nocobase/flow-engine';
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { Tooltip } from 'antd';
 import { DisplayTitleFieldModel } from './DisplayTitleFieldModel';
 
@@ -21,8 +22,14 @@ const JSONClassName = css`
   border: none !important;
 `;
 
-const EllipsisJSON = ({ content, style, className }) => {
-  const ref = useRef(null);
+interface EllipsisJSONProps {
+  content: string;
+  style?: CSSProperties;
+  className?: string;
+}
+
+const EllipsisJSON = ({ content, style, className }: EllipsisJSONProps) => {
+  const ref = useRef<HTMLDivElement>(null);
   const [overflow, setOverflow] = useState(false);
 
   useEffect(() => {
@@ -75,7 +82,7 @@ const EllipsisJSON = ({ content, style, className }) => {
 };
 
 export class DisplayJSONFieldModel extends DisplayTitleFieldModel {
-  public renderComponent(value) {
+  public renderComponent(value: unknown) {
     const { space, style, className, overflowMode } = this.props;
     let content = '';
     if (value !== undefined && value !== null) {
@@ -95,6 +102,10 @@ export class DisplayJSONFieldModel extends DisplayTitleFieldModel {
         {content}
       </pre>
     );
+  }
+
+  public render() {
+    return this.renderComponent(this.props.value);
   }
 }
 

--- a/packages/core/client-v2/src/flow/models/fields/__tests__/DisplayJSONFieldModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/__tests__/DisplayJSONFieldModel.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DisplayJSONFieldModel } from '../DisplayJSONFieldModel';
+
+describe('DisplayJSONFieldModel', () => {
+  it('renders object field values as formatted JSON', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ DisplayJSONFieldModel });
+
+    const model = engine.createModel<DisplayJSONFieldModel>({
+      use: DisplayJSONFieldModel,
+      uid: 'display-json-object-value',
+      props: {
+        value: {
+          enabled: true,
+          name: 'NocoBase',
+        },
+      },
+    });
+
+    const { container } = render(model.render());
+
+    expect(container.textContent).toContain('"enabled": true');
+    expect(container.textContent).toContain('"name": "NocoBase"');
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
JSON fields in client v2 display views could receive object values but render an empty table cell because the generic display normalization treated objects as association/title-field values.

### Description
This PR makes `DisplayJSONFieldModel` render from the original field value so object and array values are formatted as JSON instead of being normalized away.

It also adds a regression test covering object JSON display values.

Testing:
- `yarn eslint --fix packages/core/client-v2/src/flow/models/fields/DisplayJSONFieldModel.tsx packages/core/client-v2/src/flow/models/fields/__tests__/DisplayJSONFieldModel.test.tsx`
- `yarn test packages/core/client-v2/src/flow/models/fields/__tests__/DisplayJSONFieldModel.test.tsx --run --reporter=verbose`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed JSON fields in client v2 display views rendering blank cells for object values. |
| 🇨🇳 Chinese | 修复 client v2 阅读态 JSON 字段对象值显示为空的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
