### PR TITLE
fix(plugin-map): register v2 map field interfaces

### DIFF
--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/__tests__/pluginMapV2Registration.test.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/__tests__/pluginMapV2Registration.test.tsx
@@ -17,6 +17,27 @@ import { formatMapDisplayValue } from '../models/fieldModels/DisplayMapFieldMode
 import PluginMapClient from '../plugin';
 
 describe('PluginMapClient v2 registration', () => {
+  it('registers map geometry field interfaces for data source manager', async () => {
+    const app = new Application({
+      plugins: [PluginMapClient],
+    });
+
+    await app.load();
+
+    const manager = app.dataSourceManager.collectionFieldInterfaceManager;
+    const interfaces = manager.getFieldInterfaces().map((fieldInterface) => fieldInterface.name);
+
+    expect(interfaces).toContain('point');
+    expect(interfaces).toContain('lineString');
+    expect(interfaces).toContain('circle');
+    expect(interfaces).toContain('polygon');
+    expect(manager.getFieldInterfaceGroup('map')?.label).toContain('Map-based geometry');
+    expect(manager.getFieldInterfaceGroup('map')?.label).toContain('@nocobase/plugin-map');
+    expect(manager.getFieldInterfaceGroup('map')?.order).toBe(300);
+    expect(manager.getFieldInterface('point')?.default?.type).toBe('point');
+    expect(manager.getFieldInterface('point')?.configure?.items?.[0]?.name).toBe('uiSchema.x-component-props.mapType');
+  });
+
   it('registers map models through lazy loaders', async () => {
     const app = new Application({
       plugins: [PluginMapClient],

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/circle.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/circle.ts
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr } from '../locale';
+import { CommonMapFieldInterface } from './schema';
+
+export class CircleFieldInterface extends CommonMapFieldInterface {
+  name = 'circle';
+  order = 3;
+  title = tExpr('Circle');
+  description = tExpr('Circle');
+  availableTypes = ['circle', 'json'];
+  default = this.createDefault('circle');
+}

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/index.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/index.ts
@@ -1,0 +1,17 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { CircleFieldInterface } from './circle';
+import { LineStringFieldInterface } from './lineString';
+import { PointFieldInterface } from './point';
+import { PolygonFieldInterface } from './polygon';
+
+export const fields = [PointFieldInterface, LineStringFieldInterface, CircleFieldInterface, PolygonFieldInterface];
+
+export { CircleFieldInterface, LineStringFieldInterface, PointFieldInterface, PolygonFieldInterface };

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/lineString.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/lineString.ts
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr } from '../locale';
+import { CommonMapFieldInterface } from './schema';
+
+export class LineStringFieldInterface extends CommonMapFieldInterface {
+  name = 'lineString';
+  order = 2;
+  title = tExpr('Line');
+  description = tExpr('Line');
+  availableTypes = ['lineString', 'json'];
+  default = this.createDefault('lineString');
+}

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/point.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/point.ts
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr } from '../locale';
+import { CommonMapFieldInterface } from './schema';
+
+export class PointFieldInterface extends CommonMapFieldInterface {
+  name = 'point';
+  order = 1;
+  title = tExpr('Point');
+  description = tExpr('Point');
+  availableTypes = ['point', 'json'];
+  default = this.createDefault('point');
+}

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/polygon.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/polygon.ts
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr } from '../locale';
+import { CommonMapFieldInterface } from './schema';
+
+export class PolygonFieldInterface extends CommonMapFieldInterface {
+  name = 'polygon';
+  order = 4;
+  title = tExpr('Polygon');
+  description = tExpr('Polygon');
+  availableTypes = ['polygon', 'json'];
+  default = this.createDefault('polygon');
+}

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/schema.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/fields/schema.ts
@@ -1,0 +1,50 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { CollectionFieldInterface, type FieldInterfaceConfigure } from '@nocobase/client-v2';
+import { MapTypes } from '../constants';
+import { tExpr } from '../locale';
+
+export class CommonMapFieldInterface extends CollectionFieldInterface {
+  type = 'object';
+  group = 'map';
+  sortable = true;
+  titleUsable = false;
+  availableTypes = ['json'];
+  configure: FieldInterfaceConfigure = {
+    items: [
+      {
+        name: 'uiSchema.x-component-props.mapType',
+        title: tExpr('Map type'),
+        component: 'Select',
+        required: true,
+        disabled: ({ context }) => !context.createOnly,
+        defaultValue: 'amap',
+        componentProps: {
+          showSearch: false,
+          allowClear: false,
+        },
+        options: MapTypes,
+      },
+    ],
+  };
+
+  protected createDefault(type: string) {
+    return {
+      interface: type,
+      type,
+      uiSchema: {
+        type: 'void',
+        'x-component': 'Map',
+        'x-component-designer': 'Map.Designer',
+        'x-component-props': {},
+      },
+    };
+  }
+}

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Block.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Block.tsx
@@ -84,7 +84,7 @@ export const GoogleMapsBlock = (props) => {
       });
     }
     const listenerSet = new Set<() => void>();
-    mapRef.current?.drawingManager.setDrawingMode(google.maps.drawing.OverlayType.POLYGON);
+    mapRef.current?.drawingManager.setDrawingMode('polygon');
     mapRef.current?.drawingManager.addListener('overlaycomplete', (event) => {
       const polygon = event.overlay as google.maps.Polygon;
       mapRef.current?.drawingManager.setDrawingMode(null);
@@ -145,7 +145,7 @@ export const GoogleMapsBlock = (props) => {
     setSelectedRecordKeys((lastIds) => ids.concat(lastIds));
     overlay?.unbindAll();
     overlay?.setMap(null);
-    mapRef.current?.drawingManager.setDrawingMode(google.maps.drawing.OverlayType.POLYGON);
+    mapRef.current?.drawingManager.setDrawingMode('polygon');
   });
 
   useEffect(() => {

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
@@ -65,7 +65,7 @@ const methodMapping = {
 
 export class GoogleMapsDrawingManager {
   private readonly listeners = new Set<OverlayCompleteListener>();
-  private readonly mapListeners: google.maps.MapsEventListener[] = [];
+  private readonly mapListeners: Array<google.maps.MapsEventListener | undefined> = [];
   private readonly options: OverlayOptions & { map?: google.maps.Map };
   private drawingMode: GoogleMapsDrawingMode = null;
   private draftOverlay: google.maps.Polygon | google.maps.Polyline | google.maps.Circle | null = null;
@@ -124,7 +124,7 @@ export class GoogleMapsDrawingManager {
   }
 
   private clearMapEvents() {
-    this.mapListeners.forEach((listener) => listener.remove());
+    this.mapListeners.forEach((listener) => listener?.remove?.());
     this.mapListeners.length = 0;
   }
 

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
@@ -99,6 +99,9 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
   const { accessKey } = useMapConfig(props.mapType) || {};
   const t = useT();
   const ctx = useFlowContext();
+  const getLoadFailedMessage = useMemoizedFn(() =>
+    t('Load google maps failed, Please check the Api key and refresh the page'),
+  );
   const drawingManagerRef = useRef<google.maps.drawing.DrawingManager>();
   const map = useRef<google.maps.Map>();
   const overlayRef = useRef<google.maps.Marker | google.maps.Polygon | google.maps.Polyline | google.maps.Circle>();
@@ -304,19 +307,31 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
     setupOverlay(nextOverlay);
     // Focus on the overlay
     setFitView([nextOverlay]);
-  }, [value, needUpdateFlag, type, disabled, readonly, setOverlay, setFitView, setupOverlay]);
+  }, [
+    value,
+    needUpdateFlag,
+    type,
+    disabled,
+    readonly,
+    setOverlay,
+    setFitView,
+    setupOverlay,
+    onChange,
+    toRemoveOverlay,
+  ]);
 
   useEffect(() => {
     if (!accessKey || map.current || !mapContainerRef.current) return;
     let loader: Loader;
+    let disposed = false;
     try {
       loader = new Loader({
         apiKey: accessKey,
-        version: 'weekly',
+        version: 'quarterly',
         language: ctx.api.auth.getLocale(),
       });
     } catch (err) {
-      setErrMessage(t('Load google maps failed, Please check the Api key and refresh the page'));
+      setErrMessage(getLoadFailedMessage());
       return;
     }
 
@@ -324,7 +339,7 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
     const error = console.error;
     console.error = (err, ...args) => {
       if (err?.includes?.('InvalidKeyMapError')) {
-        setErrMessage(t('Load google maps failed, Please check the Api key and refresh the page'));
+        setErrMessage(getLoadFailedMessage());
       }
       error(err, ...args);
     };
@@ -332,7 +347,12 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
     Promise.all([loader.importLibrary('drawing'), loader.importLibrary('core'), loader.importLibrary('geometry')])
       .then(async (res) => {
         const center = await getCurrentPosition();
-        map.current = new google.maps.Map(mapContainerRef.current, {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        const mapContainer = mapContainerRef.current;
+        if (disposed || !(mapContainer instanceof HTMLElement)) {
+          return;
+        }
+        map.current = new google.maps.Map(mapContainer, {
           zoom,
           center,
           mapTypeId: google.maps.MapTypeId.ROADMAP,
@@ -342,6 +362,7 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
           mapTypeControl: false,
           fullscreenControl: false,
         });
+        google.maps.event.trigger(map.current, 'resize');
         setErrMessage('');
         forceUpdate([]);
       })
@@ -353,11 +374,12 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
       });
 
     return () => {
+      disposed = true;
       map.current?.unbindAll();
       map.current = null;
       drawingManagerRef.current?.unbindAll();
     };
-  }, [accessKey, ctx.api.auth, type, zoom]);
+  }, [accessKey, ctx.api.auth, getLoadFailedMessage, zoom]);
 
   useEffect(() => {
     if (!map.current || !type || disabled || drawingManagerRef.current) return;

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
@@ -22,6 +22,13 @@ import { Search } from './Search';
 import { getCurrentPosition, getIcon } from './utils';
 
 export type OverlayOptions = google.maps.PolygonOptions & google.maps.MarkerOptions & google.maps.PolylineOptions;
+type GoogleMapsOverlay = google.maps.Marker | google.maps.Polygon | google.maps.Polyline | google.maps.Circle;
+export type GoogleMapsDrawingMode = 'marker' | 'polygon' | 'polyline' | 'circle' | null;
+type GoogleMapsOverlayCompleteEvent = {
+  type: Exclude<GoogleMapsDrawingMode, null>;
+  overlay: GoogleMapsOverlay;
+};
+type OverlayCompleteListener = (event: GoogleMapsOverlayCompleteEvent) => void;
 
 export const getDrawingMode = (type: MapEditorType) => {
   if (type === 'point') {
@@ -56,6 +63,179 @@ const methodMapping = {
   },
 };
 
+export class GoogleMapsDrawingManager {
+  private readonly listeners = new Set<OverlayCompleteListener>();
+  private readonly mapListeners: google.maps.MapsEventListener[] = [];
+  private readonly options: OverlayOptions & { map?: google.maps.Map };
+  private drawingMode: GoogleMapsDrawingMode = null;
+  private draftOverlay: google.maps.Polygon | google.maps.Polyline | google.maps.Circle | null = null;
+  private draftPath: google.maps.LatLng[] = [];
+  private circleCenter: google.maps.LatLng | null = null;
+
+  constructor(options: OverlayOptions & { drawingMode?: GoogleMapsDrawingMode; map?: google.maps.Map }) {
+    this.options = options;
+    this.setDrawingMode(options.drawingMode || null);
+  }
+
+  addListener(eventName: 'overlaycomplete', listener: OverlayCompleteListener) {
+    if (eventName === 'overlaycomplete') {
+      this.listeners.add(listener);
+    }
+    return {
+      remove: () => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  setDrawingMode(mode: GoogleMapsDrawingMode) {
+    this.drawingMode = mode;
+    this.resetDraft();
+    this.bindMapEvents();
+  }
+
+  unbindAll() {
+    this.listeners.clear();
+    this.clearMapEvents();
+    this.resetDraft();
+    this.drawingMode = null;
+  }
+
+  private bindMapEvents() {
+    this.clearMapEvents();
+    if (!this.options.map || !this.drawingMode) {
+      return;
+    }
+    this.mapListeners.push(
+      this.options.map.addListener('click', (event: google.maps.MapMouseEvent) => {
+        if (event.latLng) {
+          this.handleClick(event.latLng);
+        }
+      }),
+      this.options.map.addListener('dblclick', () => {
+        this.completePathOverlay();
+      }),
+      this.options.map.addListener('mousemove', (event: google.maps.MapMouseEvent) => {
+        if (event.latLng) {
+          this.updatePreview(event.latLng);
+        }
+      }),
+    );
+  }
+
+  private clearMapEvents() {
+    this.mapListeners.forEach((listener) => listener.remove());
+    this.mapListeners.length = 0;
+  }
+
+  private resetDraft() {
+    this.draftOverlay?.setMap(null);
+    this.draftOverlay = null;
+    this.draftPath = [];
+    this.circleCenter = null;
+  }
+
+  private handleClick(position: google.maps.LatLng) {
+    if (this.drawingMode === 'marker') {
+      this.emitComplete('marker', new google.maps.Marker({ ...this.options, icon: getIcon(defaultImage), position }));
+      return;
+    }
+
+    if (this.drawingMode === 'circle') {
+      this.handleCircleClick(position);
+      return;
+    }
+
+    if (this.drawingMode === 'polygon' || this.drawingMode === 'polyline') {
+      this.handlePathClick(position);
+    }
+  }
+
+  private handlePathClick(position: google.maps.LatLng) {
+    if (this.drawingMode !== 'polygon' && this.drawingMode !== 'polyline') {
+      return;
+    }
+    this.draftPath.push(position);
+    if (!this.draftOverlay) {
+      this.draftOverlay =
+        this.drawingMode === 'polygon'
+          ? new google.maps.Polygon({ ...this.options, paths: this.draftPath })
+          : new google.maps.Polyline({ ...this.options, path: this.draftPath });
+      return;
+    }
+    this.updatePath(this.draftPath);
+  }
+
+  private handleCircleClick(position: google.maps.LatLng) {
+    if (!this.circleCenter) {
+      this.circleCenter = position;
+      this.draftOverlay = new google.maps.Circle({ ...this.options, center: position, radius: 0 });
+      return;
+    }
+    this.updateCircle(position);
+    this.completeCircleOverlay();
+  }
+
+  private updatePreview(position: google.maps.LatLng) {
+    if (this.drawingMode === 'circle' && this.circleCenter) {
+      this.updateCircle(position);
+      return;
+    }
+    if ((this.drawingMode === 'polygon' || this.drawingMode === 'polyline') && this.draftOverlay) {
+      this.updatePath([...this.draftPath, position]);
+    }
+  }
+
+  private updatePath(path: google.maps.LatLng[]) {
+    if (this.draftOverlay instanceof google.maps.Polygon) {
+      this.draftOverlay.setPath(path);
+    } else if (this.draftOverlay instanceof google.maps.Polyline) {
+      this.draftOverlay.setPath(path);
+    }
+  }
+
+  private updateCircle(position: google.maps.LatLng) {
+    if (!(this.draftOverlay instanceof google.maps.Circle) || !this.circleCenter) {
+      return;
+    }
+    this.draftOverlay.setRadius(google.maps.geometry.spherical.computeDistanceBetween(this.circleCenter, position));
+  }
+
+  private completePathOverlay() {
+    if ((this.drawingMode !== 'polygon' && this.drawingMode !== 'polyline') || !this.draftOverlay) {
+      return;
+    }
+    if (
+      (this.drawingMode === 'polygon' && this.draftPath.length < 3) ||
+      (this.drawingMode === 'polyline' && this.draftPath.length < 2)
+    ) {
+      return;
+    }
+    const overlay = this.draftOverlay;
+    const type = this.drawingMode;
+    this.updatePath(this.draftPath);
+    this.draftOverlay = null;
+    this.draftPath = [];
+    this.emitComplete(type, overlay);
+  }
+
+  private completeCircleOverlay() {
+    if (!(this.draftOverlay instanceof google.maps.Circle)) {
+      return;
+    }
+    const overlay = this.draftOverlay;
+    this.draftOverlay = null;
+    this.circleCenter = null;
+    this.emitComplete('circle', overlay);
+  }
+
+  private emitComplete(type: Exclude<GoogleMapsDrawingMode, null>, overlay: GoogleMapsOverlay) {
+    this.listeners.forEach((listener) => {
+      listener({ type, overlay });
+    });
+  }
+}
+
 export interface GoogleMapsCompProps {
   value?: any;
   onChange?: (value: number[]) => void;
@@ -77,10 +257,10 @@ export interface GoogleMapForwardedRefProps {
   setOverlay: (t: MapEditorType, v: any, o?: OverlayOptions) => google.maps.MVCObject;
   getOverlay: (t: MapEditorType, v: any, o?: OverlayOptions) => google.maps.MVCObject;
   setFitView: (overlays: google.maps.MVCObject[]) => void;
-  createDraw: (onlyCreate?: boolean, additionalOptions?: OverlayOptions) => any;
+  createDraw: (onlyCreate?: boolean, additionalOptions?: OverlayOptions) => GoogleMapsDrawingManager;
   map: google.maps.Map;
   overlay: google.maps.MVCObject;
-  drawingManager: google.maps.drawing.DrawingManager;
+  drawingManager: GoogleMapsDrawingManager;
   errMessage?: string;
 }
 
@@ -102,7 +282,7 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
   const getLoadFailedMessage = useMemoizedFn(() =>
     t('Load google maps failed, Please check the Api key and refresh the page'),
   );
-  const drawingManagerRef = useRef<google.maps.drawing.DrawingManager>();
+  const drawingManagerRef = useRef<GoogleMapsDrawingManager>();
   const map = useRef<google.maps.Map>();
   const overlayRef = useRef<google.maps.Marker | google.maps.Polygon | google.maps.Polyline | google.maps.Circle>();
   const [needUpdateFlag, forceUpdate] = useState([]);
@@ -114,7 +294,7 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
     }
   }, [zoom, block]);
 
-  const drawingMode = useRef(getDrawingMode(type) as google.maps.drawing.OverlayType);
+  const drawingMode = useRef(getDrawingMode(type) as GoogleMapsDrawingMode);
 
   const [commonOptions] = useState<OverlayOptions>({
     strokeWeight: 5,
@@ -243,18 +423,14 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
       ...additionalOptions,
       map: map.current,
     };
-    drawingManagerRef.current = new google.maps.drawing.DrawingManager({
+    drawingManagerRef.current = new GoogleMapsDrawingManager({
       drawingMode: drawingMode.current,
-      drawingControl: false,
-      markerOptions: { ...currentOptions, icon: getIcon(defaultImage) },
-      polygonOptions: currentOptions,
-      polylineOptions: currentOptions,
-      circleOptions: currentOptions,
-      map: map.current,
+      ...currentOptions,
+      icon: getIcon(defaultImage),
     });
 
     if (!onlyCreate) {
-      drawingManagerRef.current.addListener('overlaycomplete', (event: { type: string; overlay: unknown }) => {
+      drawingManagerRef.current.addListener('overlaycomplete', (event) => {
         const overlay = event.overlay as google.maps.Marker;
         onMapChange(overlay);
       });
@@ -327,7 +503,7 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
     try {
       loader = new Loader({
         apiKey: accessKey,
-        version: 'quarterly',
+        version: 'weekly',
         language: ctx.api.auth.getLocale(),
       });
     } catch (err) {
@@ -344,7 +520,12 @@ export const GoogleMapsCom = React.forwardRef<GoogleMapForwardedRefProps, Google
       error(err, ...args);
     };
 
-    Promise.all([loader.importLibrary('drawing'), loader.importLibrary('core'), loader.importLibrary('geometry')])
+    Promise.all([
+      loader.importLibrary('maps'),
+      loader.importLibrary('marker'),
+      loader.importLibrary('core'),
+      loader.importLibrary('geometry'),
+    ])
       .then(async (res) => {
         const center = await getCurrentPosition();
         await new Promise((resolve) => requestAnimationFrame(resolve));

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/plugin.tsx
@@ -8,10 +8,20 @@
  */
 
 import { Plugin } from '@nocobase/client-v2';
+import { fields } from './fields';
+import { tExpr } from './locale';
 import { setDefaultZoomLevel } from './models/fieldModels/setDefaultZoomLevel';
 
 export class PluginMapClient extends Plugin {
   async load() {
+    this.app.addFieldInterfaces(fields);
+    this.app.addFieldInterfaceGroups({
+      map: {
+        label: tExpr('Map-based geometry'),
+        order: 300,
+      },
+    });
+
     this.pluginSettingsManager.addMenuItem({
       key: 'map',
       title: this.t('Map manager'),


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 data source manager did not show map geometry fields even when the map plugin was enabled, because the v2 client registered map field models but did not register the corresponding collection field interfaces.

### Description
This PR registers the v2 map geometry field interfaces for `point`, `lineString`, `circle`, and `polygon` in the map plugin.

It also adds a `Map-based geometry` field interface group with an explicit order so the group appears after the built-in advanced fields instead of at the top of the add-field menu.

The map field interfaces reuse the v2 field configuration shape and include the map type configuration used by the existing map field UI.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed map geometry fields missing from the v2 data source manager add-field menu after enabling the map plugin. |
| 🇨🇳 Chinese | 修复启用地图插件后，v2 数据源管理的添加字段菜单中缺少地图几何字段的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
