### PR TITLE
fix(plugin-block-list): refresh row action linkage by record

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListItemModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-list/src/client/models/ListItemModel.tsx
@@ -8,6 +8,8 @@
  */
 
 import {
+  createRecordResolveOnServerWithLocal,
+  ForkFlowModel,
   PropertyMetaFactory,
   createRecordMetaFactory,
   DndProvider,
@@ -30,6 +32,36 @@ type ListItemModelStructure = {
     actions: ActionModel[];
   };
 };
+
+const recordIdentityByFork = new WeakMap<ForkFlowModel<FlowModel>, string>();
+
+type CollectionLike = {
+  filterTargetKey?: string | string[];
+  getFilterByTK?: (record: Record<string, unknown>) => unknown;
+  getFilterTargetKey?: () => string | string[];
+};
+
+function getRecordValue(record: unknown, key: string) {
+  if (!record || typeof record !== 'object') return undefined;
+
+  return (record as Record<string, unknown>)[key];
+}
+
+function getRecordIdentity(record: unknown, collection?: CollectionLike) {
+  if (record && typeof record === 'object') {
+    const filterByTk = collection?.getFilterByTK?.(record as Record<string, unknown>);
+
+    if (typeof filterByTk !== 'undefined' && filterByTk !== null) {
+      return String(filterByTk);
+    }
+  }
+
+  const filterTargetKey = collection?.getFilterTargetKey?.() || collection?.filterTargetKey || 'id';
+  const keys = Array.isArray(filterTargetKey) ? filterTargetKey : [filterTargetKey];
+  const values = keys.map((key) => getRecordValue(record, key));
+
+  return values.map((value) => String(value ?? '')).join('-');
+}
 
 export class ListItemModel extends FlowModel<ListItemModelStructure> {
   onInit(options: any): void {
@@ -104,10 +136,22 @@ export class ListItemModel extends FlowModel<ListItemModelStructure> {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <Space wrap>
                 {this.mapSubModels('actions', (action, i) => {
-                  const fork = action.createFork({}, `${index}`);
-                  if (fork.hidden && !isConfigMode) {
+                  if (action.hidden && !isConfigMode) {
                     return;
                   }
+                  const slotKey = `${getRecordValue(record, '__index') ?? index}`;
+                  const recordIdentity = getRecordIdentity(record, this.context.collection);
+                  const cachedFork = action.getFork?.(slotKey);
+
+                  if (cachedFork && recordIdentityByFork.get(cachedFork) !== recordIdentity) {
+                    cachedFork.dispose();
+                  }
+
+                  const fork = action.createFork({}, slotKey);
+                  recordIdentityByFork.set(fork, recordIdentity);
+                  fork.invalidateFlowCache('beforeRender');
+                  const actionRenderKey = `${fork.uid}-${slotKey}-${recordIdentity}`;
+
                   const recordMeta: PropertyMetaFactory = createRecordMetaFactory(
                     () => (fork.context as any).collection,
                     fork.context.t('Current record'),
@@ -123,12 +167,15 @@ export class ListItemModel extends FlowModel<ListItemModelStructure> {
                   );
                   fork.context.defineProperty('record', {
                     get: () => this.context.record,
-                    resolveOnServer: true,
+                    resolveOnServer: createRecordResolveOnServerWithLocal(
+                      () => (fork.context as any).collection,
+                      () => record,
+                    ),
                     meta: recordMeta,
                     cache: false,
                   });
                   return (
-                    <Droppable model={fork} key={fork.uid}>
+                    <Droppable model={fork} key={actionRenderKey}>
                       <div
                         className={css`
                           button {
@@ -138,7 +185,9 @@ export class ListItemModel extends FlowModel<ListItemModelStructure> {
                         `}
                       >
                         <FlowModelRenderer
+                          key={actionRenderKey}
                           model={fork}
+                          inputArgs={record}
                           showFlowSettings={{ showBackground: false, showBorder: false, toolbarPosition: 'above' }}
                           extraToolbarItems={[
                             {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
List block row actions are rendered from reusable action forks. When linkage rules depend on the current row record, the reused fork can keep stale hidden or disabled state after the row record changes, causing row action state to be inconsistent with the current record.

### Description
This PR updates list block row action rendering to keep row-scoped linkage state aligned with the current record:

- Tracks action fork identity by the current record's filter target key, including composite filter target keys.
- Disposes stale row action forks when a reused row slot renders another record.
- Invalidates row action `beforeRender` cache before rendering.
- Passes the current row record to `FlowModelRenderer` as `inputArgs`.
- Uses local current-record resolution for row action variables.
- Uses record-aware render keys to avoid reusing stale React branches for another record.

Potential risk: list row actions now recalculate `beforeRender` more eagerly, matching the existing table row action behavior. This may add work for very large list pages with many row actions, but it avoids stale row-scoped linkage state.

Testing:

```bash
yarn eslint --fix packages/plugins/@nocobase/plugin-block-list/src/client/models/ListItemModel.tsx
yarn test packages/plugins/@nocobase/plugin-block-list/src/client/models/__tests__/ListBlockModel.blockHeight.test.tsx --run --reporter=verbose
```

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed stale row action linkage state in list blocks when actions depend on the current record. |
| 🇨🇳 Chinese | 修复列表区块行按钮依赖当前记录时联动状态可能残留的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
