### PR TITLE
fix(client): avoid syncing action hidden state to fields

### DIFF
--- a/packages/core/client/src/flow/actions/__tests__/actionLinkageRules.race.repro.test.ts
+++ b/packages/core/client/src/flow/actions/__tests__/actionLinkageRules.race.repro.test.ts
@@ -10,6 +10,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { actionLinkageRules } from '../linkageRules';
 
+class ActionModel {}
+class PopupSubTableEditActionModel extends ActionModel {}
+
 function createActionModel() {
   const model: any = {
     uid: 'edit-action',
@@ -195,5 +198,47 @@ describe('actionLinkageRules props patch isolation', () => {
     await secondRun;
 
     expect(model.hidden).toBe(true);
+  });
+
+  it('does not sync row action hidden state to the popup subtable field path', async () => {
+    const model = createActionModel();
+    Object.defineProperty(model, 'constructor', {
+      value: PopupSubTableEditActionModel,
+    });
+    model.isFork = true;
+    model.context = {
+      blockModel: { uid: 'form-block' },
+      fieldPathArray: ['org_o2m'],
+    };
+    const fieldModel: any = {
+      uid: 'org-o2m-field',
+      hidden: false,
+      context: {
+        blockModel: { uid: 'form-block' },
+        fieldPathArray: ['org_o2m'],
+      },
+    };
+    const { ctx } = createRuntime(model, { pauseHiddenAction: false });
+    ctx.engine = {
+      forEachModel: (visitor: (m: any) => void) => {
+        visitor(model);
+        visitor(fieldModel);
+      },
+    };
+
+    await actionLinkageRules.handler(
+      ctx,
+      createLinkageParams([
+        {
+          name: 'linkageSetActionProps',
+          params: {
+            value: 'hidden',
+          },
+        },
+      ]),
+    );
+
+    expect(model.hidden).toBe(true);
+    expect(fieldModel.hidden).toBe(false);
   });
 });

--- a/packages/core/client/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client/src/flow/actions/linkageRules.tsx
@@ -106,6 +106,18 @@ const getLinkageScopeDepthFromContext = (ctx: FlowContext): number => {
   return getLinkageScopeDepthFromModel((ctx as any)?.model);
 };
 
+const isActionFlowModel = (model: any): boolean => {
+  if (!model || typeof model !== 'object') return false;
+
+  let proto = model.constructor?.prototype;
+  while (proto) {
+    if (proto.constructor?.name === 'ActionModel') return true;
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return false;
+};
+
 // 获取表单中所有字段的 model 实例的通用函数
 const getFormFields = (ctx: any) => {
   try {
@@ -2104,7 +2116,7 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
     model.setProps(_.omit(newProps, ['hiddenModel', 'value', 'hiddenText']));
     syncFieldOptionsToForks(model, patchProps);
     model.hidden = nextHidden;
-    if (prevHidden !== nextHidden) {
+    if (prevHidden !== nextHidden && !isActionFlowModel(model)) {
       hiddenStatePatches.push({ model, hidden: nextHidden });
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Hiding a row action inside a popup subtable could incorrectly hide the whole subtable field, because the action's hidden state was synchronized to other models with the same field path.

### Description 
This PR prevents action models from propagating hidden state through field-path synchronization in linkage rules. Field models still keep the existing hidden-state synchronization behavior.

Testing performed:
- `yarn eslint --fix packages/core/client/src/flow/actions/linkageRules.tsx packages/core/client/src/flow/actions/__tests__/actionLinkageRules.race.repro.test.ts`
- `yarn test packages/core/client/src/flow/actions/__tests__/actionLinkageRules.race.repro.test.ts --run --reporter=verbose`
- `yarn test packages/core/client/src/flow/actions/__tests__/fieldLinkageRules.scopeDepth.test.ts --run --reporter=verbose`
- `git diff --check`

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed popup subtable row actions hiding the whole subtable field when the action is hidden by linkage rules |
| 🇨🇳 Chinese | 修复弹窗子表格行按钮通过联动规则隐藏时误隐藏整个子表格字段的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需文档 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
