### PR TITLE
fix(auth): lower empty token log level

### DIFF
--- a/packages/core/auth/src/base/auth.ts
+++ b/packages/core/auth/src/base/auth.ts
@@ -84,6 +84,7 @@ export class BaseAuth extends Auth {
       this.ctx.throw(401, {
         message: this.ctx.t('Unauthenticated. Please sign in to continue.', { ns: localeNamespace }),
         code: AuthErrorCode.EMPTY_TOKEN,
+        logLevel: 'trace',
       });
     }
 

--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/__tests__/middleware.test.ts
@@ -9,7 +9,9 @@
 
 import { Database } from '@nocobase/database';
 import { MockServer, createMockServer } from '@nocobase/test';
+import { vi } from 'vitest';
 import Plugin from '..';
+import { ErrorHandler } from '../error-handler';
 
 describe('middleware', () => {
   let app: MockServer;
@@ -69,5 +71,61 @@ describe('middleware', () => {
     expect(response.body).toEqual({
       errors: ['custom error'],
     });
+  });
+
+  it('should respect error log level', async () => {
+    const errorHandler = new ErrorHandler();
+    const trace = vi.fn();
+    const error = vi.fn();
+    const err = Object.assign(new Error('Unauthenticated. Please sign in to continue.'), {
+      code: 'EMPTY_TOKEN',
+      logLevel: 'trace',
+      status: 401,
+    });
+    const ctx = { log: { trace, error } };
+
+    await errorHandler.middleware()(ctx, async () => {
+      throw err;
+    });
+
+    expect(ctx).toMatchObject({
+      status: 401,
+      body: {
+        errors: [
+          {
+            code: 'EMPTY_TOKEN',
+            message: 'Unauthenticated. Please sign in to continue.',
+          },
+        ],
+      },
+    });
+    expect(trace).toHaveBeenCalledWith(err.message, {
+      method: 'error-handler',
+      err: err.stack,
+      cause: err.cause,
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('should keep errors without log level as error logs', async () => {
+    const errorHandler = new ErrorHandler();
+    const trace = vi.fn();
+    const error = vi.fn();
+    const err = Object.assign(new Error('Your session has expired. Please sign in again.'), {
+      code: 'INVALID_TOKEN',
+      status: 401,
+    });
+    const ctx = { log: { trace, error } };
+
+    await errorHandler.middleware()(ctx, async () => {
+      throw err;
+    });
+
+    expect(error).toHaveBeenCalledWith(err.message, {
+      method: 'error-handler',
+      err: err.stack,
+      cause: err.cause,
+    });
+    expect(trace).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-error-handler/src/server/error-handler.ts
+++ b/packages/plugins/@nocobase/plugin-error-handler/src/server/error-handler.ts
@@ -55,14 +55,25 @@ export class ErrorHandler {
       try {
         await next();
       } catch (err) {
-        ctx.log.error(err.message, { method: 'error-handler', err: err.stack, cause: err.cause });
-
         if (err.statusCode) {
           ctx.status = err.statusCode;
         }
 
         self.renderError(err, ctx);
+
+        const logMethod = getLogMethod(err);
+        ctx.log[logMethod](err.message, { method: 'error-handler', err: err.stack, cause: err.cause });
       }
     };
   }
+}
+
+const logMethods = ['trace', 'debug', 'info', 'warn', 'error'];
+
+function getLogMethod(err) {
+  if (logMethods.includes(err?.logLevel)) {
+    return err.logLevel;
+  }
+
+  return 'error';
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Normal unauthenticated requests without a token are expected in some flows, but they were logged as error-level entries by the error handler.

### Description 
Allow thrown errors to carry a `logLevel` marker, and let the error handler use that marker when writing its own exception log.

The empty-token authentication error now marks itself as `trace`, while other authentication errors continue to use the default error-level log behavior.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reduced noisy error logs for normal unauthenticated requests without a token |
| 🇨🇳 Chinese | 降低正常未登录且未携带 token 请求产生的错误日志噪声 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
