### PR TITLE
fix(ai): load data-query skill before querying data

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
@@ -114,7 +114,8 @@ const toCollection = async (model: CollectionBlockModel) => {
       collection: {
         ...collection,
       },
-      prompt: `You can use the tools dataSourceQuery to query data from a data source and dataSourceCounting to get record counts.
+      prompt: `Before querying, first call getSkill with skillName="data-query" to load the data-query skill and make dataSourceQuery and dataSourceCounting available.
+After the skill is loaded, use dataSourceQuery to query data from a data source and dataSourceCounting to get record counts.
 When analyzing user messages, if any words or phrases are related or similar to a known collectionName, prioritize retrieving relevant data before responding.
 When the user asks about quantities, totals, or record counts, you must first call dataSourceCounting to obtain accurate numbers before answering.
 Always apply dataScope.filter when calling dataSourceQuery or dataSourceCounting. Ensure that the filter structure is properly transformed to match the tools’ input format.

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/SKILLS.md
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/ai/skills/data-query/SKILLS.md
@@ -3,7 +3,6 @@ scope: GENERAL
 name: data-query
 description: Inspect schemas, retrieve records, and run aggregate queries on specified datasources
 tools:
-  - getSkill
   - dataQuery
   - dataSourceQuery
   - dataSourceCounting


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI employees need to load the data-query skill before using datasource query/counting tools. The data-query skill itself should not expose `getSkill` as one of its loaded tools.

### Description 
This PR updates the AI employee collection prompt to explicitly call `getSkill` with `skillName="data-query"` before querying data. It also removes `getSkill` from the data-query skill tool list so the loaded skill only provides its datasource query/counting tools.

Potential risk is limited to AI employee tool guidance for datasource querying.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx`
- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-employee-skill-binding.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/server/__tests__/ai-data-query-tool.test.ts`

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved AI employee data-query prompts to load the required skill before using query tools. |
| 🇨🇳 Chinese | 优化 AI 员工数据查询提示词，引导其先加载所需技能再使用查询工具。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
