### PR TITLE
feat(plugin-environment-variables): expose $env on the flow-engine context in v1 too

### DIFF
--- a/packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/plugin.tsx
@@ -9,28 +9,7 @@
 
 import type { Application } from '@nocobase/client-v2';
 import { Plugin } from '@nocobase/client-v2';
-import type { PropertyMeta } from '@nocobase/flow-engine';
-
-type EnvironmentVariable = {
-  name: string;
-  value?: string;
-  type?: 'default' | 'secret';
-};
-
-const ENV_VARS_LIST_URL = 'environmentVariables?paginate=false';
-
-async function fetchEnvironmentVariables(apiClient: Application['apiClient']): Promise<EnvironmentVariable[]> {
-  try {
-    const response = await apiClient.request({
-      url: ENV_VARS_LIST_URL,
-      skipNotify: true,
-    } as any);
-    const list = (response as any)?.data?.data;
-    return Array.isArray(list) ? list : [];
-  } catch {
-    return [];
-  }
-}
+import { registerEnvProperty } from './registerEnvProperty';
 
 export class PluginEnvironmentVariablesClientV2 extends Plugin<Record<string, never>, Application> {
   async load() {
@@ -52,28 +31,9 @@ export class PluginEnvironmentVariablesClientV2 extends Plugin<Record<string, ne
 
     // Expose `$env` to all v2 plugins via FlowContext, replacing v1's
     // `addGlobalVar('$env', ...)` + Provider chain. Lazy-loaded — the API is
-    // only hit on first read, then cached by FlowContext.
-    this.flowEngine.context.defineProperty('$env', {
-      get: async () => {
-        const list = await fetchEnvironmentVariables(this.app.apiClient);
-        return Object.fromEntries(list.map((item) => [item.name, item.value]));
-      },
-      meta: {
-        type: 'object',
-        title: this.t('Variables and secrets') as unknown as string,
-        properties: async (): Promise<Record<string, PropertyMeta>> => {
-          const list = await fetchEnvironmentVariables(this.app.apiClient);
-          const out: Record<string, PropertyMeta> = {};
-          for (const item of list) {
-            out[item.name] = {
-              type: item.type === 'secret' ? 'string' : item.type || 'string',
-              title: item.name,
-            };
-          }
-          return out;
-        },
-      },
-    });
+    // only hit on first read, then cached by FlowContext. Shared with the v1
+    // runtime via `registerEnvProperty` (see `./registerEnvProperty`).
+    registerEnvProperty(this.flowEngine.context, this.app.apiClient, (key) => this.t(key));
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/registerEnvProperty.ts
+++ b/packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/registerEnvProperty.ts
@@ -1,0 +1,84 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * Shared registration of the `$env` property on a flow-engine context — the
+ * single source of truth used by BOTH client runtimes:
+ *   - v2 (`client-v2/plugin.tsx`) registers it on its own flow-engine context;
+ *   - v1 (`client/index.tsx`) imports this same helper via the allowed v1 → v2
+ *     direction and registers it on v1's flow-engine context, so workflow's v2
+ *     config drawer (which renders detached from the React tree and therefore
+ *     can't reach v1's React-context-based `addGlobalVar('$env')`) can still read
+ *     `$env` from `flowEngine.context.getPropertyMetaTree()`.
+ *
+ * Framework-agnostic: dependencies (`apiClient`, `t`) are injected as parameters,
+ * so it carries no React hooks and no `@nocobase/client` import — usable from
+ * either runtime. The list is fetched lazily (first read only) and cached by the
+ * flow-engine context, so the picker never re-requests on every expand.
+ */
+
+import type { FlowContext, PropertyMeta } from '@nocobase/flow-engine';
+
+type EnvironmentVariable = {
+  name: string;
+  value?: string;
+  type?: 'default' | 'secret';
+};
+
+/** Minimal structural slice of the API client — only the one call this needs.
+ *  Avoids importing the concrete `APIClient` type across the package boundary. */
+type EnvApiClient = {
+  request(options: { url: string; skipNotify?: boolean }): Promise<unknown>;
+};
+
+const ENV_VARS_LIST_URL = 'environmentVariables?paginate=false';
+const ENV_ROOT = '$env';
+
+export async function fetchEnvironmentVariables(apiClient: EnvApiClient): Promise<EnvironmentVariable[]> {
+  try {
+    const response = await apiClient.request({ url: ENV_VARS_LIST_URL, skipNotify: true });
+    const list = (response as { data?: { data?: unknown } })?.data?.data;
+    return Array.isArray(list) ? (list as EnvironmentVariable[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** A translator for the scope label. Accepts the i18next `t` from either runtime
+ *  (its return type isn't a bare `string` — it's a `TFunctionDetailedResult` /
+ *  union), so the result is coerced to a string by the helper. */
+type Translate = (key: string) => unknown;
+
+/**
+ * Define `$env` on the given flow-engine context. `t` translates the scope label
+ * ("Variables and secrets"); `apiClient` fetches the variable list lazily.
+ */
+export function registerEnvProperty(context: FlowContext, apiClient: EnvApiClient, t: Translate): void {
+  context.defineProperty(ENV_ROOT, {
+    get: async () => {
+      const list = await fetchEnvironmentVariables(apiClient);
+      return Object.fromEntries(list.map((item) => [item.name, item.value]));
+    },
+    meta: {
+      type: 'object',
+      title: String(t('Variables and secrets')),
+      properties: async (): Promise<Record<string, PropertyMeta>> => {
+        const list = await fetchEnvironmentVariables(apiClient);
+        const out: Record<string, PropertyMeta> = {};
+        for (const item of list) {
+          out[item.name] = {
+            type: item.type === 'secret' ? 'string' : item.type || 'string',
+            title: item.name,
+          };
+        }
+        return out;
+      },
+    },
+  });
+}

--- a/packages/plugins/@nocobase/plugin-environment-variables/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-environment-variables/src/client/index.tsx
@@ -11,6 +11,9 @@ import { Plugin } from '@nocobase/client';
 import { EnvironmentVariablesAndSecretsProvider } from './EnvironmentVariablesAndSecretsProvider';
 import EnvironmentPage from './components/EnvironmentPage';
 import { useGetEnvironmentVariables, useGetEnvironmentVariablesCtx } from './utils';
+// Shared `$env` registration, defined once in client-v2 and imported back here
+// via the allowed v1 → v2 direction (see the helper's doc comment).
+import { registerEnvProperty } from '../client-v2/registerEnvProperty';
 
 export class PluginEnvironmentVariablesClient extends Plugin {
   async load() {
@@ -19,8 +22,15 @@ export class PluginEnvironmentVariablesClient extends Plugin {
       icon: 'TableOutlined',
       Component: EnvironmentPage,
     });
+    // Legacy v1 path: `$env` as a React-context global var, consumed by the v1
+    // Formily `Variable.Input` scope (`useGlobalVariable('$env')`). Kept as-is.
     this.app.addGlobalVar('$env', useGetEnvironmentVariables, useGetEnvironmentVariablesCtx);
     this.app.use(EnvironmentVariablesAndSecretsProvider);
+    // Also expose `$env` on the flow-engine context (the v2 mechanism), so v2 UI
+    // rendered in the v1 runtime — e.g. workflow's config drawer, which mounts
+    // detached from the React tree and can't read the React-context global var —
+    // can still resolve `$env` via `flowEngine.context.getPropertyMetaTree()`.
+    registerEnvProperty(this.app.flowEngine.context, this.app.apiClient, (key) => this.t(key));
   }
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

The environment-variables plugin exposes `$env` differently per runtime: v2 registers it on the flow-engine context (`defineProperty('$env')`), while v1 only registers it as a React-context global var (`addGlobalVar('$env')`). v2 UI that is reused in the v1 runtime but renders detached from the v1 React tree (e.g. a drawer mounted at the React root) cannot reach the React-context global var, so `$env` shows up empty there. The two registrations also duplicate the same fetch/shape logic.

### Description
- Extract the v2 `defineProperty('$env')` registration into a framework-agnostic `registerEnvProperty(context, apiClient, t)` helper (no React hooks; dependencies injected as parameters).
- The v2 plugin now calls the shared helper instead of inlining the logic.
- The v1 client entry also calls it (via the allowed v1 → v2 import), putting `$env` on the v1 flow-engine context so detached v2 UI can resolve it from `getPropertyMetaTree()`; the list is fetched once and cached.
- The legacy v1 `addGlobalVar('$env')` + provider path is kept untouched.

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Environment variables (`$env`) can now be selected by flow-engine-based variable pickers in the v1 runtime. |
| 🇨🇳 Chinese | 环境变量（`$env`）现在在 v1 运行时能被基于 flow-engine 的变量选择器选取。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
