### PR TITLE
fix: restore v2 popup block context

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
@@ -445,18 +445,24 @@ export class CalendarBlockModel extends CollectionBlockModel {
       popupAction: action,
       fieldNames: this.getFieldNames(),
     });
-
-    await action.dispatchEvent(
-      'click',
-      {
-        ...(Object.keys(formData).length ? { formData } : {}),
-        defineProperties: {
-          calendarSelectedSlot: { value: slotInfo },
-          calendarFieldNames: { value: this.getFieldNames() },
-        },
+    const inputArgs = {
+      ...(Object.keys(formData).length ? { formData } : {}),
+      ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+      ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
+      navigation: false,
+      target: this.context?.layoutContentElement,
+      defineProperties: {
+        calendarSelectedSlot: { value: slotInfo },
+        calendarFieldNames: { value: this.getFieldNames() },
       },
-      { debounce: true },
-    );
+    };
+
+    if (typeof this.context?.openView === 'function' && action.uid) {
+      await this.context.openView(action.uid, inputArgs);
+      return;
+    }
+
+    await action.dispatchEvent('click', inputArgs, { debounce: true });
   }
 
   async openEvent(record: any) {
@@ -469,14 +475,20 @@ export class CalendarBlockModel extends CollectionBlockModel {
     if (!filterByTk) {
       return;
     }
+    const inputArgs = {
+      ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+      ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
+      filterByTk,
+      navigation: false,
+      target: this.context?.layoutContentElement,
+    };
 
-    await action.dispatchEvent(
-      'click',
-      {
-        filterByTk,
-      },
-      { debounce: true },
-    );
+    if (typeof this.context?.openView === 'function' && action.uid) {
+      await this.context.openView(action.uid, inputArgs);
+      return;
+    }
+
+    await action.dispatchEvent('click', inputArgs, { debounce: true });
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
@@ -632,4 +632,106 @@ describe('calendarPopupModels', () => {
       dataSourceKey: 'main',
     });
   });
+
+  it('should keep popup collection context in add and event drawers', () => {
+    const model = Object.create(CalendarBlockModel.prototype) as CalendarBlockModel;
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'events',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      configurable: true,
+    });
+
+    expect(model.getPopupSettings({ uid: 'quick-action' }, 'quickCreateAction')).toMatchObject({
+      uid: 'quick-action',
+      collectionName: 'events',
+      dataSourceKey: 'main',
+    });
+    expect(model.getPopupSettings({ uid: 'event-action' }, 'eventViewAction')).toMatchObject({
+      uid: 'event-action',
+      collectionName: 'events',
+      dataSourceKey: 'main',
+    });
+  });
+
+  it('should open quick-create drawer through flow context openView with selected slot data', async () => {
+    const openView = vi.fn().mockResolvedValue(undefined);
+    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'quick-create-action' });
+    const slotInfo = {
+      start: new Date(2026, 3, 20, 9, 30, 0),
+      end: new Date(2026, 3, 20, 10, 30, 0),
+    };
+
+    await CalendarBlockModel.prototype.openQuickCreate.call(
+      {
+        props: {},
+        context: {
+          openView,
+          layoutContentElement: { id: 'layout-root' },
+        },
+        collection: {
+          name: 'events',
+          dataSourceKey: 'main',
+          getField: () => ({
+            getComponentProps: () => ({ picker: 'date', showTime: true }),
+          }),
+        },
+        ensurePopupAction,
+        getFieldNames: () => ({ start: 'startsAt', end: 'endsAt' }),
+      } as any,
+      slotInfo,
+    );
+
+    expect(ensurePopupAction).toHaveBeenCalledWith('quickCreateAction');
+    expect(openView).toHaveBeenCalledWith('quick-create-action', {
+      formData: {
+        startsAt: '2026-04-20 09:30:00',
+        endsAt: '2026-04-20 10:30:00',
+      },
+      dataSourceKey: 'main',
+      collectionName: 'events',
+      navigation: false,
+      target: { id: 'layout-root' },
+      defineProperties: {
+        calendarSelectedSlot: { value: slotInfo },
+        calendarFieldNames: { value: { start: 'startsAt', end: 'endsAt' } },
+      },
+    });
+  });
+
+  it('should open event drawer through flow context openView with record filter key', async () => {
+    const openView = vi.fn().mockResolvedValue(undefined);
+    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'event-view-action' });
+
+    await CalendarBlockModel.prototype.openEvent.call(
+      {
+        context: {
+          openView,
+          layoutContentElement: { id: 'layout-root' },
+        },
+        collection: {
+          name: 'events',
+          dataSourceKey: 'main',
+          filterTargetKey: 'id',
+          getFilterByTK: (record: any) => record.id,
+        },
+        ensurePopupAction,
+      } as any,
+      { id: 7 },
+    );
+
+    expect(ensurePopupAction).toHaveBeenCalledWith('eventViewAction');
+    expect(openView).toHaveBeenCalledWith('event-view-action', {
+      dataSourceKey: 'main',
+      collectionName: 'events',
+      filterByTk: 7,
+      navigation: false,
+      target: { id: 'layout-root' },
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
@@ -797,16 +797,19 @@ describe('GanttBlockModel settings', () => {
     });
     const action = await model.ensurePopupAction('eventViewAction');
     action.dispatchEvent = vi.fn();
+    const openView = vi.fn();
+    model.context.defineMethod('openView', openView);
 
     await model.openEvent({ id: 12 });
 
-    expect(action.dispatchEvent).toHaveBeenCalledWith(
-      'click',
-      {
-        filterByTk: 12,
-      },
-      { debounce: true },
-    );
+    expect(openView).toHaveBeenCalledWith('calendar-gantt-eventViewAction', {
+      dataSourceKey: 'main',
+      collectionName: 'calendar',
+      filterByTk: 12,
+      navigation: false,
+      target: model.context.layoutContentElement,
+    });
+    expect(action.dispatchEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
@@ -489,14 +489,20 @@ export class GanttBlockModel extends TableBlockModel {
     if (!filterByTk) {
       return;
     }
+    const inputArgs = {
+      ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+      ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
+      filterByTk,
+      navigation: false,
+      target: this.context?.layoutContentElement,
+    };
 
-    await action.dispatchEvent(
-      'click',
-      {
-        filterByTk,
-      },
-      { debounce: true },
-    );
+    if (typeof this.context?.openView === 'function' && action.uid) {
+      await this.context.openView(action.uid, inputArgs);
+      return;
+    }
+
+    await action.dispatchEvent('click', inputArgs, { debounce: true });
   }
 
   getActionsColumn() {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
@@ -293,6 +293,38 @@ describe('KanbanBlockModel.filterCollection', () => {
     });
   });
 
+  test('syncPopupAction persists collection context for popup add-block menus', async () => {
+    const setStepParams = vi.fn();
+
+    await KanbanBlockModel.prototype.syncPopupAction.call(
+      {
+        context: { flowSettingsEnabled: false },
+      },
+      {
+        uid: 'card-view-action',
+        getStepParams: () => ({ mode: 'drawer' }),
+        setStepParams,
+      },
+      {
+        mode: 'drawer',
+        size: 'medium',
+        uid: 'card-view-action',
+        dataSourceKey: 'main',
+        collectionName: 'tasks',
+      },
+    );
+
+    expect(setStepParams).toHaveBeenCalledWith('popupSettings', 'openView', {
+      mode: 'drawer',
+      size: 'medium',
+      popupTemplateUid: undefined,
+      uid: 'card-view-action',
+      pageModelClass: undefined,
+      dataSourceKey: 'main',
+      collectionName: 'tasks',
+    });
+  });
+
   test('syncPopupAction overwrites removed popup settings with undefined so stale template params do not survive merges', async () => {
     const setStepParams = vi.fn();
 
@@ -1806,6 +1838,8 @@ describe('KanbanBlockModel.filterCollection', () => {
         },
         translate: (value: string) => value,
         collection: {
+          name: 'tasks',
+          dataSourceKey: 'main',
           getFilterByTK: (record: any) => record.id,
           filterTargetKey: 'id',
         },
@@ -1821,6 +1855,8 @@ describe('KanbanBlockModel.filterCollection', () => {
     expect(ensureCardViewAction).toHaveBeenCalledTimes(1);
     expect(openView).toHaveBeenCalledWith('card-view-action', {
       mode: 'dialog',
+      dataSourceKey: 'main',
+      collectionName: 'tasks',
       filterByTk: 1,
       navigation: false,
       target: { id: 'layout-root' },

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
@@ -842,7 +842,15 @@ export class KanbanBlockModel extends CollectionBlockModel<{
 
   async syncPopupAction(
     action: any,
-    options: { mode: string; size: string; popupTemplateUid?: string; uid?: string; pageModelClass?: string },
+    options: {
+      mode: string;
+      size: string;
+      popupTemplateUid?: string;
+      uid?: string;
+      pageModelClass?: string;
+      dataSourceKey?: string;
+      collectionName?: string;
+    },
   ) {
     if (!action) {
       return;
@@ -864,13 +872,17 @@ export class KanbanBlockModel extends CollectionBlockModel<{
 
     const resolvedUid = sanitizedUid || (nextPopupTemplateUid ? currentUid || selfUid : selfUid);
     const nextPageModelClass = options.pageModelClass || undefined;
+    const nextDataSourceKey = options.dataSourceKey || undefined;
+    const nextCollectionName = options.collectionName || undefined;
 
     if (
       currentParams.mode === nextMode &&
       currentParams.size === nextSize &&
       currentParams.popupTemplateUid === nextPopupTemplateUid &&
       normalizeKanbanPopupTargetUid(currentParams.uid) === resolvedUid &&
-      currentParams.pageModelClass === nextPageModelClass
+      currentParams.pageModelClass === nextPageModelClass &&
+      currentParams.dataSourceKey === nextDataSourceKey &&
+      currentParams.collectionName === nextCollectionName
     ) {
       return;
     }
@@ -882,6 +894,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       popupTemplateUid: nextPopupTemplateUid,
       uid: resolvedUid,
       pageModelClass: nextPageModelClass,
+      ...(nextDataSourceKey ? { dataSourceKey: nextDataSourceKey } : {}),
+      ...(nextCollectionName ? { collectionName: nextCollectionName } : {}),
     };
 
     action.setStepParams('popupSettings', 'openView', nextParams);
@@ -898,6 +912,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       popupTemplateUid: this.getCardPopupTemplateUid(),
       uid: this.getCardPopupTargetUid(),
       pageModelClass: this.getCardPopupPageModelClass(),
+      dataSourceKey: this.collection?.dataSourceKey,
+      collectionName: this.collection?.name,
     });
   }
 
@@ -944,6 +960,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       popupTemplateUid: this.getPopupTemplateUid(),
       uid: this.getPopupTargetUid(),
       pageModelClass: this.getPopupPageModelClass(),
+      dataSourceKey: this.collection?.dataSourceKey,
+      collectionName: this.collection?.name,
     });
   }
 
@@ -1008,6 +1026,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       if (typeof this.context?.openView === 'function') {
         await this.context.openView(action.uid, {
           formData: this.buildQuickCreateFormData(column),
+          ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+          ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
           navigation: false,
           target: this.context.layoutContentElement,
         });
@@ -1018,6 +1038,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
         'click',
         {
           formData: this.buildQuickCreateFormData(column),
+          ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+          ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
           navigation: false,
           target: this.context?.layoutContentElement,
         },
@@ -1056,6 +1078,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       if (typeof this.context?.openView === 'function' && action.uid) {
         await this.context.openView(action.uid, {
           mode: this.getCardOpenMode(),
+          ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+          ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
           filterByTk,
           navigation: false,
           target: this.context.layoutContentElement,
@@ -1067,6 +1091,8 @@ export class KanbanBlockModel extends CollectionBlockModel<{
         'click',
         {
           mode: this.getCardOpenMode(),
+          ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
+          ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
           filterByTk,
           navigation: false,
           target: this.context?.layoutContentElement,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 calendar, kanban, and gantt popup detail drawers did not consistently preserve the current collection and record context. As a result, users could not add Details or Edit blocks inside task/event detail popups.

### Description 
This PR ensures v2 calendar, kanban, and gantt popup drawers pass the current data source, collection, and record filter context when opening hidden popup actions.

Key changes:
- Calendar event and quick-create popups now open through `context.openView` when available and pass collection context.
- Gantt task detail popups now open through `context.openView` when available and pass collection context.
- Kanban popup actions now persist and pass `dataSourceKey` and `collectionName` so popup Add block menus can resolve the current collection.
- Added focused regression tests for popup context propagation.

Potential risk:
- Low. The change keeps dispatch fallback paths and only adds missing popup context for existing v2 plugin popup flows.

Testing:
- `yarn eslint --fix` on touched files
- `yarn test packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts --run --reporter=verbose`
- `git diff --check`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where Details and Edit blocks could not be added in v2 calendar block detail drawers |
| 🇨🇳 Chinese | 修复 v2 日历区块详情弹窗中无法添加详情和编辑区块的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
