### PR TITLE
fix(client-v2): support single popup selection for to-many fields

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
@@ -31,7 +31,90 @@ import {
   createRootItemChain,
   type ItemChain,
 } from './itemChain';
-import { buildOpenerUids, LabelByField } from './recordSelectShared';
+import { buildOpenerUids, LabelByField, type AssociationFieldNames } from './recordSelectShared';
+
+const MULTIPLE_ASSOCIATION_TYPES = ['belongsToMany', 'hasMany', 'belongsToArray'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function canRecordPickerSelectMultiple(
+  collectionField: { type?: string } | null | undefined,
+  allowMultiple?: boolean,
+) {
+  return (
+    !!collectionField?.type && MULTIPLE_ASSOCIATION_TYPES.includes(collectionField.type) && allowMultiple !== false
+  );
+}
+
+export function shouldClearRecordPickerValueOnMultipleChange(
+  collectionField: { type?: string } | null | undefined,
+  previousAllowMultiple?: boolean,
+  nextAllowMultiple?: boolean,
+) {
+  return (
+    canRecordPickerSelectMultiple(collectionField, previousAllowMultiple) !==
+    canRecordPickerSelectMultiple(collectionField, nextAllowMultiple)
+  );
+}
+
+export function normalizeRecordPickerSelectedRows(value: unknown, allowMultiple: boolean) {
+  if (!value) {
+    return [];
+  }
+  if (allowMultiple) {
+    return Array.isArray(value) ? value : [value];
+  }
+  return Array.isArray(value) ? value.slice(0, 1) : [value];
+}
+
+export function getRecordPickerEmptyValue(allowMultiple: boolean) {
+  return allowMultiple ? [] : undefined;
+}
+
+export function getRecordPickerClearedValue() {
+  return undefined;
+}
+
+export function normalizeRecordPickerValue(value: unknown, fieldNames: AssociationFieldNames, allowMultiple: boolean) {
+  if (!value) {
+    return getRecordPickerEmptyValue(allowMultiple);
+  }
+  const toSelectItem = (item: Record<string, unknown>) => ({
+    ...item,
+    label: item[fieldNames.label],
+    value: item[fieldNames.value],
+  });
+  if (!allowMultiple) {
+    const item = Array.isArray(value) ? value[0] : value;
+    return isRecord(item) ? toSelectItem(item) : undefined;
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord).map(toSelectItem);
+}
+
+function applyRecordPickerAllowMultiple(ctx: any, params: any, previousParams?: any) {
+  const shouldClearValue =
+    previousParams &&
+    shouldClearRecordPickerValueOnMultipleChange(
+      ctx.collectionField,
+      previousParams?.allowMultiple,
+      params?.allowMultiple,
+    );
+  const emptyValue = getRecordPickerClearedValue();
+
+  ctx.model.setProps({
+    allowMultiple: params?.allowMultiple,
+    ...(shouldClearValue ? { value: emptyValue } : {}),
+  });
+  if (shouldClearValue) {
+    ctx.model.selectedRows.value = emptyValue;
+    ctx.model.props.onChange?.(emptyValue);
+  }
+}
 
 export function buildRecordPickerParentItemContext(ctx: any): {
   parentItem: ItemChain;
@@ -241,25 +324,10 @@ export function RecordPickerContent({ model, toOne = false }) {
 function RecordPickerField(props) {
   const { fieldNames, onClick, disabled } = props;
   const ctx = useFlowContext();
-  const toOne = ['belongsTo', 'hasOne'].includes(ctx.collectionField.type);
+  const allowMultiple = canRecordPickerSelectMultiple(ctx.collectionField, props.allowMultiple);
   useEffect(() => {
     ctx.model.selectedRows.value = props.value;
-  }, [props.value]);
-  const normalizeValue = (value, fieldNames, toOne) => {
-    if (!value) return toOne ? undefined : [];
-    if (toOne) {
-      return {
-        ...value,
-        label: value[fieldNames.label],
-        value: value[fieldNames.value],
-      };
-    }
-    return value.map((v) => ({
-      ...v,
-      label: v[fieldNames.label],
-      value: v[fieldNames.value],
-    }));
-  };
+  }, [ctx.model.selectedRows, props.value]);
 
   return (
     <Select
@@ -270,12 +338,12 @@ function RecordPickerField(props) {
           onClick(e);
         }
       }}
-      value={normalizeValue(props.value, fieldNames, toOne)}
+      value={normalizeRecordPickerValue(props.value, fieldNames, allowMultiple)}
       labelRender={(item) => {
         return <LabelByField option={item} fieldNames={fieldNames} />;
       }}
       labelInValue
-      mode={toOne ? undefined : 'multiple'}
+      mode={allowMultiple ? 'multiple' : undefined}
       options={props.value}
       allowClear
       onChange={(newValue, option) => {
@@ -405,7 +473,7 @@ RecordPickerFieldModel.registerFlow({
       },
       handler(ctx, params) {
         const { onChange } = ctx.inputArgs;
-        const toOne = ['belongsTo', 'hasOne'].includes(ctx.collectionField.type);
+        const allowMultiple = canRecordPickerSelectMultiple(ctx.collectionField, ctx.model.props.allowMultiple);
         const sizeToWidthMap: Record<string, any> = {
           drawer: {
             small: '30%',
@@ -441,9 +509,9 @@ RecordPickerFieldModel.registerFlow({
               currentItemValue: ctx.inputArgs.currentItemValue ?? {},
             }),
             rowSelectionProps: {
-              type: toOne ? 'radio' : 'checkbox',
+              type: allowMultiple ? 'checkbox' : 'radio',
               defaultSelectedRows: () => {
-                return ctx.model.props.value;
+                return normalizeRecordPickerSelectedRows(ctx.model.props.value, allowMultiple);
               },
               renderCell: undefined,
               selectedRowKeys: undefined,
@@ -452,8 +520,7 @@ RecordPickerFieldModel.registerFlow({
                 const selectTable = selectBlockModel.findSubModel('items', (m) => {
                   return m;
                 });
-                if (toOne) {
-                  // 单选
+                if (!allowMultiple) {
                   ctx.model.selectedRows.value = selectedRows?.[0];
                   onChange(ctx.model.selectedRows.value);
                   ctx.model._closeView?.();
@@ -475,7 +542,7 @@ RecordPickerFieldModel.registerFlow({
               },
             },
           },
-          content: () => <RecordPickerContent model={ctx.model} toOne={toOne} />,
+          content: () => <RecordPickerContent model={ctx.model} toOne={!allowMultiple} />,
           styles: {
             content: {
               padding: 0,
@@ -499,6 +566,24 @@ RecordPickerFieldModel.registerFlow({
   steps: {
     fieldNames: {
       use: 'titleField',
+    },
+    allowMultiple: {
+      title: tExpr('Multiple'),
+      uiMode: { type: 'switch', key: 'allowMultiple' },
+      hideInSettings(ctx) {
+        return !canRecordPickerSelectMultiple(ctx.collectionField, true);
+      },
+      defaultParams(ctx) {
+        return {
+          allowMultiple: canRecordPickerSelectMultiple(ctx.collectionField, true),
+        };
+      },
+      afterParamsSave(ctx, params, previousParams) {
+        applyRecordPickerAllowMultiple(ctx, params, previousParams);
+      },
+      handler(ctx, params) {
+        applyRecordPickerAllowMultiple(ctx, params);
+      },
     },
   },
 });

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/RecordPickerFieldModel.itemContext.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/RecordPickerFieldModel.itemContext.test.ts
@@ -20,6 +20,14 @@ import {
   resolveRecordPersistenceState,
 } from '../itemChain';
 import { injectRecordPickerPopupContext } from '@nocobase/client-v2';
+import {
+  canRecordPickerSelectMultiple,
+  getRecordPickerClearedValue,
+  getRecordPickerEmptyValue,
+  normalizeRecordPickerSelectedRows,
+  normalizeRecordPickerValue,
+  shouldClearRecordPickerValueOnMultipleChange,
+} from '../RecordPickerFieldModel';
 
 function createMockCollection() {
   return {
@@ -32,6 +40,59 @@ function createMockCollection() {
 }
 
 describe('RecordPickerFieldModel item context', () => {
+  it('resolves popup select multiple mode for association fields', () => {
+    expect(canRecordPickerSelectMultiple({ type: 'belongsToMany' })).toBe(true);
+    expect(canRecordPickerSelectMultiple({ type: 'hasMany' })).toBe(true);
+    expect(canRecordPickerSelectMultiple({ type: 'belongsToArray' })).toBe(true);
+    expect(canRecordPickerSelectMultiple({ type: 'belongsToMany' }, false)).toBe(false);
+    expect(canRecordPickerSelectMultiple({ type: 'belongsTo' })).toBe(false);
+    expect(canRecordPickerSelectMultiple({ type: 'hasOne' })).toBe(false);
+  });
+
+  it('normalizes popup select selected rows according to multiple mode', () => {
+    const rows = [
+      { id: 1, name: 'A' },
+      { id: 2, name: 'B' },
+    ];
+
+    expect(normalizeRecordPickerSelectedRows(rows, true)).toEqual(rows);
+    expect(normalizeRecordPickerSelectedRows(rows, false)).toEqual([{ id: 1, name: 'A' }]);
+    expect(normalizeRecordPickerSelectedRows({ id: 1, name: 'A' }, false)).toEqual([{ id: 1, name: 'A' }]);
+    expect(normalizeRecordPickerSelectedRows(undefined, true)).toEqual([]);
+  });
+
+  it('normalizes popup select display value according to multiple mode', () => {
+    const fieldNames = { label: 'name', value: 'id' };
+    const rows = [
+      { id: 1, name: 'A' },
+      { id: 2, name: 'B' },
+    ];
+
+    expect(normalizeRecordPickerValue(rows, fieldNames, true)).toEqual([
+      { id: 1, name: 'A', label: 'A', value: 1 },
+      { id: 2, name: 'B', label: 'B', value: 2 },
+    ]);
+    expect(normalizeRecordPickerValue(rows, fieldNames, false)).toEqual({ id: 1, name: 'A', label: 'A', value: 1 });
+    expect(normalizeRecordPickerValue(undefined, fieldNames, true)).toEqual([]);
+    expect(normalizeRecordPickerValue(undefined, fieldNames, false)).toBeUndefined();
+  });
+
+  it('returns the empty popup select value for the current multiple mode', () => {
+    expect(getRecordPickerEmptyValue(true)).toEqual([]);
+    expect(getRecordPickerEmptyValue(false)).toBeUndefined();
+  });
+
+  it('clears popup select value to undefined when multiple mode changes', () => {
+    expect(getRecordPickerClearedValue()).toBeUndefined();
+  });
+
+  it('detects when changing multiple mode should clear popup select value', () => {
+    expect(shouldClearRecordPickerValueOnMultipleChange({ type: 'belongsToMany' }, true, false)).toBe(true);
+    expect(shouldClearRecordPickerValueOnMultipleChange({ type: 'belongsToMany' }, false, true)).toBe(true);
+    expect(shouldClearRecordPickerValueOnMultipleChange({ type: 'belongsToMany' }, true, true)).toBe(false);
+    expect(shouldClearRecordPickerValueOnMultipleChange({ type: 'belongsTo' }, true, false)).toBe(false);
+  });
+
   it('itemChain helpers: createParentItemAccessorsFromInputArgs works', () => {
     const inputArgs = {
       parentItem: { value: { id: 1 } },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
To-many association fields using the v2 popup select component always opened a multi-select table. Users need a setting to disable multiple selection and make the popup table use single-row selection instead.

### Description 
This PR adds a `Multiple` setting to the v2 popup select association field for to-many relations.

Key changes:
- Supports disabling multiple selection for `belongsToMany`, `hasMany`, and `belongsToArray` popup select fields.
- Switches the popup table selection type between checkbox and radio based on the setting.
- Clears the selected value to `undefined` when the `Multiple` setting changes.
- Keeps the popup select display value and selected-row normalization consistent with the current selection mode.
- Adds unit tests for selection-mode resolution and value normalization.

Potential risks:
- The actual settings popover interaction is not covered by an end-to-end test.
- Clearing the form value relies on the normal field `onChange` path.

Testing suggestions:
- Configure a to-many association field as Popup select, select records, then toggle `Multiple` off and confirm the field is cleared.
- Open the select popup after toggling `Multiple` off and confirm the table uses radio selection.
- Toggle `Multiple` on again and confirm the table uses checkbox selection.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added support for disabling multiple selection in v2 popup select association fields. |
| 🇨🇳 Chinese | 支持在 v2 弹窗选择关系字段中关闭多选。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
