### PR TITLE
refactor(plugin-file-manager): support upload sub paths

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
@@ -8,6 +8,7 @@
  */
 
 import path from 'path';
+import { promises as fs } from 'fs';
 import { Readable } from 'stream';
 
 import { getApp } from '.';
@@ -112,6 +113,44 @@ describe('file manager > server', () => {
         };
         expect(model.toJSON()).toMatchObject(matcher);
       });
+
+      it('should append subPath under storage path', async () => {
+        const storage = await StorageRepo.create({
+          values: {
+            name: 'local2',
+            type: STORAGE_TYPE_LOCAL,
+            baseUrl: DEFAULT_LOCAL_BASE_URL,
+            path: 'base',
+            rules: {
+              size: 1024,
+            },
+            paranoid: true,
+          },
+        });
+
+        const model = await plugin.createFileRecord({
+          collectionName: 'attachments',
+          storageName: 'local2',
+          filePath: path.resolve(__dirname, './files/text.txt'),
+          subPath: 'orders/123',
+        });
+
+        expect(model.toJSON()).toMatchObject({
+          title: 'text',
+          extname: '.txt',
+          path: 'base/orders/123',
+          meta: {},
+          storageId: storage.id,
+        });
+
+        const cachedStorage = plugin.storagesCache.get(storage.id);
+        expect(cachedStorage.path).toBe('base');
+
+        const file = await fs.readFile(
+          path.resolve(process.cwd(), LOCAL_STORAGE_DEST, 'base/orders/123', model.get('filename')),
+        );
+        expect(file.toString().includes('Hello world!')).toBe(true);
+      });
     });
 
     describe('uploadFile', () => {
@@ -128,6 +167,43 @@ describe('file manager > server', () => {
           storageId: defaultStorage.id,
         };
         expect(data).toMatchObject(matcher);
+      });
+
+      it('should upload file to subPath', async () => {
+        const data = await plugin.uploadFile({
+          filePath: path.resolve(__dirname, './files/text.txt'),
+          documentRoot: 'storage/backups/test',
+          subPath: 'exports/2026',
+        });
+
+        expect(data).toMatchObject({
+          title: 'text',
+          extname: '.txt',
+          path: 'exports/2026',
+          meta: {},
+          storageId: defaultStorage.id,
+        });
+
+        const file = await fs.readFile(
+          path.resolve(process.cwd(), 'storage/backups/test', 'exports/2026', data.filename),
+        );
+        expect(file.toString().includes('Hello world!')).toBe(true);
+      });
+
+      it('should reject unsafe subPath before upload', async () => {
+        await expect(
+          plugin.uploadFile({
+            filePath: path.resolve(__dirname, './files/text.txt'),
+            subPath: '../outside',
+          }),
+        ).rejects.toThrow('Access denied');
+
+        await expect(
+          plugin.uploadFile({
+            filePath: path.resolve(__dirname, './files/text.txt'),
+            subPath: '/absolute',
+          }),
+        ).rejects.toThrow('Invalid storage sub path');
       });
     });
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
@@ -12,7 +12,7 @@ import PluginFileManagerServer from '../server';
 
 import { STORAGE_TYPE_LOCAL } from '../../constants';
 
-import { cloudFilenameGetter, getFileKey } from '../utils';
+import { cloudFilenameGetter, getFileKey, normalizeStorageSubPath, resolveStoragePath } from '../utils';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -97,6 +97,25 @@ describe('file manager > utils', () => {
   describe('getFileKey', () => {
     it('handles null path', async () => {
       expect(getFileKey({ path: null, filename: 'test.jpg' })).toBe('test.jpg');
+    });
+  });
+
+  describe('storage sub path helpers', () => {
+    it('appends subPath under storage path', () => {
+      expect(resolveStoragePath('base/path', 'orders/123')).toBe('base/path/orders/123');
+      expect(resolveStoragePath('/base/path//', 'orders\\123')).toBe('base/path/orders/123');
+    });
+
+    it('does not append empty subPath', () => {
+      expect(resolveStoragePath('base/path', '')).toBe('base/path');
+      expect(resolveStoragePath('base/path')).toBe('base/path');
+    });
+
+    it('rejects unsafe subPath', () => {
+      expect(() => normalizeStorageSubPath('/absolute')).toThrow('Invalid storage sub path');
+      expect(() => normalizeStorageSubPath('../outside')).toThrow('Access denied');
+      expect(() => normalizeStorageSubPath('safe\0path')).toThrow('Invalid storage sub path');
+      expect(() => normalizeStorageSubPath(1)).toThrow('Invalid storage sub path');
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
@@ -23,7 +23,7 @@ import StorageTypeAliOss from './storages/ali-oss';
 import StorageTypeLocal, { validateLocalStorageConfig } from './storages/local';
 import StorageTypeS3 from './storages/s3';
 import StorageTypeTxCos from './storages/tx-cos';
-import { encodeURL } from './utils';
+import { encodeURL, resolveStoragePath } from './utils';
 import { registerRepairFilenamesCommand } from './commands/repair-filenames';
 
 export type * from './storages';
@@ -44,12 +44,14 @@ export type FileRecordOptions = {
   collectionName: string;
   filePath: string;
   storageName?: string;
+  subPath?: string;
   values?: any;
 } & Transactionable;
 
 export type UploadFileOptions = {
   filePath: string;
   storageName?: string;
+  subPath?: string;
   documentRoot?: string;
 };
 
@@ -94,14 +96,14 @@ export class PluginFileManagerServer extends Plugin {
   }
 
   async createFileRecord(options: FileRecordOptions) {
-    const { values, storageName, collectionName, filePath, transaction } = options;
+    const { values, storageName, subPath, collectionName, filePath, transaction } = options;
     const collection = this.db.getCollection(collectionName);
     if (!collection) {
       throw new Error(`collection does not exist`);
     }
     const collectionRepository = this.db.getRepository(collectionName);
     const name = storageName || collection.options.storage;
-    const data = await this.uploadFile({ storageName: name, filePath });
+    const data = await this.uploadFile({ storageName: name, subPath, filePath });
     return await collectionRepository.create({ values: { ...data, ...values }, transaction });
   }
 
@@ -110,17 +112,23 @@ export class PluginFileManagerServer extends Plugin {
   }
 
   async uploadFile(options: UploadFileOptions) {
-    const { storageName, filePath, documentRoot } = options;
+    const { storageName, subPath, filePath, documentRoot } = options;
 
     if (!this.storagesCache.size) {
       await this.loadStorages();
     }
     const storages = Array.from(this.storagesCache.values());
-    const storage = storages.find((item) => item.name === storageName) || storages.find((item) => item.default);
+    const cachedStorage = storages.find((item) => item.name === storageName) || storages.find((item) => item.default);
 
-    if (!storage) {
+    if (!cachedStorage) {
       throw new Error('[file-manager] no linked or default storage provided');
     }
+
+    const storage = {
+      ...cachedStorage,
+      options: { ...(cachedStorage.options || {}) },
+      path: resolveStoragePath(cachedStorage.path, subPath),
+    };
 
     const fileStream = fs.createReadStream(filePath);
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/utils.ts
@@ -103,6 +103,48 @@ export function getFileKey(record) {
   return urlJoin(record.path || '', record.filename).replace(/^\//, '');
 }
 
+function pathError(message: string) {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = 'PATH_TRAVERSAL';
+  return error;
+}
+
+function normalizeStoragePathForJoin(value: unknown, message: string, { allowLeadingSlash = false } = {}) {
+  if (value == null || value === '') {
+    return '';
+  }
+  if (typeof value !== 'string' || value.includes('\0')) {
+    throw pathError(message);
+  }
+  const normalized = value.replace(/\\/g, '/');
+  if (!allowLeadingSlash && normalized.startsWith('/')) {
+    throw pathError(message);
+  }
+  const segments = normalized
+    .replace(/^\/+|\/+$/g, '')
+    .split('/')
+    .filter((segment) => segment && segment !== '.');
+  if (segments.some((segment) => segment === '..')) {
+    throw pathError('Access denied');
+  }
+  return segments.join('/');
+}
+
+export function normalizeStorageSubPath(subPath?: unknown) {
+  return normalizeStoragePathForJoin(subPath, 'Invalid storage sub path');
+}
+
+export function resolveStoragePath(storagePath?: unknown, subPath?: unknown) {
+  const normalizedSubPath = normalizeStorageSubPath(subPath);
+  if (!normalizedSubPath) {
+    return typeof storagePath === 'string' ? storagePath : '';
+  }
+  const normalizedStoragePath = normalizeStoragePathForJoin(storagePath, 'Invalid storage path', {
+    allowLeadingSlash: true,
+  });
+  return normalizedStoragePath ? `${normalizedStoragePath}/${normalizedSubPath}` : normalizedSubPath;
+}
+
 export function ensureUrlEncoded(value) {
   try {
     // 如果解码后与原字符串不同，说明已经被转义过


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Allow internal file-manager callers to place uploaded files under a per-file subdirectory without mutating storage configuration or overriding record fields after upload.

### Description 
- Added `subPath` to `createFileRecord()` and `uploadFile()`.
- Resolve the final upload path as `storage.path + subPath` using a cloned storage config.
- Added normalization and safety checks for `subPath` before upload.
- Added service-level and utility tests covering path append, empty subPath, unsafe subPath, local file placement, and cache isolation.

Potential risk: this changes internal upload service path resolution when `subPath` is provided. The HTTP upload action is unchanged.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add internal upload `subPath` support for file manager. |
| 🇨🇳 Chinese | 为文件管理器内部上传接口增加 `subPath` 支持。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
