### PR TITLE
fix(database): hash password on bulk update

### DIFF
--- a/packages/core/database/src/__tests__/fields/password-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/password-field.test.ts
@@ -62,6 +62,48 @@ describe('password field', () => {
     expect(await pwd.verify('123456', user.password)).toBeTruthy();
   });
 
+  it('should hash password values when bulk updating', async () => {
+    const User = db.collection({
+      name: 'users',
+      fields: [
+        { type: 'string', name: 'name' },
+        { type: 'password', name: 'password' },
+      ],
+    });
+    await db.sync();
+
+    await User.model.bulkCreate([
+      {
+        password: '123456',
+        name: 'zhangsan',
+      },
+      {
+        password: '123456',
+        name: 'lisi',
+      },
+    ]);
+
+    await User.model.update(
+      {
+        password: '654321',
+      },
+      {
+        where: {
+          name: ['zhangsan', 'lisi'],
+        },
+      },
+    );
+
+    const pwd = User.getField<PasswordField>('password');
+    const users = await User.model.findAll({ order: [['name', 'ASC']] });
+    expect(users).toHaveLength(2);
+
+    for (const user of users) {
+      expect(user.password).not.toBe('654321');
+      expect(await pwd.verify('654321', user.password)).toBeTruthy();
+    }
+  });
+
   it('should hash numeric password values', async () => {
     const User = db.collection({
       name: 'users',

--- a/packages/core/database/src/fields/password-field.ts
+++ b/packages/core/database/src/fields/password-field.ts
@@ -9,6 +9,7 @@
 
 import crypto from 'crypto';
 import { DataTypes } from 'sequelize';
+import type { UpdateOptions } from 'sequelize';
 import { Model } from '../model';
 import { BaseColumnFieldOptions, Field } from './field';
 
@@ -25,17 +26,57 @@ export interface PasswordFieldOptions extends BaseColumnFieldOptions {
 }
 
 type PasswordValue = string | number;
+type BulkUpdateOptions = UpdateOptions<Record<string, unknown>> & {
+  attributes?: Record<string, unknown>;
+};
 
 export class PasswordField extends Field {
   get dataType() {
     return DataTypes.STRING;
   }
 
-  async verify(password: PasswordValue, hash: string) {
+  listener = async (instances: Model | Model[]) => {
+    const { name } = this.options;
+    const fieldName = name as string;
+    instances = Array.isArray(instances) ? instances : [instances];
+    for (const instance of instances) {
+      if (!instance.changed(fieldName)) {
+        continue;
+      }
+      const value = instance.get(fieldName);
+      if (value !== null && value !== undefined && value !== '') {
+        const password = typeof value === 'number' ? value : String(value);
+        const hash = await this.hash(password);
+        instance.set(fieldName, hash);
+      } else {
+        instance.set(fieldName, instance.previous(fieldName));
+      }
+    }
+  };
+
+  bulkUpdateListener = async (options: BulkUpdateOptions) => {
+    const { name } = this.options;
+    const fieldName = name as string;
+    const { attributes } = options;
+    if (!attributes || !Object.prototype.hasOwnProperty.call(attributes, fieldName)) {
+      return;
+    }
+
+    const value = attributes[fieldName];
+    if (value !== null && value !== undefined && value !== '') {
+      const password = typeof value === 'number' ? value : String(value);
+      attributes[fieldName] = await this.hash(password);
+    } else {
+      delete attributes[fieldName];
+      options.fields = options.fields?.filter((field) => field !== fieldName);
+    }
+  };
+
+  async verify(password: PasswordValue, hash: string): Promise<boolean> {
     const passwordString = password === null || password === undefined ? '' : String(password);
     hash = hash || '';
     const { length = 64, randomBytesSize = 8 } = this.options;
-    return new Promise((resolve, reject) => {
+    return new Promise<boolean>((resolve, reject) => {
       const salt = hash.substring(0, randomBytesSize * 2);
       const key = hash.substring(randomBytesSize * 2);
       crypto.scrypt(passwordString, salt, length / 2 - randomBytesSize, (err, derivedKey) => {
@@ -45,10 +86,10 @@ export class PasswordField extends Field {
     });
   }
 
-  async hash(password: PasswordValue) {
+  async hash(password: PasswordValue): Promise<string> {
     const passwordString = String(password);
     const { length = 64, randomBytesSize = 8 } = this.options;
-    return new Promise((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
       const salt = crypto.randomBytes(randomBytesSize).toString('hex');
       crypto.scrypt(passwordString, salt, length / 2 - randomBytesSize, (err, derivedKey) => {
         if (err) reject(err);
@@ -57,32 +98,12 @@ export class PasswordField extends Field {
     });
   }
 
-  init() {
-    const { name } = this.options;
-    const fieldName = name as string;
-    this.listener = async (instances: Model[]) => {
-      instances = Array.isArray(instances) ? instances : [instances];
-      for (const instance of instances) {
-        if (!instance.changed(fieldName)) {
-          continue;
-        }
-        const value = instance.get(fieldName);
-        if (value !== null && value !== undefined && value !== '') {
-          const password = typeof value === 'number' ? value : String(value);
-          const hash = await this.hash(password);
-          instance.set(fieldName, hash);
-        } else {
-          instance.set(fieldName, instance.previous(fieldName));
-        }
-      }
-    };
-  }
-
   bind() {
     super.bind();
     this.on('beforeCreate', this.listener);
     this.on('beforeBulkCreate', this.listener);
     this.on('beforeUpdate', this.listener);
+    this.on('beforeBulkUpdate', this.bulkUpdateListener);
   }
 
   unbind() {
@@ -90,5 +111,6 @@ export class PasswordField extends Field {
     this.off('beforeCreate', this.listener);
     this.off('beforeBulkCreate', this.listener);
     this.off('beforeUpdate', this.listener);
+    this.off('beforeBulkUpdate', this.bulkUpdateListener);
   }
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Password fields were not hashed correctly when updated through bulk update operations because the bulk update hook receives update options instead of model instances.

### Description
Add a dedicated `beforeBulkUpdate` listener for password fields that hashes password values from bulk update attributes before they are persisted.

Add a regression test covering `Model.update()` bulk password updates and verifying that the stored value is not plaintext and can be verified with the new password.

### Related issues
Task: 4521

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed password fields not being hashed during bulk updates. |
| 🇨🇳 Chinese | 修复密码字段在批量更新时未正确加密的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
