### PR TITLE
fix(client-v2): gate datasource bootstrap

### DIFF
--- a/packages/core/client-v2/src/__tests__/nocobase-buildin-plugin-auth.test.tsx
+++ b/packages/core/client-v2/src/__tests__/nocobase-buildin-plugin-auth.test.tsx
@@ -12,12 +12,41 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { NocoBaseBuildInPlugin } from '../nocobase-buildin-plugin';
 
+const TestingAppSpin = () => <div data-testid="app-spin">app spin</div>;
+
+const TestingAppError = ({ error }: { error: Error }) => <div role="alert">{error.message}</div>;
+
 class SkippedPublicRoutePlugin extends Plugin {
   async load() {
     this.router.add('public', {
       path: '/public',
       skipAuthCheck: true,
       Component: () => <div>public page</div>,
+    });
+  }
+}
+
+class DummySigninRoutePlugin extends Plugin {
+  async load() {
+    this.router.add('signin-test', {
+      path: '/signin',
+      skipAuthCheck: true,
+      Component: () => <div>signin page</div>,
+    });
+  }
+}
+
+class AuthBootstrapRoutePlugin extends Plugin {
+  async load() {
+    this.router.add('secure', {
+      path: '/secure',
+      authCheck: true,
+      Component: () => <div>secure page</div>,
+    });
+    this.router.add('guest', {
+      path: '/guest',
+      authCheck: false,
+      Component: () => <div>guest page</div>,
     });
   }
 }
@@ -153,6 +182,176 @@ describe('nocobase buildin plugin auth redirect', () => {
       expect(app.router.router.state.location.pathname).toBe('/v2/signin');
       expect(app.router.router.state.location.search).toBe('?redirect=%2Fv2%2Fadmin');
     });
+  });
+
+  it('should defer data source bootstrap until auth-required route is authenticated after signin redirect', async () => {
+    const app = createMockClient({
+      publicPath: '/v2/',
+      plugins: [NocoBaseBuildInPlugin as any, DummySigninRoutePlugin as any, AuthBootstrapRoutePlugin as any],
+      components: { AppSpin: TestingAppSpin },
+      router: { type: 'memory', initialEntries: ['/v2/secure'] },
+    });
+    app.apiMock.onGet('app:getLang').reply(200, {
+      data: { lang: 'en-US', resources: { client: {} }, cron: {} },
+    });
+    const events: string[] = [];
+    app.apiMock.onGet('/auth:check').replyOnce(() => {
+      events.push('auth:first');
+      return [200, { data: {} }];
+    });
+    app.apiMock.onGet('/auth:check').reply(() => {
+      events.push('auth:second');
+      return [200, { data: { id: 1 } }];
+    });
+
+    const ensureLoaded = vi.spyOn(app.dataSourceManager, 'ensureLoaded').mockImplementation(() => {
+      if (!app.apiClient.auth.token) {
+        const pending = new Promise<void>(() => undefined);
+        app.dataSourceManager.loadingPromise = pending;
+        return pending;
+      }
+      events.push('bootstrap');
+      expect(events).toContain('auth:second');
+      return Promise.resolve();
+    });
+
+    const Root = app.getRootComponent();
+    render(<Root />);
+
+    await waitFor(() => {
+      expect(app.router.router.state.location.pathname).toBe('/v2/signin');
+      expect(app.router.router.state.location.search).toBe('?redirect=%2Fv2%2Fsecure');
+    });
+    expect(await screen.findByText('signin page')).toBeInTheDocument();
+    expect(screen.queryByTestId('app-spin')).not.toBeInTheDocument();
+    expect(ensureLoaded).not.toHaveBeenCalled();
+    expect(app.dataSourceManager.loadingPromise).toBeNull();
+    expect(events).toEqual(['auth:first']);
+
+    act(() => {
+      app.apiClient.auth.setToken('test-token');
+    });
+
+    await act(async () => {
+      await app.router.router.navigate('/secure');
+    });
+
+    expect(await screen.findByText('secure page')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.querySelector('.ant-spin-spinning')).not.toBeInTheDocument();
+    });
+    expect(ensureLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('should redirect on auth-required /auth:check 401 without bootstrapping data sources', async () => {
+    const app = createMockClient({
+      publicPath: '/v2/',
+      plugins: [NocoBaseBuildInPlugin as any, DummySigninRoutePlugin as any, AuthBootstrapRoutePlugin as any],
+      components: { AppSpin: TestingAppSpin },
+      router: { type: 'memory', initialEntries: ['/v2/secure'] },
+    });
+    app.apiMock.onGet('app:getLang').reply(200, {
+      data: { lang: 'en-US', resources: { client: {} }, cron: {} },
+    });
+    app.apiMock.onGet('/auth:check').reply(401, { errors: [{ code: 'EMPTY_TOKEN' }] });
+    const ensureLoaded = vi.spyOn(app.dataSourceManager, 'ensureLoaded').mockImplementation(() => {
+      const pending = new Promise<void>(() => undefined);
+      app.dataSourceManager.loadingPromise = pending;
+      return pending;
+    });
+
+    const Root = app.getRootComponent();
+    render(<Root />);
+
+    await waitFor(() => {
+      expect(app.router.router.state.location.pathname).toBe('/v2/signin');
+      expect(app.router.router.state.location.search).toBe('?redirect=%2Fv2%2Fsecure');
+    });
+    expect(await screen.findByText('signin page')).toBeInTheDocument();
+    expect(screen.queryByTestId('app-spin')).not.toBeInTheDocument();
+    expect(ensureLoaded).not.toHaveBeenCalled();
+    expect(app.dataSourceManager.loadingPromise).toBeNull();
+  });
+
+  it('should surface non-auth /auth:check errors instead of leaving auth-required route spinning', async () => {
+    const app = createMockClient({
+      publicPath: '/v2/',
+      plugins: [NocoBaseBuildInPlugin as any, AuthBootstrapRoutePlugin as any],
+      components: { AppSpin: TestingAppSpin, AppError: TestingAppError },
+      router: { type: 'memory', initialEntries: ['/v2/secure'] },
+    });
+    app.apiMock.onGet('app:getLang').reply(200, {
+      data: { lang: 'en-US', resources: { client: {} }, cron: {} },
+    });
+    app.apiMock.onGet('/auth:check').reply(500, { errors: [{ message: 'auth check failed' }] });
+    const ensureLoaded = vi.spyOn(app.dataSourceManager, 'ensureLoaded').mockResolvedValue(undefined);
+
+    const Root = app.getRootComponent();
+    render(<Root />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Request failed with status code 500');
+    expect(screen.queryByTestId('app-spin')).not.toBeInTheDocument();
+    expect(ensureLoaded).not.toHaveBeenCalled();
+  });
+
+  it.each(['/v2/signin', '/v2/public'])('should not bootstrap data sources on skipped auth route: %s', async (path) => {
+    const app = createMockClient({
+      publicPath: '/v2/',
+      plugins: [NocoBaseBuildInPlugin as any, DummySigninRoutePlugin as any, SkippedPublicRoutePlugin as any],
+      components: { AppSpin: TestingAppSpin },
+      router: { type: 'memory', initialEntries: [path] },
+    });
+    app.apiMock.onGet('app:getLang').reply(200, {
+      data: { lang: 'en-US', resources: { client: {} }, cron: {} },
+    });
+    const ensureLoaded = vi.spyOn(app.dataSourceManager, 'ensureLoaded').mockResolvedValue(undefined);
+
+    const Root = app.getRootComponent();
+    render(<Root />);
+
+    expect(await screen.findByText(path === '/v2/signin' ? 'signin page' : 'public page')).toBeInTheDocument();
+    expect(screen.queryByTestId('app-spin')).not.toBeInTheDocument();
+    expect(ensureLoaded).not.toHaveBeenCalled();
+    expect(app.apiMock.history.get.filter((request) => request.url === '/auth:check')).toHaveLength(0);
+  });
+
+  it('should bootstrap data sources for authenticated auth-required route access', async () => {
+    const app = createMockClient({
+      publicPath: '/v2/',
+      plugins: [NocoBaseBuildInPlugin as any, AuthBootstrapRoutePlugin as any],
+      router: { type: 'memory', initialEntries: ['/v2/secure'] },
+    });
+    app.apiClient.auth.setToken('test-token');
+    app.apiMock.onGet('app:getLang').reply(200, {
+      data: { lang: 'en-US', resources: { client: {} }, cron: {} },
+    });
+    app.apiMock.onGet('/auth:check').reply(200, { data: { id: 1 } });
+    const ensureLoaded = vi.spyOn(app.dataSourceManager, 'ensureLoaded').mockResolvedValue(undefined);
+
+    const Root = app.getRootComponent();
+    render(<Root />);
+
+    expect(await screen.findByText('secure page')).toBeInTheDocument();
+    expect(ensureLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not auth-check or bootstrap authCheck false routes', async () => {
+    const app = createMockClient({
+      publicPath: '/v2/',
+      plugins: [NocoBaseBuildInPlugin as any, AuthBootstrapRoutePlugin as any],
+      router: { type: 'memory', initialEntries: ['/v2/guest'] },
+    });
+    app.apiMock.onGet('app:getLang').reply(200, {
+      data: { lang: 'en-US', resources: { client: {} }, cron: {} },
+    });
+    const ensureLoaded = vi.spyOn(app.dataSourceManager, 'ensureLoaded').mockResolvedValue(undefined);
+
+    const Root = app.getRootComponent();
+    render(<Root />);
+
+    expect(await screen.findByText('guest page')).toBeInTheDocument();
+    expect(ensureLoaded).not.toHaveBeenCalled();
+    expect(app.apiMock.history.get.filter((request) => request.url === '/auth:check')).toHaveLength(0);
   });
 
   it('should render v2 admin root without redirecting away', async () => {

--- a/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
+++ b/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
@@ -28,6 +28,13 @@ export type CurrentUserState = {
   loading: boolean;
 };
 
+type CurrentUserAuthStatus = 'unknown' | 'authenticated' | 'unauthenticated' | 'redirecting';
+
+type CurrentUserInternalState = CurrentUserState & {
+  authStatus: CurrentUserAuthStatus;
+  error?: Error | null;
+};
+
 export type CurrentRoleOption = {
   name: string;
   title: string;
@@ -151,7 +158,7 @@ const DataSourceBootstrapProvider: FC = ({ children }) => {
       }
     };
 
-    void run();
+    run();
 
     return () => {
       mounted = false;
@@ -173,21 +180,33 @@ const CurrentUserProvider: FC = ({ children }) => {
   const app = useApp<Application>();
   const location = useLocation();
   const navigate = useNavigate();
-  const [state, setState] = useState<CurrentUserState>({ loading: true });
+  const [state, setState] = useState<CurrentUserInternalState>({ loading: true, authStatus: 'unknown' });
   const locationRef = useRef(location);
   locationRef.current = location;
   const authCheckRouteState = getCurrentUserAuthCheckRouteState(app, location.pathname);
+  const shouldBlockAuthRequiredRoute = authCheckRouteState === 'required' && state.authStatus !== 'authenticated';
+  const contextValue = useMemo<CurrentUserState>(
+    () => ({
+      data: state.data,
+      loading: state.loading,
+    }),
+    [state.data, state.loading],
+  );
 
   useEffect(() => {
     let mounted = true;
 
     if (authCheckRouteState !== 'required') {
       // 认证页等免鉴权路由不应再执行 `/auth:check`，否则未登录时会重复鉴权并触发重定向抖动。
-      setState({ loading: false });
+      setState({ loading: false, authStatus: 'unauthenticated', error: null });
       return;
     }
 
-    setState((previous) => (previous.loading ? previous : { ...previous, loading: true }));
+    setState((previous) =>
+      previous.authStatus === 'authenticated'
+        ? previous
+        : { data: previous.data, loading: true, authStatus: 'unknown', error: null },
+    );
 
     const run = async () => {
       try {
@@ -204,11 +223,12 @@ const CurrentUserProvider: FC = ({ children }) => {
         const user = res?.data?.data;
         // 服务端通过 `{ code: 302, redirect }` 通知客户端先去某个中间页(例如 2FA 验证页)。这类响应没有 user.id,但也不能视为未登录——否则会和处理 302 的全局响应拦截器 (例如 plugin-two-factor-authentication 注册的那一个)竞态,而 `window.location.replace` 会覆盖更早发出的 `window.location.href`,把用户错误地弹回登录页。让响应拦截器接管跳转。
         if (user?.code === 302) {
-          setState({ loading: false });
+          setState({ loading: false, authStatus: 'redirecting', error: null });
           return;
         }
         if (user?.id == null) {
           // 用 react-router navigate (虚拟跳转)而不是 location.replace, 这样如果有其他响应拦截器已经发起了 window.location.href 整页跳转(例如 2FA 插件接收到服务端 302 重定向), 真实跳转可以胜出 navigate, 不会被这里的 signin 重定向覆盖。
+          setState({ loading: true, authStatus: 'unauthenticated', error: null });
           navigate(`/signin?redirect=${encodeURIComponent(getCurrentV2RedirectPath(app, locationRef.current))}`, {
             replace: true,
           });
@@ -230,21 +250,28 @@ const CurrentUserProvider: FC = ({ children }) => {
         setState({
           data: res?.data,
           loading: false,
+          authStatus: 'authenticated',
+          error: null,
         });
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (!mounted) {
           return;
         }
 
-        const isAuthError = error?.response?.status === 401 || error?.status === 401;
+        const errorLike = error as { response?: { status?: number }; status?: number };
+        const isAuthError = errorLike?.response?.status === 401 || errorLike?.status === 401;
         if (isAuthError) {
+          setState({ loading: true, authStatus: 'unauthenticated', error: null });
           navigate(`/signin?redirect=${encodeURIComponent(getCurrentV2RedirectPath(app, locationRef.current))}`, {
             replace: true,
           });
           return;
         }
-        setState({ loading: false });
-        throw error;
+        setState({
+          loading: false,
+          authStatus: 'unknown',
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
       }
     };
 
@@ -255,11 +282,15 @@ const CurrentUserProvider: FC = ({ children }) => {
     };
   }, [app, authCheckRouteState, navigate]);
 
-  if (state.loading) {
+  if (state.error) {
+    throw state.error;
+  }
+
+  if (state.loading || shouldBlockAuthRequiredRoute) {
     return app.renderComponent('AppSpin');
   }
 
-  return <CurrentUserContext.Provider value={state}>{children}</CurrentUserContext.Provider>;
+  return <CurrentUserContext.Provider value={contextValue}>{children}</CurrentUserContext.Provider>;
 };
 
 const RootRedirect: FC = () => {
@@ -289,8 +320,9 @@ export class NocoBaseBuildInPlugin extends Plugin<any, Application> {
     this.addComponents();
     this.addRoutes();
 
-    this.app.use(DataSourceBootstrapProvider);
+    // Auth-required routes must finish auth check or redirect before data source metadata requests can start.
     this.app.use(CurrentUserProvider);
+    this.app.use(DataSourceBootstrapProvider);
     this.app.flowEngine.registerModels({
       AdminLayoutModel,
       AdminLayoutMenuItemModel,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/utils.test.ts
@@ -16,7 +16,13 @@ import PluginFileManagerServer from '../server';
 
 import { STORAGE_TYPE_LOCAL } from '../../constants';
 
-import { cloudFilenameGetter, getFileKey, normalizeStorageSubPath, resolveStoragePath } from '../utils';
+import {
+  cloudFilenameGetter,
+  getFileKey,
+  normalizeDocumentRoot,
+  normalizeStorageSubPath,
+  resolveStoragePath,
+} from '../utils';
 import {
   getRepairedAttachmentValues,
   repairAttachmentFilenames,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
未登录用户直接访问需要登录的 v2 页面时，会先跳转到登录页。此前登录成功并回到目标页面后，页面可能一直停留在全局加载状态，用户必须手动刷新才能正常使用。

### Description 
本次调整让需要登录的 v2 页面先完成登录状态确认或跳转登录页，再继续加载页面所需的数据源信息。这样未登录阶段不会提前发起会被登录拦截中断的数据请求，登录成功回跳后也可以正常显示目标页面。

已覆盖登录页、跳过鉴权页面、无需鉴权页面、已登录访问、登录后回跳、401 鉴权失败以及非鉴权错误等场景。测试建议：使用无登录态访问 `/v/admin/...`，确认跳转登录页后登录可直接回到目标页面，无需刷新。

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where v2 pages could keep loading after signing in |
| 🇨🇳 Chinese | 修复 v2 页面登录后一直加载的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
