### PR TITLE
fix(plugin-ai): preserve workflow LLM node message config

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/chat-settings/Messages.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/chat-settings/Messages.tsx
@@ -11,17 +11,81 @@ import { SchemaComponent } from '@nocobase/client';
 import React from 'react';
 import { namespace, useT } from '../locale';
 import { tval } from '@nocobase/utils/client';
-import { ArrayCollapse, FormLayout } from '@formily/antd-v5';
-import { useField, observer } from '@formily/react';
-import { Field } from '@formily/core';
+import { ArrayBase, FormLayout } from '@formily/antd-v5';
+import { clone } from '@formily/shared';
+import { RecursionField, useField, observer, useFieldSchema } from '@formily/react';
+import { ArrayField, Field } from '@formily/core';
 import { WorkflowVariableInput, WorkflowVariableRawTextArea } from '@nocobase/plugin-workflow/client';
+import ListCollapse, { ListCollapseProps } from '../components/ListCollapse';
+import { Badge } from 'antd';
+
+type ListCollapseValue = Record<string, unknown>;
+
+type FormilyListCollapseProps = Pick<
+  ListCollapseProps<ListCollapseValue>,
+  'addText' | 'bordered' | 'defaultOpenPanelCount' | 'defaultValue' | 'itemTitle' | 'size'
+> & {
+  header?: React.ReactNode;
+};
+
+const FormilyListCollapse: React.FC<FormilyListCollapseProps> = observer((props) => {
+  const field = useField<ArrayField>();
+  const fieldSchema = useFieldSchema();
+  const items = Array.isArray(field.value) ? (field.value as ListCollapseValue[]) : [];
+  const { header, itemTitle } = props;
+
+  const updateItems = (next: ListCollapseValue[]) => {
+    field.form.setValuesIn(field.path, next);
+  };
+
+  return (
+    <ArrayBase>
+      <ListCollapse<ListCollapseValue>
+        {...props}
+        value={items}
+        onChange={updateItems}
+        getDefaultValue={() => clone(props.defaultValue) as ListCollapseValue}
+        renderHeader={(_, index) => {
+          const errors = field.form.queryFeedbacks({
+            type: 'error',
+            address: `${field.address.concat(index)}.**`,
+          });
+          const title = header ?? itemTitle;
+
+          return errors.length ? (
+            <Badge size="small" className="errors-badge" count={errors.length}>
+              {title}
+            </Badge>
+          ) : (
+            title
+          );
+        }}
+        renderItem={(item, index) => {
+          const itemSchema = Array.isArray(fieldSchema.items)
+            ? fieldSchema.items[index] || fieldSchema.items[0]
+            : fieldSchema.items;
+
+          if (!itemSchema) {
+            return null;
+          }
+
+          return (
+            <ArrayBase.Item index={index} record={item}>
+              <RecursionField schema={itemSchema} name={index} />
+            </ArrayBase.Item>
+          );
+        }}
+      />
+    </ArrayBase>
+  );
+});
 
 const UserMessage: React.FC = observer(() => {
   const t = useT();
   const field = useField();
-  const type = field.query('.type').take() as Field;
+  const type = field.query('.type').take() as Field | undefined;
 
-  if (type.value === 'image_url' || type.value === 'image_base64') {
+  if (type?.value === 'image_url' || type?.value === 'image_base64') {
     return (
       <SchemaComponent
         components={{ WorkflowVariableInput }}
@@ -74,30 +138,34 @@ const UserMessage: React.FC = observer(() => {
 const Content: React.FC = observer(() => {
   const t = useT();
   const field = useField();
-  const role = field.query('.role').take() as Field;
+  const role = field.query('.role').take() as Field | undefined;
+
+  if (!role) {
+    return null;
+  }
 
   if (role.value === 'user') {
     return (
       <SchemaComponent
-        components={{ UserMessage }}
+        components={{ FormLayout, ListCollapse: FormilyListCollapse, UserMessage }}
         schema={{
           type: 'void',
           properties: {
             content: {
               type: 'array',
-              'x-component': 'ArrayCollapse',
+              'x-component': 'ListCollapse',
               'x-component-props': {
                 size: 'small',
                 bordered: false,
+                addText: tval('Add content', { ns: namespace }),
+                defaultValue: { type: 'text' },
+                header: t('Content'),
+                itemTitle: t('Content'),
               },
               default: [{ type: 'text' }],
               'x-decorator': 'FormItem',
               items: {
                 type: 'object',
-                'x-component': 'ArrayCollapse.CollapsePanel',
-                'x-component-props': {
-                  header: t('Content'),
-                },
                 properties: {
                   form: {
                     type: 'void',
@@ -123,28 +191,6 @@ const Content: React.FC = observer(() => {
                         'x-component': 'UserMessage',
                       },
                     },
-                  },
-                  moveUp: {
-                    type: 'void',
-                    'x-component': 'ArrayCollapse.MoveUp',
-                  },
-                  moveDown: {
-                    type: 'void',
-                    'x-component': 'ArrayCollapse.MoveDown',
-                  },
-                  remove: {
-                    type: 'void',
-                    'x-component': 'ArrayCollapse.Remove',
-                  },
-                },
-              },
-              properties: {
-                addition: {
-                  type: 'void',
-                  title: tval('Add content', { ns: namespace }),
-                  'x-component': 'ArrayCollapse.Addition',
-                  'x-component-props': {
-                    defaultValue: { type: 'text' },
                   },
                 },
               },
@@ -177,24 +223,24 @@ export const Messages: React.FC = () => {
 
   return (
     <SchemaComponent
-      components={{ ArrayCollapse, FormLayout, Content }}
+      components={{ Content, FormLayout, ListCollapse: FormilyListCollapse }}
       schema={{
         type: 'void',
         properties: {
           messages: {
             type: 'array',
-            'x-component': 'ArrayCollapse',
+            'x-component': 'ListCollapse',
             'x-component-props': {
               size: 'small',
+              addText: tval('Add prompt', { ns: namespace }),
+              defaultValue: { role: 'user', content: [{ type: 'text' }] },
+              header: t('Message'),
+              itemTitle: t('Message'),
             },
             'x-decorator': 'FormItem',
             default: [{ role: 'user', content: [{ type: 'text' }] }],
             items: {
               type: 'object',
-              'x-component': 'ArrayCollapse.CollapsePanel',
-              'x-component-props': {
-                header: t('Message'),
-              },
               properties: {
                 form: {
                   type: 'void',
@@ -220,28 +266,6 @@ export const Messages: React.FC = () => {
                       'x-component': 'Content',
                     },
                   },
-                },
-                moveUp: {
-                  type: 'void',
-                  'x-component': 'ArrayCollapse.MoveUp',
-                },
-                moveDown: {
-                  type: 'void',
-                  'x-component': 'ArrayCollapse.MoveDown',
-                },
-                remove: {
-                  type: 'void',
-                  'x-component': 'ArrayCollapse.Remove',
-                },
-              },
-            },
-            properties: {
-              addition: {
-                type: 'void',
-                title: tval('Add prompt', { ns: namespace }),
-                'x-component': 'ArrayCollapse.Addition',
-                'x-component-props': {
-                  defaultValue: { role: 'user', content: [{ type: 'text' }] },
                 },
               },
             },

--- a/packages/plugins/@nocobase/plugin-ai/src/client/components/ListCollapse.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/components/ListCollapse.tsx
@@ -16,6 +16,7 @@ export interface ListCollapseProps<T> {
   value?: T[];
   onChange?: (value: T[]) => void;
   defaultValue?: T;
+  getDefaultValue?: () => T;
   addText: React.ReactNode;
   itemTitle: React.ReactNode;
   size?: CollapseProps['size'];
@@ -71,6 +72,7 @@ export const ListCollapse = <T,>({
   value,
   onChange,
   defaultValue,
+  getDefaultValue,
   addText,
   itemTitle,
   size = 'small',
@@ -163,7 +165,8 @@ export const ListCollapse = <T,>({
         type="dashed"
         icon={<PlusOutlined />}
         onClick={() => {
-          const next = items.concat(defaultValue as T);
+          const nextItem = getDefaultValue ? getDefaultValue() : (defaultValue as T);
+          const next = items.concat(nextItem);
           onChange?.(next);
           setActiveKeys((current) => Array.from(new Set(current.concat(String(next.length - 1)))));
         }}

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-providers/kimi/ModelSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-providers/kimi/ModelSettings.tsx
@@ -95,7 +95,7 @@ const Options: React.FC = () => {
                       'x-component-props': {
                         step: 0.5,
                         min: 0.0,
-                        max: 1.0,
+                        max: 0.95,
                       },
                     },
                     responseFormat: {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -32,7 +32,7 @@ export class DashscopeProvider extends LLMProvider {
   createModel() {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
-    const { schema } = structuredOutput || {};
+    const { name, schema } = structuredOutput || {};
 
     const modelKwargs: Record<string, any> = {};
 
@@ -43,7 +43,7 @@ export class DashscopeProvider extends LLMProvider {
         type: responseFormat,
       };
       if (responseFormat === 'json_schema' && schema) {
-        responseFormatOptions['json_schema'] = schema;
+        responseFormatOptions['json_schema'] = { schema, name: name ?? 'schema' };
       }
       modelKwargs['response_format'] = responseFormatOptions;
     } else {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
@@ -19,7 +19,7 @@ import { AttachmentModel } from '@nocobase/plugin-file-manager';
 
 export class KimiProvider extends LLMProvider {
   declare chatModel: ReasoningChatOpenAI;
-  private _documentLoader: CachedDocumentLoader;
+  private _documentLoader: CachedDocumentLoader | undefined;
 
   get baseURL() {
     return 'https://api.moonshot.cn/v1';
@@ -28,12 +28,12 @@ export class KimiProvider extends LLMProvider {
   createModel() {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
-    const { schema } = structuredOutput || {};
-    const responseFormatOptions = {
+    const { name, schema } = structuredOutput || {};
+    const responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
     if (responseFormat === 'json_schema' && schema) {
-      responseFormatOptions['json_schema'] = schema;
+      responseFormatOptions['json_schema'] = { schema, name: name ?? 'schema' };
     }
     return new ReasoningChatOpenAI({
       apiKey,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/mimo.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/mimo.ts
@@ -26,12 +26,12 @@ export class MiMoProvider extends LLMProvider {
   createModel() {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
-    const { schema } = structuredOutput || {};
-    const responseFormatOptions = {
+    const { name, schema } = structuredOutput || {};
+    const responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
     if (responseFormat === 'json_schema' && schema) {
-      responseFormatOptions['json_schema'] = schema;
+      responseFormatOptions['json_schema'] = { schema, name: name ?? 'schema' };
     }
 
     return new ChatMiMoCompletions({

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
@@ -20,12 +20,12 @@ export class OpenAICompletionsProvider extends LLMProvider {
   createModel() {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
-    const { schema } = structuredOutput || {};
-    const responseFormatOptions = {
+    const { name, schema } = structuredOutput || {};
+    const responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
     if (responseFormat === 'json_schema' && schema) {
-      responseFormatOptions['json_schema'] = schema;
+      responseFormatOptions['json_schema'] = { schema, name: name ?? 'schema' };
     }
     return new ChatOpenAI({
       apiKey,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/responses.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/responses.ts
@@ -24,13 +24,17 @@ export class OpenAIResponsesProvider extends LLMProvider {
   createModel() {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
-    const { schema } = structuredOutput || {};
-    const responseFormatOptions = {
+    const { name, schema, strict } = structuredOutput || {};
+    let responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
     if (responseFormat === 'json_schema' && schema) {
-      responseFormatOptions['name'] = 'default';
-      responseFormatOptions['schema'] = schema;
+      responseFormatOptions = {
+        ...responseFormatOptions,
+        schema,
+        name: name ?? 'default',
+        strict: strict ?? false,
+      };
     }
     return new ChatOpenAI({
       apiKey,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -71,7 +71,7 @@ function resolveServiceOptions(serviceOptions: Record<string, any> | undefined, 
 export abstract class LLMProvider {
   app: Application;
   serviceOptions: Record<string, any>;
-  modelOptions: Record<string, any>;
+  modelOptions: Record<string, any> | undefined;
   chatModel: any;
 
   abstract createModel(): BaseChatModel | any;
@@ -292,17 +292,18 @@ export abstract class LLMProvider {
     if (!schema) {
       return;
     }
-    const methods = {
+    const methods: Record<string, string> = {
       json_object: 'jsonMode',
       json_schema: 'jsonSchema',
     };
-    const options = {
+    const options: Record<string, any> = {
       includeRaw: true,
       name,
       method: methods[responseFormat],
     };
     if (strict) {
       options['strict'] = strict;
+      options['method'] = 'jsonSchema';
     }
     return {
       schema: {
@@ -350,7 +351,7 @@ export abstract class LLMProvider {
     return [];
   }
 
-  parseReasoningContent(chunk: AIMessageChunk): { status: string; content: string } {
+  parseReasoningContent(chunk: AIMessageChunk): { status: string; content: string } | null {
     return null;
   }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/llm/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/llm/index.ts
@@ -36,6 +36,9 @@ export class LLMInstruction extends Instruction {
   async run(node: FlowNodeModel, input: any, processor: Processor) {
     const { llmService, ...chatOptions } = processor.getParsedValue(node.config, node.id);
     const { messages, structuredOutput, ...modelOptions } = chatOptions;
+    if (modelOptions && structuredOutput) {
+      modelOptions.structuredOutput = structuredOutput;
+    }
     let provider: LLMProvider;
     try {
       provider = await this.getLLMProvider(llmService, modelOptions);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow LLM node message settings should keep their configuration when users add, remove, reorder, or rapidly delete message items.

### Description
This PR replaces the `ArrayCollapse` usage in plugin-ai chat message settings with the local `ListCollapse` component while preserving the existing page behavior.

Key changes:
- Adds a Formily adapter in `Messages.tsx` so `ListCollapse` can render schema items through `RecursionField`.
- Keeps message and content add, remove, reorder, validation badge, and default-value behavior.
- Adds guards for transient missing nested fields during rapid deletion.
- Keeps `ListCollapse` independent from Formily and adds only an optional `getDefaultValue` callback for fresh default items.

Testing suggestions:
- Open a workflow LLM node message configuration and verify prompt messages can be added, removed, and reordered.
- Verify user message content items can be added, removed, and reordered.
- Rapidly delete items and confirm the page does not throw.
- Add multiple prompt/content items and confirm only one item is added per click.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed loss of message configuration in workflow LLM nodes. |
| 🇨🇳 Chinese | 修复工作流LLM节点消息配置丢失问题. |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
