### PR TITLE
feat(locale-tester): add client v2 settings page

### DIFF
--- a/packages/plugins/@nocobase/plugin-locale-tester/client-v2.d.ts
+++ b/packages/plugins/@nocobase/plugin-locale-tester/client-v2.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/client-v2';
+export { default } from './dist/client-v2';

--- a/packages/plugins/@nocobase/plugin-locale-tester/client-v2.js
+++ b/packages/plugins/@nocobase/plugin-locale-tester/client-v2.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/client-v2/index.js');

--- a/packages/plugins/@nocobase/plugin-locale-tester/package.json
+++ b/packages/plugins/@nocobase/plugin-locale-tester/package.json
@@ -8,6 +8,7 @@
   "main": "dist/server/index.js",
   "peerDependencies": {
     "@nocobase/client": "2.x",
+    "@nocobase/client-v2": "2.x",
     "@nocobase/server": "2.x",
     "@nocobase/test": "2.x"
   },

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/__tests__/LocaleTesterPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/__tests__/LocaleTesterPage.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LocaleTesterPage from '../pages/LocaleTesterPage';
+
+const testState = vi.hoisted(() => ({
+  request: vi.fn(),
+  messageSuccess: vi.fn(),
+  reloadWindow: vi.fn(),
+}));
+
+vi.mock('../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../utils', () => ({
+  reloadWindow: testState.reloadWindow,
+}));
+
+vi.mock('@nocobase/client-v2', async () => {
+  const actual = await vi.importActual<typeof import('@nocobase/client-v2')>('@nocobase/client-v2');
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    ...actual,
+    JsonTextArea: ({ value, onChange }: { value?: unknown; onChange?: (value: unknown) => void }) =>
+      React.createElement('textarea', {
+        'aria-label': 'Translations',
+        value: value == null ? '' : JSON.stringify(value),
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+          onChange?.(event.target.value ? JSON.parse(event.target.value) : null);
+        },
+      }),
+  };
+});
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<typeof import('@nocobase/flow-engine')>('@nocobase/flow-engine');
+
+  return {
+    ...actual,
+    useFlowContext: () => ({
+      api: {
+        request: testState.request,
+      },
+    }),
+  };
+});
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+
+  return {
+    ...actual,
+    App: {
+      ...actual.App,
+      useApp: () => ({
+        message: {
+          success: testState.messageSuccess,
+        },
+      }),
+    },
+  };
+});
+
+function renderPage() {
+  return render(<LocaleTesterPage />);
+}
+
+describe('LocaleTesterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.request.mockResolvedValue({
+      data: {
+        data: {
+          id: 1,
+          locale: {
+            '@nocobase/plugin-demo': {
+              Hello: 'Hello',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('loads the locale tester record into the JSON editor', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(testState.request).toHaveBeenCalledWith({
+        url: 'localeTester:get',
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText('Translations')).toHaveValue(
+        JSON.stringify({
+          '@nocobase/plugin-demo': {
+            Hello: 'Hello',
+          },
+        }),
+      );
+    });
+  });
+
+  it('submits the v1-compatible updateOrCreate payload', async () => {
+    renderPage();
+
+    const editor = await screen.findByLabelText('Translations');
+    fireEvent.change(editor, {
+      target: {
+        value: JSON.stringify({
+          '@nocobase/plugin-demo': {
+            Hello: 'Hi',
+          },
+        }),
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(testState.request).toHaveBeenCalledWith({
+        url: 'localeTester:updateOrCreate',
+        method: 'post',
+        params: {
+          filterKeys: ['id'],
+        },
+        data: {
+          id: 1,
+          locale: {
+            '@nocobase/plugin-demo': {
+              Hello: 'Hi',
+            },
+          },
+        },
+      });
+    });
+    expect(testState.messageSuccess).toHaveBeenCalledWith('Saved successfully!');
+    expect(testState.reloadWindow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/__tests__/plugin.test.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+describe('PluginLocaleTesterClientV2', () => {
+  it('registers the locale tester settings page lazily', async () => {
+    const { default: PluginLocaleTesterClientV2 } = await import('../plugin');
+    const app = {
+      i18n: {
+        t: vi.fn((key) => key),
+      },
+      pluginSettingsManager: {
+        addMenuItem: vi.fn(),
+        addPageTabItem: vi.fn(),
+      },
+    };
+    const plugin = new PluginLocaleTesterClientV2({} as never, app as never);
+
+    await plugin.load();
+
+    expect(app.pluginSettingsManager.addMenuItem).toHaveBeenCalledWith({
+      key: 'locale-tester',
+      title: 'Locale tester',
+      icon: 'TranslationOutlined',
+      aclSnippet: 'pm.locale-tester',
+    });
+    expect(app.pluginSettingsManager.addPageTabItem).toHaveBeenCalledWith({
+      menuKey: 'locale-tester',
+      key: 'index',
+      title: 'Locale tester',
+      componentLoader: expect.any(Function),
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/index.tsx
@@ -1,0 +1,10 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export { default } from './plugin';

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/locale.ts
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/locale.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr as flowTExpr, useFlowEngine } from '@nocobase/flow-engine';
+// @ts-ignore
+import pkg from '../../package.json';
+
+export const NAMESPACE = pkg.name;
+
+export function tExpr(key: string) {
+  return flowTExpr(key, { ns: [NAMESPACE, 'client'] });
+}
+
+export function useT() {
+  const engine = useFlowEngine();
+  return (key: string, options?: Record<string, unknown>) =>
+    engine.context.t(key, { ns: [NAMESPACE, 'client'], ...options });
+}

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/pages/LocaleTesterPage.tsx
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/pages/LocaleTesterPage.tsx
@@ -1,0 +1,112 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { JsonTextArea } from '@nocobase/client-v2';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import { Alert, App, Button, Card, Flex, Form, theme } from 'antd';
+import React from 'react';
+import { useT } from '../locale';
+import { reloadWindow } from '../utils';
+
+type LocaleTesterRecord = {
+  id?: number | string;
+  locale?: unknown;
+};
+
+type ResourceResponse<T> = {
+  data?: T;
+};
+
+type LocaleTesterFormValues = {
+  locale?: unknown;
+};
+
+const descriptionKey =
+  'Please go to <a target="_blank" href="https://github.com/nocobase/locales">nocobase/locales</a> to get the language file that needs translation, then paste it below and provide the translation.';
+
+const LocaleTesterPage = () => {
+  const ctx = useFlowContext();
+  const t = useT();
+  const { message } = App.useApp();
+  const { token } = theme.useToken();
+  const [form] = Form.useForm<LocaleTesterFormValues>();
+
+  const localeRequest = useRequest<LocaleTesterRecord | undefined, []>(
+    async () => {
+      const response = await ctx.api.request<ResourceResponse<LocaleTesterRecord>>({
+        url: 'localeTester:get',
+      });
+
+      return response.data?.data;
+    },
+    {
+      onSuccess(record) {
+        form.setFieldsValue({
+          locale: record?.locale,
+        });
+      },
+    },
+  );
+
+  const saveRequest = useRequest(
+    async (values: LocaleTesterFormValues) => {
+      await ctx.api.request({
+        url: 'localeTester:updateOrCreate',
+        method: 'post',
+        params: {
+          filterKeys: ['id'],
+        },
+        data: {
+          id: localeRequest.data?.id,
+          locale: values.locale,
+        },
+      });
+    },
+    {
+      manual: true,
+      onSuccess() {
+        message.success(t('Saved successfully!'));
+        reloadWindow();
+      },
+    },
+  );
+
+  const handleSubmit = (values: LocaleTesterFormValues) => {
+    saveRequest.run(values);
+  };
+
+  return (
+    <Card loading={localeRequest.loading}>
+      <Flex vertical gap={token.marginSM}>
+        <Alert
+          description={
+            <span
+              dangerouslySetInnerHTML={{
+                __html: t(descriptionKey),
+              }}
+            />
+          }
+        />
+        <Form form={form} layout="vertical" onFinish={handleSubmit}>
+          <Form.Item name="locale" label={t('Translations')}>
+            <JsonTextArea autoSize={{ minRows: 20, maxRows: 30 }} />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={saveRequest.loading}>
+              {t('Submit')}
+            </Button>
+          </Form.Item>
+        </Form>
+      </Flex>
+    </Card>
+  );
+};
+
+export default LocaleTesterPage;

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/plugin.tsx
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Application } from '@nocobase/client-v2';
+import { Plugin } from '@nocobase/client-v2';
+
+export class PluginLocaleTesterClientV2 extends Plugin<Record<string, never>, Application> {
+  async load() {
+    const title = this.t('Locale tester') as unknown as string;
+
+    this.pluginSettingsManager.addMenuItem({
+      key: 'locale-tester',
+      title,
+      icon: 'TranslationOutlined',
+      aclSnippet: 'pm.locale-tester',
+    });
+
+    this.pluginSettingsManager.addPageTabItem({
+      menuKey: 'locale-tester',
+      key: 'index',
+      title,
+      componentLoader: () => import('./pages/LocaleTesterPage'),
+    });
+  }
+}
+
+export default PluginLocaleTesterClientV2;

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/utils.ts
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/client-v2/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export function reloadWindow() {
+  window.location.reload();
+}

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/locale/en-US.json
@@ -2,5 +2,7 @@
   "Locale": "Locale",
   "Locale tester": "Locale tester",
   "Please go to <a target=\"_blank\" href=\"https://github.com/nocobase/locales\">nocobase/locales</a> to get the language file that needs translation, then paste it below and provide the translation.": "Please go to <a target=\"_blank\" href=\"https://github.com/nocobase/locales\">nocobase/locales</a> to get the language file that needs translation, then paste it below and provide the translation.",
+  "Saved successfully!": "Saved successfully!",
+  "Submit": "Submit",
   "Translations": "Translations"
 }

--- a/packages/plugins/@nocobase/plugin-locale-tester/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-locale-tester/src/locale/zh-CN.json
@@ -2,5 +2,7 @@
   "Locale": "Locale",
   "Locale tester": "翻译测试工具",
   "Please go to <a target=\"_blank\" href=\"https://github.com/nocobase/locales\">nocobase/locales</a> to get the language file that needs translation, then paste it below and provide the translation.": "请前往 <a target=\"_blank\" href=\"https://github.com/nocobase/locales\">nocobase/locales</a> 获取需要翻译的语言文件，粘贴到下方并进行翻译。",
+  "Saved successfully!": "保存成功！",
+  "Submit": "提交",
   "Translations": "翻译"
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Migrate the locale tester plugin settings page to the client v2 runtime while preserving its existing behavior.

### Description
This PR adds a client v2 entry for `@nocobase/plugin-locale-tester` and registers the locale tester settings page through the v2 plugin settings manager.

Key changes:
- Added `client-v2.js`, `client-v2.d.ts`, and `src/client-v2/` entry files.
- Reimplemented the locale tester settings page with React, antd Form, and the shared `JsonTextArea` component from `@nocobase/client-v2`.
- Preserved the existing `localeTester:get` and `localeTester:updateOrCreate` request shapes.
- Added focused tests for plugin registration, locale loading, and save payload compatibility.

### Related issues

### Showcase
Screenshot captured during local validation: `/tmp/locale-tester-page.png`

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added a client v2 settings page for the locale tester. |
| 🇨🇳 Chinese | 为翻译测试工具新增 client v2 设置页面。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
