### PR TITLE
fix(plugins): normalize popup action URLs

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
@@ -94,6 +94,15 @@ type CalendarActionSubModel = ActionModel & {
   uid: string;
 };
 
+type CalendarPopupActionOptions = {
+  persist?: boolean;
+};
+
+const CALENDAR_LEGACY_POPUP_ACTION_UID_MARKERS: Record<'quickCreateAction' | 'eventViewAction', string[]> = {
+  quickCreateAction: ['quickCreateAction', 'quick-create-action'],
+  eventViewAction: ['eventViewAction', 'event-view-action'],
+};
+
 const DRAG_HANDLER_TOOLBAR_ITEMS = [
   {
     key: 'drag-handler',
@@ -297,8 +306,10 @@ export class CalendarBlockModel extends CollectionBlockModel {
     return this.subModels?.eventViewAction as any;
   }
 
-  getPopupActionUid(actionKey: 'quickCreateAction' | 'eventViewAction') {
-    return `${this.uid}-${actionKey}`;
+  isLegacyPopupActionUid(actionKey: 'quickCreateAction' | 'eventViewAction', actionUid?: string) {
+    return Boolean(
+      actionUid && CALENDAR_LEGACY_POPUP_ACTION_UID_MARKERS[actionKey].some((marker) => actionUid.includes(marker)),
+    );
   }
 
   getPopupSettingsDefaults(actionUid?: string) {
@@ -374,7 +385,11 @@ export class CalendarBlockModel extends CollectionBlockModel {
     };
   }
 
-  async syncPopupActionSettings(action: any, actionKey: 'quickCreateAction' | 'eventViewAction') {
+  async syncPopupActionSettings(
+    action: any,
+    actionKey: 'quickCreateAction' | 'eventViewAction',
+    options: CalendarPopupActionOptions = {},
+  ) {
     if (!action) {
       return;
     }
@@ -387,25 +402,27 @@ export class CalendarBlockModel extends CollectionBlockModel {
 
     action.setStepParams('popupSettings', 'openView', nextSettings);
 
-    if (this.context.flowSettingsEnabled && action?.saveStepParams) {
+    if (options.persist && this.context.flowSettingsEnabled && action?.saveStepParams) {
       await action.saveStepParams();
     }
   }
 
   async loadPopupAction(actionKey: 'quickCreateAction' | 'eventViewAction') {
-    const actionUid = this.getPopupActionUid(actionKey);
     try {
-      return this.flowEngine.getModel(actionUid) || (await this.flowEngine.loadModel({ uid: actionUid }));
+      return await this.flowEngine.loadModel({ parentId: this.uid, subKey: actionKey });
     } catch (error) {
       return null;
     }
   }
 
-  async ensurePopupAction(actionKey: 'quickCreateAction' | 'eventViewAction') {
+  async ensurePopupAction(
+    actionKey: 'quickCreateAction' | 'eventViewAction',
+    options: CalendarPopupActionOptions = {},
+  ) {
     const buildActionOptions =
       actionKey === 'quickCreateAction'
-        ? () => createCalendarQuickCreateActionOptions(this.getPopupActionUid(actionKey))
-        : () => createCalendarEventViewActionOptions(this.getPopupActionUid(actionKey));
+        ? () => createCalendarQuickCreateActionOptions()
+        : () => createCalendarEventViewActionOptions();
     let action = this.subModels?.[actionKey] as any;
 
     if (!action) {
@@ -420,11 +437,33 @@ export class CalendarBlockModel extends CollectionBlockModel {
       action = this.subModels?.[actionKey] as any;
     }
 
-    if (this.context.flowSettingsEnabled && action?.save) {
+    const legacyAction =
+      action?.__legacyPopupAction || (this.isLegacyPopupActionUid(actionKey, action?.uid) ? action : null);
+    if (legacyAction === action && typeof action?.clone === 'function') {
+      const clonedAction = action.clone();
+      Object.defineProperty(clonedAction, '__legacyPopupAction', {
+        value: action,
+        configurable: true,
+      });
+      action = clonedAction;
+      this.setSubModel(actionKey, action);
+    }
+
+    if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
-    await this.syncPopupActionSettings(action, actionKey);
+    await this.syncPopupActionSettings(action, actionKey, options);
+
+    if (
+      options.persist &&
+      legacyAction &&
+      legacyAction.uid !== action?.uid &&
+      typeof legacyAction.destroy === 'function'
+    ) {
+      await legacyAction.destroy();
+      delete action.__legacyPopupAction;
+    }
 
     return action;
   }
@@ -449,12 +488,7 @@ export class CalendarBlockModel extends CollectionBlockModel {
       ...(Object.keys(formData).length ? { formData } : {}),
       ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
       ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
-      navigation: false,
       target: this.context?.layoutContentElement,
-      defineProperties: {
-        calendarSelectedSlot: { value: slotInfo },
-        calendarFieldNames: { value: this.getFieldNames() },
-      },
     };
 
     if (typeof this.context?.openView === 'function' && action.uid) {
@@ -479,7 +513,6 @@ export class CalendarBlockModel extends CollectionBlockModel {
       ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
       ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
       filterByTk,
-      navigation: false,
       target: this.context?.layoutContentElement,
     };
 
@@ -594,11 +627,11 @@ const CalendarBlockRenderer = observer(
         weekStart={model.getWeekStart()}
         resource={model.resource}
         rangeLoadEnabled
-        onSelectSlot={(slotInfo) => {
-          void model.openQuickCreate(slotInfo);
+        onSelectSlot={async (slotInfo) => {
+          await model.openQuickCreate(slotInfo);
         }}
-        onSelectEvent={({ record }) => {
-          void model.openEvent(record);
+        onSelectEvent={async ({ record }) => {
+          await model.openEvent(record);
         }}
         {...colorFunctions}
       />
@@ -828,13 +861,12 @@ CalendarBlockModel.registerFlow({
       async defaultParams(ctx) {
         const model = ctx.model as CalendarBlockModel;
         const action = await model.ensurePopupAction('quickCreateAction');
-        return model.getPopupSettings(action, 'quickCreateAction', model.getPopupActionUid('quickCreateAction'));
+        return model.getPopupSettings(action, 'quickCreateAction', action?.uid);
       },
       async handler(ctx, params) {
         const model = ctx.model as CalendarBlockModel;
         model.setPopupSettings('quickCreateAction', params);
-        const action = await model.ensurePopupAction('quickCreateAction');
-        await model.syncPopupActionSettings(action, 'quickCreateAction');
+        await model.ensurePopupAction('quickCreateAction', { persist: true });
       },
     },
     eventPopupSettings: {
@@ -843,13 +875,12 @@ CalendarBlockModel.registerFlow({
       async defaultParams(ctx) {
         const model = ctx.model as CalendarBlockModel;
         const action = await model.ensurePopupAction('eventViewAction');
-        return model.getPopupSettings(action, 'eventViewAction', model.getPopupActionUid('eventViewAction'));
+        return model.getPopupSettings(action, 'eventViewAction', action?.uid);
       },
       async handler(ctx, params) {
         const model = ctx.model as CalendarBlockModel;
         model.setPopupSettings('eventViewAction', params);
-        const action = await model.ensurePopupAction('eventViewAction');
-        await model.syncPopupActionSettings(action, 'eventViewAction');
+        await model.ensurePopupAction('eventViewAction', { persist: true });
       },
     },
     showLunar: {

--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
@@ -659,9 +659,160 @@ describe('calendarPopupModels', () => {
     });
   });
 
+  it('should not persist hidden popup actions while opening calendar popups', async () => {
+    const save = vi.fn();
+    const saveStepParams = vi.fn();
+    const action = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save,
+      saveStepParams,
+    };
+    const model = Object.create(CalendarBlockModel.prototype) as CalendarBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'events',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      configurable: true,
+    });
+
+    await model.ensurePopupAction('eventViewAction');
+
+    expect(save).not.toHaveBeenCalled();
+    expect(saveStepParams).not.toHaveBeenCalled();
+    expect(action.setStepParams).toHaveBeenCalledWith('popupSettings', 'openView', {
+      mode: 'drawer',
+      size: 'medium',
+      pageModelClass: 'ChildPageModel',
+      uid: 'u_event_popup',
+      collectionName: 'events',
+      dataSourceKey: 'main',
+    });
+  });
+
+  it('should persist hidden popup actions only when calendar popup settings are saved', async () => {
+    const save = vi.fn();
+    const saveStepParams = vi.fn();
+    const action = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save,
+      saveStepParams,
+    };
+    const model = Object.create(CalendarBlockModel.prototype) as CalendarBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'events',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      configurable: true,
+    });
+
+    await model.ensurePopupAction('eventViewAction', { persist: true });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(saveStepParams).toHaveBeenCalledTimes(1);
+  });
+
+  it('should replace legacy calendar popup action uid when popup settings are saved', async () => {
+    const destroy = vi.fn();
+    const clonedAction = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
+    };
+    const action = {
+      uid: 'calendar-block-eventViewAction',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      clone: vi.fn(() => clonedAction),
+      destroy,
+    };
+    const model = Object.create(CalendarBlockModel.prototype) as CalendarBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'events',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      configurable: true,
+    });
+    model.setSubModel = vi.fn(function (this: any, key, value) {
+      this.subModels[key] = value;
+      return value;
+    }) as any;
+
+    await model.ensurePopupAction('eventViewAction');
+
+    expect(action.clone).toHaveBeenCalledTimes(1);
+    expect(model.subModels.eventViewAction).toBe(clonedAction);
+    expect(clonedAction.save).not.toHaveBeenCalled();
+    expect(clonedAction.saveStepParams).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+
+    await model.ensurePopupAction('eventViewAction', { persist: true });
+
+    expect(action.clone).toHaveBeenCalledTimes(1);
+    expect(clonedAction.save).toHaveBeenCalledTimes(1);
+    expect(clonedAction.saveStepParams).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('should open quick-create drawer through flow context openView with selected slot data', async () => {
     const openView = vi.fn().mockResolvedValue(undefined);
-    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'quick-create-action' });
+    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'u_quick_create_popup' });
     const slotInfo = {
       start: new Date(2026, 3, 20, 9, 30, 0),
       end: new Date(2026, 3, 20, 10, 30, 0),
@@ -688,25 +839,21 @@ describe('calendarPopupModels', () => {
     );
 
     expect(ensurePopupAction).toHaveBeenCalledWith('quickCreateAction');
-    expect(openView).toHaveBeenCalledWith('quick-create-action', {
+    expect(openView).toHaveBeenCalledWith('u_quick_create_popup', {
       formData: {
         startsAt: '2026-04-20 09:30:00',
         endsAt: '2026-04-20 10:30:00',
       },
       dataSourceKey: 'main',
       collectionName: 'events',
-      navigation: false,
       target: { id: 'layout-root' },
-      defineProperties: {
-        calendarSelectedSlot: { value: slotInfo },
-        calendarFieldNames: { value: { start: 'startsAt', end: 'endsAt' } },
-      },
     });
+    expect(openView.mock.calls[0][0]).not.toContain('quickCreateAction');
   });
 
   it('should open event drawer through flow context openView with record filter key', async () => {
     const openView = vi.fn().mockResolvedValue(undefined);
-    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'event-view-action' });
+    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'u_event_view_popup' });
 
     await CalendarBlockModel.prototype.openEvent.call(
       {
@@ -726,12 +873,12 @@ describe('calendarPopupModels', () => {
     );
 
     expect(ensurePopupAction).toHaveBeenCalledWith('eventViewAction');
-    expect(openView).toHaveBeenCalledWith('event-view-action', {
+    expect(openView).toHaveBeenCalledWith('u_event_view_popup', {
       dataSourceKey: 'main',
       collectionName: 'events',
       filterByTk: 7,
-      navigation: false,
       target: { id: 'layout-root' },
     });
+    expect(openView.mock.calls[0][0]).not.toContain('eventViewAction');
   });
 });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
@@ -768,10 +768,11 @@ describe('GanttBlockModel settings', () => {
       mode: 'drawer',
       size: 'medium',
       pageModelClass: 'ChildPageModel',
-      uid: 'calendar-gantt-eventViewAction',
       dataSourceKey: 'main',
       collectionName: 'calendar',
     });
+    expect(params.uid).toBeTruthy();
+    expect(params.uid).not.toContain('eventViewAction');
   });
 
   test('opens the configured event popup with the clicked task record', async () => {
@@ -802,14 +803,161 @@ describe('GanttBlockModel settings', () => {
 
     await model.openEvent({ id: 12 });
 
-    expect(openView).toHaveBeenCalledWith('calendar-gantt-eventViewAction', {
+    expect(action.uid).not.toContain('eventViewAction');
+    expect(openView).toHaveBeenCalledWith(action.uid, {
       dataSourceKey: 'main',
       collectionName: 'calendar',
       filterByTk: 12,
-      navigation: false,
       target: model.context.layoutContentElement,
     });
     expect(action.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  test('does not persist hidden popup actions while opening gantt popups', async () => {
+    const save = vi.fn();
+    const saveStepParams = vi.fn();
+    const action = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save,
+      saveStepParams,
+    };
+    const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'calendar',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    await model.ensurePopupAction('eventViewAction');
+
+    expect(save).not.toHaveBeenCalled();
+    expect(saveStepParams).not.toHaveBeenCalled();
+    expect(action.setStepParams).toHaveBeenCalled();
+  });
+
+  test('persists hidden popup actions only when gantt popup settings are saved', async () => {
+    const save = vi.fn();
+    const saveStepParams = vi.fn();
+    const action = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save,
+      saveStepParams,
+    };
+    const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'calendar',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    await model.ensurePopupAction('eventViewAction', { persist: true });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(saveStepParams).toHaveBeenCalledTimes(1);
+  });
+
+  test('replaces legacy gantt popup action uid when popup settings are saved', async () => {
+    const destroy = vi.fn();
+    const clonedAction = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
+    };
+    const action = {
+      uid: 'calendar-gantt-eventViewAction',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      clone: vi.fn(() => clonedAction),
+      destroy,
+    };
+    const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'calendar',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+    model.setSubModel = vi.fn(function (this: any, key, value) {
+      this.subModels[key] = value;
+      return value;
+    }) as any;
+
+    await model.ensurePopupAction('eventViewAction');
+
+    expect(action.clone).toHaveBeenCalledTimes(1);
+    expect(model.subModels.eventViewAction).toBe(clonedAction);
+    expect(clonedAction.save).not.toHaveBeenCalled();
+    expect(clonedAction.saveStepParams).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+
+    await model.ensurePopupAction('eventViewAction', { persist: true });
+
+    expect(action.clone).toHaveBeenCalledTimes(1);
+    expect(clonedAction.save).toHaveBeenCalledTimes(1);
+    expect(clonedAction.saveStepParams).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
@@ -477,13 +477,12 @@ export function registerGanttBlockModelSettings(GanttBlockModel: any) {
         async defaultParams(ctx) {
           const model = getGanttModel(ctx);
           const action = await model.ensurePopupAction('eventViewAction');
-          return model.getPopupSettings(action, model.getPopupActionUid('eventViewAction'));
+          return model.getPopupSettings(action, action?.uid);
         },
         async handler(ctx, params) {
           const model = getGanttModel(ctx);
           model.setPopupSettings(params);
-          const action = await model.ensurePopupAction('eventViewAction');
-          await model.syncPopupActionSettings(action);
+          await model.ensurePopupAction('eventViewAction', { persist: true });
         },
       },
     },

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
@@ -56,6 +56,13 @@ type GanttScrollToDateOptions = {
   behavior?: ScrollBehavior;
 };
 
+type GanttPopupActionOptions = {
+  persist?: boolean;
+};
+
+const isLegacyGanttPopupActionUid = (actionUid?: string) =>
+  Boolean(actionUid && ['eventViewAction', 'event-view-action'].some((marker) => actionUid.includes(marker)));
+
 export class GanttBlockModel extends TableBlockModel {
   static scene = BlockSceneEnum.many;
 
@@ -366,10 +373,6 @@ export class GanttBlockModel extends TableBlockModel {
     return (this.subModels as GanttBlockStructure['subModels'])?.eventViewAction as any;
   }
 
-  getPopupActionUid(actionKey: 'eventViewAction') {
-    return `${this.uid}-${actionKey}`;
-  }
-
   getPopupSettingsDefaults(actionUid?: string) {
     return {
       mode: normalizeEventOpenMode(this.props?.eventOpenMode),
@@ -428,7 +431,7 @@ export class GanttBlockModel extends TableBlockModel {
     };
   }
 
-  async syncPopupActionSettings(action: any) {
+  async syncPopupActionSettings(action: any, options: GanttPopupActionOptions = {}) {
     if (!action) {
       return;
     }
@@ -441,21 +444,20 @@ export class GanttBlockModel extends TableBlockModel {
 
     action.setStepParams('popupSettings', 'openView', nextSettings);
 
-    if (this.context.flowSettingsEnabled && action?.saveStepParams) {
+    if (options.persist && this.context.flowSettingsEnabled && action?.saveStepParams) {
       await action.saveStepParams();
     }
   }
 
   async loadPopupAction(actionKey: 'eventViewAction') {
-    const actionUid = this.getPopupActionUid(actionKey);
     try {
-      return this.flowEngine.getModel(actionUid) || (await this.flowEngine.loadModel({ uid: actionUid }));
+      return await this.flowEngine.loadModel({ parentId: this.uid, subKey: actionKey });
     } catch (error) {
       return null;
     }
   }
 
-  async ensurePopupAction(actionKey: 'eventViewAction' = 'eventViewAction') {
+  async ensurePopupAction(actionKey: 'eventViewAction' = 'eventViewAction', options: GanttPopupActionOptions = {}) {
     let action = (this.subModels as GanttBlockStructure['subModels'])?.[actionKey] as any;
 
     if (!action) {
@@ -464,17 +466,38 @@ export class GanttBlockModel extends TableBlockModel {
       if (loadedAction) {
         this.setSubModel(actionKey, loadedAction);
       } else {
-        this.setSubModel(actionKey, createGanttEventViewActionOptions(this.getPopupActionUid(actionKey)));
+        this.setSubModel(actionKey, createGanttEventViewActionOptions());
       }
 
       action = (this.subModels as GanttBlockStructure['subModels'])?.[actionKey] as any;
     }
 
-    if (this.context.flowSettingsEnabled && action?.save) {
+    const legacyAction = action?.__legacyPopupAction || (isLegacyGanttPopupActionUid(action?.uid) ? action : null);
+    if (legacyAction === action && typeof action?.clone === 'function') {
+      const clonedAction = action.clone();
+      Object.defineProperty(clonedAction, '__legacyPopupAction', {
+        value: action,
+        configurable: true,
+      });
+      action = clonedAction;
+      this.setSubModel(actionKey, action);
+    }
+
+    if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
-    await this.syncPopupActionSettings(action);
+    await this.syncPopupActionSettings(action, options);
+
+    if (
+      options.persist &&
+      legacyAction &&
+      legacyAction.uid !== action?.uid &&
+      typeof legacyAction.destroy === 'function'
+    ) {
+      await legacyAction.destroy();
+      delete action.__legacyPopupAction;
+    }
 
     return action;
   }
@@ -493,7 +516,6 @@ export class GanttBlockModel extends TableBlockModel {
       ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
       ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
       filterByTk,
-      navigation: false,
       target: this.context?.layoutContentElement,
     };
 

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
@@ -203,7 +203,7 @@ describe('KanbanBlockModel.filterCollection', () => {
 
   test('card click uses flow context openView with the latest card-item props', async () => {
     const openView = vi.fn().mockResolvedValue(undefined);
-    const ensureCardViewAction = vi.fn().mockResolvedValue({ uid: 'card-view-action' });
+    const ensureCardViewAction = vi.fn().mockResolvedValue({ uid: 'u_card_view_popup' });
 
     await KanbanBlockModel.prototype.openCard.call(
       {
@@ -229,10 +229,9 @@ describe('KanbanBlockModel.filterCollection', () => {
     );
 
     expect(ensureCardViewAction).toHaveBeenCalledTimes(1);
-    expect(openView).toHaveBeenCalledWith('card-view-action', {
+    expect(openView).toHaveBeenCalledWith('u_card_view_popup', {
       mode: 'dialog',
       filterByTk: 1,
-      navigation: false,
       target: { id: 'layout-root' },
     });
   });
@@ -323,6 +322,203 @@ describe('KanbanBlockModel.filterCollection', () => {
       dataSourceKey: 'main',
       collectionName: 'tasks',
     });
+  });
+
+  test('does not persist hidden popup actions while opening kanban popups', async () => {
+    const save = vi.fn();
+    const saveStepParams = vi.fn();
+    const action = {
+      uid: 'kanban-block-quick-create-action',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save,
+      saveStepParams,
+    };
+    const model = Object.create(KanbanBlockModel.prototype) as KanbanBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        quickCreateAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'tasks',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    await model.ensureQuickCreateAction();
+
+    expect(save).not.toHaveBeenCalled();
+    expect(saveStepParams).not.toHaveBeenCalled();
+    expect(action.setStepParams).toHaveBeenCalled();
+  });
+
+  test('persists hidden popup actions only when kanban popup settings are saved', async () => {
+    const save = vi.fn();
+    const saveStepParams = vi.fn();
+    const action = {
+      uid: 'kanban-block-card-view-action',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save,
+      saveStepParams,
+    };
+    const model = Object.create(KanbanBlockModel.prototype) as KanbanBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        cardViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'tasks',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    await model.ensureCardViewAction({ persist: true });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(saveStepParams).toHaveBeenCalledTimes(1);
+  });
+
+  test('loads persisted kanban popup actions before creating hidden actions', async () => {
+    const loadedAction = {
+      uid: 'u_quick_create_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+    };
+    const model = Object.create(KanbanBlockModel.prototype) as KanbanBlockModel;
+    Object.defineProperty(model, 'uid', {
+      value: 'kanban-block',
+      configurable: true,
+    });
+    Object.defineProperty(model, 'subModels', {
+      value: {},
+      configurable: true,
+    });
+    Object.defineProperty(model, 'flowEngine', {
+      value: {
+        loadModel: vi.fn().mockResolvedValue(loadedAction),
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'tasks',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+    model.setSubModel = vi.fn(function (this: any, key, value) {
+      this.subModels[key] = value;
+      return value;
+    }) as any;
+
+    await model.ensureQuickCreateAction();
+
+    expect(model.flowEngine.loadModel).toHaveBeenCalledWith({ parentId: 'kanban-block', subKey: 'quickCreateAction' });
+    expect(model.subModels.quickCreateAction).toBe(loadedAction);
+  });
+
+  test('replaces legacy kanban popup action uid when popup settings are saved', async () => {
+    const destroy = vi.fn();
+    const clonedAction = {
+      uid: 'u_card_view_popup',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
+    };
+    const action = {
+      uid: 'kanban-block-card-view-action',
+      getStepParams: vi.fn(() => ({})),
+      setStepParams: vi.fn(),
+      clone: vi.fn(() => clonedAction),
+      destroy,
+    };
+    const model = Object.create(KanbanBlockModel.prototype) as KanbanBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        cardViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'tasks',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+    model.setSubModel = vi.fn(function (this: any, key, value) {
+      this.subModels[key] = value;
+      return value;
+    }) as any;
+
+    await model.ensureCardViewAction();
+
+    expect(action.clone).toHaveBeenCalledTimes(1);
+    expect(model.subModels.cardViewAction).toBe(clonedAction);
+    expect(clonedAction.save).not.toHaveBeenCalled();
+    expect(clonedAction.saveStepParams).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+
+    await model.ensureCardViewAction({ persist: true });
+
+    expect(action.clone).toHaveBeenCalledTimes(1);
+    expect(clonedAction.save).toHaveBeenCalledTimes(1);
+    expect(clonedAction.saveStepParams).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
   });
 
   test('syncPopupAction overwrites removed popup settings with undefined so stale template params do not survive merges', async () => {
@@ -472,7 +668,10 @@ describe('KanbanBlockModel.filterCollection', () => {
         return this.props.popupTargetUid;
       },
       getAction: () => ({ beforeParamsSave: vi.fn().mockResolvedValue(undefined) }),
-      ensureQuickCreateAction: vi.fn().mockResolvedValue(action),
+      ensureQuickCreateAction: vi.fn(async function (this: any, options) {
+        await this.syncQuickCreateAction(action, options);
+        return action;
+      }),
       syncQuickCreateAction: KanbanBlockModel.prototype.syncQuickCreateAction,
       syncPopupAction: KanbanBlockModel.prototype.syncPopupAction,
       getPopupMode: () => 'drawer',
@@ -568,8 +767,8 @@ describe('KanbanBlockModel.filterCollection', () => {
     expect(parentModel.props).toMatchObject({
       cardPopupPageModelClass: 'PopupPageModel',
     });
-    expect(ensureCardViewAction).toHaveBeenCalledTimes(1);
-    expect(syncCardViewAction).toHaveBeenCalledWith({ uid: 'card-view-action' });
+    expect(ensureCardViewAction).toHaveBeenCalledWith({ persist: true });
+    expect(syncCardViewAction).not.toHaveBeenCalled();
   });
 
   test('grouping uiSchema does not embed cyclical runtime objects in component props', () => {
@@ -1604,8 +1803,8 @@ describe('KanbanBlockModel.filterCollection', () => {
       popupTemplateUid: 'tpl-quick-create',
       popupTargetUid: 'popup-action-1',
     });
-    expect(ensureQuickCreateAction).toHaveBeenCalledTimes(1);
-    expect(syncQuickCreateAction).toHaveBeenCalledWith({ uid: 'quick-create-action' });
+    expect(ensureQuickCreateAction).toHaveBeenCalledWith({ persist: true });
+    expect(syncQuickCreateAction).not.toHaveBeenCalled();
   });
 
   test('kanban model wraps openView popup template selector without changing the global action', async () => {
@@ -1756,7 +1955,7 @@ describe('KanbanBlockModel.filterCollection', () => {
 
   test('quick create uses flow context openView with the prefilled form data', async () => {
     const openView = vi.fn().mockResolvedValue(undefined);
-    const ensureQuickCreateAction = vi.fn().mockResolvedValue({ uid: 'quick-create-action' });
+    const ensureQuickCreateAction = vi.fn().mockResolvedValue({ uid: 'u_quick_create_popup' });
 
     await KanbanBlockModel.prototype.openQuickCreate.call(
       {
@@ -1775,9 +1974,8 @@ describe('KanbanBlockModel.filterCollection', () => {
     );
 
     expect(ensureQuickCreateAction).toHaveBeenCalledTimes(1);
-    expect(openView).toHaveBeenCalledWith('quick-create-action', {
+    expect(openView).toHaveBeenCalledWith('u_quick_create_popup', {
       formData: { status: 'todo' },
-      navigation: false,
       target: { id: 'layout-root' },
     });
   });
@@ -1785,7 +1983,7 @@ describe('KanbanBlockModel.filterCollection', () => {
   test('quick create falls back to an empty popup shell when the popup action open fails', async () => {
     const open = vi.fn().mockResolvedValue(undefined);
     const openView = vi.fn().mockRejectedValue(new Error('open failed'));
-    const ensureQuickCreateAction = vi.fn().mockResolvedValue({ uid: 'quick-create-action' });
+    const ensureQuickCreateAction = vi.fn().mockResolvedValue({ uid: 'u_quick_create_popup' });
 
     await KanbanBlockModel.prototype.openQuickCreate.call(
       {
@@ -1809,9 +2007,8 @@ describe('KanbanBlockModel.filterCollection', () => {
     );
 
     expect(ensureQuickCreateAction).toHaveBeenCalledTimes(1);
-    expect(openView).toHaveBeenCalledWith('quick-create-action', {
+    expect(openView).toHaveBeenCalledWith('u_quick_create_popup', {
       formData: { status: 'todo' },
-      navigation: false,
       target: { id: 'layout-root' },
     });
     expect(open).toHaveBeenCalledWith(
@@ -1827,7 +2024,7 @@ describe('KanbanBlockModel.filterCollection', () => {
   test('card click falls back to an empty popup shell when the popup action open fails', async () => {
     const open = vi.fn().mockResolvedValue(undefined);
     const openView = vi.fn().mockRejectedValue(new Error('open failed'));
-    const ensureCardViewAction = vi.fn().mockResolvedValue({ uid: 'card-view-action' });
+    const ensureCardViewAction = vi.fn().mockResolvedValue({ uid: 'u_card_view_popup' });
 
     await KanbanBlockModel.prototype.openCard.call(
       {
@@ -1853,12 +2050,11 @@ describe('KanbanBlockModel.filterCollection', () => {
     );
 
     expect(ensureCardViewAction).toHaveBeenCalledTimes(1);
-    expect(openView).toHaveBeenCalledWith('card-view-action', {
+    expect(openView).toHaveBeenCalledWith('u_card_view_popup', {
       mode: 'dialog',
       dataSourceKey: 'main',
       collectionName: 'tasks',
       filterByTk: 1,
-      navigation: false,
       target: { id: 'layout-root' },
     });
     expect(open).toHaveBeenCalledWith(

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanCardItemModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanCardItemModel.test.ts
@@ -83,8 +83,8 @@ describe('KanbanCardItemModel.cardSettings', () => {
       popupTemplateUid: 'tpl-card',
       popupTargetUid: 'popup-card-1',
     });
-    expect(ensureCardViewAction).toHaveBeenCalledTimes(1);
-    expect(syncCardViewAction).toHaveBeenCalledWith(masterBlock.subModels.cardViewAction);
+    expect(ensureCardViewAction).toHaveBeenCalledWith({ persist: true });
+    expect(syncCardViewAction).not.toHaveBeenCalled();
   });
 
   test('popup default params keep an explicitly cleared item template instead of falling back to parent template', async () => {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
@@ -84,6 +84,13 @@ const KANBAN_POPUP_WIDTH_MAP: Record<'drawer' | 'dialog', Record<string, string>
   },
 };
 
+type KanbanPopupActionOptions = {
+  persist?: boolean;
+};
+
+const isLegacyKanbanPopupActionUid = (actionUid: string | undefined, markers: string[]) =>
+  Boolean(actionUid && markers.some((marker) => actionUid.includes(marker)));
+
 const DRAG_SORT_FIELD_TIP =
   'Choose the sorting field that matches the current grouping field. Other sorting fields cannot be used for drag sorting.';
 const DRAG_SORT_FIELD_TIP_EXPR = tExpr(DRAG_SORT_FIELD_TIP, { ns: 'kanban' });
@@ -253,8 +260,7 @@ const applyKanbanBlockPopupSettings = async (model: KanbanBlockModel, params: Re
     popupTargetUid: normalizedParams.uid,
   });
 
-  const action = await model.ensureQuickCreateAction();
-  await model.syncQuickCreateAction(action);
+  await model.ensureQuickCreateAction({ persist: true });
 };
 
 const getKanbanBaseOpenViewAction = (ctx: any): ActionDefinition | undefined => {
@@ -833,11 +839,19 @@ export class KanbanBlockModel extends CollectionBlockModel<{
   }
 
   getPopupActionUid() {
-    return `${this.uid}-card-view-action`;
+    return this.subModels?.cardViewAction?.uid;
   }
 
   getQuickCreateActionUid() {
-    return `${this.uid}-quick-create-action`;
+    return this.subModels?.quickCreateAction?.uid;
+  }
+
+  async loadPopupAction(actionKey: 'cardViewAction' | 'quickCreateAction') {
+    try {
+      return await this.flowEngine.loadModel({ parentId: this.uid, subKey: actionKey });
+    } catch (error) {
+      return null;
+    }
   }
 
   async syncPopupAction(
@@ -851,6 +865,7 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       dataSourceKey?: string;
       collectionName?: string;
     },
+    syncOptions: KanbanPopupActionOptions = {},
   ) {
     if (!action) {
       return;
@@ -900,35 +915,67 @@ export class KanbanBlockModel extends CollectionBlockModel<{
 
     action.setStepParams('popupSettings', 'openView', nextParams);
 
-    if (this.context.flowSettingsEnabled && action?.saveStepParams) {
+    if (syncOptions.persist && this.context.flowSettingsEnabled && action?.saveStepParams) {
       await action.saveStepParams();
     }
   }
 
-  async syncCardViewAction(action: any) {
-    await this.syncPopupAction(action, {
-      mode: this.getCardOpenMode(),
-      size: this.getCardPopupSize(),
-      popupTemplateUid: this.getCardPopupTemplateUid(),
-      uid: this.getCardPopupTargetUid(),
-      pageModelClass: this.getCardPopupPageModelClass(),
-      dataSourceKey: this.collection?.dataSourceKey,
-      collectionName: this.collection?.name,
-    });
+  async syncCardViewAction(action: any, options: KanbanPopupActionOptions = {}) {
+    await this.syncPopupAction(
+      action,
+      {
+        mode: this.getCardOpenMode(),
+        size: this.getCardPopupSize(),
+        popupTemplateUid: this.getCardPopupTemplateUid(),
+        uid: this.getCardPopupTargetUid(),
+        pageModelClass: this.getCardPopupPageModelClass(),
+        dataSourceKey: this.collection?.dataSourceKey,
+        collectionName: this.collection?.name,
+      },
+      options,
+    );
   }
 
-  async ensureCardViewAction() {
+  async ensureCardViewAction(options: KanbanPopupActionOptions = {}) {
     let action = this.subModels?.cardViewAction as any;
     if (!action) {
-      this.setSubModel('cardViewAction', createKanbanCardViewActionOptions(this.getPopupActionUid()));
+      const loadedAction = await this.loadPopupAction('cardViewAction');
+      if (loadedAction) {
+        this.setSubModel('cardViewAction', loadedAction);
+      } else {
+        this.setSubModel('cardViewAction', createKanbanCardViewActionOptions());
+      }
       action = this.subModels?.cardViewAction as any;
     }
 
-    if (this.context.flowSettingsEnabled && action?.save) {
+    const legacyAction =
+      action?.__legacyPopupAction ||
+      (isLegacyKanbanPopupActionUid(action?.uid, ['cardViewAction', 'card-view-action']) ? action : null);
+    if (legacyAction === action && typeof action?.clone === 'function') {
+      const clonedAction = action.clone();
+      Object.defineProperty(clonedAction, '__legacyPopupAction', {
+        value: action,
+        configurable: true,
+      });
+      action = clonedAction;
+      this.setSubModel('cardViewAction', action);
+    }
+
+    if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
-    await this.syncCardViewAction(action);
+    await this.syncCardViewAction(action, options);
+
+    if (
+      options.persist &&
+      legacyAction &&
+      legacyAction.uid !== action?.uid &&
+      typeof legacyAction.destroy === 'function'
+    ) {
+      await legacyAction.destroy();
+      delete action.__legacyPopupAction;
+    }
 
     return action;
   }
@@ -937,32 +984,64 @@ export class KanbanBlockModel extends CollectionBlockModel<{
     return this.subModels?.quickCreateAction as any;
   }
 
-  async ensureQuickCreateAction() {
+  async ensureQuickCreateAction(options: KanbanPopupActionOptions = {}) {
     let action = this.subModels?.quickCreateAction as any;
     if (!action) {
-      this.setSubModel('quickCreateAction', createKanbanQuickCreateActionOptions(this.getQuickCreateActionUid()));
+      const loadedAction = await this.loadPopupAction('quickCreateAction');
+      if (loadedAction) {
+        this.setSubModel('quickCreateAction', loadedAction);
+      } else {
+        this.setSubModel('quickCreateAction', createKanbanQuickCreateActionOptions());
+      }
       action = this.subModels?.quickCreateAction as any;
     }
 
-    if (this.context.flowSettingsEnabled && action?.save) {
+    const legacyAction =
+      action?.__legacyPopupAction ||
+      (isLegacyKanbanPopupActionUid(action?.uid, ['quickCreateAction', 'quick-create-action']) ? action : null);
+    if (legacyAction === action && typeof action?.clone === 'function') {
+      const clonedAction = action.clone();
+      Object.defineProperty(clonedAction, '__legacyPopupAction', {
+        value: action,
+        configurable: true,
+      });
+      action = clonedAction;
+      this.setSubModel('quickCreateAction', action);
+    }
+
+    if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
-    await this.syncQuickCreateAction(action);
+    await this.syncQuickCreateAction(action, options);
+
+    if (
+      options.persist &&
+      legacyAction &&
+      legacyAction.uid !== action?.uid &&
+      typeof legacyAction.destroy === 'function'
+    ) {
+      await legacyAction.destroy();
+      delete action.__legacyPopupAction;
+    }
 
     return action;
   }
 
-  async syncQuickCreateAction(action: any) {
-    await this.syncPopupAction(action, {
-      mode: this.getPopupMode(),
-      size: this.getPopupSize(),
-      popupTemplateUid: this.getPopupTemplateUid(),
-      uid: this.getPopupTargetUid(),
-      pageModelClass: this.getPopupPageModelClass(),
-      dataSourceKey: this.collection?.dataSourceKey,
-      collectionName: this.collection?.name,
-    });
+  async syncQuickCreateAction(action: any, options: KanbanPopupActionOptions = {}) {
+    await this.syncPopupAction(
+      action,
+      {
+        mode: this.getPopupMode(),
+        size: this.getPopupSize(),
+        popupTemplateUid: this.getPopupTemplateUid(),
+        uid: this.getPopupTargetUid(),
+        pageModelClass: this.getPopupPageModelClass(),
+        dataSourceKey: this.collection?.dataSourceKey,
+        collectionName: this.collection?.name,
+      },
+      options,
+    );
   }
 
   async openEmptyPopupShell(options: { mode?: string; size?: string; title?: string }) {
@@ -1028,7 +1107,6 @@ export class KanbanBlockModel extends CollectionBlockModel<{
           formData: this.buildQuickCreateFormData(column),
           ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
           ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
-          navigation: false,
           target: this.context.layoutContentElement,
         });
         return;
@@ -1040,7 +1118,6 @@ export class KanbanBlockModel extends CollectionBlockModel<{
           formData: this.buildQuickCreateFormData(column),
           ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
           ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
-          navigation: false,
           target: this.context?.layoutContentElement,
         },
         { debounce: true },
@@ -1081,7 +1158,6 @@ export class KanbanBlockModel extends CollectionBlockModel<{
           ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
           ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
           filterByTk,
-          navigation: false,
           target: this.context.layoutContentElement,
         });
         return;
@@ -1094,7 +1170,6 @@ export class KanbanBlockModel extends CollectionBlockModel<{
           ...(this.collection?.dataSourceKey ? { dataSourceKey: this.collection.dataSourceKey } : {}),
           ...(this.collection?.name ? { collectionName: this.collection.name } : {}),
           filterByTk,
-          navigation: false,
           target: this.context?.layoutContentElement,
         },
         { debounce: true },

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanCardItemModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanCardItemModel.tsx
@@ -105,8 +105,7 @@ const applyKanbanCardPopupSettings = async (model: any, params: Record<string, a
   parentModel?.setProps?.({
     cardPopupPageModelClass: normalizedParams.pageModelClass,
   });
-  const action = await parentModel?.ensureCardViewAction?.();
-  await parentModel?.syncCardViewAction?.(action || parentModel?.subModels?.cardViewAction);
+  await parentModel?.ensureCardViewAction?.({ persist: true });
 };
 
 export class KanbanCardItemModel extends FlowModel<KanbanCardItemStructure> {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Calendar, Kanban, and Gantt popup drawers should update the URL consistently without exposing internal action keys such as eventViewAction, quickCreateAction, or cardViewAction. Opening runtime popups should also avoid saving flow models.

### Description
- Use generated popup action UIDs for calendar, kanban, and gantt hidden popup actions.
- Allow popup open actions to update the URL while keeping internal action keys out of the route.
- Persist hidden popup action settings only from settings save paths, not runtime popup opens.
- Handle legacy semantic popup action UIDs by cloning to generated UIDs and cleaning up legacy actions on settings save.
- Add focused regression tests for runtime save behavior, URL action UID behavior, persisted action loading, and legacy UID migration.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed URL support for calendar and related popups. |
| 🇨🇳 Chinese | 修复日历等弹窗支持URL |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
