### PR TITLE
fix(plugin-api-doc): fix current app info declaration build

### DIFF
--- a/packages/plugins/@nocobase/plugin-api-doc/src/client/Documentation.tsx
+++ b/packages/plugins/@nocobase/plugin-api-doc/src/client/Documentation.tsx
@@ -12,15 +12,9 @@ import React from 'react';
 import DocumentationContent from '../client-v2/pages/DocumentationContent';
 import { useTranslation } from '../locale';
 
-type AppInfo = {
-  data?: {
-    name?: string;
-  };
-};
-
 const Documentation = () => {
   const apiClient = useAPIClient();
-  const appInfo = useCurrentAppInfo<AppInfo>();
+  const appInfo = useCurrentAppInfo();
   const { t } = useTranslation();
 
   return <DocumentationContent apiClient={apiClient} appName={appInfo?.data?.name} t={t} />;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The API documentation package declaration build failed because the v1 client entry passed a generic type argument to `useCurrentAppInfo` from `@nocobase/client`, whose v1 signature does not accept type arguments.

### Description 
Removed the unused local `AppInfo` type from the v1 documentation component and call `useCurrentAppInfo()` without a generic argument, preserving the existing `appInfo?.data?.name` behavior.

Potential risk is low because this only adjusts TypeScript usage in the legacy client entry and does not change runtime behavior.

Testing suggestion: run `yarn build @nocobase/plugin-api-doc`.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the API documentation package declaration build failure. |
| 🇨🇳 Chinese | 修复 API 文档插件声明文件构建失败的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
