### PR TITLE
fix(plugin-ai): fix pasted attachment removal

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/Sender.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/Sender.tsx
@@ -161,12 +161,16 @@ export const Sender: React.FC = () => {
           setAttachments((prev) =>
             prev.map((item) => {
               if (item.uid === uid) {
+                if (!fileData) {
+                  return {
+                    ...item,
+                    status: 'done',
+                    response,
+                  };
+                }
                 return {
-                  ...item,
-                  status: 'done',
-                  response: response,
                   ...fileData,
-                  url: fileData?.url || item.url,
+                  status: 'done',
                 };
               }
               return item;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Pasted image attachments in the AI employee chat box could not be removed after upload because the paste upload path stored a different attachment shape from normal uploads.

### Description 
Align the successful paste-upload attachment state with the existing `useUploadFiles` `onChange` handling. When the upload API returns file data, the pasted attachment now stores the server response data plus the completed status instead of keeping the temporary upload object's `name`.

Testing suggestions:
- Paste an image into the AI employee sender.
- Wait for the attachment upload to finish.
- Remove the pasted attachment from the attachment header.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where attachments pasted into the AI employee dialog could not be removed. |
| 🇨🇳 Chinese | 修复 AI 员工对话框粘贴的附件无法删除问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
