### PR TITLE
fix(client): show horizontal grid fields

### DIFF
--- a/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/FormItem.tsx
@@ -108,7 +108,7 @@ export const FormItem: any = withDynamicSchemaProps(
           field.description
         );
       }
-    }, [field.description]);
+    }, [field.description, t]);
     const className = useMemo(() => {
       return cx(formItemWrapCss, {
         [formItemLabelCss]: showTitle === false,
@@ -126,10 +126,10 @@ export const FormItem: any = withDynamicSchemaProps(
             className={cx(
               'nb-form-item',
               css`
-                .ant-formily-item-layout-horizontal .ant-formily-item-control {
-                  max-width: ${showTitle === false || schema['x-component'] !== 'CollectionField'
-                    ? '100% !important'
-                    : null};
+                ${showTitle === false || schema['x-component'] !== 'CollectionField'
+                  ? '.ant-formily-item-layout-horizontal .ant-formily-item-control'
+                  : '.nb-grid-col & .ant-formily-item-layout-horizontal .ant-formily-item-control'} {
+                  max-width: 100% !important;
                 }
               `,
             )}

--- a/packages/core/client/src/schema-component/antd/form-item/__tests__/form-item.test.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/__tests__/form-item.test.tsx
@@ -82,10 +82,12 @@ describe('FormItem', () => {
     expect(document.querySelector('.nb-grid-container')).toBeInTheDocument();
     expect(document.querySelector('.ant-formily-item')).toHaveClass('ant-formily-item-layout-horizontal');
     expect(screen.getByTestId('collection-field')).toHaveAttribute('data-component', 'CollectionField');
-    expect(
-      Array.from(document.querySelectorAll('style'))
-        .map((style) => style.textContent)
-        .join('\n'),
-    ).toContain('.nb-grid-col');
+    const styleText = Array.from(document.querySelectorAll('style'))
+      .map((style) => style.textContent)
+      .join('\n');
+
+    expect(styleText).toContain('.nb-grid-col');
+    expect(styleText).toContain('.ant-formily-item-layout-horizontal .ant-formily-item-control');
+    expect(styleText).toMatch(/max-width:\s*100%\s*!important/);
   });
 });

--- a/packages/core/client/src/schema-component/antd/form-item/__tests__/form-item.test.tsx
+++ b/packages/core/client/src/schema-component/antd/form-item/__tests__/form-item.test.tsx
@@ -7,7 +7,8 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { render, screen, waitFor } from '@nocobase/test/client';
+import { useFieldSchema } from '@formily/react';
+import { render, renderAppOptions, screen, waitFor } from '@nocobase/test/client';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import App1 from '../demos/demo1';
@@ -23,5 +24,68 @@ describe('FormItem', () => {
     await waitFor(() => {
       expect(screen.getByText('title')).toBeInTheDocument();
     });
+  });
+
+  it('should scope the horizontal collection field control override to grid columns', async () => {
+    const CollectionField = () => {
+      const schema = useFieldSchema();
+      return <input data-testid="collection-field" data-component={schema['x-component'] as string} />;
+    };
+
+    await renderAppOptions({
+      enableUserListDataBlock: true,
+      appOptions: {
+        components: {
+          CollectionField,
+        },
+      },
+      schema: {
+        type: 'void',
+        'x-component': 'FormV2',
+        'x-component-props': {
+          layout: 'horizontal',
+        },
+        properties: {
+          grid: {
+            type: 'void',
+            'x-component': 'Grid',
+            properties: {
+              row: {
+                type: 'void',
+                'x-component': 'Grid.Row',
+                properties: {
+                  col: {
+                    type: 'void',
+                    'x-component': 'Grid.Col',
+                    properties: {
+                      nickname: {
+                        type: 'string',
+                        title: 'Nickname',
+                        'x-decorator': 'FormItem',
+                        'x-component': 'CollectionField',
+                        'x-collection-field': 'users.nickname',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Nickname')).toBeInTheDocument();
+    });
+
+    expect(document.querySelector('.nb-grid-container')).toBeInTheDocument();
+    expect(document.querySelector('.ant-formily-item')).toHaveClass('ant-formily-item-layout-horizontal');
+    expect(screen.getByTestId('collection-field')).toHaveAttribute('data-component', 'CollectionField');
+    expect(
+      Array.from(document.querySelectorAll('style'))
+        .map((style) => style.textContent)
+        .join('\n'),
+    ).toContain('.nb-grid-col');
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
v1 水平布局子表单中，如果一行配置多个字段，字段输入区域会被压缩到几乎不可见，用户无法正常查看或输入数据。

### Description
- 修复 Grid 列内水平布局的字段宽度问题，让子表单一行多个字段时仍能显示输入区域。
- 保留普通水平表单项原有的标签宽度处理，避免影响非目标场景。
- 补充结构性测试，确保 Grid 列内的字段宽度修复规则不会丢失。

测试建议：在 v1 水平布局子表单中配置一行多个字段，确认每个字段的输入区域都能正常显示。

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where fields in horizontal subforms are too narrow to display data |
| 🇨🇳 Chinese | 修复水平子表单中字段过窄导致数据不显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
