### PR TITLE
fix(plugin-data-source-manager): reset collections after deleting active category

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/ConfigurationTabs.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/ConfigurationTabs.tsx
@@ -31,7 +31,7 @@ import {
 } from '@nocobase/client';
 import { App, Badge, Card, Dropdown, Space, Tabs } from 'antd';
 import _ from 'lodash';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CollectionFields } from './CollectionFields';
 import { collectionTableSchema } from './schemas/collections';
@@ -166,12 +166,6 @@ export const ConfigurationTabs = () => {
     return res;
   }, [data]);
 
-  useEffect(() => {
-    if (activeKey.tab !== 'all') {
-      onChange(activeKey.tab);
-    }
-  }, []);
-
   const onChange = (key: string) => {
     setActiveKey({ tab: key });
     setKey(uid());
@@ -191,14 +185,19 @@ export const ConfigurationTabs = () => {
       title: compile("{{t('Delete category')}}"),
       content: compile("{{t('Are you sure you want to delete it?')}}"),
       onOk: async () => {
+        const isActiveCategory = String(key) === activeKey.tab;
         await api.resource('collectionCategories').destroy({
           filter: {
             id: key,
           },
         });
-        key === +activeKey.tab && setActiveKey({ tab: 'all' });
+        if (isActiveCategory) {
+          onChange('all');
+        }
         await refresh();
-        await refreshCM();
+        if (!isActiveCategory) {
+          await refreshCM();
+        }
       },
     });
   };
@@ -261,7 +260,7 @@ export const ConfigurationTabs = () => {
           />
         }
         onChange={onChange}
-        defaultActiveKey={activeKey.tab || 'all'}
+        activeKey={activeKey.tab || 'all'}
         type="editable-card"
         destroyInactiveTabPane={true}
         tabBarStyle={{ marginBottom: '0px' }}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Deleting the active collection category in the v1 data source manager switched the UI back to All collections, but the collections table could keep the deleted category filter and display an empty list.

### Description 
- Make the category tabs controlled so switching to All collections is reflected by the rendered Tabs state.
- When the active category is deleted, reuse the All collections tab change path to clear the category filter state and reload the unfiltered collections list.
- Keep the existing refresh behavior when deleting a non-active category.

Risk is low. The change is limited to the v1 data source manager category tab state and request parameters; it does not touch server APIs, database schema, permissions, or shared collection APIs.

Tested with:
`yarn eslint --fix packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/ConfigurationTabs.tsx`

Manual browser verification of the exact category deletion flow is still recommended.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where deleting the active collection category in the v1 data source manager could leave the All collections tab empty. |
| 🇨🇳 Chinese | 修复 v1 数据源管理中删除当前集合分类后，All collections 标签页可能显示为空的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary