### PR TITLE
fix(data-source-manager): avoid repeated field action rerenders

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/CollectionFields.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/CollectionFields.tsx
@@ -75,7 +75,7 @@ export const CollectionFields = () => {
         options?.onSuccess(service.data);
         field.componentProps.dragSort = !!service.dragSort;
       }
-    }, [field.componentProps, options, service.data, service.dragSort, service.loading]);
+    }, [service.loading]);
     return service;
   };
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v1 external data source Configure fields page could repeatedly refresh the table data source after PR #9623 changed the `useDataSource` effect dependencies. This caused row actions such as `EditFieldAction` to rerender continuously and reset their local schema state, leaving the edit field drawer body blank.

### Description 
Restore the Configure fields table data source effect to run only when `service.loading` changes. This avoids retriggering the effect from unstable `options`, `service.data`, and `field.componentProps` references while preserving the original data loading behavior.

Testing:
- `yarn build @nocobase/plugin-data-source-manager --no-dts`

Potential risks:
- Low. The change restores the previous dependency behavior for this effect.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the blank edit field drawer caused by repeated rerenders on the v1 external data source Configure fields page. |
| 🇨🇳 Chinese | 修复 v1 外部数据源 Configure fields 页面反复重渲染导致字段编辑弹窗内容为空的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
