### PR TITLE
fix(client): render command maintaining components

### DIFF
--- a/packages/core/client-v2/src/components/AppComponents.tsx
+++ b/packages/core/client-v2/src/components/AppComponents.tsx
@@ -21,7 +21,13 @@ import type { Application } from '../Application';
 interface AppErrorPayload {
   code?: string;
   message?: string;
-  command?: { name: string };
+  command?: {
+    name: string;
+    components?: {
+      maintaining?: string;
+      maintainingDialog?: string;
+    };
+  };
   [key: string]: any;
 }
 
@@ -188,7 +194,12 @@ export const AppError: FC<{ error: Error & { title?: string }; app: Application 
 );
 
 export const AppMaintaining: FC<{ app: Application; error: Error }> = observer(
-  ({ app }) => {
+  ({ app, error }) => {
+    const component = (error as AppErrorPayload | undefined)?.command?.components?.maintaining;
+    if (component) {
+      return app.renderComponent(component, { app, error });
+    }
+
     const { icon, status, title, subTitle } = getProps(app);
     return (
       <div>
@@ -211,7 +222,12 @@ export const AppMaintaining: FC<{ app: Application; error: Error }> = observer(
 );
 
 export const AppMaintainingDialog: FC<{ app: Application; error: Error }> = observer(
-  ({ app }) => {
+  ({ app, error }) => {
+    const component = (error as AppErrorPayload | undefined)?.command?.components?.maintainingDialog;
+    if (component) {
+      return app.renderComponent(component, { app, error });
+    }
+
     const { icon, status, title, subTitle } = getProps(app);
     return (
       <Modal open={true} footer={null} closable={false}>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Migration commands can provide custom maintaining components, but the shared maintaining UI only rendered the default result view. This prevented plugin-specific migration progress from appearing.

### Description
Render custom maintaining and maintaining dialog components from the command payload when they are provided, while keeping the existing default maintaining UI as the fallback.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed migration progress not showing its dedicated progress view |
| 🇨🇳 Chinese | 修复迁移进度未显示专用进度视图的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
