### PR TITLE
fix(plugin-workflow-sql): rerun unsafe injection migration

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-sql/src/server/__tests__/migrations/20260327120000-add-unsafe-injection-flag.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-sql/src/server/__tests__/migrations/20260327120000-add-unsafe-injection-flag.test.ts
@@ -39,6 +39,12 @@ describe('migration - add unsafe injection flag', () => {
 
   afterEach(() => app.destroy());
 
+  it('should not restrict by app version', async () => {
+    const migration = new Migration({ db: app.db, app } as any);
+
+    expect(migration.appVersion).toBeFalsy();
+  });
+
   it('should mark node with variables as unsafeInjection', async () => {
     const n1 = await workflow.createNode({
       type: 'sql',

--- a/packages/plugins/@nocobase/plugin-workflow-sql/src/server/migrations/20260327120000-add-unsafe-injection-flag.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-sql/src/server/migrations/20260327120000-add-unsafe-injection-flag.ts
@@ -11,7 +11,6 @@ import { Migration } from '@nocobase/server';
 import { parse } from '@nocobase/utils';
 
 export default class extends Migration {
-  appVersion = '<2.0.30';
   async up() {
     const { db } = this.context;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The SQL workflow unsafe-injection migration was previously limited to app versions lower than 2.0.30. Some users who were already on beta versions did not run this migration, so legacy SQL workflow nodes containing historical `{{...}}` template variables were not marked with `unsafeInjection`.

### Description 
This PR removes the app version restriction from the SQL workflow unsafe-injection migration so it can run for affected beta users that previously missed it.

The migration still only updates SQL workflow nodes whose SQL content is detected by `json-templates` parsing as containing template parameters. SQL nodes without legacy template variables are skipped.

The migration test now also asserts that this migration is not restricted by app version.

Potential risk: SQL text that intentionally contains `{{...}}` template syntax will be classified as unsafe injection. This is the intended conservative behavior for preserving compatibility with legacy SQL workflow nodes.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow-sql/src/server/migrations/20260327120000-add-unsafe-injection-flag.ts packages/plugins/@nocobase/plugin-workflow-sql/src/server/__tests__/migrations/20260327120000-add-unsafe-injection-flag.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow-sql/src/server/__tests__/migrations/20260327120000-add-unsafe-injection-flag.test.ts`

### Related issues

### Showcase
Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed SQL workflow legacy template-variable migration being skipped for some beta-version users. |
| 🇨🇳 Chinese | 修复部分 beta 版本用户跳过 SQL 工作流历史模板变量迁移的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
