### PR TITLE
refactor(plugin-workflow): improve workflow metadata editing

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -17,6 +17,7 @@ import {
   Button,
   Descriptions,
   Dropdown,
+  Input,
   Modal,
   Result,
   Spin,
@@ -277,6 +278,7 @@ function WorkflowMenu() {
   const { workflow, revisions = [] } = useFlowContext();
   const [historyVisible, setHistoryVisible] = useState(false);
   const [detailsVisible, setDetailsVisible] = useState(false);
+  const [editingDescription, setEditingDescription] = useState('');
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { modal } = App.useApp();
@@ -284,6 +286,7 @@ function WorkflowMenu() {
   const { resource } = useResourceContext();
   const { refresh } = useResourceActionContext();
   const { message } = App.useApp();
+  const { styles } = useStyles();
   const allExecuted = useWorkflowAnyExecuted();
 
   const onRevision = useCallback(async () => {
@@ -369,6 +372,33 @@ function WorkflowMenu() {
   const formatUser = useCallback((user) => user?.nickname || user?.username || user?.email || user?.id || '-', []);
   const formatTime = useCallback((value) => (value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-'), []);
 
+  useEffect(() => {
+    if (detailsVisible) {
+      setEditingDescription(workflow.description ?? '');
+    }
+  }, [detailsVisible, workflow.description]);
+
+  const onChangeDescription = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setEditingDescription(event.target.value);
+  }, []);
+
+  const onBlurDescription = useCallback(
+    async (event: React.FocusEvent<HTMLTextAreaElement>) => {
+      const description = event.target.value;
+      if (description === (workflow.description ?? '')) {
+        return;
+      }
+      await resource.update({
+        filterByTk: workflow.id,
+        values: {
+          description,
+        },
+      });
+      refresh();
+    },
+    [refresh, resource, workflow.description, workflow.id],
+  );
+
   return (
     <>
       <Dropdown
@@ -428,7 +458,15 @@ function WorkflowMenu() {
           <Descriptions.Item label={t('Last updated by')}>{formatUser(workflow.updatedBy)}</Descriptions.Item>
           <Descriptions.Item label={t('Last updated at')}>{formatTime(workflow.updatedAt)}</Descriptions.Item>
           <Descriptions.Item label={t('Description')} span={2}>
-            <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{workflow.description || '-'}</div>
+            <Input.TextArea
+              aria-label={t('Description')}
+              value={editingDescription}
+              onChange={onChangeDescription}
+              onBlur={onBlurDescription}
+              placeholder="-"
+              className={styles.workflowDetailsDescriptionClass}
+              autoSize={{ minRows: 3, maxRows: 8 }}
+            />
           </Descriptions.Item>
         </Descriptions>
       </Modal>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowPane.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowPane.tsx
@@ -7,9 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { App, Switch, Tooltip } from 'antd';
-import { onFieldChange, onFieldValueChange } from '@formily/core';
+import { createForm, onFieldChange, onFieldValueChange } from '@formily/core';
 import { useField, useForm, useFormEffects } from '@formily/react';
 
 import {
@@ -123,6 +123,44 @@ function useRevisionAction() {
       }
     },
   };
+}
+
+type DuplicateWorkflowFormValues = {
+  title?: string;
+  description?: string;
+};
+
+function getDuplicateWorkflowFormValues(record: DuplicateWorkflowFormValues): DuplicateWorkflowFormValues {
+  return {
+    title: record.title ?? '',
+    description: record.description ?? '',
+  };
+}
+
+function useDuplicateWorkflowFormProps() {
+  const record = useRecord<DuplicateWorkflowFormValues>() ?? {};
+  const { title, description } = record;
+  const { visible, setFormValueChanged } = useActionContext();
+  const form = useMemo(
+    () =>
+      createForm({
+        initialValues: getDuplicateWorkflowFormValues({ title, description }),
+      }),
+    [description, title],
+  );
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    const values = getDuplicateWorkflowFormValues({ title, description });
+    form.setInitialValues(values);
+    form.setValues(values);
+    form.reset();
+    setFormValueChanged?.(false);
+  }, [description, form, setFormValueChanged, title, visible]);
+
+  return { form };
 }
 
 function TriggerPresetFieldset() {
@@ -243,6 +281,7 @@ export function WorkflowPane() {
           useResourceFilterActionProps,
           useRefreshActionProps,
           useRevisionAction,
+          useDuplicateWorkflowFormProps,
           TriggerOptionRender,
           // ExecutedLink,
           ExecutionStatusOptions,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/schemas/workflows.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/schemas/workflows.ts
@@ -456,14 +456,11 @@ export const workflowSchema: ISchema = {
                               type: 'void',
                               title: `{{t("Duplicate to new workflow", { ns: "${NAMESPACE}" })}}`,
                               'x-decorator': 'FormV2',
+                              'x-use-decorator-props': 'useDuplicateWorkflowFormProps',
                               'x-component': 'Action.Modal',
                               properties: {
-                                title: {
-                                  type: 'string',
-                                  title: '{{t("Title")}}',
-                                  'x-decorator': 'FormItem',
-                                  'x-component': 'Input',
-                                },
+                                title: workflowFieldset.title,
+                                description: workflowFieldset.description,
                                 footer: {
                                   type: 'void',
                                   'x-component': 'Action.Modal.Footer',

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx
@@ -132,6 +132,30 @@ const useStyles = createStyles(({ css, token }) => {
       }
     `,
 
+    workflowDetailsDescriptionClass: css`
+      &.ant-input {
+        border-color: transparent;
+        background: transparent;
+        box-shadow: none;
+        cursor: text;
+        resize: none;
+        transition:
+          background-color 0.3s ease,
+          border-color 0.3s ease;
+
+        &:hover {
+          border-color: ${token.colorPrimaryBorderHover};
+          background: ${token.colorBgContainer};
+        }
+
+        &:focus {
+          border-color: ${token.colorPrimary};
+          background: ${token.colorBgContainer};
+          box-shadow: 0 0 0 2px ${token.colorPrimaryBg};
+        }
+      }
+    `,
+
     branchBlockClass: css`
       display: flex;
       position: relative;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Workflow metadata is frequently reviewed and adjusted while configuring workflows. Editing the description from the details modal and pre-filling duplicate metadata reduces repeated navigation and manual copying.

### Description 
- Changed the workflow details modal description from read-only text to a textarea that looks like read mode by default and saves changed content on blur.
- Pre-filled the duplicate workflow modal with the source workflow title and description.

Potential risks:
- The details modal now performs an update request when the description textarea loses focus after changes.

Testing suggestions:
- Open a workflow details modal, edit the description, blur the textarea, and confirm the description is saved after refresh.
- Duplicate a workflow and confirm the duplicate modal is pre-filled with the source title and description.

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved workflow metadata editing by allowing descriptions to be edited from the details modal and pre-filling duplicate workflow metadata. |
| 🇨🇳 Chinese | 优化工作流元数据编辑体验，支持在详情弹窗中编辑描述，并在复制工作流时默认填充源工作流元数据。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Validation performed:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx packages/plugins/@nocobase/plugin-workflow/src/client/style.tsx packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowPane.tsx packages/plugins/@nocobase/plugin-workflow/src/client/schemas/workflows.ts`
