### PR TITLE
fix(plugin-workflow): update workflow modifier on node changes

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/nodes.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/nodes.test.ts
@@ -51,6 +51,25 @@ describe('workflow > actions > nodes', () => {
       expect(data.type).toBe('echo');
     });
 
+    it('updates workflow updatedBy when creating node', async () => {
+      const user = await db.getCollection('users').repository.findOne();
+      const userAgent = await app.agent().loginUsingId(user.id);
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+
+      const { status } = await userAgent.resource('workflows.nodes', workflow.id).create({
+        values: {
+          type: 'echo',
+        },
+      });
+      expect(status).toBe(200);
+
+      await workflow.reload();
+      expect(String(workflow.get('updatedById'))).toBe(String(user.id));
+    });
+
     it.skipIf(process.env.DB_DIALECT === 'sqlite')('create in executed workflow', async () => {
       const workflow = await WorkflowModel.create({
         enabled: true,
@@ -230,6 +249,32 @@ describe('workflow > actions > nodes', () => {
       } else {
         delete process.env.WORKFLOW_NODES_LIMIT;
       }
+    });
+  });
+
+  describe('update', () => {
+    it('updates workflow updatedBy when updating node', async () => {
+      const user = await db.getCollection('users').repository.findOne();
+      const userAgent = await app.agent().loginUsingId(user.id);
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+
+      const node = await workflow.createNode({
+        type: 'echo',
+      });
+
+      const { status } = await userAgent.resource('flow_nodes').update({
+        filterByTk: node.id,
+        values: {
+          title: 'Updated node',
+        },
+      });
+      expect(status).toBe(200);
+
+      await workflow.reload();
+      expect(String(workflow.get('updatedById'))).toBe(String(user.id));
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/nodes.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/nodes.ts
@@ -8,7 +8,7 @@
  */
 
 import { Context, utils } from '@nocobase/actions';
-import { MultipleRelationRepository, Op, Repository } from '@nocobase/database';
+import { MultipleRelationRepository, Op, Repository, type Transaction } from '@nocobase/database';
 import WorkflowPlugin from '..';
 import type { FlowNodeModel, WorkflowModel } from '../types';
 
@@ -42,6 +42,24 @@ function validateNode(context: Context, workflow: WorkflowModel | null, values: 
       throw new NodeValidationError(errors);
     }
   }
+}
+
+async function touchWorkflow(context: Context, workflowId: number | string, transaction: Transaction) {
+  const values: { updatedAt: Date; updatedById?: number | string } = {
+    updatedAt: new Date(),
+  };
+  const currentUserId = context.state?.currentUser?.id;
+  if (currentUserId != null) {
+    values.updatedById = currentUserId;
+  }
+
+  await context.db.getCollection('workflows').model.update(values, {
+    where: {
+      id: workflowId,
+    },
+    transaction,
+    hooks: false,
+  });
 }
 
 export async function create(context: Context, next) {
@@ -95,6 +113,7 @@ export async function create(context: Context, next) {
         await instance.setDownstream(previousHead, { transaction });
         instance.set('downstream', previousHead);
       }
+      await touchWorkflow(context, workflow.id, transaction);
       return instance;
     }
 
@@ -143,6 +162,7 @@ export async function create(context: Context, next) {
 
     instance.set('upstream', upstream);
 
+    await touchWorkflow(context, workflow.id, transaction);
     return instance;
   });
 
@@ -224,6 +244,7 @@ export async function duplicate(context: Context, next) {
         await instance.setDownstream(previousHead, { transaction });
         instance.set('downstream', previousHead);
       }
+      await touchWorkflow(context, origin.workflowId, transaction);
       return instance;
     }
 
@@ -272,6 +293,7 @@ export async function duplicate(context: Context, next) {
 
     instance.set('upstream', upstream);
 
+    await touchWorkflow(context, origin.workflowId, transaction);
     return instance;
   });
 
@@ -423,6 +445,7 @@ export async function destroy(context: Context, next) {
       filterByTk: [instance.id, ...branchNodesToDelete.map((item) => item.id)],
       transaction,
     });
+    await touchWorkflow(context, instance.workflowId, transaction);
   });
 
   context.body = instance;
@@ -459,6 +482,7 @@ export async function destroyBranch(context: Context, next) {
   let deletedBranchHead = null;
 
   await db.sequelize.transaction(async (transaction) => {
+    let shouldTouchWorkflow = false;
     const nodes = await repository.find({
       filter: {
         workflowId: instance.workflowId,
@@ -493,6 +517,7 @@ export async function destroyBranch(context: Context, next) {
           filterByTk: idsToDelete,
           transaction,
         });
+        shouldTouchWorkflow = true;
       }
     }
 
@@ -508,6 +533,12 @@ export async function destroyBranch(context: Context, next) {
           ),
         ),
       );
+      if (headsToShift.length) {
+        shouldTouchWorkflow = true;
+      }
+    }
+    if (shouldTouchWorkflow) {
+      await touchWorkflow(context, instance.workflowId, transaction);
     }
   });
 
@@ -625,6 +656,7 @@ export async function move(context: Context, next) {
         { transaction },
       );
 
+      await touchWorkflow(context, instance.workflowId, transaction);
       return instance;
     }
 
@@ -662,6 +694,7 @@ export async function move(context: Context, next) {
         { transaction },
       );
 
+      await touchWorkflow(context, instance.workflowId, transaction);
       return instance;
     }
 
@@ -693,6 +726,7 @@ export async function move(context: Context, next) {
       { transaction },
     );
 
+    await touchWorkflow(context, instance.workflowId, transaction);
     return instance;
   });
 
@@ -719,7 +753,7 @@ export async function update(context: Context, next) {
     const merged = Object.assign({}, instance.get(), values);
     validateNode(context, null, merged);
 
-    return repository.update({
+    const result = await repository.update({
       filterByTk,
       values,
       whitelist,
@@ -729,6 +763,8 @@ export async function update(context: Context, next) {
       context,
       transaction,
     });
+    await touchWorkflow(context, instance.workflowId, transaction);
+    return result;
   });
 
   await next();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow records already track `updatedBy`, but changes to their flow nodes were not reflected on the parent workflow. As a result, the workflow list could show an outdated last modifier after users changed workflow node configuration or structure.

### Description
- Mark the parent workflow as updated after successful node create, update, delete, branch delete, duplicate, and move actions.
- Update the parent workflow in the same transaction as the node change.
- Avoid triggering workflow update hooks while touching `updatedAt` and `updatedById`.
- Add server tests for updating workflow `updatedById` when creating and updating nodes.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow last modifier tracking after workflow nodes are changed. |
| 🇨🇳 Chinese | 修复工作流节点变更后工作流最后更新人未同步更新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
