### PR TITLE
fix: avoid runtime popup action persistence

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/CalendarBlockModel.tsx
@@ -98,11 +98,6 @@ type CalendarPopupActionOptions = {
   persist?: boolean;
 };
 
-const CALENDAR_LEGACY_POPUP_ACTION_UID_MARKERS: Record<'quickCreateAction' | 'eventViewAction', string[]> = {
-  quickCreateAction: ['quickCreateAction', 'quick-create-action'],
-  eventViewAction: ['eventViewAction', 'event-view-action'],
-};
-
 const DRAG_HANDLER_TOOLBAR_ITEMS = [
   {
     key: 'drag-handler',
@@ -306,12 +301,6 @@ export class CalendarBlockModel extends CollectionBlockModel {
     return this.subModels?.eventViewAction as any;
   }
 
-  isLegacyPopupActionUid(actionKey: 'quickCreateAction' | 'eventViewAction', actionUid?: string) {
-    return Boolean(
-      actionUid && CALENDAR_LEGACY_POPUP_ACTION_UID_MARKERS[actionKey].some((marker) => actionUid.includes(marker)),
-    );
-  }
-
   getPopupSettingsDefaults(actionUid?: string) {
     return {
       mode: normalizeEventOpenMode(this.props?.eventOpenMode),
@@ -437,33 +426,11 @@ export class CalendarBlockModel extends CollectionBlockModel {
       action = this.subModels?.[actionKey] as any;
     }
 
-    const legacyAction =
-      action?.__legacyPopupAction || (this.isLegacyPopupActionUid(actionKey, action?.uid) ? action : null);
-    if (legacyAction === action && typeof action?.clone === 'function') {
-      const clonedAction = action.clone();
-      Object.defineProperty(clonedAction, '__legacyPopupAction', {
-        value: action,
-        configurable: true,
-      });
-      action = clonedAction;
-      this.setSubModel(actionKey, action);
-    }
-
     if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
     await this.syncPopupActionSettings(action, actionKey, options);
-
-    if (
-      options.persist &&
-      legacyAction &&
-      legacyAction.uid !== action?.uid &&
-      typeof legacyAction.destroy === 'function'
-    ) {
-      await legacyAction.destroy();
-      delete action.__legacyPopupAction;
-    }
 
     return action;
   }
@@ -866,6 +833,10 @@ CalendarBlockModel.registerFlow({
       async handler(ctx, params) {
         const model = ctx.model as CalendarBlockModel;
         model.setPopupSettings('quickCreateAction', params);
+      },
+      async beforeParamsSave(ctx, params) {
+        const model = ctx.model as CalendarBlockModel;
+        model.setPopupSettings('quickCreateAction', params);
         await model.ensurePopupAction('quickCreateAction', { persist: true });
       },
     },
@@ -878,6 +849,10 @@ CalendarBlockModel.registerFlow({
         return model.getPopupSettings(action, 'eventViewAction', action?.uid);
       },
       async handler(ctx, params) {
+        const model = ctx.model as CalendarBlockModel;
+        model.setPopupSettings('eventViewAction', params);
+      },
+      async beforeParamsSave(ctx, params) {
         const model = ctx.model as CalendarBlockModel;
         model.setPopupSettings('eventViewAction', params);
         await model.ensurePopupAction('eventViewAction', { persist: true });

--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/__tests__/calendarPopupModels.test.ts
@@ -292,6 +292,28 @@ describe('calendarPopupModels', () => {
     expect(step?.hideInSettings?.({ model } as any)).toBe(true);
   });
 
+  it('should persist popup actions only from popup settings save hooks', async () => {
+    const flow: any = (CalendarBlockModel as any).globalFlowRegistry.getFlow('calendarSettings');
+    const quickCreateStep = flow?.steps?.quickCreatePopupSettings;
+    const eventStep = flow?.steps?.eventPopupSettings;
+    const ensurePopupAction = vi.fn().mockResolvedValue({ uid: 'u_popup_action' });
+    const model = {
+      setPopupSettings: vi.fn(),
+      ensurePopupAction,
+    };
+
+    await quickCreateStep.handler({ model } as any, { mode: 'drawer' });
+    await eventStep.handler({ model } as any, { mode: 'dialog' });
+
+    expect(ensurePopupAction).not.toHaveBeenCalled();
+
+    await quickCreateStep.beforeParamsSave({ model } as any, { mode: 'drawer' });
+    await eventStep.beforeParamsSave({ model } as any, { mode: 'dialog' });
+
+    expect(ensurePopupAction).toHaveBeenCalledWith('quickCreateAction', { persist: true });
+    expect(ensurePopupAction).toHaveBeenCalledWith('eventViewAction', { persist: true });
+  });
+
   it('should build quick-create formData from the selected slot', () => {
     const slotInfo = {
       start: new Date(2026, 3, 20, 9, 30, 0),
@@ -749,20 +771,15 @@ describe('calendarPopupModels', () => {
     expect(saveStepParams).toHaveBeenCalledTimes(1);
   });
 
-  it('should replace legacy calendar popup action uid when popup settings are saved', async () => {
+  it('should keep legacy calendar popup action uid usable when popup settings are saved', async () => {
     const destroy = vi.fn();
-    const clonedAction = {
-      uid: 'u_event_popup',
-      getStepParams: vi.fn(() => ({})),
-      setStepParams: vi.fn(),
-      save: vi.fn(),
-      saveStepParams: vi.fn(),
-    };
     const action = {
       uid: 'calendar-block-eventViewAction',
       getStepParams: vi.fn(() => ({})),
       setStepParams: vi.fn(),
-      clone: vi.fn(() => clonedAction),
+      clone: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
       destroy,
     };
     const model = Object.create(CalendarBlockModel.prototype) as CalendarBlockModel;
@@ -796,18 +813,19 @@ describe('calendarPopupModels', () => {
 
     await model.ensurePopupAction('eventViewAction');
 
-    expect(action.clone).toHaveBeenCalledTimes(1);
-    expect(model.subModels.eventViewAction).toBe(clonedAction);
-    expect(clonedAction.save).not.toHaveBeenCalled();
-    expect(clonedAction.saveStepParams).not.toHaveBeenCalled();
+    expect(action.clone).not.toHaveBeenCalled();
+    expect(model.subModels.eventViewAction).toBe(action);
+    expect(action.save).not.toHaveBeenCalled();
+    expect(action.saveStepParams).not.toHaveBeenCalled();
     expect(destroy).not.toHaveBeenCalled();
 
     await model.ensurePopupAction('eventViewAction', { persist: true });
 
-    expect(action.clone).toHaveBeenCalledTimes(1);
-    expect(clonedAction.save).toHaveBeenCalledTimes(1);
-    expect(clonedAction.saveStepParams).toHaveBeenCalledTimes(1);
-    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(action.clone).not.toHaveBeenCalled();
+    expect(model.subModels.eventViewAction).toBe(action);
+    expect(action.save).toHaveBeenCalledTimes(1);
+    expect(action.saveStepParams).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
   });
 
   it('should open quick-create drawer through flow context openView with selected slot data', async () => {

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
@@ -775,6 +775,22 @@ describe('GanttBlockModel settings', () => {
     expect(params.uid).not.toContain('eventViewAction');
   });
 
+  test('persists popup actions only from popup settings save hooks', async () => {
+    const step = (GanttBlockModel as any).globalFlowRegistry.getFlow('ganttSettings')?.steps?.eventPopupSettings;
+    const model = {
+      setPopupSettings: vi.fn(),
+      ensurePopupAction: vi.fn().mockResolvedValue({ uid: 'u_event_popup' }),
+    };
+
+    await step?.handler?.({ model } as any, { mode: 'drawer' });
+
+    expect(model.ensurePopupAction).not.toHaveBeenCalled();
+
+    await step?.beforeParamsSave?.({ model } as any, { mode: 'dialog' });
+
+    expect(model.ensurePopupAction).toHaveBeenCalledWith('eventViewAction', { persist: true });
+  });
+
   test('opens the configured event popup with the clicked task record', async () => {
     const flowEngine = new FlowEngine();
     flowEngine.registerModels({ GanttBlockModel, GanttEventViewActionModel });
@@ -898,20 +914,15 @@ describe('GanttBlockModel settings', () => {
     expect(saveStepParams).toHaveBeenCalledTimes(1);
   });
 
-  test('replaces legacy gantt popup action uid when popup settings are saved', async () => {
+  test('keeps legacy gantt popup action uid usable when popup settings are saved', async () => {
     const destroy = vi.fn();
-    const clonedAction = {
-      uid: 'u_event_popup',
-      getStepParams: vi.fn(() => ({})),
-      setStepParams: vi.fn(),
-      save: vi.fn(),
-      saveStepParams: vi.fn(),
-    };
     const action = {
       uid: 'calendar-gantt-eventViewAction',
       getStepParams: vi.fn(() => ({})),
       setStepParams: vi.fn(),
-      clone: vi.fn(() => clonedAction),
+      clone: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
       destroy,
     };
     const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
@@ -946,18 +957,19 @@ describe('GanttBlockModel settings', () => {
 
     await model.ensurePopupAction('eventViewAction');
 
-    expect(action.clone).toHaveBeenCalledTimes(1);
-    expect(model.subModels.eventViewAction).toBe(clonedAction);
-    expect(clonedAction.save).not.toHaveBeenCalled();
-    expect(clonedAction.saveStepParams).not.toHaveBeenCalled();
+    expect(action.clone).not.toHaveBeenCalled();
+    expect(model.subModels.eventViewAction).toBe(action);
+    expect(action.save).not.toHaveBeenCalled();
+    expect(action.saveStepParams).not.toHaveBeenCalled();
     expect(destroy).not.toHaveBeenCalled();
 
     await model.ensurePopupAction('eventViewAction', { persist: true });
 
-    expect(action.clone).toHaveBeenCalledTimes(1);
-    expect(clonedAction.save).toHaveBeenCalledTimes(1);
-    expect(clonedAction.saveStepParams).toHaveBeenCalledTimes(1);
-    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(action.clone).not.toHaveBeenCalled();
+    expect(model.subModels.eventViewAction).toBe(action);
+    expect(action.save).toHaveBeenCalledTimes(1);
+    expect(action.saveStepParams).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
@@ -482,6 +482,10 @@ export function registerGanttBlockModelSettings(GanttBlockModel: any) {
         async handler(ctx, params) {
           const model = getGanttModel(ctx);
           model.setPopupSettings(params);
+        },
+        async beforeParamsSave(ctx, params) {
+          const model = getGanttModel(ctx);
+          model.setPopupSettings(params);
           await model.ensurePopupAction('eventViewAction', { persist: true });
         },
       },

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
@@ -60,9 +60,6 @@ type GanttPopupActionOptions = {
   persist?: boolean;
 };
 
-const isLegacyGanttPopupActionUid = (actionUid?: string) =>
-  Boolean(actionUid && ['eventViewAction', 'event-view-action'].some((marker) => actionUid.includes(marker)));
-
 export class GanttBlockModel extends TableBlockModel {
   static scene = BlockSceneEnum.many;
 
@@ -472,32 +469,11 @@ export class GanttBlockModel extends TableBlockModel {
       action = (this.subModels as GanttBlockStructure['subModels'])?.[actionKey] as any;
     }
 
-    const legacyAction = action?.__legacyPopupAction || (isLegacyGanttPopupActionUid(action?.uid) ? action : null);
-    if (legacyAction === action && typeof action?.clone === 'function') {
-      const clonedAction = action.clone();
-      Object.defineProperty(clonedAction, '__legacyPopupAction', {
-        value: action,
-        configurable: true,
-      });
-      action = clonedAction;
-      this.setSubModel(actionKey, action);
-    }
-
     if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
     await this.syncPopupActionSettings(action, options);
-
-    if (
-      options.persist &&
-      legacyAction &&
-      legacyAction.uid !== action?.uid &&
-      typeof legacyAction.destroy === 'function'
-    ) {
-      await legacyAction.destroy();
-      delete action.__legacyPopupAction;
-    }
 
     return action;
   }

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
@@ -459,20 +459,15 @@ describe('KanbanBlockModel.filterCollection', () => {
     expect(model.subModels.quickCreateAction).toBe(loadedAction);
   });
 
-  test('replaces legacy kanban popup action uid when popup settings are saved', async () => {
+  test('keeps legacy kanban popup action uid usable when popup settings are saved', async () => {
     const destroy = vi.fn();
-    const clonedAction = {
-      uid: 'u_card_view_popup',
-      getStepParams: vi.fn(() => ({})),
-      setStepParams: vi.fn(),
-      save: vi.fn(),
-      saveStepParams: vi.fn(),
-    };
     const action = {
       uid: 'kanban-block-card-view-action',
       getStepParams: vi.fn(() => ({})),
       setStepParams: vi.fn(),
-      clone: vi.fn(() => clonedAction),
+      clone: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
       destroy,
     };
     const model = Object.create(KanbanBlockModel.prototype) as KanbanBlockModel;
@@ -507,18 +502,19 @@ describe('KanbanBlockModel.filterCollection', () => {
 
     await model.ensureCardViewAction();
 
-    expect(action.clone).toHaveBeenCalledTimes(1);
-    expect(model.subModels.cardViewAction).toBe(clonedAction);
-    expect(clonedAction.save).not.toHaveBeenCalled();
-    expect(clonedAction.saveStepParams).not.toHaveBeenCalled();
+    expect(action.clone).not.toHaveBeenCalled();
+    expect(model.subModels.cardViewAction).toBe(action);
+    expect(action.save).not.toHaveBeenCalled();
+    expect(action.saveStepParams).not.toHaveBeenCalled();
     expect(destroy).not.toHaveBeenCalled();
 
     await model.ensureCardViewAction({ persist: true });
 
-    expect(action.clone).toHaveBeenCalledTimes(1);
-    expect(clonedAction.save).toHaveBeenCalledTimes(1);
-    expect(clonedAction.saveStepParams).toHaveBeenCalledTimes(1);
-    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(action.clone).not.toHaveBeenCalled();
+    expect(model.subModels.cardViewAction).toBe(action);
+    expect(action.save).toHaveBeenCalledTimes(1);
+    expect(action.saveStepParams).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
   });
 
   test('syncPopupAction overwrites removed popup settings with undefined so stale template params do not survive merges', async () => {
@@ -705,6 +701,7 @@ describe('KanbanBlockModel.filterCollection', () => {
       pageModelClass: undefined,
       uid: 'quick-create-action',
     });
+    expect(model.ensureQuickCreateAction).toHaveBeenCalledWith({ persist: true });
   });
 
   test('card popup getter treats an explicitly cleared item template as higher priority than legacy block props', () => {
@@ -767,7 +764,7 @@ describe('KanbanBlockModel.filterCollection', () => {
     expect(parentModel.props).toMatchObject({
       cardPopupPageModelClass: 'PopupPageModel',
     });
-    expect(ensureCardViewAction).toHaveBeenCalledWith({ persist: true });
+    expect(ensureCardViewAction).not.toHaveBeenCalled();
     expect(syncCardViewAction).not.toHaveBeenCalled();
   });
 
@@ -1803,7 +1800,7 @@ describe('KanbanBlockModel.filterCollection', () => {
       popupTemplateUid: 'tpl-quick-create',
       popupTargetUid: 'popup-action-1',
     });
-    expect(ensureQuickCreateAction).toHaveBeenCalledWith({ persist: true });
+    expect(ensureQuickCreateAction).not.toHaveBeenCalled();
     expect(syncQuickCreateAction).not.toHaveBeenCalled();
   });
 

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanCardItemModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanCardItemModel.test.ts
@@ -83,7 +83,7 @@ describe('KanbanCardItemModel.cardSettings', () => {
       popupTemplateUid: 'tpl-card',
       popupTargetUid: 'popup-card-1',
     });
-    expect(ensureCardViewAction).toHaveBeenCalledWith({ persist: true });
+    expect(ensureCardViewAction).not.toHaveBeenCalled();
     expect(syncCardViewAction).not.toHaveBeenCalled();
   });
 
@@ -193,6 +193,7 @@ describe('KanbanCardItemModel.cardSettings', () => {
 
     expect(masterItem.props.popupTargetUid).toBeUndefined();
     expect(masterItem.stepParams.cardSettings.popup.uid).toBeUndefined();
+    expect(ensureCardViewAction).toHaveBeenCalledWith({ persist: true });
   });
 
   test('layout changes persist from card forks and propagate to details items', () => {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
@@ -88,9 +88,6 @@ type KanbanPopupActionOptions = {
   persist?: boolean;
 };
 
-const isLegacyKanbanPopupActionUid = (actionUid: string | undefined, markers: string[]) =>
-  Boolean(actionUid && markers.some((marker) => actionUid.includes(marker)));
-
 const DRAG_SORT_FIELD_TIP =
   'Choose the sorting field that matches the current grouping field. Other sorting fields cannot be used for drag sorting.';
 const DRAG_SORT_FIELD_TIP_EXPR = tExpr(DRAG_SORT_FIELD_TIP, { ns: 'kanban' });
@@ -225,7 +222,11 @@ const resolveKanbanPopupTargetUid = ({
     : nextPopupTargetUid;
 };
 
-const applyKanbanBlockPopupSettings = async (model: KanbanBlockModel, params: Record<string, any>) => {
+const applyKanbanBlockPopupSettings = async (
+  model: KanbanBlockModel,
+  params: Record<string, any>,
+  options: KanbanPopupActionOptions = {},
+) => {
   const nextPopupTemplateUid = normalizeKanbanPopupTemplateUid(params.popupTemplateUid);
   const nextPopupTargetUid = normalizeKanbanPopupTargetUid(params.uid);
   const currentPopupTemplateUid =
@@ -260,7 +261,9 @@ const applyKanbanBlockPopupSettings = async (model: KanbanBlockModel, params: Re
     popupTargetUid: normalizedParams.uid,
   });
 
-  await model.ensureQuickCreateAction({ persist: true });
+  if (options.persist) {
+    await model.ensureQuickCreateAction({ persist: true });
+  }
 };
 
 const getKanbanBaseOpenViewAction = (ctx: any): ActionDefinition | undefined => {
@@ -948,34 +951,11 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       action = this.subModels?.cardViewAction as any;
     }
 
-    const legacyAction =
-      action?.__legacyPopupAction ||
-      (isLegacyKanbanPopupActionUid(action?.uid, ['cardViewAction', 'card-view-action']) ? action : null);
-    if (legacyAction === action && typeof action?.clone === 'function') {
-      const clonedAction = action.clone();
-      Object.defineProperty(clonedAction, '__legacyPopupAction', {
-        value: action,
-        configurable: true,
-      });
-      action = clonedAction;
-      this.setSubModel('cardViewAction', action);
-    }
-
     if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
     await this.syncCardViewAction(action, options);
-
-    if (
-      options.persist &&
-      legacyAction &&
-      legacyAction.uid !== action?.uid &&
-      typeof legacyAction.destroy === 'function'
-    ) {
-      await legacyAction.destroy();
-      delete action.__legacyPopupAction;
-    }
 
     return action;
   }
@@ -996,34 +976,11 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       action = this.subModels?.quickCreateAction as any;
     }
 
-    const legacyAction =
-      action?.__legacyPopupAction ||
-      (isLegacyKanbanPopupActionUid(action?.uid, ['quickCreateAction', 'quick-create-action']) ? action : null);
-    if (legacyAction === action && typeof action?.clone === 'function') {
-      const clonedAction = action.clone();
-      Object.defineProperty(clonedAction, '__legacyPopupAction', {
-        value: action,
-        configurable: true,
-      });
-      action = clonedAction;
-      this.setSubModel('quickCreateAction', action);
-    }
-
     if (options.persist && this.context.flowSettingsEnabled && action?.save) {
       await action.save();
     }
 
     await this.syncQuickCreateAction(action, options);
-
-    if (
-      options.persist &&
-      legacyAction &&
-      legacyAction.uid !== action?.uid &&
-      typeof legacyAction.destroy === 'function'
-    ) {
-      await legacyAction.destroy();
-      delete action.__legacyPopupAction;
-    }
 
     return action;
   }
@@ -1585,11 +1542,11 @@ KanbanBlockModel.registerFlow({
         };
       },
       async handler(ctx, params) {
-        await applyKanbanBlockPopupSettings(ctx.model as KanbanBlockModel, params);
+        await applyKanbanBlockPopupSettings(ctx.model as KanbanBlockModel, params, { persist: false });
       },
       async beforeParamsSave(ctx, params, previousParams) {
         await ctx.model?.getAction?.('openView')?.beforeParamsSave?.(ctx, params, previousParams);
-        await applyKanbanBlockPopupSettings(ctx.model as KanbanBlockModel, params);
+        await applyKanbanBlockPopupSettings(ctx.model as KanbanBlockModel, params, { persist: true });
       },
     },
     pageSize: {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanCardItemModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanCardItemModel.tsx
@@ -67,7 +67,11 @@ const replaceModelStepParams = (model: any, flowKey: string, stepKey: string, pa
   model.emitter?.emit?.('onStepParamsChanged');
 };
 
-const applyKanbanCardPopupSettings = async (model: any, params: Record<string, any>) => {
+const applyKanbanCardPopupSettings = async (
+  model: any,
+  params: Record<string, any>,
+  options: { persist?: boolean } = {},
+) => {
   const parentModel = getKanbanCardPersistentParentModel(model);
   const nextPopupTemplateUid = normalizeKanbanPopupTemplateUid(params.popupTemplateUid);
   const nextPopupTargetUid = normalizeKanbanPopupTargetUid(params.uid);
@@ -105,7 +109,9 @@ const applyKanbanCardPopupSettings = async (model: any, params: Record<string, a
   parentModel?.setProps?.({
     cardPopupPageModelClass: normalizedParams.pageModelClass,
   });
-  await parentModel?.ensureCardViewAction?.({ persist: true });
+  if (options.persist) {
+    await parentModel?.ensureCardViewAction?.({ persist: true });
+  }
 };
 
 export class KanbanCardItemModel extends FlowModel<KanbanCardItemStructure> {
@@ -262,11 +268,11 @@ KanbanCardItemModel.registerFlow({
         };
       },
       async handler(ctx, params) {
-        await applyKanbanCardPopupSettings(ctx.model, params);
+        await applyKanbanCardPopupSettings(ctx.model, params, { persist: false });
       },
       async beforeParamsSave(ctx, params, previousParams) {
         await ctx.model?.getAction?.('openView')?.beforeParamsSave?.(ctx, params, previousParams);
-        await applyKanbanCardPopupSettings(ctx.model, params);
+        await applyKanbanCardPopupSettings(ctx.model, params, { persist: true });
       },
     },
     layout: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Opening calendar, gantt, and kanban blocks outside edit mode could trigger hidden popup action persistence. For legacy popup action UIDs, the previous compatibility path could clone actions and destroy the old flow model tree, which could produce repeated `flowModels:destroy` requests during normal page rendering.

### Description
- Restrict hidden popup action persistence for calendar, gantt, and kanban popup settings to the settings save path.
- Keep runtime popup settings handlers limited to in-memory settings synchronization.
- Remove legacy popup action UID clone/destroy migration and keep existing action trees usable in place.
- Update focused tests for popup settings save hooks, runtime handlers, and legacy UID compatibility.

Potential risk: existing legacy popup action UIDs are intentionally preserved. Verify that popup settings can still be saved and that existing popup actions continue to open records correctly.

Testing suggestions:
- Open calendar, gantt, and kanban blocks outside edit mode and confirm no `flowModels:destroy` request is sent.
- Edit and save popup settings for calendar, gantt, and kanban blocks and confirm the popup action settings are persisted.
- Open existing record/detail popups from these blocks.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed unexpected hidden popup action persistence and repeated destroy requests when opening calendar, gantt, and kanban blocks outside edit mode. |
| 🇨🇳 Chinese | 修复非编辑态打开日历、甘特图和看板区块时意外持久化隐藏弹窗操作并重复发送删除请求的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
