### PR TITLE
fix(cli-v1): forward dev to app-dev for upgraded app projects

### DIFF
--- a/packages/core/cli-v1/src/__tests__/dev-command.test.js
+++ b/packages/core/cli-v1/src/__tests__/dev-command.test.js
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/* eslint-env jest */
+
+const { buildAppDevForwardArgs, forwardDevToAppDev } = require('../commands/dev')._test;
+
+describe('cli-v1 dev command', () => {
+  test('buildAppDevForwardArgs rewrites dev argv to app-dev while preserving extra args', () => {
+    expect(
+      buildAppDevForwardArgs(['node', 'nocobase-v1', 'dev', '--rsbuild', '--port', '13000', '--inspect=9229']),
+    ).toEqual(['app-dev', '--rsbuild', '--port', '13000', '--inspect=9229']);
+  });
+
+  test('forwardDevToAppDev delegates to nocobase-v1 app-dev for create-app projects', async () => {
+    const calls = [];
+    const runCommand = async (...args) => {
+      calls.push(args);
+    };
+
+    await forwardDevToAppDev({
+      argv: ['node', 'nocobase-v1', 'dev', '--port', '13000', '--db-sync'],
+      runCommand,
+    });
+
+    expect(calls).toEqual([['nocobase-v1', ['app-dev', '--port', '13000', '--db-sync']]]);
+  });
+});

--- a/packages/core/cli-v1/src/commands/dev.js
+++ b/packages/core/cli-v1/src/commands/dev.js
@@ -10,6 +10,7 @@ const _ = require('lodash');
 const { Command } = require('commander');
 const {
   generatePlugins,
+  hasCorePackages,
   run,
   runWithPrefix,
   postCheck,
@@ -41,6 +42,14 @@ async function buildBundleStatusHtml() {
   );
 }
 
+function buildAppDevForwardArgs(argv = process.argv) {
+  return ['app-dev', ...argv.slice(3)];
+}
+
+async function forwardDevToAppDev({ argv = process.argv, runCommand = run } = {}) {
+  await runCommand('nocobase-v1', buildAppDevForwardArgs(argv));
+}
+
 /**
  *
  * @param {Command} cli
@@ -58,6 +67,11 @@ module.exports = (cli) => {
     .option('-i, --inspect [port]')
     .allowUnknownOption()
     .action(async (opts) => {
+      if (!hasCorePackages()) {
+        await forwardDevToAppDev();
+        return;
+      }
+
       checkDBDialect();
       await buildBundleStatusHtml();
 
@@ -288,4 +302,9 @@ module.exports = (cli) => {
         runDevClientV2();
       }
     });
+};
+
+module.exports._test = {
+  buildAppDevForwardArgs,
+  forwardDevToAppDev,
 };


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
- Projects created by `create-nocobase-app` in 2.0 can still run `yarn dev` through `nocobase-v1 dev` after upgrading to 2.1.
- In app-project layouts without core packages, `nocobase-v1 dev` should reuse the `app-dev` flow instead of the source-repo dev flow.

### Description 
- Detect app projects in `packages/core/cli-v1/src/commands/dev.js` with `hasCorePackages()`.
- Forward `nocobase-v1 dev` to `nocobase-v1 app-dev` when the project does not include core packages, preserving passthrough arguments.
- Add a regression test for the command rewrite and argument forwarding behavior.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the `yarn dev` error after upgrading projects created by `create-nocobase-app` from 2.0 to 2.1. |
| 🇨🇳 Chinese | 修复 create-nocobase-app 创建的项目从 2.0 升级到 2.1 运行 yarn dev 报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
