### PR TITLE
refactor(plugin-action): load v2 action models lazily

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client-v2/flow/models/BulkEditActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client-v2/flow/models/BulkEditActionModel.tsx
@@ -32,6 +32,7 @@ export class BulkEditActionModel extends PopupActionModel {
 
 BulkEditActionModel.define({
   label: tExpr('Bulk edit'),
+  sort: 1010,
   createModelOptions: async (ctx, extra) => {
     return {
       use: 'BulkEditActionModel',

--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client-v2/index.tsx
@@ -11,13 +11,56 @@ import { Plugin } from '@nocobase/client-v2';
 import { bulkEditTitleField } from './flow/bulkEditTitleField';
 import { bulkEditFieldComponent } from './flow/bulkEditFieldComponent';
 
-import * as models from './flow/models';
-
 export class PluginActionBulkEditClient extends Plugin {
   async load() {
     // 先注册 bulkEditTitleField/bulkEditFieldComponent action，再导入 models
     this.app.flowEngine.registerActions({ bulkEditTitleField, bulkEditFieldComponent });
-    this.app.flowEngine.registerModels(models);
+    this.app.flowEngine.registerModelLoaders({
+      BulkEditActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./flow/models/BulkEditActionModel'),
+      },
+      BulkEditFormModel: {
+        extends: 'CreateFormModel',
+        loader: () => import('./flow/models/BulkEditFormModel'),
+      },
+      BulkEditFormItemModel: {
+        extends: 'FormItemModel',
+        loader: () => import('./flow/models/BulkEditFormItemModel'),
+      },
+      BulkEditFieldModel: {
+        extends: 'FieldModel',
+        loader: () => import('./flow/models/BulkEditFieldModel'),
+      },
+      BulkEditFormActionGroupModel: {
+        extends: 'ActionGroupModel',
+        loader: () => import('./flow/models/BulkEditFormActionGroupModel'),
+      },
+      BulkEditFormSubmitActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./flow/models/BulkEditFormSubmitActionModel'),
+      },
+      BulkEditChildPageTabModel: {
+        extends: 'ChildPageTabModel',
+        loader: () => import('./flow/models/BulkEditChildPageTabModel'),
+      },
+      BulkEditBlockGridModel: {
+        extends: 'BlockGridModel',
+        loader: () => import('./flow/models/BulkEditChildPageTabModel'),
+      },
+      BulkEditFormGridModel: {
+        extends: 'FormGridModel',
+        loader: () => import('./flow/models/BulkEditFormGridModel'),
+      },
+      BulkEditDataBlockModel: {
+        extends: 'DataBlockModel',
+        loader: () => import('./flow/models/BulkEditDataBlockModel'),
+      },
+      BulkEditBlockModel: {
+        extends: 'BlockModel',
+        loader: () => import('./flow/models/BulkEditDataBlockModel'),
+      },
+    });
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/BulkUpdateActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/BulkUpdateActionModel.tsx
@@ -41,6 +41,7 @@ export class BulkUpdateActionModel extends ActionModel<{
 
 BulkUpdateActionModel.define({
   label: tExpr('Bulk update'),
+  sort: 1020,
   // 使用函数型 createModelOptions，从父级上下文提取资源信息，直接注入到子模型的 resourceSettings.init
   createModelOptions: (ctx) => {
     return {

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/index.tsx
@@ -8,13 +8,15 @@
  */
 
 import { Plugin } from '@nocobase/client-v2';
-import { BulkUpdateActionModel } from './BulkUpdateActionModel';
 
 export class PluginActionBulkUpdateClient extends Plugin {
   async load() {
     // 注册 Flow 模型以支持新版流程引擎按钮动作
-    this.app.flowEngine.registerModels({
-      BulkUpdateActionModel,
+    this.app.flowEngine.registerModelLoaders({
+      BulkUpdateActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./BulkUpdateActionModel'),
+      },
     });
   }
 }

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/index.tsx
@@ -8,16 +8,21 @@
  */
 
 import { Plugin } from '@nocobase/client-v2';
-import { CustomRequestActionModel, registerCustomRequestActionGroups } from './CustomRequestActionModel';
 import { customRequestFlowAction } from './customRequestFlowAction';
 
 export class PluginActionCustomRequestClient extends Plugin {
   async load() {
     this.app.flowEngine.registerActions({ customRequestFlowAction });
-    this.app.flowEngine.registerModels({
-      CustomRequestActionModel,
+    this.app.flowEngine.registerModelLoaders({
+      CustomRequestActionModel: {
+        extends: 'ActionModel',
+        loader: async () => {
+          const module = await import('./CustomRequestActionModel');
+          module.registerCustomRequestActionGroups(this.app.flowEngine);
+          return module.CustomRequestActionModel;
+        },
+      },
     });
-    registerCustomRequestActionGroups(this.app.flowEngine);
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/index.tsx
@@ -8,12 +8,14 @@
  */
 
 import { Plugin } from '@nocobase/client-v2';
-import { DuplicateActionModel } from './DuplicateActionModel';
 
 export class PluginActionDuplicateClient extends Plugin {
   async load() {
-    this.app.flowEngine.registerModels({
-      DuplicateActionModel,
+    this.app.flowEngine.registerModelLoaders({
+      DuplicateActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./DuplicateActionModel'),
+      },
     });
   }
 }

--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
@@ -145,6 +145,7 @@ export class ExportActionModel extends ActionModel {
 
 ExportActionModel.define({
   label: escapeT('Export'),
+  sort: 1030,
 });
 
 ExportActionModel.registerFlow({

--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/index.ts
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/index.ts
@@ -8,12 +8,14 @@
  */
 
 import { Plugin } from '@nocobase/client-v2';
-import { ExportActionModel } from './ExportActionModel';
 
 export class PluginActionExportClient extends Plugin {
   async load() {
-    this.app.flowEngine.registerModels({
-      ExportActionModel,
+    this.app.flowEngine.registerModelLoaders({
+      ExportActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./ExportActionModel'),
+      },
     });
   }
 }

--- a/packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx
@@ -74,6 +74,7 @@ export class ImportActionModel extends ActionModel {
 
 ImportActionModel.define({
   label: escapeT('Import'),
+  sort: 1040,
 });
 
 const toArr = (value: any) => {

--- a/packages/plugins/@nocobase/plugin-action-import/src/client-v2/index.ts
+++ b/packages/plugins/@nocobase/plugin-action-import/src/client-v2/index.ts
@@ -8,11 +8,15 @@
  */
 
 import { Plugin } from '@nocobase/client-v2';
-import { ImportActionModel } from './ImportActionModel';
 
 export class PluginActionImportClient extends Plugin {
   async load() {
-    this.app.flowEngine.registerModels({ ImportActionModel });
+    this.app.flowEngine.registerModelLoaders({
+      ImportActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./ImportActionModel'),
+      },
+    });
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-action-print/src/client-v2/PrintActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-print/src/client-v2/PrintActionModel.tsx
@@ -94,6 +94,7 @@ export class PrintActionModel extends ActionModel {
 
 PrintActionModel.define({
   label: tExpr('Print'),
+  sort: 4000,
   hide(ctx) {
     // 仅支持“详情区块（DetailsBlockModel）”配置该动作，避免出现在表格行操作/其他区块里。
     const blockModel: any = (ctx as any)?.blockModel;

--- a/packages/plugins/@nocobase/plugin-action-print/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-action-print/src/client-v2/index.tsx
@@ -8,12 +8,14 @@
  */
 
 import { Application, Plugin } from '@nocobase/client-v2';
-import { PrintActionModel } from './PrintActionModel';
 
 export class PluginActionPrintClient extends Plugin<any, Application> {
   async load() {
-    this.flowEngine.registerModels({
-      PrintActionModel,
+    this.flowEngine.registerModelLoaders({
+      PrintActionModel: {
+        extends: 'ActionModel',
+        loader: () => import('./PrintActionModel'),
+      },
     });
   }
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Migrate the v2 action plugin model registration to lazy model loaders and avoid unstable action menu ordering after lazy loading.

### Description 
- Replace synchronous `registerModels()` usage with `registerModelLoaders()` for migrated v2 action plugins.
- Keep custom request action group registration inside the async model loader.
- Add explicit sort values for migrated action models so collection/action menus keep a stable order after models are lazily loaded.

Potential risk: other action plugins outside this migration scope can still have unstable relative ordering if they do not define an explicit `sort` value.

Testing performed:
- `yarn eslint --fix` on touched files
- `yarn test packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/__tests__/BulkUpdateActionModel.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/buildExportFieldOptions.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-action-import/src/client/__tests__/buildImportFieldOptions.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/__tests__/DuplicateActionModel.test.ts --run --reporter=verbose`
- `git diff --check`

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved v2 action plugin loading and kept migrated action buttons in a stable order. |
| 🇨🇳 Chinese | 优化 v2 操作插件加载方式，并保持已迁移操作按钮的顺序稳定。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary