### PR TITLE
fix(plugin-file-manager): load pdf.js worker from plugin static files

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/build.config.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/build.config.ts
@@ -19,5 +19,9 @@ export default defineConfig({
         force: true,
       },
     );
+    await fs.copyFile(
+      path.resolve(pdfjsDist, 'build/pdf.worker.min.mjs'),
+      path.resolve(__dirname, 'dist/client/pdfjs/pdf.worker.min.mjs'),
+    );
   },
 });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
@@ -431,19 +431,25 @@ const getPluginStaticPublicPath = (browserWindow?: NocoBaseWindow) => {
   return publicPath.replace(new RegExp(`/${escapeRegExp(modernClientPrefix)}/$`), '/');
 };
 
+const getPdfjsBaseUrl = () => {
+  const browserWindow = typeof window === 'undefined' ? undefined : (window as NocoBaseWindow);
+  const publicPath = getPluginStaticPublicPath(browserWindow);
+  return `${publicPath}static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/`;
+};
+
 export const getPdfPreviewResourceOptions = (): Pick<
   DocumentInitParameters,
   'cMapPacked' | 'cMapUrl' | 'standardFontDataUrl'
 > => {
-  const browserWindow = typeof window === 'undefined' ? undefined : (window as NocoBaseWindow);
-  const publicPath = getPluginStaticPublicPath(browserWindow);
-  const pdfjsBaseUrl = `${publicPath}static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/`;
+  const pdfjsBaseUrl = getPdfjsBaseUrl();
   return {
     cMapPacked: true,
     cMapUrl: `${pdfjsBaseUrl}cmaps/`,
     standardFontDataUrl: `${pdfjsBaseUrl}standard_fonts/`,
   };
 };
+
+export const getPdfPreviewWorkerSrc = () => `${getPdfjsBaseUrl()}pdf.worker.min.mjs`;
 
 type PdfPreviewErrorCode = 'resources' | 'file' | 'document';
 
@@ -576,10 +582,7 @@ const PdfPreviewer = ({ file }: FilePreviewerProps) => {
       }
       session.data = data;
       try {
-        pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-          'pdfjs-dist/build/pdf.worker.min.mjs',
-          import.meta.url,
-        ).toString();
+        pdfjs.GlobalWorkerOptions.workerSrc = getPdfPreviewWorkerSrc();
         session.worker = pdfjs.PDFWorker.create({});
       } catch (error) {
         throw new PdfPreviewError('resources', 'Failed to load PDF.js worker.', error);

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
@@ -12,6 +12,7 @@ import {
   getDownloadFileName,
   getFileName,
   getPdfPreviewResourceOptions,
+  getPdfPreviewWorkerSrc,
   getPreviewThumbnailUrl,
   isActiveContentFile,
 } from '../filePreviewTypes';
@@ -80,6 +81,9 @@ describe('getDownloadFileName', () => {
       cMapUrl: '/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/cmaps/',
       standardFontDataUrl: '/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/standard_fonts/',
     });
+    expect(getPdfPreviewWorkerSrc()).toBe(
+      '/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
   });
 
   it('应兼容子路径部署下的 PDF.js 预览资源地址', () => {
@@ -91,6 +95,9 @@ describe('getDownloadFileName', () => {
       cMapUrl: '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/cmaps/',
       standardFontDataUrl: '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/standard_fonts/',
     });
+    expect(getPdfPreviewWorkerSrc()).toBe(
+      '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
   });
 
   it('未注入现代客户端前缀时不应猜测默认前缀', () => {
@@ -101,6 +108,9 @@ describe('getDownloadFileName', () => {
       cMapUrl: '/nocobase/v/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/cmaps/',
       standardFontDataUrl: '/nocobase/v/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/standard_fonts/',
     });
+    expect(getPdfPreviewWorkerSrc()).toBe(
+      '/nocobase/v/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
   });
 
   it('应兼容自定义现代客户端前缀下的 PDF.js 预览资源地址', () => {
@@ -112,6 +122,9 @@ describe('getDownloadFileName', () => {
       cMapUrl: '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/cmaps/',
       standardFontDataUrl: '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/standard_fonts/',
     });
+    expect(getPdfPreviewWorkerSrc()).toBe(
+      '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
   });
 
   it('配置 CDN 地址时应优先使用 CDN 基础路径', () => {
@@ -124,5 +137,8 @@ describe('getDownloadFileName', () => {
       standardFontDataUrl:
         'https://cdn.example.com/assets/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/standard_fonts/',
     });
+    expect(getPdfPreviewWorkerSrc()).toBe(
+      'https://cdn.example.com/assets/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
PDF preview in the file manager can fail when pdf.js cannot load its worker module from the bundled `new URL('pdfjs-dist/...', import.meta.url)` path. In that case pdf.js falls back to a fake worker, the dynamic import fails, and users see the generic PDF preview failure message.

### Description 
This PR serves the pdf.js worker as a plugin static resource, using the same public path logic already used for PDF.js cMaps and standard fonts.

- Copies `pdf.worker.min.mjs` into `dist/client/pdfjs/` during plugin build.
- Resolves the worker URL from the plugin static base path at runtime.
- Adds tests for the worker URL across root path, sub-path, custom modern client prefix, and CDN public path scenarios.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-file-manager/build.config.ts packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts`

### Related issues

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed PDF preview failures caused by the pdf.js worker module not loading correctly. |
| 🇨🇳 Chinese | 修复 pdf.js worker 模块加载异常导致 PDF 预览失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
