### PR TITLE
fix(users-permissions): improve v2 management pages

### DIFF
--- a/packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx
+++ b/packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx
@@ -239,11 +239,12 @@ export const InternalAdminSettingsLayout = () => {
       <Layout.Content
         style={{
           background: token.colorBgLayout,
+          flex: 1,
           display: 'flex',
           flexDirection: 'column',
           minWidth: 0,
-          overflowY: 'auto',
-          overflowX: 'hidden',
+          minHeight: 0,
+          overflow: 'hidden',
         }}
       >
         <PageHeader
@@ -273,6 +274,10 @@ export const InternalAdminSettingsLayout = () => {
         />
         <div
           style={{
+            flex: 1,
+            minHeight: 0,
+            boxSizing: 'border-box',
+            overflow: 'auto',
             padding: token.paddingLG,
           }}
         >

--- a/packages/plugins/@nocobase/plugin-acl/src/client-v2/pages/RolesManagementPage.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client-v2/pages/RolesManagementPage.tsx
@@ -235,7 +235,7 @@ export default function RolesManagementPage() {
   const [activeTabKey, setActiveTabKey] = useState('permissions');
   const [activePermissionTabKey, setActivePermissionTabKey] = useState('general');
   const cardClassName = css`
-    height: calc(100vh - 160px);
+    height: 100%;
     min-height: 0;
 
     > .ant-card-body {

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/__tests__/departmentTree.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/__tests__/departmentTree.test.ts
@@ -56,6 +56,21 @@ describe('department tree helpers', () => {
     ]);
   });
 
+  it('does not render children under departments marked as leaf', () => {
+    expect(
+      buildDepartmentTree([
+        { id: 1, title: 'Headquarters', isLeaf: true },
+        { id: 2, title: 'Hidden sub department', parentId: 1 },
+      ]),
+    ).toEqual([
+      {
+        id: 1,
+        title: 'Headquarters',
+        isLeaf: true,
+      },
+    ]);
+  });
+
   it('keeps empty children only for lazy-loaded non-leaf departments', () => {
     expect(
       buildLazyDepartmentTreeNodes([

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/pages/DepartmentsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/pages/DepartmentsPage.tsx
@@ -64,7 +64,7 @@ const DEPARTMENT_TREE_PANEL_WIDTH = 280;
 const MEMBER_TABLE_PAGE_SIZE = 20;
 const ADD_MEMBERS_TABLE_PAGE_SIZE = 20;
 const SEARCH_RESULT_LIMIT = 10;
-const DEPARTMENTS_PAGE_HEIGHT = 'calc(100vh - 160px)';
+const DEPARTMENTS_PAGE_HEIGHT = '100%';
 const TABLE_ACTION_BUTTON_STYLE: React.CSSProperties = { paddingInline: 0, height: 'auto' };
 
 type MembersFilter = CompiledFilter;
@@ -219,16 +219,15 @@ function buildMembersFilter(department: DepartmentRecord | null, filter?: Member
 function toTreeNodes(
   records: DepartmentRecord[],
   renderTitle: (department: DepartmentRecord) => React.ReactNode,
-  excludedKeys = new Set<DepartmentPrimaryKey>(),
+  disabledKeys = new Set<DepartmentPrimaryKey>(),
 ): DataNode[] {
-  return records
-    .filter((department) => !excludedKeys.has(department.id))
-    .map((department) => ({
-      key: department.id,
-      value: department.id,
-      title: renderTitle(department),
-      children: department.children?.length ? toTreeNodes(department.children, renderTitle, excludedKeys) : undefined,
-    }));
+  return records.map((department) => ({
+    key: department.id,
+    value: department.id,
+    title: renderTitle(department),
+    disabled: disabledKeys.has(department.id),
+    children: department.children?.length ? toTreeNodes(department.children, renderTitle, disabledKeys) : undefined,
+  }));
 }
 
 function findDepartment(records: DepartmentRecord[], id?: React.Key): DepartmentRecord | null {
@@ -1241,7 +1240,7 @@ const DepartmentsPage: React.FC = () => {
     () => css`
       flex: 1;
       min-height: 0;
-      overflow-y: scroll;
+      overflow-y: auto;
       overflow-x: hidden;
       .ant-tree-treenode {
         width: 100%;
@@ -1326,7 +1325,7 @@ const DepartmentsPage: React.FC = () => {
           >
             {t('All users')}
           </Button>
-          <Button block type="dashed" icon={<PlusOutlined />} onClick={() => openDepartmentForm('create')}>
+          <Button block icon={<PlusOutlined />} onClick={() => openDepartmentForm('create')}>
             {t('New department')}
           </Button>
           <div className={departmentTreeClassName}>

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/shared/department.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/shared/department.ts
@@ -56,7 +56,10 @@ export function buildDepartmentTree(records: DepartmentRecord[]): DepartmentReco
 
   nodes.forEach((node) => {
     if (node.parentId != null && nodes.has(node.parentId)) {
-      nodes.get(node.parentId)?.children?.push(node);
+      const parent = nodes.get(node.parentId);
+      if (parent?.isLeaf !== true) {
+        parent?.children?.push(node);
+      }
       return;
     }
     roots.push(node);

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersManagementPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersManagementPage.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import UsersManagementPage from '../pages/UsersManagementPage';
+
+const { open } = vi.hoisted(() => ({
+  open: vi.fn(),
+}));
+
+vi.mock('@nocobase/client-v2', () => ({
+  useACLRoleContext: () => ({
+    parseAction: (action: string) => (action === 'users:create' ? null : {}),
+  }),
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    dataSourceManager: {
+      getDataSource: () => ({
+        getCollection: () => ({}),
+      }),
+    },
+    viewer: {
+      open,
+    },
+    api: {
+      resource: () => ({
+        destroy: vi.fn(),
+        list: vi.fn().mockResolvedValue({ data: { data: [], meta: {} } }),
+      }),
+    },
+    message: {
+      success: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('../components/resource', () => ({
+  ResourceTablePage: ({
+    toolbar,
+  }: {
+    toolbar: (args: { refresh: () => void; refreshAsync: () => Promise<void> }) => React.ReactNode;
+  }) => <div>{toolbar({ refresh: vi.fn(), refreshAsync: vi.fn().mockResolvedValue(undefined) })}</div>,
+  SettingsActionCell: () => null,
+}));
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+}));
+
+vi.mock('../pages/UserFormDrawer', () => ({
+  default: () => <div>UserFormDrawer</div>,
+}));
+
+vi.mock('../pages/ChangeUserPasswordDrawer', () => ({
+  default: () => <div>ChangeUserPasswordDrawer</div>,
+}));
+
+vi.mock('../pages/UsersSettingsForm', () => ({
+  default: () => <div>UsersSettingsForm</div>,
+}));
+
+describe('UsersManagementPage', () => {
+  it('shows the add user action even when users:create is not granted', () => {
+    render(<UsersManagementPage />);
+
+    expect(screen.getByRole('button', { name: /Add new/ })).toBeInTheDocument();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UsersManagementPage.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UsersManagementPage.tsx
@@ -40,7 +40,6 @@ function UsersTable() {
   const acl = useACLRoleContext();
   const refreshRef = useRef<() => Promise<unknown>>();
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
-  const canCreate = acl.parseAction('users:create') !== null;
   const canUpdate = acl.parseAction('users:update') !== null;
   const canDestroy = acl.parseAction('users:destroy') !== null;
 
@@ -161,11 +160,9 @@ function UsersTable() {
             </Button>
           </Popconfirm>
         ) : null}
-        {canCreate ? (
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => openUserDrawer()}>
-            {t('Add new')}
-          </Button>
-        ) : null}
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => openUserDrawer()}>
+          {t('Add new')}
+        </Button>
       </>
     );
   });
@@ -219,7 +216,7 @@ export default function UsersManagementPage() {
   const t = useT();
   const { token } = theme.useToken();
   const tabsClassName = css`
-    height: calc(100vh - 160px);
+    height: 100%;
     min-height: 0;
     display: flex;
     flex-direction: column;
@@ -259,7 +256,7 @@ export default function UsersManagementPage() {
       items={[
         {
           key: 'usersManager',
-          label: t('Users'),
+          label: t('Users manager'),
           children: (
             <div style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
               <UsersTable />

--- a/packages/plugins/@nocobase/plugin-users/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-users/src/locale/en-US.json
@@ -17,6 +17,7 @@
   "Removed successfully": "Removed successfully",
   "Username is required": "Username is required",
   "User profile is not allowed to be edited": "User profile is not allowed to be edited",
+  "User manager": "User manager",
   "Users": "Users",
   "Users & Permissions": "Users & Permissions",
   "Users manager": "Users manager"

--- a/packages/plugins/@nocobase/plugin-users/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-users/src/locale/zh-CN.json
@@ -17,6 +17,7 @@
   "Removed successfully": "移除成功",
   "Username is required": "请输入用户名",
   "User profile is not allowed to be edited": "用户资料不允许修改",
+  "User manager": "用户管理",
   "Users": "用户",
   "Users & Permissions": "用户和权限",
   "Users manager": "用户管理"


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Improve the Users & Permissions v2 management experience and align department tree behavior with v1.

### Description 
- Rename the Users tab title to User manager.
- Improve Users, Roles, and Departments settings page height and scroll behavior.
- Update the Departments tree panel to avoid forced scrollbar space.
- Change the New department action from dashed to a normal button.
- Keep unavailable superior departments visible as disabled options.
- Preserve v1 behavior by not rendering children under departments marked as leaf.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved the Users & Permissions v2 page layout and department tree behavior. |
| 🇨🇳 Chinese | 优化用户和权限 v2 页面布局及部门树行为。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
