### PR TITLE
fix(plugin-workflow): recover dispatcher after unexpected errors

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -241,42 +241,51 @@ export default class Dispatcher {
 
     this.executing = (async () => {
       let next: ExecutionPlan | null = null;
-      const pending: Pending | null = this.pending.shift() ?? null;
-      if (pending || (this.ready && this.plugin.serving())) {
-        const execution: ExecutionModel | null = await this.prepare(pending?.execution ?? null, {
-          immediate: pending?.immediate,
-        });
-        if (execution) {
-          next = [execution, pending?.job, pending?.rerun];
+      let pending: Pending | null = null;
+      try {
+        pending = this.pending.shift() ?? null;
+        if (pending || (this.ready && this.plugin.serving())) {
+          const execution: ExecutionModel | null = await this.prepare(pending?.execution ?? null, {
+            immediate: pending?.immediate,
+          });
+          if (execution) {
+            next = [execution, pending?.job, pending?.rerun];
+          }
+          if (pending && next) {
+            this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
+          }
+        } else {
+          this.plugin
+            .getLogger('dispatcher')
+            .warn(
+              `${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance or app not ready, new dispatching will be ignored`,
+            );
         }
-        if (pending && next) {
-          this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
-        }
-      } else {
-        this.plugin
-          .getLogger('dispatcher')
-          .warn(
-            `${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance or app not ready, new dispatching will be ignored`,
-          );
-      }
-      if (next) {
-        try {
-          await this.process(next[0], next[1], { rerun: next[2] });
-        } catch (error) {
-          this.plugin.getLogger(next[0].workflowId).error(`execution (${next[0].id}) process failed`, { error });
-          if (pending && isLockAcquireError(error)) {
-            this.pending.unshift({ ...pending, execution: next[0], immediate: true });
+        if (next) {
+          try {
+            await this.process(next[0], next[1], { rerun: next[2] });
+          } catch (error) {
+            this.plugin.getLogger(next[0].workflowId).error(`execution (${next[0].id}) process failed`, { error });
+            if (pending && isLockAcquireError(error)) {
+              this.pending.unshift({ ...pending, execution: next[0], immediate: true });
+            }
           }
         }
-      }
-      setImmediate(() => {
-        this.executing = null;
-
-        if (next || this.pending.length) {
-          this.plugin.getLogger('dispatcher').debug(`last process finished, will do another dispatch`);
-          this.dispatch();
+      } catch (error) {
+        this.plugin.getLogger('dispatcher').error(`workflow dispatch failed`, { error });
+        if (pending && !next) {
+          this.pending.unshift(pending);
         }
-      });
+      } finally {
+        setImmediate(() => {
+          this.executing = null;
+
+          if (next || this.pending.length) {
+            this.plugin.getLogger('dispatcher').debug(`last process finished, will do another dispatch`);
+            this.dispatch();
+          }
+        });
+      }
     })();
   }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -21,6 +21,7 @@ import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 import { getExecutionLockKey, isLockAcquireError } from './utils';
 
 const EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
+const PENDING_DISPATCH_MAX_ATTEMPTS = 3;
 
 type AcquireRetryLogger = Pick<ReturnType<PluginWorkflowServer['getLogger']>, 'warn'>;
 
@@ -31,6 +32,7 @@ type Pending = {
   job?: JobModel;
   immediate?: boolean;
   rerun?: ProcessorRerunOptions;
+  dispatchAttempts?: number;
 };
 
 type CachedEvent = [WorkflowModel, any, EventOptions];
@@ -273,8 +275,18 @@ export default class Dispatcher {
         }
       } catch (error) {
         this.plugin.getLogger('dispatcher').error(`workflow dispatch failed`, { error });
-        if (pending && !next) {
-          this.pending.unshift(pending);
+        if (pending) {
+          const dispatchAttempts = (pending.dispatchAttempts ?? 0) + 1;
+          if (dispatchAttempts < PENDING_DISPATCH_MAX_ATTEMPTS) {
+            this.pending.push({ ...pending, dispatchAttempts });
+          } else {
+            this.plugin
+              .getLogger(pending.execution.workflowId)
+              .error(`pending execution (${pending.execution.id}) dispatch failed, local retry limit reached`, {
+                error,
+                dispatchAttempts,
+              });
+          }
         }
       } finally {
         setImmediate(() => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -352,6 +352,83 @@ describe('workflow > Plugin', () => {
       expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
     });
 
+    it('should recover after unexpected dispatch error before cleanup', async () => {
+      type RecoveringDispatcher = {
+        dispatch(): void;
+        executing: Promise<unknown> | null;
+        pending: unknown[];
+        idle: boolean;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: RecoveringDispatcher }).dispatcher;
+      const serving = plugin.serving;
+
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await w1.createNode({
+        type: 'echo',
+      });
+      await w1.createExecution({
+        key: w1.key,
+        context: { first: true },
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+
+      plugin.serving = (() => {
+        const stack = new Error().stack;
+        if (stack?.includes('Dispatcher.ts')) {
+          throw new Error('simulated serving check failure');
+        }
+        return serving.call(plugin);
+      }) as typeof plugin.serving;
+
+      try {
+        dispatcher.dispatch();
+        await dispatcher.executing?.catch(() => null);
+
+        for (let i = 0; i < 20; i++) {
+          if (!dispatcher.executing) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        expect(dispatcher.executing).toBeNull();
+        expect(dispatcher.idle).toBe(true);
+
+        plugin.serving = serving;
+
+        const w2 = await WorkflowModel.create({
+          enabled: true,
+          type: 'asyncTrigger',
+        });
+        await w2.createNode({
+          type: 'echo',
+        });
+
+        plugin.trigger(w2, { second: true });
+
+        let e2: ExecutionModel | null = null;
+        for (let i = 0; i < 20; i++) {
+          [e2] = await w2.getExecutions();
+          if (e2?.status === EXECUTION_STATUS.RESOLVED) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        expect(e2?.status).toBe(EXECUTION_STATUS.RESOLVED);
+        expect(e2?.dispatched).toBe(true);
+      } finally {
+        plugin.serving = serving;
+        await dispatcher.executing?.catch(() => null);
+        dispatcher.executing = null;
+        dispatcher.pending = [];
+      }
+    });
+
     it('should treat postgres deadlock as concurrent acquire error', () => {
       type ConcurrentAcquireDispatcher = {
         isConcurrentAcquireError(error: unknown): boolean;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -429,6 +429,84 @@ describe('workflow > Plugin', () => {
       }
     });
 
+    it('should stop retrying local pending after repeated unexpected dispatch errors', async () => {
+      type RecoveringDispatcher = {
+        run(pending: { execution: ExecutionModel }): Promise<void>;
+        prepare(input: ExecutionModel | null, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
+        executing: Promise<unknown> | null;
+        pending: unknown[];
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: RecoveringDispatcher }).dispatcher;
+      const prepare = dispatcher.prepare;
+      let prepareCalls = 0;
+
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await w1.createNode({
+        type: 'echo',
+      });
+      const e1 = await w1.createExecution({
+        key: w1.key,
+        context: { first: true },
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+
+      dispatcher.prepare = (async () => {
+        prepareCalls += 1;
+        throw new Error('simulated prepare failure');
+      }) as typeof dispatcher.prepare;
+
+      try {
+        await dispatcher.run({ execution: e1 });
+
+        for (let i = 0; i < 20; i++) {
+          if (!dispatcher.executing && !dispatcher.pending.length) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        const callsAfterDrain = prepareCalls;
+        await sleep(100);
+
+        expect(callsAfterDrain).toBe(3);
+        expect(prepareCalls).toBe(callsAfterDrain);
+        expect(dispatcher.executing).toBeNull();
+        expect(dispatcher.pending).toHaveLength(0);
+
+        dispatcher.prepare = prepare;
+
+        const w2 = await WorkflowModel.create({
+          enabled: true,
+          type: 'asyncTrigger',
+        });
+        await w2.createNode({
+          type: 'echo',
+        });
+
+        plugin.trigger(w2, { second: true });
+
+        let e2: ExecutionModel | null = null;
+        for (let i = 0; i < 20; i++) {
+          [e2] = await w2.getExecutions();
+          if (e2?.status === EXECUTION_STATUS.RESOLVED) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        expect(e2?.status).toBe(EXECUTION_STATUS.RESOLVED);
+      } finally {
+        dispatcher.prepare = prepare;
+        await dispatcher.executing?.catch(() => null);
+        dispatcher.executing = null;
+        dispatcher.pending = [];
+      }
+    });
+
     it('should treat postgres deadlock as concurrent acquire error', () => {
       type ConcurrentAcquireDispatcher = {
         isConcurrentAcquireError(error: unknown): boolean;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/utils.test.ts
@@ -71,7 +71,7 @@ describe('workflow > utils', () => {
     expect(execution.set).toHaveBeenCalledWith('reason', EXECUTION_REASON.TIMEOUT);
   });
 
-  it('should cascade timeout abort to started child executions', async () => {
+  it('should cascade timeout abort to started and queueing child executions', async () => {
     const parent = {
       id: 1,
       workflowId: 1,
@@ -83,6 +83,13 @@ describe('workflow > utils', () => {
       id: 2,
       workflowId: 2,
       status: EXECUTION_STATUS.STARTED,
+      update: vi.fn(),
+      set: vi.fn(),
+    };
+    const queueingChild = {
+      id: 3,
+      workflowId: 3,
+      status: EXECUTION_STATUS.QUEUEING,
       update: vi.fn(),
       set: vi.fn(),
     };
@@ -103,11 +110,14 @@ describe('workflow > utils', () => {
         if (filterByTk === child.id) {
           return child;
         }
+        if (filterByTk === queueingChild.id) {
+          return queueingChild;
+        }
         return null;
       }),
       find: vi.fn(({ filter }) => {
         if (filter.parentExecutionId === parent.id) {
-          return [child];
+          return [child, queueingChild];
         }
         return [];
       }),
@@ -170,8 +180,23 @@ describe('workflow > utils', () => {
         transaction,
       },
     );
+    expect(executionRepo.model.update).toHaveBeenCalledWith(
+      {
+        status: EXECUTION_STATUS.ABORTED,
+        reason: EXECUTION_REASON.PARENT_ABORTED,
+      },
+      {
+        where: {
+          id: queueingChild.id,
+          status: EXECUTION_STATUS.QUEUEING,
+        },
+        individualHooks: true,
+        transaction,
+      },
+    );
     expect(plugin.timeoutManager.clear).toHaveBeenCalledWith(parent.id);
     expect(plugin.timeoutManager.clear).toHaveBeenCalledWith(child.id);
+    expect(plugin.timeoutManager.clear).toHaveBeenCalledWith(queueingChild.id);
   });
 
   it('should abort pending jobs when aborting execution', async () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/utils.test.ts
@@ -152,6 +152,13 @@ describe('workflow > utils', () => {
     );
 
     expect(plugin.db.sequelize.transaction).toHaveBeenCalledTimes(1);
+    expect(executionRepo.find).toHaveBeenCalledWith({
+      filter: {
+        parentExecutionId: parent.id,
+        status: [EXECUTION_STATUS.QUEUEING, EXECUTION_STATUS.STARTED],
+      },
+      transaction,
+    });
     expect(executionRepo.model.update).toHaveBeenCalledWith(
       {
         status: EXECUTION_STATUS.ABORTED,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
@@ -114,10 +114,17 @@ export async function abortExecution(
         : {}),
     };
 
+    const expectedStatus =
+      typeof execution.status === 'undefined' ? EXECUTION_STATUS.STARTED : (execution.status as number | null);
+
+    if (![EXECUTION_STATUS.QUEUEING, EXECUTION_STATUS.STARTED].includes(expectedStatus)) {
+      return false;
+    }
+
     const [affected] = await ExecutionRepo.model.update(abortValues, {
       where: {
         id: execution.id,
-        status: EXECUTION_STATUS.STARTED,
+        status: expectedStatus ?? null,
       },
       individualHooks: true,
       transaction,
@@ -142,12 +149,14 @@ export async function abortExecution(
     const childExecutions = await plugin.db.getRepository('executions').find({
       filter: {
         parentExecutionId: execution.id,
-        status: EXECUTION_STATUS.STARTED,
       },
       transaction,
     });
 
     for (const child of childExecutions) {
+      if (![EXECUTION_STATUS.QUEUEING, EXECUTION_STATUS.STARTED].includes(child.status)) {
+        continue;
+      }
       await abortExecution(plugin, child, { transaction, reason: EXECUTION_REASON.PARENT_ABORTED });
     }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
@@ -124,7 +124,7 @@ export async function abortExecution(
     const [affected] = await ExecutionRepo.model.update(abortValues, {
       where: {
         id: execution.id,
-        status: expectedStatus ?? null,
+        status: expectedStatus,
       },
       individualHooks: true,
       transaction,
@@ -149,6 +149,7 @@ export async function abortExecution(
     const childExecutions = await plugin.db.getRepository('executions').find({
       filter: {
         parentExecutionId: execution.id,
+        status: [EXECUTION_STATUS.QUEUEING, EXECUTION_STATUS.STARTED],
       },
       transaction,
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow dispatch can remain non-idle when an unexpected dispatch error happens before the dispatcher reaches its cleanup step. In that state, `executing` remains set and later dispatch attempts are ignored.

### Description 
This PR wraps the dispatcher execution loop with `try/catch/finally` so unexpected dispatch errors are logged and `executing` is always cleared.

It also restores a local pending execution if it was removed from the pending list before the dispatch failure and adds a regression test that verifies the dispatcher recovers and continues processing later executions.

Scope: this change only handles rejected/throwing dispatch paths. It does not change behavior for executions that keep running or never settle, such as a long-running `prepare()`, `process()`, lock acquisition, `runExclusive()`, or instruction promise. Those cases remain covered by the existing workflow timeout configuration.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow dispatcher recovery after unexpected dispatch errors. |
| 🇨🇳 Chinese | 修复工作流调度器在调度异常后的恢复问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary