### PR TITLE
feat(backups): support Kingbase backup toolchains

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
@@ -93,7 +93,7 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
         ]}
       >
         <Form layout="vertical" autoComplete="off">
-          {dialect === 'postgres' && (
+          {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
               label={<strong>{t('Confirm the application database schema')}</strong>}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
@@ -129,7 +129,7 @@ export const RestoreFromLocal = () => {
               <p className="ant-upload-text">{t('Click or drag file to this area to upload')}</p>
             </Upload.Dragger>
           </Form.Item>
-          {dialect === 'postgres' && (
+          {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
               label={<strong>{t('Confirm the application database schema')}</strong>}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}

--- a/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromBackup.tsx
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { useAPIClient } from '@nocobase/client';
 import { Button, Input, Modal, Form } from 'antd';
 import React from 'react';
@@ -75,7 +84,7 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
         ]}
       >
         <Form layout={'vertical'} autoComplete="off">
-          {dialect === 'postgres' && (
+          {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
               label={<strong>{t('Confirm the application database schema')}</strong>}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}

--- a/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromLocal.tsx
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { InboxOutlined, QuestionCircleOutlined, UploadOutlined } from '@ant-design/icons';
 import { useAPIClient } from '@nocobase/client';
 import { App, Button, Checkbox, Flex, Input, Modal, Tooltip, Upload, Form, UploadFile } from 'antd';
@@ -110,7 +119,7 @@ export const RestoreFromLocal = () => {
               <p className="ant-upload-text"> {t('Click or drag file to this area to upload')}</p>
             </Upload.Dragger>
           </Form.Item>
-          {dialect === 'postgres' && (
+          {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
               label={<strong>{t('Confirm the application database schema')}</strong>}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/adapters/database.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/adapters/database.test.ts
@@ -280,6 +280,88 @@ describe('DatabaseAdapter', () => {
     });
   });
 
+  describe('KingbaseAdapter', () => {
+    const dbOpts: DatabaseOptions = {
+      dialect: 'kingbase',
+      username: 'test',
+      password: 'secret',
+      database: 'test',
+      host: 'localhost',
+      port: 54321,
+    } as DatabaseOptions;
+
+    it('uses Kingbase client tools by default', async () => {
+      const mockedExec = cp.exec as unknown as Mock;
+      mockedExec.mockClear();
+      mockedExec.mockImplementation((_command, _options, callback) => {
+        callback(null, { stdout: 'done' });
+      });
+      const adapter = getDBAdapter(dbOpts);
+      const dir = os.tmpdir();
+
+      await adapter.backup({ dir });
+      await adapter.restore({ filePath: os.tmpdir(), skipDropAllTables: true });
+
+      expect(adapter.backupToolchain).toBe('kingbase');
+      expect(mockedExec.mock.calls[0][0]).toContain('sys_dump');
+      expect(mockedExec.mock.calls[0][0]).toContain('--schema=public');
+      expect(mockedExec.mock.calls[0][1].env).toEqual(expect.objectContaining({ KINGBASE_PASSWORD: 'secret' }));
+      expect(mockedExec.mock.calls[1][0]).toContain('sys_restore');
+      expect(mockedExec.mock.calls[1][1].env).toEqual(expect.objectContaining({ KINGBASE_PASSWORD: 'secret' }));
+    });
+
+    it('falls back to PostgreSQL client tools when Kingbase tools are missing', async () => {
+      (cp.execSync as Mock).mockImplementation((command) => {
+        if (
+          String(command).includes('sys_dump') ||
+          String(command).includes('sys_restore') ||
+          String(command).includes('ksql')
+        ) {
+          throw new Error('Command not found');
+        }
+        return 'PostgreSQL 16.1';
+      });
+      const mockedExec = cp.exec as unknown as Mock;
+      mockedExec.mockClear();
+      mockedExec.mockImplementation((_command, _options, callback) => {
+        callback(null, { stdout: 'done' });
+      });
+      const adapter = getDBAdapter(dbOpts);
+
+      await adapter.backup({ dir: os.tmpdir() });
+      await adapter.restore({ filePath: os.tmpdir(), skipDropAllTables: true });
+
+      expect(adapter.backupToolchain).toBe('postgres');
+      expect(mockedExec.mock.calls[0][0]).toContain('pg_dump');
+      expect(mockedExec.mock.calls[1][0]).toContain('pg_restore');
+    });
+
+    it('uses sys_restore schema remapping for Kingbase backup toolchain', async () => {
+      (cp.execSync as Mock).mockImplementation(() => 'KingbaseES V009R001C010');
+      const mockedExec = cp.exec as unknown as Mock;
+      mockedExec.mockClear();
+      mockedExec.mockImplementation((_command, _options, callback) => {
+        callback(null, { stdout: 'done' });
+      });
+      const adapter = getDBAdapter({
+        ...dbOpts,
+        schema: 'target_schema',
+      } as DatabaseOptions);
+
+      await adapter.restore({ filePath: os.tmpdir(), schema: 'source_schema', skipDropAllTables: true });
+
+      const commands = mockedExec.mock.calls.map(([command]) => command);
+      expect(commands.some((command) => command.includes('CREATE SCHEMA IF NOT EXISTS \\"target_schema\\"'))).toBe(
+        true,
+      );
+      expect(commands.some((command) => command.includes('sys_restore') && command.includes('-g source_schema'))).toBe(
+        true,
+      );
+      expect(commands.some((command) => command.includes('-G target_schema'))).toBe(true);
+      expect(commands.some((command) => command.includes('jsonb_set'))).toBe(true);
+    });
+  });
+
   describe('MySQLAdapter', () => {
     const dbOpts: DatabaseOptions = {
       dialect: 'mysql',

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
@@ -392,6 +392,67 @@ describe('RestoreManager', () => {
     expect(app.runCommand).toHaveBeenCalledWith('upgrade');
   });
 
+  it('allows Kingbase schema mismatch with force schema restore', async () => {
+    vi.spyOn(app, 'runCommand').mockReturnValue({} as any);
+    await createBackupArchive(
+      schemaMismatchBackupFilePath,
+      createMetadata({
+        dialect: 'kingbase',
+        toolchain: 'kingbase',
+        version: 'KingbaseES V009R001C010',
+        backupClientVersion: 'sys_dump (KingbaseES) V009R001C010',
+      }),
+    );
+    const restoreManager = new RestoreManager(createCtx(), {
+      dialect: 'kingbase',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      host: 'localhost',
+      port: 54321,
+      schema: 'target_schema',
+    });
+
+    await expect(
+      restoreManager.restore(schemaMismatchBackupFilePath, 'task_id', undefined, true, true, {
+        forceSchemaRestore: true,
+      }),
+    ).resolves.toBeUndefined();
+    await sleep(3000);
+    expect(app.runCommand).toHaveBeenCalledWith('upgrade');
+  });
+
+  it('infers PostgreSQL toolchain for legacy Kingbase backups created by pg_dump', async () => {
+    const { backupFilePath } = createBackupFile('kingbase-pg-toolchain');
+    await createBackupArchive(
+      backupFilePath,
+      createMetadata({
+        dialect: 'kingbase',
+        schema: 'source_schema',
+        version: 'KingbaseES V009R001C010',
+        backupClientVersion: 'pg_dump (PostgreSQL) 17.2',
+      }),
+    );
+    const mockedExec = cp.exec as unknown as Mock;
+    mockedExec.mockClear();
+    const restoreManager = new RestoreManager(createCtx(), {
+      dialect: 'kingbase',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      host: 'localhost',
+      port: 54321,
+      schema: 'source_schema',
+    });
+
+    await restoreManager.restore(backupFilePath, 'task_id', undefined, true, true);
+
+    await vi.waitFor(() => {
+      expect(mockedExec.mock.calls.some(([command]) => command.includes('pg_restore'))).toBe(true);
+    });
+    expect(mockedExec.mock.calls.some(([, options]) => options.env?.PGPASSWORD === 'test')).toBe(true);
+  });
+
   it('does not ignore dialect mismatch with force schema restore', async () => {
     await createBackupArchive(schemaMismatchBackupFilePath, createMetadata({ dialect: 'mysql' }));
     const restoreManager = new RestoreManager(createCtx(), {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/adapters/database.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/adapters/database.ts
@@ -33,10 +33,14 @@ export type DBRestoreOptions = {
   filePath: string;
   schema?: string;
   skipDropAllTables?: boolean;
+  toolchain?: DBBackupToolchain;
 };
+
+export type DBBackupToolchain = 'postgres' | 'kingbase';
 
 export interface DBAdapter {
   dbOpts: DatabaseOptions;
+  backupToolchain?: DBBackupToolchain;
   backup(options: DBBackupOptions): Promise<void>;
   restore(options: DBRestoreOptions): Promise<void>;
   check(op: 'backup' | 'restore'): Promise<void>;
@@ -94,6 +98,15 @@ abstract class BaseDBAdapter implements DBAdapter {
       );
     }
   };
+
+  protected hasCommand(command: string) {
+    try {
+      execSync(`${command} --version`);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
 }
 
 class MySQLAdapter extends BaseDBAdapter {
@@ -378,25 +391,43 @@ class MySQLAdapter extends BaseDBAdapter {
 }
 
 class PostgresAdapter extends BaseDBAdapter {
-  get #backupCmd() {
+  get backupToolchain(): DBBackupToolchain {
+    return 'postgres';
+  }
+
+  protected getBackupCommandName(_toolchain: DBBackupToolchain = this.backupToolchain) {
     return formatPathInEnv(process.env.PG_DUMP_PATH) || 'pg_dump';
   }
-  get #restoreCmd() {
+
+  protected getRestoreCommandName(_toolchain: DBBackupToolchain = this.backupToolchain) {
     return formatPathInEnv(process.env.PG_RESTORE_PATH) || 'pg_restore';
   }
+
+  protected getSqlCommandName(_toolchain: DBBackupToolchain = this.backupToolchain) {
+    return formatPathInEnv(process.env.PSQL_PATH) || 'psql';
+  }
+
+  protected getPasswordEnvVars(password: string, _toolchain: DBBackupToolchain = this.backupToolchain) {
+    return { PGPASSWORD: password };
+  }
+
+  protected getBackupSchema() {
+    return this.dbOpts.schema;
+  }
+
   async check(op: 'backup' | 'restore') {
     switch (op) {
       case 'backup':
-        this.assertCommand(this.#backupCmd);
+        this.assertCommand(this.getBackupCommandName());
         break;
       case 'restore':
-        this.assertCommand(this.#restoreCmd);
+        this.assertCommand(this.getRestoreCommandName());
         break;
     }
   }
 
   async clientVersion(op: 'backup' | 'restore'): Promise<string | void> {
-    const cmd = op === 'backup' ? this.#backupCmd : this.#restoreCmd;
+    const cmd = op === 'backup' ? this.getBackupCommandName() : this.getRestoreCommandName();
     try {
       return execSync(`${cmd} --version`).toString();
     } catch (_error) {
@@ -405,8 +436,9 @@ class PostgresAdapter extends BaseDBAdapter {
   }
 
   async backup({ dir, includeTables, excludeTables }: DBBackupOptions): Promise<void> {
-    const { username, host, port, database, password, schema: backupSchema } = this.dbOpts;
+    const { username, host, port, database, password } = this.dbOpts;
     const filePath = `${dir}/data`;
+    const backupSchema = this.getBackupSchema();
     const schemaOption = backupSchema ? `--schema=${backupSchema}` : '';
     const includeOption =
       Array.isArray(includeTables) && includeTables.length
@@ -421,13 +453,18 @@ class PostgresAdapter extends BaseDBAdapter {
             .join(' ')
         : '';
     // set the password in the environment variable, so we don't need to pass it in the command
-    const command = `${this.#backupCmd} ${includeOption} ${excludeOption} -U ${username} -h ${host} ${
+    const command = `${this.getBackupCommandName()} ${includeOption} ${excludeOption} -U ${username} -h ${host} ${
       port ? `-p ${port}` : ''
     } -F c -b --quote-all-identifiers ${schemaOption} -f ${filePath} ${database}`;
-    await run(command, { PGPASSWORD: password });
+    await run(command, this.getPasswordEnvVars(password));
   }
 
-  async restore({ filePath, schema, skipDropAllTables = false }: DBRestoreOptions): Promise<void> {
+  async restore({
+    filePath,
+    schema,
+    skipDropAllTables = false,
+    toolchain = this.backupToolchain,
+  }: DBRestoreOptions): Promise<void> {
     const { username, host, port, database, password } = this.dbOpts;
     let schemaOption = this.dbOpts.schema;
     if (schema && !schemaOption) {
@@ -448,7 +485,9 @@ class PostgresAdapter extends BaseDBAdapter {
       ? `WHERE relnamespace = '${schemaOption}'::regnamespace`
       : `WHERE tgrelid IN (SELECT oid FROM pg_class WHERE relnamespace NOT IN (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname IN ('pg_catalog', 'information_schema')))`;
     if (!skipDropAllTables) {
-      const dropDataCommand = `psql -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
+      const dropDataCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
+        port ? `-p ${port}` : ''
+      } -d ${database} -c "
     DO ${D$$} DECLARE r RECORD;
     BEGIN
     FOR r IN (SELECT viewname,schemaname FROM pg_views ${schemaNameCondition}) LOOP
@@ -490,29 +529,46 @@ class PostgresAdapter extends BaseDBAdapter {
     END ${D$$};"`.replace(/\n/g, ' ');
 
       // Run the command to drop all existing data
-      await run(dropDataCommand, { PGPASSWORD: password });
+      await run(dropDataCommand, this.getPasswordEnvVars(password, toolchain));
     }
 
     if (schema === schemaOption || !schemaOption) {
       // current schema is the same as the backup schema
-      const pgRestoreCommand = `${this.#restoreCmd} -U ${username} -h ${host} ${
+      const pgRestoreCommand = `${this.getRestoreCommandName(toolchain)} -U ${username} -h ${host} ${
         port ? `-p ${port}` : ''
       } -d ${database} --clean --if-exists --no-owner -j ${j} ${filePath}`;
-      await run(pgRestoreCommand, { PGPASSWORD: password });
+      await run(pgRestoreCommand, this.getPasswordEnvVars(password, toolchain));
     } else {
       const srcSchema = schema || 'public';
-      const pgRestoreCommand = `${this.#restoreCmd} -U ${username} -h ${host} ${
-        port ? `-p ${port}` : ''
-      } -n ${srcSchema} -d ${database} --clean --if-exists --no-owner -j ${j} ${filePath}`;
-      await this.#restoreSchema(srcSchema, schemaOption, pgRestoreCommand);
+      const pgRestoreCommand = this.buildSchemaRestoreCommand(srcSchema, schemaOption, filePath, j, toolchain);
+      await this.restoreSchema(srcSchema, schemaOption, pgRestoreCommand, toolchain);
     }
   }
 
-  async #restoreSchema(srcSchema: string, targetSchema: string, pgRestoreCommand: string) {
+  protected buildSchemaRestoreCommand(
+    srcSchema: string,
+    _targetSchema: string,
+    filePath: string,
+    jobs: number,
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ) {
+    const { username, host, port, database } = this.dbOpts;
+    return `${this.getRestoreCommandName(toolchain)} -U ${username} -h ${host} ${
+      port ? `-p ${port}` : ''
+    } -n ${srcSchema} -d ${database} --clean --if-exists --no-owner -j ${jobs} ${filePath}`;
+  }
+
+  protected async restoreSchema(
+    srcSchema: string,
+    targetSchema: string,
+    pgRestoreCommand: string,
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ) {
     const { username, host, port, database, password } = this.dbOpts;
     const ts = Date.now();
     // 1. backup current schema to srcSchema_ts if exists and create new schema (same name as srcSchema)
-    const preCommand = `psql -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
+    const sqlCommandName = this.getSqlCommandName(toolchain);
+    const preCommand = `${sqlCommandName} -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
     DO ${D$$}
     BEGIN
         IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '${srcSchema}') THEN
@@ -520,7 +576,7 @@ class PostgresAdapter extends BaseDBAdapter {
         END IF;
         EXECUTE 'CREATE SCHEMA ${srcSchema}';
     END ${D$$};"`.replace(/\n/g, ' ');
-    const postCommand = `psql -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
+    const postCommand = `${sqlCommandName} -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
     DO ${D$$}
     BEGIN
         EXECUTE 'DROP SCHEMA ${targetSchema} CASCADE';
@@ -530,22 +586,26 @@ class PostgresAdapter extends BaseDBAdapter {
         END IF;
     END ${D$$};"`.replace(/\n/g, ' ');
 
-    await run(preCommand, { PGPASSWORD: password });
+    await run(preCommand, this.getPasswordEnvVars(password, toolchain));
     try {
-      await run(pgRestoreCommand, { PGPASSWORD: password });
+      await run(pgRestoreCommand, this.getPasswordEnvVars(password, toolchain));
     } finally {
-      await run(postCommand, { PGPASSWORD: password });
+      await run(postCommand, this.getPasswordEnvVars(password, toolchain));
     }
-    await this.#syncCollectionSchemaMetadata(srcSchema, targetSchema);
+    await this.syncCollectionSchemaMetadata(srcSchema, targetSchema, toolchain);
   }
 
-  async #syncCollectionSchemaMetadata(srcSchema: string, targetSchema: string) {
+  protected async syncCollectionSchemaMetadata(
+    srcSchema: string,
+    targetSchema: string,
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ) {
     const { username, host, port, database, password, tablePrefix } = this.dbOpts;
     const collectionsTable = `${tablePrefix || ''}collections`;
     const targetSchemaLiteral = escapeStringLiteral(targetSchema);
     const srcSchemaLiteral = escapeStringLiteral(srcSchema);
     const collectionsTableLiteral = escapeStringLiteral(collectionsTable);
-    const updateCollectionSchemaCommand = `psql -U ${username} -h ${host} ${
+    const updateCollectionSchemaCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
       port ? `-p ${port}` : ''
     } -d ${database} -c "
     DO ${D$$}
@@ -567,7 +627,94 @@ class PostgresAdapter extends BaseDBAdapter {
             );
         END IF;
     END ${D$$};"`.replace(/\n/g, ' ');
-    await run(updateCollectionSchemaCommand, { PGPASSWORD: password });
+    await run(updateCollectionSchemaCommand, this.getPasswordEnvVars(password, toolchain));
+  }
+}
+
+class KingbaseAdapter extends PostgresAdapter {
+  get backupToolchain(): DBBackupToolchain {
+    return this.hasKingbaseToolchain() ? 'kingbase' : 'postgres';
+  }
+
+  private getKingbaseBackupCommandName() {
+    return formatPathInEnv(process.env.KINGBASE_DUMP_PATH) || 'sys_dump';
+  }
+
+  private getKingbaseRestoreCommandName() {
+    return formatPathInEnv(process.env.KINGBASE_RESTORE_PATH) || 'sys_restore';
+  }
+
+  private getKingbaseSqlCommandName() {
+    return formatPathInEnv(process.env.KINGBASE_PSQL_PATH) || 'ksql';
+  }
+
+  private hasKingbaseToolchain() {
+    return (
+      this.hasCommand(this.getKingbaseBackupCommandName()) &&
+      this.hasCommand(this.getKingbaseRestoreCommandName()) &&
+      this.hasCommand(this.getKingbaseSqlCommandName())
+    );
+  }
+
+  protected getBackupCommandName(toolchain: DBBackupToolchain = this.backupToolchain) {
+    return toolchain === 'kingbase' ? this.getKingbaseBackupCommandName() : super.getBackupCommandName(toolchain);
+  }
+
+  protected getRestoreCommandName(toolchain: DBBackupToolchain = this.backupToolchain) {
+    return toolchain === 'kingbase' ? this.getKingbaseRestoreCommandName() : super.getRestoreCommandName(toolchain);
+  }
+
+  protected getSqlCommandName(toolchain: DBBackupToolchain = this.backupToolchain) {
+    return toolchain === 'kingbase' ? this.getKingbaseSqlCommandName() : super.getSqlCommandName(toolchain);
+  }
+
+  protected getPasswordEnvVars(password: string, toolchain: DBBackupToolchain = this.backupToolchain) {
+    if (toolchain === 'postgres') {
+      return super.getPasswordEnvVars(password, toolchain);
+    }
+    return { KINGBASE_PASSWORD: password };
+  }
+
+  protected getBackupSchema() {
+    return this.dbOpts.schema || 'public';
+  }
+
+  protected buildSchemaRestoreCommand(
+    srcSchema: string,
+    targetSchema: string,
+    filePath: string,
+    jobs: number,
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ) {
+    if (toolchain === 'postgres') {
+      return super.buildSchemaRestoreCommand(srcSchema, targetSchema, filePath, jobs, toolchain);
+    }
+    const { username, host, port, database } = this.dbOpts;
+    return `${this.getRestoreCommandName(toolchain)} -U ${username} -h ${host} ${
+      port ? `-p ${port}` : ''
+    } -g ${srcSchema} -G ${targetSchema} -d ${database} --clean --if-exists --no-owner -j ${jobs} ${filePath}`;
+  }
+
+  protected async restoreSchema(
+    srcSchema: string,
+    targetSchema: string,
+    restoreCommand: string,
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ) {
+    if (toolchain === 'postgres') {
+      await super.restoreSchema(srcSchema, targetSchema, restoreCommand, toolchain);
+      return;
+    }
+
+    const { username, host, port, database, password } = this.dbOpts;
+    const targetSchemaIdentifier = quotePgIdentifier(targetSchema).replace(/"/g, '\\"');
+    const createSchemaCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
+      port ? `-p ${port}` : ''
+    } -d ${database} -c "CREATE SCHEMA IF NOT EXISTS ${targetSchemaIdentifier};"`;
+
+    await run(createSchemaCommand, this.getPasswordEnvVars(password, toolchain));
+    await run(restoreCommand, this.getPasswordEnvVars(password, toolchain));
+    await this.syncCollectionSchemaMetadata(srcSchema, targetSchema, toolchain);
   }
 }
 
@@ -592,6 +739,7 @@ class MariaDBAdapter extends MySQLAdapter {}
 const adapterMap = {
   mysql: MySQLAdapter,
   postgres: PostgresAdapter,
+  kingbase: KingbaseAdapter,
   sqlite: SQLiteAdapter,
   mariadb: MariaDBAdapter,
 };

--- a/packages/plugins/@nocobase/plugin-backups/src/server/adapters/database.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/adapters/database.ts
@@ -407,7 +407,10 @@ class PostgresAdapter extends BaseDBAdapter {
     return formatPathInEnv(process.env.PSQL_PATH) || 'psql';
   }
 
-  protected getPasswordEnvVars(password: string, _toolchain: DBBackupToolchain = this.backupToolchain) {
+  protected getPasswordEnvVars(
+    password: string,
+    _toolchain: DBBackupToolchain = this.backupToolchain,
+  ): NodeJS.ProcessEnv {
     return { PGPASSWORD: password };
   }
 
@@ -668,7 +671,10 @@ class KingbaseAdapter extends PostgresAdapter {
     return toolchain === 'kingbase' ? this.getKingbaseSqlCommandName() : super.getSqlCommandName(toolchain);
   }
 
-  protected getPasswordEnvVars(password: string, toolchain: DBBackupToolchain = this.backupToolchain) {
+  protected getPasswordEnvVars(
+    password: string,
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ): NodeJS.ProcessEnv {
     if (toolchain === 'postgres') {
       return super.getPasswordEnvVars(password, toolchain);
     }

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
@@ -241,6 +241,7 @@ export class BackupManager {
       createdBy: opts.createdBy,
       database: {
         dialect,
+        toolchain: this.#dbAdapter.backupToolchain,
         underscored,
         tablePrefix,
         schema,

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/restore.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/restore.ts
@@ -16,7 +16,7 @@ import { storagePathJoin } from '@nocobase/utils';
 import semver from 'semver';
 import { Readable } from 'stream';
 import { promisify } from 'util';
-import { DBAdapter, getDBAdapter } from '../adapters/database';
+import { DBAdapter, DBBackupToolchain, getDBAdapter } from '../adapters/database';
 import {
   Extractor,
   BACKUP_EXTENSION,
@@ -33,6 +33,7 @@ interface Metadata {
   version: string;
   database: {
     dialect: string;
+    toolchain?: DBBackupToolchain;
     underscored: boolean;
     tablePrefix: string;
     schema: string;
@@ -191,6 +192,7 @@ export class RestoreManager {
         filePath: path.join(extractedDir, dbFile),
         schema: metadata.database.schema,
         skipDropAllTables: options?.skipDropAllTables === true,
+        toolchain: this.#resolveRestoreToolchain(metadata),
       });
       this.ctx.logger.info('Database restored successfully', { module: BACKUPS });
       // copy the uploads directory
@@ -256,7 +258,7 @@ export class RestoreManager {
           // await sleep(5000); // wait for the client to show the error message, for debug
           await this.ctx.app.runCommand('upgrade');
         } else {
-          if (!tolerentMode && this.#dbAdapter.dbOpts.dialect === 'postgres') {
+          if (!tolerentMode && this.#isPostgresLikeDialect(this.#dbAdapter.dbOpts.dialect)) {
             const backupClientVersion = Number(toMajorVersion(metadata.database.backupClientVersion));
             const dbServerVersion = Number(toMajorVersion(dbVersion));
             if (backupClientVersion > 16 && dbServerVersion <= 16) {
@@ -312,7 +314,7 @@ export class RestoreManager {
       throw new Error(this.#t('Database table prefix mismatch'));
     }
 
-    const forceSchemaRestore = options?.forceSchemaRestore === true && dialect === 'postgres';
+    const forceSchemaRestore = options?.forceSchemaRestore === true && this.#isPostgresLikeDialect(dialect);
     if (!forceSchemaRestore) {
       if (this.ctx.request?.body?.dbSchema && this.ctx.request?.body?.dbSchema !== (schema || 'public')) {
         throw new Error(this.#t('Database schema mismatch'));
@@ -355,6 +357,30 @@ export class RestoreManager {
       });
     }
     return true;
+  }
+
+  #isPostgresLikeDialect(dialect: string) {
+    return dialect === 'postgres' || dialect === 'kingbase';
+  }
+
+  #resolveRestoreToolchain(metadata: Metadata): DBBackupToolchain | undefined {
+    if (metadata.database.dialect !== 'kingbase') {
+      return undefined;
+    }
+
+    if (metadata.database.toolchain === 'kingbase' || metadata.database.toolchain === 'postgres') {
+      return metadata.database.toolchain;
+    }
+
+    const backupClientVersion = metadata.database.backupClientVersion || '';
+    if (/sys_dump/i.test(backupClientVersion)) {
+      return 'kingbase';
+    }
+    if (/pg_dump|postgresql/i.test(backupClientVersion)) {
+      return 'postgres';
+    }
+
+    return this.#dbAdapter.backupToolchain;
   }
 
   async #decompressFiles(filePath: string, password?: string): Promise<string> {
@@ -473,6 +499,7 @@ export class RestoreManager {
         filePath: path.join(extractedDir, dbFile),
         schema: metadata.database.schema,
         skipDropAllTables: options?.skipDropAllTables === true,
+        toolchain: this.#resolveRestoreToolchain(metadata),
       });
       this.ctx.logger.info('Database restored successfully', { module: BACKUPS });
       // copy the uploads directory

--- a/packages/plugins/@nocobase/plugin-backups/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/utils.ts
@@ -202,6 +202,7 @@ const dbVersionCommands = {
   mysql: 'select version() as version',
   mariadb: 'select version() as version',
   postgres: 'select version() as version',
+  kingbase: 'select version() as version',
 };
 
 export async function getDBVersion(db: Database): Promise<string> {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Support Kingbase backup and restore workflows while keeping PostgreSQL-compatible toolchains usable when the installed client tools are PostgreSQL tools.

### Description 
Adds Kingbase database backup and restore support to plugin-backups. The adapter detects whether the Kingbase client tools are available, falls back to the PostgreSQL tools when they are not, records the selected toolchain in backup metadata, and uses the recorded toolchain during restore.

The restore UI now allows schema remapping for Kingbase. Server tests cover Kingbase toolchain selection, PostgreSQL fallback, metadata inference, and schema remapping behavior.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support backup and restore for KingBase as the primary database |
| 🇨🇳 Chinese | 支持 KingBase 主数据库备份和还原 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
