### PR TITLE
fix(client): translate filter checkbox options

### DIFF
--- a/packages/core/client-v2/src/flow/internal/utils/operatorSchemaHelper.ts
+++ b/packages/core/client-v2/src/flow/internal/utils/operatorSchemaHelper.ts
@@ -9,6 +9,7 @@
 
 import React, { type ComponentType, type CSSProperties, type ReactNode } from 'react';
 import { DateFilterDynamicComponent } from '../../models/blocks/filter-form/fields/date-time/components/DateFilterDynamicComponent';
+import { translateOptions } from './enumOptionsUtils';
 
 type OperatorMeta = {
   value?: string;
@@ -26,6 +27,7 @@ type OperatorComponentFieldModel = {
   props?: Record<string, unknown>;
   render?: () => ReactNode;
   __originalRender?: () => ReactNode;
+  translate?: (text: string) => string;
 };
 
 type OperatorComponentRenderOptions = {
@@ -93,6 +95,17 @@ export function restoreOperatorComponentRender(fieldModel?: unknown) {
   return true;
 }
 
+function translateComponentOptions(props: Record<string, unknown>, translate: ((text: string) => string) | undefined) {
+  if (!Array.isArray(props.options) || typeof translate !== 'function') {
+    return props;
+  }
+
+  return {
+    ...props,
+    options: translateOptions(props.options, translate),
+  };
+}
+
 export function applyOperatorComponentRender({
   app,
   fieldModel,
@@ -118,8 +131,9 @@ export function applyOperatorComponentRender({
   mutableFieldModel.render = () => {
     const fieldProps = mutableFieldModel.props || {};
     const fieldStyle = pickOperatorStyle(fieldProps.style);
-    const componentProps =
+    const mergedProps =
       propsPriority === 'operator' ? { ...fieldProps, ...operatorProps } : { ...operatorProps, ...fieldProps };
+    const componentProps = translateComponentOptions(mergedProps, mutableFieldModel.translate);
     const componentStyle =
       propsPriority === 'operator' ? { ...fieldStyle, ...operatorStyle } : { ...operatorStyle, ...fieldStyle };
     const mergedStyle = { ...(style || {}), ...componentStyle };

--- a/packages/core/client-v2/src/flow/models/blocks/filter-manager/flow-actions/__tests__/customizeFilterRender.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-manager/flow-actions/__tests__/customizeFilterRender.test.tsx
@@ -18,11 +18,22 @@ type TestFieldModel = {
   setupReactiveRender: ReturnType<typeof vi.fn>;
   _reactiveWrapperCache?: unknown;
   __originalRender?: () => React.ReactNode;
+  translate?: (text: string) => string;
 };
 
 const MultipleKeywordsInput = (props: Record<string, unknown>) => {
   return <div data-testid="multiple-keywords-input" {...props} />;
 };
+
+const Select = (props: Record<string, unknown>) => {
+  return <div data-testid="select" {...props} />;
+};
+
+function mockT(text: string) {
+  if (text === '{{t("Yes")}}') return '是';
+  if (text === '{{t("No")}}') return '否';
+  return text;
+}
 
 function createFieldModel() {
   return {
@@ -52,7 +63,10 @@ function createFilterItemModel({
     collectionField,
     context: {
       app: {
-        getComponent: (name: string) => (name === 'MultipleKeywordsInput' ? MultipleKeywordsInput : undefined),
+        getComponent: (name: string) => {
+          if (name === 'MultipleKeywordsInput') return MultipleKeywordsInput;
+          if (name === 'Select') return Select;
+        },
       },
       collectionField,
     },
@@ -110,6 +124,47 @@ describe('customizeFilterRender action', () => {
     const rerenderedElement = fieldModel.render();
     expect((rerenderedElement as React.ReactElement).props.value).toEqual(['3']);
     expect((rerenderedElement as React.ReactElement).props.placeholder).toBe('updated runtime placeholder');
+  });
+
+  it('translates operator schema select options', () => {
+    const fieldModel = {
+      ...createFieldModel(),
+      translate: mockT,
+    };
+    const model = createFilterItemModel({
+      fieldModel,
+      operator: '$isTruly',
+      collectionField: {
+        interface: 'checkbox',
+        type: 'boolean',
+        filterable: {
+          operators: [
+            {
+              label: '{{t("Yes")}}',
+              value: '$isTruly',
+              schema: {
+                'x-component': 'Select',
+                'x-component-props': {
+                  options: [
+                    { label: '{{t("Yes")}}', value: true },
+                    { label: '{{t("No")}}', value: false },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    customizeFilterRender.handler?.({ model } as any);
+
+    const element = fieldModel.render();
+    expect((element as React.ReactElement).type).toBe(Select);
+    expect((element as React.ReactElement).props.options).toEqual([
+      { label: '是', value: true },
+      { label: '否', value: false },
+    ]);
   });
 
   it('restores original render when switching to an operator without a schema component', () => {

--- a/packages/core/client-v2/src/flow/models/fields/SelectFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/SelectFieldModel.tsx
@@ -15,17 +15,20 @@ import { MobileSelect } from './mobile-components/MobileSelect';
 import { enumToOptions, getSelectedEnumLabels, translateOptionLabel } from '../../internal/utils/enumOptionsUtils';
 
 const getOriginalEnumOptions = (model: SelectFieldModel) => {
-  const fromEnum = enumToOptions(model.context.collectionField?.uiSchema?.enum, (text) => text) || [];
+  const fromEnum = enumToOptions(model.context.collectionField?.uiSchema?.enum, model.translate) || [];
   if (fromEnum.length > 0) {
     return fromEnum.map((option) => ({ ...option }));
   }
   const current = Array.isArray(model.props.options) ? model.props.options : [];
-  return current.map((option) => ({ ...option }));
+  return current.map((option) => ({
+    ...option,
+    label: translateOptionLabel(option.label, model.translate),
+  }));
 };
-
 export class SelectFieldModel extends FieldModel {
   render() {
     const fallbackOptions = getOriginalEnumOptions(this);
+
     const options = this.props.options?.map((v) => {
       return {
         ...v,
@@ -46,7 +49,6 @@ export class SelectFieldModel extends FieldModel {
     if (this.context.isMobileLayout) {
       return <MobileSelect {...this.props} options={options} displayValue={value} />;
     }
-
     return (
       <Select
         {...this.props}

--- a/packages/core/client-v2/src/flow/models/fields/__tests__/SelectFieldModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/__tests__/SelectFieldModel.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { SelectFieldModel } from '../SelectFieldModel';
+
+function mockT(text: string) {
+  if (text === '{{t("Yes")}}') return '是';
+  if (text === '{{t("No")}}') return '否';
+  return text;
+}
+
+describe('SelectFieldModel', () => {
+  it('translates enum fallback labels for selected values', () => {
+    const model = {
+      props: {
+        value: true,
+      },
+      context: {
+        collectionField: {
+          uiSchema: {
+            enum: [
+              { label: '{{t("Yes")}}', value: true },
+              { label: '{{t("No")}}', value: false },
+            ],
+          },
+        },
+      },
+      translate: mockT,
+    } as unknown as SelectFieldModel;
+
+    const element = SelectFieldModel.prototype.render.call(model) as React.ReactElement;
+
+    expect(element.props.value).toEqual({ label: '是', value: true });
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 filter form checkbox field can render its value input through operator schema components. In that path, option labels such as `{{t("Yes")}}` and `{{t("No")}}` were passed directly to the Select component, so the dropdown showed untranslated template text.

### Description 
- Translate enum fallback labels in `SelectFieldModel` through `getOriginalEnumOptions`.
- Translate operator schema Select options when filter form field rendering is customized by the selected operator.
- Add tests for both the SelectFieldModel fallback path and the filter operator schema render path.

Potential risk is low; the change only translates option labels that explicitly use `{{t(...)}}` templates and preserves non-template labels as-is.

Testing suggestions:
- Verify a v2 filter form checkbox field shows translated Yes/No dropdown options.
- Verify selected checkbox filter values still display correctly.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed untranslated Yes/No options in v2 filter form checkbox dropdowns. |
| 🇨🇳 Chinese | 修复 v2 筛选表单中复选框下拉选项未显示翻译文本的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
