### PR TITLE
refactor(plugin-workflow): migrate end node config to v2

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/endFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/endFieldset.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Form } from 'antd';
+import { EndFieldset } from '../components/end';
+
+vi.mock('../../locale', () => ({
+  NAMESPACE: 'workflow',
+  useT: () => (key: string) => key,
+}));
+
+describe('EndFieldset', () => {
+  it('renders the v1-aligned end status options and default value', () => {
+    render(
+      <Form>
+        <EndFieldset />
+      </Form>,
+    );
+
+    expect(screen.getByText('End status')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Succeeded' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Failed' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Succeeded' })).toBeChecked();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/endInstruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/endInstruction.test.ts
@@ -1,0 +1,30 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import V2EndInstruction from '../end';
+import V1EndInstruction from '../../../client/nodes/end';
+
+describe('EndInstruction', () => {
+  it('keeps the v1 node as a thin compatibility entry over the v2 implementation', () => {
+    const instruction = new V1EndInstruction();
+
+    expect(instruction).toBeInstanceOf(V2EndInstruction);
+    expect(typeof instruction.FieldsetLoader).toBe('function');
+  });
+
+  it('preserves the v1 metadata in the v2 instruction', () => {
+    const instruction = new V2EndInstruction();
+
+    expect(instruction.type).toBe('end');
+    expect(instruction.group).toBe('control');
+    expect(instruction.description).toBe('{{t("End the process immediately, with set status.", { ns: "workflow" })}}');
+    expect(instruction.end).toBe(true);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/end.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/end.tsx
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { Form, Radio } from 'antd';
+import { JOB_STATUS } from '../../components/jobStatus';
+import { useT } from '../../locale';
+
+const END_STATUS_OPTIONS = [
+  { value: JOB_STATUS.RESOLVED, label: 'Succeeded' },
+  { value: JOB_STATUS.FAILED, label: 'Failed' },
+] as const;
+
+export function EndFieldset() {
+  const t = useT();
+
+  return (
+    <Form.Item
+      name={['config', 'endStatus']}
+      label={t('End status')}
+      rules={[{ required: true }]}
+      initialValue={JOB_STATUS.RESOLVED}
+    >
+      <Radio.Group options={END_STATUS_OPTIONS.map((option) => ({ ...option, label: t(option.label) }))} />
+    </Form.Item>
+  );
+}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/end.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/end.tsx
@@ -18,6 +18,8 @@ export default class extends Instruction {
   type = 'end';
   title = t('End process');
   group = 'control';
+  description = t('End the process immediately, with set status.');
   icon = (<StopOutlined />);
+  FieldsetLoader = () => import('./components/end').then((m) => ({ default: m.EndFieldset }));
   end = true;
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/end.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/nodes/end.tsx
@@ -7,32 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React from 'react';
-import { StopOutlined } from '@ant-design/icons';
+import V2EndInstruction from '../../client-v2/nodes/end';
 
-import { Instruction } from '.';
-import { NAMESPACE } from '../locale';
-import { JOB_STATUS } from '../constants';
-
-export default class extends Instruction {
-  title = `{{t("End process", { ns: "${NAMESPACE}" })}}`;
-  type = 'end';
-  group = 'control';
-  description = `{{t("End the process immediately, with set status.", { ns: "${NAMESPACE}" })}}`;
-  icon = (<StopOutlined style={{}} />);
-  fieldset = {
-    endStatus: {
-      type: 'number',
-      title: `{{t("End status", { ns: "${NAMESPACE}" })}}`,
-      'x-decorator': 'FormItem',
-      'x-component': 'Radio.Group',
-      enum: [
-        { label: `{{t("Succeeded", { ns: "${NAMESPACE}" })}}`, value: JOB_STATUS.RESOLVED },
-        { label: `{{t("Failed", { ns: "${NAMESPACE}" })}}`, value: JOB_STATUS.FAILED },
-      ],
-      required: true,
-      default: JOB_STATUS.RESOLVED,
-    },
-  };
-  end = true;
-}
+export default class extends V2EndInstruction {}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The workflow end node still relied on the legacy schema-based config on the canvas, so the migrated workflow canvas could not open a v2 config drawer for this node.

### Description 
- add a v2 `EndFieldset` with native antd radio controls for `endStatus`
- wire the end instruction to the v2 `FieldsetLoader` and preserve the existing node metadata
- turn the legacy `src/client/nodes/end.tsx` into a thin compatibility entry that reuses the v2 instruction
- add tests covering the compatibility entry and the v1-aligned end status options

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Migrate the workflow end node to the v2 implementation. |
| 🇨🇳 Chinese | 迁移工作流的结束节点到 v2 版本。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
