### PR TITLE
refactor(plugin-file-manager): split PDF preview by file origin

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/build.config.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/build.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
       },
     );
     await fs.copyFile(
-      path.resolve(pdfjsDist, 'build/pdf.worker.min.mjs'),
+      path.resolve(pdfjsDist, 'legacy/build/pdf.min.mjs'),
+      path.resolve(__dirname, 'dist/client/pdfjs/pdf.min.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(pdfjsDist, 'legacy/build/pdf.worker.min.mjs'),
       path.resolve(__dirname, 'dist/client/pdfjs/pdf.worker.min.mjs'),
     );
   },

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
@@ -233,6 +233,18 @@ export const isPdfFile = (file: any, url?: string) => {
   return getFileExt(file, url) === 'pdf';
 };
 
+export const isSameOriginUrl = (url?: string) => {
+  if (!url || typeof window === 'undefined') {
+    return true;
+  }
+
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch (error) {
+    return true;
+  }
+};
+
 export const getFileName = (file: any, url?: string) => {
   const nameFromUrl = getNameFromUrl(url || getFileUrl(file));
   if (!file || typeof file === 'string') {
@@ -400,7 +412,7 @@ const IframePreviewer = ({ file }: FilePreviewerProps) => {
   return <iframe src={src} width="100%" height="100%" style={{ border: 'none' }} />;
 };
 
-type PdfJs = typeof import('pdfjs-dist/build/pdf.mjs');
+type PdfJs = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
 type PdfTextLayer = InstanceType<PdfJs['TextLayer']>;
 
 let pdfjsPromise: Promise<PdfJs> | null = null;
@@ -451,6 +463,8 @@ export const getPdfPreviewResourceOptions = (): Pick<
   };
 };
 
+export const getPdfPreviewApiSrc = () => `${getPdfjsBaseUrl()}pdf.min.mjs`;
+
 export const getPdfPreviewWorkerSrc = () => `${getPdfjsBaseUrl()}pdf.worker.min.mjs`;
 
 type PdfPreviewErrorCode = 'resources' | 'file' | 'document';
@@ -476,7 +490,7 @@ export const getPdfPreviewErrorCode = (error: unknown): PdfPreviewErrorCode => {
 
 const loadPdfJs = async () => {
   if (!pdfjsPromise) {
-    pdfjsPromise = import('pdfjs-dist/build/pdf.mjs');
+    pdfjsPromise = import(/* @vite-ignore */ /* webpackIgnore: true */ getPdfPreviewApiSrc()) as Promise<PdfJs>;
   }
   return pdfjsPromise;
 };
@@ -914,6 +928,11 @@ const PdfPreviewer = ({ file }: FilePreviewerProps) => {
   );
 };
 
+const PdfHybridPreviewer = (props: FilePreviewerProps) => {
+  const src = getFileUrl(props.file);
+  return isSameOriginUrl(src) ? <PdfPreviewer {...props} /> : <IframePreviewer {...props} />;
+};
+
 const AudioPreviewer = ({ file }: FilePreviewerProps) => {
   const { t } = useTranslation();
   const src = getFileUrl(file);
@@ -1013,7 +1032,7 @@ filePreviewTypes.add({
   match(file) {
     return isPdfFile(file, getFileUrl(file));
   },
-  Previewer: wrapWithModalPreviewer(PdfPreviewer),
+  Previewer: wrapWithModalPreviewer(PdfHybridPreviewer),
 });
 
 export const FilePreviewRenderer = (props: FilePreviewerProps) => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
@@ -11,10 +11,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   getDownloadFileName,
   getFileName,
+  getPdfPreviewApiSrc,
   getPdfPreviewResourceOptions,
   getPdfPreviewWorkerSrc,
   getPreviewThumbnailUrl,
   isActiveContentFile,
+  isSameOriginUrl,
 } from '../filePreviewTypes';
 
 describe('getDownloadFileName', () => {
@@ -75,6 +77,12 @@ describe('getDownloadFileName', () => {
     );
   });
 
+  it('应识别同源和跨源文件地址', () => {
+    expect(isSameOriginUrl('/storage/uploads/report.pdf')).toBe(true);
+    expect(isSameOriginUrl(`${window.location.origin}/storage/uploads/report.pdf`)).toBe(true);
+    expect(isSameOriginUrl('https://files.example.com/storage/uploads/report.pdf')).toBe(false);
+  });
+
   it('应为 PDF.js 预览资源生成插件静态目录地址', () => {
     expect(getPdfPreviewResourceOptions()).toEqual({
       cMapPacked: true,
@@ -84,6 +92,7 @@ describe('getDownloadFileName', () => {
     expect(getPdfPreviewWorkerSrc()).toBe(
       '/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
     );
+    expect(getPdfPreviewApiSrc()).toBe('/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.min.mjs');
   });
 
   it('应兼容子路径部署下的 PDF.js 预览资源地址', () => {
@@ -98,6 +107,9 @@ describe('getDownloadFileName', () => {
     expect(getPdfPreviewWorkerSrc()).toBe(
       '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
     );
+    expect(getPdfPreviewApiSrc()).toBe(
+      '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.min.mjs',
+    );
   });
 
   it('未注入现代客户端前缀时不应猜测默认前缀', () => {
@@ -110,6 +122,9 @@ describe('getDownloadFileName', () => {
     });
     expect(getPdfPreviewWorkerSrc()).toBe(
       '/nocobase/v/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
+    expect(getPdfPreviewApiSrc()).toBe(
+      '/nocobase/v/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.min.mjs',
     );
   });
 
@@ -125,6 +140,9 @@ describe('getDownloadFileName', () => {
     expect(getPdfPreviewWorkerSrc()).toBe(
       '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
     );
+    expect(getPdfPreviewApiSrc()).toBe(
+      '/nocobase/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.min.mjs',
+    );
   });
 
   it('配置 CDN 地址时应优先使用 CDN 基础路径', () => {
@@ -139,6 +157,9 @@ describe('getDownloadFileName', () => {
     });
     expect(getPdfPreviewWorkerSrc()).toBe(
       'https://cdn.example.com/assets/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.worker.min.mjs',
+    );
+    expect(getPdfPreviewApiSrc()).toBe(
+      'https://cdn.example.com/assets/static/plugins/@nocobase/plugin-file-manager/dist/client/pdfjs/pdf.min.mjs',
     );
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
PDF previews need to balance browser-native viewing quality with the security constraints introduced for same-origin uploaded files. Same-origin PDF files should keep using PDF.js, while files served from an isolated origin can use the browser's native PDF viewer.

### Description
This PR updates the file manager PDF preview flow to:

- render same-origin PDF files with PDF.js;
- render cross-origin PDF files with the native iframe previewer;
- load the PDF.js API from the plugin static directory with native ESM import so it is not bundled by webpack/rspack;
- copy the legacy PDF.js API and worker files during plugin build;
- cover origin detection and PDF.js static resource URL generation in tests.

Potential risks:

- Cross-origin native PDF preview depends on the file host allowing iframe rendering.
- CDN deployments must serve `.mjs` files with a JavaScript MIME type.

Testing suggestions:

- Preview a same-origin uploaded PDF and verify PDF.js rendering still works.
- Preview a PDF served from a different origin and verify the browser-native PDF viewer is used.
- Verify sub-path and CDN deployments resolve `pdf.min.mjs`, `pdf.worker.min.mjs`, CMaps, and standard fonts from the expected plugin static directory.

### Related issues

- #9566

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved PDF previews by using the browser-native viewer for cross-origin PDF files while keeping same-origin PDF files rendered with PDF.js. |
| 🇨🇳 Chinese | 改进 PDF 预览：跨源 PDF 文件使用浏览器原生预览，同源 PDF 文件继续使用 PDF.js 渲染。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
