### PR TITLE
fix(plugin-workflow-custom-action-trigger): validate v2 trigger workflow bindings

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -78,6 +78,15 @@ const buildTriggerWorkflows = (group?: TriggerWorkflowBinding[]) => {
     : undefined;
 };
 
+function ensureTriggerWorkflowsConfigured(ctx: FlowRuntimeContext, group?: TriggerWorkflowBinding[]) {
+  if (group?.length) {
+    return true;
+  }
+  ctx.message.error(ctx.t('Button is not configured properly, please contact the administrator.', { ns: NAMESPACE }));
+  ctx.exit();
+  return false;
+}
+
 function getRecordKey(record, collection) {
   if (!record || !collection) {
     return null;
@@ -293,11 +302,7 @@ FormTriggerWorkflowActionModel.registerFlow({
           },
         }),
       async handler(ctx, params) {
-        if (!params.group?.length) {
-          ctx.message.error(
-            ctx.t('Button is not configured properly, please contact the administrator.', { ns: NAMESPACE }),
-          );
-          ctx.exit();
+        if (!ensureTriggerWorkflowsConfigured(ctx, params.group)) {
           return;
         }
 
@@ -369,11 +374,7 @@ RecordTriggerWorkflowActionModel.registerFlow({
           ctx.exit();
           return;
         }
-        if (!params.group?.length) {
-          ctx.message.error(
-            ctx.t('Button is not configured properly, please contact the administrator.', { ns: NAMESPACE }),
-          );
-          ctx.exit();
+        if (!ensureTriggerWorkflowsConfigured(ctx, params.group)) {
           return;
         }
         try {
@@ -472,11 +473,7 @@ CollectionTriggerWorkflowActionModel.registerFlow({
         const step = ctx.model.stepParams.customCollectionTriggerWorkflowsActionSettings;
         const { type } = step.setContextType;
         const { group, contextData } = step.triggerWorkflows ?? {};
-        if (!group?.length) {
-          ctx.message.error(
-            ctx.t('Button is not configured properly, please contact the administrator.', { ns: NAMESPACE }),
-          );
-          ctx.exit();
+        if (!ensureTriggerWorkflowsConfigured(ctx, group)) {
           return;
         }
         if (type === CONTEXT_TYPE.MULTIPLE_RECORDS) {
@@ -562,6 +559,10 @@ function globalTriggerWorkflowUiSchema() {
 }
 
 async function globalTriggerWorkflowHandler(ctx, params) {
+  if (!ensureTriggerWorkflowsConfigured(ctx, params.group)) {
+    return;
+  }
+
   let values;
   if (params.contextData) {
     try {

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -580,9 +580,9 @@ async function globalTriggerWorkflowHandler(ctx, params) {
       },
       data: { values },
     });
-    ctx.message.success(ctx.t('Operation succeeded'));
   } catch (error) {
     console.error('Error triggering workflows:', error);
+    ctx.exit();
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
@@ -172,4 +172,70 @@ describe('WorkbenchTriggerWorkflowActionModel', () => {
     expect(ctx.message.success).not.toHaveBeenCalled();
     expect(ctx.exit).toHaveBeenCalled();
   });
+
+  it('sends trigger request without showing duplicate success message when workflow is bound', async () => {
+    const flowEngine = createEngine();
+    const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({
+      use: 'WorkbenchTriggerWorkflowActionModel',
+      uid: 'workbench-trigger-workflow-action-bound',
+    });
+    const request = vi.fn().mockResolvedValue({});
+    const ctx = {
+      api: {
+        request,
+      },
+      message: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+      t: (value: string) => value,
+      exit: vi.fn(),
+    };
+
+    const handler = getWorkbenchTriggerWorkflowHandler(model);
+
+    await handler(ctx, { group: [{ workflowKey: 'workflow-1' }] });
+
+    expect(request).toHaveBeenCalledWith({
+      url: 'workflows:trigger',
+      method: 'post',
+      params: {
+        triggerWorkflows: 'workflow-1',
+      },
+      data: { values: undefined },
+    });
+    expect(ctx.message.error).not.toHaveBeenCalled();
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.exit).not.toHaveBeenCalled();
+  });
+
+  it('exits flow when trigger request fails', async () => {
+    const flowEngine = createEngine();
+    const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({
+      use: 'WorkbenchTriggerWorkflowActionModel',
+      uid: 'workbench-trigger-workflow-action-failed',
+    });
+    const request = vi.fn().mockRejectedValue(new Error('trigger failed'));
+    const ctx = {
+      api: {
+        request,
+      },
+      message: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+      t: (value: string) => value,
+      exit: vi.fn(),
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const handler = getWorkbenchTriggerWorkflowHandler(model);
+
+    await handler(ctx, { group: [{ workflowKey: 'workflow-1' }] });
+
+    expect(request).toHaveBeenCalled();
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.exit).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
 });

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
@@ -14,7 +14,7 @@ import {
   RecordActionGroupModel,
 } from '@nocobase/client-v2';
 import { FlowEngine } from '@nocobase/flow-engine';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CollectionTriggerWorkflowActionModel,
   FormTriggerWorkflowActionModel,
@@ -91,6 +91,14 @@ async function getTriggerWorkflowItemNames(ModelClass: any, ctx: any) {
   return items.map((item) => item.useModel).filter((name) => triggerWorkflowActionModelNames.has(name));
 }
 
+function getWorkbenchTriggerWorkflowHandler(model: WorkbenchTriggerWorkflowActionModel) {
+  const step = model.getFlow('workbenchTriggerWorkflowsActionSettings')?.getStep('triggerWorkflows')?.serialize() as
+    | { handler?: (ctx: any, params: { group?: unknown[] }) => Promise<void> }
+    | undefined;
+  expect(step?.handler).toBeTypeOf('function');
+  return step.handler;
+}
+
 describe('trigger workflow action model registration', () => {
   beforeEach(() => {
     actionGroupModelSnapshots = actionGroupModelClasses.map((ModelClass) => [
@@ -130,5 +138,38 @@ describe('trigger workflow action model registration', () => {
     expect(await getTriggerWorkflowItemNames(ActionPanelGroupActionModel, ctx)).toEqual([
       'WorkbenchTriggerWorkflowActionModel',
     ]);
+  });
+});
+
+describe('WorkbenchTriggerWorkflowActionModel', () => {
+  it('does not send trigger request when no workflow is bound', async () => {
+    const flowEngine = createEngine();
+    const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({
+      use: 'WorkbenchTriggerWorkflowActionModel',
+      uid: 'workbench-trigger-workflow-action',
+    });
+    const request = vi.fn();
+    const ctx = {
+      api: {
+        request,
+      },
+      message: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+      t: (value: string) => value,
+      exit: vi.fn(),
+    };
+
+    const handler = getWorkbenchTriggerWorkflowHandler(model);
+
+    await handler(ctx, {});
+
+    expect(request).not.toHaveBeenCalled();
+    expect(ctx.message.error).toHaveBeenCalledWith(
+      'Button is not configured properly, please contact the administrator.',
+    );
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.exit).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In action panel v2, clicking a custom action event trigger workflow button without bound workflows still sent a trigger request. The UI could show a success message while the request failed with `parameter "triggerWorkflows" is required`, which was inconsistent with v1 behavior.

### Description 
- Added a shared v2 workflow-binding guard for trigger workflow action handlers.
- Applied the guard to the action panel/global trigger workflow handler so unconfigured buttons show the existing configuration error and stop before any request is sent.
- Added a regression test for the action panel trigger workflow button with no bound workflows.

Potential risk: low. The change only adds an early validation path when no workflow binding is configured.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed action panel v2 trigger workflow buttons showing success and sending a request when no workflow is bound. |
| 🇨🇳 Chinese | 修复操作面板 v2 触发工作流按钮未绑定工作流时仍提示成功并发送请求的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
