### PR TITLE
fix(plugin-workflow): align workflow v2 migration regressions

### DIFF
--- a/packages/core/client-v2/src/components/form/TypedVariableInput.tsx
+++ b/packages/core/client-v2/src/components/form/TypedVariableInput.tsx
@@ -80,6 +80,13 @@ export interface TypedVariableInputProps {
    * allowed types or a variable reference.
    */
   nullable?: boolean;
+  /**
+   * Opt-in: when the incoming `value` is `undefined`, initialize the editor to
+   * the first allowed constant type instead of rendering the null-mode
+   * placeholder. `null` still keeps its explicit null semantics; only
+   * `undefined` triggers this path.
+   */
+  defaultToFirstConstantTypeWhenUndefined?: boolean;
   /** Variable-token delimiters. Default `['{{', '}}']` — see `VariableInput`. */
   delimiters?: VariableDelimiters;
   disabled?: boolean;
@@ -391,6 +398,7 @@ export function TypedVariableInput(props: TypedVariableInputProps) {
     extraNodes,
     metaTree: metaTreeProp,
     nullable = true,
+    defaultToFirstConstantTypeWhenUndefined = false,
     delimiters,
     disabled,
     placeholder,
@@ -410,7 +418,21 @@ export function TypedVariableInput(props: TypedVariableInputProps) {
   const formatVariablePath = useMemo(() => makeFormatVariablePath(delimiters), [delimiters]);
 
   const normalizedTypes = useMemo(() => normalizeTypes(types), [types]);
-  const detected = useMemo(() => detectMode(value, parseVariablePath), [value, parseVariablePath]);
+  const defaultedValue = useMemo(() => {
+    if (!defaultToFirstConstantTypeWhenUndefined || value !== undefined) {
+      return undefined;
+    }
+    const firstType = normalizedTypes[0];
+    return firstType ? defaultValueFor(firstType.type) : undefined;
+  }, [defaultToFirstConstantTypeWhenUndefined, normalizedTypes, value]);
+  const effectiveValue = value === undefined && defaultedValue !== undefined ? defaultedValue : value;
+  const detected = useMemo(() => detectMode(effectiveValue, parseVariablePath), [effectiveValue, parseVariablePath]);
+
+  useEffect(() => {
+    if (value === undefined && defaultedValue !== undefined) {
+      onChange?.(defaultedValue);
+    }
+  }, [defaultedValue, onChange, value]);
 
   // rc-cascader caches its options by *reference* (useEntities), so lazily filling a node's children in place is
   // invisible to it. We mirror `FlowContextSelector`: lazy `loadData` mutates the **meta tree** in place, bumps
@@ -537,6 +559,16 @@ export function TypedVariableInput(props: TypedVariableInputProps) {
     return isVariable && detected.variablePath ? resolveVariableLabels(detected.variablePath, metaTree) : [];
   }, [isVariable, detected.variablePath, metaTree, updateFlag]);
 
+  const switcherValue = useMemo(() => {
+    if (isVariable && detected.variablePath?.length) {
+      return detected.variablePath;
+    }
+    if (isNull) {
+      return [NULL_KEY];
+    }
+    return [CONST_KEY, constantTypeForRendering];
+  }, [constantTypeForRendering, detected.variablePath, isNull, isVariable]);
+
   // Preload a saved variable's label path across lazy levels. `resolveVariableLabels` can only read already-loaded
   // `children`; when a saved reference points below a node whose children are still a lazy thunk (e.g. a relation field
   // that hasn't been expanded), the deep segments render as raw names. Walk the saved path on mount / value change,
@@ -645,7 +677,7 @@ export function TypedVariableInput(props: TypedVariableInputProps) {
             // field looking visibly empty/inactive rather than holding a real text value.
             <Input placeholder={`<${t('Null')}>`} readOnly disabled={disabled} style={{ width: '100%' }} />
           ) : (
-            renderConstantEditor(constantTypeForRendering, value, onChange, {
+            renderConstantEditor(constantTypeForRendering, effectiveValue, onChange, {
               typedProps,
               disabled,
               placeholder,
@@ -656,6 +688,7 @@ export function TypedVariableInput(props: TypedVariableInputProps) {
         </div>
         <Cascader<SwitcherOption>
           options={switcherOptions}
+          value={switcherValue}
           onChange={onSwitcherChange}
           loadData={loadData}
           disabled={disabled}

--- a/packages/core/client-v2/src/components/form/TypedVariableInput.tsx
+++ b/packages/core/client-v2/src/components/form/TypedVariableInput.tsx
@@ -398,7 +398,7 @@ export function TypedVariableInput(props: TypedVariableInputProps) {
     extraNodes,
     metaTree: metaTreeProp,
     nullable = true,
-    defaultToFirstConstantTypeWhenUndefined = false,
+    defaultToFirstConstantTypeWhenUndefined = true,
     delimiters,
     disabled,
     placeholder,

--- a/packages/core/client-v2/src/components/form/__tests__/TypedVariableInput.test.tsx
+++ b/packages/core/client-v2/src/components/form/__tests__/TypedVariableInput.test.tsx
@@ -78,6 +78,52 @@ describe('TypedVariableInput - constant rendering', () => {
     expect(nullInput).toBeInTheDocument();
     expect(nullInput.getAttribute('readonly')).not.toBeNull();
   });
+
+  it('can default undefined to the first constant type when explicitly enabled', async () => {
+    const ctx = createContextWithEnv();
+    const handleChange = vi.fn();
+    renderWithCtx(
+      ctx,
+      <TypedVariableInput
+        value={undefined}
+        types={['string', 'number']}
+        namespaces={['$env']}
+        nullable
+        defaultToFirstConstantTypeWhenUndefined
+        onChange={handleChange}
+      />,
+    );
+
+    expect(screen.queryByPlaceholderText('<Null>')).toBeNull();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith('');
+    });
+  });
+
+  it('highlights the defaulted first constant type when the switcher opens', async () => {
+    const ctx = createContextWithEnv();
+    renderWithCtx(
+      ctx,
+      <TypedVariableInput
+        value={undefined}
+        types={['string', 'number']}
+        namespaces={['$env']}
+        nullable
+        defaultToFirstConstantTypeWhenUndefined
+        onChange={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'variable-switcher' }));
+
+    await waitFor(() => {
+      const constant = screen.getAllByText('Constant')[0];
+      const string = screen.getAllByText('String')[0];
+      expect(constant.closest('.ant-cascader-menu-item-active')).not.toBeNull();
+      expect(string.closest('.ant-cascader-menu-item-active')).not.toBeNull();
+    });
+  });
 });
 
 describe('TypedVariableInput - variable rendering', () => {

--- a/packages/core/client-v2/src/components/form/__tests__/TypedVariableInput.test.tsx
+++ b/packages/core/client-v2/src/components/form/__tests__/TypedVariableInput.test.tsx
@@ -79,7 +79,7 @@ describe('TypedVariableInput - constant rendering', () => {
     expect(nullInput.getAttribute('readonly')).not.toBeNull();
   });
 
-  it('can default undefined to the first constant type when explicitly enabled', async () => {
+  it('defaults undefined to the first constant type', async () => {
     const ctx = createContextWithEnv();
     const handleChange = vi.fn();
     renderWithCtx(
@@ -89,7 +89,6 @@ describe('TypedVariableInput - constant rendering', () => {
         types={['string', 'number']}
         namespaces={['$env']}
         nullable
-        defaultToFirstConstantTypeWhenUndefined
         onChange={handleChange}
       />,
     );
@@ -101,6 +100,24 @@ describe('TypedVariableInput - constant rendering', () => {
     });
   });
 
+  it('can still opt out to keep the null placeholder for undefined', async () => {
+    const ctx = createContextWithEnv();
+    renderWithCtx(
+      ctx,
+      <TypedVariableInput
+        value={undefined}
+        types={['string', 'number']}
+        namespaces={['$env']}
+        nullable
+        defaultToFirstConstantTypeWhenUndefined={false}
+        onChange={() => undefined}
+      />,
+    );
+
+    const nullInput = await screen.findByPlaceholderText('<Null>');
+    expect(nullInput).toBeInTheDocument();
+  });
+
   it('highlights the defaulted first constant type when the switcher opens', async () => {
     const ctx = createContextWithEnv();
     renderWithCtx(
@@ -110,7 +127,6 @@ describe('TypedVariableInput - constant rendering', () => {
         types={['string', 'number']}
         namespaces={['$env']}
         nullable
-        defaultToFirstConstantTypeWhenUndefined
         onChange={() => undefined}
       />,
     );

--- a/packages/plugins/@nocobase/plugin-client/src/server/__tests__/cron.test.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/__tests__/cron.test.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getCronLocale } from '../cron';
+
+describe('getCronLocale', () => {
+  it('loads zh-CN from the hyphenated cron locale file instead of returning an empty object', () => {
+    const locale = getCronLocale('zh-CN');
+
+    expect(locale).toMatchObject({
+      everyText: '每',
+      emptyMonths: '每月',
+      yearOption: '年',
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-client/src/server/cron.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/cron.ts
@@ -11,10 +11,12 @@ import { requireModule } from '@nocobase/utils';
 import { resolve } from 'path';
 
 export const getCronLocale = (lang: string) => {
-  const lng = lang.replace('-', '_');
-  const files = [resolve(__dirname, `./../locale/cron/${lng}`)];
+  const candidates = Array.from(new Set([lang, lang.replace('-', '_')]));
+  const files = candidates.map((candidate) => resolve(__dirname, `./../locale/cron/${candidate}`));
   if (process.env.APP_ENV !== 'production') {
-    files.push(`@nocobase/client/src/locale/cron/${lng}`, `@nocobase/client/lib/locale/cron/${lng}`);
+    for (const candidate of candidates) {
+      files.push(`@nocobase/client/src/locale/cron/${candidate}`, `@nocobase/client/lib/locale/cron/${candidate}`);
+    }
   }
   for (const file of files) {
     try {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/AddNodeContext.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/AddNodeContext.tsx
@@ -221,6 +221,21 @@ export function AddNodeContextProvider(props: { children: React.ReactNode }) {
       return;
     }
 
+    if (decision.kind === 'branch-fallback') {
+      ctx.viewer.dialog({
+        width: 520,
+        closable: true,
+        content: () => (
+          <PresetDialogForm
+            instruction={decision.instruction}
+            hasDownstream
+            onSubmit={(values) => createNode(anchor, decision.instruction, values)}
+          />
+        ),
+      });
+      return;
+    }
+
     await createNode(anchor, decision.instruction, {});
   });
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/NodeConfigDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/NodeConfigDrawer.tsx
@@ -179,7 +179,7 @@ function NodeConfigForm({
     <span />
   ) : (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
-      <div>{instruction?.testable ? <TestRunButton data={data} form={form} /> : null}</div>
+      <div>{instruction?.testable ? <TestRunButton data={data} form={form} workflow={workflow} /> : null}</div>
       <Space>
         <Button onClick={() => view.close()}>{t('Cancel')}</Button>
         <Button

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/AddNodeContext.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/AddNodeContext.test.tsx
@@ -13,6 +13,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App } from 'antd';
 import { PresetDialogForm } from '../AddNodeContext';
 import ConditionInstruction from '../../nodes/condition';
+import MultiConditionsInstruction from '../../nodes/multi-conditions';
 
 vi.mock('../../locale', () => ({
   NAMESPACE: 'workflow',
@@ -49,6 +50,23 @@ describe('PresetDialogForm', () => {
       expect(screen.getByText('After end of branches')).toBeInTheDocument();
       expect(screen.getByText('Inside of "Yes" branch')).toBeInTheDocument();
       expect(screen.getByText('Inside of "No" branch')).toBeInTheDocument();
+    });
+  });
+
+  it('shows downstream-branch placement options immediately for multi-conditions when inserted before downstream nodes', async () => {
+    const instruction = new MultiConditionsInstruction();
+
+    render(
+      <App>
+        <PresetDialogForm instruction={instruction} hasDownstream onSubmit={vi.fn()} />
+      </App>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Move all downstream nodes to')).toBeInTheDocument();
+      expect(screen.getByText('After end of branches')).toBeInTheDocument();
+      expect(screen.getByText('Inside of "First condition" branch')).toBeInTheDocument();
+      expect(screen.getByText('Inside of "Otherwise" branch')).toBeInTheDocument();
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/addNodeController.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/addNodeController.test.ts
@@ -70,6 +70,31 @@ describe('resolveAddNodeDecision', () => {
     });
   });
 
+  it('keeps branch-fallback for multi-conditions so the UI can open the downstream-placement dialog first', () => {
+    const instruction = {
+      type: 'multi-conditions',
+      title: 'Multi conditions',
+      createDefaultConfig: () => ({ conditions: [{ uid: '1' }], continueOnNoMatch: false }),
+      branching: [
+        { label: 'First condition', value: 1 },
+        { label: 'Otherwise', value: 0 },
+      ],
+    } as any;
+
+    const decision = resolveAddNodeDecision({
+      type: 'multi-conditions',
+      anchor: { upstream: { id: 10 }, branchIndex: null },
+      runtime: {
+        workflow: { id: 1 },
+        nodes: [{ id: 11, upstreamId: 10, branchIndex: null }],
+        getInstruction: () => instruction,
+        translateTitle,
+      },
+    });
+
+    expect(decision.kind).toBe('branch-fallback');
+  });
+
   it('returns blocked when runtime availability says no', () => {
     const instruction = {
       type: 'async-node',

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/ExecutionStatusTag.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/ExecutionStatusTag.tsx
@@ -7,10 +7,31 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import {
+  CheckOutlined,
+  CloseOutlined,
+  ExclamationOutlined,
+  HourglassOutlined,
+  LoadingOutlined,
+  MinusOutlined,
+  RedoOutlined,
+} from '@ant-design/icons';
 import { Tag } from 'antd';
 import React from 'react';
-import { EXECUTION_STATUS_OPTIONS_MAP } from '../../common/executionStatus';
+import { EXECUTION_STATUS, EXECUTION_STATUS_OPTIONS_MAP } from '../../common/executionStatus';
 import { useT } from '../locale';
+
+const STATUS_ICON: Record<string, React.ReactNode> = {
+  [EXECUTION_STATUS.QUEUEING as number]: <HourglassOutlined />,
+  [EXECUTION_STATUS.STARTED]: <LoadingOutlined />,
+  [EXECUTION_STATUS.RESOLVED]: <CheckOutlined />,
+  [EXECUTION_STATUS.FAILED]: <ExclamationOutlined />,
+  [EXECUTION_STATUS.ERROR]: <CloseOutlined />,
+  [EXECUTION_STATUS.ABORTED]: <MinusOutlined rotate={90} />,
+  [EXECUTION_STATUS.CANCELED]: <MinusOutlined rotate={45} />,
+  [EXECUTION_STATUS.REJECTED]: <MinusOutlined />,
+  [EXECUTION_STATUS.RETRY_NEEDED]: <RedoOutlined />,
+};
 
 export function ExecutionStatusTag({ value }: { value: number | null }) {
   const compile = useT();
@@ -18,7 +39,12 @@ export function ExecutionStatusTag({ value }: { value: number | null }) {
   if (!option) {
     return null;
   }
-  return <Tag color={option.color}>{compile(option.label)}</Tag>;
+  const icon = STATUS_ICON[value as number];
+  return (
+    <Tag color={option.color} icon={icon}>
+      {compile(option.label)}
+    </Tag>
+  );
 }
 
 export default ExecutionStatusTag;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/SyncModeTag.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/SyncModeTag.tsx
@@ -1,0 +1,19 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Tag } from 'antd';
+import React from 'react';
+import { useWorkflowTranslation } from '../locale';
+
+export function SyncModeTag({ value }: { value?: boolean | null }) {
+  const { t } = useWorkflowTranslation();
+  return value ? <Tag color="orange">{t('Synchronously')}</Tag> : <Tag color="cyan">{t('Asynchronously')}</Tag>;
+}
+
+export default SyncModeTag;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/TestRunButton.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/TestRunButton.tsx
@@ -32,7 +32,7 @@ import { TypedVariableInput, type TypedConstantSpec } from '@nocobase/client-v2'
 import { useFlowContext as useFlowEngineContext } from '@nocobase/flow-engine';
 import { parse } from '@nocobase/utils/client';
 import { useT } from '../locale';
-import { NodeContext } from '../canvas/contexts';
+import { CurrentWorkflowContext, NodeContext, useCurrentWorkflowContext } from '../canvas/contexts';
 import { WorkflowVariableInput } from '../canvas/WorkflowVariableInput';
 
 // Replacement values accept any literal, matching v1's
@@ -59,7 +59,13 @@ function VariableReplacer({
       </div>
       <div style={{ flex: 1, minWidth: 0 }}>
         {/* metaTree={[]} → no variable branch, pure constant (mirrors v1). */}
-        <TypedVariableInput metaTree={[]} types={REPLACE_TYPES} value={value} onChange={onChange} />
+        <TypedVariableInput
+          metaTree={[]}
+          types={REPLACE_TYPES}
+          value={value}
+          onChange={onChange}
+          defaultToFirstConstantTypeWhenUndefined
+        />
       </div>
     </div>
   );
@@ -105,14 +111,14 @@ type TestResult = { status: number; result?: unknown; log?: string };
 function TestRunDialog({ data }: { data: any }) {
   const ctx = useFlowEngineContext();
   const t = useT();
-  const [replaceValues, setReplaceValues] = useState<Record<string, unknown>>({});
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<TestResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
   // Variable keys referenced by the node config (e.g. `$jobsMapByNodeKey.x.y`).
   const template = useMemo(() => parse(data.config ?? {}), [data.config]);
   const keys = useMemo(() => template.parameters.map((p: { key: string }) => p.key), [template]);
+  const [replaceValues, setReplaceValues] = useState<Record<string, unknown>>({});
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const onRun = async () => {
     setLoading(true);
@@ -194,23 +200,33 @@ function TestRunDialog({ data }: { data: any }) {
  * nodes. `form` is the drawer's antd form — its live `config` value is snapshot
  * into the dialog when opened.
  */
-export function TestRunButton({ data, form }: { data: any; form: any }) {
+export function TestRunButton({ data, form, workflow: workflowProp }: { data: any; form: any; workflow?: any }) {
   const ctx = useFlowEngineContext();
   const t = useT();
+  // Footer actions are rendered through the detached `view.Footer` slot, so they
+  // cannot rely on inheriting the drawer body's React contexts. Prefer the
+  // explicitly-threaded workflow prop; fall back to the local context only when
+  // the button is rendered inside the body tree.
+  const workflowFromContext = useCurrentWorkflowContext();
+  const workflow = workflowProp ?? workflowFromContext;
 
   const onOpen = () => {
     const config = form.getFieldsValue()?.config ?? data.config ?? {};
     // The dialog renders in a detached portal, so React contexts from the drawer (NodeContext) don't cross into it.
-    // Re-provide it from the same `data` node object — its live `.upstream` linked-list lets the variable pills resolve
-    // labels (Node result / field names), exactly as the config drawer does.
+    // Re-provide both workflow + node contexts from the config drawer tree:
+    //   - `CurrentWorkflowContext` keeps trigger-scope variable pills resolving to their labelled path instead of
+    //     falling back to the raw `{{...}}` template;
+    //   - `NodeContext` keeps node-result variables resolving through the live upstream linked-list.
     ctx.viewer.dialog({
       width: 800,
       closable: true,
       title: t('Test run'),
       content: () => (
-        <NodeContext.Provider value={{ ...data, config }}>
-          <TestRunDialog data={{ ...data, config }} />
-        </NodeContext.Provider>
+        <CurrentWorkflowContext.Provider value={workflow}>
+          <NodeContext.Provider value={{ ...data, config }}>
+            <TestRunDialog data={{ ...data, config }} />
+          </NodeContext.Provider>
+        </CurrentWorkflowContext.Provider>
       ),
     });
   };

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowCanvasHeader.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowCanvasHeader.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Breadcrumb, Tag, Tooltip, theme } from 'antd';
+import { Breadcrumb, Tooltip, theme } from 'antd';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useT, useWorkflowTranslation } from '../locale';
@@ -16,6 +16,7 @@ import { WorkflowEnabledSwitch } from './WorkflowEnabledSwitch';
 import { WorkflowMenu } from './WorkflowMenu';
 import { WorkflowRevisionsDropdown } from './WorkflowRevisionsDropdown';
 import { ExecuteWorkflowButton } from '../triggers/ExecuteWorkflowButton';
+import { SyncModeTag } from './SyncModeTag';
 
 const WORKFLOW_HOMEPAGE = '/admin/settings/workflow';
 
@@ -62,7 +63,7 @@ export function WorkflowCanvasHeader({
             },
           ]}
         />
-        {record.sync ? <Tag color="orange">{t('Synchronously')}</Tag> : <Tag color="cyan">{t('Asynchronously')}</Tag>}
+        <SyncModeTag value={record.sync} />
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: token.marginXS }}>
         <ExecuteWorkflowButton record={record} refresh={refresh} />

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowDetailsModal.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowDetailsModal.tsx
@@ -7,8 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Descriptions, Modal } from 'antd';
-import React from 'react';
+import { useMemoizedFn } from 'ahooks';
+import { Descriptions, Input, Modal } from 'antd';
+import React, { useEffect, useState } from 'react';
+import useStyles from '../canvas/style';
 import { useWorkflowTranslation } from '../locale';
 import { formatTime, formatUser, type WorkflowCanvasRecord } from './workflowCanvas';
 
@@ -16,12 +18,43 @@ export function WorkflowDetailsModal({
   record,
   open,
   onClose,
+  resource,
+  refresh,
 }: {
   record: WorkflowCanvasRecord;
   open: boolean;
   onClose: () => void;
+  resource: { update: (options: { filterByTk: string | number; values: { description: string } }) => Promise<unknown> };
+  refresh: () => void;
 }) {
   const { t } = useWorkflowTranslation();
+  const { styles } = useStyles();
+  const [editingDescription, setEditingDescription] = useState(record.description ?? '');
+
+  useEffect(() => {
+    if (open) {
+      setEditingDescription(record.description ?? '');
+    }
+  }, [open, record.description]);
+
+  const onChangeDescription = useMemoizedFn((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setEditingDescription(event.target.value);
+  });
+
+  const onBlurDescription = useMemoizedFn(async (event: React.FocusEvent<HTMLTextAreaElement>) => {
+    const description = event.target.value;
+    if (description === (record.description ?? '')) {
+      return;
+    }
+    await resource.update({
+      filterByTk: record.id,
+      values: {
+        description,
+      },
+    });
+    refresh();
+  });
+
   return (
     <Modal open={open} title={t('Details')} width={640} footer={null} onCancel={onClose}>
       <Descriptions bordered column={2} size="small">
@@ -33,7 +66,15 @@ export function WorkflowDetailsModal({
         <Descriptions.Item label={t('Last updated by')}>{formatUser(record.updatedBy)}</Descriptions.Item>
         <Descriptions.Item label={t('Last updated at')}>{formatTime(record.updatedAt)}</Descriptions.Item>
         <Descriptions.Item label={t('Description')} span={2}>
-          <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{record.description || '-'}</div>
+          <Input.TextArea
+            aria-label={t('Description')}
+            value={editingDescription}
+            onChange={onChangeDescription}
+            onBlur={onBlurDescription}
+            placeholder="-"
+            className={styles.workflowDetailsDescriptionClass}
+            autoSize={{ minRows: 3, maxRows: 8 }}
+          />
         </Descriptions.Item>
       </Descriptions>
     </Modal>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowMenu.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowMenu.tsx
@@ -117,7 +117,13 @@ export function WorkflowMenu({
       >
         <Button aria-label="more" type="text" icon={<EllipsisOutlined />} />
       </Dropdown>
-      <WorkflowDetailsModal record={record} open={detailsVisible} onClose={() => setDetailsVisible(false)} />
+      <WorkflowDetailsModal
+        record={record}
+        open={detailsVisible}
+        onClose={() => setDetailsVisible(false)}
+        resource={resource}
+        refresh={refresh}
+      />
     </>
   );
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowRevisionsDropdown.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowRevisionsDropdown.tsx
@@ -14,6 +14,7 @@ import { Button, Dropdown, theme } from 'antd';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import React, { useMemo } from 'react';
+import useStyles from '../canvas/style';
 import { useWorkflowRuntimePaths } from '../hooks/useWorkflowRuntimePaths';
 import { useWorkflowTranslation } from '../locale';
 import type { WorkflowCanvasRecord, WorkflowRevision } from './workflowCanvas';
@@ -24,7 +25,7 @@ export function WorkflowRevisionsDropdown({ record, resource }: { record: Workfl
   const { t } = useWorkflowTranslation();
   const ctx = useFlowContext();
   const { getWorkflowCanvasPath } = useWorkflowRuntimePaths();
-  const { token } = theme.useToken();
+  const { cx, styles } = useStyles();
   const { data, run } = useRequest(
     async () => {
       const response = await resource.list({
@@ -47,32 +48,29 @@ export function WorkflowRevisionsDropdown({ record, resource }: { record: Workfl
 
   return (
     <Dropdown
+      className="workflow-versions"
       trigger={['click']}
       onOpenChange={(open) => open && run()}
       menu={{
         onClick: onSwitchVersion,
         selectedKeys: [`${record.id}`],
+        className: cx(styles.dropdownClass, styles.workflowVersionDropdownClass),
         items: revisions
           .slice()
           .sort((a, b) => Number(b.id) - Number(a.id))
           .map((item) => ({
             key: `${item.id}`,
             icon: item.current ? <RightOutlined /> : null,
+            className: cx({
+              executed: Number(item.versionStats?.executed || 0) > 0,
+              unexecuted: Number(item.versionStats?.executed || 0) === 0,
+              enabled: item.enabled,
+            }),
             label: (
-              <span
-                style={{
-                  display: 'flex',
-                  alignItems: 'baseline',
-                  justifyContent: 'space-between',
-                  gap: token.marginXL,
-                  minWidth: token.sizeXXL * 5,
-                }}
-              >
-                <strong style={{ fontWeight: item.enabled ? 'bold' : 'normal' }}>{`#${item.id}`}</strong>
-                <time style={{ fontSize: token.fontSizeSM, color: token.colorTextTertiary }}>
-                  {item.createdAt ? dayjs(item.createdAt).fromNow() : ''}
-                </time>
-              </span>
+              <>
+                <strong>{`#${item.id}`}</strong>
+                <time>{item.createdAt ? dayjs(item.createdAt).fromNow() : ''}</time>
+              </>
             ),
           })),
       }}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/SyncModeTag.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/SyncModeTag.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { SyncModeTag } from '../SyncModeTag';
+
+vi.mock('../../locale', () => ({
+  useWorkflowTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('SyncModeTag', () => {
+  it('renders synchronously with the v1 orange color', () => {
+    render(<SyncModeTag value />);
+
+    const tag = screen.getByText('Synchronously').closest('.ant-tag');
+    expect(tag?.className).toContain('ant-tag-orange');
+  });
+
+  it('renders asynchronously with the v1 cyan color', () => {
+    render(<SyncModeTag value={false} />);
+
+    const tag = screen.getByText('Asynchronously').closest('.ant-tag');
+    expect(tag?.className).toContain('ant-tag-cyan');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/TestRunButton.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/TestRunButton.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TestRunButton } from '../TestRunButton';
+
+const holder = vi.hoisted(() => ({
+  dialogOptions: null as any,
+  currentWorkflow: { id: 1, type: 'collection', config: { collection: 'roles' } } as any,
+  typedVariableInputProps: [] as Array<{ value: unknown; defaultToFirstConstantTypeWhenUndefined?: boolean }>,
+}));
+const mockContexts = vi.hoisted(() => {
+  const React = require('react');
+  return {
+    CurrentWorkflowContext: React.createContext({}),
+    NodeContext: React.createContext({}),
+  };
+});
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    api: {
+      resource: () => ({
+        test: vi.fn(),
+      }),
+    },
+    viewer: {
+      dialog: (options: any) => {
+        holder.dialogOptions = options;
+      },
+    },
+  }),
+}));
+
+vi.mock('../../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../../canvas/contexts', () => {
+  return {
+    CurrentWorkflowContext: mockContexts.CurrentWorkflowContext,
+    NodeContext: mockContexts.NodeContext,
+    useCurrentWorkflowContext: () => React.useContext(mockContexts.CurrentWorkflowContext),
+  };
+});
+
+vi.mock('../../canvas/WorkflowVariableInput', () => ({
+  WorkflowVariableInput: () => {
+    const workflow = React.useContext(mockContexts.CurrentWorkflowContext);
+    return <div data-testid="workflow-variable-pill">{workflow?.type ? 'resolved-pill' : 'raw-template'}</div>;
+  },
+}));
+
+vi.mock('@nocobase/client-v2', () => ({
+  TypedVariableInput: (props: any) => {
+    holder.typedVariableInputProps.push({
+      value: props.value,
+      defaultToFirstConstantTypeWhenUndefined: props.defaultToFirstConstantTypeWhenUndefined,
+    });
+    return <div data-testid="typed-variable-input" />;
+  },
+}));
+
+vi.mock('@nocobase/utils/client', () => ({
+  parse: () => {
+    const fn = (values: any) => values;
+    fn.parameters = [{ key: '$context.data.name' }];
+    return fn;
+  },
+}));
+
+describe('TestRunButton', () => {
+  it('re-provides the explicit workflow prop into the detached dialog content', () => {
+    holder.typedVariableInputProps = [];
+
+    render(
+      <TestRunButton
+        data={{ type: 'condition', config: {} }}
+        form={{ getFieldsValue: () => ({ config: {} }) }}
+        workflow={holder.currentWorkflow}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Test run').closest('button') as HTMLButtonElement);
+
+    expect(holder.dialogOptions).toBeTruthy();
+
+    render(holder.dialogOptions.content());
+
+    expect(screen.getByTestId('workflow-variable-pill')).toHaveTextContent('resolved-pill');
+    expect(screen.getByTestId('typed-variable-input')).toBeInTheDocument();
+    expect(holder.typedVariableInputProps).toEqual([
+      {
+        value: undefined,
+        defaultToFirstConstantTypeWhenUndefined: true,
+      },
+    ]);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/WorkflowDetailsModal.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/WorkflowDetailsModal.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkflowDetailsModal } from '../WorkflowDetailsModal';
+
+vi.mock('../../canvas/style', () => ({
+  default: () => ({
+    styles: {
+      workflowDetailsDescriptionClass: 'workflow-details-description',
+    },
+  }),
+}));
+
+vi.mock('../../locale', () => ({
+  useWorkflowTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('WorkflowDetailsModal', () => {
+  const record = {
+    id: 11,
+    key: 'k0vffw52ic5',
+    description: '123',
+    createdBy: null,
+    updatedBy: { nickname: 'Super Admin' },
+    createdAt: '2026-06-16T06:58:57.000Z',
+    updatedAt: '2026-06-16T07:03:56.000Z',
+  } as any;
+
+  it('renders an editable textarea with the shared hover/focus style class', () => {
+    render(
+      <WorkflowDetailsModal
+        record={record}
+        open
+        onClose={() => undefined}
+        resource={{ update: vi.fn() }}
+        refresh={() => undefined}
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Description' });
+    expect(textarea).toHaveValue('123');
+    expect(textarea).toHaveAttribute('placeholder', '-');
+    expect(textarea.className).toContain('workflow-details-description');
+  });
+
+  it('updates description on blur when the value changed', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const refresh = vi.fn();
+
+    render(
+      <WorkflowDetailsModal record={record} open onClose={() => undefined} resource={{ update }} refresh={refresh} />,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Description' });
+    fireEvent.change(textarea, { target: { value: '456' } });
+    fireEvent.blur(textarea, { target: { value: '456' } });
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith({
+        filterByTk: 11,
+        values: {
+          description: '456',
+        },
+      });
+    });
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('does not update when blur keeps the original description', async () => {
+    const update = vi.fn();
+
+    render(
+      <WorkflowDetailsModal
+        record={record}
+        open
+        onClose={() => undefined}
+        resource={{ update }}
+        refresh={() => undefined}
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox', { name: 'Description' });
+    fireEvent.blur(textarea, { target: { value: '123' } });
+
+    await waitFor(() => {
+      expect(update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/WorkflowRevisionsDropdown.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/WorkflowRevisionsDropdown.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  dropdownProps: null as any,
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    router: { navigate: vi.fn() },
+  }),
+}));
+
+vi.mock('../../locale', () => ({
+  useWorkflowTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../hooks/useWorkflowRuntimePaths', () => ({
+  useWorkflowRuntimePaths: () => ({
+    getWorkflowCanvasPath: (id: string | number) => `/admin/workflow/workflows/${id}`,
+  }),
+}));
+
+vi.mock('../../canvas/style', () => ({
+  default: () => ({
+    cx: (...classes: Array<string | Record<string, any>>) =>
+      classes
+        .flatMap((item) => {
+          if (typeof item === 'string') return [item];
+          return Object.entries(item)
+            .filter(([, enabled]) => Boolean(enabled))
+            .map(([name]) => name);
+        })
+        .join(' '),
+    styles: {
+      dropdownClass: 'dropdown-class',
+      workflowVersionDropdownClass: 'workflow-version-dropdown-class',
+    },
+  }),
+}));
+
+vi.mock('antd', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Dropdown: (props: any) => {
+    holder.dropdownProps = props;
+    return <div>{props.children}</div>;
+  },
+  theme: {
+    useToken: () => ({ token: {} }),
+  },
+}));
+
+vi.mock('ahooks', () => ({
+  useMemoizedFn: (fn: any) => fn,
+  useRequest: () => ({
+    data: [
+      {
+        id: 369886707974144,
+        createdAt: '2026-06-16T00:00:00.000Z',
+        current: true,
+        enabled: true,
+        versionStats: { executed: 1 },
+      },
+      {
+        id: 369813449801731,
+        createdAt: '2026-06-15T00:00:00.000Z',
+        current: false,
+        enabled: false,
+        versionStats: { executed: 0 },
+      },
+    ],
+    run: vi.fn(),
+  }),
+}));
+
+import { WorkflowRevisionsDropdown } from '../WorkflowRevisionsDropdown';
+
+describe('WorkflowRevisionsDropdown', () => {
+  it('uses the shared v1-aligned dropdown classes and strong+time label structure', () => {
+    render(
+      <WorkflowRevisionsDropdown record={{ id: 369886707974144, key: 'wf-key' } as any} resource={{ list: vi.fn() }} />,
+    );
+
+    expect(screen.getByRole('button', { name: /Version/i })).toBeInTheDocument();
+    expect(holder.dropdownProps.className).toBe('workflow-versions');
+    expect(holder.dropdownProps.menu.className).toBe('dropdown-class workflow-version-dropdown-class');
+
+    const [first] = holder.dropdownProps.menu.items;
+    expect(first.className).toContain('enabled');
+    expect(first.label.type).toBe(React.Fragment);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/multiConditionsFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/multiConditionsFieldset.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Form } from 'antd';
 import { MultiConditionsFieldset } from '../components/multi-conditions';
 
@@ -29,5 +29,39 @@ describe('MultiConditionsFieldset', () => {
     expect(screen.getByText('When no condition matches')).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'End as failed' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Continue the workflow' })).toBeInTheDocument();
+  });
+
+  it('keeps existing conditions in form values when only continueOnNoMatch changes', () => {
+    let formInstance: ReturnType<typeof Form.useForm>[0] | null = null;
+
+    function Wrapper() {
+      const [form] = Form.useForm();
+      formInstance = form;
+
+      return (
+        <Form
+          form={form}
+          initialValues={{
+            config: {
+              continueOnNoMatch: false,
+              conditions: [{ uid: 'c1', title: 'Condition 1' }],
+            },
+          }}
+        >
+          <MultiConditionsFieldset />
+        </Form>
+      );
+    }
+
+    render(<Wrapper />);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Continue the workflow' }));
+
+    expect(formInstance?.getFieldsValue(true)).toEqual({
+      config: {
+        continueOnNoMatch: true,
+        conditions: [{ uid: 'c1', title: 'Condition 1' }],
+      },
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/multi-conditions.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/multi-conditions.tsx
@@ -297,14 +297,23 @@ export function MultiConditionsFieldset() {
   const t = useT();
 
   return (
-    <Form.Item name={['config', 'continueOnNoMatch']} label={t('When no condition matches')} initialValue={false}>
-      <RadioWithTooltip
-        options={[
-          { label: t('End as failed'), value: false },
-          { label: t('Continue the workflow'), value: true },
-        ]}
-      />
-    </Form.Item>
+    <>
+      {/* Keep the configured condition branches in the submitted `config`
+          payload. The shared node drawer submits `values.config` wholesale; if
+          the form omits `config.conditions`, toggling only
+          `continueOnNoMatch` would overwrite the branch list away. */}
+      <Form.Item name={['config', 'conditions']} hidden>
+        <Input />
+      </Form.Item>
+      <Form.Item name={['config', 'continueOnNoMatch']} label={t('When no condition matches')} initialValue={false}>
+        <RadioWithTooltip
+          options={[
+            { label: t('End as failed'), value: false },
+            { label: t('Continue the workflow'), value: true },
+          ]}
+        />
+      </Form.Item>
+    </>
   );
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/ExecutionHistoryDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/ExecutionHistoryDrawer.tsx
@@ -7,11 +7,11 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { DeleteOutlined, ReloadOutlined } from '@ant-design/icons';
+import { DeleteOutlined, ExclamationCircleFilled, ReloadOutlined, StopOutlined } from '@ant-design/icons';
 import { CollectionFilter, ExtendCollectionsProvider, Table } from '@nocobase/client-v2';
 import { useFlowContext, useFlowEngine } from '@nocobase/flow-engine';
 import { useMemoizedFn, useRequest } from 'ahooks';
-import { App, Button, Flex, Space, theme } from 'antd';
+import { App, Button, Flex, Space, Tooltip, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import React, { useMemo, useState } from 'react';
@@ -129,6 +129,7 @@ function ExecutionHistoryDrawerInner({ workflowKey }: { workflowKey: string | nu
   const handleCancel = useMemoizedFn((record: ExecutionRecord) => {
     modal.confirm({
       title: t('Cancel the execution'),
+      icon: <ExclamationCircleFilled />,
       content: t('Are you sure you want to cancel the execution?'),
       async onOk() {
         await resource.cancel({ filterByTk: record.id });
@@ -165,10 +166,17 @@ function ExecutionHistoryDrawerInner({ workflowKey }: { workflowKey: string | nu
         render: (value, record) => (
           <Space>
             <ExecutionStatusTag value={value} />
-            {value === EXECUTION_STATUS.STARTED || value === EXECUTION_STATUS.QUEUEING ? (
-              <Button type="link" danger size="small" onClick={() => handleCancel(record)}>
-                {t('Cancel the execution')}
-              </Button>
+            {record.status === EXECUTION_STATUS.STARTED || record.status === EXECUTION_STATUS.QUEUEING ? (
+              <Tooltip title={t('Cancel the execution')}>
+                <Button
+                  type="link"
+                  danger
+                  onClick={() => handleCancel(record)}
+                  shape="circle"
+                  size="small"
+                  icon={<StopOutlined />}
+                />
+              </Tooltip>
             ) : null}
           </Space>
         ),

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowCategoryTabs.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowCategoryTabs.tsx
@@ -55,10 +55,11 @@ export type WorkflowCategoryTabsProps = {
   onChange: (key: string) => void;
   categories: WorkflowCategory[];
   refreshCategories: () => void;
+  className?: string;
 };
 
 export function WorkflowCategoryTabs(props: WorkflowCategoryTabsProps) {
-  const { activeKey, onChange, categories, refreshCategories } = props;
+  const { activeKey, onChange, categories, refreshCategories, className } = props;
   const { t } = useWorkflowTranslation();
   const compile = useT();
   const ctx = useFlowContext();
@@ -140,6 +141,7 @@ export function WorkflowCategoryTabs(props: WorkflowCategoryTabsProps) {
   return (
     <>
       <SortableCategoryTabs
+        className={className}
         activeKey={activeKey}
         onChange={onChange}
         allTab={{ key: ALL_CATEGORY_KEY, label: t('All') }}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowPane.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowPane.tsx
@@ -16,9 +16,10 @@ import {
   ExtendCollectionsProvider,
   Table,
 } from '@nocobase/client-v2';
+import { css } from '@emotion/css';
 import { useFlowContext } from '@nocobase/flow-engine';
 import { useMemoizedFn, useRequest } from 'ahooks';
-import { App, Button, Card, Flex, Form, Input, Space, Switch, Tag, Tooltip, theme } from 'antd';
+import { App, Button, Flex, Form, Input, Space, Switch, Tag, Tooltip, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import React, { useMemo, useState } from 'react';
 import workflowCollection from '../../common/collections/workflows';
@@ -128,6 +129,32 @@ function WorkflowPaneInner() {
   const { modal, message } = App.useApp();
   const resource = ctx.api.resource('workflows');
   const plugin = ctx.app.pm.get(PluginWorkflowClientV2);
+  const workflowContainerClassName = css`
+    background: ${token.colorBgLayout};
+    padding: 0;
+  `;
+  const workflowTabsClassName = css`
+    padding: ${token.padding}px ${token.padding}px 0 calc(${token.padding}px - ${token.lineWidth}px);
+    background: ${token.colorBgLayout};
+
+    .ant-tabs {
+      margin-bottom: 0;
+    }
+
+    .ant-tabs-nav {
+      margin-bottom: 0;
+    }
+
+    .ant-tabs-content-holder {
+      display: none;
+    }
+  `;
+  const workflowContentClassName = css`
+    margin: 0 ${token.padding}px ${token.padding}px;
+    padding: ${token.paddingLG}px;
+    background: ${token.colorBgContainer};
+    border-radius: 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px ${token.borderRadiusLG}px;
+  `;
   const filterCollection = useMemo(
     () => ctx.dataSourceManager?.getDataSource?.('main')?.getCollection?.('workflows'),
     [ctx],
@@ -308,8 +335,9 @@ function WorkflowPaneInner() {
   );
 
   return (
-    <Card variant="borderless">
+    <div className={workflowContainerClassName}>
       <WorkflowCategoryTabs
+        className={workflowTabsClassName}
         activeKey={activeCategory}
         onChange={(key) => {
           setActiveCategory(key);
@@ -318,45 +346,47 @@ function WorkflowPaneInner() {
         categories={categories}
         refreshCategories={refreshCategories}
       />
-      <Flex justify="space-between" align="center" style={{ marginBottom: token.margin }}>
-        <CollectionFilter
-          collection={filterCollection}
-          nonfilterableFieldNames={WORKFLOWS_NONFILTERABLE_FIELD_NAMES}
-          onChange={handleFilterChange}
-          t={compile}
+      <div className={workflowContentClassName}>
+        <Flex justify="space-between" align="center" style={{ marginBottom: token.margin }}>
+          <CollectionFilter
+            collection={filterCollection}
+            nonfilterableFieldNames={WORKFLOWS_NONFILTERABLE_FIELD_NAMES}
+            onChange={handleFilterChange}
+            t={compile}
+          />
+          <Space>
+            <Button icon={<ReloadOutlined />} onClick={() => refresh()}>
+              {t('Refresh')}
+            </Button>
+            {showSync ? (
+              <Tooltip title={t('Sync enabled status of all workflows from database')}>
+                <Button icon={<SyncOutlined />} onClick={handleSync}>
+                  {t('Sync')}
+                </Button>
+              </Tooltip>
+            ) : null}
+            <Button
+              icon={<DeleteOutlined />}
+              disabled={!selectedRowKeys.length}
+              onClick={() => handleDelete(selectedRowKeys)}
+            >
+              {t('Delete')}
+            </Button>
+            <Button type="primary" icon={<PlusOutlined />} onClick={() => openForm('create')}>
+              {t('Add new')}
+            </Button>
+          </Space>
+        </Flex>
+        <Table<WorkflowRecord>
+          rowKey="id"
+          loading={loading}
+          columns={columns}
+          dataSource={data?.records || []}
+          rowSelection={{ selectedRowKeys, onChange: setSelectedRowKeys }}
+          pagination={{ current: page, pageSize, total: data?.total || 0, onChange: handlePaginationChange }}
         />
-        <Space>
-          <Button icon={<ReloadOutlined />} onClick={() => refresh()}>
-            {t('Refresh')}
-          </Button>
-          {showSync ? (
-            <Tooltip title={t('Sync enabled status of all workflows from database')}>
-              <Button icon={<SyncOutlined />} onClick={handleSync}>
-                {t('Sync')}
-              </Button>
-            </Tooltip>
-          ) : null}
-          <Button
-            icon={<DeleteOutlined />}
-            disabled={!selectedRowKeys.length}
-            onClick={() => handleDelete(selectedRowKeys)}
-          >
-            {t('Delete')}
-          </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => openForm('create')}>
-            {t('Add new')}
-          </Button>
-        </Space>
-      </Flex>
-      <Table<WorkflowRecord>
-        rowKey="id"
-        loading={loading}
-        columns={columns}
-        dataSource={data?.records || []}
-        rowSelection={{ selectedRowKeys, onChange: setSelectedRowKeys }}
-        pagination={{ current: page, pageSize, total: data?.total || 0, onChange: handlePaginationChange }}
-      />
-    </Card>
+      </div>
+    </div>
   );
 }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowPane.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowPane.tsx
@@ -366,7 +366,9 @@ export default function WorkflowPane() {
   // The shared `workflows` collection is `schema-only`, so it isn't published to the v2 data source — register a
   // client-only copy so `CollectionFilter` can resolve its fields. Its `type` field carries the v1 Formily template
   // `enum: '{{useTriggersOptions()}}'`, which the v2 filter value renderer can't compile; replace it with the
-  // registered trigger options up front so the Trigger type condition renders as a Select (matching v1).
+  // registered trigger options up front so the Trigger type condition renders as a Select (matching v1). Keep the
+  // injected collection hidden so workflow-internal schema-only collections do not leak into trigger collection
+  // pickers that enumerate visible collections from the current data source.
   const collections = useMemo(() => {
     const triggerOptions = Array.from(plugin.triggers.getEntities() as Iterable<[string, { title?: string }]>)
       .map(([value, opt]) => ({ value, label: opt?.title ? compile(opt.title) : String(value) }))
@@ -374,6 +376,7 @@ export default function WorkflowPane() {
     return [
       {
         ...workflowCollection,
+        hidden: true,
         fields: workflowCollection.fields.map((field) =>
           field?.name === 'type' && field.uiSchema
             ? { ...field, uiSchema: { ...field.uiSchema, enum: triggerOptions } }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowPane.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowPane.tsx
@@ -22,6 +22,7 @@ import { App, Button, Card, Flex, Form, Input, Space, Switch, Tag, Tooltip, them
 import type { ColumnsType } from 'antd/es/table';
 import React, { useMemo, useState } from 'react';
 import workflowCollection from '../../common/collections/workflows';
+import { SyncModeTag } from '../components/SyncModeTag';
 import { useWorkflowRuntimePaths } from '../hooks/useWorkflowRuntimePaths';
 import { useT, useWorkflowTranslation } from '../locale';
 import PluginWorkflowClientV2 from '../plugin';
@@ -271,7 +272,7 @@ function WorkflowPaneInner() {
         title: t('Execute mode'),
         dataIndex: 'sync',
         width: 140,
-        render: (value) => <Tag>{value ? t('Synchronously') : t('Asynchronously')}</Tag>,
+        render: (value) => <SyncModeTag value={value} />,
       },
       {
         title: t('Enabled'),

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/ExecutionHistoryDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/ExecutionHistoryDrawer.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { App } from 'antd';
+import { get } from 'lodash';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { EXECUTION_STATUS } from '../../../common/executionStatus';
+
+const holder = vi.hoisted(() => ({ ctx: null as any }));
+
+vi.mock('@nocobase/flow-engine', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useFlowContext: () => holder.ctx,
+    useFlowEngine: () => ({
+      context: {
+        dataSourceManager: {
+          getDataSource: () => ({
+            getCollection: () => undefined,
+          }),
+        },
+      },
+    }),
+  };
+});
+
+vi.mock('../../locale', () => ({
+  useT: () => (key: string) => {
+    const matched = key.match(/^{{t\("(.+?)"(?:, \{.*\})?\)}}$/);
+    return matched?.[1] ?? key;
+  },
+  useWorkflowTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../hooks/useWorkflowRuntimePaths', () => ({
+  useWorkflowRuntimePaths: () => ({
+    getWorkflowExecutionPath: (id: string | number) => `/admin/workflow/executions/${id}`,
+  }),
+}));
+
+vi.mock('@nocobase/client-v2', () => ({
+  CollectionFilter: () => null,
+  ExtendCollectionsProvider: ({ children }: any) => <>{children}</>,
+  Table: ({ dataSource = [], columns = [] }: any) => (
+    <table>
+      <tbody>
+        {dataSource.map((record: any) => (
+          <tr key={record.id}>
+            {columns.map((col: any, index: number) => (
+              <td key={index}>
+                {typeof col.render === 'function'
+                  ? col.render(col.dataIndex ? get(record, col.dataIndex) : undefined, record)
+                  : col.dataIndex
+                    ? get(record, col.dataIndex)
+                    : null}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+import { ExecutionHistoryDrawer } from '../ExecutionHistoryDrawer';
+
+function renderWithApp(node: React.ReactNode) {
+  return render(<App>{node}</App>);
+}
+
+describe('ExecutionHistoryDrawer', () => {
+  it('renders the v1-style loading status tag and icon-only cancel action for started executions', async () => {
+    const executions = {
+      list: vi.fn().mockResolvedValue({
+        data: {
+          data: [
+            {
+              id: 370295881138176,
+              createdAt: '2026-06-16T07:27:15.000Z',
+              workflowId: 370295837097984,
+              status: EXECUTION_STATUS.STARTED,
+            },
+          ],
+          meta: { count: 1 },
+        },
+      }),
+      cancel: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    holder.ctx = {
+      api: { resource: (name: string) => ({ executions })[name] },
+      router: { navigate: vi.fn() },
+      view: { close: vi.fn() },
+    };
+
+    renderWithApp(<ExecutionHistoryDrawer workflowKey="wf-key" />);
+
+    await waitFor(() => {
+      expect(executions.list).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('On going')).toBeInTheDocument();
+    expect(document.querySelector('.anticon-loading')).not.toBeNull();
+    expect(screen.queryByText('Cancel the execution')).toBeNull();
+
+    const cancelButton = screen.getByRole('button', { name: 'stop' });
+    expect(cancelButton).toBeInTheDocument();
+    expect(cancelButton.className).toContain('ant-btn-link');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowPane.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowPane.test.tsx
@@ -15,7 +15,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Mock the FlowContext so `useFlowContext()` returns our controlled ctx ---
 const holder = vi.hoisted(() => ({ ctx: null as any }));
-const providerHolder = vi.hoisted(() => ({ collections: null as any }));
+const providerHolder = vi.hoisted(() => ({ collections: null as any, workflowTabsClassName: null as string | null }));
 vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual, useFlowContext: () => holder.ctx };
@@ -76,6 +76,14 @@ vi.mock('@nocobase/client-v2', () => ({
   ),
 }));
 
+vi.mock('../WorkflowCategoryTabs', () => ({
+  ALL_CATEGORY_KEY: 'all',
+  WorkflowCategoryTabs: ({ className }: any) => {
+    providerHolder.workflowTabsClassName = className ?? null;
+    return <div data-testid="workflow-category-tabs" />;
+  },
+}));
+
 import { WorkflowFormDrawer } from '../WorkflowFormDrawer';
 import WorkflowPane from '../WorkflowPane';
 
@@ -100,6 +108,7 @@ describe('WorkflowPane (request layer)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     providerHolder.collections = null;
+    providerHolder.workflowTabsClassName = null;
   });
 
   it('fires resource.create on submit in create mode', async () => {
@@ -285,5 +294,26 @@ describe('WorkflowPane (request layer)', () => {
       name: 'workflows',
       hidden: true,
     });
+  });
+
+  it('passes a dedicated tabs container class to WorkflowCategoryTabs so the page can match the legacy top strip layout', async () => {
+    const workflows = {
+      list: vi.fn().mockResolvedValue({
+        data: {
+          data: [],
+          meta: { count: 0 },
+        },
+      }),
+    };
+    const workflowCategories = { list: vi.fn().mockResolvedValue({ data: { data: [] } }) };
+    holder.ctx = makeCtx({ workflows, workflowCategories });
+
+    renderWithApp(<WorkflowPane />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-category-tabs')).toBeInTheDocument();
+    });
+
+    expect(providerHolder.workflowTabsClassName).toBeTruthy();
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowPane.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowPane.test.tsx
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Mock the FlowContext so `useFlowContext()` returns our controlled ctx ---
 const holder = vi.hoisted(() => ({ ctx: null as any }));
+const providerHolder = vi.hoisted(() => ({ collections: null as any }));
 vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual, useFlowContext: () => holder.ctx };
@@ -34,7 +35,10 @@ vi.mock('@nocobase/client-v2', () => ({
   Plugin: class Plugin {},
   SortableCategoryTabs: () => null,
   CollectionFilter: () => null,
-  ExtendCollectionsProvider: ({ children }: any) => <>{children}</>,
+  ExtendCollectionsProvider: ({ children, collections }: any) => {
+    providerHolder.collections = collections;
+    return <>{children}</>;
+  },
   DrawerFormLayout: ({ children, onSubmit }: any) => (
     <div>
       {children}
@@ -95,6 +99,7 @@ function renderWithApp(node: React.ReactNode) {
 describe('WorkflowPane (request layer)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    providerHolder.collections = null;
   });
 
   it('fires resource.create on submit in create mode', async () => {
@@ -255,5 +260,30 @@ describe('WorkflowPane (request layer)', () => {
     expect(label).toBeInTheDocument();
     expect(label).toHaveStyle({ fontWeight: '600' });
     expect(await screen.findByText('preset-field')).toBeInTheDocument();
+  });
+
+  it('injects the client-only workflows collection as hidden so it does not leak into visible collection pickers', async () => {
+    const workflows = {
+      list: vi.fn().mockResolvedValue({
+        data: {
+          data: [],
+          meta: { count: 0 },
+        },
+      }),
+    };
+    const workflowCategories = { list: vi.fn().mockResolvedValue({ data: { data: [] } }) };
+    holder.ctx = makeCtx({ workflows, workflowCategories });
+
+    renderWithApp(<WorkflowPane />);
+
+    await waitFor(() => {
+      expect(providerHolder.collections).toBeTruthy();
+    });
+
+    expect(providerHolder.collections).toHaveLength(1);
+    expect(providerHolder.collections[0]).toMatchObject({
+      name: 'workflows',
+      hidden: true,
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/triggers/schedule/RepeatField.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/triggers/schedule/RepeatField.tsx
@@ -12,6 +12,7 @@ import { useMemoizedFn } from 'ahooks';
 import { InputNumber, Select } from 'antd';
 import React from 'react';
 import { Cron, type Locale } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
 import { useWorkflowTranslation } from '../../locale';
 
 declare global {
@@ -121,14 +122,21 @@ export function RepeatField({
           border: 1px dashed #ccc;
 
           .react-js-cron-field {
+            flex-shrink: 0;
             margin-bottom: 0.5em;
 
             > span {
+              flex-shrink: 0;
               margin: 0 0.5em 0 0;
             }
 
             > .react-js-cron-select {
               margin: 0 0.5em 0 0;
+
+              .ant-select-selection-overflow {
+                align-items: center;
+                flex: initial;
+              }
             }
           }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/triggers/schedule/__tests__/RepeatField.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/triggers/schedule/__tests__/RepeatField.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  cronProps: null as any,
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowEngine: () => ({}),
+}));
+
+vi.mock('../../../locale', () => ({
+  useWorkflowTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-js-cron', () => ({
+  Cron: (props: any) => {
+    holder.cronProps = props;
+    return <div data-testid="react-js-cron" />;
+  },
+}));
+
+import { RepeatField } from '../RepeatField';
+
+describe('RepeatField', () => {
+  it('passes window.cronLocale through to react-js-cron', () => {
+    window.cronLocale = {
+      everyText: '每',
+      emptyMonths: '每月',
+    } as any;
+
+    render(<RepeatField value="0 * * * * *" onChange={() => undefined} />);
+
+    expect(screen.getByTestId('react-js-cron')).toBeInTheDocument();
+    expect(holder.cronProps?.locale).toEqual({
+      everyText: '每',
+      emptyMonths: '每月',
+    });
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The ongoing `plugin-workflow` client-to-client-v2 migration introduced several behavior and visual regressions across workflow triggers, condition nodes, multi-conditions, execution history, and related workflow runtime surfaces.

### Description 
- Restore schedule trigger parity in client-v2, including advanced repeat-mode layout, cron locale loading, payload behavior, and trigger form behavior.
- Restore collection trigger parity in client-v2, including collection filtering, shared collection UI, payload semantics, and manual execute behavior.
- Restore condition and multi-conditions node parity in client-v2, including branch insertion dialogs, variable-input defaults, test-run dialogs, branch preservation, and execution/result affordances.
- Align workflow canvas and execution history UI details with v1, including sync mode tags, revision dropdown layout, status actions, workflow details editing, and runtime-specific routing behavior.
- Add regression tests for the affected workflow v2 shared components, add-node controller flows, schedule/collection trigger behavior, and server-side cron locale loading.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
