### PR TITLE
fix(plugin-action-custom-request): avoid sending unconfigured v2 custom requests

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/__tests__/customRequestFlowAction.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/__tests__/customRequestFlowAction.test.ts
@@ -1,0 +1,110 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { customRequestFlowAction } from '../customRequestFlowAction';
+import type { CustomRequestStepParams } from '../customRequestFlowActionTypes';
+
+const createContext = (request = vi.fn()) => {
+  return {
+    request,
+    message: {
+      error: vi.fn(),
+      success: vi.fn(),
+    },
+    t: vi.fn((key: string) => key),
+    exit: vi.fn(),
+    model: {
+      getStepParams: vi.fn(() => ({})),
+    },
+  };
+};
+
+const runCustomRequestAction = customRequestFlowAction.handler as unknown as (
+  ctx: ReturnType<typeof createContext>,
+  params: CustomRequestStepParams,
+) => Promise<unknown>;
+
+describe('customRequestFlowAction', () => {
+  it('should show configure message without sending request when custom request is not configured', async () => {
+    const request = vi.fn();
+    const ctx = createContext(request);
+
+    await runCustomRequestAction(ctx, { key: 'req-not-configured' });
+
+    expect(ctx.message.error).toHaveBeenCalledWith('Please configure the request settings first');
+    expect(ctx.exit).toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('should show configure message without sending request when custom request has no key', async () => {
+    const request = vi.fn();
+    const ctx = createContext(request);
+
+    await runCustomRequestAction(ctx, {});
+
+    expect(ctx.message.error).toHaveBeenCalledWith('Please configure the request settings first');
+    expect(ctx.exit).toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('should send custom request when saved config has url', async () => {
+    const request = vi.fn().mockResolvedValue({ data: { data: { ok: true } } });
+    const ctx = createContext(request);
+
+    await runCustomRequestAction(ctx, { key: 'req-ready', configured: true, responseType: 'json', variablePaths: [] });
+
+    expect(ctx.message.error).not.toHaveBeenCalled();
+    expect(ctx.message.success).toHaveBeenCalledWith('Request success');
+    expect(ctx.exit).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({
+      url: '/customRequests:send/req-ready',
+      method: 'POST',
+      responseType: 'json',
+      data: {
+        vars: undefined,
+      },
+    });
+  });
+
+  it('should keep sending custom request for legacy saved config without configured flag', async () => {
+    const request = vi.fn().mockResolvedValue({ data: { data: { ok: true } } });
+    const ctx = createContext(request);
+
+    await runCustomRequestAction(ctx, { key: 'req-legacy-ready', variablePaths: [] });
+
+    expect(ctx.message.error).not.toHaveBeenCalled();
+    expect(ctx.message.success).toHaveBeenCalledWith('Request success');
+    expect(ctx.exit).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({
+      url: '/customRequests:send/req-legacy-ready',
+      method: 'POST',
+      responseType: 'json',
+      data: {
+        vars: undefined,
+      },
+    });
+  });
+
+  it('should throw request errors for configured custom request', async () => {
+    const requestError = new Error('remote service unavailable');
+    const request = vi.fn().mockRejectedValue(requestError);
+    const ctx = createContext(request);
+
+    await expect(runCustomRequestAction(ctx, { key: 'req-ready', configured: true, variablePaths: [] })).rejects.toBe(
+      requestError,
+    );
+
+    expect(ctx.message.error).not.toHaveBeenCalled();
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.exit).toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowAction.tsx
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowAction.tsx
@@ -22,12 +22,17 @@ import { customRequestUiSchema } from './customRequestUiSchema';
 const buildSanitizedParams = (key: string, params: CustomRequestStepParams): CustomRequestStepParams => {
   return {
     key,
+    configured: true,
     variablePaths: extractVariablePaths(params),
     responseType: params?.responseType || 'json',
   };
 };
 
 export const CUSTOM_REQUEST_ACTION_NAME = 'customRequest';
+
+const isCustomRequestConfigured = (params: CustomRequestStepParams) => {
+  return params?.configured === true || Array.isArray(params?.variablePaths);
+};
 
 export const customRequestFlowAction = defineAction({
   name: CUSTOM_REQUEST_ACTION_NAME,
@@ -36,22 +41,22 @@ export const customRequestFlowAction = defineAction({
   sort: 1000,
   paramsRequired: true,
   uiSchema: customRequestUiSchema,
-  defaultParams(ctx: any) {
+  defaultParams() {
     return {
       key: makeRequestKey(),
       ...DEFAULT_CUSTOM_REQUEST_SETTINGS,
     };
   },
-  async beforeParamsSave(ctx: any, params: CustomRequestStepParams) {
+  async beforeParamsSave(ctx, params: CustomRequestStepParams) {
     const key = params?.key || makeRequestKey();
     await saveCustomRequestConfig(ctx, key, params);
 
     const sanitizedParams = buildSanitizedParams(key, params);
 
     Object.keys(params || {}).forEach((fieldKey) => {
-      delete (params as Record<string, any>)[fieldKey];
+      delete (params as Record<string, unknown>)[fieldKey];
     });
-    Object.assign(params as Record<string, any>, sanitizedParams);
+    Object.assign(params as Record<string, unknown>, sanitizedParams);
 
     if (ctx.model.stepParams?.customRequestClickSettings) {
       ctx.model.stepParams.customRequestClickSettings = {
@@ -65,14 +70,16 @@ export const customRequestFlowAction = defineAction({
     const runtimeParams = params?.key ? params : { ...savedParams, key: savedParams?.key };
     const requestKey = runtimeParams?.key;
 
-    if (!requestKey) {
+    if (!requestKey || !isCustomRequestConfigured(runtimeParams)) {
       ctx.message.error(ctx.t('Please configure the request settings first', { ns: NAMESPACE }));
       ctx.exit();
       return;
     }
 
     try {
-      return await executeCustomRequest(ctx, { ...runtimeParams, key: requestKey }, { throwOnError: true });
+      const response = await executeCustomRequest(ctx, { ...runtimeParams, key: requestKey }, { throwOnError: true });
+      ctx.message.success(ctx.t('Request success'));
+      return response;
     } catch (error) {
       ctx.exit();
       throw error;

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowActionTypes.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowActionTypes.ts
@@ -14,6 +14,7 @@ export type RequestNameValue = {
 
 export type CustomRequestStepParams = {
   key?: string;
+  configured?: boolean;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   url?: string;
   headers?: RequestNameValue[];


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 custom request actions could still send `/customRequests:send` when the request settings had not been configured, causing an additional `request config not found` error notification after the expected configuration prompt.

### Description 
- Mark V2 custom request action params as configured after request settings are saved.
- Stop unconfigured V2 custom request actions before sending a request and show `Please configure the request settings first`.
- Keep legacy saved V2 params working when they already contain `variablePaths`.
- Add unit tests for unconfigured actions, legacy saved params, successful requests, and configured request errors.

Potential risk: low. The runtime guard only blocks actions without a saved configuration marker or legacy `variablePaths`; existing saved V2 actions remain compatible.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowAction.tsx packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowActionTypes.ts packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/__tests__/customRequestFlowAction.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/__tests__/customRequestFlowAction.test.ts --run --reporter=verbose`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed V2 custom request actions showing an extra error when request settings are not configured. |
| 🇨🇳 Chinese | 修复 V2 自定义请求操作未配置请求设置时额外弹出错误提示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
