### PR TITLE
Exclude dataCategory runtime tables from backups

### DIFF
--- a/packages/core/database/src/collection.ts
+++ b/packages/core/database/src/collection.ts
@@ -100,11 +100,6 @@ export type MigrationRule = 'overwrite' | 'skip' | 'upsert' | 'schema-only' | 'i
  */
 export type DataCategory = 'system' | 'business' | 'runtime';
 export type DataCategories = DataCategory | DataCategory[];
-export const TAG = {
-  basic: 'basic',
-  business: 'business',
-  ignoredBackup: 'ignored:backup',
-};
 
 export interface CollectionOptions extends Omit<ModelOptions, 'name' | 'hooks'> {
   name: string;

--- a/packages/plugins/@nocobase/plugin-ai/src/server/collections/lc-checkpoint-blobs.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/collections/lc-checkpoint-blobs.ts
@@ -11,7 +11,7 @@ import { defineCollection } from '@nocobase/database';
 
 export default defineCollection({
   name: 'lcCheckpointBlobs',
-  dataCategory: 'business',
+  dataCategory: 'runtime',
   migrationRules: ['schema-only'],
   autoGenId: false,
   fields: [

--- a/packages/plugins/@nocobase/plugin-ai/src/server/collections/lc-checkpoint-writes.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/collections/lc-checkpoint-writes.ts
@@ -11,7 +11,7 @@ import { defineCollection } from '@nocobase/database';
 
 export default defineCollection({
   name: 'lcCheckpointWrites',
-  dataCategory: 'business',
+  dataCategory: 'runtime',
   migrationRules: ['schema-only'],
   autoGenId: false,
   fields: [

--- a/packages/plugins/@nocobase/plugin-ai/src/server/collections/lc-checkpoints.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/collections/lc-checkpoints.ts
@@ -11,7 +11,7 @@ import { defineCollection } from '@nocobase/database';
 
 export default defineCollection({
   name: 'lcCheckpoints',
-  dataCategory: 'business',
+  dataCategory: 'runtime',
   migrationRules: ['schema-only'],
   autoGenId: false,
   fields: [

--- a/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
@@ -106,6 +106,46 @@ export class PluginAIServer extends Plugin {
       await this.ai.employeeManager.init();
       await this.ai.mcpManager.init();
     });
+    this.app.on('afterUpgrade', async () => {
+      await this.resetConversationThreadsWhenCheckpointsEmpty();
+    });
+  }
+
+  private async resetConversationThreadsWhenCheckpointsEmpty() {
+    const [checkpointCount, checkpointWriteCount, checkpointBlobCount, conversationsWithThreadCount] =
+      await Promise.all([
+        this.db.getRepository('lcCheckpoints').count(),
+        this.db.getRepository('lcCheckpointWrites').count(),
+        this.db.getRepository('lcCheckpointBlobs').count(),
+        this.db.getRepository('aiConversations').count({
+          filter: {
+            thread: {
+              $gt: 0,
+            },
+          },
+        }),
+      ]);
+
+    if (
+      checkpointCount > 0 ||
+      checkpointWriteCount > 0 ||
+      checkpointBlobCount > 0 ||
+      conversationsWithThreadCount <= 1
+    ) {
+      return;
+    }
+
+    await this.db.getRepository('aiConversations').update({
+      filter: {
+        thread: {
+          $gt: 0,
+        },
+      },
+      values: {
+        thread: 0,
+      },
+    });
+    this.app.logger.info(`Reset ${conversationsWithThreadCount} AI conversation threads after empty checkpoints`);
   }
 
   async load() {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
@@ -167,6 +167,63 @@ describe('BackupManager', async () => {
       }
     });
 
+    it('should exclude runtime tables while preserving backup option exclusions', async () => {
+      const spawnMock = vi.mocked(cp.spawn);
+      spawnMock.mockClear();
+      const runtimeCollection = {
+        name: 'runtime_records',
+        dataCategory: 'runtime',
+        getTableNameWithSchemaAsString: () => 'runtime_records',
+      };
+      const businessCollection = {
+        name: 'business_records',
+        dataCategory: 'business',
+        getTableNameWithSchemaAsString: () => 'business_records',
+      };
+      const fakeApp = {
+        name: 'main',
+        db: {
+          options: {
+            dialect: 'mysql',
+            username: 'root',
+            host: 'localhost',
+            database: 'backup_test',
+            password: '',
+          },
+          collections: new Map([
+            [runtimeCollection.name, runtimeCollection],
+            [businessCollection.name, businessCollection],
+          ]),
+          sequelize: {
+            getDialect: () => 'mysql',
+            query: vi.fn().mockResolvedValue([{ version: '8.0.0' }]),
+          },
+        },
+        pm: {
+          has: vi.fn().mockReturnValue(false),
+          getPlugins: vi.fn().mockReturnValue(new Map()),
+        },
+        version: {
+          get: vi.fn().mockResolvedValue('1.0.0'),
+        },
+        logger: {
+          error: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+        },
+      } as unknown as ConstructorParameters<typeof BackupManager>[0];
+      const backupManager = new BackupManager(fakeApp, null, defaultBackupSettings);
+
+      await backupManager.backup(backupFileBaseName, {
+        excludeTables: ['audit_logs'],
+      });
+
+      const mysqldumpArgs = spawnMock.mock.calls[0]?.[1] as string[];
+      expect(mysqldumpArgs).toContain('--ignore-table=backup_test.audit_logs');
+      expect(mysqldumpArgs).toContain('--ignore-table=backup_test.runtime_records');
+      expect(mysqldumpArgs).not.toContain('--ignore-table=backup_test.business_records');
+    });
+
     it('should warn and continue when a file collection query fails', async () => {
       const backupManager = new BackupManager(app, null, {
         ...defaultBackupSettings,

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
@@ -122,7 +122,12 @@ export class BackupManager {
 
   async backup(fileBaseName: string, opts?: Partial<BackupSettings>) {
     const contentPath = path.join(this.#tempDir, fileBaseName);
-    return this.#runBackupTask({ ...this.#settings, ...(opts ?? {}) }, fileBaseName, contentPath);
+    const runtimeTables = [...this.app.db.collections.values()]
+      .filter((collection) => collection.dataCategory === 'runtime')
+      .map((collection) => collection.getTableNameWithSchemaAsString());
+    const backupOptions = { ...this.#settings, ...(opts ?? {}) };
+    backupOptions.excludeTables = [...new Set([...(backupOptions.excludeTables ?? []), ...runtimeTables])];
+    return this.#runBackupTask(backupOptions, fileBaseName, contentPath);
   }
 
   async destroy(fileName: string) {

--- a/packages/plugins/@nocobase/plugin-custom-variables/src/server/collections/customVariables.ts
+++ b/packages/plugins/@nocobase/plugin-custom-variables/src/server/collections/customVariables.ts
@@ -11,6 +11,7 @@ import { defineCollection } from '@nocobase/database';
 
 export default defineCollection({
   name: 'customVariables',
+  dataCategory: 'system',
   dumpRules: 'required',
   migrationRules: ['overwrite', 'schema-only'],
   shared: true,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Runtime-only data should not be included in application backups because it can be regenerated and may cause restore-time state conflicts.

### Description
This PR automatically excludes tables whose collection `dataCategory` is marked as `'runtime'` from backup exports while preserving explicitly configured excluded tables.

It also marks AI checkpoint collections as runtime data and resets AI conversation thread IDs after upgrade when checkpoint tables are empty, preventing stale conversation thread references from pointing at missing runtime checkpoint data.

Testing suggestion:
- `yarn test packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts`

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tables whose collection `dataCategory` is marked as `'runtime'` are now excluded from backups automatically. |
| 🇨🇳 Chinese | `dataCategory` 标记为 `'runtime'` 的数据表现在会自动从备份中排除。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
