### PR TITLE
fix(ai): include shortcut attachments when triggering tasks

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/ProfileCard.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/ProfileCard.tsx
@@ -15,7 +15,8 @@ import { AIEmployeeProfileCard } from '../../client-v2';
 export const ProfileCard: React.FC<{
   aiEmployee: AIEmployee;
   tasks?: Task[];
-}> = ({ aiEmployee, tasks }) => {
+  onTaskTriggered?: () => void;
+}> = ({ aiEmployee, tasks, onTaskTriggered }) => {
   tasks = tasks?.filter((task) => task.title) || [];
 
   const { triggerTask } = useChatBoxActions();
@@ -28,12 +29,13 @@ export const ProfileCard: React.FC<{
     <AIEmployeeProfileCard
       aiEmployee={aiEmployee}
       tasks={tasks}
-      onTaskClick={(task) =>
+      onTaskClick={(task) => {
+        onTaskTriggered?.();
         triggerTask({
           aiEmployee,
           tasks: [task as Task],
-        })
-      }
+        });
+      }}
     />
   );
 };

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatBoxActions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatBoxActions.ts
@@ -8,7 +8,7 @@
  */
 
 import { useCallback } from 'react';
-import { AIEmployee, ClearOptions, Message, SendOptions, TriggerTaskOptions } from '../../types';
+import { AIEmployee, Attachment, ClearOptions, Message, SendOptions, TriggerTaskOptions } from '../../types';
 import { useChatBoxStore } from '../stores/chat-box';
 import { useChatConversationsStore } from '../stores/chat-conversations';
 import { useChat } from '../hooks/useChat';
@@ -256,12 +256,14 @@ export const useChatBoxActions = () => {
         } else {
           setSenderValue('');
         }
-        if (attachments) {
-          draftChat.setAttachments(attachments);
-        }
+        let contextAttachments: Attachment[] = [];
         if (workContext) {
           draftChat.setContextItems(workContext);
-          syncContextAttachments(workContext);
+          contextAttachments = syncContextAttachments(workContext);
+        }
+        const resolvedAttachments = [...(attachments ?? []), ...contextAttachments];
+        if (resolvedAttachments.length) {
+          draftChat.setAttachments(resolvedAttachments);
         }
         if (systemMessage) {
           draftChat.setSystemMessage(systemMessage);
@@ -274,7 +276,7 @@ export const useChatBoxActions = () => {
             aiEmployee,
             systemMessage,
             messages: [userMessage ?? { type: 'text', content: '' }],
-            attachments,
+            attachments: resolvedAttachments.length ? resolvedAttachments : undefined,
             workContext,
             skillSettings,
             webSearch: resolvedWebSearch,

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatMessageActions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useChatMessageActions.ts
@@ -10,7 +10,7 @@
 import { useChat } from '../hooks/useChat';
 import { useCallback } from 'react';
 import { useAPIClient, useApp } from '@nocobase/client';
-import { AIEmployee, Message, ResendOptions, SendOptions } from '../../types';
+import { AIEmployee, Attachment, ContextItem, Message, ResendOptions, SendOptions } from '../../types';
 import { uid } from '@formily/shared';
 import { useLoadMoreObserver } from './useLoadMoreObserver';
 import { useT } from '../../../locale';
@@ -21,7 +21,6 @@ import { aiDebugLogger } from '../../../debug-logger'; // [AI_DEBUG]
 import { useChatToolCallStore } from '../stores/chat-tool-call';
 import { useAIConfigRepository } from '../../../repositories/hooks/useAIConfigRepository';
 import { ensureModel, getAllModels, isSameModel, isValidModel } from '../model';
-import { ContextItem } from '../../types';
 import { FlowUtils } from '../../flow';
 import { UploadFieldModel } from '@nocobase/plugin-file-manager/client';
 
@@ -105,9 +104,9 @@ export const useChatMessageActions = () => {
     [api, aiConfigRepository, setModel],
   );
 
-  const syncContextAttachments = useCallback(
-    (items: ContextItem | ContextItem[]) => {
-      const sessionChat = getSessionChat(useChatConversationsStore.getState().currentConversation);
+  const extractContextAttachments = useCallback(
+    (items: ContextItem | ContextItem[]): Attachment[] => {
+      const attachments: Attachment[] = [];
       const contextItems = Array.isArray(items) ? items : [items];
       for (const item of contextItems.filter((it) => it.type?.startsWith('flow-model'))) {
         const model = app.flowEngine.getModel(item.uid, true);
@@ -120,12 +119,25 @@ export const useChatMessageActions = () => {
             subModel.props?.value?.length &&
             typeof subModel.props.value !== 'string'
           ) {
-            sessionChat.addAttachments(subModel.props.value.map((it) => ({ ...it, status: 'done' })));
+            attachments.push(...subModel.props.value.map((it) => ({ ...it, status: 'done' })));
           }
         });
       }
+      return attachments;
     },
-    [app, getSessionChat],
+    [app],
+  );
+
+  const syncContextAttachments = useCallback(
+    (items: ContextItem | ContextItem[]) => {
+      const attachments = extractContextAttachments(items);
+      if (attachments.length) {
+        const sessionChat = getSessionChat(useChatConversationsStore.getState().currentConversation);
+        sessionChat.addAttachments(attachments);
+      }
+      return attachments;
+    },
+    [extractContextAttachments, getSessionChat],
   );
 
   const loadMessages = useCallback(

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx
@@ -115,13 +115,22 @@ const Shortcut: React.FC<ShortcutProps> = ({
     return nextWorkContext;
   }, [ctx, context.workContext]);
 
+  const syncShortcutContext = useCallback(() => {
+    const shortcutContext = getShortcutContext();
+    if (!shortcutContext.length) {
+      return;
+    }
+    addContextItems(shortcutContext);
+    syncContextAttachments(shortcutContext);
+  }, [addContextItems, getShortcutContext, syncContextAttachments]);
+
   if (!aiEmployee) {
     return null;
   }
 
   return (
     <Spin spinning={loading}>
-      <Popover content={<ProfileCard aiEmployee={aiEmployee} tasks={tasks} />}>
+      <Popover content={<ProfileCard aiEmployee={aiEmployee} tasks={tasks} onTaskTriggered={syncShortcutContext} />}>
         <Avatar
           src={currentAvatar}
           size={size || 52}
@@ -136,11 +145,7 @@ const Shortcut: React.FC<ShortcutProps> = ({
           onMouseLeave={() => setFocus(false)}
           onClick={() => {
             triggerTask({ aiEmployee, tasks, auto });
-            if (context?.workContext?.length) {
-              const shortcutContext = getShortcutContext();
-              addContextItems(shortcutContext);
-              syncContextAttachments(shortcutContext);
-            }
+            syncShortcutContext();
           }}
         />
       </Popover>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When an AI employee task is triggered from the shortcut popover, the shortcut work context and attachments should be synchronized before the task runs. Previously, this path could miss attachment extraction.

### Description
This PR updates the AI employee shortcut task trigger so both avatar clicks and task clicks in the profile popover synchronize shortcut context items and attachments before triggering the task.

Potential risk is limited to the AI employee shortcut trigger behavior.

Testing suggestion: open an AI employee shortcut with work context attachments, trigger a task from the avatar and from the profile popover task list, and verify the task receives the expected attachments.

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI employee shortcut task triggers so attachments from the current work context are included when running a task from the shortcut profile. |
| 🇨🇳 Chinese | 修复 AI 员工快捷入口触发任务时未携带当前工作上下文附件的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
