### PR TITLE
fix(file-manager): pass upload data source as params

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/models/UploadActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/models/UploadActionModel.tsx
@@ -20,12 +20,17 @@ import { useTranslation } from 'react-i18next';
 
 const FILE_SIZE_LIMIT_DEFAULT = 1024 * 1024 * 20;
 
-function getDataSourceHeaders(dataSourceKey?: string) {
-  return dataSourceKey && dataSourceKey !== 'main' ? { 'x-data-source': dataSourceKey } : {};
-}
-
 function getModelDataSourceKey(model) {
   return model.context.collection?.dataSourceKey || model.context.blockModel.collection?.dataSourceKey;
+}
+
+function appendUploadDataSourceKey(url: string, dataSourceKey?: string) {
+  if (!dataSourceKey || dataSourceKey === 'main') {
+    return url;
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}uploadDataSourceKey=${encodeURIComponent(dataSourceKey)}`;
 }
 
 function useSizeHint(size: number) {
@@ -130,13 +135,12 @@ const useUploadFiles = (model) => {
 
 export function useStorage(storage, dataSourceKey?: string) {
   const name = storage ?? '';
-  const url = `storages:getBasicInfo/${name}`;
+  const url = appendUploadDataSourceKey(`storages:getBasicInfo/${name}`, dataSourceKey);
   const ctx = useFlowContext();
   const { loading, data, run } = useRequest(
     async () => {
       const response = await ctx.api.request({
         url,
-        headers: getDataSourceHeaders(dataSourceKey),
         skipNotify: true,
       });
       return response?.data;
@@ -174,11 +178,11 @@ export function useStorageUploadProps(props, model) {
   const useStorageTypeUploadProps = storageType?.useUploadProps;
   const storageTypeUploadProps = useStorageTypeUploadProps?.({ storage, rules: storage.rules, ...props }) || {};
   const headers = {
-    ...getDataSourceHeaders(dataSourceKey),
     ...storageTypeUploadProps.headers,
   };
 
   return {
+    action: appendUploadDataSourceKey(props.action, dataSourceKey),
     rules: storage?.rules,
     ...storageTypeUploadProps,
     headers,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/models/UploadFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/models/UploadFieldModel.tsx
@@ -23,8 +23,13 @@ import {
   shouldShowUploadActionSlot,
 } from './uploadFieldUtils';
 
-function getDataSourceHeaders(dataSourceKey?: string) {
-  return dataSourceKey && dataSourceKey !== 'main' ? { 'x-data-source': dataSourceKey } : {};
+function appendUploadDataSourceKey(url: string, dataSourceKey?: string) {
+  if (!dataSourceKey || dataSourceKey === 'main') {
+    return url;
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}uploadDataSourceKey=${encodeURIComponent(dataSourceKey)}`;
 }
 
 export const CardUpload = (props) => {
@@ -358,12 +363,11 @@ UploadFieldModel.registerFlow({
         }
         try {
           // 上传前检查存储策略
-          const { data: checkData } = await ctx.api
-            .resource('storages', null, getDataSourceHeaders(dataSourceKey))
-            .check({
-              fileCollectionName: fileCollection,
-              storageName: collectionField.options.storage,
-            });
+          const { data: checkData } = await ctx.api.resource('storages').check({
+            fileCollectionName: fileCollection,
+            uploadDataSourceKey: dataSourceKey,
+            storageName: collectionField.options.storage,
+          });
 
           if (!checkData?.data?.isSupportToUploadFiles) {
             const messageValue = ctx
@@ -382,7 +386,10 @@ UploadFieldModel.registerFlow({
             const customRequest = storageType.createUploadCustomRequest({
               ...ctx.model.props,
               api: ctx.api,
-              action: `${fileCollection}:create?attachmentField=${collectionField.collectionName}.${collectionField.name}`,
+              action: appendUploadDataSourceKey(
+                `${fileCollection}:create?attachmentField=${collectionField.collectionName}.${collectionField.name}`,
+                dataSourceKey,
+              ),
               storage,
             });
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/models/UploadFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/models/UploadFieldModel.tsx
@@ -365,7 +365,7 @@ UploadFieldModel.registerFlow({
           // 上传前检查存储策略
           const { data: checkData } = await ctx.api.resource('storages').check({
             fileCollectionName: fileCollection,
-            uploadDataSourceKey: dataSourceKey,
+            ...(dataSourceKey && dataSourceKey !== 'main' ? { uploadDataSourceKey: dataSourceKey } : {}),
             storageName: collectionField.options.storage,
           });
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
@@ -312,6 +312,10 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
     const { file, storageType, storageId, storageRules, dataSourceKey, query = {} } = options;
     const fileCollectionName = options.fileCollectionName || 'attachments';
     const storageTypeObject = this.getStorageType(storageType);
+    const uploadQuery = {
+      ...query,
+      ...(dataSourceKey && dataSourceKey !== 'main' ? { uploadDataSourceKey: dataSourceKey } : {}),
+    };
 
     if (storageTypeObject?.upload) {
       return await storageTypeObject.upload({
@@ -322,7 +326,7 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
         storageRules,
         dataSourceKey,
         fileCollectionName,
-        query,
+        query: uploadQuery,
       });
     }
 
@@ -331,7 +335,7 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
       formData.append('file', file);
 
       const queryString = new URLSearchParams(
-        Object.entries(query).map(([key, value]) => [key, String(value)]),
+        Object.entries(uploadQuery).map(([key, value]) => [key, String(value)]),
       ).toString();
       const url = queryString ? `${fileCollectionName}:create?${queryString}` : `${fileCollectionName}:create`;
 
@@ -339,7 +343,6 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
         url,
         method: 'post',
         data: formData,
-        headers: dataSourceKey && dataSourceKey !== 'main' ? { 'x-data-source': dataSourceKey } : {},
       });
 
       return { data: response.data?.data };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageRules.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageRules.ts
@@ -9,14 +9,17 @@
 
 import { useEffect } from 'react';
 import { useField } from '@formily/react';
-import {
-  getDataSourceHeaders,
-  useCollectionField,
-  useCollectionManager,
-  useDataSourceKey,
-  useRequest,
-} from '@nocobase/client';
+import { useCollectionField, useCollectionManager, useDataSourceKey, useRequest } from '@nocobase/client';
 import { useStorageUploadProps } from './useStorageUploadProps';
+
+function appendUploadDataSourceKey(url: string, dataSourceKey?: string) {
+  if (!dataSourceKey || dataSourceKey === 'main') {
+    return url;
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}uploadDataSourceKey=${encodeURIComponent(dataSourceKey)}`;
+}
 
 export function useStorageRules(storage) {
   const name = storage ?? '';
@@ -24,8 +27,7 @@ export function useStorageRules(storage) {
   const field = useField<any>();
   const { loading, data, run } = useRequest<any>(
     {
-      url: `storages:getBasicInfo/${name}`,
-      headers: getDataSourceHeaders(dataSourceKey),
+      url: appendUploadDataSourceKey(`storages:getBasicInfo/${name}`, dataSourceKey),
     },
     {
       manual: true,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageUploadProps.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/hooks/useStorageUploadProps.ts
@@ -8,7 +8,6 @@
  */
 
 import {
-  getDataSourceHeaders,
   useCollection,
   useCollectionField,
   useCollectionManager,
@@ -19,15 +18,22 @@ import {
 import { useEffect } from 'react';
 import FileManagerPlugin from '../';
 
+function appendUploadDataSourceKey(url: string, dataSourceKey?: string) {
+  if (!dataSourceKey || dataSourceKey === 'main') {
+    return url;
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}uploadDataSourceKey=${encodeURIComponent(dataSourceKey)}`;
+}
+
 export function useStorage(storage) {
   const name = storage ?? '';
-  const url = `storages:getBasicInfo/${name}`;
   const dataSourceKey = useDataSourceKey();
-  const headers = getDataSourceHeaders(dataSourceKey);
+  const url = appendUploadDataSourceKey(`storages:getBasicInfo/${name}`, dataSourceKey);
   const { loading, data, run } = useRequest<any>(
     {
       url,
-      headers,
     },
     {
       manual: true,
@@ -62,11 +68,11 @@ export function useStorageUploadProps(props) {
   const useStorageTypeUploadProps = storageType?.useUploadProps;
   const storageTypeUploadProps = useStorageTypeUploadProps?.({ storage, rules: storage.rules, ...props }) || {};
   const headers = {
-    ...getDataSourceHeaders(dataSourceKey),
     ...storageTypeUploadProps.headers,
   };
 
   return {
+    action: appendUploadDataSourceKey(props.action, dataSourceKey),
     rules: storage?.rules,
     ...storageTypeUploadProps,
     headers,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/index.tsx
@@ -148,6 +148,10 @@ export class PluginFileManagerClient extends Plugin {
     const fileCollectionName = options?.fileCollectionName || 'attachments';
 
     const storageTypeObj = this.getStorageType(storageType);
+    const uploadQuery = {
+      ...query,
+      ...(dataSourceKey && dataSourceKey !== 'main' ? { uploadDataSourceKey: dataSourceKey } : {}),
+    };
 
     // 1. storageType 自定义上传
     if (storageTypeObj?.upload) {
@@ -159,7 +163,7 @@ export class PluginFileManagerClient extends Plugin {
         storageRules,
         dataSourceKey,
         fileCollectionName,
-        query,
+        query: uploadQuery,
       });
     }
 
@@ -169,14 +173,13 @@ export class PluginFileManagerClient extends Plugin {
       formData.append('file', file);
 
       /** ⭐️ 拼接 URL 查询参数 */
-      const queryString = new URLSearchParams(query).toString();
+      const queryString = new URLSearchParams(uploadQuery).toString();
       const url = queryString ? `${fileCollectionName}:create?${queryString}` : `${fileCollectionName}:create`;
 
       const res = await this.app.apiClient.request({
         url,
         method: 'post',
         data: formData,
-        headers: dataSourceKey && dataSourceKey !== 'main' ? { 'x-data-source': dataSourceKey } : {},
       });
 
       return { data: res.data?.data };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
File uploads from external data sources could use the wrong upload routing when file-manager upload APIs received the data source through request headers.

### Description 
This change passes the upload data source as request params for v1 and v2 file-manager upload flows, including storage info, storage check, attachment creation, and storage-type custom upload queries.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed 404 errors when uploading files to attachment URL fields in external data sources |
| 🇨🇳 Chinese | 修复外部数据源附件 URL 字段上传文件时接口 404 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
