### PR TITLE
fix(users-permissions): align v2 settings layouts with v1 behavior

### DIFF
--- a/packages/plugins/@nocobase/plugin-acl/src/client-v2/pages/RolesManagementPage.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client-v2/pages/RolesManagementPage.tsx
@@ -7,7 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { css } from '@emotion/css';
 import { MoreOutlined, PlusOutlined, TagOutlined } from '@ant-design/icons';
 import { useACLRoleContext } from '@nocobase/client-v2';
 import { randomId, useFlowContext } from '@nocobase/flow-engine';
@@ -234,93 +233,6 @@ export default function RolesManagementPage() {
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
   const [activeTabKey, setActiveTabKey] = useState('permissions');
   const [activePermissionTabKey, setActivePermissionTabKey] = useState('general');
-  const cardClassName = css`
-    height: 100%;
-    min-height: 0;
-
-    > .ant-card-body {
-      height: 100%;
-      min-height: 0;
-      overflow: hidden;
-    }
-  `;
-  const layoutClassName = css`
-    &.acl-role-tabs > .ant-tabs-nav {
-      margin-bottom: ${token.marginLG}px;
-    }
-
-    &.acl-role-tabs,
-    &.acl-role-tabs > .ant-tabs-content-holder,
-    &.acl-role-tabs > .ant-tabs-content-holder > .ant-tabs-content,
-    &.acl-role-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
-      min-height: 0;
-    }
-
-    &.acl-role-tabs {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    &.acl-role-tabs > .ant-tabs-nav {
-      flex: none;
-    }
-
-    &.acl-role-tabs > .ant-tabs-content-holder {
-      flex: 1;
-      min-height: 0;
-      overflow: hidden;
-    }
-
-    &.acl-role-tabs > .ant-tabs-content-holder > .ant-tabs-content,
-    &.acl-role-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
-      height: 100%;
-      min-height: 0;
-    }
-
-    &.acl-role-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
-      overflow: hidden;
-      padding: 0;
-    }
-  `;
-  const scrollPaneStyle: React.CSSProperties = {
-    height: '100%',
-    minHeight: 0,
-    overflow: 'hidden',
-  };
-  const permissionPaneStyle: React.CSSProperties = {
-    height: '100%',
-    minHeight: 0,
-    overflow: 'auto',
-    paddingRight: token.paddingXS,
-  };
-  const nestedTabsClassName = css`
-    height: 100%;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-
-    > .ant-tabs-nav {
-      flex: none;
-    }
-
-    > .ant-tabs-content-holder {
-      flex: 1;
-      min-height: 0;
-      overflow: hidden;
-    }
-
-    > .ant-tabs-content-holder > .ant-tabs-content,
-    > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
-      height: 100%;
-      min-height: 0;
-    }
-
-    > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
-      overflow: hidden;
-      padding: 0;
-    }
-  `;
 
   const service = useRequest(async () => {
     const response = await ctx.api.resource('roles').list({
@@ -490,11 +402,9 @@ export default function RolesManagementPage() {
       key,
       label,
       children: (
-        <div style={scrollPaneStyle}>
-          <Suspense fallback={null}>
-            <Component active={activeTabKey === key} role={selectedRole} onRoleChange={handleRoleChange} />
-          </Suspense>
-        </div>
+        <Suspense fallback={null}>
+          <Component active={activeTabKey === key} role={selectedRole} onRoleChange={handleRoleChange} />
+        </Suspense>
       ),
     };
   });
@@ -510,7 +420,7 @@ export default function RolesManagementPage() {
       key,
       label,
       children: (
-        <div style={permissionPaneStyle}>
+        <div style={{ maxHeight: '60vh', overflowY: 'auto', paddingRight: token.paddingXS }}>
           <Suspense fallback={null}>
             <Component {...props} />
           </Suspense>
@@ -526,8 +436,6 @@ export default function RolesManagementPage() {
       children: permissionTabs.length ? (
         <Tabs
           type="card"
-          className={nestedTabsClassName}
-          style={{ height: '100%', minHeight: 0 }}
           activeKey={activePermissionTabKey}
           onChange={setActivePermissionTabKey}
           items={permissionTabs}
@@ -540,11 +448,9 @@ export default function RolesManagementPage() {
   ];
 
   return (
-    <Card className={cardClassName}>
+    <Card>
       <div
         style={{
-          height: '100%',
-          minHeight: 0,
           display: 'flex',
           gap: token.marginLG,
           alignItems: 'stretch',
@@ -560,7 +466,6 @@ export default function RolesManagementPage() {
             borderRight: `1px solid ${token.colorBorderSecondary}`,
             display: 'flex',
             flexDirection: 'column',
-            overflow: 'hidden',
           }}
         >
           <div
@@ -578,7 +483,7 @@ export default function RolesManagementPage() {
             <RoleModeSelect />
           </div>
           <Divider style={{ flex: '0 0 auto', marginBlock: token.marginSM }} />
-          <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+          <div style={{ maxHeight: '65vh', overflowY: 'auto' }}>
             {roles.length ? (
               <List<Role>
                 loading={service.loading}
@@ -663,32 +568,21 @@ export default function RolesManagementPage() {
           style={{
             flex: '1 1 auto',
             minWidth: 0,
-            height: '100%',
-            minHeight: 320,
-            overflow: 'hidden',
-            display: 'flex',
-            flexDirection: 'column',
           }}
         >
           {selectedRoleName && selectedRoleService.loading && selectedRole?.name !== selectedRoleName ? (
             <div
               style={{
-                height: '100%',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
+                minHeight: 160,
               }}
             >
               <Spin />
             </div>
           ) : selectedRole ? (
-            <Tabs
-              className={`acl-role-tabs ${layoutClassName}`}
-              style={{ flex: 1, minHeight: 0 }}
-              activeKey={activeTabKey}
-              onChange={setActiveTabKey}
-              items={tabs}
-            />
+            <Tabs activeKey={activeTabKey} onChange={setActiveTabKey} items={tabs} />
           ) : (
             <Typography.Text type="secondary">{t('Select a role to configure permissions')}</Typography.Text>
           )}

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowAction.tsx
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/client-v2/customRequestFlowAction.tsx
@@ -36,7 +36,7 @@ const isCustomRequestConfigured = (params: CustomRequestStepParams) => {
 
 export const customRequestFlowAction = defineAction({
   name: CUSTOM_REQUEST_ACTION_NAME,
-  title: tExpr('Custom request', { ns: NAMESPACE }),
+  title: tExpr('Request settings', { ns: NAMESPACE }),
   scene: [ActionScene.DYNAMIC_EVENT_FLOW],
   sort: 1000,
   paramsRequired: true,

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/__tests__/departmentRequests.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/__tests__/departmentRequests.test.ts
@@ -32,7 +32,7 @@ describe('department request helpers', () => {
     expect(resource.create).toHaveBeenCalledWith({
       values: {
         title: 'Engineering',
-        parentId: null,
+        parent: null,
         roles: [{ name: 'admin' }],
       },
     });
@@ -56,9 +56,26 @@ describe('department request helpers', () => {
       filterByTk: 987654321,
       values: {
         title: 'Product',
-        parentId: 123,
+        parent: { id: 123 },
         roles: [{ name: 'member' }],
         owners: [{ id: 1 }, { id: 2 }],
+      },
+    });
+  });
+
+  it('maps parentId to parent relation on create submit', async () => {
+    const resource = makeResource();
+
+    await createDepartment(resource, {
+      title: 'Frontend',
+      parentId: 456,
+    });
+
+    expect(resource.create).toHaveBeenCalledWith({
+      values: {
+        title: 'Frontend',
+        parent: { id: 456 },
+        roles: [],
       },
     });
   });

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/api.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/api.ts
@@ -16,9 +16,13 @@ export interface DepartmentFormValues {
   ownerIds?: DepartmentPrimaryKey[];
 }
 
+interface DepartmentParentValue {
+  id: DepartmentPrimaryKey;
+}
+
 export interface DepartmentPayload {
   title: string;
-  parentId: DepartmentPrimaryKey | null;
+  parent: DepartmentParentValue | null;
   roles?: Array<{ name: string }>;
   owners?: Array<{ id: DepartmentPrimaryKey }>;
 }
@@ -30,9 +34,11 @@ export interface DepartmentResource {
 }
 
 export function buildDepartmentPayload(values: DepartmentFormValues, includeOwners = false): DepartmentPayload {
+  const parentId = values.parentId ?? null;
+
   return {
     title: values.title,
-    parentId: values.parentId ?? null,
+    parent: parentId != null ? { id: parentId } : null,
     roles: (values.roleNames || []).map((name) => ({ name })),
     ...(includeOwners ? { owners: (values.ownerIds || []).map((id) => ({ id })) } : {}),
   };

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/pages/DepartmentsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/pages/DepartmentsPage.tsx
@@ -64,7 +64,6 @@ const DEPARTMENT_TREE_PANEL_WIDTH = 280;
 const MEMBER_TABLE_PAGE_SIZE = 20;
 const ADD_MEMBERS_TABLE_PAGE_SIZE = 20;
 const SEARCH_RESULT_LIMIT = 10;
-const DEPARTMENTS_PAGE_HEIGHT = '100%';
 const TABLE_ACTION_BUTTON_STYLE: React.CSSProperties = { paddingInline: 0, height: 'auto' };
 
 type MembersFilter = CompiledFilter;
@@ -291,7 +290,7 @@ function DepartmentForm(props: {
   mode: 'create' | 'edit';
   record?: DepartmentRecord;
   departments: DepartmentRecord[];
-  onSubmitted: () => void;
+  onSubmitted: (values: DepartmentFormValues) => void;
 }) {
   const t = useT();
   const ctx = useFlowContext();
@@ -311,13 +310,13 @@ function DepartmentForm(props: {
     try {
       if (props.mode === 'create') {
         await createDepartment(resource, values);
-        props.onSubmitted();
+        props.onSubmitted(values);
         return;
       }
 
       if (props.record) {
         await updateDepartment(resource, props.record, values);
-        props.onSubmitted();
+        props.onSubmitted(values);
         return;
       }
 
@@ -869,7 +868,17 @@ const DepartmentsPage: React.FC = () => {
         closable: true,
         width: FORM_DRAWER_WIDTH,
         content: () => (
-          <DepartmentForm mode={mode} record={record} departments={departments} onSubmitted={() => refreshAll()} />
+          <DepartmentForm
+            mode={mode}
+            record={record}
+            departments={departments}
+            onSubmitted={(values) => {
+              if (values.parentId != null) {
+                setExpandedKeys((keys) => Array.from(new Set([...keys, values.parentId as React.Key])));
+              }
+              refreshAll();
+            }}
+          />
         ),
       });
     },
@@ -1192,54 +1201,15 @@ const DepartmentsPage: React.FC = () => {
   );
   const departmentsPageClassName = useMemo(
     () => css`
-      height: ${DEPARTMENTS_PAGE_HEIGHT};
-      min-height: 0;
-      overflow: hidden;
       > .ant-card-body {
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-      }
-    `,
-    [],
-  );
-  const membersTableClassName = useMemo(
-    () => css`
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      flex-direction: column;
-      .ant-spin-nested-loading,
-      .ant-spin-container,
-      .ant-table,
-      .ant-table-container {
-        min-height: 0;
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-      }
-      .ant-table-content {
-        flex: 1;
-        min-height: 0;
-      }
-      .ant-table-body {
-        flex: 1;
-        min-height: 0;
-      }
-      .ant-table-thead > tr > th {
-        white-space: nowrap;
-      }
-      .ant-pagination {
-        flex: 0 0 auto;
+        overflow-x: auto;
       }
     `,
     [],
   );
   const departmentTreeClassName = useMemo(
     () => css`
-      flex: 1;
-      min-height: 0;
+      max-height: 65vh;
       overflow-y: auto;
       overflow-x: hidden;
       .ant-tree-treenode {
@@ -1259,15 +1229,27 @@ const DepartmentsPage: React.FC = () => {
         line-height: 32px;
         overflow: hidden;
         padding-inline: 8px;
+        border-radius: ${token.borderRadiusLG}px;
       }
       .ant-tree-title {
         display: block;
       }
-      .ant-tree-node-selected {
-        background-color: ${token.colorPrimaryBg};
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-switcher,
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper,
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper .anticon,
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper .ant-btn {
+        color: ${token.colorText};
+      }
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper,
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper:hover {
+        background: ${token.controlItemBgActive};
+      }
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper::before,
+      .ant-tree.ant-tree-directory .ant-tree-treenode-selected .ant-tree-node-content-wrapper:hover::before {
+        background: ${token.controlItemBgActive};
       }
     `,
-    [token.colorPrimaryBg],
+    [token.borderRadiusLG, token.colorText, token.controlItemBgActive],
   );
   const memberResponse = membersRequest.data;
   const members = memberResponse?.data || [];
@@ -1275,15 +1257,13 @@ const DepartmentsPage: React.FC = () => {
 
   return (
     <Card className={departmentsPageClassName}>
-      <Flex gap={token.marginLG} align="stretch" style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+      <Flex gap={token.marginLG} align="stretch" wrap={false}>
         <Flex
           vertical
           gap={token.marginSM}
           style={{
             width: DEPARTMENT_TREE_PANEL_WIDTH,
             flex: `0 0 ${DEPARTMENT_TREE_PANEL_WIDTH}px`,
-            minHeight: 0,
-            overflow: 'hidden',
           }}
         >
           <Dropdown trigger={['click']} open={searchOpen} onOpenChange={setSearchOpen} menu={{ items: searchItems }}>
@@ -1316,7 +1296,7 @@ const DepartmentsPage: React.FC = () => {
             style={{
               textAlign: 'center',
               justifyContent: 'center',
-              background: !selectedDepartment && !selectedUser ? token.colorPrimaryBg : undefined,
+              background: !selectedDepartment && !selectedUser ? token.controlItemBgActive : undefined,
             }}
             onClick={() => {
               setSelectedDepartment(null);
@@ -1357,8 +1337,6 @@ const DepartmentsPage: React.FC = () => {
             borderInlineStart: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
             paddingInlineStart: token.paddingLG,
             minWidth: 0,
-            minHeight: 0,
-            overflow: 'hidden',
           }}
         >
           <Flex vertical gap={token.marginSM} style={{ flex: '0 0 auto' }}>
@@ -1400,11 +1378,10 @@ const DepartmentsPage: React.FC = () => {
           <Table<UserRecord>
             rowKey="id"
             showIndex={false}
-            className={membersTableClassName}
             loading={membersRequest.loading}
             dataSource={members}
             columns={memberColumns}
-            scroll={{ x: 'max-content', y: '100%' }}
+            scroll={{ x: 'max-content' }}
             rowSelection={
               selectedDepartment
                 ? {

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/pages/RoleDepartmentsManager.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/pages/RoleDepartmentsManager.tsx
@@ -352,43 +352,6 @@ export default function RoleDepartmentsManager(props: RoleTabProps) {
   const [filter, setFilter] = useState<CompiledFilter>();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(ROLE_DEPARTMENTS_PAGE_SIZE);
-  const tableClassName = useMemo(
-    () => css`
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      flex-direction: column;
-
-      .ant-spin-nested-loading,
-      .ant-spin-container,
-      .ant-table,
-      .ant-table-container {
-        min-height: 0;
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .ant-table-content {
-        flex: 1;
-        min-height: 0;
-      }
-
-      .ant-table-body {
-        flex: 1;
-        min-height: 0;
-      }
-
-      .ant-table-thead > tr > th {
-        white-space: nowrap;
-      }
-
-      .ant-pagination {
-        flex: 0 0 auto;
-      }
-    `,
-    [],
-  );
 
   const departmentsRequest = useRequest(
     async () => {
@@ -477,7 +440,7 @@ export default function RoleDepartmentsManager(props: RoleTabProps) {
   }
 
   return (
-    <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <div>
       <div
         style={{
           flex: '0 0 auto',
@@ -523,8 +486,7 @@ export default function RoleDepartmentsManager(props: RoleTabProps) {
         loading={departmentsRequest.loading}
         dataSource={departmentsRequest.data?.data || []}
         columns={columns}
-        scroll={{ x: 'max-content', y: '100%' }}
-        className={tableClassName}
+        scroll={{ x: 'max-content' }}
         pagination={{
           current: departmentsRequest.data?.page ?? page,
           pageSize: departmentsRequest.data?.pageSize ?? pageSize,

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/models.utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/models.utils.test.ts
@@ -44,9 +44,18 @@ describe('kanban model utils', () => {
     );
 
     expect(options).toEqual([
-      { value: 'todo', label: 'Backlog', color: 'blue', isUnknown: undefined },
+      { value: 'todo', label: 'Todo', color: 'blue', isUnknown: undefined },
       { value: 'done', label: 'Done', color: 'green', isUnknown: undefined },
     ]);
+  });
+
+  test('normalizeKanbanGroupOptions prefers the latest source label over saved relation labels', () => {
+    const options = normalizeKanbanGroupOptions(
+      [{ value: 'u1', label: 'User 1 renamed' }],
+      [{ value: 'u1', label: 'User 1 old', color: 'blue' }],
+    );
+
+    expect(options).toEqual([{ value: 'u1', label: 'User 1 renamed', color: 'blue', isUnknown: undefined }]);
   });
 
   test('normalizeKanbanGroupOptions preserves saved order and appends new source options', () => {

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/components/KanbanGroupingSelector.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/components/KanbanGroupingSelector.tsx
@@ -8,6 +8,7 @@
  */
 
 import { observer, useFlowSettingsContext, useFlowStep } from '@nocobase/flow-engine';
+import { css } from '@emotion/css';
 import { Alert, Select, Space, Spin } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { KanbanBlockModel } from '../KanbanBlockModel';
@@ -36,6 +37,28 @@ const buildSelectedGroupOptions = (availableOptions: KanbanGroupOption[], nextVa
   return nextValues
     .map((value) => optionMap.get(getGroupingOptionKey(value)))
     .filter((option): option is KanbanGroupOption => Boolean(option));
+};
+
+const groupingSelectorPopupClassName = css`
+  .ant-select-item,
+  .ant-select-item-option,
+  .ant-select-item-option-content {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .ant-select-item-option-content {
+    overflow: hidden;
+  }
+`;
+
+const groupingSelectorOptionStyle: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 };
 
 export const KanbanGroupingSelector = observer(
@@ -193,11 +216,21 @@ export const KanbanGroupingSelector = observer(
             mode="multiple"
             disabled={disabled || !currentField}
             style={{ width: '100%' }}
+            popupMatchSelectWidth
+            popupClassName={groupingSelectorPopupClassName}
             value={selectedValues}
             options={availableOptions.map((option) => ({
               label: option.label,
               value: option.value,
             }))}
+            optionRender={({ label }) => {
+              const optionTitle = typeof label === 'string' || typeof label === 'number' ? String(label) : undefined;
+              return (
+                <span title={optionTitle} style={groupingSelectorOptionStyle}>
+                  {label}
+                </span>
+              );
+            }}
             placeholder={translate(currentField ? 'Select group values' : 'Select a grouping field first')}
             onChange={(nextValues) => {
               emitChange(buildSelectedGroupOptions(availableOptions, nextValues));

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/utils.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/utils.ts
@@ -504,10 +504,11 @@ export const normalizeKanbanGroupOptions = (
     const savedColor =
       preserveSavedColors && typeof saved?.color === 'string' && saved.color !== 'default' ? saved.color : undefined;
     const resolvedColor = sourceColor || savedColor || (useDefaultColors ? getDefaultKanbanColor(0) : undefined);
+    const resolvedLabel = getKanbanGroupOptionLabel(item) || (saved?.label ? String(saved.label) : value);
 
     return {
       value,
-      label: saved?.label ? String(saved.label) : getKanbanGroupOptionLabel(item),
+      label: resolvedLabel,
       color: resolvedColor,
       isUnknown: item.isUnknown ?? saved?.isUnknown,
     } satisfies KanbanGroupOption;

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/components/resource/ResourceTablePage.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/components/resource/ResourceTablePage.tsx
@@ -120,12 +120,18 @@ export function ResourceTablePage<RecordType extends object = Record<string, unk
       current: data?.page ?? page,
       pageSize: data?.pageSize ?? pageSize,
       total: data?.total,
+      showTotal:
+        typeof data?.total === 'number'
+          ? (count) => {
+              return t('Total {{count}} items', { count });
+            }
+          : false,
       onChange: (nextPage, nextPageSize) => {
         setPage(nextPage);
         setPageSize(nextPageSize);
       },
     }),
-    [data?.page, data?.pageSize, data?.total, page, pageSize],
+    [data?.page, data?.pageSize, data?.total, page, pageSize, t],
   );
 
   const handleFilterChange = useMemoizedFn((nextFilter: CompiledFilter) => {

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/components/resource/ResourceTablePage.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/components/resource/ResourceTablePage.tsx
@@ -125,7 +125,7 @@ export function ResourceTablePage<RecordType extends object = Record<string, unk
           ? (count) => {
               return t('Total {{count}} items', { count });
             }
-          : false,
+          : undefined,
       onChange: (nextPage, nextPageSize) => {
         setPage(nextPage);
         setPageSize(nextPageSize);

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/RoleUsersManager.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/RoleUsersManager.tsx
@@ -163,7 +163,6 @@ export default function RoleUsersManager(props: RoleTabProps) {
 
   return (
     <ResourceTablePage<User>
-      fillHeight
       padding={false}
       collection={collection}
       rowKey="id"

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UsersManagementPage.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UsersManagementPage.tsx
@@ -169,7 +169,6 @@ function UsersTable() {
 
   return (
     <ResourceTablePage<User>
-      fillHeight
       collection={collection}
       rowKey="id"
       columns={columns}
@@ -216,35 +215,18 @@ export default function UsersManagementPage() {
   const t = useT();
   const { token } = theme.useToken();
   const tabsClassName = css`
-    height: 100%;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-
     .ant-tabs-nav {
       flex: 0 0 auto;
       margin-bottom: 0;
     }
 
-    .ant-tabs-content {
-      height: 100%;
-      min-height: 0;
-    }
-
     .ant-tabs-content-holder,
     .ant-tabs-tabpane {
       background: ${token.colorBgContainer};
-      min-height: 0;
     }
 
     .ant-tabs-content-holder {
-      flex: 1;
       border-radius: ${token.borderRadiusLG}px;
-      overflow: hidden;
-    }
-
-    .ant-tabs-tabpane {
-      height: 100%;
       overflow: hidden;
     }
   `;
@@ -257,17 +239,13 @@ export default function UsersManagementPage() {
         {
           key: 'usersManager',
           label: t('Users manager'),
-          children: (
-            <div style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
-              <UsersTable />
-            </div>
-          ),
+          children: <UsersTable />,
         },
         {
           key: 'usersSettings',
           label: t('Settings'),
           children: (
-            <div style={{ height: '100%', minHeight: 0, overflow: 'auto', padding: token.paddingLG }}>
+            <div style={{ padding: token.paddingLG }}>
               <UsersSettingsForm />
             </div>
           ),


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Align the v2 Users & Permissions settings pages with the expected v1 behavior for layout, pagination visibility, department creation, and permissions panel scrolling.

### Description 
This PR updates the v2 Users & Permissions settings pages to better match the legacy behavior without backend changes.

Key changes:
- Removed forced full-height card/table layouts from the users, roles, and departments settings pages, so the pages follow natural document flow again.
- Restored visible pagination totals in shared resource tables and related settings tables.
- Fixed v2 department create/update requests to use the `parent` relation payload expected by the existing backend behavior, without requiring backend changes.
- Kept the created parent department expanded after creating a sub-department in the departments page.
- Fixed department tree selected-state styling to match the roles list selected state.
- Restored equal-height layout between the roles list and the detail panel, so the divider does not break on long permission content.
- Restored internal scrolling for the System permissions panel in Roles & Permissions, matching the v1 interaction pattern.

Potential risks:
- These changes adjust shared settings-page layout behavior and panel scrolling in the Users & Permissions area, so adjacent settings pages should be spot-checked for visual regressions.

Testing suggestions:
- Verify users, roles, departments, and spaces tabs in Users & Permissions.
- Create and move departments, including creating sub-departments.
- Check pagination totals and selected-state styling.
- Verify long permissions content scrolls inside the System panel.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Aligned the v2 Users & Permissions settings pages with v1 behavior, including pagination totals, department tree behavior, selected styles, and internal permissions-panel scrolling. |
| 🇨🇳 Chinese | 对齐 v2 用户和权限设置页与 v1 的行为，包括分页总数显示、部门树交互、选中样式，以及权限面板内部滚动。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
