### PR TITLE
fix(client-v2): require opt-in association value updates

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/AssociationFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/AssociationFieldModel.tsx
@@ -11,7 +11,7 @@ import { FormItemModel } from '../../blocks/form/FormItemModel';
 import { FieldModel } from '../../base/FieldModel';
 export class AssociationFieldModel extends FieldModel {
   operator = '$eq';
-  updateAssociation = true;
+  updateAssociation = false;
 }
 
 AssociationFieldModel.registerFlow({

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/AssociationFieldModel.updateAssociation.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/AssociationFieldModel.updateAssociation.test.ts
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { AssociationFieldModel } from '../AssociationFieldModel';
+
+class DefaultAssociationFieldModel extends AssociationFieldModel {}
+
+class UpdateAssociationFieldModel extends AssociationFieldModel {
+  updateAssociation = true;
+}
+
+async function runAssociationFieldInit(FieldModelClass: typeof AssociationFieldModel) {
+  const engine = new FlowEngine();
+  engine.registerModels({
+    DefaultAssociationFieldModel,
+    UpdateAssociationFieldModel,
+  });
+
+  const addUpdateAssociationValues = vi.fn();
+  const blockModel = engine.createModel<FlowModel>({
+    use: 'FlowModel',
+    uid: 'form-block',
+  });
+  blockModel.context.defineProperty('resource', {
+    value: { addUpdateAssociationValues },
+  });
+
+  const formItem = engine.createModel<FlowModel>({
+    use: 'FlowModel',
+    uid: 'form-item',
+  });
+  (formItem as FlowModel & { fieldPath: string }).fieldPath = 'author';
+  formItem.context.defineProperty('blockModel', { value: blockModel });
+
+  const field = engine.createModel<AssociationFieldModel>({
+    use: FieldModelClass,
+    uid: 'association-field',
+    parentId: formItem.uid,
+  });
+  field.context.defineProperty('collectionField', {
+    value: {
+      dataSourceKey: 'main',
+      target: 'users',
+    },
+  });
+
+  await field.applyFlow('AssociationFieldInit');
+
+  return addUpdateAssociationValues;
+}
+
+describe('AssociationFieldModel updateAssociation', () => {
+  it('does not add updateAssociationValues by default', async () => {
+    const addUpdateAssociationValues = await runAssociationFieldInit(DefaultAssociationFieldModel);
+
+    expect(addUpdateAssociationValues).not.toHaveBeenCalled();
+  });
+
+  it('adds updateAssociationValues for opt-in association fields', async () => {
+    const addUpdateAssociationValues = await runAssociationFieldInit(UpdateAssociationFieldModel);
+
+    expect(addUpdateAssociationValues).toHaveBeenCalledWith('author');
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Association field models in client-v2 were adding `updateAssociationValues` by default. This made selection-style association fields opt into association value updates even though only subform/subtable-style fields need to update nested association objects.

### Description
This PR changes `AssociationFieldModel` so association value updates are opt-in by default.

Subform and subtable field models keep their explicit `updateAssociation = true` behavior, while selection-style fields that only inherit the base association model no longer add `updateAssociationValues` automatically.

Added unit coverage for the default non-updating behavior and explicit opt-in behavior.

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | remove unexpected updateAssociationValues from association fields|
| 🇨🇳 Chinese | 修复关系字段错误携带`updateAssociationValues` 问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Tests:

```bash
yarn eslint --fix packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/AssociationFieldModel.tsx packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/AssociationFieldModel.updateAssociation.test.ts
yarn test packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/AssociationFieldModel.updateAssociation.test.ts --run --reporter=verbose
git diff --check
```
