### PR TITLE
fix(plugin-workflow-custom-action-trigger): send custom context as object

### DIFF
--- a/packages/core/client-v2/src/components/form/JsonTextArea.tsx
+++ b/packages/core/client-v2/src/components/form/JsonTextArea.tsx
@@ -10,8 +10,9 @@
 import { css, cx } from '@emotion/css';
 import { Input, Typography } from 'antd';
 import type { TextAreaProps } from 'antd/es/input';
+import type { TextAreaRef } from 'antd/es/input/TextArea';
 import JSON5 from 'json5';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, type ChangeEvent, type FocusEvent } from 'react';
 
 export interface JsonTextAreaProps extends Omit<TextAreaProps, 'value' | 'onChange'> {
   value?: unknown;
@@ -36,14 +37,14 @@ function stringifyJsonValue(value: unknown, json: typeof JSON | typeof JSON5, sp
       json.parse(value);
       return value;
     } catch {
-      return json.stringify(value, undefined, space);
+      return json.stringify(value, undefined, space) ?? '';
     }
   }
 
-  return json.stringify(value, undefined, space);
+  return json.stringify(value, undefined, space) ?? '';
 }
 
-export const JsonTextArea = React.memo((props: JsonTextAreaProps) => {
+const JsonTextAreaComponent = React.forwardRef<TextAreaRef, JsonTextAreaProps>((props, ref) => {
   const {
     value,
     onChange,
@@ -74,11 +75,8 @@ export const JsonTextArea = React.memo((props: JsonTextAreaProps) => {
     [json],
   );
 
-  const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const nextText = event.target.value;
-      setText(nextText);
-
+  const validateText = useCallback(
+    (nextText: string) => {
       try {
         parseText(nextText);
         setError(undefined);
@@ -89,12 +87,21 @@ export const JsonTextArea = React.memo((props: JsonTextAreaProps) => {
     [parseText],
   );
 
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const nextText = event.target.value;
+      setText(nextText);
+      validateText(nextText);
+    },
+    [validateText],
+  );
+
   const handleBlur = useCallback(
-    (event: React.FocusEvent<HTMLTextAreaElement>) => {
+    (event: FocusEvent<HTMLTextAreaElement>) => {
       try {
         const parsed = parseText(event.target.value);
         setError(undefined);
-        setText(parsed == null ? '' : json.stringify(parsed, undefined, space));
+        setText(parsed == null ? '' : json.stringify(parsed, undefined, space) ?? '');
         onChange?.(parsed);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
@@ -111,6 +118,7 @@ export const JsonTextArea = React.memo((props: JsonTextAreaProps) => {
     <>
       <Input.TextArea
         {...textAreaProps}
+        ref={ref}
         value={text}
         onChange={handleChange}
         onBlur={handleBlur}
@@ -125,5 +133,7 @@ export const JsonTextArea = React.memo((props: JsonTextAreaProps) => {
     </>
   );
 });
+
+export const JsonTextArea = React.memo(JsonTextAreaComponent);
 
 JsonTextArea.displayName = 'JsonTextArea';

--- a/packages/core/client-v2/src/components/form/VariableJsonTextArea.tsx
+++ b/packages/core/client-v2/src/components/form/VariableJsonTextArea.tsx
@@ -1,0 +1,172 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { css, cx } from '@emotion/css';
+import { FlowContextSelector, useFlowContext, type MetaTreeNode } from '@nocobase/flow-engine';
+import { Button, theme } from 'antd';
+import type { TextAreaRef } from 'antd/es/input/TextArea';
+import React, { useCallback, useMemo, useRef } from 'react';
+import { JsonTextArea, type JsonTextAreaProps } from './JsonTextArea';
+import { makeFormatVariablePath, useFilteredMetaTree, type VariableDelimiters } from './VariableInput';
+
+export interface VariableJsonTextAreaProps extends JsonTextAreaProps {
+  namespaces?: string[];
+  extraNodes?: MetaTreeNode[];
+  metaTree?: MetaTreeNode[] | (() => MetaTreeNode[] | Promise<MetaTreeNode[]>);
+  delimiters?: VariableDelimiters;
+  formatPathToValue?: (meta: MetaTreeNode) => string | undefined;
+}
+
+export const VariableJsonTextArea = React.memo((props: VariableJsonTextAreaProps) => {
+  const {
+    value,
+    onChange,
+    space = 2,
+    json5 = false,
+    showError = true,
+    className,
+    status,
+    onBlur,
+    namespaces,
+    extraNodes,
+    metaTree,
+    delimiters,
+    formatPathToValue: customFormatPathToValue,
+    ...textAreaProps
+  } = props;
+  const { token } = theme.useToken();
+  const flowCtx = useFlowContext();
+  const filteredMetaTree = useFilteredMetaTree({ namespaces, extraNodes });
+  const ref = useRef<TextAreaRef>(null);
+
+  const insertAtCaret = useCallback((valueToInsert: string) => {
+    const textArea = ref.current?.resizableTextArea?.textArea;
+    if (!textArea) return;
+
+    const start = textArea.selectionStart ?? textArea.value.length;
+    const end = textArea?.selectionEnd ?? start;
+    const nextText = textArea.value.slice(0, start) + valueToInsert + textArea.value.slice(end);
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
+
+    nativeInputValueSetter?.call(textArea, nextText);
+    textArea.dispatchEvent(new Event('input', { bubbles: true }));
+
+    requestAnimationFrame(() => {
+      const nextPosition = start + valueToInsert.length;
+      textArea.setSelectionRange(start, nextPosition);
+      textArea.focus();
+    });
+  }, []);
+
+  const handleVariableSelected = useCallback(
+    (nextValue: string) => {
+      if (nextValue) {
+        insertAtCaret(nextValue);
+      }
+    },
+    [insertAtCaret],
+  );
+
+  const selectorMetaTree = useMemo(
+    () => metaTree ?? filteredMetaTree ?? (() => flowCtx.getPropertyMetaTree?.() ?? []),
+    [filteredMetaTree, flowCtx, metaTree],
+  );
+
+  const formatPathToValue = useMemo(() => {
+    if (customFormatPathToValue) {
+      return customFormatPathToValue;
+    }
+    return makeFormatVariablePath(delimiters);
+  }, [customFormatPathToValue, delimiters]);
+
+  const wrapperClassName = useMemo(
+    () => css`
+      position: relative;
+      width: 100%;
+
+      .ant-input {
+        width: 100%;
+      }
+    `,
+    [],
+  );
+
+  const textAreaClassName = useMemo(
+    () => css`
+      font-size: ${token.fontSizeSM}px;
+      font-family: ${token.fontFamilyCode};
+    `,
+    [token.fontFamilyCode, token.fontSizeSM],
+  );
+
+  const selectorClassName = useMemo(
+    () => css`
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      z-index: 1;
+      line-height: 0;
+
+      .ant-btn {
+        font-size: ${token.fontSizeSM}px;
+      }
+    `,
+    [token.fontSizeSM],
+  );
+
+  const buttonClassName = useMemo(
+    () => css`
+      &:not(:hover) {
+        border-inline-end-color: transparent;
+        border-block-start-color: transparent;
+        background-color: transparent;
+      }
+    `,
+    [],
+  );
+
+  return (
+    <div className={wrapperClassName}>
+      <JsonTextArea
+        {...textAreaProps}
+        ref={ref}
+        value={value}
+        onChange={onChange}
+        space={space}
+        json5={json5}
+        showError={showError}
+        className={cx(textAreaClassName, className)}
+        status={status}
+        onBlur={onBlur}
+        disabled={textAreaProps.disabled}
+      />
+      <div className={selectorClassName}>
+        <FlowContextSelector
+          metaTree={selectorMetaTree}
+          disabled={textAreaProps.disabled}
+          formatPathToValue={(meta) => formatPathToValue(meta) ?? ''}
+          onChange={handleVariableSelected}
+        >
+          <Button
+            aria-label="variable-json-switcher"
+            disabled={textAreaProps.disabled}
+            className={buttonClassName}
+            style={{ fontStyle: 'italic', fontFamily: token.fontFamilyCode }}
+          >
+            x
+          </Button>
+        </FlowContextSelector>
+      </div>
+    </div>
+  );
+});
+
+VariableJsonTextArea.displayName = 'VariableJsonTextArea';
+
+export const VariableJSON = VariableJsonTextArea;

--- a/packages/core/client-v2/src/components/form/VariableJsonTextArea.tsx
+++ b/packages/core/client-v2/src/components/form/VariableJsonTextArea.tsx
@@ -8,18 +8,22 @@
  */
 
 import { css, cx } from '@emotion/css';
-import { FlowContextSelector, useFlowContext, type MetaTreeNode } from '@nocobase/flow-engine';
+import {
+  FlowContextSelector,
+  formatPathToValue as formatFlowPathToValue,
+  useFlowContext,
+  type MetaTreeNode,
+} from '@nocobase/flow-engine';
 import { Button, theme } from 'antd';
 import type { TextAreaRef } from 'antd/es/input/TextArea';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { JsonTextArea, type JsonTextAreaProps } from './JsonTextArea';
-import { makeFormatVariablePath, useFilteredMetaTree, type VariableDelimiters } from './VariableInput';
+import { useFilteredMetaTree } from './VariableInput';
 
 export interface VariableJsonTextAreaProps extends JsonTextAreaProps {
   namespaces?: string[];
   extraNodes?: MetaTreeNode[];
   metaTree?: MetaTreeNode[] | (() => MetaTreeNode[] | Promise<MetaTreeNode[]>);
-  delimiters?: VariableDelimiters;
   formatPathToValue?: (meta: MetaTreeNode) => string | undefined;
 }
 
@@ -36,7 +40,6 @@ export const VariableJsonTextArea = React.memo((props: VariableJsonTextAreaProps
     namespaces,
     extraNodes,
     metaTree,
-    delimiters,
     formatPathToValue: customFormatPathToValue,
     ...textAreaProps
   } = props;
@@ -79,11 +82,11 @@ export const VariableJsonTextArea = React.memo((props: VariableJsonTextAreaProps
   );
 
   const formatPathToValue = useMemo(() => {
-    if (customFormatPathToValue) {
-      return customFormatPathToValue;
+    if (!customFormatPathToValue) {
+      return;
     }
-    return makeFormatVariablePath(delimiters);
-  }, [customFormatPathToValue, delimiters]);
+    return (meta: MetaTreeNode) => customFormatPathToValue(meta) ?? formatFlowPathToValue(meta);
+  }, [customFormatPathToValue]);
 
   const wrapperClassName = useMemo(
     () => css`
@@ -150,7 +153,7 @@ export const VariableJsonTextArea = React.memo((props: VariableJsonTextAreaProps
         <FlowContextSelector
           metaTree={selectorMetaTree}
           disabled={textAreaProps.disabled}
-          formatPathToValue={(meta) => formatPathToValue(meta) ?? ''}
+          formatPathToValue={formatPathToValue}
           onChange={handleVariableSelected}
         >
           <Button

--- a/packages/core/client-v2/src/components/form/__tests__/JsonTextArea.test.tsx
+++ b/packages/core/client-v2/src/components/form/__tests__/JsonTextArea.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { JsonTextArea } from '../JsonTextArea';
+
+describe('JsonTextArea', () => {
+  it('formats object values and emits parsed JSON on blur', async () => {
+    const handleChange = vi.fn();
+
+    render(<JsonTextArea value={{ foo: 'bar' }} onChange={handleChange} />);
+
+    const textArea = await screen.findByRole('textbox');
+    expect(textArea).toHaveValue('{\n  "foo": "bar"\n}');
+
+    fireEvent.change(textArea, { target: { value: '{"foo":"baz"}' } });
+    fireEvent.blur(textArea);
+
+    expect(handleChange).toHaveBeenCalledWith({ foo: 'baz' });
+    expect(textArea).toHaveValue('{\n  "foo": "baz"\n}');
+  });
+
+  it('shows JSON parse errors and does not emit invalid values', async () => {
+    const handleChange = vi.fn();
+
+    render(<JsonTextArea value={{}} onChange={handleChange} />);
+
+    const textArea = await screen.findByRole('textbox');
+    fireEvent.change(textArea, { target: { value: '{' } });
+    fireEvent.blur(textArea);
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(await screen.findByText(/JSON/)).toBeInTheDocument();
+  });
+});

--- a/packages/core/client-v2/src/components/form/__tests__/VariableJsonTextArea.test.tsx
+++ b/packages/core/client-v2/src/components/form/__tests__/VariableJsonTextArea.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowContext, FlowContextProvider } from '@nocobase/flow-engine';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { VariableJsonTextArea } from '../VariableJsonTextArea';
+
+function createContextWithEnv() {
+  const ctx = new FlowContext();
+  (ctx as unknown as { t: (key: string) => string }).t = (key: string) => key;
+
+  ctx.defineProperty('$env', {
+    value: { API_KEY: 'secret' },
+    meta: {
+      title: 'Env',
+      type: 'object',
+      properties: {
+        API_KEY: { title: 'API Key', type: 'string' },
+      },
+    },
+  });
+
+  return ctx;
+}
+
+function renderWithCtx(ctx: FlowContext, node: React.ReactNode) {
+  return render(<FlowContextProvider context={ctx}>{node}</FlowContextProvider>);
+}
+
+describe('VariableJsonTextArea', () => {
+  it('formats object values and emits parsed JSON on blur', async () => {
+    const ctx = createContextWithEnv();
+    const handleChange = vi.fn();
+
+    renderWithCtx(ctx, <VariableJsonTextArea value={{ foo: 'bar' }} onChange={handleChange} />);
+
+    const textArea = await screen.findByRole('textbox');
+    expect(textArea).toHaveValue('{\n  "foo": "bar"\n}');
+
+    fireEvent.change(textArea, { target: { value: '{"foo":"baz"}' } });
+    fireEvent.blur(textArea);
+
+    expect(handleChange).toHaveBeenCalledWith({ foo: 'baz' });
+    expect(textArea).toHaveValue('{\n  "foo": "baz"\n}');
+  });
+
+  it('shows JSON parse errors and does not emit invalid values', async () => {
+    const ctx = createContextWithEnv();
+    const handleChange = vi.fn();
+
+    renderWithCtx(ctx, <VariableJsonTextArea value={{}} onChange={handleChange} />);
+
+    const textArea = await screen.findByRole('textbox');
+    fireEvent.change(textArea, { target: { value: '{' } });
+    fireEvent.blur(textArea);
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(await screen.findByText(/JSON/)).toBeInTheDocument();
+  });
+
+  it('inserts selected variables with the client-v2 template format', async () => {
+    const ctx = createContextWithEnv();
+
+    renderWithCtx(ctx, <VariableJsonTextArea value={null} namespaces={['$env']} onChange={() => undefined} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'variable-json-switcher' }));
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('Env'));
+    });
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('API Key'));
+    });
+
+    expect(await screen.findByRole('textbox')).toHaveValue('{{$env.API_KEY}}');
+  });
+});

--- a/packages/core/client-v2/src/components/form/__tests__/VariableJsonTextArea.test.tsx
+++ b/packages/core/client-v2/src/components/form/__tests__/VariableJsonTextArea.test.tsx
@@ -81,6 +81,6 @@ describe('VariableJsonTextArea', () => {
       fireEvent.click(screen.getByText('API Key'));
     });
 
-    expect(await screen.findByRole('textbox')).toHaveValue('{{$env.API_KEY}}');
+    expect(await screen.findByRole('textbox')).toHaveValue('{{ ctx.$env.API_KEY }}');
   });
 });

--- a/packages/core/client-v2/src/components/form/index.tsx
+++ b/packages/core/client-v2/src/components/form/index.tsx
@@ -19,3 +19,4 @@ export * from './RemoteSelect';
 export * from './ScanInput';
 export * from './TypedVariableInput';
 export * from './VariableInput';
+export * from './VariableJsonTextArea';

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -13,10 +13,10 @@ import {
   ActionSceneEnum,
   CollectionActionModel,
   FormActionModel,
-  TextAreaWithContextSelector,
+  JsonTextArea,
 } from '@nocobase/client-v2';
 import { css } from '@emotion/css';
-import { MultiRecordResource, resolveExpressions, useFlowContext } from '@nocobase/flow-engine';
+import { MultiRecordResource, useFlowContext } from '@nocobase/flow-engine';
 import type { FlowEngine, FlowRuntimeContext, ModelConstructor } from '@nocobase/flow-engine';
 import { Alert, Select, Space } from 'antd';
 import type { ButtonProps } from 'antd/es/button';
@@ -77,6 +77,13 @@ const buildTriggerWorkflows = (group?: TriggerWorkflowBinding[]) => {
     ? group.map((row) => [row.workflowKey, row.context].filter(Boolean).join('!')).join(',')
     : undefined;
 };
+
+function parseContextData(contextData: unknown) {
+  if (typeof contextData !== 'string') {
+    return contextData;
+  }
+  return JSON.parse(contextData);
+}
 
 function ensureTriggerWorkflowsConfigured(ctx: FlowRuntimeContext, group?: TriggerWorkflowBinding[]) {
   if (group?.length) {
@@ -245,13 +252,13 @@ function createTriggerWorkflowsSchema({
     ...(withContextData
       ? {
           contextData: {
-            type: 'string',
+            type: 'object',
             title: tExpr('Context data'),
             description: tExpr(
               'Input JSON as context data passed into the workflow. Frontend variables are supported.',
             ),
             'x-decorator': 'FormItem',
-            'x-component': TextAreaWithContextSelector,
+            'x-component': JsonTextArea,
             'x-component-props': {
               rows: 5,
             },
@@ -504,7 +511,7 @@ CollectionTriggerWorkflowActionModel.registerFlow({
           let values;
           if (contextData) {
             try {
-              values = await resolveExpressions(contextData, ctx);
+              values = parseContextData(contextData);
             } catch (e) {
               // resolution error, ignore
             }
@@ -516,7 +523,7 @@ CollectionTriggerWorkflowActionModel.registerFlow({
               params: {
                 triggerWorkflows: buildTriggerWorkflows(group),
               },
-              data: { values },
+              data: values,
             });
           } catch (error) {
             console.error('Error triggering workflows:', error);
@@ -566,7 +573,7 @@ async function globalTriggerWorkflowHandler(ctx, params) {
   let values;
   if (params.contextData) {
     try {
-      values = await resolveExpressions(params.contextData, ctx);
+      values = parseContextData(params.contextData);
     } catch (e) {
       // resolution error, ignore
     }
@@ -578,7 +585,7 @@ async function globalTriggerWorkflowHandler(ctx, params) {
       params: {
         triggerWorkflows: buildTriggerWorkflows(params.group),
       },
-      data: { values },
+      data: values,
     });
   } catch (error) {
     console.error('Error triggering workflows:', error);

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -13,7 +13,7 @@ import {
   ActionSceneEnum,
   CollectionActionModel,
   FormActionModel,
-  JsonTextArea,
+  VariableJsonTextArea,
 } from '@nocobase/client-v2';
 import { css } from '@emotion/css';
 import { MultiRecordResource, useFlowContext } from '@nocobase/flow-engine';
@@ -258,7 +258,7 @@ function createTriggerWorkflowsSchema({
               'Input JSON as context data passed into the workflow. Frontend variables are supported.',
             ),
             'x-decorator': 'FormItem',
-            'x-component': JsonTextArea,
+            'x-component': VariableJsonTextArea,
             'x-component-props': {
               rows: 5,
             },

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
@@ -93,7 +93,7 @@ async function getTriggerWorkflowItemNames(ModelClass: any, ctx: any) {
 
 function getWorkbenchTriggerWorkflowHandler(model: WorkbenchTriggerWorkflowActionModel) {
   const step = model.getFlow('workbenchTriggerWorkflowsActionSettings')?.getStep('triggerWorkflows')?.serialize() as
-    | { handler?: (ctx: any, params: { group?: unknown[] }) => Promise<void> }
+    | { handler?: (ctx: any, params: { group?: unknown[]; contextData?: unknown }) => Promise<void> }
     | undefined;
   expect(step?.handler).toBeTypeOf('function');
   return step.handler;
@@ -202,7 +202,58 @@ describe('WorkbenchTriggerWorkflowActionModel', () => {
       params: {
         triggerWorkflows: 'workflow-1',
       },
-      data: { values: undefined },
+      data: undefined,
+    });
+    expect(ctx.message.error).not.toHaveBeenCalled();
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.exit).not.toHaveBeenCalled();
+  });
+
+  it('sends custom context data as trigger request body', async () => {
+    const flowEngine = createEngine();
+    const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({
+      use: 'WorkbenchTriggerWorkflowActionModel',
+      uid: 'workbench-trigger-workflow-action-context-data',
+    });
+    const request = vi.fn().mockResolvedValue({});
+    const ctx = {
+      api: {
+        request,
+      },
+      message: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+      t: (value: string) => value,
+      exit: vi.fn(),
+    };
+
+    const handler = getWorkbenchTriggerWorkflowHandler(model);
+
+    await handler(ctx, {
+      group: [{ workflowKey: 'workflow-1' }],
+      contextData: {
+        a: '1',
+        userId: '{{$user.id}}',
+        nested: {
+          b: '2',
+        },
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith({
+      url: 'workflows:trigger',
+      method: 'post',
+      params: {
+        triggerWorkflows: 'workflow-1',
+      },
+      data: {
+        a: '1',
+        userId: '{{$user.id}}',
+        nested: {
+          b: '2',
+        },
+      },
     });
     expect(ctx.message.error).not.toHaveBeenCalled();
     expect(ctx.message.success).not.toHaveBeenCalled();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Custom action workflow buttons with custom context could submit JSON context data under an extra `values` property, and JSON editor content could be sent as a serialized string instead of an object. This made `$context.data` in the triggered workflow inconsistent with the configured context data.

### Description
This PR updates the custom action workflow trigger button configuration to use an object JSON editor for custom context data.

It also sends the parsed context object directly as the workflow trigger request body instead of wrapping it in `{ values }`.

Existing flow model parameter resolution remains responsible for frontend variable resolution before the trigger request is sent.

Tests were added for the workbench trigger workflow action to verify custom context data is sent as the trigger request body.

### Related issues

Task-4483

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed custom action workflow trigger buttons sending custom context JSON under an extra `values` property or as a serialized string. |
| 🇨🇳 Chinese | 修复自定义操作工作流触发按钮将自定义上下文 JSON 放到额外的 `values` 层级或作为序列化字符串提交的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
