### PR TITLE
fix(plugin-workflow-javascript): register script instruction class

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/ScriptInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/ScriptInstruction.tsx
@@ -14,6 +14,11 @@ import { ValueBlock } from '@nocobase/plugin-workflow/client';
 import { lang } from '../locale';
 
 export default class extends V2ScriptInstruction {
+  constructor() {
+    super();
+    this.bindTranslate(lang);
+  }
+
   useInitializers(node: { id: string | number; title?: string }): SchemaInitializerItemType {
     return {
       name: node.title ?? `#${node.id}`,

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/__tests__/scriptCompatibility.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/__tests__/scriptCompatibility.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { PluginWorkflowScriptClient } from '../';
 import V1ScriptInstruction from '../ScriptInstruction';
 import { lang } from '../../locale';
 import V2ScriptInstruction from '../../client-v2/nodes/script';
@@ -33,5 +34,30 @@ describe('ScriptInstruction compatibility', () => {
       title: 'Script node',
       resultTitle: lang('Script result'),
     });
+  });
+
+  it('registers the v1 instruction as a class to avoid cross-entry instanceof checks', async () => {
+    const calls: unknown[][] = [];
+    const plugin = Object.create(PluginWorkflowScriptClient.prototype) as PluginWorkflowScriptClient & {
+      app: {
+        pm: {
+          get: () => {
+            registerInstruction: (...args: unknown[]) => number;
+          };
+        };
+      };
+    };
+
+    plugin.app = {
+      pm: {
+        get: () => ({
+          registerInstruction: (...args: unknown[]) => calls.push(args),
+        }),
+      },
+    };
+
+    await plugin.load();
+
+    expect(calls).toEqual([['script', V1ScriptInstruction]]);
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/client/index.tsx
@@ -16,7 +16,7 @@ import { lang } from '../locale';
 export class PluginWorkflowScriptClient extends Plugin {
   async load() {
     const workflow = this.app.pm.get('workflow') as WorkflowPlugin;
-    workflow.registerInstruction('script', new ScriptInstruction().bindTranslate(lang));
+    workflow.registerInstruction('script', ScriptInstruction);
   }
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The workflow JavaScript plugin could fail during v1 client instruction registration with `invalid instruction type to register` when registering a v2-derived instruction instance across package entry points.

### Description
Register the v1 script instruction as a class instead of a pre-created instance so the workflow registry uses its constructor branch and avoids brittle cross-entry `instanceof` checks.

The legacy translation binding is moved into the v1 instruction constructor to preserve the previous behavior. A regression test now verifies that the v1 plugin registers the instruction class.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed JavaScript workflow node registration failure in the legacy workflow client. |
| 🇨🇳 Chinese | 修复旧版工作流客户端中 JavaScript 节点注册失败的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
