### PR TITLE
feat(workflow): export v2 canvas building blocks

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
@@ -14,6 +14,11 @@ export * from './models';
 // their config UI to the modern canvas.
 export { Instruction } from './canvas/Instruction';
 export type { LoaderOf, NodeAvailableContext, TempAssociationSource } from './canvas/Instruction';
+export { Branch } from './canvas/Branch';
+export { NodeDefaultView } from './canvas/Node';
+export { useFlowContext } from './canvas/contexts';
+export type { CanvasNode, WorkflowCanvasFlowContextValue } from './canvas/contexts';
+export { default as useStyles } from './canvas/style';
 export { WorkflowVariableInput } from './canvas/WorkflowVariableInput';
 export type { WorkflowVariableInputProps } from './canvas/WorkflowVariableInput';
 export { WorkflowVariableTextArea } from './canvas/WorkflowVariableTextArea';


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Workflow-family plugins migrating to client-v2 need to reuse the workflow canvas building blocks instead of importing private source paths or duplicating canvas behavior.

### Description 
Expose the migrated workflow v2 canvas building blocks from the `@nocobase/plugin-workflow/client-v2` entry:

- `Branch`
- `NodeDefaultView`
- `useFlowContext`
- canvas context types
- `useStyles`

Potential risk: this expands the public client-v2 surface for workflow canvas internals. It is intentionally narrow and supports downstream workflow node migration.

Testing:

- Ran Prettier check on the changed file.
- ESLint was blocked locally by duplicate `@typescript-eslint` plugin resolution between this app and the parent workspace.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Exposed workflow v2 canvas building blocks for downstream workflow node migrations. |
| 🇨🇳 Chinese | 暴露工作流 v2 画布构建组件，以支持下游工作流节点迁移。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
