### PR TITLE
fix(plugin-workflow): export v2 canvas extension APIs

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
@@ -14,6 +14,11 @@ export * from './models';
 // their config UI to the modern canvas.
 export { Instruction } from './canvas/Instruction';
 export type { LoaderOf, NodeAvailableContext, TempAssociationSource } from './canvas/Instruction';
+export { Branch } from './canvas/Branch';
+export { NodeDefaultView } from './canvas/Node';
+export { useFlowContext } from './canvas/contexts';
+export type { CanvasNode } from './canvas/contexts';
+export { default as useStyles } from './canvas/style';
 export { WorkflowVariableInput } from './canvas/WorkflowVariableInput';
 export type { WorkflowVariableInputProps } from './canvas/WorkflowVariableInput';
 export { WorkflowVariableTextArea } from './canvas/WorkflowVariableTextArea';


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Workflow node plugins migrated to client-v2 need to reuse the workflow v2 canvas building blocks when rendering branch nodes. `plugin-workflow-transaction` depends on these APIs to keep its Run and After rollback branches visible in the v2 canvas.

### Description 

This PR exports the workflow v2 canvas extension APIs from `@nocobase/plugin-workflow/client-v2`:

- `Branch`
- `NodeDefaultView`
- `useFlowContext`
- `CanvasNode`
- `useStyles`

This keeps downstream workflow node plugins on the public package entry instead of importing private source paths.

Testing performed:

- `yarn prettier --check packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx`
- `git diff --check`
- `yarn build @nocobase/plugin-workflow --no-dts`

Notes:

- Full declaration build is blocked locally by unrelated existing type output drift in `@nocobase/client-v2` / `@nocobase/flow-engine`.

### Related issues

Related to nocobase/pro-plugins#599

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Exported workflow v2 canvas extension APIs for downstream workflow node plugins. |
| 🇨🇳 Chinese | 导出工作流 v2 画布扩展 API，供下游工作流节点插件复用。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
