### PR TITLE
fix(gantt): reuse openView for task popup settings

### DIFF
--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
@@ -777,21 +777,162 @@ describe('GanttBlockModel settings', () => {
 
   test('persists popup actions only from popup settings save hooks', async () => {
     const step = (GanttBlockModel as any).globalFlowRegistry.getFlow('ganttSettings')?.steps?.eventPopupSettings;
+    const action = { uid: 'u_event_popup' };
     const model = {
-      setPopupSettings: vi.fn(),
-      ensurePopupAction: vi.fn().mockResolvedValue({ uid: 'u_event_popup' }),
+      getEventViewAction: vi.fn(() => null),
+      getPopupSettingsDefaults: vi.fn(() => ({
+        mode: 'drawer',
+        size: 'medium',
+        pageModelClass: 'ChildPageModel',
+        uid: 'u_event_popup',
+        collectionName: 'calendar',
+        dataSourceKey: 'main',
+      })),
+      getPopupActionSettings: vi.fn(() => ({})),
+      setPopupActionSettings: vi.fn(),
+      clearStoredPopupSettings: vi.fn(),
+      ensurePopupAction: vi.fn().mockResolvedValue(action),
     };
 
     await step?.handler?.({ model } as any, { mode: 'drawer' });
 
     expect(model.ensurePopupAction).not.toHaveBeenCalled();
+    expect(model.setPopupActionSettings).not.toHaveBeenCalled();
 
     await step?.beforeParamsSave?.({ model } as any, { mode: 'dialog' });
 
-    expect(model.ensurePopupAction).toHaveBeenCalledWith('eventViewAction', { persist: true });
+    expect(model.ensurePopupAction).toHaveBeenCalledWith('eventViewAction');
+    expect(model.setPopupActionSettings).toHaveBeenCalledWith(
+      action,
+      {
+        mode: 'dialog',
+        uid: 'u_event_popup',
+        collectionName: 'calendar',
+        dataSourceKey: 'main',
+      },
+      { persist: true },
+    );
+    expect(model.clearStoredPopupSettings).toHaveBeenCalled();
   });
 
-  test('opens the configured event popup with the clicked task record', async () => {
+  test('runs openView beforeParamsSave when saving gantt popup template settings', async () => {
+    const step = (GanttBlockModel as any).globalFlowRegistry.getFlow('ganttSettings')?.steps?.eventPopupSettings;
+    const openViewBeforeParamsSave = vi.fn(async (_ctx, params) => {
+      params.uid = 'u_template_popup';
+    });
+    const action = { uid: 'u_event_popup' };
+    const model = {
+      getAction: vi.fn(() => ({
+        beforeParamsSave: openViewBeforeParamsSave,
+      })),
+      getPopupActionSettings: vi.fn(() => ({ uid: 'u_old_popup' })),
+      setPopupActionSettings: vi.fn(),
+      clearStoredPopupSettings: vi.fn(),
+      ensurePopupAction: vi.fn().mockResolvedValue(action),
+    };
+    const params = { popupTemplateUid: 'tpl-popup', uid: 'u_old_popup' };
+
+    await step?.beforeParamsSave?.({ model } as any, params);
+
+    expect(openViewBeforeParamsSave).toHaveBeenCalledWith({ model }, params, { uid: 'u_old_popup' });
+    expect(model.setPopupActionSettings).toHaveBeenCalledWith(
+      action,
+      {
+        popupTemplateUid: 'tpl-popup',
+        uid: 'u_template_popup',
+      },
+      { persist: true },
+    );
+    expect(model.clearStoredPopupSettings).toHaveBeenCalled();
+  });
+
+  test('clears stale popup template params when the gantt popup template setting is removed', async () => {
+    const step = (GanttBlockModel as any).globalFlowRegistry.getFlow('ganttSettings')?.steps?.eventPopupSettings;
+    const previousParams = {
+      mode: 'drawer',
+      size: 'medium',
+      popupTemplateUid: 'tpl-popup',
+      uid: 'u_template_popup',
+      dataSourceKey: 'main',
+      collectionName: 'templateTasks',
+      filterByTk: '{{ ctx.record.id }}',
+    };
+    const openViewBeforeParamsSave = vi.fn(async (_ctx, params) => {
+      expect(params).toEqual({
+        mode: 'drawer',
+        size: 'medium',
+        uid: 'u_event_popup',
+        dataSourceKey: 'main',
+        collectionName: 'calendar',
+      });
+    });
+    const action = { uid: 'u_event_popup' };
+    const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
+    Object.defineProperties(model, {
+      getAction: {
+        value: vi.fn(() => ({
+          beforeParamsSave: openViewBeforeParamsSave,
+        })),
+      },
+      getStepParams: {
+        value: vi.fn(() => previousParams),
+      },
+      getPopupActionSettings: {
+        value: vi.fn(() => previousParams),
+      },
+      setPopupActionSettings: {
+        value: vi.fn(),
+      },
+      clearStoredPopupSettings: {
+        value: vi.fn(),
+      },
+      ensurePopupAction: {
+        value: vi.fn().mockResolvedValue(action),
+      },
+      collection: {
+        value: {
+          name: 'calendar',
+          dataSourceKey: 'main',
+        },
+      },
+      props: {
+        value: {},
+      },
+    });
+    const params = {
+      mode: 'drawer',
+      size: 'medium',
+      uid: 'u_template_popup',
+      dataSourceKey: 'main',
+      collectionName: 'templateTasks',
+      filterByTk: '{{ ctx.record.id }}',
+    };
+
+    await step?.beforeParamsSave?.({ model } as any, params);
+
+    expect(openViewBeforeParamsSave).toHaveBeenCalledWith({ model }, params, previousParams);
+    expect(params).toEqual({
+      mode: 'drawer',
+      size: 'medium',
+      uid: 'u_event_popup',
+      dataSourceKey: 'main',
+      collectionName: 'calendar',
+    });
+    expect(model.setPopupActionSettings).toHaveBeenCalledWith(
+      action,
+      {
+        mode: 'drawer',
+        size: 'medium',
+        uid: 'u_event_popup',
+        dataSourceKey: 'main',
+        collectionName: 'calendar',
+      },
+      { persist: true },
+    );
+    expect(model.clearStoredPopupSettings).toHaveBeenCalled();
+  });
+
+  test('dispatches the hidden popup action so openView template handling can run', async () => {
     const flowEngine = new FlowEngine();
     flowEngine.registerModels({ GanttBlockModel, GanttEventViewActionModel });
     flowEngine.dataSourceManager.getDataSource('main').addCollection({
@@ -820,13 +961,19 @@ describe('GanttBlockModel settings', () => {
     await model.openEvent({ id: 12 });
 
     expect(action.uid).not.toContain('eventViewAction');
-    expect(openView).toHaveBeenCalledWith(action.uid, {
-      dataSourceKey: 'main',
-      collectionName: 'calendar',
-      filterByTk: 12,
-      target: model.context.layoutContentElement,
-    });
-    expect(action.dispatchEvent).not.toHaveBeenCalled();
+    expect(action.dispatchEvent).toHaveBeenCalledWith(
+      'click',
+      {
+        dataSourceKey: 'main',
+        collectionName: 'calendar',
+        filterByTk: 12,
+        target: model.context.layoutContentElement,
+      },
+      {
+        debounce: true,
+      },
+    );
+    expect(openView).not.toHaveBeenCalled();
   });
 
   test('does not persist hidden popup actions while opening gantt popups', async () => {
@@ -870,6 +1017,144 @@ describe('GanttBlockModel settings', () => {
     expect(save).not.toHaveBeenCalled();
     expect(saveStepParams).not.toHaveBeenCalled();
     expect(action.setStepParams).toHaveBeenCalled();
+  });
+
+  test('uses popup template settings stored on the hidden popup action while opening gantt popups', async () => {
+    const action = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => ({
+        uid: 'u_template_popup',
+        popupTemplateUid: 'tpl-popup',
+        collectionName: 'templateTasks',
+        dataSourceKey: 'main',
+        filterByTk: '{{ ctx.record.id }}',
+      })),
+      setStepParams: vi.fn(),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
+    };
+    const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'calendar',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {
+        eventPopupSettings: {
+          mode: 'dialog',
+          size: 'large',
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    await model.ensurePopupAction('eventViewAction');
+
+    expect(action.setStepParams).toHaveBeenCalledWith('popupSettings', {
+      openView: expect.objectContaining({
+        mode: 'drawer',
+        size: 'medium',
+        uid: 'u_template_popup',
+        popupTemplateUid: 'tpl-popup',
+        collectionName: 'templateTasks',
+        dataSourceKey: 'main',
+        filterByTk: '{{ ctx.record.id }}',
+      }),
+    });
+  });
+
+  test('replaces hidden popup openView params when gantt popup settings are saved without a template', async () => {
+    let currentOpenViewParams = {
+      uid: 'u_template_popup',
+      popupTemplateUid: 'tpl-popup',
+      collectionName: 'templateTasks',
+      dataSourceKey: 'main',
+    };
+    const action = {
+      uid: 'u_event_popup',
+      getStepParams: vi.fn(() => currentOpenViewParams),
+      setStepParams: vi.fn((_flowKey, stepParams) => {
+        currentOpenViewParams = stepParams.openView;
+      }),
+      save: vi.fn(),
+      saveStepParams: vi.fn(),
+    };
+    const model = Object.create(GanttBlockModel.prototype) as GanttBlockModel;
+    Object.defineProperty(model, 'subModels', {
+      value: {
+        eventViewAction: action,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'context', {
+      value: {
+        flowSettingsEnabled: true,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'collection', {
+      value: {
+        name: 'calendar',
+        dataSourceKey: 'main',
+      },
+      configurable: true,
+    });
+    Object.defineProperty(model, 'props', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(model, '_options', {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+
+    await model.setPopupActionSettings(
+      action,
+      {
+        mode: 'drawer',
+        size: 'medium',
+        uid: 'u_event_popup',
+        collectionName: 'calendar',
+        dataSourceKey: 'main',
+      },
+      { persist: true },
+    );
+
+    expect(action.setStepParams).toHaveBeenCalledWith('popupSettings', {
+      openView: {
+        mode: 'drawer',
+        size: 'medium',
+        uid: 'u_event_popup',
+        collectionName: 'calendar',
+        dataSourceKey: 'main',
+      },
+    });
+    expect(currentOpenViewParams).toMatchObject({
+      mode: 'drawer',
+      size: 'medium',
+      uid: 'u_event_popup',
+      collectionName: 'calendar',
+      dataSourceKey: 'main',
+    });
+    expect(currentOpenViewParams).not.toHaveProperty('popupTemplateUid');
   });
 
   test('persists hidden popup actions only when gantt popup settings are saved', async () => {

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/__tests__/GanttBlockModel.test.ts
@@ -932,6 +932,37 @@ describe('GanttBlockModel settings', () => {
     expect(model.clearStoredPopupSettings).toHaveBeenCalled();
   });
 
+  test('keeps popup template copy mode when saving gantt popup settings', async () => {
+    const step = (GanttBlockModel as any).globalFlowRegistry.getFlow('ganttSettings')?.steps?.eventPopupSettings;
+    const previousParams = {
+      mode: 'drawer',
+      size: 'medium',
+      uid: 'u_template_copy_popup',
+      dataSourceKey: 'main',
+      collectionName: 'templateTasks',
+      popupTemplateContext: true,
+      filterByTk: '{{ ctx.record.id }}',
+    };
+    const openViewBeforeParamsSave = vi.fn();
+    const action = { uid: 'u_event_popup' };
+    const model = {
+      getAction: vi.fn(() => ({
+        beforeParamsSave: openViewBeforeParamsSave,
+      })),
+      getPopupActionSettings: vi.fn(() => previousParams),
+      setPopupActionSettings: vi.fn(),
+      clearStoredPopupSettings: vi.fn(),
+      ensurePopupAction: vi.fn().mockResolvedValue(action),
+    };
+    const params = { ...previousParams };
+
+    await step?.beforeParamsSave?.({ model } as any, params);
+
+    expect(openViewBeforeParamsSave).toHaveBeenCalledWith({ model }, params, previousParams);
+    expect(model.setPopupActionSettings).toHaveBeenCalledWith(action, previousParams, { persist: true });
+    expect(model.clearStoredPopupSettings).toHaveBeenCalled();
+  });
+
   test('dispatches the hidden popup action so openView template handling can run', async () => {
     const flowEngine = new FlowEngine();
     flowEngine.registerModels({ GanttBlockModel, GanttEventViewActionModel });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
@@ -23,6 +23,10 @@ import { tExpr } from '../locale';
 
 const getGanttModel = (ctx: { model: any }) => ctx.model as GanttBlockModelType;
 
+const getPopupTemplateUid = (params?: Record<string, any>) => {
+  return typeof params?.popupTemplateUid === 'string' ? params.popupTemplateUid.trim() : '';
+};
+
 const shouldHideGanttTreeSetting = (ctx: { model: any; view?: any }) => {
   const model = getGanttModel(ctx);
   return !model.isTreeCollection() || ctx.view?.inputArgs?.scene === 'select';
@@ -481,12 +485,36 @@ export function registerGanttBlockModelSettings(GanttBlockModel: any) {
         },
         async handler(ctx, params) {
           const model = getGanttModel(ctx);
-          model.setPopupSettings(params);
+          const action = model.getEventViewAction();
+          if (action) {
+            await model.setPopupActionSettings(action, params);
+          }
         },
-        async beforeParamsSave(ctx, params) {
+        async beforeParamsSave(ctx, params, previousParams) {
           const model = getGanttModel(ctx);
-          model.setPopupSettings(params);
-          await model.ensurePopupAction('eventViewAction', { persist: true });
+          const action = await model.ensurePopupAction('eventViewAction');
+          const storedParams = model.getPopupActionSettings(action);
+          if (!getPopupTemplateUid(params)) {
+            const defaults = model.getPopupSettingsDefaults(action?.uid);
+            Object.assign(params, {
+              uid: defaults.uid,
+              collectionName: defaults.collectionName,
+              dataSourceKey: defaults.dataSourceKey,
+            });
+            delete params.popupTemplateUid;
+            delete params.popupTemplateMode;
+            delete params.popupTemplateContext;
+            delete params.popupTemplateHasFilterByTk;
+            delete params.popupTemplateHasSourceId;
+            delete params.associationName;
+            delete params.filterByTk;
+            delete params.sourceId;
+          }
+
+          const openViewAction = ctx.model.getAction?.('openView') || ctx.engine?.getAction?.('openView');
+          await openViewAction?.beforeParamsSave?.(ctx, params, storedParams || previousParams || {});
+          await model.setPopupActionSettings(action, params, { persist: true });
+          model.clearStoredPopupSettings();
         },
       },
     },

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.settings.tsx
@@ -27,6 +27,10 @@ const getPopupTemplateUid = (params?: Record<string, any>) => {
   return typeof params?.popupTemplateUid === 'string' ? params.popupTemplateUid.trim() : '';
 };
 
+const isPopupTemplateCopyMode = (params?: Record<string, any>) => {
+  return params?.popupTemplateContext === true;
+};
+
 const shouldHideGanttTreeSetting = (ctx: { model: any; view?: any }) => {
   const model = getGanttModel(ctx);
   return !model.isTreeCollection() || ctx.view?.inputArgs?.scene === 'select';
@@ -494,7 +498,7 @@ export function registerGanttBlockModelSettings(GanttBlockModel: any) {
           const model = getGanttModel(ctx);
           const action = await model.ensurePopupAction('eventViewAction');
           const storedParams = model.getPopupActionSettings(action);
-          if (!getPopupTemplateUid(params)) {
+          if (!getPopupTemplateUid(params) && !isPopupTemplateCopyMode(params)) {
             const defaults = model.getPopupSettingsDefaults(action?.uid);
             Object.assign(params, {
               uid: defaults.uid,

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/models/GanttBlockModel.tsx
@@ -58,7 +58,22 @@ type GanttScrollToDateOptions = {
 
 type GanttPopupActionOptions = {
   persist?: boolean;
+  preserveActionTemplate?: boolean;
 };
+
+const POPUP_TEMPLATE_SETTING_KEYS = [
+  'uid',
+  'dataSourceKey',
+  'collectionName',
+  'associationName',
+  'filterByTk',
+  'sourceId',
+  'popupTemplateUid',
+  'popupTemplateMode',
+  'popupTemplateContext',
+  'popupTemplateHasFilterByTk',
+  'popupTemplateHasSourceId',
+];
 
 export class GanttBlockModel extends TableBlockModel {
   static scene = BlockSceneEnum.many;
@@ -382,7 +397,64 @@ export class GanttBlockModel extends TableBlockModel {
   }
 
   getStoredPopupSettings() {
-    return this.props?.eventPopupSettings || {};
+    if (this.props?.eventPopupSettings) {
+      return this.props.eventPopupSettings;
+    }
+
+    try {
+      return this.getStepParams('ganttSettings', 'eventPopupSettings') || {};
+    } catch {
+      return {};
+    }
+  }
+
+  clearStoredPopupSettings() {
+    this.setProps({
+      eventPopupSettings: undefined,
+    });
+    this.setStepParams('ganttSettings', {
+      eventPopupSettings: {},
+    });
+  }
+
+  getPopupActionSettings(action: any) {
+    return action?.getStepParams?.('popupSettings', 'openView') || {};
+  }
+
+  hasPopupTemplateState(popupSettings?: Record<string, any>) {
+    if (!popupSettings || typeof popupSettings !== 'object') {
+      return false;
+    }
+
+    const popupTemplateUid =
+      typeof popupSettings.popupTemplateUid === 'string'
+        ? popupSettings.popupTemplateUid.trim()
+        : popupSettings.popupTemplateUid;
+
+    return !!popupTemplateUid || popupSettings.popupTemplateContext === true;
+  }
+
+  mergePopupTemplateSettings(baseSettings: Record<string, any>, popupSettings?: Record<string, any>) {
+    if (!this.hasPopupTemplateState(popupSettings)) {
+      return baseSettings;
+    }
+
+    const nextSettings = { ...baseSettings };
+    POPUP_TEMPLATE_SETTING_KEYS.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(popupSettings, key)) {
+        nextSettings[key] = popupSettings[key];
+      }
+    });
+
+    if (popupSettings?.popupTemplateContext === true) {
+      delete nextSettings.popupTemplateUid;
+      delete nextSettings.popupTemplateHasFilterByTk;
+      delete nextSettings.popupTemplateHasSourceId;
+    } else if (popupSettings?.popupTemplateUid) {
+      delete nextSettings.popupTemplateContext;
+    }
+
+    return nextSettings;
   }
 
   normalizePopupSettings(popupSettings?: Record<string, any>) {
@@ -398,9 +470,13 @@ export class GanttBlockModel extends TableBlockModel {
       (popupTemplateUid === undefined || popupTemplateUid === null || popupTemplateUid === '')
     ) {
       delete nextParams.popupTemplateUid;
+      delete nextParams.popupTemplateMode;
       delete nextParams.popupTemplateContext;
       delete nextParams.popupTemplateHasFilterByTk;
       delete nextParams.popupTemplateHasSourceId;
+      delete nextParams.associationName;
+      delete nextParams.filterByTk;
+      delete nextParams.sourceId;
       delete nextParams.uid;
     }
 
@@ -415,17 +491,23 @@ export class GanttBlockModel extends TableBlockModel {
     return normalized;
   }
 
-  getPopupSettings(action: any, actionUid?: string) {
+  getPopupSettings(action: any, actionUid?: string, options: GanttPopupActionOptions = {}) {
     const defaults = this.getPopupSettingsDefaults(action?.uid || actionUid);
-    const currentParams = this.getStoredPopupSettings();
-
-    return {
+    const actionParams = this.getPopupActionSettings(action);
+    const currentParams = Object.keys(actionParams).length > 0 ? actionParams : this.getStoredPopupSettings();
+    const popupSettings = {
       ...defaults,
       ...currentParams,
       uid: currentParams.uid || defaults.uid,
       collectionName: currentParams.collectionName || defaults.collectionName,
       dataSourceKey: currentParams.dataSourceKey || defaults.dataSourceKey,
     };
+
+    if (options.preserveActionTemplate === false) {
+      return popupSettings;
+    }
+
+    return this.mergePopupTemplateSettings(popupSettings, action?.getStepParams?.('popupSettings', 'openView'));
   }
 
   async syncPopupActionSettings(action: any, options: GanttPopupActionOptions = {}) {
@@ -433,17 +515,37 @@ export class GanttBlockModel extends TableBlockModel {
       return;
     }
 
-    const nextSettings = this.getPopupSettings(action, action?.uid);
-    const currentParams = action.getStepParams?.('popupSettings', 'openView') || {};
+    const nextSettings = this.getPopupSettings(action, action?.uid, options);
+    const currentParams = this.getPopupActionSettings(action);
     if (JSON.stringify(currentParams) === JSON.stringify(nextSettings)) {
       return;
     }
 
-    action.setStepParams('popupSettings', 'openView', nextSettings);
+    await this.setPopupActionSettings(action, nextSettings, options);
+  }
+
+  async setPopupActionSettings(
+    action: any,
+    popupSettings?: Record<string, any>,
+    options: GanttPopupActionOptions = {},
+  ) {
+    if (!action) {
+      return {};
+    }
+
+    const nextSettings = this.normalizePopupSettings(popupSettings);
+    action.setStepParams('popupSettings', {
+      openView: nextSettings,
+    });
 
     if (options.persist && this.context.flowSettingsEnabled && action?.saveStepParams) {
+      if (action?.save) {
+        await action.save();
+      }
       await action.saveStepParams();
     }
+
+    return nextSettings;
   }
 
   async loadPopupAction(actionKey: 'eventViewAction') {
@@ -469,10 +571,6 @@ export class GanttBlockModel extends TableBlockModel {
       action = (this.subModels as GanttBlockStructure['subModels'])?.[actionKey] as any;
     }
 
-    if (options.persist && this.context.flowSettingsEnabled && action?.save) {
-      await action.save();
-    }
-
     await this.syncPopupActionSettings(action, options);
 
     return action;
@@ -494,11 +592,6 @@ export class GanttBlockModel extends TableBlockModel {
       filterByTk,
       target: this.context?.layoutContentElement,
     };
-
-    if (typeof this.context?.openView === 'function' && action.uid) {
-      await this.context.openView(action.uid, inputArgs);
-      return;
-    }
 
     await action.dispatchEvent('click', inputArgs, { debounce: true });
   }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The V2 Gantt task popup settings could not correctly apply or clear popup templates because task clicks bypassed the standard openView action flow, and popup settings were split between the Gantt block and the hidden popup action.

### Description 
This PR updates the Gantt V2 task popup flow to use the hidden popup action as the single source of openView settings.

Key changes:
- Dispatch task clicks through the hidden popup action so standard openView handling runs.
- Save task popup settings to the hidden action's `popupSettings.openView`.
- Replace hidden action openView params on save to avoid stale popup template fields after clearing templates.
- Keep legacy Gantt block popup settings as a compatibility fallback.
- Add regression tests for popup template save, clear, and hidden action behavior.

Potential risks:
- Existing Gantt blocks with legacy popup settings rely on the compatibility fallback during migration.
- The task popup settings now persist primarily on the hidden popup action.

Testing suggestions:
- Configure a popup template in Gantt task popup settings, save, and click a task.
- Clear the popup template, save, reopen settings, and verify the template remains cleared.
- Click a task after clearing the template and verify the default task popup opens.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Gantt task popup template settings not applying or clearing correctly. |
| 🇨🇳 Chinese | 修复甘特图任务弹窗模板设置无法正确生效或清空的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
