### PR TITLE
fix(auth): filter hidden fields from auth check

### DIFF
--- a/packages/core/auth/src/actions.ts
+++ b/packages/core/auth/src/actions.ts
@@ -10,6 +10,26 @@
 /* istanbul ignore file -- @preserve */
 import { Handlers } from '@nocobase/resourcer';
 
+function filterHiddenFields(ctx, user) {
+  if (!user) {
+    return {};
+  }
+
+  const data = typeof user.toJSON === 'function' ? user.toJSON() : { ...user };
+  const collection = ctx.db?.getCollection?.('users');
+  if (!collection) {
+    return data;
+  }
+
+  for (const field of collection.fields.values()) {
+    if (field.options.hidden) {
+      delete data[field.options.name];
+    }
+  }
+
+  return data;
+}
+
 export const actions = {
   signIn: async (ctx, next) => {
     ctx.body = await ctx.auth.signIn();
@@ -25,7 +45,7 @@ export const actions = {
     await next();
   },
   check: async (ctx, next) => {
-    ctx.body = ctx.auth.user || {};
+    ctx.body = filterHiddenFields(ctx, ctx.auth.user);
     await next();
   },
 } as Handlers;

--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts
@@ -162,6 +162,7 @@ describe('actions', () => {
 
       res = await agent.get('/auth:check').set({ Authorization: `Bearer ${token}`, 'X-Authenticator': 'basic' });
       expect(res.body.data.id).toBeDefined();
+      expect(res.body.data.password).toBeUndefined();
     });
 
     it('should disable sign up', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Encrypted password data should not be exposed with current user information.

### Description 
Filters hidden user fields before returning current user information from authentication checks. This keeps model instances on the existing `toJSON()` path and also handles plain objects loaded from auth cache.

Tested with:
- `yarn test packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts`
- `yarn eslint --fix packages/core/auth/src/actions.ts packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Encrypted password data is no longer included in sign-in status responses |
| 🇨🇳 Chinese | 登录状态响应不再包含加密密码数据 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
