### PR TITLE
feat(plugin-user-data-sync): add client v2 support

### DIFF
--- a/packages/plugins/@nocobase/plugin-user-data-sync/client-v2.d.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/client-v2.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/client-v2';
+export { default } from './dist/client-v2';

--- a/packages/plugins/@nocobase/plugin-user-data-sync/client-v2.js
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/client-v2.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/client-v2/index.js');

--- a/packages/plugins/@nocobase/plugin-user-data-sync/package.json
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/package.json
@@ -10,6 +10,7 @@
   "main": "dist/server/index.js",
   "peerDependencies": {
     "@nocobase/client": "2.x",
+    "@nocobase/client-v2": "2.x",
     "@nocobase/server": "2.x",
     "@nocobase/test": "2.x"
   },

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/__tests__/sourceRequests.test.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/__tests__/sourceRequests.test.ts
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { deleteSourceRecord, saveSourceRecord, type SourceResource } from '../pages/sourceRequests';
+
+describe('user-data-sync client-v2 source requests', () => {
+  it('fires resource.create on submit in create mode', async () => {
+    const resource: SourceResource = {
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await saveSourceRecord({
+      mode: 'create',
+      resource,
+      values: { name: 'wecom', sourceType: 'wecom', options: { corpId: 'corp' } },
+    });
+
+    expect(resource.create).toHaveBeenCalledWith({
+      values: { name: 'wecom', sourceType: 'wecom', options: { corpId: 'corp' } },
+    });
+    expect(resource.update).not.toHaveBeenCalled();
+  });
+
+  it('fires resource.update with the correct filterByTk on submit in edit mode', async () => {
+    const resource: SourceResource = {
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await saveSourceRecord({
+      mode: 'edit',
+      resource,
+      record: { id: 12, name: 'wecom', sourceType: 'wecom', options: { corpId: 'old', token: 'keep' } },
+      values: { name: 'wecom', sourceType: 'wecom', options: { corpId: 'new' } },
+    });
+
+    expect(resource.update).toHaveBeenCalledWith({
+      filterByTk: 12,
+      values: {
+        id: 12,
+        name: 'wecom',
+        sourceType: 'wecom',
+        options: { corpId: 'new', token: 'keep' },
+      },
+    });
+    expect(resource.create).not.toHaveBeenCalled();
+  });
+
+  it('fires resource.destroy on row-level delete', async () => {
+    const resource: SourceResource = {
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await deleteSourceRecord(resource, { id: 12, name: 'wecom' });
+
+    expect(resource.destroy).toHaveBeenCalledWith({ filterByTk: 12 });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export { default } from './plugin';
+export { PluginUserDataSyncClientV2 } from './plugin';
+export type { SourceOptions, SourceAdminSettingsFormProps, SourceAdminSettingsFormLoader } from './types';

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/locale.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/locale.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowEngine } from '@nocobase/flow-engine';
+import { useTranslation } from 'react-i18next';
+
+export const NAMESPACE = 'user-data-sync';
+
+export function useUserDataSyncSourceTranslation() {
+  return useTranslation([NAMESPACE, 'client'], { nsMode: 'fallback' });
+}
+
+export function useT() {
+  const engine = useFlowEngine();
+  return (key: string) => engine.context.t(key, { ns: [NAMESPACE, 'client'], nsMode: 'fallback' });
+}

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/UserDataSyncSourcePage.tsx
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/UserDataSyncSourcePage.tsx
@@ -1,0 +1,428 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { DeleteOutlined, DownOutlined, PlusOutlined } from '@ant-design/icons';
+import { DrawerFormLayout, Table, DEFAULT_PAGE_SIZE } from '@nocobase/client-v2';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { useRequest } from 'ahooks';
+import {
+  App,
+  Button,
+  Card,
+  Checkbox,
+  Dropdown,
+  Empty,
+  Flex,
+  Form,
+  Input,
+  Popconfirm,
+  Select,
+  Space,
+  Spin,
+  Tag,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import React, { lazy, Suspense, useMemo, useState } from 'react';
+import { useT, useUserDataSyncSourceTranslation } from '../locale';
+import PluginUserDataSyncClientV2 from '../plugin';
+import type { SourceAdminSettingsFormLoader } from '../types';
+import {
+  deleteSourceRecord,
+  saveSourceRecord,
+  type SourceFormValues,
+  type SourceRecord,
+  type SourceResource,
+} from './sourceRequests';
+
+type SyncType = {
+  name: string;
+  title?: string;
+};
+
+type ListResult = {
+  records: SourceRecord[];
+  total: number;
+};
+
+type TaskRecord = {
+  id: number | string;
+  batch?: string;
+  status?: string;
+  message?: string;
+  sourceId?: number | string;
+};
+
+function normalizeListResponse(response: unknown): ListResult {
+  const body = (response as { data?: { data?: unknown; meta?: { count?: number; total?: number } } })?.data;
+  const payload = body?.data;
+  const records = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as { data?: unknown })?.data)
+      ? (payload as { data: SourceRecord[] }).data
+      : [];
+  const meta = body?.meta || (payload as { meta?: { count?: number; total?: number } })?.meta || {};
+  return {
+    records,
+    total: meta.count || meta.total || records.length,
+  };
+}
+
+function useSourceResource() {
+  const ctx = useFlowContext();
+  return ctx.api.resource('userDataSyncSources');
+}
+
+function DynamicOptions(props: { loader?: SourceAdminSettingsFormLoader }) {
+  const Body = useMemo(() => (props.loader ? lazy(props.loader) : null), [props.loader]);
+
+  if (!Body) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={<Spin />}>
+      <Body />
+    </Suspense>
+  );
+}
+
+function SourceForm(props: {
+  mode: 'create' | 'edit';
+  record?: SourceRecord;
+  sourceType: string;
+  sourceTypes: { label: string; value: string }[];
+  onSubmitted: () => void;
+}) {
+  const { t } = useUserDataSyncSourceTranslation();
+  const ctx = useFlowContext();
+  const plugin = ctx.app.pm.get(PluginUserDataSyncClientV2);
+  const resource = useSourceResource();
+  const [form] = Form.useForm<SourceFormValues>();
+  const [submitting, setSubmitting] = useState(false);
+  const currentSourceType = Form.useWatch('sourceType', form) || props.sourceType || props.record?.sourceType;
+  const loader = currentSourceType
+    ? plugin?.sourceTypes.get(currentSourceType)?.components?.AdminSettingsFormLoader
+    : undefined;
+
+  const initialValues = useMemo<SourceFormValues>(
+    () =>
+      props.mode === 'edit'
+        ? {
+            name: props.record?.name,
+            sourceType: props.record?.sourceType,
+            enabled: props.record?.enabled,
+            options: props.record?.options || {},
+          }
+        : {
+            sourceType: props.sourceType,
+            enabled: false,
+            options: {},
+          },
+    [props.mode, props.record, props.sourceType],
+  );
+
+  const handleSourceTypeChange = () => {
+    form.setFieldValue('options', {});
+  };
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      await saveSourceRecord({
+        mode: props.mode,
+        resource: resource as unknown as SourceResource,
+        values,
+        record: props.record,
+      });
+      props.onSubmitted();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <DrawerFormLayout
+      title={props.mode === 'create' ? t('Add new') : t('Configure')}
+      submitText={t('Submit')}
+      cancelText={t('Cancel')}
+      submitting={submitting}
+      onSubmit={handleSubmit}
+    >
+      <Form form={form} layout="vertical" initialValues={initialValues}>
+        <Form.Item
+          name="name"
+          label={t('Source name')}
+          rules={[{ required: true, message: t('The field value is required') }]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
+          name="sourceType"
+          label={t('Type')}
+          rules={[{ required: true, message: t('The field value is required') }]}
+        >
+          <Select options={props.sourceTypes} onChange={handleSourceTypeChange} disabled={props.mode === 'edit'} />
+        </Form.Item>
+        <Form.Item name="enabled" label={t('Enabled')} valuePropName="checked">
+          <Checkbox />
+        </Form.Item>
+        <DynamicOptions loader={loader} />
+      </Form>
+    </DrawerFormLayout>
+  );
+}
+
+function TasksDrawer(props: { source: SourceRecord }) {
+  const { t } = useUserDataSyncSourceTranslation();
+  const ctx = useFlowContext();
+  const { message } = App.useApp();
+  const { data, loading, refresh } = useRequest(async () => {
+    const response = await ctx.api.resource('userDataSyncTasks').list({
+      pageSize: DEFAULT_PAGE_SIZE,
+      filter: { sourceId: props.source.id },
+      sort: ['-sort'],
+    });
+    const list = normalizeListResponse(response);
+    return {
+      records: list.records as TaskRecord[],
+      total: list.total,
+    };
+  });
+
+  const retry = async (record: TaskRecord) => {
+    await ctx.api.resource('userData').retry({ id: record.id, sourceId: record.sourceId });
+    await refresh();
+    message.success(t('Retry'));
+  };
+
+  const columns: ColumnsType<TaskRecord> = [
+    { dataIndex: 'batch', title: t('Batch') },
+    {
+      dataIndex: 'status',
+      title: t('Status'),
+      render: (value: string) => <Tag>{t(value || '')}</Tag>,
+    },
+    {
+      dataIndex: 'message',
+      title: t('Message'),
+      render: (value: string) => t(value || ''),
+    },
+    {
+      key: 'actions',
+      title: t('Actions'),
+      render: (_, record) =>
+        record.status === 'failed' ? (
+          <Button type="link" onClick={() => retry(record)}>
+            {t('Retry')}
+          </Button>
+        ) : null,
+    },
+  ];
+
+  return (
+    <Table<TaskRecord>
+      rowKey="id"
+      loading={loading}
+      columns={columns}
+      dataSource={data?.records || []}
+      pagination={false}
+      showIndex
+    />
+  );
+}
+
+export default function UserDataSyncSourcePage() {
+  const { t } = useUserDataSyncSourceTranslation();
+  const compileT = useT();
+  const ctx = useFlowContext();
+  const { message } = App.useApp();
+  const resource = useSourceResource();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
+  const { data: syncTypes } = useRequest(async () => {
+    const response = await ctx.api.resource('userData').listSyncTypes();
+    const payload = (response as { data?: { data?: SyncType[] } })?.data?.data || [];
+    return payload.map((type) => ({
+      label: compileT(type.title || type.name),
+      value: type.name,
+    }));
+  });
+  const { data, loading, refresh } = useRequest(
+    async () => {
+      const response = await resource.list({
+        page,
+        pageSize,
+        sort: ['sort'],
+      });
+      return normalizeListResponse(response);
+    },
+    {
+      refreshDeps: [page, pageSize],
+    },
+  );
+
+  const sourceTypes = syncTypes || [];
+
+  const openForm = (mode: 'create' | 'edit', sourceType: string, record?: SourceRecord) => {
+    ctx.viewer.drawer({
+      closable: true,
+      size: 'large',
+      content: () => (
+        <SourceForm
+          mode={mode}
+          sourceType={sourceType}
+          sourceTypes={sourceTypes}
+          record={record}
+          onSubmitted={refresh}
+        />
+      ),
+    });
+  };
+
+  const openTasks = (record: SourceRecord) => {
+    ctx.viewer.drawer({
+      title: t('Tasks'),
+      closable: true,
+      content: () => <TasksDrawer source={record} />,
+    });
+  };
+
+  const handleDelete = async (record: SourceRecord) => {
+    await deleteSourceRecord(resource as unknown as SourceResource, record);
+    setSelectedRowKeys((keys) => keys.filter((key) => key !== record.id));
+    await refresh();
+  };
+
+  const handleBulkDelete = async () => {
+    const selectedRecords = (data?.records || []).filter((record) => selectedRowKeys.includes(record.id));
+    for (const record of selectedRecords) {
+      await deleteSourceRecord(resource as unknown as SourceResource, record);
+    }
+    setSelectedRowKeys([]);
+    await refresh();
+  };
+
+  const handleSync = async (record: SourceRecord) => {
+    await ctx.api.resource('userData').pull({ name: record.name });
+    await refresh();
+    message.success(t("The synchronization has started. You can click on 'Tasks' to view the synchronization status."));
+  };
+
+  const createItems =
+    sourceTypes.length > 0
+      ? sourceTypes.map((type) => ({
+          key: type.value,
+          label: type.label,
+          onClick: () => openForm('create', type.value),
+        }))
+      : [
+          {
+            key: '__empty__',
+            label: (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('No user data source plugin installed')} />
+            ),
+          },
+        ];
+
+  const columns: ColumnsType<SourceRecord> = [
+    { dataIndex: 'name', title: t('Source name') },
+    {
+      dataIndex: 'sourceType',
+      title: t('Type'),
+      render: (value: string) => sourceTypes.find((type) => type.value === value)?.label || value,
+    },
+    {
+      dataIndex: 'enabled',
+      title: t('Enabled'),
+      render: (value: boolean) => <Checkbox checked={value} disabled />,
+    },
+    {
+      key: 'actions',
+      title: t('Actions'),
+      render: (_, record) => (
+        <Space split="|">
+          {record.enabled ? (
+            <Button type="link" onClick={() => handleSync(record)}>
+              {t('Sync')}
+            </Button>
+          ) : null}
+          {record.enabled ? (
+            <Button type="link" onClick={() => openTasks(record)}>
+              {t('Tasks')}
+            </Button>
+          ) : null}
+          <Button type="link" onClick={() => openForm('edit', record.sourceType || '', record)}>
+            {t('Configure')}
+          </Button>
+          <Popconfirm
+            title={t('Delete')}
+            description={t('Are you sure you want to delete it?')}
+            onConfirm={() => handleDelete(record)}
+          >
+            <Button type="link" danger>
+              {t('Delete')}
+            </Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  const handlePaginationChange = (nextPage: number, nextPageSize: number) => {
+    if (nextPageSize !== pageSize) {
+      setPageSize(nextPageSize);
+      setPage(1);
+      return;
+    }
+    setPage(nextPage);
+  };
+
+  return (
+    <Card>
+      <Flex vertical gap="middle">
+        <Flex justify="flex-end" gap="small">
+          <Popconfirm
+            title={t('Delete')}
+            description={t('Are you sure you want to delete it?')}
+            onConfirm={handleBulkDelete}
+          >
+            <Button icon={<DeleteOutlined />} disabled={selectedRowKeys.length === 0}>
+              {t('Delete')}
+            </Button>
+          </Popconfirm>
+          <Dropdown menu={{ items: createItems }}>
+            <Button icon={<PlusOutlined />} type="primary">
+              {t('Add new')} <DownOutlined />
+            </Button>
+          </Dropdown>
+        </Flex>
+        <Table<SourceRecord>
+          rowKey="id"
+          loading={loading}
+          columns={columns}
+          dataSource={data?.records || []}
+          showIndex
+          rowSelection={{
+            type: 'checkbox',
+            selectedRowKeys,
+            onChange: setSelectedRowKeys,
+          }}
+          pagination={{
+            current: page,
+            pageSize,
+            total: data?.total || 0,
+            onChange: handlePaginationChange,
+          }}
+        />
+      </Flex>
+    </Card>
+  );
+}

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/UserDataSyncSourcePage.tsx
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/UserDataSyncSourcePage.tsx
@@ -58,6 +58,13 @@ type TaskRecord = {
   sourceId?: number | string;
 };
 
+const TASK_STATUS_OPTIONS = [
+  { label: '{{t("Init")}}', value: 'init', color: 'default' },
+  { label: '{{t("Processing")}}', value: 'processing', color: 'processing' },
+  { label: '{{t("Success")}}', value: 'success', color: 'success' },
+  { label: '{{t("Failed")}}', value: 'failed', color: 'error' },
+];
+
 function normalizeListResponse(response: unknown): ListResult {
   const body = (response as { data?: { data?: unknown; meta?: { count?: number; total?: number } } })?.data;
   const payload = body?.data;
@@ -181,6 +188,7 @@ function SourceForm(props: {
 
 function TasksDrawer(props: { source: SourceRecord }) {
   const { t } = useUserDataSyncSourceTranslation();
+  const compileT = useT();
   const ctx = useFlowContext();
   const { message } = App.useApp();
   const { data, loading, refresh } = useRequest(async () => {
@@ -207,7 +215,10 @@ function TasksDrawer(props: { source: SourceRecord }) {
     {
       dataIndex: 'status',
       title: t('Status'),
-      render: (value: string) => <Tag>{t(value || '')}</Tag>,
+      render: (value: string) => {
+        const option = TASK_STATUS_OPTIONS.find((item) => item.value === value);
+        return <Tag color={option?.color}>{option ? compileT(option.label) : t(value || '')}</Tag>;
+      },
     },
     {
       dataIndex: 'message',
@@ -217,12 +228,8 @@ function TasksDrawer(props: { source: SourceRecord }) {
     {
       key: 'actions',
       title: t('Actions'),
-      render: (_, record) =>
-        record.status === 'failed' ? (
-          <Button type="link" onClick={() => retry(record)}>
-            {t('Retry')}
-          </Button>
-        ) : null,
+      width: 80,
+      render: (_, record) => (record.status === 'failed' ? <a onClick={() => retry(record)}>{t('Retry')}</a> : null),
     },
   ];
 
@@ -291,6 +298,7 @@ export default function UserDataSyncSourcePage() {
     ctx.viewer.drawer({
       title: t('Tasks'),
       closable: true,
+      size: 'large',
       content: () => <TasksDrawer source={record} />,
     });
   };
@@ -347,29 +355,18 @@ export default function UserDataSyncSourcePage() {
     {
       key: 'actions',
       title: t('Actions'),
+      width: 240,
       render: (_, record) => (
         <Space split="|">
-          {record.enabled ? (
-            <Button type="link" onClick={() => handleSync(record)}>
-              {t('Sync')}
-            </Button>
-          ) : null}
-          {record.enabled ? (
-            <Button type="link" onClick={() => openTasks(record)}>
-              {t('Tasks')}
-            </Button>
-          ) : null}
-          <Button type="link" onClick={() => openForm('edit', record.sourceType || '', record)}>
-            {t('Configure')}
-          </Button>
+          {record.enabled ? <a onClick={() => handleSync(record)}>{t('Sync')}</a> : null}
+          {record.enabled ? <a onClick={() => openTasks(record)}>{t('Tasks')}</a> : null}
+          <a onClick={() => openForm('edit', record.sourceType || '', record)}>{t('Configure')}</a>
           <Popconfirm
             title={t('Delete')}
             description={t('Are you sure you want to delete it?')}
             onConfirm={() => handleDelete(record)}
           >
-            <Button type="link" danger>
-              {t('Delete')}
-            </Button>
+            <a>{t('Delete')}</a>
           </Popconfirm>
         </Space>
       ),

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/UserDataSyncSourcePage.tsx
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/UserDataSyncSourcePage.tsx
@@ -21,11 +21,13 @@ import {
   Flex,
   Form,
   Input,
+  Popover,
   Popconfirm,
   Select,
   Space,
   Spin,
   Tag,
+  theme,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import React, { lazy, Suspense, useMemo, useState } from 'react';
@@ -64,6 +66,76 @@ const TASK_STATUS_OPTIONS = [
   { label: '{{t("Success")}}', value: 'success', color: 'success' },
   { label: '{{t("Failed")}}', value: 'failed', color: 'error' },
 ];
+
+const containedTableComponents = {
+  table: (props: React.HTMLAttributes<HTMLTableElement>) =>
+    React.createElement('table', {
+      ...props,
+      style: {
+        ...props.style,
+        width: '100%',
+      },
+    }),
+};
+
+function getContentWidth(element: HTMLElement | null) {
+  if (!element) {
+    return 0;
+  }
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  return range.getBoundingClientRect().width;
+}
+
+function EllipsisMessage(props: { value: string }) {
+  const { token } = theme.useToken();
+  const [overflow, setOverflow] = useState(false);
+  const [open, setOpen] = useState(false);
+  const elementRef = React.useRef<HTMLDivElement>(null);
+  const ellipsisStyle = useMemo<React.CSSProperties>(
+    () => ({
+      overflow: 'hidden',
+      overflowWrap: 'break-word',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      wordBreak: 'break-all',
+    }),
+    [],
+  );
+  const popoverStyle = useMemo<React.CSSProperties>(
+    () => ({
+      width: token.sizeXXL * 6,
+      overflow: 'auto',
+      maxHeight: token.sizeXXL * 8,
+    }),
+    [token.sizeXXL],
+  );
+
+  const handleMouseEnter = () => {
+    const element = elementRef.current;
+    setOverflow(Boolean(element && getContentWidth(element) > element.offsetWidth));
+  };
+
+  const content = (
+    <div ref={elementRef} style={ellipsisStyle} onMouseEnter={handleMouseEnter}>
+      {props.value}
+    </div>
+  );
+
+  if (!overflow) {
+    return content;
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => setOpen(overflow && nextOpen)}
+      content={<div style={popoverStyle}>{props.value}</div>}
+    >
+      {content}
+    </Popover>
+  );
+}
 
 function normalizeListResponse(response: unknown): ListResult {
   const body = (response as { data?: { data?: unknown; meta?: { count?: number; total?: number } } })?.data;
@@ -190,6 +262,7 @@ function TasksDrawer(props: { source: SourceRecord }) {
   const { t } = useUserDataSyncSourceTranslation();
   const compileT = useT();
   const ctx = useFlowContext();
+  const { token } = theme.useToken();
   const { message } = App.useApp();
   const { data, loading, refresh } = useRequest(async () => {
     const response = await ctx.api.resource('userDataSyncTasks').list({
@@ -211,10 +284,11 @@ function TasksDrawer(props: { source: SourceRecord }) {
   };
 
   const columns: ColumnsType<TaskRecord> = [
-    { dataIndex: 'batch', title: t('Batch') },
+    { dataIndex: 'batch', title: t('Batch'), width: token.sizeXXL * 4 },
     {
       dataIndex: 'status',
       title: t('Status'),
+      width: token.sizeXXL * 3,
       render: (value: string) => {
         const option = TASK_STATUS_OPTIONS.find((item) => item.value === value);
         return <Tag color={option?.color}>{option ? compileT(option.label) : t(value || '')}</Tag>;
@@ -223,12 +297,16 @@ function TasksDrawer(props: { source: SourceRecord }) {
     {
       dataIndex: 'message',
       title: t('Message'),
-      render: (value: string) => t(value || ''),
+      ellipsis: true,
+      render: (value: string) => {
+        const text = t(value || '');
+        return <EllipsisMessage value={text} />;
+      },
     },
     {
       key: 'actions',
       title: t('Actions'),
-      width: 80,
+      width: token.sizeXXL * 2,
       render: (_, record) => (record.status === 'failed' ? <a onClick={() => retry(record)}>{t('Retry')}</a> : null),
     },
   ];
@@ -241,6 +319,8 @@ function TasksDrawer(props: { source: SourceRecord }) {
       dataSource={data?.records || []}
       pagination={false}
       showIndex
+      tableLayout="fixed"
+      components={containedTableComponents}
     />
   );
 }
@@ -249,6 +329,7 @@ export default function UserDataSyncSourcePage() {
   const { t } = useUserDataSyncSourceTranslation();
   const compileT = useT();
   const ctx = useFlowContext();
+  const { token } = theme.useToken();
   const { message } = App.useApp();
   const resource = useSourceResource();
   const [page, setPage] = useState(1);
@@ -357,7 +438,7 @@ export default function UserDataSyncSourcePage() {
       title: t('Actions'),
       width: 240,
       render: (_, record) => (
-        <Space split="|">
+        <Space size={token.marginSM}>
           {record.enabled ? <a onClick={() => handleSync(record)}>{t('Sync')}</a> : null}
           {record.enabled ? <a onClick={() => openTasks(record)}>{t('Tasks')}</a> : null}
           <a onClick={() => openForm('edit', record.sourceType || '', record)}>{t('Configure')}</a>

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/sourceRequests.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/pages/sourceRequests.ts
@@ -1,0 +1,67 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export type SourceRecord = {
+  id: number | string;
+  name?: string;
+  sourceType?: string;
+  enabled?: boolean;
+  options?: Record<string, unknown>;
+};
+
+export type SourceFormValues = {
+  name?: string;
+  sourceType?: string;
+  enabled?: boolean;
+  options?: Record<string, unknown>;
+};
+
+export type SourceResource = {
+  create(params: { values: SourceFormValues }): Promise<unknown>;
+  update(params: { filterByTk: SourceRecord['id']; values: SourceFormValues }): Promise<unknown>;
+  destroy(params: { filterByTk: SourceRecord['id'] }): Promise<unknown>;
+};
+
+export async function saveSourceRecord(params: {
+  mode: 'create' | 'edit';
+  resource: SourceResource;
+  values: SourceFormValues;
+  record?: SourceRecord;
+}) {
+  const { mode, resource, values, record } = params;
+
+  if (mode === 'create') {
+    await resource.create({ values });
+    return;
+  }
+
+  if (record?.id == null) {
+    throw new Error('Edit mode requires record.id');
+  }
+
+  await resource.update({
+    filterByTk: record.id,
+    values: {
+      ...record,
+      ...values,
+      options: {
+        ...(record.options || {}),
+        ...(values.options || {}),
+      },
+    },
+  });
+}
+
+export async function deleteSourceRecord(resource: SourceResource, record: SourceRecord) {
+  if (record.id == null) {
+    throw new Error('Delete requires record.id');
+  }
+
+  await resource.destroy({ filterByTk: record.id });
+}

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/plugin.tsx
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Plugin } from '@nocobase/client-v2';
+import type { Application } from '@nocobase/client-v2';
+import { Registry } from '@nocobase/utils/client';
+import type { SourceOptions } from './types';
+
+export class PluginUserDataSyncClientV2 extends Plugin<Record<string, never>, Application> {
+  sourceTypes = new Registry<SourceOptions>();
+
+  registerType(sourceType: string, options: SourceOptions) {
+    this.sourceTypes.register(sourceType, options);
+  }
+
+  async load() {
+    this.flowEngine.context.defineProperty('userDataSyncSourceTypes', {
+      get: () => this.sourceTypes,
+    });
+
+    this.pluginSettingsManager.addPageTabItem({
+      menuKey: 'users-permissions',
+      key: 'sync',
+      title: this.t('Synchronize'),
+      icon: 'SyncOutlined',
+      sort: 99,
+      aclSnippet: 'pm.user-data-sync',
+      componentLoader: () => import('./pages/UserDataSyncSourcePage'),
+    });
+  }
+}
+
+export default PluginUserDataSyncClientV2;

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/types.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/client-v2/types.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { ComponentType } from 'react';
+
+export type SourceAdminSettingsFormProps = Record<string, never>;
+
+export type SourceAdminSettingsFormLoader = () => Promise<{
+  default: ComponentType<SourceAdminSettingsFormProps>;
+}>;
+
+export type SourceOptions = {
+  components?: {
+    AdminSettingsFormLoader?: SourceAdminSettingsFormLoader;
+  };
+};


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Support the modern client runtime for the user data synchronization settings page.

### Description 

Adds a `client-v2` entry and FlowEngine-based settings page for user data synchronization. The page keeps the existing source management workflow, including source creation, editing, synchronization actions, task viewing, deletion, and request-layer coverage for create/update/delete behavior.

### Related issues

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added modern UI support for user data synchronization settings |
| 🇨🇳 Chinese | 新增用户数据同步设置的新版界面支持 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
