### PR TITLE
fix(build): ignore unrelated currentScript when inferring plugin public path

### DIFF
--- a/packages/core/app/client/src/__tests__/runtimePublicPath.test.ts
+++ b/packages/core/app/client/src/__tests__/runtimePublicPath.test.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { resolveRuntimeAssetPublicPath } from '../runtimePublicPath';
+
+describe('resolveRuntimeAssetPublicPath', () => {
+  it('should prefer the injected window public path over an auto-detected runtime path', () => {
+    expect(resolveRuntimeAssetPublicPath('/dist/2.1.8/', 'https://static.cloudflareinsights.com/assets/../')).toBe(
+      '/dist/2.1.8/',
+    );
+  });
+
+  it('should fall back to the runtime public path when the injected value is missing', () => {
+    expect(resolveRuntimeAssetPublicPath(undefined, 'https://cdn.nocobase.com/dist/2.1.8/')).toBe(
+      'https://cdn.nocobase.com/dist/2.1.8/',
+    );
+  });
+});

--- a/packages/core/app/client/src/main.tsx
+++ b/packages/core/app/client/src/main.tsx
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import './runtimePublicPath';
 import { app } from './pages/index';
 
 app.mount('#root');

--- a/packages/core/app/client/src/runtimePublicPath.ts
+++ b/packages/core/app/client/src/runtimePublicPath.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+declare global {
+  interface Window {
+    __webpack_public_path__?: string;
+  }
+}
+
+function normalizePublicPath(value: string | undefined, fallback = '/') {
+  let normalized = value?.trim() || fallback;
+  if (!normalized.endsWith('/')) {
+    normalized = `${normalized}/`;
+  }
+  return normalized;
+}
+
+export function resolveRuntimeAssetPublicPath(
+  windowPublicPath: string | undefined,
+  runtimePublicPath: string | undefined,
+) {
+  return normalizePublicPath(windowPublicPath, normalizePublicPath(runtimePublicPath, '/'));
+}
+
+// `__webpack_public_path__` is a webpack magic global that must be assigned
+// before any lazy-loaded chunk request happens.
+declare let __webpack_public_path__: string;
+
+const runtimePublicPath = typeof __webpack_public_path__ === 'string' ? __webpack_public_path__ : undefined;
+
+if (typeof window !== 'undefined' && typeof __webpack_public_path__ !== 'undefined') {
+  // eslint-disable-next-line prefer-const
+  __webpack_public_path__ = resolveRuntimeAssetPublicPath(window.__webpack_public_path__, runtimePublicPath);
+}

--- a/packages/core/build/src/injectPublicPathPlugin.ts
+++ b/packages/core/build/src/injectPublicPathPlugin.ts
@@ -12,11 +12,14 @@ function createPluginClientPublicPathDataUri(packageName: string, clientDistDir:
 var publicPath = '';
 var currentScript = typeof document !== 'undefined' ? document.currentScript : null;
 if (currentScript && currentScript.src) {
-  publicPath = currentScript.src
+  var currentScriptSrc = currentScript.src
     .replace(/^blob:/, '')
     .replace(/#.*$/, '')
-    .replace(/\\?.*$/, '')
-    .replace(/\\/[^\\/]+$/, '/');
+    .replace(/\\?.*$/, '');
+  var expectedPluginPath = '/static/plugins/${packageName}/dist/${clientDistDir}/';
+  if (currentScriptSrc.indexOf(expectedPluginPath) >= 0) {
+    publicPath = currentScriptSrc.replace(/\\/[^\\/]+$/, '/');
+  }
 }
 if (!publicPath) {
   var runtimeAssetBase = window['__webpack_public_path__'] || '';

--- a/packages/core/test/src/__tests__/build/injectPublicPathPlugin.test.ts
+++ b/packages/core/test/src/__tests__/build/injectPublicPathPlugin.test.ts
@@ -95,4 +95,25 @@ describe('AutoInjectPublicPathPlugin', () => {
       'https://cdn.nocobase.com/2.1.0-alpha.13.20260327061223/static/plugins/@nocobase/plugin-auth/dist/client/',
     );
   });
+
+  it('should ignore unrelated currentScript src values and fall back to runtime asset base', () => {
+    const script = createInjectedScript('@nocobase/plugin-auth');
+    const run = new Function(
+      'window',
+      'document',
+      `let __webpack_public_path__ = ''; ${script}; return __webpack_public_path__;`,
+    );
+
+    const result = run(
+      {
+        __webpack_public_path__: 'https://example.com/v/',
+      },
+      {
+        currentScript: {
+          src: 'https://static.example.com/beacon.min.js',
+        },
+      },
+    );
+
+    expect(result).toBe('https://example.com/v/static/plugins/@nocobase/plugin-auth/dist/client/');
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Ignore unrelated currentScript when inferring plugin public path |
| 🇨🇳 Chinese |   避免在推断插件 public path 时使用无关的 currentScript  |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
