### PR TITLE
chore: add block context when add ai employee through buid api

### DIFF
--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/flow-surfaces.ai-employee.contract.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/flow-surfaces.ai-employee.contract.test.ts
@@ -146,6 +146,22 @@ describe('flowSurfaces AI employee action contract', () => {
     );
   }
 
+  function withoutAIEmployeeWorkContext(settings: Record<string, any>) {
+    const next = _.cloneDeep(settings);
+    delete next.workContext;
+    return withoutAIEmployeeTaskWorkContext(next);
+  }
+
+  function withoutAIEmployeeTaskWorkContext(settings: Record<string, any>) {
+    const next = _.cloneDeep(settings);
+    _.castArray(next.tasks || []).forEach((task: any) => {
+      if (_.isPlainObject(task?.message)) {
+        delete task.message.workContext;
+      }
+    });
+    return next;
+  }
+
   async function createTable() {
     const page = await createPage(rootAgent, {
       title: `AI employee action page ${Date.now()}`,
@@ -179,6 +195,37 @@ describe('flowSurfaces AI employee action contract', () => {
 
   function getPersistedTasks(action: any) {
     return _.get(action, ['stepParams', 'shortcutSettings', 'editTasks', 'tasks']);
+  }
+
+  async function patchStepTaskWorkContext(actionUid: string, workContext: 'omitted' | any) {
+    const persisted = await readAction(actionUid);
+    const legacyStepParams = _.cloneDeep(persisted.stepParams);
+    if (workContext === 'omitted') {
+      delete legacyStepParams.shortcutSettings.editTasks.tasks[0].message.workContext;
+    } else {
+      legacyStepParams.shortcutSettings.editTasks.tasks[0].message.workContext = workContext;
+    }
+    await flowRepo.patch({
+      uid: actionUid,
+      stepParams: legacyStepParams,
+    });
+  }
+
+  async function patchActionWorkContext(actionUid: string, workContext: 'omitted' | any[]) {
+    const persisted = await readAction(actionUid);
+    const props = _.cloneDeep(persisted.props || {});
+    if (!_.isPlainObject(props.context)) {
+      props.context = {};
+    }
+    if (workContext === 'omitted') {
+      delete props.context.workContext;
+    } else {
+      props.context.workContext = workContext;
+    }
+    await flowRepo.patch({
+      uid: actionUid,
+      props,
+    });
   }
 
   function expectNoPersistedPropsTasks(action: any) {
@@ -264,12 +311,30 @@ describe('flowSurfaces AI employee action contract', () => {
 
   it('creates collection and record AI employee actions with resolved public settings', async () => {
     const { table } = await createTable();
+    const recordSettings = aiEmployeeSettings({
+      style: { size: 36 },
+      tasks: [
+        {
+          title: 'Analyze current record',
+          message: {
+            system: 'Use no task context.',
+            user: DEFAULT_AI_EMPLOYEE_USER_MESSAGE,
+            workContext: [],
+          },
+          autoSend: false,
+          skillSettings: { skills: ['crm'], tools: [] },
+          model: null,
+          webSearch: false,
+        },
+      ],
+    });
+    delete recordSettings.workContext;
     const collectionAction = getData(
       await rootAgent.resource('flowSurfaces').addAction({
         values: {
           target: { uid: table.uid },
           type: 'aiEmployee',
-          settings: aiEmployeeSettings(),
+          settings: withoutAIEmployeeWorkContext(aiEmployeeSettings()),
         },
       }),
     );
@@ -278,19 +343,19 @@ describe('flowSurfaces AI employee action contract', () => {
         values: {
           target: { uid: table.uid },
           type: 'aiEmployee',
-          settings: aiEmployeeSettings({ style: { size: 36 } }),
+          settings: recordSettings,
         },
       }),
     );
 
-    for (const actionUid of [collectionAction.uid, recordAction.uid]) {
-      const persisted = await readAction(actionUid);
+    const persistedCollectionAction = await readAction(collectionAction.uid);
+    const persistedRecordAction = await readAction(recordAction.uid);
+    for (const persisted of [persistedCollectionAction, persistedRecordAction]) {
       expect(persisted?.use).toBe('AIEmployeeButtonModel');
       expect(persisted?.props?.aiEmployee?.username).toBe('dex');
       expect(persisted?.props?.auto).toBe(false);
       expectResolvedFlowModelContext(persisted?.props?.context?.workContext, table.uid);
       const persistedTasks = getPersistedTasks(persisted);
-      expectResolvedFlowModelContext(persistedTasks?.[0]?.message?.workContext, table.uid);
       expect(persistedTasks?.[0]).toMatchObject({
         title: 'Analyze current record',
         autoSend: false,
@@ -299,12 +364,12 @@ describe('flowSurfaces AI employee action contract', () => {
       });
       expectNoPersistedPropsTasks(persisted);
     }
-    const persistedCollectionAction = await readAction(collectionAction.uid);
-    const persistedRecordAction = await readAction(recordAction.uid);
     expect(persistedCollectionAction?.props?.style).toEqual({ size: 40, mask: false });
     expect(persistedRecordAction?.props?.style).toEqual({ size: 36, mask: false });
+    expectResolvedFlowModelContext(getPersistedTasks(persistedCollectionAction)?.[0]?.message?.workContext, table.uid);
     expect(getPersistedTasks(persistedCollectionAction)?.[0]?.message?.user).toBe(DEFAULT_AI_EMPLOYEE_USER_MESSAGE);
     expect(getPersistedTasks(persistedRecordAction)?.[0]?.message?.user).toBe(DEFAULT_AI_EMPLOYEE_RECORD_USER_MESSAGE);
+    expect(getPersistedTasks(persistedRecordAction)?.[0]?.message?.workContext).toEqual([]);
 
     const updateRecordActionRes = await rootAgent.resource('flowSurfaces').updateSettings({
       values: {
@@ -430,8 +495,8 @@ describe('flowSurfaces AI employee action contract', () => {
               collectionName: 'employees',
             },
             fields: ['nickname'],
-            actions: [{ type: 'aiEmployee', settings: aiEmployeeSettings() }],
-            recordActions: [{ type: 'aiEmployee', settings: aiEmployeeSettings() }],
+            actions: [{ type: 'aiEmployee', settings: withoutAIEmployeeWorkContext(aiEmployeeSettings()) }],
+            recordActions: [{ type: 'aiEmployee', settings: withoutAIEmployeeWorkContext(aiEmployeeSettings()) }],
           },
         ],
       },
@@ -493,6 +558,12 @@ describe('flowSurfaces AI employee action contract', () => {
   });
 
   it('rejects duplicate AI employee actions in the same applyBlueprint action container', async () => {
+    const inheritedTaskContextSettings = withoutAIEmployeeTaskWorkContext(aiEmployeeSettings());
+    const emptyTaskContextSettings = aiEmployeeSettings();
+    _.set(emptyTaskContextSettings, ['tasks', 0, 'message', 'workContext'], []);
+    const nullTaskContextSettings = aiEmployeeSettings();
+    _.set(nullTaskContextSettings, ['tasks', 0, 'message', 'workContext'], null);
+
     const executeRes = await rootAgent.resource('flowSurfaces').applyBlueprint({
       values: {
         version: '1',
@@ -513,8 +584,9 @@ describe('flowSurfaces AI employee action contract', () => {
                 collection: 'employees',
                 fields: ['nickname', 'status', 'email'],
                 recordActions: [
-                  { type: 'aiEmployee', settings: aiEmployeeSettings() },
-                  { type: 'aiEmployee', settings: aiEmployeeSettings() },
+                  { type: 'aiEmployee', settings: inheritedTaskContextSettings },
+                  { type: 'aiEmployee', settings: nullTaskContextSettings },
+                  { type: 'aiEmployee', settings: emptyTaskContextSettings },
                 ],
               },
             ],
@@ -628,7 +700,7 @@ describe('flowSurfaces AI employee action contract', () => {
                 type: 'createForm',
                 collection: 'employees',
                 fields: ['nickname'],
-                actions: [{ type: 'aiEmployee', settings: aiEmployeeSettings() }],
+                actions: [{ type: 'aiEmployee', settings: withoutAIEmployeeWorkContext(aiEmployeeSettings()) }],
               },
               {
                 key: 'employeesTable',
@@ -638,9 +710,11 @@ describe('flowSurfaces AI employee action contract', () => {
                 actions: [
                   {
                     type: 'aiEmployee',
-                    settings: aiEmployeeSettings({
-                      workContext: [{ type: 'flow-model', target: 'employeeForm' }],
-                    }),
+                    settings: withoutAIEmployeeTaskWorkContext(
+                      aiEmployeeSettings({
+                        workContext: [{ type: 'flow-model', target: 'employeeForm' }],
+                      }),
+                    ),
                   },
                 ],
                 recordActions: [{ type: 'aiEmployee', settings: aiEmployeeSettings() }],
@@ -676,7 +750,7 @@ describe('flowSurfaces AI employee action contract', () => {
     expectResolvedFlowModelContext(formAction?.props?.context?.workContext, formBlock.uid);
     expectResolvedFlowModelContext(getPersistedTasks(formAction)?.[0]?.message?.workContext, formBlock.uid);
     expectResolvedFlowModelContext(tableAction?.props?.context?.workContext, formBlock.uid);
-    expectResolvedFlowModelContext(getPersistedTasks(tableAction)?.[0]?.message?.workContext, tableBlock.uid);
+    expectResolvedFlowModelContext(getPersistedTasks(tableAction)?.[0]?.message?.workContext, formBlock.uid);
     expectResolvedFlowModelContext(recordAction?.props?.context?.workContext, tableBlock.uid);
     expectResolvedFlowModelContext(getPersistedTasks(recordAction)?.[0]?.message?.workContext, tableBlock.uid);
     expect(getPersistedTasks(formAction)?.[0]?.message?.user).toBe(DEFAULT_AI_EMPLOYEE_USER_MESSAGE);
@@ -1087,7 +1161,6 @@ describe('flowSurfaces AI employee action contract', () => {
                 {
                   message: {
                     user: 'Raw step params task.',
-                    workContext: [{ type: 'flow-model', target: 'self' }],
                   },
                   skillSettings: {
                     skills: [],
@@ -1134,6 +1207,255 @@ describe('flowSurfaces AI employee action contract', () => {
     expect(readErrorMessage(rawStepParamsRes)).toContain('flowSurfaces:context');
   });
 
+  it('preserves empty action workContext as the default for raw stepParams tasks', async () => {
+    const { table } = await createTable();
+    const action = getData(
+      await rootAgent.resource('flowSurfaces').addAction({
+        values: {
+          target: { uid: table.uid },
+          type: 'aiEmployee',
+          settings: aiEmployeeSettings(),
+        },
+      }),
+    );
+
+    const updateRes = await rootAgent.resource('flowSurfaces').updateSettings({
+      values: {
+        target: { uid: action.uid },
+        workContext: [],
+        stepParams: {
+          shortcutSettings: {
+            editTasks: {
+              tasks: [
+                {
+                  message: {
+                    user: 'Raw task inherits empty action context.',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(updateRes.status, readErrorMessage(updateRes)).toBe(200);
+
+    const updated = await readAction(action.uid);
+    expect(updated?.props?.context?.workContext).toEqual([]);
+    expect(getPersistedTasks(updated)?.[0]?.message).not.toHaveProperty('workContext');
+  });
+
+  it('rebases inherited empty AI employee task workContext when only action context changes', async () => {
+    const { page, table } = await createTable();
+    const action = getData(
+      await rootAgent.resource('flowSurfaces').addAction({
+        values: {
+          target: { uid: table.uid },
+          type: 'aiEmployee',
+          settings: aiEmployeeSettings({
+            workContext: [],
+            tasks: [
+              {
+                title: 'Inherited empty context task',
+                message: {
+                  user: 'Inherit the empty action context.',
+                },
+                autoSend: false,
+                skillSettings: null,
+                model: null,
+                webSearch: false,
+              },
+              {
+                title: 'Explicit empty context task',
+                message: {
+                  user: 'Keep explicit empty context.',
+                  workContext: [],
+                },
+                autoSend: false,
+                skillSettings: null,
+                model: null,
+                webSearch: false,
+              },
+            ],
+          }),
+        },
+      }),
+    );
+    const persisted = await readAction(action.uid);
+    expect(persisted?.props?.context?.workContext).toEqual([]);
+    expect(getPersistedTasks(persisted)?.[0]?.message).not.toHaveProperty('workContext');
+    expect(getPersistedTasks(persisted)?.[1]?.message?.workContext).toEqual([]);
+
+    const updateRes = await rootAgent.resource('flowSurfaces').updateSettings({
+      values: {
+        target: { uid: action.uid },
+        workContext: [{ type: 'flow-model', uid: page.tabSchemaUid }],
+      },
+    });
+    expect(updateRes.status, readErrorMessage(updateRes)).toBe(200);
+
+    const updated = await readAction(action.uid);
+    const tasks = getPersistedTasks(updated);
+    expectResolvedFlowModelContext(updated?.props?.context?.workContext, page.tabSchemaUid);
+    expectResolvedFlowModelContext(tasks?.[0]?.message?.workContext, page.tabSchemaUid);
+    expect(tasks?.[1]?.message?.workContext).toEqual([]);
+  });
+
+  it('rebases legacy null AI employee task workContext from flowSurfaces get round trips', async () => {
+    const { page, table } = await createTable();
+    const action = getData(
+      await rootAgent.resource('flowSurfaces').addAction({
+        values: {
+          target: { uid: table.uid },
+          type: 'aiEmployee',
+          settings: aiEmployeeSettings(),
+        },
+      }),
+    );
+    await patchStepTaskWorkContext(action.uid, null);
+
+    const readback = await getSurface(rootAgent, { uid: action.uid });
+    const roundTripStepParams = _.cloneDeep(readback?.tree?.stepParams);
+    expect(roundTripStepParams?.shortcutSettings?.editTasks?.tasks?.[0]?.message?.workContext).toBeNull();
+
+    const updateRes = await rootAgent.resource('flowSurfaces').updateSettings({
+      values: {
+        target: { uid: action.uid },
+        workContext: [{ type: 'flow-model', uid: page.tabSchemaUid }],
+        stepParams: roundTripStepParams,
+      },
+    });
+    expect(updateRes.status, readErrorMessage(updateRes)).toBe(200);
+
+    const updated = await readAction(action.uid);
+    expectResolvedFlowModelContext(updated?.props?.context?.workContext, page.tabSchemaUid);
+    expectResolvedFlowModelContext(getPersistedTasks(updated)?.[0]?.message?.workContext, page.tabSchemaUid);
+  });
+
+  it('uses default AI employee workContext for legacy action-level context during task updates', async () => {
+    async function createLegacyAction(tableUid: string, actionWorkContext: 'omitted' | any[]) {
+      const action = getData(
+        await rootAgent.resource('flowSurfaces').addAction({
+          values: {
+            target: { uid: tableUid },
+            type: 'aiEmployee',
+            settings: aiEmployeeSettings(),
+          },
+        }),
+      );
+      await patchActionWorkContext(action.uid, actionWorkContext);
+      await patchStepTaskWorkContext(action.uid, 'omitted');
+      return action;
+    }
+
+    const { table: publicTable } = await createTable();
+    const publicAction = await createLegacyAction(publicTable.uid, 'omitted');
+    const publicUpdateRes = await rootAgent.resource('flowSurfaces').updateSettings({
+      values: {
+        target: { uid: publicAction.uid },
+        tasks: [
+          {
+            message: {
+              user: 'Public task inherits legacy action context.',
+            },
+          },
+        ],
+      },
+    });
+    expect(publicUpdateRes.status, readErrorMessage(publicUpdateRes)).toBe(200);
+    const publicUpdated = await readAction(publicAction.uid);
+    expectResolvedFlowModelContext(publicUpdated?.props?.context?.workContext, publicTable.uid);
+    expectResolvedFlowModelContext(getPersistedTasks(publicUpdated)?.[0]?.message?.workContext, publicTable.uid);
+
+    const { table: rawTable } = await createTable();
+    const rawAction = await createLegacyAction(rawTable.uid, [{ uid: rawTable.uid }]);
+    const rawUpdateRes = await rootAgent.resource('flowSurfaces').updateSettings({
+      values: {
+        target: { uid: rawAction.uid },
+        stepParams: {
+          shortcutSettings: {
+            editTasks: {
+              tasks: [
+                {
+                  message: {
+                    user: 'Raw task inherits legacy action context.',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(rawUpdateRes.status, readErrorMessage(rawUpdateRes)).toBe(200);
+    const rawUpdated = await readAction(rawAction.uid);
+    expectResolvedFlowModelContext(rawUpdated?.props?.context?.workContext, rawTable.uid);
+    expectResolvedFlowModelContext(getPersistedTasks(rawUpdated)?.[0]?.message?.workContext, rawTable.uid);
+  });
+
+  it('rebases untouched AI employee tasks when updating workContext with a partial task patch', async () => {
+    const { page, table } = await createTable();
+    const action = getData(
+      await rootAgent.resource('flowSurfaces').addAction({
+        values: {
+          target: { uid: table.uid },
+          type: 'aiEmployee',
+          settings: aiEmployeeSettings({
+            tasks: [
+              {
+                title: 'First inherited context task',
+                message: {
+                  system: 'Use the current UI context.',
+                  user: 'First task.',
+                  workContext: [{ type: 'flow-model', target: 'self' }],
+                },
+                autoSend: false,
+                skillSettings: { skills: ['crm'], tools: [] },
+                model: null,
+                webSearch: false,
+              },
+              {
+                title: 'Second inherited context task',
+                message: {
+                  system: 'Use the current UI context.',
+                  user: 'Second task.',
+                  workContext: [{ type: 'flow-model', target: 'self' }],
+                },
+                autoSend: false,
+                skillSettings: { skills: ['crm'], tools: [] },
+                model: null,
+                webSearch: false,
+              },
+            ],
+          }),
+        },
+      }),
+    );
+
+    const updateRes = await rootAgent.resource('flowSurfaces').updateSettings({
+      values: {
+        target: { uid: action.uid },
+        workContext: [{ type: 'flow-model', uid: page.tabSchemaUid }],
+        tasks: [
+          {
+            message: {
+              user: 'First task updated.',
+            },
+          },
+        ],
+      },
+    });
+    expect(updateRes.status, readErrorMessage(updateRes)).toBe(200);
+
+    const updated = await readAction(action.uid);
+    const tasks = getPersistedTasks(updated);
+    expectResolvedFlowModelContext(updated?.props?.context?.workContext, page.tabSchemaUid);
+    expect(tasks?.[0]?.message?.user).toBe('First task updated.');
+    expectResolvedFlowModelContext(tasks?.[0]?.message?.workContext, page.tabSchemaUid);
+    expect(tasks?.[1]?.title).toBe('Second inherited context task');
+    expectResolvedFlowModelContext(tasks?.[1]?.message?.workContext, page.tabSchemaUid);
+  });
+
   it('rejects adding the same AI employee record action twice to one table', async () => {
     const { table } = await createTable();
     const firstRes = await rootAgent.resource('flowSurfaces').addRecordAction({
@@ -1156,6 +1478,103 @@ describe('flowSurfaces AI employee action contract', () => {
     expect(duplicateRes.status).toBe(400);
     expect(readErrorMessage(duplicateRes)).toContain('duplicates an existing AI employee action');
     expect(duplicateRes.body?.errors?.[0]?.ruleId).toBe('duplicate-ai-employee-action');
+  });
+
+  it('rejects duplicate AI employee actions when the existing action has legacy workContext', async () => {
+    const { table } = await createTable();
+    const firstAction = getData(
+      await rootAgent.resource('flowSurfaces').addRecordAction({
+        values: {
+          target: { uid: table.uid },
+          type: 'aiEmployee',
+          settings: aiEmployeeSettings(),
+        },
+      }),
+    );
+    await patchActionWorkContext(firstAction.uid, 'omitted');
+    const legacyAction = await readAction(firstAction.uid);
+    expect(legacyAction?.props?.context).not.toHaveProperty('workContext');
+
+    const duplicateRes = await rootAgent.resource('flowSurfaces').addRecordAction({
+      values: {
+        target: { uid: table.uid },
+        type: 'aiEmployee',
+        settings: aiEmployeeSettings(),
+      },
+    });
+
+    expect(duplicateRes.status).toBe(400);
+    expect(readErrorMessage(duplicateRes)).toContain('duplicates an existing AI employee action');
+    expect(duplicateRes.body?.errors?.[0]?.ruleId).toBe('duplicate-ai-employee-action');
+  });
+
+  it('rejects update/configure writes that would duplicate a sibling AI employee action', async () => {
+    async function createSiblingActions(legacyWorkContext?: 'omitted' | 'missingType') {
+      const { table } = await createTable();
+      const firstAction = getData(
+        await rootAgent.resource('flowSurfaces').addAction({
+          values: {
+            target: { uid: table.uid },
+            type: 'aiEmployee',
+            settings: aiEmployeeSettings(),
+          },
+        }),
+      );
+      if (legacyWorkContext) {
+        await patchActionWorkContext(
+          firstAction.uid,
+          legacyWorkContext === 'omitted' ? 'omitted' : [{ uid: table.uid }],
+        );
+      }
+      const secondAction = getData(
+        await rootAgent.resource('flowSurfaces').addAction({
+          values: {
+            target: { uid: table.uid },
+            type: 'aiEmployee',
+            settings: aiEmployeeSettings({ auto: true }),
+          },
+        }),
+      );
+      return secondAction;
+    }
+
+    for (const scenario of ['public', 'raw', 'legacy-configure'] as const) {
+      const secondAction = await createSiblingActions(scenario === 'legacy-configure' ? 'missingType' : undefined);
+      const duplicateRes =
+        scenario === 'legacy-configure'
+          ? await rootAgent.resource('flowSurfaces').configure({
+              values: {
+                target: { uid: secondAction.uid },
+                changes: {
+                  auto: false,
+                  tasks: withoutAIEmployeeTaskWorkContext(aiEmployeeSettings()).tasks,
+                },
+              },
+            })
+          : await rootAgent.resource('flowSurfaces').updateSettings({
+              values: {
+                target: { uid: secondAction.uid },
+                auto: false,
+                ...(scenario === 'raw'
+                  ? {
+                      stepParams: {
+                        shortcutSettings: {
+                          editTasks: {
+                            tasks: withoutAIEmployeeTaskWorkContext(aiEmployeeSettings()).tasks,
+                          },
+                        },
+                      },
+                    }
+                  : {
+                      tasks: withoutAIEmployeeTaskWorkContext(aiEmployeeSettings()).tasks,
+                    }),
+              },
+            });
+
+      expect(duplicateRes.status).toBe(400);
+      expect(readErrorMessage(duplicateRes)).toContain('duplicates an existing AI employee action');
+      expect(duplicateRes.body?.errors?.[0]?.ruleId).toBe('duplicate-ai-employee-action');
+    }
   });
 
   it('allows adding AI employee record actions that differ by public settings', async () => {
@@ -1257,7 +1676,7 @@ describe('flowSurfaces AI employee action contract', () => {
             message: {
               system: 'Legacy system.',
               user: 'Legacy user.',
-              workContext: [{ type: 'flow-model', uid: table.uid }],
+              workContext: null,
             },
             autoSend: false,
             skillSettings: { skills: ['legacy-skill'], tools: [] },
@@ -1324,7 +1743,7 @@ describe('flowSurfaces AI employee action contract', () => {
             message: {
               system: 'Legacy system.',
               user: 'Legacy user.',
-              workContext: [{ type: 'flow-model', uid: table.uid }],
+              workContext: null,
             },
             autoSend: false,
             skillSettings: { skills: ['legacy-skill'], tools: [] },
@@ -1360,6 +1779,7 @@ describe('flowSurfaces AI employee action contract', () => {
       },
       webSearch: false,
     });
+    expectResolvedFlowModelContext(getPersistedTasks(migrated)?.[0]?.message?.workContext, table.uid);
     expect(migrated?.props?.style).toEqual({ size: 40, mask: true });
     expectNoPersistedPropsTasks(migrated);
   });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/authoring-validation.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/authoring-validation.ts
@@ -7452,13 +7452,14 @@ function buildAuthoringAIEmployeeActionIdentity(settings: any) {
 }
 
 function normalizeAuthoringAIEmployeePublicSettingsForIdentity(settings: Record<string, any>) {
+  const workContext = Object.prototype.hasOwnProperty.call(settings, 'workContext')
+    ? normalizeAuthoringAIEmployeeWorkContextForIdentity(settings.workContext)
+    : [{ type: 'flow-model', target: 'self' }];
   return {
     username: String(settings.username || '').trim(),
     auto: typeof settings.auto === 'boolean' ? settings.auto : false,
-    workContext: Object.prototype.hasOwnProperty.call(settings, 'workContext')
-      ? normalizeAuthoringAIEmployeeWorkContextForIdentity(settings.workContext)
-      : [{ type: 'flow-model', target: 'self' }],
-    tasks: normalizeAuthoringAIEmployeeTasksForIdentity(settings.tasks),
+    workContext,
+    tasks: normalizeAuthoringAIEmployeeTasksForIdentity(settings.tasks, workContext),
     style: {
       ...AUTHORING_AI_EMPLOYEE_DEFAULT_STYLE,
       ...(_.isPlainObject(settings.style) ? _.pick(settings.style, AUTHORING_AI_EMPLOYEE_STYLE_PUBLIC_KEYS) : {}),
@@ -7479,7 +7480,15 @@ function normalizeAuthoringAIEmployeeWorkContextForIdentity(value: any) {
   });
 }
 
-function normalizeAuthoringAIEmployeeTasksForIdentity(value: any) {
+function normalizeAuthoringAIEmployeeTaskWorkContextForIdentity(value: any, defaultWorkContext?: any[]) {
+  const normalized = normalizeAuthoringAIEmployeeWorkContextForIdentity(value);
+  if (Array.isArray(defaultWorkContext) && !normalized.length) {
+    return _.cloneDeep(defaultWorkContext);
+  }
+  return normalized;
+}
+
+function normalizeAuthoringAIEmployeeTasksForIdentity(value: any, defaultWorkContext?: any[]) {
   return _.castArray(value || []).map((task: any) => {
     if (!_.isPlainObject(task)) {
       return task;
@@ -7487,10 +7496,11 @@ function normalizeAuthoringAIEmployeeTasksForIdentity(value: any) {
     const output = _.pick(task, AUTHORING_AI_EMPLOYEE_TASK_PUBLIC_SETTING_KEYS);
     if (_.isPlainObject(output.message)) {
       output.message = _.pick(output.message, AUTHORING_AI_EMPLOYEE_TASK_MESSAGE_PUBLIC_KEYS);
-      if (_.isPlainObject(output.message.workContext)) {
-        output.message.workContext = normalizeAuthoringAIEmployeeWorkContextForIdentity(output.message.workContext);
-      } else if (Array.isArray(output.message.workContext)) {
-        output.message.workContext = normalizeAuthoringAIEmployeeWorkContextForIdentity(output.message.workContext);
+      if (Object.prototype.hasOwnProperty.call(output.message, 'workContext')) {
+        output.message.workContext = normalizeAuthoringAIEmployeeTaskWorkContextForIdentity(
+          output.message.workContext,
+          defaultWorkContext,
+        );
       }
     }
     if (
@@ -7501,6 +7511,16 @@ function normalizeAuthoringAIEmployeeTasksForIdentity(value: any) {
         ...(_.isPlainObject(output.message) ? output.message : {}),
         user: task.prompt,
       };
+    }
+    if (!_.isPlainObject(output.message) && Array.isArray(defaultWorkContext)) {
+      output.message = {
+        workContext: _.cloneDeep(defaultWorkContext),
+      };
+    } else if (
+      _.isPlainObject(output.message) &&
+      !Object.prototype.hasOwnProperty.call(output.message, 'workContext')
+    ) {
+      output.message.workContext = _.cloneDeep(defaultWorkContext || []);
     }
     if (_.isPlainObject(output.model)) {
       output.model = _.pick(output.model, AUTHORING_AI_EMPLOYEE_TASK_MODEL_PUBLIC_KEYS);

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service.ts
@@ -14806,6 +14806,7 @@ export class FlowSurfacesService {
     }
     if (this.isAIEmployeeActionUse(current?.use) && this.hasAIEmployeePublicSettings(normalizedValues)) {
       const enabledPackages = await this.resolveEnabledPluginPackages(options);
+      const hasRawAIEmployeeStepTasks = _.has(normalizedValues, ['stepParams', ...AI_EMPLOYEE_TASK_STEP_PARAMS_PATH]);
       const aiEmployeeSettingsPayload = await this.normalizeAIEmployeeActionPublicSettings(
         'updateSettings',
         _.pick(normalizedValues, AI_EMPLOYEE_PUBLIC_SETTING_KEYS),
@@ -14819,6 +14820,7 @@ export class FlowSurfacesService {
             kind: 'target',
             targetUid: current?.uid || writeTarget.uid,
           },
+          skipExistingTaskWorkContextRebase: hasRawAIEmployeeStepTasks,
         },
       );
       AI_EMPLOYEE_PUBLIC_SETTING_KEYS.forEach((key) => {
@@ -14965,6 +14967,13 @@ export class FlowSurfacesService {
     if (Object.keys(nextPayload).length === 1) {
       return { uid: current.uid };
     }
+
+    await this.assertNoDuplicateAIEmployeeActionForUpdateSettings(
+      options.openViewActionName || 'updateSettings',
+      current,
+      effectiveNode,
+      options.transaction,
+    );
 
     if (target.kind === 'tab' && target.tabRoute) {
       await this.routeSync.persistTabSettings(target, current, nextPayload, options.transaction);
@@ -22582,18 +22591,20 @@ export class FlowSurfacesService {
     return JSON.stringify(value);
   }
 
-  private buildAIEmployeeActionDedupIdentity(values: Record<string, any>) {
+  private buildAIEmployeeActionDedupIdentity(values: Record<string, any>, defaultActionWorkContext?: any[]) {
     const username = String(values?.props?.aiEmployee?.username || '').trim();
     if (!username) {
       return '';
     }
+    const workContext = this.normalizeAIEmployeeActionWorkContextForDedupIdentity(
+      values?.props?.context?.workContext,
+      defaultActionWorkContext,
+    );
     return this.stableSerializeAIEmployeeValue({
       username,
       auto: typeof values?.props?.auto === 'boolean' ? values.props.auto : false,
-      workContext: this.normalizeAIEmployeeWorkContextForDedupIdentity(values?.props?.context?.workContext),
-      tasks: this.normalizeAIEmployeeTasksForDedupIdentity(
-        _.get(values, ['stepParams', ...AI_EMPLOYEE_TASK_STEP_PARAMS_PATH]),
-      ),
+      workContext,
+      tasks: this.normalizeAIEmployeeTasksForDedupIdentity(this.readAIEmployeePersistedTasks(values), workContext),
       style: {
         ...AI_EMPLOYEE_DEFAULT_STYLE,
         ...(_.isPlainObject(values?.props?.style) ? _.pick(values.props.style, AI_EMPLOYEE_STYLE_PUBLIC_KEYS) : {}),
@@ -22602,12 +22613,39 @@ export class FlowSurfacesService {
   }
 
   private normalizeAIEmployeeWorkContextForDedupIdentity(value: any) {
-    return _.castArray(value || []).map((item: any) =>
-      _.isPlainObject(item) ? _.pick(item, AI_EMPLOYEE_WORK_CONTEXT_PUBLIC_KEYS) : item,
-    );
+    return _.castArray(value || []).map((item: any) => {
+      if (!_.isPlainObject(item)) {
+        return item;
+      }
+      const output = _.pick(item, AI_EMPLOYEE_WORK_CONTEXT_PUBLIC_KEYS);
+      if (!Object.prototype.hasOwnProperty.call(output, 'type') || _.isUndefined(output.type) || output.type === null) {
+        output.type = 'flow-model';
+      }
+      return output;
+    });
   }
 
-  private normalizeAIEmployeeTasksForDedupIdentity(value: any) {
+  private normalizeAIEmployeeActionWorkContextForDedupIdentity(value: any, defaultWorkContext?: any[]) {
+    if (!Array.isArray(value)) {
+      return _.cloneDeep(defaultWorkContext || []);
+    }
+    return this.normalizeAIEmployeeWorkContextForDedupIdentity(value);
+  }
+
+  private normalizeAIEmployeeDefaultActionWorkContextForSelfUid(selfUid?: string) {
+    const uid = String(selfUid || '').trim();
+    return uid ? [{ type: 'flow-model', uid }] : [];
+  }
+
+  private normalizeAIEmployeeTaskWorkContextForDedupIdentity(value: any, defaultWorkContext?: any[]) {
+    const normalized = this.normalizeAIEmployeeWorkContextForDedupIdentity(value);
+    if (Array.isArray(defaultWorkContext) && !normalized.length) {
+      return _.cloneDeep(defaultWorkContext);
+    }
+    return normalized;
+  }
+
+  private normalizeAIEmployeeTasksForDedupIdentity(value: any, defaultWorkContext?: any[]) {
     return _.castArray(value || []).map((task: any) => {
       if (!_.isPlainObject(task)) {
         return task;
@@ -22616,8 +22654,21 @@ export class FlowSurfacesService {
       if (_.isPlainObject(output.message)) {
         output.message = _.pick(output.message, AI_EMPLOYEE_TASK_MESSAGE_PUBLIC_KEYS);
         if (Object.prototype.hasOwnProperty.call(output.message, 'workContext')) {
-          output.message.workContext = this.normalizeAIEmployeeWorkContextForDedupIdentity(output.message.workContext);
+          output.message.workContext = this.normalizeAIEmployeeTaskWorkContextForDedupIdentity(
+            output.message.workContext,
+            defaultWorkContext,
+          );
         }
+      }
+      if (!_.isPlainObject(output.message) && Array.isArray(defaultWorkContext)) {
+        output.message = {
+          workContext: _.cloneDeep(defaultWorkContext),
+        };
+      } else if (
+        _.isPlainObject(output.message) &&
+        !Object.prototype.hasOwnProperty.call(output.message, 'workContext')
+      ) {
+        output.message.workContext = _.cloneDeep(defaultWorkContext || []);
       }
       if (_.isPlainObject(output.model)) {
         output.model = _.pick(output.model, AI_EMPLOYEE_TASK_MODEL_PUBLIC_KEYS);
@@ -22634,26 +22685,40 @@ export class FlowSurfacesService {
     parentUid: string,
     values: Record<string, any>,
     transaction?: any,
+    excludeUid?: string,
   ) {
-    const identity = this.buildAIEmployeeActionDedupIdentity(values);
-    if (!identity) {
-      return;
-    }
     const parentNode = await this.repository.findModelById(parentUid, {
       transaction,
       includeAsyncNode: true,
     });
-    const duplicate = _.castArray(parentNode?.subModels?.actions || []).find((action: any) => {
+    const defaultActionWorkContext = this.normalizeAIEmployeeDefaultActionWorkContextForSelfUid(
+      await this.resolveAIEmployeeActionSelfUidFromParentNode(parentNode, transaction),
+    );
+    const identity = this.buildAIEmployeeActionDedupIdentity(values, defaultActionWorkContext);
+    if (!identity) {
+      return;
+    }
+    let duplicate: any;
+    for (const action of _.castArray(parentNode?.subModels?.actions || [])) {
       if (!this.isAIEmployeeActionUse(action?.use)) {
-        return false;
+        continue;
       }
-      return (
-        this.buildAIEmployeeActionDedupIdentity({
-          props: action.props,
-          stepParams: action.stepParams,
-        }) === identity
-      );
-    });
+      if (excludeUid && String(action?.uid || '') === excludeUid) {
+        continue;
+      }
+      if (
+        this.buildAIEmployeeActionDedupIdentity(
+          {
+            props: action.props,
+            stepParams: action.stepParams,
+          },
+          defaultActionWorkContext,
+        ) === identity
+      ) {
+        duplicate = action;
+        break;
+      }
+    }
     if (!duplicate?.uid) {
       return;
     }
@@ -22667,6 +22732,33 @@ export class FlowSurfacesService {
             'Remove the duplicate aiEmployee action, or change username, task title/key, or workContext if this is a genuinely different AI employee action.',
         },
       },
+    );
+  }
+
+  private async assertNoDuplicateAIEmployeeActionForUpdateSettings(
+    actionName: string,
+    current: any,
+    effectiveNode: any,
+    transaction?: any,
+  ) {
+    if (!this.isAIEmployeeActionUse(current?.use)) {
+      return;
+    }
+    const parentUid =
+      String(current?.parentId || '').trim() ||
+      (current?.uid ? await this.locator.findParentUid(current.uid, transaction).catch(() => '') : '');
+    if (!parentUid) {
+      return;
+    }
+    await this.assertNoDuplicateAIEmployeeAction(
+      actionName,
+      parentUid,
+      {
+        props: effectiveNode?.props,
+        stepParams: effectiveNode?.stepParams,
+      },
+      transaction,
+      String(current?.uid || ''),
     );
   }
 
@@ -22738,10 +22830,24 @@ export class FlowSurfacesService {
   private readAIEmployeePersistedTasks(current: any) {
     const stepTasks = _.get(current, ['stepParams', ...AI_EMPLOYEE_TASK_STEP_PARAMS_PATH]);
     if (Array.isArray(stepTasks)) {
-      return stepTasks;
+      return this.normalizeAIEmployeeLegacyInheritedTaskWorkContext(stepTasks);
     }
-    const legacyPropsTasks = current?.props?.tasks;
+    const legacyPropsTasks = this.normalizeAIEmployeeLegacyInheritedTaskWorkContext(current?.props?.tasks);
     return Array.isArray(legacyPropsTasks) ? legacyPropsTasks : [];
+  }
+
+  private normalizeAIEmployeeLegacyInheritedTaskWorkContext(tasks: any) {
+    if (!Array.isArray(tasks)) {
+      return tasks;
+    }
+    return tasks.map((task) => {
+      if (!_.isPlainObject(task) || !_.isPlainObject(task.message) || task.message.workContext !== null) {
+        return task;
+      }
+      const nextTask = _.cloneDeep(task);
+      delete nextTask.message.workContext;
+      return nextTask;
+    });
   }
 
   private buildAIEmployeeTaskStepParams(tasks: any[]) {
@@ -22777,7 +22883,7 @@ export class FlowSurfacesService {
     if (!this.isAIEmployeeActionUse(current?.use)) {
       return;
     }
-    const legacyPropsTasks = current?.props?.tasks;
+    const legacyPropsTasks = this.normalizeAIEmployeeLegacyInheritedTaskWorkContext(current?.props?.tasks);
     const hasLegacyPropsTasks = Array.isArray(legacyPropsTasks);
     const hasNextStepTasks = _.has(nextPayload, ['stepParams', ...AI_EMPLOYEE_TASK_STEP_PARAMS_PATH]);
     const currentStepTasks = _.get(current, ['stepParams', ...AI_EMPLOYEE_TASK_STEP_PARAMS_PATH]);
@@ -22981,6 +23087,33 @@ export class FlowSurfacesService {
         type: 'flow-model',
         uid: uidValueFromTarget,
       };
+    });
+  }
+
+  private normalizeAIEmployeeEffectiveActionWorkContext(
+    actionName: string,
+    settings: Record<string, any>,
+    currentProps: Record<string, any>,
+    options: {
+      selfUid?: string;
+      keyMap?: Record<string, FlowSurfaceComposeTargetKey | undefined>;
+      requireUsername?: boolean;
+    },
+  ) {
+    const hasSettingsWorkContext = Object.prototype.hasOwnProperty.call(settings, 'workContext');
+    const currentWorkContext = currentProps?.context?.workContext;
+    if (!hasSettingsWorkContext && !Array.isArray(currentWorkContext) && !options.requireUsername && !options.selfUid) {
+      return undefined;
+    }
+    const rawWorkContext = hasSettingsWorkContext
+      ? settings.workContext
+      : Array.isArray(currentWorkContext)
+        ? currentWorkContext
+        : [{ type: 'flow-model', target: 'self' }];
+    return this.normalizeAIEmployeeWorkContext(actionName, rawWorkContext, {
+      selfUid: options.selfUid,
+      keyMap: options.keyMap,
+      path: 'settings.workContext',
     });
   }
 
@@ -23399,15 +23532,66 @@ export class FlowSurfacesService {
       return;
     }
     const actionName = options.openViewActionName || 'updateSettings';
-    const normalizedTasks = this.normalizeAIEmployeeTasks(
-      actionName,
-      tasks,
-      this.readAIEmployeePersistedTasks(current),
-      {
-        selfUid: await this.resolveAIEmployeeActionSelfUid(current || { uid: writeTarget.uid }, options.transaction),
-        path: 'stepParams.shortcutSettings.editTasks.tasks',
+    const selfUid = await this.resolveAIEmployeeActionSelfUid(current || { uid: writeTarget.uid }, options.transaction);
+    const currentPropsForDefault = _.mergeWith(
+      {},
+      _.isPlainObject(current?.props) ? current.props : {},
+      _.isPlainObject(nextPayload.props) ? nextPayload.props : {},
+      (_currentValue, nextValue) => {
+        if (Array.isArray(nextValue)) {
+          return _.cloneDeep(nextValue);
+        }
+        return undefined;
       },
     );
+    const defaultWorkContext = this.normalizeAIEmployeeEffectiveActionWorkContext(
+      actionName,
+      {},
+      currentPropsForDefault,
+      {
+        selfUid,
+        requireUsername: true,
+      },
+    );
+    const currentTasks = this.readAIEmployeePersistedTasks(current);
+    const previousActionWorkContext = this.normalizeAIEmployeeActionWorkContextForDedupIdentity(
+      current?.props?.context?.workContext,
+      this.normalizeAIEmployeeDefaultActionWorkContextForSelfUid(selfUid),
+    );
+    const nextActionWorkContext = this.normalizeAIEmployeeActionWorkContextForDedupIdentity(
+      currentPropsForDefault?.context?.workContext,
+      defaultWorkContext,
+    );
+    if (
+      Array.isArray(defaultWorkContext) &&
+      !_.isEqual(currentPropsForDefault?.context?.workContext, defaultWorkContext)
+    ) {
+      nextPayload.props = _.mergeWith(
+        {},
+        currentPropsForDefault,
+        {
+          context: {
+            workContext: _.cloneDeep(defaultWorkContext),
+          },
+        },
+        (_currentValue, nextValue) => {
+          if (Array.isArray(nextValue)) {
+            return _.cloneDeep(nextValue);
+          }
+          return undefined;
+        },
+      );
+    }
+    const currentTasksForNormalization = this.rebaseAIEmployeeInheritedTaskWorkContext(
+      currentTasks,
+      previousActionWorkContext,
+      nextActionWorkContext,
+    );
+    const normalizedTasks = this.normalizeAIEmployeeTasks(actionName, tasks, currentTasksForNormalization, {
+      selfUid,
+      defaultWorkContext,
+      path: 'stepParams.shortcutSettings.editTasks.tasks',
+    });
     _.set(nextPayload, ['stepParams', ...AI_EMPLOYEE_TASK_STEP_PARAMS_PATH], normalizedTasks);
   }
 
@@ -23419,6 +23603,7 @@ export class FlowSurfacesService {
     options: {
       selfUid?: string;
       keyMap?: Record<string, FlowSurfaceComposeTargetKey | undefined>;
+      defaultWorkContext?: any[];
     },
   ) {
     if (!_.isPlainObject(value)) {
@@ -23446,12 +23631,20 @@ export class FlowSurfacesService {
     if (Object.prototype.hasOwnProperty.call(nextMessage, 'user') && typeof nextMessage.user !== 'string') {
       throwBadRequest(`flowSurfaces ${actionName} ${path}.user must be a string`);
     }
-    if (Object.prototype.hasOwnProperty.call(value, 'workContext')) {
+    if (value.workContext === null) {
+      delete nextMessage.workContext;
+    } else if (Object.prototype.hasOwnProperty.call(value, 'workContext')) {
       nextMessage.workContext = this.normalizeAIEmployeeWorkContext(actionName, value.workContext, {
         selfUid: options.selfUid,
         keyMap: options.keyMap,
         path: `${path}.workContext`,
       });
+    }
+    if (
+      !Object.prototype.hasOwnProperty.call(nextMessage, 'workContext') &&
+      this.shouldMaterializeAIEmployeeTaskDefaultWorkContext(options.defaultWorkContext)
+    ) {
+      nextMessage.workContext = _.cloneDeep(options.defaultWorkContext);
     }
     return nextMessage;
   }
@@ -23464,6 +23657,7 @@ export class FlowSurfacesService {
       selfUid?: string;
       keyMap?: Record<string, FlowSurfaceComposeTargetKey | undefined>;
       path: string;
+      defaultWorkContext?: any[];
     },
   ) {
     if (!_.isPlainObject(patch)) {
@@ -23493,6 +23687,7 @@ export class FlowSurfacesService {
         next.message = this.normalizeAIEmployeeTaskMessage(actionName, `${options.path}.message`, value, next.message, {
           selfUid: options.selfUid,
           keyMap: options.keyMap,
+          defaultWorkContext: options.defaultWorkContext,
         });
         return;
       }
@@ -23545,6 +23740,12 @@ export class FlowSurfacesService {
     if (!_.isPlainObject(next.message)) {
       next.message = {};
     }
+    if (
+      !Object.prototype.hasOwnProperty.call(next.message, 'workContext') &&
+      this.shouldMaterializeAIEmployeeTaskDefaultWorkContext(options.defaultWorkContext)
+    ) {
+      next.message.workContext = _.cloneDeep(options.defaultWorkContext);
+    }
     if (_.isPlainObject(next.skillSettings)) {
       if (
         Array.isArray(next.skillSettings.skills) &&
@@ -23570,6 +23771,7 @@ export class FlowSurfacesService {
       selfUid?: string;
       keyMap?: Record<string, FlowSurfaceComposeTargetKey | undefined>;
       path: string;
+      defaultWorkContext?: any[];
     },
   ) {
     if (_.isUndefined(value) || value === null) {
@@ -23588,9 +23790,58 @@ export class FlowSurfacesService {
         selfUid: options.selfUid,
         keyMap: options.keyMap,
         path: `${options.path}[${index}]`,
+        defaultWorkContext: options.defaultWorkContext,
       });
     });
-    return nextTasks;
+    return this.withAIEmployeeTaskDefaultWorkContext(nextTasks, options.defaultWorkContext);
+  }
+
+  private withAIEmployeeTaskDefaultWorkContext(tasks: any, defaultWorkContext?: any[]) {
+    const nextTasks = Array.isArray(tasks) ? _.cloneDeep(tasks) : [];
+    if (!this.shouldMaterializeAIEmployeeTaskDefaultWorkContext(defaultWorkContext)) {
+      return nextTasks;
+    }
+    return nextTasks.map((task) => {
+      if (!_.isPlainObject(task)) {
+        return task;
+      }
+      const nextTask = _.cloneDeep(task);
+      if (!_.isPlainObject(nextTask.message)) {
+        nextTask.message = {
+          workContext: _.cloneDeep(defaultWorkContext),
+        };
+      } else if (!Object.prototype.hasOwnProperty.call(nextTask.message, 'workContext')) {
+        nextTask.message.workContext = _.cloneDeep(defaultWorkContext);
+      }
+      return nextTask;
+    });
+  }
+
+  private shouldMaterializeAIEmployeeTaskDefaultWorkContext(defaultWorkContext?: any[]) {
+    return Array.isArray(defaultWorkContext) && defaultWorkContext.length > 0;
+  }
+
+  private rebaseAIEmployeeInheritedTaskWorkContext(
+    currentTasks: any,
+    previousActionWorkContext: any[],
+    nextActionWorkContext: any[],
+  ) {
+    const tasks = this.normalizeAIEmployeeLegacyInheritedTaskWorkContext(currentTasks) || [];
+    if (!previousActionWorkContext.length || _.isEqual(previousActionWorkContext, nextActionWorkContext)) {
+      return tasks;
+    }
+    return tasks.map((task) => {
+      const nextTask = _.cloneDeep(task);
+      if (_.isPlainObject(nextTask?.message)) {
+        const currentTaskWorkContext = this.normalizeAIEmployeeWorkContextForDedupIdentity(
+          nextTask.message.workContext,
+        );
+        if (_.isEqual(currentTaskWorkContext, previousActionWorkContext)) {
+          delete nextTask.message.workContext;
+        }
+      }
+      return nextTask;
+    });
   }
 
   private normalizeAIEmployeeActionSettingsReferences(
@@ -23613,9 +23864,16 @@ export class FlowSurfacesService {
       });
     }
     if (Object.prototype.hasOwnProperty.call(nextSettings, 'tasks')) {
+      const defaultWorkContext = this.normalizeAIEmployeeEffectiveActionWorkContext(
+        actionName,
+        nextSettings,
+        {},
+        options,
+      );
       nextSettings.tasks = this.normalizeAIEmployeeTasks(actionName, nextSettings.tasks, [], {
         ...options,
         path: 'settings.tasks',
+        defaultWorkContext,
       });
     }
     return nextSettings;
@@ -23633,6 +23891,7 @@ export class FlowSurfacesService {
       promptContext?: AIEmployeePromptContextOptions;
       keyMap?: Record<string, FlowSurfaceComposeTargetKey | undefined>;
       currentRoles?: FlowSurfaceRequestRoles;
+      skipExistingTaskWorkContextRebase?: boolean;
     },
   ) {
     this.assertAIEmployeePluginEnabled(actionName, options.enabledPackages);
@@ -23657,6 +23916,17 @@ export class FlowSurfacesService {
 
     const props: Record<string, any> = {};
     const stepParams: Record<string, any> = {};
+    const effectiveActionWorkContext = this.normalizeAIEmployeeEffectiveActionWorkContext(
+      actionName,
+      settings,
+      currentProps,
+      options,
+    );
+    const previousActionWorkContext = this.normalizeAIEmployeeActionWorkContextForDedupIdentity(
+      currentProps?.context?.workContext,
+      this.normalizeAIEmployeeDefaultActionWorkContextForSelfUid(options.selfUid),
+    );
+    const nextActionWorkContext = this.normalizeAIEmployeeWorkContextForDedupIdentity(effectiveActionWorkContext);
     if (effectiveUsername && (hasUsername || options.requireUsername)) {
       props.aiEmployee = {
         ...(_.isPlainObject(currentProps.aiEmployee) ? _.cloneDeep(currentProps.aiEmployee) : {}),
@@ -23674,30 +23944,30 @@ export class FlowSurfacesService {
       }
       props.auto = auto;
     }
-    if (Object.prototype.hasOwnProperty.call(settings, 'workContext') || options.requireUsername) {
-      const rawWorkContext = Object.prototype.hasOwnProperty.call(settings, 'workContext')
-        ? settings.workContext
-        : [{ type: 'flow-model', target: 'self' }];
+    if (
+      Array.isArray(effectiveActionWorkContext) &&
+      (Object.prototype.hasOwnProperty.call(settings, 'workContext') ||
+        options.requireUsername ||
+        !_.isEqual(currentProps?.context?.workContext, effectiveActionWorkContext))
+    ) {
       props.context = {
         ...(_.isPlainObject(currentProps.context) ? _.cloneDeep(currentProps.context) : {}),
-        workContext: this.normalizeAIEmployeeWorkContext(actionName, rawWorkContext, {
-          selfUid: options.selfUid,
-          keyMap: options.keyMap,
-          path: 'settings.workContext',
-        }),
+        workContext: _.cloneDeep(effectiveActionWorkContext),
       };
     }
     if (Object.prototype.hasOwnProperty.call(settings, 'tasks')) {
-      const normalizedTasks = this.normalizeAIEmployeeTasks(
-        actionName,
-        settings.tasks,
-        this.readAIEmployeePersistedTasks(options.current),
-        {
-          selfUid: options.selfUid,
-          keyMap: options.keyMap,
-          path: 'settings.tasks',
-        },
+      const currentTasks = this.readAIEmployeePersistedTasks(options.current);
+      const currentTasksForNormalization = this.rebaseAIEmployeeInheritedTaskWorkContext(
+        currentTasks,
+        previousActionWorkContext,
+        nextActionWorkContext,
       );
+      const normalizedTasks = this.normalizeAIEmployeeTasks(actionName, settings.tasks, currentTasksForNormalization, {
+        selfUid: options.selfUid,
+        keyMap: options.keyMap,
+        path: 'settings.tasks',
+        defaultWorkContext: effectiveActionWorkContext,
+      });
       const validation =
         options.promptContext && normalizedTasks.length
           ? await this.buildAIEmployeePromptValidationContext(
@@ -23721,6 +23991,21 @@ export class FlowSurfacesService {
       const tasks = this.appendAIEmployeeCurrentRecordPromptVariableToTasks(normalizedTasks, validation);
       this.assertAIEmployeeTaskPromptVariablesAllowed(actionName, tasks, validation);
       _.merge(stepParams, this.buildAIEmployeeTaskStepParams(tasks));
+    } else if (
+      !options.skipExistingTaskWorkContextRebase &&
+      Object.prototype.hasOwnProperty.call(settings, 'workContext') &&
+      !_.isEqual(previousActionWorkContext, nextActionWorkContext)
+    ) {
+      const currentTasks = this.readAIEmployeePersistedTasks(options.current);
+      const rebasedTasks = this.rebaseAIEmployeeInheritedTaskWorkContext(
+        currentTasks,
+        previousActionWorkContext,
+        nextActionWorkContext,
+      );
+      const tasks = this.withAIEmployeeTaskDefaultWorkContext(rebasedTasks, effectiveActionWorkContext);
+      if (tasks.length) {
+        _.merge(stepParams, this.buildAIEmployeeTaskStepParams(tasks));
+      }
     }
     if (Object.prototype.hasOwnProperty.call(settings, 'style') || options.requireUsername) {
       const style = Object.prototype.hasOwnProperty.call(settings, 'style') ? settings.style : {};
@@ -23767,7 +24052,19 @@ export class FlowSurfacesService {
       transaction,
       includeAsyncNode: true,
     });
-    if (['TableActionsColumnModel', 'ListItemModel', 'GridCardItemModel'].includes(String(parentNode?.use || ''))) {
+    return (await this.resolveAIEmployeeActionSelfUidFromParentNode(parentNode, transaction)) || parentUid;
+  }
+
+  private async resolveAIEmployeeActionSelfUidFromParentNode(parentNode: any, transaction?: any) {
+    const parentUid = String(parentNode?.uid || '').trim();
+    if (!parentUid) {
+      return '';
+    }
+    if (
+      ['TableActionsColumnModel', 'ListItemModel', 'GridCardItemModel', 'CommentItemModel'].includes(
+        String(parentNode?.use || ''),
+      )
+    ) {
       const ownerUid =
         String(parentNode?.parentId || '').trim() ||
         (parentNode?.uid ? await this.locator.findParentUid(parentNode.uid, transaction).catch(() => '') : '');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added the current block to the user context by default when building AI employees using the Flow Surface API. |
| 🇨🇳 Chinese | 利用 flowsurface api 搭建 AI 员工时默认将当前区块添加至用户上下文中。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
