### PR TITLE
fix(client): adjust v2 system settings layout

### DIFF
--- a/packages/core/client-v2/src/__tests__/settings-center.test.tsx
+++ b/packages/core/client-v2/src/__tests__/settings-center.test.tsx
@@ -14,7 +14,7 @@ import { message } from 'antd';
 import { AdminSettingsLayoutModel as ClientV2AdminSettingsLayoutModel } from '../settings-center';
 import { AdminSettingsLayoutModel as ClientV1AdminSettingsLayoutModel } from '../../../client/src/pm/AdminSettingsLayoutModel';
 import { NocoBaseBuildInPlugin } from '../nocobase-buildin-plugin';
-import { matchSettingsRoute } from '../settings-center/utils';
+import { matchSettingsRoute, sortTopLevelSettings } from '../settings-center/utils';
 
 class TestAclPlugin extends Plugin {
   async load() {
@@ -166,6 +166,12 @@ describe('settings center', () => {
     expect(matchSettingsRoute(settings, '/admin/settings/public-forms/advanced/form-1')).toMatchObject({
       name: 'public-forms.advanced',
     });
+  });
+
+  it('should sort system-settings with other top-level settings by normal ordering', () => {
+    const settings = [{ name: 'system-settings' }, { name: 'api-keys' }, { name: 'backups' }] as any;
+
+    expect(sortTopLevelSettings(settings).map((item) => item.name)).toEqual(['api-keys', 'backups', 'system-settings']);
   });
 
   it('should redirect /admin/settings to system-settings by default', async () => {

--- a/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
+++ b/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
@@ -355,7 +355,6 @@ export class NocoBaseBuildInPlugin extends Plugin<any, Application> {
       title: this.app.i18n.t('System settings'),
       icon: 'SettingOutlined',
       aclSnippet: 'pm.system-settings.system-settings',
-      sort: -100,
     });
     this.app.pluginSettingsManager.addPageTabItem({
       menuKey: 'system-settings',
@@ -363,7 +362,6 @@ export class NocoBaseBuildInPlugin extends Plugin<any, Application> {
       title: this.app.i18n.t('System settings'),
       componentLoader: () => import('../settings-center/SystemSettingsPage'),
       aclSnippet: 'pm.system-settings.system-settings',
-      sort: -100,
     });
     // Parent menu for security-related plugin settings (password policy, locked users, etc.). Registered here in the buildin plugin so any pro plugin can attach page tabs to `menuKey: 'security'` without each one re-registering the same parent.
     this.app.pluginSettingsManager.addMenuItem({

--- a/packages/core/client-v2/src/settings-center/SystemSettingsPage.tsx
+++ b/packages/core/client-v2/src/settings-center/SystemSettingsPage.tsx
@@ -221,7 +221,6 @@ export const SystemSettingsPage = () => {
   return (
     <div
       style={{
-        minHeight: '100%',
         background: token.colorBgContainer,
         borderRadius: token.borderRadiusLG,
         padding: token.paddingLG,

--- a/packages/core/client-v2/src/settings-center/utils.tsx
+++ b/packages/core/client-v2/src/settings-center/utils.tsx
@@ -85,12 +85,6 @@ export function filterVisibleSettings(settings: readonly PluginSettingsPageType[
  */
 export function sortTopLevelSettings(settings: PluginSettingsPageType[] = []) {
   return [...settings].sort((a, b) => {
-    if (a.name === SYSTEM_SETTINGS_SETTING_NAME && b.name !== SYSTEM_SETTINGS_SETTING_NAME) {
-      return -1;
-    }
-    if (b.name === SYSTEM_SETTINGS_SETTING_NAME && a.name !== SYSTEM_SETTINGS_SETTING_NAME) {
-      return 1;
-    }
     if ((a.sort || 0) !== (b.sort || 0)) {
       return (a.sort || 0) - (b.sort || 0);
     }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The v2 system settings entry and page layout should follow the same visual behavior as the rest of the settings center.

### Description 
This PR removes the special top placement of the v2 System settings menu item so it is ordered with other settings by the normal sort and name rules.

It also removes the forced full-height styling from the v2 System settings page container so the panel height is determined by its content.

Testing suggestions:
- Open the v2 settings center and confirm System settings appears in the normal menu order.
- Open System settings and confirm the white panel height follows the form content instead of filling the whole viewport.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjusted the v2 System settings menu order and page panel height to match the standard settings layout. |
| 🇨🇳 Chinese | 调整 v2 系统设置菜单顺序和页面面板高度，使其与设置中心的统一布局保持一致。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
