### PR TITLE
fix(flow-engine): keep resize popup open

### DIFF
--- a/packages/core/flow-engine/src/components/settings/wrappers/contextual/FlowsFloatContextMenu.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/contextual/FlowsFloatContextMenu.tsx
@@ -11,6 +11,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom';
 import { Alert, Space } from 'antd';
 import { css } from '@emotion/css';
+import { useMemoizedFn } from 'ahooks';
 import { FlowModel } from '../../../../models';
 import { ToolbarItemConfig } from '../../../../types';
 import { useFlowModelById } from '../../../../hooks';
@@ -394,6 +395,49 @@ const isModelByIdProps = (props: FlowsFloatContextMenuProps): props is ModelById
   return 'uid' in props && 'modelClassName' in props && Boolean(props.uid) && Boolean(props.modelClassName);
 };
 
+const stopResizeInteractionEvent = (event?: MouseEvent | React.MouseEvent) => {
+  if (!event) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+
+  const nativeEvent = 'nativeEvent' in event ? event.nativeEvent : event;
+  nativeEvent.stopImmediatePropagation?.();
+};
+
+const pendingResizeClickSuppressions = new WeakMap<
+  Document,
+  { listener: (event: MouseEvent) => void; timer: number }
+>();
+
+const clearPendingResizeClickSuppression = (ownerDocument: Document) => {
+  const pending = pendingResizeClickSuppressions.get(ownerDocument);
+  if (!pending) {
+    return;
+  }
+
+  ownerDocument.removeEventListener('click', pending.listener, true);
+  (ownerDocument.defaultView || window).clearTimeout(pending.timer);
+  pendingResizeClickSuppressions.delete(ownerDocument);
+};
+
+const suppressNextResizeClick = (ownerDocument: Document) => {
+  clearPendingResizeClickSuppression(ownerDocument);
+
+  const listener = (event: MouseEvent) => {
+    stopResizeInteractionEvent(event);
+    clearPendingResizeClickSuppression(ownerDocument);
+  };
+  const timer = (ownerDocument.defaultView || window).setTimeout(() => {
+    clearPendingResizeClickSuppression(ownerDocument);
+  }, 0);
+
+  pendingResizeClickSuppressions.set(ownerDocument, { listener, timer });
+  ownerDocument.addEventListener('click', listener, true);
+};
+
 /**
  * FlowsFloatContextMenu组件 - 悬浮配置工具栏组件
  *
@@ -442,55 +486,80 @@ const ResizeHandles: React.FC<{
   const isDraggingRef = useRef<boolean>(false);
   const dragTypeRef = useRef<'left' | 'right' | null>(null);
   const dragStartPosRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const dragOwnerDocumentRef = useRef<Document | null>(null);
   const { onDragStart, onDragEnd } = props;
 
   // 把拖拽位移转成上层已约定的 resize 事件。
-  const handleDragMove = useCallback(
-    (e: MouseEvent) => {
-      if (!isDraggingRef.current || !dragTypeRef.current) return;
+  const handleDragMove = useMemoizedFn((e: MouseEvent) => {
+    if (!isDraggingRef.current || !dragTypeRef.current) return;
 
-      const deltaX = e.clientX - dragStartPosRef.current.x;
+    stopResizeInteractionEvent(e);
+    const deltaX = e.clientX - dragStartPosRef.current.x;
 
-      switch (dragTypeRef.current) {
-        case 'left':
-          props.model.parent.emitter.emit('onResizeLeft', { resizeDistance: -deltaX, model: props.model });
-          break;
-        case 'right':
-          props.model.parent.emitter.emit('onResizeRight', { resizeDistance: deltaX, model: props.model });
-          break;
-      }
-    },
-    [props.model],
-  );
+    switch (dragTypeRef.current) {
+      case 'left':
+        props.model.parent.emitter.emit('onResizeLeft', { resizeDistance: -deltaX, model: props.model });
+        break;
+      case 'right':
+        props.model.parent.emitter.emit('onResizeRight', { resizeDistance: deltaX, model: props.model });
+        break;
+    }
+  });
 
-  const handleDragEnd = useCallback(() => {
+  const handleDragEnd = useMemoizedFn((e?: MouseEvent) => {
+    if (!isDraggingRef.current) {
+      return;
+    }
+
+    stopResizeInteractionEvent(e);
+    const ownerDocument = dragOwnerDocumentRef.current || document;
+
+    ownerDocument.removeEventListener('mousemove', handleDragMove, true);
+    ownerDocument.removeEventListener('mouseup', handleDragEnd, true);
+    suppressNextResizeClick(ownerDocument);
+
     isDraggingRef.current = false;
     dragTypeRef.current = null;
     dragStartPosRef.current = { x: 0, y: 0 };
-
-    document.removeEventListener('mousemove', handleDragMove);
-    document.removeEventListener('mouseup', handleDragEnd);
+    dragOwnerDocumentRef.current = null;
 
     props.model.parent.emitter.emit('onResizeEnd');
     onDragEnd?.();
-  }, [handleDragMove, onDragEnd, props.model]);
+  });
 
-  const handleDragStart = useCallback(
-    (e: React.MouseEvent, type: 'left' | 'right') => {
-      e.preventDefault();
-      e.stopPropagation();
+  useEffect(() => {
+    return () => {
+      const dragOwnerDocument = dragOwnerDocumentRef.current;
+      dragOwnerDocument?.removeEventListener('mousemove', handleDragMove, true);
+      dragOwnerDocument?.removeEventListener('mouseup', handleDragEnd, true);
 
-      isDraggingRef.current = true;
-      dragTypeRef.current = type;
-      dragStartPosRef.current = { x: e.clientX, y: e.clientY };
+      if (isDraggingRef.current) {
+        suppressNextResizeClick(dragOwnerDocument || document);
+        props.model.parent.emitter.emit('onResizeEnd');
+        onDragEnd?.();
+      }
 
-      document.addEventListener('mousemove', handleDragMove);
-      document.addEventListener('mouseup', handleDragEnd);
+      isDraggingRef.current = false;
+      dragTypeRef.current = null;
+      dragStartPosRef.current = { x: 0, y: 0 };
+      dragOwnerDocumentRef.current = null;
+    };
+  }, [handleDragMove, handleDragEnd, onDragEnd, props.model]);
 
-      onDragStart?.();
-    },
-    [handleDragMove, handleDragEnd, onDragStart],
-  );
+  const handleDragStart = useMemoizedFn((e: React.MouseEvent, type: 'left' | 'right') => {
+    stopResizeInteractionEvent(e);
+    const ownerDocument = e.currentTarget.ownerDocument;
+
+    isDraggingRef.current = true;
+    dragTypeRef.current = type;
+    dragStartPosRef.current = { x: e.clientX, y: e.clientY };
+    dragOwnerDocumentRef.current = ownerDocument;
+
+    ownerDocument.addEventListener('mousemove', handleDragMove, true);
+    ownerDocument.addEventListener('mouseup', handleDragEnd, true);
+
+    onDragStart?.();
+  });
 
   return (
     <>
@@ -601,6 +670,7 @@ const FlowsFloatContextMenuWithModel: React.FC<ModelProvidedProps> = observer(
         getPopupContainer,
         handleSettingsMenuOpenChange,
         model,
+        modelUid,
         settingsMenuLevel,
         showCopyUidButton,
         showDeleteButton,

--- a/packages/core/flow-engine/src/components/settings/wrappers/contextual/__tests__/FlowsFloatContextMenu.test.tsx
+++ b/packages/core/flow-engine/src/components/settings/wrappers/contextual/__tests__/FlowsFloatContextMenu.test.tsx
@@ -567,6 +567,137 @@ describe('FlowsFloatContextMenu', () => {
     });
   });
 
+  it('does not let resize handle drag release close the surrounding modal wrap', async () => {
+    const engine = new FlowEngine();
+    await engine.flowSettings.forceEnable();
+    const parentModel = createModel(engine, 'resize-parent-model');
+    const model = createModel(engine, 'resize-child-model');
+    model.setParent(parentModel);
+    const appContainer = createAppContainer();
+    const modalWrap = createPopupRoot('ant-modal-wrap');
+    const onModalWrapClick = vi.fn();
+    modalWrap.addEventListener('click', onModalWrapClick);
+    appContainer.appendChild(modalWrap);
+    mockRect(appContainer, { top: 0, left: 0, width: 1280, height: 900 });
+    mockRect(modalWrap, { top: 100, left: 200, width: 640, height: 520 });
+
+    const { getByTestId } = renderWithProviders(
+      engine,
+      <FlowsFloatContextMenu model={model} showDragHandle>
+        <div data-testid="resize-content">content</div>
+      </FlowsFloatContextMenu>,
+      { container: modalWrap },
+    );
+
+    const host = getHost(getByTestId('resize-content'));
+    mockRect(host, { top: 140, left: 280, width: 220, height: 48 });
+
+    fireEvent.mouseEnter(host);
+
+    const overlay = await waitFor(() => {
+      const nextOverlay = modalWrap.querySelector('[data-model-uid="resize-child-model"]') as HTMLDivElement | null;
+      expect(nextOverlay).toBeTruthy();
+      return nextOverlay as HTMLDivElement;
+    });
+
+    const resizeHandle = overlay.querySelector('.resize-handle-right') as HTMLDivElement;
+    expect(resizeHandle).toBeTruthy();
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 500, clientY: 164 });
+    fireEvent.mouseMove(document, { clientX: 460, clientY: 164 });
+    fireEvent.mouseUp(modalWrap, { clientX: 460, clientY: 164 });
+    fireEvent.click(modalWrap, { clientX: 460, clientY: 164 });
+
+    expect(onModalWrapClick).not.toHaveBeenCalled();
+  });
+
+  it('emits resize end when resize handles unmount during a drag', async () => {
+    const engine = new FlowEngine();
+    await engine.flowSettings.forceEnable();
+    const parentModel = createModel(engine, 'resize-unmount-parent-model');
+    const model = createModel(engine, 'resize-unmount-child-model');
+    model.setParent(parentModel);
+    const appContainer = createAppContainer();
+    const onResizeEnd = vi.fn();
+    parentModel.emitter.on('onResizeEnd', onResizeEnd);
+    mockRect(appContainer, { top: 0, left: 0, width: 1280, height: 900 });
+
+    const { getByTestId, unmount } = renderWithProviders(
+      engine,
+      <FlowsFloatContextMenu model={model} showDragHandle>
+        <div data-testid="resize-unmount-content">content</div>
+      </FlowsFloatContextMenu>,
+      { container: appContainer },
+    );
+
+    const host = getHost(getByTestId('resize-unmount-content'));
+    mockRect(host, { top: 140, left: 280, width: 220, height: 48 });
+
+    fireEvent.mouseEnter(host);
+
+    const overlay = await waitFor(() => {
+      const nextOverlay = appContainer.querySelector(
+        '[data-model-uid="resize-unmount-child-model"]',
+      ) as HTMLDivElement | null;
+      expect(nextOverlay).toBeTruthy();
+      return nextOverlay as HTMLDivElement;
+    });
+
+    const resizeHandle = overlay.querySelector('.resize-handle-right') as HTMLDivElement;
+    expect(resizeHandle).toBeTruthy();
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 500, clientY: 164 });
+    unmount();
+
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the resize release click suppressed after handles unmount', async () => {
+    const engine = new FlowEngine();
+    await engine.flowSettings.forceEnable();
+    const parentModel = createModel(engine, 'resize-release-unmount-parent-model');
+    const model = createModel(engine, 'resize-release-unmount-child-model');
+    model.setParent(parentModel);
+    const appContainer = createAppContainer();
+    const modalWrap = createPopupRoot('ant-modal-wrap');
+    const onModalWrapClick = vi.fn();
+    modalWrap.addEventListener('click', onModalWrapClick);
+    appContainer.appendChild(modalWrap);
+    mockRect(appContainer, { top: 0, left: 0, width: 1280, height: 900 });
+    mockRect(modalWrap, { top: 100, left: 200, width: 640, height: 520 });
+
+    const { getByTestId, unmount } = renderWithProviders(
+      engine,
+      <FlowsFloatContextMenu model={model} showDragHandle>
+        <div data-testid="resize-release-unmount-content">content</div>
+      </FlowsFloatContextMenu>,
+      { container: modalWrap },
+    );
+
+    const host = getHost(getByTestId('resize-release-unmount-content'));
+    mockRect(host, { top: 140, left: 280, width: 220, height: 48 });
+
+    fireEvent.mouseEnter(host);
+
+    const overlay = await waitFor(() => {
+      const nextOverlay = modalWrap.querySelector(
+        '[data-model-uid="resize-release-unmount-child-model"]',
+      ) as HTMLDivElement | null;
+      expect(nextOverlay).toBeTruthy();
+      return nextOverlay as HTMLDivElement;
+    });
+
+    const resizeHandle = overlay.querySelector('.resize-handle-right') as HTMLDivElement;
+    expect(resizeHandle).toBeTruthy();
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 500, clientY: 164 });
+    fireEvent.mouseUp(modalWrap, { clientX: 460, clientY: 164 });
+    unmount();
+    fireEvent.click(modalWrap, { clientX: 460, clientY: 164 });
+
+    expect(onModalWrapClick).not.toHaveBeenCalled();
+  });
+
   it('hides parent toolbar when hovering a nested child host', async () => {
     const engine = new FlowEngine();
     await engine.flowSettings.forceEnable();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在详情弹窗中调整表单字段宽度时，释放拖拽后弹窗会被异常关闭，用户会回到底层列表页面，无法继续在当前详情弹窗中完成字段布局调整。

### Description 
本次修复了详情弹窗内拖拽字段宽度句柄时的关闭问题。调整字段宽度时，拖拽过程和释放后的点击不会再被弹窗误判为外部点击，因此详情弹窗会保持打开。

同时补充了相关测试，覆盖拖拽释放、拖拽过程中组件卸载，以及释放后组件卸载等场景，避免后续再次出现弹窗异常关闭。

测试建议：
- 在详情弹窗内拖拽字段宽度句柄，确认弹窗保持打开。
- 确认字段宽度调整功能仍然可用。

### Showcase
无界面样式变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where resizing fields closes the detail popup |
| 🇨🇳 Chinese | 修复调整字段宽度时详情弹窗异常关闭的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
