### PR TITLE
fix(plugin-public-forms): separate v1 and v2 settings

### DIFF
--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormsSettingsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormsSettingsPage.test.ts
@@ -11,9 +11,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App } from 'antd';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { FlowEngine } from '@nocobase/flow-engine';
+import { FlowContext, FlowEngine } from '@nocobase/flow-engine';
 import { MemoryRouter } from 'react-router-dom';
 import PublicFormsSettingsLayoutModel from '../models/PublicFormsSettingsLayoutModel';
+import PublicFormsSettingsDetailPage from '../pages/PublicFormsSettingsDetailPage';
 import PublicFormsSettingsPage, {
   fromCollectionCascaderValue,
   toCollectionCascaderValue,
@@ -34,12 +35,28 @@ const testState = vi.hoisted(() => ({
   update: vi.fn(),
   navigate: vi.fn(),
   viewerDrawer: vi.fn(),
+  ensurePublicFormFlowModel: vi.fn(),
+  flowEngine: { uid: 'test-flow-engine' } as Record<string, unknown>,
+  flowContext: null as unknown,
   outlet: null as unknown,
+  routeParams: {} as Record<string, string | undefined>,
+  renderedFlowView: null as unknown,
+  renderedFlowSettingsEnabled: null as unknown,
+  renderedModelFlowView: null as unknown,
+  renderedModelFlowSettingsEnabled: null as unknown,
 }));
 
 vi.mock('../locale', () => ({
   useT: () => (key: string) => key,
 }));
+
+vi.mock('../modelTree', async () => {
+  const actual = await vi.importActual<typeof import('../modelTree')>('../modelTree');
+  return {
+    ...actual,
+    ensurePublicFormFlowModel: testState.ensurePublicFormFlowModel,
+  };
+});
 
 vi.mock('antd', async () => {
   const actual = await vi.importActual<typeof import('antd')>('antd');
@@ -91,6 +108,7 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     useNavigate: () => testState.navigate,
     useOutlet: () => testState.outlet,
+    useParams: () => testState.routeParams,
   };
 });
 
@@ -131,37 +149,58 @@ vi.mock('@nocobase/client-v2', async () => {
 
 vi.mock('@nocobase/flow-engine', async () => {
   const actual = await vi.importActual<typeof import('@nocobase/flow-engine')>('@nocobase/flow-engine');
+  const React = await vi.importActual<typeof import('react')>('react');
 
   return {
     ...actual,
-    useFlowContext: () => ({
-      api: {
-        resource: () => ({
-          list: testState.list,
-          get: testState.get,
-          create: vi.fn(),
-          update: testState.update,
-          destroy: vi.fn(),
-        }),
-      },
-      app: {
-        router: {
-          getBasename: () => '',
-        },
-        pluginSettingsManager: {
-          getRoutePath: () => '/admin/settings/public-forms',
-        },
-      },
-      dataSourceManager: {
-        getDataSources: () => testState.dataSources,
-      },
-      viewer: {
-        drawer: testState.viewerDrawer,
-      },
-    }),
-    useFlowEngine: () => ({}),
+    FlowModelRenderer: (props: { model?: { uid?: string; context?: { view?: unknown } } }) => {
+      const ctx = actual.useFlowContext();
+      testState.renderedFlowView = ctx?.view;
+      testState.renderedFlowSettingsEnabled = ctx?.flowSettingsEnabled;
+      testState.renderedModelFlowView = props.model?.context?.view;
+      testState.renderedModelFlowSettingsEnabled = props.model?.context?.flowSettingsEnabled;
+      return React.createElement('div', { 'data-testid': 'flow-model-renderer' }, props.model?.uid);
+    },
+    useFlowContext: () => testState.flowContext,
+    useFlowEngine: () => testState.flowEngine,
   };
 });
+
+function createFlowContext() {
+  const ctx = new FlowContext();
+  ctx.defineProperty('api', {
+    value: {
+      resource: () => ({
+        list: testState.list,
+        get: testState.get,
+        create: vi.fn(),
+        update: testState.update,
+        destroy: vi.fn(),
+      }),
+    },
+  });
+  ctx.defineProperty('app', {
+    value: {
+      router: {
+        getBasename: () => '',
+      },
+      pluginSettingsManager: {
+        getRoutePath: () => '/admin/settings/public-forms',
+      },
+    },
+  });
+  ctx.defineProperty('dataSourceManager', {
+    value: {
+      getDataSources: () => testState.dataSources,
+    },
+  });
+  ctx.defineProperty('viewer', {
+    value: {
+      drawer: testState.viewerDrawer,
+    },
+  });
+  return ctx;
+}
 
 beforeEach(() => {
   testState.dataSources = [];
@@ -170,7 +209,16 @@ beforeEach(() => {
   testState.update.mockReset();
   testState.navigate.mockReset();
   testState.viewerDrawer.mockReset();
+  testState.ensurePublicFormFlowModel.mockReset();
+  testState.flowEngine = { uid: 'test-flow-engine' };
+  testState.flowContext = createFlowContext();
   testState.outlet = null;
+  testState.routeParams = {};
+  testState.renderedFlowView = null;
+  testState.renderedFlowSettingsEnabled = null;
+  testState.renderedModelFlowView = null;
+  testState.renderedModelFlowSettingsEnabled = null;
+  testState.ensurePublicFormFlowModel.mockResolvedValue({ uid: 'form-1' });
   testState.list.mockResolvedValue({
     data: {
       data: [],
@@ -244,6 +292,13 @@ describe('PublicFormsSettingsPage toolbar', () => {
     await waitFor(() => {
       expect(testState.list).toHaveBeenCalledTimes(1);
     });
+    expect(testState.list).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        filter: {
+          version: 'v2',
+        },
+      }),
+    );
 
     const refreshButton = screen.getByRole('button', { name: /Refresh/i });
     await waitFor(() => {
@@ -294,9 +349,156 @@ describe('PublicFormsSettingsPage toolbar', () => {
     expect(screen.getByText('Form')).toBeTruthy();
     expect(container.querySelector('.anticon-check')).toBeTruthy();
   });
+
+  it('opens configure page using the same settings detail path as v1', async () => {
+    testState.list.mockResolvedValue({
+      data: {
+        data: [
+          {
+            key: 'form-1',
+            title: 'Form 1',
+            collection: 'main:users',
+            type: 'form',
+            enabled: true,
+          },
+        ],
+        meta: {
+          count: 1,
+        },
+      },
+    });
+
+    render(React.createElement(App, null, React.createElement(PublicFormsSettingsPage)));
+
+    expect(await screen.findByText('Form 1')).toBeTruthy();
+    fireEvent.click(screen.getByText('Configure'));
+
+    await waitFor(() => {
+      expect(testState.ensurePublicFormFlowModel).toHaveBeenCalledWith(
+        testState.flowEngine,
+        expect.objectContaining({ key: 'form-1' }),
+        expect.any(Function),
+      );
+      expect(testState.navigate).toHaveBeenCalledWith('/admin/settings/public-forms/form-1');
+    });
+  });
 });
 
 describe('PublicFormsSettingsLayoutModel password settings', () => {
+  it('renders the configured page model inside an embed FlowView context', async () => {
+    const pageModel = {
+      uid: 'page-model-1',
+      context: new FlowContext(),
+    };
+    const routeModel = {
+      uid: 'form-1',
+      subModels: {
+        page: pageModel,
+      },
+    };
+    testState.routeParams = {
+      name: 'form-1',
+    };
+    testState.get.mockResolvedValue({
+      data: {
+        data: {
+          key: 'form-1',
+          title: 'Form 1',
+          version: 'v2',
+          enabled: true,
+        },
+      },
+    });
+    testState.ensurePublicFormFlowModel.mockResolvedValue(routeModel);
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(App, null, React.createElement(PublicFormsSettingsDetailPage)),
+      ),
+    );
+
+    expect((await screen.findByTestId('flow-model-renderer')).textContent).toBe('page-model-1');
+    expect(testState.renderedFlowView).toMatchObject({
+      type: 'embed',
+      inputArgs: {},
+    });
+    expect(testState.renderedFlowSettingsEnabled).toBe(true);
+    expect(testState.renderedModelFlowView).toMatchObject({
+      type: 'embed',
+      inputArgs: {},
+    });
+    expect(testState.renderedModelFlowSettingsEnabled).toBe(true);
+  });
+
+  it('does not render v1 records from the v2 configure route', async () => {
+    testState.routeParams = {
+      name: 'v1-form',
+    };
+    testState.get.mockResolvedValue({
+      data: {
+        data: {
+          key: 'v1-form',
+          title: 'V1 form',
+          version: 'v1',
+          enabled: true,
+        },
+      },
+    });
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(App, null, React.createElement(PublicFormsSettingsDetailPage)),
+      ),
+    );
+
+    expect(await screen.findByText('The form is not found')).toBeTruthy();
+    expect(testState.ensurePublicFormFlowModel).not.toHaveBeenCalled();
+  });
+
+  it('waits until the public form FlowModel is ensured before rendering the outlet', async () => {
+    let resolveEnsure: (value: unknown) => void = () => {};
+    const ensurePromise = new Promise((resolve) => {
+      resolveEnsure = resolve;
+    });
+    testState.outlet = React.createElement('div', { 'data-testid': 'settings-outlet' }, 'Configured form blocks');
+    testState.get.mockResolvedValue({
+      data: {
+        data: {
+          key: 'form-1',
+          title: 'Form 1',
+          version: 'v2',
+          enabled: true,
+        },
+      },
+    });
+    testState.ensurePublicFormFlowModel.mockReturnValue(ensurePromise);
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(App, null, React.createElement(SettingsLayoutHarness)),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(testState.ensurePublicFormFlowModel).toHaveBeenCalledWith(
+        testState.flowEngine,
+        expect.objectContaining({ key: 'form-1' }),
+        expect.any(Function),
+      );
+    });
+    expect(screen.queryByTestId('settings-outlet')).toBeNull();
+
+    resolveEnsure({ uid: 'form-1' });
+
+    expect(await screen.findByTestId('settings-outlet')).toBeTruthy();
+  });
+
   it('updates password without remounting the configured form outlet', async () => {
     testState.outlet = React.createElement('div', { 'data-testid': 'settings-outlet' }, 'Configured form blocks');
     testState.get.mockResolvedValue({
@@ -304,6 +506,7 @@ describe('PublicFormsSettingsLayoutModel password settings', () => {
         data: {
           key: 'form-1',
           title: 'Form 1',
+          version: 'v2',
           enabled: true,
           password: 'old-password',
         },

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/modelTree.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/modelTree.test.ts
@@ -7,9 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { FlowEngine, FlowModel } from '@nocobase/flow-engine';
 import { DEFAULT_SUCCESS_MESSAGE, PUBLIC_FORM_PAGE_MODEL, PUBLIC_FORM_SUBMIT_ACTION_MODEL } from '../constants';
-import { createPublicFormFlowModelTree } from '../modelTree';
+import { createPublicFormFlowModelTree, ensurePublicFormFlowModel } from '../modelTree';
 
 describe('public form model tree', () => {
   it('creates a FlowModel tree for public form settings and runtime', () => {
@@ -64,5 +65,68 @@ describe('public form model tree', () => {
         },
       },
     });
+  });
+
+  it('keeps an existing persisted model when it already has sub models', async () => {
+    const existing = {
+      uid: 'form-1',
+      subModels: {
+        page: {
+          uid: 'page-model-1',
+          subModels: {},
+        },
+      },
+    } as unknown as FlowModel;
+    const flowEngine = {
+      loadModel: vi.fn().mockResolvedValue(existing),
+      getModel: vi.fn(),
+      removeModelWithSubModels: vi.fn(),
+      resolveModelTree: vi.fn(),
+      createModelAsync: vi.fn(),
+    };
+
+    await expect(
+      ensurePublicFormFlowModel(
+        flowEngine as unknown as FlowEngine,
+        {
+          key: 'form-1',
+          title: 'Feedback',
+          collection: 'main:posts',
+        },
+        (key) => key,
+      ),
+    ).resolves.toBe(existing);
+    expect(flowEngine.removeModelWithSubModels).not.toHaveBeenCalled();
+    expect(flowEngine.createModelAsync).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds a local empty route shell before creating the default model tree', async () => {
+    const save = vi.fn();
+    const created = {
+      uid: 'form-1',
+      save,
+    };
+    const flowEngine = {
+      loadModel: vi.fn().mockResolvedValue(null),
+      getModel: vi.fn().mockReturnValue({ uid: 'form-1' }),
+      removeModelWithSubModels: vi.fn(),
+      resolveModelTree: vi.fn(),
+      createModelAsync: vi.fn().mockResolvedValue(created),
+    };
+
+    await expect(
+      ensurePublicFormFlowModel(
+        flowEngine as unknown as FlowEngine,
+        {
+          key: 'form-1',
+          title: 'Feedback',
+          collection: 'main:posts',
+        },
+        (key) => key,
+      ),
+    ).resolves.toBe(created);
+    expect(flowEngine.removeModelWithSubModels).toHaveBeenCalledWith('form-1');
+    expect(flowEngine.createModelAsync).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/plugin.test.ts
@@ -15,14 +15,11 @@ import {
   PUBLIC_FORM_ROUTE_NAME,
   PUBLIC_FORM_SUBMIT_ACTION_MODEL,
   PUBLIC_FORMS_NAMESPACE,
-  PUBLIC_FORMS_SETTINGS_CONFIGURE_ROUTE_PATH,
   PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL,
-  PUBLIC_FORMS_SETTINGS_LAYOUT_UID,
-  PUBLIC_FORMS_SETTINGS_ROUTE_NAME,
 } from '../constants';
 
 describe('PluginPublicFormsClientV2', () => {
-  it('registers settings parent route, nested layout and public route', async () => {
+  it('registers settings list/detail routes and public route', async () => {
     const { default: PluginPublicFormsClientV2 } = await import('../plugin');
     const app = {
       i18n: {
@@ -74,12 +71,17 @@ describe('PluginPublicFormsClientV2', () => {
       title: 'Public forms',
       componentLoader: expect.any(Function),
     });
-    expect(app.layoutManager.registerLayout).toHaveBeenCalledWith({
-      routeName: PUBLIC_FORMS_SETTINGS_ROUTE_NAME,
-      routePath: PUBLIC_FORMS_SETTINGS_CONFIGURE_ROUTE_PATH,
-      uid: PUBLIC_FORMS_SETTINGS_LAYOUT_UID,
-      layoutModelClass: PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL,
+    expect(app.pluginSettingsManager.addPageTabItem).toHaveBeenCalledWith({
+      menuKey: PUBLIC_FORMS_NAMESPACE,
+      key: ':name',
+      title: false,
+      hidden: true,
+      componentLoader: expect.any(Function),
     });
+    const detailPageOptions = app.pluginSettingsManager.addPageTabItem.mock.calls.find(
+      ([options]) => options.key === ':name',
+    )?.[0];
+    await expect(detailPageOptions.componentLoader()).resolves.toHaveProperty('default');
     expect(app.layoutManager.registerLayout).toHaveBeenCalledWith({
       routeName: PUBLIC_FORM_ROUTE_NAME,
       routePath: '/public-forms',

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/modelTree.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/modelTree.ts
@@ -8,6 +8,7 @@
  */
 
 import type { FlowEngine } from '@nocobase/flow-engine';
+import type { FlowModel } from '@nocobase/flow-engine';
 import { randomId } from '@nocobase/flow-engine';
 import { DEFAULT_SUCCESS_MESSAGE, PUBLIC_FORM_PAGE_MODEL, PUBLIC_FORM_SUBMIT_ACTION_MODEL } from './constants';
 
@@ -16,10 +17,11 @@ export interface PublicFormRecord {
   title?: string;
   collection?: string;
   type?: string;
+  version?: string;
   description?: string;
   enabled?: boolean;
   password?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export function parseCollectionValue(value?: string) {
@@ -34,6 +36,20 @@ export function parseCollectionValue(value?: string) {
 
 function createUid(prefix: string) {
   return randomId(prefix);
+}
+
+function hasSubModels(model?: FlowModel | null) {
+  const subModels = model?.subModels;
+  if (!subModels) {
+    return false;
+  }
+
+  return Object.values(subModels).some((subModel) => {
+    if (Array.isArray(subModel)) {
+      return subModel.length > 0;
+    }
+    return !!subModel;
+  });
 }
 
 export function createPublicFormFlowModelTree(record: PublicFormRecord, t: (key: string) => string) {
@@ -165,8 +181,12 @@ export async function ensurePublicFormFlowModel(
   }
 
   const existing = await flowEngine.loadModel({ uid: key, refresh: true });
-  if (existing) {
+  if (hasSubModels(existing)) {
     return existing;
+  }
+
+  if (existing || flowEngine.getModel(key)) {
+    flowEngine.removeModelWithSubModels(key);
   }
 
   const tree = createPublicFormFlowModelTree(record, t);

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormLayoutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormLayoutModel.tsx
@@ -179,8 +179,13 @@ const PublicFormLayoutComponent = observer((props: { model: PublicFormLayoutMode
       @media (max-width: ${token.screenSM}px) {
         padding: 0;
       }
+
+      .public-form-powered-by {
+        margin-top: ${token.marginXL}px;
+        padding-bottom: ${token.paddingLG}px;
+      }
     `,
-    [token.colorBgLayout, token.padding, token.paddingXL, token.screenSM],
+    [token.colorBgLayout, token.marginXL, token.padding, token.paddingLG, token.paddingXL, token.screenSM],
   );
 
   usePublicFormTokenHeader();
@@ -291,7 +296,7 @@ const PublicFormLayoutComponent = observer((props: { model: PublicFormLayoutMode
         <div ref={bindLayoutContentElement} className={routeContentClassName} style={routeContentStyle}>
           {outlet}
         </div>
-        <div>
+        <div className="public-form-powered-by">
           <PoweredBy />
         </div>
       </div>

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormPageModel.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormPageModel.tsx
@@ -31,8 +31,8 @@ const PublicFormSettingsContent = observer((props: { model: PublicFormPageModel 
   const { token } = theme.useToken();
   const className = useMemo(
     () => css`
-      max-width: 800px;
-      margin: 20px auto 0;
+      max-width: ${token.screenMD}px;
+      margin: ${token.marginLG}px auto 0;
 
       .nb-block-grid {
         padding: 0 !important;
@@ -55,7 +55,7 @@ const PublicFormSettingsContent = observer((props: { model: PublicFormPageModel 
       }
 
       @media (max-width: ${token.screenMD}px) {
-        margin-top: 20px;
+        margin-top: ${token.marginLG}px;
       }
     `,
     [

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormsSettingsLayoutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormsSettingsLayoutModel.tsx
@@ -9,12 +9,13 @@
 
 import { EyeOutlined, SettingOutlined } from '@ant-design/icons';
 import { BaseLayoutModel, DrawerFormLayout, EnvVariableInput } from '@nocobase/client-v2';
-import { observer, useFlowContext } from '@nocobase/flow-engine';
+import { observer, useFlowContext, useFlowEngine } from '@nocobase/flow-engine';
+import type { FlowModel } from '@nocobase/flow-engine';
 import { useRequest } from 'ahooks';
-import { App, Breadcrumb, Button, Dropdown, Form, Popover, QRCode, Space, Spin, Switch, theme } from 'antd';
+import { App, Breadcrumb, Button, Dropdown, Form, Popover, QRCode, Result, Space, Spin, Switch, theme } from 'antd';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link, useOutlet } from 'react-router-dom';
-import type { PublicFormRecord } from '../modelTree';
+import { ensurePublicFormFlowModel, type PublicFormRecord } from '../modelTree';
 import { useT } from '../locale';
 import { getPublicFormRoutePath } from '../route';
 
@@ -92,29 +93,42 @@ function PasswordForm(props: { record: PublicFormRecord; onSubmitted: (values: P
   );
 }
 
-const PublicFormsSettingsLayoutComponent = observer((props: { model: PublicFormsSettingsLayoutModel }) => {
-  const { model } = props;
-  const outlet = useOutlet();
+type PublicFormsSettingsDetailViewProps = {
+  pageUid?: string;
+  children?: React.ReactNode | ((routeModel: FlowModel) => React.ReactNode);
+};
+
+export const PublicFormsSettingsDetailView = observer((props: PublicFormsSettingsDetailViewProps) => {
+  const { pageUid, children } = props;
   const ctx = useFlowContext();
+  const flowEngine = useFlowEngine();
   const t = useT();
   const { message } = App.useApp();
   const { token } = theme.useToken();
-  const pageUid = model.getPageUidFromLayoutRoute(model.currentLayoutRoute);
   const publicFormLink = usePublicFormLink(pageUid);
   const resource = ctx.api.resource('publicForms');
-  const { data, mutate } = useRequest(
+  const { data, loading, mutate } = useRequest(
     async () => {
       if (!pageUid) {
         return null;
       }
       const response = await resource.get({ filterByTk: pageUid });
-      return normalizeRecordResponse(response);
+      const nextRecord = normalizeRecordResponse(response);
+      if (nextRecord?.key === pageUid && nextRecord.version === 'v2') {
+        const routeModel = await ensurePublicFormFlowModel(flowEngine, nextRecord, t);
+        return {
+          record: nextRecord,
+          routeModel,
+        };
+      }
+      return null;
     },
     {
       refreshDeps: [pageUid],
     },
   );
-  const record = data?.key === pageUid ? (data as PublicFormRecord) : null;
+  const record = data?.record?.key === pageUid ? data.record : null;
+  const routeModel = data?.routeModel || null;
 
   const handleUpdate = useCallback(
     async (values: Partial<PublicFormRecord>) => {
@@ -126,11 +140,14 @@ const PublicFormsSettingsLayoutComponent = observer((props: { model: PublicForms
         values,
       });
       mutate({
-        ...record,
-        ...values,
+        record: {
+          ...record,
+          ...values,
+        },
+        routeModel,
       });
     },
-    [mutate, record, resource],
+    [mutate, record, resource, routeModel],
   );
 
   const handleCopyLink = useCallback(async () => {
@@ -145,16 +162,29 @@ const PublicFormsSettingsLayoutComponent = observer((props: { model: PublicForms
     ctx.viewer.drawer({
       width: token.screenSM,
       closable: true,
-      content: () => <PasswordForm record={record} onSubmitted={(values) => mutate({ ...record, ...values })} />,
+      content: () => (
+        <PasswordForm
+          record={record}
+          onSubmitted={(values) =>
+            mutate({
+              record: {
+                ...record,
+                ...values,
+              },
+              routeModel,
+            })
+          }
+        />
+      ),
     });
-  }, [ctx.viewer, mutate, record, token.screenSM]);
+  }, [ctx.viewer, mutate, record, routeModel, token.screenSM]);
 
-  if (!outlet) {
-    return null;
+  if (loading) {
+    return <Spin />;
   }
 
-  if (!record) {
-    return <Spin />;
+  if (!record || !routeModel) {
+    return <Result status="warning" title={t('The form is not found')} />;
   }
 
   return (
@@ -243,10 +273,22 @@ const PublicFormsSettingsLayoutComponent = observer((props: { model: PublicForms
           width: '100%',
         }}
       >
-        {outlet}
+        {typeof children === 'function' ? children(routeModel) : children}
       </div>
     </div>
   );
+});
+
+const PublicFormsSettingsLayoutComponent = observer((props: { model: PublicFormsSettingsLayoutModel }) => {
+  const { model } = props;
+  const outlet = useOutlet();
+  const pageUid = model.getPageUidFromLayoutRoute(model.currentLayoutRoute);
+
+  if (!outlet) {
+    return null;
+  }
+
+  return <PublicFormsSettingsDetailView pageUid={pageUid}>{outlet}</PublicFormsSettingsDetailView>;
 });
 
 export class PublicFormsSettingsLayoutModel extends BaseLayoutModel {

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsDetailPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsDetailPage.tsx
@@ -1,0 +1,109 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowContext, FlowModelRenderer, FlowViewContextProvider, useFlowContext } from '@nocobase/flow-engine';
+import type { FlowModel } from '@nocobase/flow-engine';
+import { Spin } from 'antd';
+import React, { useLayoutEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { PublicFormsSettingsDetailView } from '../models/PublicFormsSettingsLayoutModel';
+
+function getPublicFormPageModel(routeModel: FlowModel) {
+  const page = routeModel.subModels?.page;
+  return Array.isArray(page) ? page[0] : page;
+}
+
+type EmbedFlowView = {
+  type: 'embed';
+  inputArgs: Record<string, unknown>;
+  Header: null;
+  Footer: null;
+  close: () => Promise<void>;
+  update: () => void;
+};
+
+function PublicFormPageRenderer(props: { model: FlowModel }) {
+  const { model } = props;
+  const ctx = useFlowContext();
+  const [attachedContext, setAttachedContext] = useState<{ model: FlowModel; context: FlowContext } | null>(null);
+  const viewContext = useMemo(() => {
+    const view: EmbedFlowView = {
+      type: 'embed',
+      inputArgs: {},
+      Header: null,
+      Footer: null,
+      close: async () => undefined,
+      update: () => undefined,
+    };
+    const nextContext = new FlowContext();
+
+    if (ctx instanceof FlowContext) {
+      nextContext.addDelegate(ctx);
+    }
+
+    nextContext.defineProperty('view', {
+      value: view,
+    });
+    nextContext.defineProperty('flowSettingsEnabled', {
+      value: true,
+    });
+    return nextContext;
+  }, [ctx]);
+  const needsModelDelegate = useMemo(() => {
+    if (model.context instanceof FlowContext && viewContext instanceof FlowContext) {
+      return true;
+    }
+    return false;
+  }, [model.context, viewContext]);
+
+  useLayoutEffect(() => {
+    if (!(model.context instanceof FlowContext) || !(viewContext instanceof FlowContext)) {
+      setAttachedContext(null);
+      return;
+    }
+
+    model.context.addDelegate(viewContext);
+    setAttachedContext({ model, context: viewContext });
+
+    return () => {
+      if (model.context instanceof FlowContext) {
+        model.context.removeDelegate(viewContext);
+      }
+    };
+  }, [model, model.context, viewContext]);
+
+  if (needsModelDelegate && (attachedContext?.model !== model || attachedContext.context !== viewContext)) {
+    return <Spin />;
+  }
+
+  return (
+    <FlowViewContextProvider context={viewContext}>
+      <FlowModelRenderer model={model} showFlowSettings={false} />
+    </FlowViewContextProvider>
+  );
+}
+
+export default function PublicFormsSettingsDetailPage() {
+  const params = useParams<{ name?: string }>();
+  const pageUid = params.name;
+
+  return (
+    <PublicFormsSettingsDetailView pageUid={pageUid}>
+      {(routeModel) => {
+        const pageModel = getPublicFormPageModel(routeModel);
+
+        if (!pageModel) {
+          return <Spin />;
+        }
+
+        return <PublicFormPageRenderer model={pageModel} />;
+      }}
+    </PublicFormsSettingsDetailView>
+  );
+}

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsPage.tsx
@@ -15,7 +15,7 @@ import { App, Button, Card, Cascader, Form, Input, Radio, Space, Switch, Tag, th
 import type { ColumnsType } from 'antd/es/table';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useOutlet } from 'react-router-dom';
-import { PUBLIC_FORMS_NAMESPACE, PUBLIC_FORMS_SETTINGS_CONFIGURE_ROUTE_PATH } from '../constants';
+import { PUBLIC_FORMS_NAMESPACE } from '../constants';
 import { useT } from '../locale';
 import { ensurePublicFormFlowModel, type PublicFormRecord } from '../modelTree';
 
@@ -158,13 +158,17 @@ function PublicFormDrawer(props: { mode: 'create' | 'edit'; record?: PublicFormR
           ...values,
           type: values.type || 'form',
           key: randomId(),
+          version: 'v2',
         };
         await resource.create({ values: nextRecord });
         await ensurePublicFormFlowModel(flowEngine, nextRecord, t);
       } else if (record?.key) {
         await resource.update({
           filterByTk: record.key,
-          values,
+          values: {
+            ...values,
+            version: 'v2',
+          },
         });
       } else {
         throw new Error('[NocoBase] Missing public form key.');
@@ -233,6 +237,9 @@ export default function PublicFormsSettingsPage() {
         pageSize,
         sort: ['-createdAt'],
         appends: ['createdBy', 'updatedBy'],
+        filter: {
+          version: 'v2',
+        },
       });
       return normalizeListResponse(response);
     },
@@ -280,7 +287,7 @@ export default function PublicFormsSettingsPage() {
     async (record: PublicFormRecord) => {
       await ensurePublicFormFlowModel(flowEngine, record, t);
       const basePath = ctx.app.pluginSettingsManager.getRoutePath(`${PUBLIC_FORMS_NAMESPACE}.index`);
-      navigate(`${basePath}/${PUBLIC_FORMS_SETTINGS_CONFIGURE_ROUTE_PATH}/${record.key}`);
+      navigate(`${basePath}/${record.key}`);
     },
     [ctx.app.pluginSettingsManager, flowEngine, navigate, t],
   );

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/plugin.tsx
@@ -16,10 +16,7 @@ import {
   PUBLIC_FORM_ROUTE_NAME,
   PUBLIC_FORM_SUBMIT_ACTION_MODEL,
   PUBLIC_FORMS_NAMESPACE,
-  PUBLIC_FORMS_SETTINGS_CONFIGURE_ROUTE_PATH,
   PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL,
-  PUBLIC_FORMS_SETTINGS_LAYOUT_UID,
-  PUBLIC_FORMS_SETTINGS_ROUTE_NAME,
 } from './constants';
 
 export class PluginPublicFormsClientV2 extends Plugin<Record<string, never>, Application> {
@@ -55,11 +52,12 @@ export class PluginPublicFormsClientV2 extends Plugin<Record<string, never>, App
       componentLoader: () => import('./pages/PublicFormsSettingsPage'),
     });
 
-    this.app.layoutManager.registerLayout({
-      routeName: PUBLIC_FORMS_SETTINGS_ROUTE_NAME,
-      routePath: PUBLIC_FORMS_SETTINGS_CONFIGURE_ROUTE_PATH,
-      uid: PUBLIC_FORMS_SETTINGS_LAYOUT_UID,
-      layoutModelClass: PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL,
+    this.pluginSettingsManager.addPageTabItem({
+      menuKey: PUBLIC_FORMS_NAMESPACE,
+      key: ':name',
+      title: false,
+      hidden: true,
+      componentLoader: () => import('./pages/PublicFormsSettingsDetailPage'),
     });
 
     this.app.layoutManager.registerLayout({

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/publicFormsSchema.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/publicFormsSchema.test.ts
@@ -1,0 +1,19 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { publicFormsSchema } from '../schemas/publicForms';
+
+describe('publicFormsSchema', () => {
+  it('lists v1 public forms and historical unversioned records', () => {
+    expect(publicFormsSchema['x-decorator-props']?.params?.filter).toEqual({
+      $or: [{ version: 'v1' }, { 'version.$empty': true }],
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/collections/publicForms.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/collections/publicForms.ts
@@ -46,6 +46,16 @@ export const publicFormsCollection = {
     },
     {
       type: 'string',
+      name: 'version',
+      interface: 'input',
+      uiSchema: {
+        type: 'string',
+        title: 'Version',
+        'x-component': 'Input',
+      },
+    },
+    {
+      type: 'string',
       name: 'collection',
       interface: 'collection',
       uiSchema: {

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/useSubmitActionProps.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/useSubmitActionProps.ts
@@ -73,7 +73,10 @@ export const useSubmitActionProps = () => {
       const values = form.values;
       if (values[collection.filterTargetKey]) {
         await resource.update({
-          values,
+          values: {
+            ...values,
+            version: 'v1',
+          },
           filterByTk: values[collection.filterTargetKey],
         });
       } else {
@@ -95,6 +98,7 @@ export const useSubmitActionProps = () => {
           values: {
             ...values,
             key,
+            version: 'v1',
           },
         });
         await api.resource('uiSchemas').insert({ values: schema });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/publicForms.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/publicForms.tsx
@@ -26,6 +26,9 @@ export const publicFormsSchema: ISchema = {
     params: {
       sort: '-createdAt',
       appends: ['createdBy', 'updatedBy'],
+      filter: {
+        $or: [{ version: 'v1' }, { 'version.$empty': true }],
+      },
     },
     showIndex: true,
     dragSort: false,

--- a/packages/plugins/@nocobase/plugin-public-forms/src/server/collections/publicForms.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/server/collections/publicForms.ts
@@ -32,6 +32,10 @@ export default defineCollection({
     },
     {
       type: 'string',
+      name: 'version',
+    },
+    {
+      type: 'string',
       name: 'collection',
     },
     {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Public forms in v1 and v2 should be managed independently. The v2 public forms list should not show forms created by the v1 configuration UI, and v2 Configure should open the same kind of configurable form detail page as v1 while staying in configuration mode.

### Description 

This PR separates public form records by version and treats historical records without a version as v1 records. V1 creation/update writes `version: 'v1'`; v2 creation/update writes `version: 'v2'`; v1 and v2 list queries now apply their own version filters.

It also changes v2 Configure navigation to a settings detail page, ensures only v2 records can be rendered from the v2 configure route, and renders the stored public form FlowModel in an embedded configuration context. The public form Powered by NocoBase spacing was adjusted with Ant Design tokens.

A `version` field was added to the public forms collection schema so list filtering can happen at the database query layer with correct pagination. Existing unversioned records remain visible in v1 by default.

Potential risk is limited to the public forms plugin. The main residual risk is that the v2 settings CRUD page still has broader request-layer coverage opportunity for create/edit/delete paths, although the changed configure and filtering paths are covered and the plugin build passes.

### Related issues

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Separated v1 and v2 public form lists and fixed the v2 Configure page to open a configurable form detail page. |
| 🇨🇳 Chinese | 区分 V1 和 V2 的公开表单列表，并修复 V2 Configure 进入可配置表单详情页的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
