### PR TITLE
fix(client-v2): show plugin settings links

### DIFF
--- a/packages/core/client-v2/src/PluginSettingsManager.ts
+++ b/packages/core/client-v2/src/PluginSettingsManager.ts
@@ -97,6 +97,7 @@ interface InternalPageItemRecord extends PluginSettingsPageItemOptions {
 export class PluginSettingsManager<TApp extends BaseApplication<any> = BaseApplication<any>> {
   protected menus: Record<string, InternalMenuItemRecord> = {};
   protected pages: Record<string, InternalPageItemRecord> = {};
+  protected pluginSettingsLinks: Record<string, string> = {};
   protected aclSnippets: string[] = [];
   public app: TApp;
 
@@ -292,6 +293,58 @@ export class PluginSettingsManager<TApp extends BaseApplication<any> = BaseAppli
    */
   has(name: string) {
     return !!(this.menus[name] || this.pages[name]);
+  }
+
+  /**
+   * 绑定插件管理列表中的 plugin name 到实际 settings 入口。
+   *
+   * 插件管理列表使用 applicationPlugins.name 判断是否显示 Settings 入口，
+   * 但部分插件会把设置页挂到共享菜单或历史路径下。
+   *
+   * @param pluginName 插件管理列表中的插件名
+   * @param settingsName menu 或 page 名称
+   * @returns {void}
+   */
+  setPluginSettingsLink(pluginName: string, settingsName: string) {
+    if (!pluginName) {
+      throw new Error('Plugin settings link pluginName is required');
+    }
+
+    if (!settingsName) {
+      throw new Error('Plugin settings link settingsName is required');
+    }
+
+    this.pluginSettingsLinks[pluginName] = settingsName;
+  }
+
+  /**
+   * 获取插件管理列表中的 plugin name 对应的 settings 名称。
+   *
+   * @param pluginName 插件管理列表中的插件名
+   * @returns {string} settings 名称
+   */
+  getPluginSettingsName(pluginName: string) {
+    return this.pluginSettingsLinks[pluginName] || pluginName;
+  }
+
+  /**
+   * 判断插件管理列表中的插件是否有可跳转的 settings 入口。
+   *
+   * @param pluginName 插件管理列表中的插件名
+   * @returns {boolean} 是否已注册 settings 入口
+   */
+  hasPluginSettings(pluginName: string) {
+    return this.has(this.getPluginSettingsName(pluginName));
+  }
+
+  /**
+   * 获取插件管理列表中的插件对应的 settings 路径。
+   *
+   * @param pluginName 插件管理列表中的插件名
+   * @returns {string} settings 绝对路径
+   */
+  getPluginSettingsRoutePath(pluginName: string) {
+    return this.getRoutePath(this.getPluginSettingsName(pluginName));
   }
 
   /**

--- a/packages/core/client-v2/src/__tests__/PluginSettingsManager.test.ts
+++ b/packages/core/client-v2/src/__tests__/PluginSettingsManager.test.ts
@@ -78,6 +78,19 @@ describe('PluginSettingsManager v2', () => {
     expect(app.router.get('admin.settings.demo.advanced')).toMatchObject({ path: 'advanced' });
   });
 
+  it('should resolve plugin settings links for plugin manager entries', () => {
+    const app = createMockClient();
+
+    app.pluginSettingsManager.addMenuItem({ key: 'shared', title: 'Shared' });
+    app.pluginSettingsManager.addPageTabItem({ menuKey: 'shared', key: 'target', title: 'Target' });
+    app.pluginSettingsManager.setPluginSettingsLink('demo-plugin', 'shared.target');
+
+    expect(app.pluginSettingsManager.has('demo-plugin')).toBe(false);
+    expect(app.pluginSettingsManager.hasPluginSettings('demo-plugin')).toBe(true);
+    expect(app.pluginSettingsManager.getPluginSettingsName('demo-plugin')).toBe('shared.target');
+    expect(app.pluginSettingsManager.getPluginSettingsRoutePath('demo-plugin')).toBe('/admin/settings/shared/target');
+  });
+
   it('should render string icon on both menu and page tab via renderIcon', () => {
     // Previously `renderPage` spread the raw `icon` string straight to the antd
     // Menu item, which displayed "LockOutlinedTitle" as text. Both `renderMenuItem`

--- a/packages/core/client-v2/src/__tests__/plugin-manager.test.tsx
+++ b/packages/core/client-v2/src/__tests__/plugin-manager.test.tsx
@@ -18,6 +18,19 @@ class TestAclPlugin extends Plugin {
   }
 }
 
+class TestSettingsLinkPlugin extends Plugin {
+  async load() {
+    this.app.pluginSettingsManager.addMenuItem({ key: 'shared-settings', title: 'Shared settings' });
+    this.app.pluginSettingsManager.addPageTabItem({
+      menuKey: 'shared-settings',
+      key: 'target',
+      title: 'Target settings',
+      Component: () => <div>Target settings page</div>,
+    });
+    this.app.pluginSettingsManager.setPluginSettingsLink('demo-plugin', 'shared-settings.target');
+  }
+}
+
 type MockClientApplication = ReturnType<typeof createMockClient>;
 
 const renderApp = (app: MockClientApplication) => {
@@ -35,9 +48,9 @@ const waitForGetRequests = async (app: MockClientApplication, urls: string[]) =>
   );
 };
 
-const setupApp = (pmList: any[]) => {
+const setupApp = (pmList: any[], plugins: Array<typeof Plugin> = []) => {
   const app = createMockClient({
-    plugins: [NocoBaseBuildInPlugin, TestAclPlugin],
+    plugins: [NocoBaseBuildInPlugin, TestAclPlugin, ...plugins],
     router: { type: 'memory', initialEntries: ['/admin/settings/plugin-manager'] },
   });
 
@@ -173,5 +186,34 @@ describe('plugin-manager page', () => {
       expect(removeCall).toBeDefined();
       expect(removeCall?.params).toMatchObject({ filterByTk: 'demo-plugin' });
     });
+  });
+
+  it('shows Settings for a plugin linked to a different settings page', async () => {
+    const app = setupApp(
+      [
+        {
+          name: 'demo-plugin',
+          packageName: '@nocobase/demo-plugin',
+          displayName: 'Demo plugin',
+          description: 'A demo',
+          enabled: true,
+          builtIn: false,
+          removable: false,
+          version: '0.1.0',
+          isCompatible: true,
+          keywords: [],
+        },
+      ],
+      [TestSettingsLinkPlugin],
+    );
+
+    renderApp(app);
+    await waitForGetRequests(app, ['/auth:check', 'roles:check', 'pm:list']);
+
+    const card = await screen.findByRole('button', { name: 'Demo plugin' });
+    const settingsLink = within(card.closest('.ant-card') as HTMLElement).getByText('Settings');
+    fireEvent.click(settingsLink);
+
+    expect(await screen.findByText('Target settings page')).toBeInTheDocument();
   });
 });

--- a/packages/core/client-v2/src/settings-center/plugin-manager/PluginCard.tsx
+++ b/packages/core/client-v2/src/settings-center/plugin-manager/PluginCard.tsx
@@ -116,7 +116,7 @@ export const PluginCard: FC<PluginCardProps> = ({ data }) => {
   });
 
   const openSettings = useMemoizedFn(() => {
-    navigate(app.pluginSettingsManager.getRoutePath(name));
+    navigate(app.pluginSettingsManager.getPluginSettingsRoutePath(name));
   });
 
   const cardClassName = useMemo(
@@ -180,7 +180,7 @@ export const PluginCard: FC<PluginCardProps> = ({ data }) => {
           <ReadOutlined /> {t('Docs')}
         </a>
       )}
-      {enabled && app.pluginSettingsManager.has(name) && (
+      {enabled && app.pluginSettingsManager.hasPluginSettings(name) && (
         <a
           onClick={(e) => {
             e.stopPropagation();

--- a/packages/plugins/@nocobase-example/plugin-settings-page/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase-example/plugin-settings-page/src/client-v2/plugin.tsx
@@ -35,6 +35,7 @@ export class PluginSettingsPageClientV2 extends Plugin<any, Application> {
       title: this.t('About') as unknown as string,
       componentLoader: () => import('./pages/AboutPage'),
     });
+    this.pluginSettingsManager.setPluginSettingsLink('settings-page', 'external-api');
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-acl/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-acl/src/client-v2/plugin.tsx
@@ -35,6 +35,7 @@ export class PluginAclClientV2 extends Plugin<any, Application> {
       sort: 4,
       componentLoader: () => import('./pages/RolesManagementPage'),
     });
+    this.pluginSettingsManager.setPluginSettingsLink('acl', 'users-permissions.roles');
     this.settingsUI.addPermissionsTab({
       key: 'general',
       label: String(this.t('System')),

--- a/packages/plugins/@nocobase/plugin-departments/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-departments/src/client-v2/plugin.tsx
@@ -32,6 +32,7 @@ export class PluginDepartmentsClientV2 extends Plugin<Record<string, never>, App
       aclSnippet: 'pm.departments',
       componentLoader: () => import('./pages/DepartmentsPage'),
     });
+    this.pluginSettingsManager.setPluginSettingsLink('departments', 'users-permissions.departments');
 
     const aclPlugin = this.app.pm.get(PluginAclClientV2) as PluginAclClientV2 | undefined;
     aclPlugin?.rolesManager.add('departments', {

--- a/packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/plugin.tsx
@@ -28,6 +28,7 @@ export class PluginEnvironmentVariablesClientV2 extends Plugin<Record<string, ne
       title,
       componentLoader: () => import('./pages/EnvironmentPage'),
     });
+    this.pluginSettingsManager.setPluginSettingsLink('environment-variables', 'environment');
 
     // Expose `$env` to all v2 plugins via FlowContext, replacing v1's
     // `addGlobalVar('$env', ...)` + Provider chain. Lazy-loaded — the API is

--- a/packages/plugins/@nocobase/plugin-license/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-license/src/client-v2/plugin.tsx
@@ -28,6 +28,7 @@ export class PluginLicenseClientV2 extends Plugin<Record<string, never>, Applica
       aclSnippet: 'pm.license-settings',
       componentLoader: () => import('./pages/LicenseSetting'),
     });
+    this.pluginSettingsManager.setPluginSettingsLink('license', 'license-settings');
   }
 }
 

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts
@@ -21,6 +21,7 @@ describe('PluginUiLayoutClientV2', () => {
       pluginSettingsManager: {
         addMenuItem: vi.fn(),
         addPageTabItem: vi.fn(),
+        setPluginSettingsLink: vi.fn(),
       },
       apiClient: {
         request: vi.fn().mockResolvedValue({
@@ -113,6 +114,7 @@ describe('PluginUiLayoutClientV2', () => {
         key: 'index',
       }),
     );
+    expect(app.pluginSettingsManager.setPluginSettingsLink).toHaveBeenCalledWith('ui-layout', 'routes');
     const settingsApp = createMockClient();
     for (const [menuItem] of app.pluginSettingsManager.addMenuItem.mock.calls) {
       settingsApp.pluginSettingsManager.addMenuItem(menuItem);

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx
@@ -91,6 +91,7 @@ export class PluginUiLayoutClientV2 extends Plugin<Record<string, never>, Applic
         return { default: module.MobileRoutesPage };
       },
     });
+    this.pluginSettingsManager.setPluginSettingsLink('ui-layout', 'routes');
 
     registerLayoutAwareDesktopRoutesPermissionsTab(this.app, (key) => this.t(key));
 

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/plugin.tsx
@@ -55,6 +55,7 @@ export class PluginUsersClientV2 extends Plugin {
       sort: 2,
       componentLoader: () => import('./pages/UsersManagementPage'),
     });
+    this.pluginSettingsManager.setPluginSettingsLink('users', 'users-permissions.users');
 
     const aclPlugin = this.app.pm.get(PluginAclClientV2) as PluginAclClientV2 | undefined;
     aclPlugin?.rolesManager.add('users', {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Some Client V2 plugin manager cards did not show the `Settings` entry because the plugin record name and the registered settings key were different. For example, `license` registers settings under `license-settings`, and users-related plugins register under the shared `users-permissions` menu.

### Description 
This PR adds a small plugin-settings link mapping in the Client V2 `PluginSettingsManager` and updates plugin manager cards to resolve settings entries through that mapping before checking visibility or navigating.

It registers mappings for the affected V2 plugins:

- `acl` -> `users-permissions.roles`
- `users` -> `users-permissions.users`
- `departments` -> `users-permissions.departments`
- `environment-variables` -> `environment`
- `license` -> `license-settings`
- `ui-layout` -> `routes`
- example `settings-page` -> `external-api`

Risk assessment: low. The change is additive, keeps existing settings routes and ACL snippets unchanged, and falls back to the original plugin name when no mapping is registered. Existing plugins with matching names continue to use the old path.

Testing performed:

- `yarn eslint --fix packages/core/client-v2/src/PluginSettingsManager.ts packages/core/client-v2/src/settings-center/plugin-manager/PluginCard.tsx packages/core/client-v2/src/__tests__/PluginSettingsManager.test.ts packages/core/client-v2/src/__tests__/plugin-manager.test.tsx packages/plugins/@nocobase/plugin-acl/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-departments/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-environment-variables/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-license/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx packages/plugins/@nocobase-example/plugin-settings-page/src/client-v2/plugin.tsx`
- `yarn test packages/core/client-v2/src/__tests__/PluginSettingsManager.test.ts --run --reporter=verbose`
- `yarn test packages/core/client-v2/src/__tests__/plugin-manager.test.tsx --run --reporter=verbose`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed missing Settings entries for Client V2 plugin manager cards when a plugin uses a shared or legacy settings path. |
| 🇨🇳 Chinese | 修复 Client V2 插件管理卡片在插件使用共享或历史设置路径时缺少 Settings 入口的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
