### PR TITLE
fix(plugin-workflow-custom-action-trigger): resolve v2 custom context action variables

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -85,6 +85,14 @@ function parseContextData(contextData: unknown) {
   return JSON.parse(contextData);
 }
 
+async function resolveContextData(ctx: FlowRuntimeContext, contextData: unknown) {
+  const parsedContextData = parseContextData(contextData);
+  if (typeof ctx.resolveJsonTemplate !== 'function') {
+    return parsedContextData;
+  }
+  return await ctx.resolveJsonTemplate(parsedContextData);
+}
+
 function ensureTriggerWorkflowsConfigured(ctx: FlowRuntimeContext, group?: TriggerWorkflowBinding[]) {
   if (group?.length) {
     return true;
@@ -511,7 +519,7 @@ CollectionTriggerWorkflowActionModel.registerFlow({
           let values;
           if (contextData) {
             try {
-              values = parseContextData(contextData);
+              values = await resolveContextData(ctx, contextData);
             } catch (e) {
               // resolution error, ignore
             }
@@ -573,7 +581,7 @@ async function globalTriggerWorkflowHandler(ctx, params) {
   let values;
   if (params.contextData) {
     try {
-      values = parseContextData(params.contextData);
+      values = await resolveContextData(ctx, params.contextData);
     } catch (e) {
       // resolution error, ignore
     }

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
@@ -22,6 +22,7 @@ import {
   registerTriggerWorkflowActionGroups,
   WorkbenchTriggerWorkflowActionModel,
 } from '../TriggerWorkflowActionModels';
+import { CONTEXT_TYPE } from '../../../../common/constants';
 
 class ActionPanelGroupActionModel extends ActionGroupModel {}
 
@@ -94,6 +95,14 @@ async function getTriggerWorkflowItemNames(ModelClass: any, ctx: any) {
 function getWorkbenchTriggerWorkflowHandler(model: WorkbenchTriggerWorkflowActionModel) {
   const step = model.getFlow('workbenchTriggerWorkflowsActionSettings')?.getStep('triggerWorkflows')?.serialize() as
     | { handler?: (ctx: any, params: { group?: unknown[]; contextData?: unknown }) => Promise<void> }
+    | undefined;
+  expect(step?.handler).toBeTypeOf('function');
+  return step.handler;
+}
+
+function getCollectionTriggerHandler(model: CollectionTriggerWorkflowActionModel) {
+  const step = model.getFlow('customCollectionTriggerWorkflowsActionEventSettings')?.getStep('trigger')?.serialize() as
+    | { handler?: (ctx: any) => Promise<void> }
     | undefined;
   expect(step?.handler).toBeTypeOf('function');
   return step.handler;
@@ -260,6 +269,69 @@ describe('WorkbenchTriggerWorkflowActionModel', () => {
     expect(ctx.exit).not.toHaveBeenCalled();
   });
 
+  it('resolves custom context data before sending trigger request body', async () => {
+    const flowEngine = createEngine();
+    const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({
+      use: 'WorkbenchTriggerWorkflowActionModel',
+      uid: 'workbench-trigger-workflow-action-context-data-resolved',
+    });
+    const request = vi.fn().mockResolvedValue({});
+    const resolveJsonTemplate = vi.fn(async () => ({
+      a: '1',
+      userId: 100,
+      nested: {
+        b: '2',
+      },
+    }));
+    const ctx = {
+      api: {
+        request,
+      },
+      message: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+      resolveJsonTemplate,
+      t: (value: string) => value,
+      exit: vi.fn(),
+    };
+
+    const handler = getWorkbenchTriggerWorkflowHandler(model);
+
+    await handler(ctx, {
+      group: [{ workflowKey: 'workflow-1' }],
+      contextData: {
+        a: '1',
+        userId: '{{$user.id}}',
+        nested: {
+          b: '2',
+        },
+      },
+    });
+
+    expect(resolveJsonTemplate).toHaveBeenCalledWith({
+      a: '1',
+      userId: '{{$user.id}}',
+      nested: {
+        b: '2',
+      },
+    });
+    expect(request).toHaveBeenCalledWith({
+      url: 'workflows:trigger',
+      method: 'post',
+      params: {
+        triggerWorkflows: 'workflow-1',
+      },
+      data: {
+        a: '1',
+        userId: 100,
+        nested: {
+          b: '2',
+        },
+      },
+    });
+  });
+
   it('exits flow when trigger request fails', async () => {
     const flowEngine = createEngine();
     const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({
@@ -288,5 +360,66 @@ describe('WorkbenchTriggerWorkflowActionModel', () => {
     expect(ctx.message.success).not.toHaveBeenCalled();
     expect(ctx.exit).toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+});
+
+describe('CollectionTriggerWorkflowActionModel', () => {
+  it('resolves custom context data before sending trigger request body', async () => {
+    const flowEngine = createEngine();
+    const model = flowEngine.createModel<CollectionTriggerWorkflowActionModel>({
+      use: 'CollectionTriggerWorkflowActionModel',
+      uid: 'collection-trigger-workflow-action-context-data-resolved',
+    });
+    model.setStepParams('customCollectionTriggerWorkflowsActionSettings', 'setContextType', {
+      type: CONTEXT_TYPE.GLOBAL,
+    });
+    model.setStepParams('customCollectionTriggerWorkflowsActionSettings', 'triggerWorkflows', {
+      group: [{ workflowKey: 'workflow-1' }],
+      contextData: {
+        title: 'hello',
+        currentUserId: '{{$user.id}}',
+      },
+    });
+
+    const request = vi.fn().mockResolvedValue({});
+    const resolveJsonTemplate = vi.fn(async () => ({
+      title: 'hello',
+      currentUserId: 200,
+    }));
+    const ctx = {
+      api: {
+        request,
+      },
+      message: {
+        error: vi.fn(),
+        warning: vi.fn(),
+        success: vi.fn(),
+      },
+      model,
+      resolveJsonTemplate,
+      t: (value: string) => value,
+      exit: vi.fn(),
+    };
+
+    const handler = getCollectionTriggerHandler(model);
+
+    await handler(ctx);
+
+    expect(resolveJsonTemplate).toHaveBeenCalledWith({
+      title: 'hello',
+      currentUserId: '{{$user.id}}',
+    });
+    expect(request).toHaveBeenCalledWith({
+      url: 'workflows:trigger',
+      method: 'post',
+      params: {
+        triggerWorkflows: 'workflow-1',
+      },
+      data: {
+        title: 'hello',
+        currentUserId: 200,
+      },
+    });
+    expect(ctx.exit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Custom-context workflow trigger actions in the v2 action models were sending unresolved frontend variable expressions in `contextData`. This caused trigger workflow buttons in collection action areas such as table-related flows to submit raw template strings instead of resolved values.

### Description

- Added shared custom-context resolution before trigger requests are sent in the v2 workflow custom action action models.
- Applied the resolution path to both collection custom-context actions and workbench/global custom-context actions.
- Added regression tests to verify `contextData` is resolved before the request body is submitted.

Risk is low because the change is limited to custom-context request payload preparation in the workflow custom action trigger plugin.

Testing suggestions:
- Bind a custom-context workflow to a table or similar collection action button and verify variables such as `{{ctx.user.id}}` are resolved in the request payload.
- Bind a custom-context workflow to a workbench trigger button and verify the payload is also resolved correctly.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed custom-context trigger workflow actions so frontend variables in request payloads are resolved before submission in v2 action buttons |
| 🇨🇳 Chinese | 修复 v2 触发工作流按钮在自定义上下文请求体提交前未解析前端变量的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
