### PR TITLE
fix(plugin-embed): persist v2 embed token across refresh

### DIFF
--- a/packages/plugins/@nocobase/plugin-embed/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-embed/src/client-v2/__tests__/plugin.test.ts
@@ -22,6 +22,7 @@ describe('PluginEmbedClientV2', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.history.pushState({}, '', '/');
+    window.name = '';
   });
 
   it('registers embed layout through layoutManager instead of manual page routes', async () => {
@@ -73,6 +74,7 @@ describe('PluginEmbedClientV2', () => {
         storage: null,
         createStorage: vi.fn(() => storage),
         auth: {
+          getToken: vi.fn(() => null),
           setToken: vi.fn(),
         },
       },
@@ -85,7 +87,105 @@ describe('PluginEmbedClientV2', () => {
 
     expect(app.apiClient.createStorage).toHaveBeenCalledWith('sessionStorage');
     expect(app.apiClient.storage).toBe(storage);
+    expect(app.apiClient.storagePrefix).toMatch(/^NOCOBASE_EMBED_[0-9A-Z]+_[0-9A-Z]+_$/);
     expect(app.apiClient.auth.setToken).toHaveBeenCalledWith('test-token');
+  });
+
+  it('uses stable embed session storage when refreshing an embed route without token', async () => {
+    const { default: PluginEmbedClientV2 } = await import('../plugin');
+    const storage = {};
+    const app = {
+      router: {
+        getBasename: () => '/v2/apps/app1',
+      },
+      getPublicPath: () => '/v2/',
+      apiClient: {
+        storagePrefix: '',
+        storage: null,
+        createStorage: vi.fn(() => storage),
+        auth: {
+          getToken: vi.fn(() => 'test-token'),
+          setToken: vi.fn(),
+        },
+      },
+    };
+    const plugin = new PluginEmbedClientV2({} as any, app as any);
+
+    window.history.pushState({}, '', '/v2/apps/app1/embed/page-uid?token=test-token');
+    await plugin.beforeLoad();
+    const firstStoragePrefix = app.apiClient.storagePrefix;
+
+    window.history.pushState({}, '', '/v2/apps/app1/embed/page-uid');
+    await plugin.beforeLoad();
+
+    expect(app.apiClient.createStorage).toHaveBeenCalledTimes(2);
+    expect(app.apiClient.storage).toBe(storage);
+    expect(app.apiClient.storagePrefix).toBe(firstStoragePrefix);
+    expect(app.apiClient.auth.setToken).toHaveBeenCalledTimes(1);
+    expect(app.apiClient.auth.setToken).toHaveBeenCalledWith('test-token');
+  });
+
+  it('keeps default storage for embed route without query token or existing embed token', async () => {
+    const { default: PluginEmbedClientV2 } = await import('../plugin');
+    const originalStorage = {};
+    const embedStorage = {};
+    const app = {
+      router: {
+        getBasename: () => '/v2/apps/app1',
+      },
+      getPublicPath: () => '/v2/',
+      apiClient: {
+        storagePrefix: 'NOCOBASE_',
+        storage: originalStorage,
+        createStorage: vi.fn(() => embedStorage),
+        auth: {
+          getToken: vi.fn(() => null),
+          setToken: vi.fn(),
+        },
+      },
+    };
+    const plugin = new PluginEmbedClientV2({} as any, app as any);
+
+    window.history.pushState({}, '', '/v2/apps/app1/embed/page-uid');
+    await plugin.beforeLoad();
+
+    expect(app.apiClient.createStorage).toHaveBeenCalledWith('sessionStorage');
+    expect(app.apiClient.auth.getToken).toHaveBeenCalledTimes(1);
+    expect(app.apiClient.storagePrefix).toBe('NOCOBASE_');
+    expect(app.apiClient.storage).toBe(originalStorage);
+    expect(app.apiClient.auth.setToken).not.toHaveBeenCalled();
+  });
+
+  it('uses different embed storage prefixes for different router basenames', async () => {
+    const { default: PluginEmbedClientV2 } = await import('../plugin');
+    const createApp = (basename: string) => ({
+      router: {
+        getBasename: () => basename,
+      },
+      getPublicPath: () => '/v2/',
+      apiClient: {
+        storagePrefix: '',
+        storage: null,
+        createStorage: vi.fn(() => ({})),
+        auth: {
+          getToken: vi.fn(() => null),
+          setToken: vi.fn(),
+        },
+      },
+    });
+    const app1 = createApp('/v2/apps/app1');
+    const app2 = createApp('/v2/apps/app2');
+
+    window.name = 'embed-frame';
+    window.history.pushState({}, '', '/v2/apps/app1/embed/page-uid?token=test-token');
+    await new PluginEmbedClientV2({} as any, app1 as any).beforeLoad();
+
+    window.history.pushState({}, '', '/v2/apps/app2/embed/page-uid?token=test-token');
+    await new PluginEmbedClientV2({} as any, app2 as any).beforeLoad();
+
+    expect(app1.apiClient.storagePrefix).toMatch(/^NOCOBASE_EMBED_[0-9A-Z]+_[0-9A-Z]+_$/);
+    expect(app2.apiClient.storagePrefix).toMatch(/^NOCOBASE_EMBED_[0-9A-Z]+_[0-9A-Z]+_$/);
+    expect(app1.apiClient.storagePrefix).not.toBe(app2.apiClient.storagePrefix);
   });
 
   it('does not set token for non-embed route under router basename', async () => {

--- a/packages/plugins/@nocobase/plugin-embed/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-embed/src/client-v2/plugin.tsx
@@ -14,16 +14,62 @@ import { registerCopyEmbedLinkFlow } from './copyEmbedLinkFlow';
 import { isEmbedRoutePathname } from './route';
 
 const EMBED_ROUTE_PREFIX = '/embed';
+const EMBED_STORAGE_PREFIX = 'NOCOBASE_EMBED';
+const EMBED_WINDOW_NAME_PREFIX = '__nocobase_embed_';
+
+type EmbedAppLike = {
+  router?: {
+    getBasename?: () => string | undefined;
+  };
+  getPublicPath?: () => string;
+};
+
+function hashStorageSegment(value: string) {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash.toString(36).toUpperCase();
+}
+
+function getEmbedWindowName() {
+  if (!window.name) {
+    window.name = `${EMBED_WINDOW_NAME_PREFIX}${uid()}`;
+  }
+
+  return window.name;
+}
+
+function getEmbedStoragePrefix(app: EmbedAppLike) {
+  const appScope = app.router?.getBasename?.() || app.getPublicPath?.() || window.location.origin;
+  const frameScope = getEmbedWindowName();
+
+  return `${EMBED_STORAGE_PREFIX}_${hashStorageSegment(appScope)}_${hashStorageSegment(frameScope)}_`;
+}
 
 export class PluginEmbedClientV2 extends Plugin<any, Application> {
   async beforeLoad() {
     const url = new URL(window.location.href);
     const token = url.searchParams.get('token');
 
-    if (token && isEmbedRoutePathname(this.app, window.location.pathname)) {
-      this.app.apiClient.storagePrefix = `${uid().toUpperCase()}_`;
+    if (isEmbedRoutePathname(this.app, window.location.pathname)) {
+      const originalStoragePrefix = this.app.apiClient.storagePrefix;
+      const originalStorage = this.app.apiClient.storage;
+
+      this.app.apiClient.storagePrefix = getEmbedStoragePrefix(this.app);
       this.app.apiClient.storage = this.app.apiClient.createStorage('sessionStorage');
-      this.app.apiClient.auth.setToken(token);
+
+      if (token) {
+        this.app.apiClient.auth.setToken(token);
+        return;
+      }
+
+      if (!this.app.apiClient.auth.getToken()) {
+        this.app.apiClient.storagePrefix = originalStoragePrefix;
+        this.app.apiClient.storage = originalStorage;
+      }
     }
   }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Embed links with a `token` query parameter can be opened successfully the first time, but after the token is consumed and removed from the URL, refreshing the v2 embed route may lose the embed authentication state and render 403.

### Description 
This PR updates the v2 embed client to use an isolated, stable session storage scope for embed routes when a query token is provided or when an existing embed session token is available. This allows embed pages to keep working after the URL token is removed and the page is refreshed, without writing embed tokens into the normal NocoBase local storage login state.

If an embed route has no query token and no existing embed session token, the client restores the default API client storage so existing logged-in NocoBase users can still access embed pages with their normal session.

Potential risks:
- The embed storage scope uses `window.name` as a frame-stable identifier, so real iframe refresh behavior should be verified in a browser.
- Existing normal login fallback is preserved when no embed token exists.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-embed/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-embed/src/client-v2/__tests__/plugin.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-embed/src/client-v2/__tests__/plugin.test.ts --run --reporter=verbose`

### Related issues

Task 4717

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed v2 embed pages losing token-based access after the URL token is removed and the page is refreshed. |
| 🇨🇳 Chinese | 修复 v2 嵌入页面在 URL token 被移除后刷新会丢失 token 访问状态的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
