### PR TITLE
fix(plugin-backups): optimize backup table styles

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { css } from '@emotion/css';
 import { Table, useCurrentAppInfo } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
 import { useRequest } from 'ahooks';
@@ -43,6 +44,14 @@ export const BackupsTable = () => {
   const ctx = useFlowContext();
   const currentAppInfo = useCurrentAppInfo<AppInfo>();
   const { token } = theme.useToken();
+  const backupsTableClassName = useMemo(
+    () => css`
+      .ant-table-tbody > tr > td {
+        line-height: ${token.controlHeight - token.paddingXXS}px;
+      }
+    `,
+    [token.controlHeight, token.paddingXXS],
+  );
   const { modal, message } = App.useApp();
   const { data, loading, refreshAsync: refresh } = useBackupsContext();
   const { runAsync: destroy } = useRequest<BackupFile[] | undefined, [string]>(
@@ -101,6 +110,7 @@ export const BackupsTable = () => {
         title: t('Backup list'),
         dataIndex: 'name',
         width: 400,
+        ellipsis: true,
         onCell: (record) => {
           return record.inProgress
             ? {
@@ -152,5 +162,13 @@ export const BackupsTable = () => {
     [handleDestroy, handleDownload, t, token.colorText],
   );
 
-  return <Table<BackupFile> rowKey="name" dataSource={data?.data} loading={loading} columns={columns} />;
+  return (
+    <Table<BackupFile>
+      rowKey="name"
+      className={backupsTableClassName}
+      dataSource={data?.data}
+      loading={loading}
+      columns={columns}
+    />
+  );
 };


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The v2 backup manager table in the backup/restore plugin should visually align with other settings tables while keeping the change scoped to the backup plugin.

### Description 
- Added backup-plugin-local table row height styling based on the Ant Design `controlHeightLG` token instead of a hardcoded pixel value.
- Added ellipsis handling to the backup file name column to keep long backup names from affecting the table layout.
- Kept the change scoped to `@nocobase/plugin-backups` and avoided global table style changes.

Risk is low because this only changes display styles for the backup list table.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved backup manager table styling and long file name display. |
| 🇨🇳 Chinese | 优化备份管理表格样式及长文件名显示。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Verification:
- yarn eslint --fix packages/plugins/@nocobase/plugin-backups/src/client-v2/components/BackupsTable.tsx
