### PR TITLE
fix(plugin-workflow-custom-action-trigger): preserve boolean workflow filters in v2 binding

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/TriggerWorkflowActionModels.tsx
@@ -116,7 +116,7 @@ function getRecordKey(record, collection) {
   return record[filterByTk];
 }
 
-function WorkflowSelect({ filter, optionFilter, ...props }) {
+export function WorkflowSelect({ filter, optionFilter, ...props }) {
   const ctx = useFlowContext();
   const [options, setOptions] = React.useState<any[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -126,16 +126,12 @@ function WorkflowSelect({ filter, optionFilter, ...props }) {
     const loadWorkflows = async () => {
       setLoading(true);
       try {
-        const res = await ctx.api.request({
-          url: 'workflows:list',
-          method: 'get',
-          params: {
-            paginate: false,
-            filter: {
-              type: EVENT_TYPE,
-              enabled: true,
-              ...filter,
-            },
+        const res = await ctx.api.resource('workflows').list({
+          paginate: false,
+          filter: {
+            type: EVENT_TYPE,
+            enabled: true,
+            ...filter,
           },
         });
         if (!mounted) {

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/models/actions/__tests__/TriggerWorkflowActionModels.test.ts
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import React from 'react';
 import {
   ActionGroupModel,
   CollectionActionGroupModel,
@@ -14,6 +15,7 @@ import {
   RecordActionGroupModel,
 } from '@nocobase/client-v2';
 import { FlowEngine } from '@nocobase/flow-engine';
+import { render, waitFor } from '@nocobase/test/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CollectionTriggerWorkflowActionModel,
@@ -21,8 +23,35 @@ import {
   RecordTriggerWorkflowActionModel,
   registerTriggerWorkflowActionGroups,
   WorkbenchTriggerWorkflowActionModel,
+  WorkflowSelect,
 } from '../TriggerWorkflowActionModels';
 import { CONTEXT_TYPE } from '../../../../common/constants';
+
+const { mockUseFlowContext, selectMockState } = vi.hoisted(() => ({
+  mockUseFlowContext: vi.fn(),
+  selectMockState: {
+    props: undefined as any,
+  },
+}));
+
+vi.mock('@nocobase/flow-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nocobase/flow-engine')>();
+  return {
+    ...actual,
+    useFlowContext: mockUseFlowContext,
+  };
+});
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return {
+    ...actual,
+    Select: (props: any) => {
+      selectMockState.props = props;
+      return React.createElement('div', { 'data-testid': 'workflow-select' });
+    },
+  };
+});
 
 class ActionPanelGroupActionModel extends ActionGroupModel {}
 
@@ -114,6 +143,8 @@ describe('trigger workflow action model registration', () => {
       ModelClass,
       new Map(ModelClass.currentModels),
     ]);
+    mockUseFlowContext.mockReset();
+    selectMockState.props = undefined;
   });
 
   afterEach(() => {
@@ -151,6 +182,47 @@ describe('trigger workflow action model registration', () => {
 });
 
 describe('WorkbenchTriggerWorkflowActionModel', () => {
+  it('loads workflows through resource list so boolean filters stay typed', async () => {
+    const list = vi.fn().mockResolvedValue({
+      data: {
+        data: [{ title: 'Workflow 1', key: 'workflow-1' }],
+      },
+    });
+    const resource = vi.fn().mockReturnValue({ list });
+    const request = vi.fn();
+
+    mockUseFlowContext.mockReturnValue({
+      api: {
+        resource,
+        request,
+      },
+    });
+
+    render(
+      React.createElement(WorkflowSelect, {
+        filter: { 'config.collection': 'posts' },
+        optionFilter: () => true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(resource).toHaveBeenCalledWith('workflows');
+      expect(list).toHaveBeenCalledWith({
+        paginate: false,
+        filter: {
+          type: 'custom-action',
+          enabled: true,
+          'config.collection': 'posts',
+        },
+      });
+    });
+
+    expect(request).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(selectMockState.props?.options).toEqual([{ label: 'Workflow 1', value: 'workflow-1' }]);
+    });
+  });
+
   it('does not send trigger request when no workflow is bound', async () => {
     const flowEngine = createEngine();
     const model = flowEngine.createModel<WorkbenchTriggerWorkflowActionModel>({


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 custom action workflow binding selector requested `workflows:list` through `ctx.api.request()` with object-style query params. That serialized `filter.enabled=true` into bracket query params, which the server parsed as the string `'true'` instead of a boolean and caused enabled custom-action workflows to be filtered out incorrectly.

### Description
- Switched the v2 workflow binding selector to `ctx.api.resource('workflows').list(...)` so the filter is serialized as JSON and boolean values keep their type on the server side.
- Added a client-side regression test to verify the selector loads workflows through the resource list API and keeps `enabled: true` inside the filter payload.
- Kept the change scoped to the custom action trigger plugin. The only test-only surface added is exporting `WorkflowSelect` for direct regression coverage.

Potential risk:
- Low. The behavior change is limited to the workflow list request path used by the v2 custom action binding UI.

Testing suggestions:
- In a v2 form or record custom action, open the workflow binding dialog and verify enabled custom-action workflows appear again for the current collection.
- Confirm disabled workflows still do not appear.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the v2 custom action workflow binding selector so enabled workflows are filtered with boolean values and can be listed correctly. |
| 🇨🇳 Chinese | 修复 v2 自定义操作绑定工作流选择器的过滤请求，保证启用状态使用布尔值过滤并能正确列出工作流。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
