### PR TITLE
fix(client-v2): prevent row action buttons from changing table row height

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/table/TableActionsColumnModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableActionsColumnModel.tsx
@@ -22,6 +22,7 @@ import {
   observer,
 } from '@nocobase/flow-engine';
 import { Skeleton, Tooltip } from 'antd';
+import classNames from 'classnames';
 import React from 'react';
 import { ActionModel } from '../../base/ActionModel';
 import { TableCustomColumnModel } from './TableCustomColumnModel';
@@ -33,6 +34,33 @@ const rowActionButtonTypeOptions = [
   { value: 'link', label: '{{t("Link")}}' },
   { value: 'text', label: '{{t("Text")}}' },
 ];
+export const tableRowActionsClassName = css`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  line-height: inherit;
+  > div:empty {
+    display: none;
+  }
+
+  .nb-table-row-action-button.ant-btn-link,
+  .nb-table-row-action-button.ant-btn-text {
+    display: inline-flex;
+    align-items: center;
+    font: inherit;
+    height: auto;
+    line-height: inherit;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
+    vertical-align: baseline;
+  }
+
+  .nb-table-row-action-button.ant-btn-link > span,
+  .nb-table-row-action-button.ant-btn-text > span {
+    line-height: inherit;
+  }
+`;
 
 const Columns = observer<any>(({ record, model, index }) => {
   const isConfigMode = !!model.context.flowSettingsEnabled;
@@ -42,17 +70,7 @@ const Columns = observer<any>(({ record, model, index }) => {
     <DndProvider>
       <div
         style={{ gap: model.context?.themeToken?.marginSM ?? 16 }}
-        className={css`
-          display: flex;
-          flex-wrap: wrap;
-          align-items: center;
-          > div:empty {
-            display: none;
-          }
-          button {
-            padding: 0;
-          }
-        `}
+        className={`nb-table-row-actions ${tableRowActionsClassName}`}
       >
         {model.mapSubModels('actions', (action: ActionModel) => {
           // Static hidden can be skipped safely; dynamic hidden is handled by fork.beforeRender + model.render wrapper.
@@ -68,7 +86,12 @@ const Columns = observer<any>(({ record, model, index }) => {
             cachedFork.dispose();
           }
 
-          const fork = action.createFork({}, slotKey);
+          const fork = action.createFork(
+            {
+              className: classNames(action.props?.className, 'nb-table-row-action-button'),
+            },
+            slotKey,
+          );
           (fork as any).buttonTypeOptions = rowActionButtonTypeOptions;
           recordIdentityByFork.set(fork, recordIdentity);
 

--- a/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableActionsColumnModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableActionsColumnModel.test.tsx
@@ -13,7 +13,7 @@ import { App, ConfigProvider } from 'antd';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
 import { ActionModel } from '../../../base/ActionModel';
-import { TableActionsColumnModel } from '../TableActionsColumnModel';
+import { TableActionsColumnModel, tableRowActionsClassName } from '../TableActionsColumnModel';
 
 const capturedDroppableUids: string[] = [];
 const capturedRendererProps: any[] = [];
@@ -59,6 +59,10 @@ class TestViewActionModel extends ActionModel {
 
 class TestAlwaysActionModel extends ActionModel {
   defaultProps: any = { type: 'link', title: 'Always' };
+}
+
+class TestTextActionModel extends ActionModel {
+  defaultProps: any = { type: 'text', title: 'Text action' };
 }
 
 // 在 beforeRender 中，根据 inputArgs（即当前行 record）决定是否隐藏按钮
@@ -157,6 +161,58 @@ describe('TableActionsColumnModel: hidden action layout', () => {
     const wrappers = container.querySelectorAll('[data-test-droppable]');
     expect(wrappers).toHaveLength(0);
     expect(secondUid).toBeTruthy();
+  });
+
+  it('renders row link and text actions with compact button styles', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ TableActionsColumnModel, TestViewActionModel, TestTextActionModel });
+
+    const actionsCol = engine.createModel<TableActionsColumnModel>({
+      use: 'TableActionsColumnModel',
+      props: { width: 200, title: 'Actions' },
+      subModels: { actions: [{ use: 'TestViewActionModel' }, { use: 'TestTextActionModel' }] },
+    });
+
+    const colProps = actionsCol.getColumnProps();
+    const record = { id: 1, phone: '000000' } as any;
+
+    const { container } = render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>{colProps.render?.(undefined, record, 0) as any}</App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('View')).toBeInTheDocument();
+      expect(screen.getByText('Text action')).toBeInTheDocument();
+    });
+
+    const actions = container.querySelector('.nb-table-row-actions');
+    expect(actions).toBeInTheDocument();
+    expect(actions).toHaveClass(tableRowActionsClassName);
+
+    const linkButton = actions?.querySelector('.ant-btn-link') as HTMLButtonElement;
+    const textButton = actions?.querySelector('.ant-btn-text') as HTMLButtonElement;
+
+    expect(linkButton).toBeInTheDocument();
+    expect(textButton).toBeInTheDocument();
+    expect(linkButton).toHaveClass('nb-table-row-action-button');
+    expect(textButton).toHaveClass('nb-table-row-action-button');
+
+    const actionButtonStyleText = Array.from(document.querySelectorAll('style'))
+      .map((style) => style.textContent || '')
+      .find((styleText) => styleText.includes('.nb-table-row-action-button.ant-btn-link'));
+    expect(actionButtonStyleText).toContain(tableRowActionsClassName);
+    expect(actionButtonStyleText).toContain('font:inherit');
+    expect(actionButtonStyleText).toContain('height:auto');
+    expect(actionButtonStyleText).toContain('line-height:inherit');
+    expect(actionButtonStyleText).toContain('padding:0');
+    expect(actionButtonStyleText).toContain('border:0');
+    expect(actionButtonStyleText).toContain('box-shadow:none');
+    expect(actionButtonStyleText).not.toContain('1.5714285714285714');
+    expect(actionButtonStyleText).not.toContain('!important');
   });
 });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Adding link or text row action buttons in v2 table blocks could slightly change the table row height because Ant Design Button metrics still participated in row layout.

### Description 
Scoped compact styles to v2 table row action link and text buttons so they inherit row text metrics and do not add button padding, border, or shadow to the row height calculation.

Tests:
- `yarn eslint --fix packages/core/client-v2/src/flow/models/blocks/table/TableActionsColumnModel.tsx packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableActionsColumnModel.test.tsx`
- `yarn test packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableActionsColumnModel.test.tsx --run --reporter=verbose`
- `git diff --check`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed v2 table row action buttons changing row height. |
| 🇨🇳 Chinese | 修复 v2 表格行操作按钮导致行高变化的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
