### PR TITLE
fix(client): handle missing table drag sort field

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -55,6 +55,7 @@ import {
   useDragSortRowComponent,
   dragSortSettings,
   dragSortBySettings,
+  hasSortField,
 } from './dragSort';
 
 const MemoizedTable = React.memo(Table);
@@ -419,9 +420,18 @@ export class TableBlockModel extends CollectionBlockModel<TableBlockModelStructu
     return nextIndex;
   }
 
+  getDragSortFieldName(): string | undefined {
+    const dragSortBy = this.props.dragSortBy;
+    if (!this.props.dragSort || typeof dragSortBy !== 'string' || !hasSortField(this.collection, dragSortBy)) {
+      return undefined;
+    }
+
+    return dragSortBy;
+  }
+
   getLeftAuxiliaryColumn() {
     const showIndex = this.isShowIndexEnabled();
-    const showDragHandle = this.props.dragSort && this.props.dragSortBy;
+    const showDragHandle = !!this.getDragSortFieldName();
     if (!showIndex && !showDragHandle) {
       return null;
     }
@@ -467,7 +477,7 @@ export class TableBlockModel extends CollectionBlockModel<TableBlockModelStructu
     index = this.getRecordIndex(record, index);
     const rowKey = getRowKey(record, this.collection.filterTargetKey);
     const rowKeyString = rowKey == null ? rowKey : String(rowKey);
-    const showDragHandle = this.props.dragSort && this.props.dragSortBy;
+    const showDragHandle = !!this.getDragSortFieldName();
     return (
       <div
         role="button"
@@ -1072,11 +1082,13 @@ const HighPerformanceTable = React.memo(
       };
     }, [rowKeys]);
 
+    const dragSortFieldName = model.getDragSortFieldName();
+
     // 拖拽相关的 Body Wrapper 组件
-    const BodyWrapperComponent = useDragSortBodyWrapper(model, dataSourceRef, getRowKeyFunc);
+    const BodyWrapperComponent = useDragSortBodyWrapper(model, dataSourceRef, getRowKeyFunc, dragSortFieldName);
 
     // 行组件
-    const RowComponent = useDragSortRowComponent(model.props.dragSort);
+    const RowComponent = useDragSortRowComponent(!!dragSortFieldName);
 
     const components = useMemo(() => {
       return {
@@ -1099,15 +1111,14 @@ const HighPerformanceTable = React.memo(
         }
       `;
 
-      const selectionPaddingClass =
-        model.props.dragSort && model.props.dragSortBy
-          ? css`
-              .ant-table-thead > tr > th.ant-table-selection-column,
-              .ant-table-tbody > tr > td.ant-table-selection-column {
-                padding-left: 32px !important;
-              }
-            `
-          : undefined;
+      const selectionPaddingClass = dragSortFieldName
+        ? css`
+            .ant-table-thead > tr > th.ant-table-selection-column,
+            .ant-table-tbody > tr > td.ant-table-selection-column {
+              padding-left: 32px !important;
+            }
+          `
+        : undefined;
 
       const tableBodyMinHeightClass = tableScroll?.y
         ? css`
@@ -1118,7 +1129,7 @@ const HighPerformanceTable = React.memo(
         : undefined;
 
       return classNames(baseClass, selectionPaddingClass, tableBodyMinHeightClass);
-    }, [model.props.dragSort, model.props.dragSortBy, tableScroll?.y]);
+    }, [dragSortFieldName, tableScroll?.y]);
 
     return (
       <MemoizedTable

--- a/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.dragSort.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.dragSort.test.ts
@@ -1,0 +1,127 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it } from 'vitest';
+import '@nocobase/client';
+import { initDragSortParams } from '../dragSort';
+import { TableBlockModel } from '../TableBlockModel';
+
+function createTableModel() {
+  const engine = new FlowEngine();
+  engine.registerModels({ TableBlockModel });
+
+  const ds = engine.dataSourceManager.getDataSource('main');
+  ds.addCollection({
+    name: 'posts',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'title', type: 'string', interface: 'input' },
+      { name: 'sort', type: 'sort', interface: 'sort' },
+    ],
+  });
+
+  return engine.createModel<TableBlockModel>({
+    uid: 'posts-table',
+    use: 'TableBlockModel',
+    stepParams: {
+      resourceSettings: {
+        init: {
+          dataSourceKey: 'main',
+          collectionName: 'posts',
+        },
+      },
+    },
+  });
+}
+
+describe('TableBlockModel drag sorting settings', () => {
+  it('does not keep a deleted drag sort field in resource sort', () => {
+    const model = createTableModel();
+
+    model.setProps('dragSort', true);
+    model.setProps('dragSortBy', 'sort');
+    model.setProps('globalSort', ['title']);
+    model.resource.setSort(['sort']);
+    model.collection.fields.delete('sort');
+
+    initDragSortParams(model);
+
+    expect(model.getDragSortFieldName()).toBeUndefined();
+    expect(model.resource.getSort()).toEqual(['title']);
+  });
+
+  it('hides the drag handle when the configured sort field was deleted', () => {
+    const model = createTableModel();
+
+    model.setProps('enableRowSelection', false);
+    model.setProps('showIndex', false);
+    model.setProps('dragSort', true);
+    model.setProps('dragSortBy', 'sort');
+    model.collection.fields.delete('sort');
+
+    expect(model.getLeftAuxiliaryColumn()).toBeNull();
+  });
+
+  it('allows clearing the configured drag sort field and restores default sorting', () => {
+    const model = createTableModel();
+    const dragSortByStep = model.getFlow('tableSettings')?.steps?.dragSortBy;
+
+    model.setProps('dragSort', true);
+    model.setProps('dragSortBy', 'sort');
+    model.setProps('globalSort', ['title']);
+    model.resource.setSort(['sort']);
+
+    const uiMode =
+      typeof dragSortByStep?.uiMode === 'function' ? dragSortByStep.uiMode({ model, t: (key: string) => key }) : null;
+    dragSortByStep?.handler({ model }, { dragSortBy: null });
+
+    expect(uiMode).toMatchObject({
+      type: 'select',
+      key: 'dragSortBy',
+      props: {
+        allowClear: true,
+      },
+    });
+    expect(model.props.dragSortBy).toBeNull();
+    expect(model.resource.getSort()).toEqual(['title']);
+  });
+
+  it('ignores a deleted drag sort field submitted by settings', () => {
+    const model = createTableModel();
+    const dragSortByStep = model.getFlow('tableSettings')?.steps?.dragSortBy;
+
+    model.setProps('dragSort', true);
+    model.setProps('dragSortBy', 'sort');
+    model.setProps('globalSort', ['title']);
+    model.resource.setSort(['sort']);
+    model.collection.fields.delete('sort');
+
+    dragSortByStep?.handler({ model }, { dragSortBy: 'sort' });
+
+    expect(model.props.dragSortBy).toBeNull();
+    expect(model.resource.getSort()).toEqual(['title']);
+  });
+
+  it('restores default sorting when drag sorting is disabled', () => {
+    const model = createTableModel();
+    const dragSortStep = model.getFlow('tableSettings')?.steps?.dragSort;
+
+    model.setProps('dragSort', true);
+    model.setProps('dragSortBy', 'sort');
+    model.setProps('globalSort', ['title']);
+    model.resource.setSort(['sort']);
+
+    dragSortStep?.handler({ model }, { dragSort: false });
+
+    expect(model.props.dragSort).toBe(false);
+    expect(model.resource.getSort()).toEqual(['title']);
+  });
+});

--- a/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.rowSelection.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.rowSelection.test.tsx
@@ -26,6 +26,7 @@ function createTableModel() {
     fields: [
       { name: 'id', type: 'integer', interface: 'number' },
       { name: 'title', type: 'string', interface: 'input' },
+      { name: 'sort', type: 'sort', interface: 'sort' },
     ],
   });
 

--- a/packages/core/client-v2/src/flow/models/blocks/table/dragSort/dragSortHooks.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/dragSort/dragSortHooks.tsx
@@ -19,16 +19,23 @@ export function useDragSortBodyWrapper(
   model: TableBlockModel,
   dataSourceRef: React.MutableRefObject<any>,
   getRowKeyFunc: (record: any) => string | number,
+  dragSortFieldName?: string,
 ) {
+  const expandedRowKeys = model.props.expandedRowKeys;
+  const defaultExpandAllRows = model.props.defaultExpandAllRows;
+  const resource = model.resource;
+  const filterTargetKey = model.collection.filterTargetKey;
+  const message = (model as { ctx?: { message?: { error?: (content: string) => void } } }).ctx?.message;
+
   return useMemo(() => {
-    if (!model.props.dragSort) {
+    if (!dragSortFieldName) {
       return (props) => <tbody {...props} />;
     }
 
     const flattenTreeData = (data: any[]) => {
       const result: any[] = [];
-      const expandedKeys = new Set((model.props.expandedRowKeys || []).map((key) => (key == null ? key : String(key))));
-      const includeAll = !!model.props.defaultExpandAllRows;
+      const expandedKeys = new Set((expandedRowKeys || []).map((key) => (key == null ? key : String(key))));
+      const includeAll = !!defaultExpandAllRows;
 
       const walk = (nodes: any[]) => {
         if (!nodes?.length) return;
@@ -73,22 +80,22 @@ export function useDragSortBodyWrapper(
         }
 
         if (from && to) {
-          model.resource
+          resource
             .runAction('move', {
               method: 'post',
               params: {
-                sourceId: getRowKey(from, model.collection.filterTargetKey),
-                targetId: getRowKey(to, model.collection.filterTargetKey),
-                sortField: model.props.dragSort ? model.props.dragSortBy : undefined,
+                sourceId: getRowKey(from, filterTargetKey),
+                targetId: getRowKey(to, filterTargetKey),
+                sortField: dragSortFieldName,
               },
             })
             .then(() => {
-              model.resource.refresh();
+              resource.refresh();
             })
             .catch((error) => {
               console.error('Move failed:', error);
               // Show a user-facing error message if the message system is available
-              (model as any)?.ctx?.message?.error?.(error?.message || 'Move failed');
+              message?.error?.(error?.message || 'Move failed');
             });
         }
       };
@@ -104,13 +111,14 @@ export function useDragSortBodyWrapper(
       );
     };
   }, [
-    model.props.dragSort,
-    model.props.dragSortBy,
-    model.props.expandedRowKeys,
-    model.props.defaultExpandAllRows,
-    model.resource,
-    model.collection.filterTargetKey,
+    dataSourceRef,
+    defaultExpandAllRows,
+    dragSortFieldName,
+    expandedRowKeys,
+    filterTargetKey,
     getRowKeyFunc,
+    message,
+    resource,
   ]);
 }
 
@@ -124,7 +132,10 @@ export function useDragSortRowComponent(dragSort: boolean) {
 }
 
 export function initDragSortParams(model: TableBlockModel) {
-  if (model.props.dragSort && model.props.dragSortBy) {
-    model.resource.setSort([model.props.dragSortBy]);
+  const dragSortFieldName = model.getDragSortFieldName();
+  if (dragSortFieldName) {
+    model.resource.setSort([dragSortFieldName]);
+  } else if (model.props.dragSort && model.props.dragSortBy) {
+    model.resource.setSort(Array.isArray(model.props.globalSort) ? model.props.globalSort : []);
   }
 }

--- a/packages/core/client-v2/src/flow/models/blocks/table/dragSort/dragSortSettings.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/table/dragSort/dragSortSettings.ts
@@ -9,7 +9,11 @@
 
 import { tExpr } from '@nocobase/flow-engine';
 import type { TableBlockModel } from '../TableBlockModel';
-import { convertFieldsToOptions, getSortFields } from './dragSortUtils';
+import { convertFieldsToOptions, getSortFields, hasSortField } from './dragSortUtils';
+
+function getFallbackSort(model: TableBlockModel): string[] {
+  return Array.isArray(model.props.globalSort) ? model.props.globalSort : [];
+}
 
 export const dragSortSettings = {
   title: tExpr('Enable drag and drop sorting'),
@@ -17,9 +21,12 @@ export const dragSortSettings = {
   defaultParams: {
     dragSort: false,
   },
-  async handler(ctx, params) {
+  handler(ctx, params) {
     const model = ctx.model as TableBlockModel;
     model.setProps('dragSort', params.dragSort);
+    if (!params.dragSort) {
+      model.resource.setSort(getFallbackSort(model));
+    }
 
     // Note: automatic configuration of the drag sort field has been removed;
     // users now configure `dragSortBy` explicitly via `dragSortBySettings`.
@@ -45,6 +52,7 @@ export const dragSortBySettings = {
       key: 'dragSortBy',
       props: {
         options,
+        allowClear: true,
         placeholder: ctx.t('Select field'),
       },
     };
@@ -54,9 +62,8 @@ export const dragSortBySettings = {
   },
   handler(ctx, params) {
     const model = ctx.model as TableBlockModel;
-    model.setProps('dragSortBy', params.dragSortBy);
-    if (params.dragSortBy) {
-      model.resource.setSort([params.dragSortBy]);
-    }
+    const dragSortBy = hasSortField(model.collection, params.dragSortBy) ? params.dragSortBy : null;
+    model.setProps('dragSortBy', dragSortBy);
+    model.resource.setSort(dragSortBy ? [dragSortBy] : getFallbackSort(model));
   },
 };

--- a/packages/core/client-v2/src/flow/models/blocks/table/dragSort/dragSortUtils.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/table/dragSort/dragSortUtils.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import type { Collection } from '@nocobase/flow-engine';
+import type { Collection, CollectionField } from '@nocobase/flow-engine';
 
 /**
  * 从 collection 中获取所有 sort 类型的字段
@@ -22,6 +22,19 @@ export function getSortFields(collection: Collection | undefined) {
   return fields.filter((field) => {
     return !field?.target && field.interface === 'sort';
   });
+}
+
+export function getSortField(
+  collection: Collection | undefined,
+  fieldName?: string | null,
+): CollectionField | undefined {
+  if (!collection || !fieldName) return undefined;
+
+  return getSortFields(collection).find((field) => field.name === fieldName);
+}
+
+export function hasSortField(collection: Collection | undefined, fieldName?: string | null): boolean {
+  return !!getSortField(collection, fieldName);
 }
 
 /**
@@ -39,7 +52,7 @@ export function getFirstSortField(collection: Collection | undefined) {
  * @param fields - 字段数组
  * @returns 选项数组
  */
-export function convertFieldsToOptions(fields: any[]) {
+export function convertFieldsToOptions(fields: CollectionField[]) {
   return fields.map((field) => ({
     label: field?.uiSchema?.title || field?.name,
     value: field?.name,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Table blocks can keep a saved drag sorting field after that field is deleted from the collection. The stale field is still applied to the runtime resource sorting, which can make the table block fail when loading data.

### Description 
- Validate the configured table drag sorting field before enabling drag sorting behavior.
- Avoid applying a deleted drag sorting field to resource sorting, drag handles, sortable rows, or move requests.
- Allow clearing the selected drag sorting field from table settings.
- Restore the block default sorting when drag sorting is disabled or the drag sorting field is cleared.
- Add focused unit tests for deleted fields, clearing the setting, and disabling drag sorting.

Potential risk: low. The change is scoped to v2 table drag sorting behavior and keeps existing row-selection drag handle behavior covered by tests.

Testing suggestions:
- Enable drag sorting on a table block, select a sort field, then delete that field from the collection and reload the table.
- Clear the drag sorting field from table settings.
- Disable drag sorting and confirm the table still loads normally.

### Related issues

N/A

### Showcase
N/A. Logic fix for table block drag sorting settings and runtime behavior.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed table blocks failing when a configured drag sorting field has been deleted, and allowed clearing the drag sorting field setting. |
| 🇨🇳 Chinese | 修复表格区块配置的拖拽排序字段被删除后运行报错的问题，并支持清空拖拽排序字段配置。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
