### PR TITLE
fix(plugin-workflow): debounce collection trigger record search

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/TriggerCollectionRecordSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/TriggerCollectionRecordSelect.test.tsx
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { Form } from 'antd';
 import { TriggerCollectionRecordSelect } from '../collection';
+import type { ReactNode } from 'react';
 
 const remoteSelectState = vi.hoisted(() => ({
   props: null as null | {
@@ -19,9 +20,12 @@ const remoteSelectState = vi.hoisted(() => ({
     onChange?: (value?: unknown) => void;
     request: () => Promise<any[]>;
     onLoaded?: (items: any[]) => void;
-    mapOptions: (item: any, index: number) => { label: React.ReactNode; value: any };
+    mapOptions: (item: any, index: number) => { label: ReactNode; value: any };
+    onSearch?: (value: string) => void;
   },
 }));
+
+const listMock = vi.fn();
 
 vi.mock('@nocobase/client-v2', () => ({
   RemoteSelect: (props: any) => {
@@ -45,18 +49,20 @@ vi.mock('@nocobase/flow-engine', () => ({
       },
       api: {
         resource: () => ({
-          list: async () => ({
-            data: {
-              data: [
-                { name: 'admin', title: '{{t("Admin")}}' },
-                { name: 'root', title: '{{t("Root")}}' },
-              ],
-            },
-          }),
+          list: listMock,
         }),
       },
     },
   }),
+}));
+
+listMock.mockImplementation(async () => ({
+  data: {
+    data: [
+      { name: 'admin', title: '{{t("Admin")}}' },
+      { name: 'root', title: '{{t("Root")}}' },
+    ],
+  },
 }));
 
 vi.mock('../../canvas/contexts', () => ({
@@ -74,6 +80,43 @@ vi.mock('../../locale', () => ({
 }));
 
 describe('TriggerCollectionRecordSelect', () => {
+  it('requests 200 records on initial load and refetches with remote includes filter after debounce', async () => {
+    vi.useFakeTimers();
+    listMock.mockClear();
+    try {
+      render(<TriggerCollectionRecordSelect />);
+
+      await remoteSelectState.props?.request();
+
+      expect(listMock).toHaveBeenLastCalledWith({ pageSize: 200 });
+
+      act(() => {
+        remoteSelectState.props?.onSearch?.('123');
+      });
+
+      await remoteSelectState.props?.request();
+
+      expect(listMock).toHaveBeenLastCalledWith({ pageSize: 200 });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await remoteSelectState.props?.request();
+
+      expect(listMock).toHaveBeenLastCalledWith({
+        pageSize: 200,
+        filter: {
+          title: {
+            $includes: '123',
+          },
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('compiles server-returned title templates before rendering remote select options', async () => {
     render(<TriggerCollectionRecordSelect />);
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/TriggerCollectionRecordSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/TriggerCollectionRecordSelect.tsx
@@ -7,10 +7,11 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { useDebounce } from 'ahooks';
 import { RemoteSelect } from '@nocobase/client-v2';
 import { useFlowEngine } from '@nocobase/flow-engine';
 import { Alert } from 'antd';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { useCurrentWorkflowContext } from '../../canvas/contexts';
 import { useT } from '../../locale';
 import { parseCollectionName } from './utils';
@@ -46,6 +47,8 @@ export function TriggerCollectionRecordSelect({
   const flowEngine = useFlowEngine();
   const t = useT();
   const loadedItemsRef = useRef<RecordValue[]>([]);
+  const [searchValue, setSearchValue] = useState('');
+  const debouncedSearchValue = useDebounce(searchValue, { wait: 300 });
 
   const [dataSourceKey, collectionName] = parseCollectionName(workflow?.config?.collection as string) as [
     string,
@@ -85,12 +88,28 @@ export function TriggerCollectionRecordSelect({
         const matched = loadedItemsRef.current.find((item) => getPrimaryValue(item, filterTargetKey) === nextValue);
         onChange?.(matched ?? nextValue);
       }}
+      filterOption={false}
+      onSearch={(nextValue) => {
+        setSearchValue(nextValue);
+      }}
       request={async () => {
         const response = await flowEngine.context.api
           .resource(collectionName, null, { 'x-data-source': dataSourceKey })
-          .list({ pageSize: 50 });
+          .list({
+            pageSize: 200,
+            ...(debouncedSearchValue
+              ? {
+                  filter: {
+                    [labelKey]: {
+                      $includes: debouncedSearchValue,
+                    },
+                  },
+                }
+              : {}),
+          });
         return response?.data?.data ?? [];
       }}
+      refreshDeps={[debouncedSearchValue, dataSourceKey, collectionName, labelKey]}
       onLoaded={(items) => {
         loadedItemsRef.current = items as RecordValue[];
       }}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
- The v2 workflow collection trigger selector in manual execution no longer matched the v1 behavior: it only loaded 50 records and fired a request on every keystroke instead of waiting briefly before searching remotely.

### Description 
- restore remote search for the v2 collection trigger record selector with `pageSize: 200`
- debounce manual-execute search input by `300ms` so v2 matches the v1 request cadence
- add regression coverage for the initial fetch size, debounced remote filtering, and full-record value semantics

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Restored debounced remote search for workflow collection trigger manual execution and aligned the selector with the v1 200-record fetch behavior. |
| 🇨🇳 Chinese | 恢复了工作流集合触发器手动执行的防抖远程搜索，并使该选择器与 v1 的 200 条记录拉取行为保持一致。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
