### PR TITLE
fix(plugin-data-source-manager): add v2 record unique key warning

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
@@ -64,6 +64,7 @@ import { compileLegacyTemplate, preferLegacyTemplateTitle } from '../../utils/co
 import { getErrorMessage, isFormValidationError } from '../../utils/error';
 import { getCollectionFieldActionUrl } from './collectionFieldApi';
 import FieldsPage from './FieldsPage';
+import { getCollectionRecordUniqueKey, RecordUniqueKeyWarningIcon } from './RecordUniqueKey';
 
 interface CollectionsPageProps {
   dataSourceKey: string;
@@ -431,31 +432,6 @@ function renderCategoryTags(value: CollectionCategoryRecord[] | undefined, t: (k
       ))}
     </Space>
   );
-}
-
-function normalizeFilterTargetKey(value: unknown) {
-  if (Array.isArray(value)) {
-    return value.filter(Boolean).map(String);
-  }
-
-  return value ? [String(value)] : undefined;
-}
-
-function getCollectionFilterTargetKey(collection: Record<string, any>) {
-  const configuredFilterTargetKey = normalizeFilterTargetKey(collection.filterTargetKey);
-  if (configuredFilterTargetKey?.length) {
-    return configuredFilterTargetKey;
-  }
-
-  if (!Array.isArray(collection.fields)) {
-    return undefined;
-  }
-
-  const primaryKeys = collection.fields
-    .filter((field) => field?.primaryKey && field?.name)
-    .map((field) => String(field.name));
-
-  return primaryKeys.length === 1 ? primaryKeys : undefined;
 }
 
 const CollectionFilterItem: FC<{ value: CollectionFilterItemValue }> = observer(
@@ -1145,7 +1121,7 @@ function CollectionEditDrawer(props: {
   const filterTargetKeyOptions = useMemo(() => {
     const fields =
       Array.isArray(collection.fields) && collection.fields.length ? collection.fields : fieldsRequest.data || [];
-    const selectedFilterTargetKeys = getCollectionFilterTargetKey(collection) || [];
+    const selectedFilterTargetKeys = getCollectionRecordUniqueKey(collection, collection.fields) || [];
     const options = fields
       .filter((field) => {
         return !!field.name;
@@ -1175,7 +1151,7 @@ function CollectionEditDrawer(props: {
       category: Array.isArray(collection.category) ? collection.category.map((item) => String(item.id)) : [],
       description: collection.description,
       simplePaginate: collection.simplePaginate,
-      filterTargetKey: getCollectionFilterTargetKey(collection),
+      filterTargetKey: getCollectionRecordUniqueKey(collection, collection.fields),
       databaseView: getDatabaseViewFormValue(collection),
       schema: collection.schema,
       viewName: collection.viewName || collection.name,
@@ -1894,7 +1870,21 @@ function CollectionsPage(props: CollectionsPageProps) {
     const nextColumns: ColumnsType<Record<string, any>> = [
       {
         title: t('Collection display name'),
-        render: (record) => compileLegacyTemplate(record.title || record.name, t),
+        render: (record) => (
+          <Space size={4}>
+            <RecordUniqueKeyWarningIcon
+              collection={record}
+              dataSourceKey={props.dataSourceKey}
+              fields={record.fields}
+              onSaved={(values) => {
+                Object.assign(record, values);
+                request.mutate(updateCollectionListRecord(request.data, record.name, values));
+                request.refresh();
+              }}
+            />
+            <span>{compileLegacyTemplate(record.title || record.name, t)}</span>
+          </Space>
+        ),
       },
       { title: t('Collection name'), dataIndex: 'name', ellipsis: true },
       {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -41,6 +41,7 @@ import {
   filterFieldInterfacesByCollectionTemplate,
 } from './collectionTemplateFieldInterfaces';
 import { FieldForm } from './FieldForm';
+import { collectionNeedsRecordUniqueKey, RecordUniqueKeyPrompt } from './RecordUniqueKey';
 
 interface FieldsPageProps {
   dataSourceKey: string;
@@ -926,6 +927,18 @@ export default function FieldsPage(props: FieldsPageProps) {
     }, {});
   }, [databaseDialect, ctx, dataSource?.options?.type, props.collection]);
   const presetFieldInterfaces = useMemo(() => getCollectionPresetFieldInterfaces(ctx), [ctx]);
+  const recordUniqueKeyFields = useMemo(() => {
+    const fieldsByName = new Map<string, Record<string, any>>();
+    [...(Array.isArray(props.collection.fields) ? props.collection.fields : []), ...(request.data || [])].forEach(
+      (field) => {
+        if (field?.name) {
+          fieldsByName.set(field.name, field);
+        }
+      },
+    );
+    return Array.from(fieldsByName.values());
+  }, [props.collection.fields, request.data]);
+  const recordUniqueKeyRequired = collectionNeedsRecordUniqueKey(props.collection, recordUniqueKeyFields);
 
   const openFieldForm = useCallback(
     (mode: 'create' | 'edit', field?: Record<string, any>, interfaceName?: string) => {
@@ -1321,6 +1334,24 @@ export default function FieldsPage(props: FieldsPageProps) {
 
   return (
     <>
+      {recordUniqueKeyRequired ? (
+        <Alert
+          style={{ marginBottom: 16 }}
+          type="warning"
+          message={
+            <RecordUniqueKeyPrompt
+              collection={props.collection}
+              dataSourceKey={props.dataSourceKey}
+              fields={recordUniqueKeyFields}
+              onSaved={(values) => {
+                Object.assign(props.collection, values);
+                props.onCollectionChange?.(props.collection.name, values);
+                request.refresh();
+              }}
+            />
+          }
+        />
+      ) : null}
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 16 }}>
         <Space>
           {fieldDeletionVisible ? (

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/RecordUniqueKey.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/RecordUniqueKey.tsx
@@ -1,0 +1,219 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ExclamationCircleTwoTone } from '@ant-design/icons';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { App, Button, Popconfirm, Popover, Select, Space } from 'antd';
+import React, { useMemo, useState } from 'react';
+import { useT } from '../../locale';
+import { compileLegacyTemplate, compileLegacyTemplateText } from '../../utils/compileLegacyTemplate';
+
+type CollectionFieldRecord = {
+  interface?: string;
+  name?: string;
+  primaryKey?: boolean;
+  title?: React.ReactNode;
+  uiSchema?: {
+    title?: React.ReactNode;
+  };
+  unique?: boolean;
+};
+
+type FieldInterfaceManager = {
+  getFieldInterface?: (name: string, dataSourceType?: string) => { titleUsable?: boolean } | undefined;
+};
+
+type RecordUniqueKeyValue = string[] | undefined;
+
+function normalizeRecordUniqueKey(value: unknown): RecordUniqueKeyValue {
+  if (Array.isArray(value)) {
+    const keys = value.filter(Boolean).map(String);
+    return keys.length ? keys : undefined;
+  }
+
+  return value ? [String(value)] : undefined;
+}
+
+function getCollectionPrimaryKey(collection: Record<string, unknown>, fields?: CollectionFieldRecord[]) {
+  const collectionPrimaryKey = normalizeRecordUniqueKey(collection.primaryKey);
+  if (collectionPrimaryKey?.length) {
+    return collectionPrimaryKey;
+  }
+
+  const fieldPrimaryKeys = (fields || [])
+    .filter((field) => field?.primaryKey && field.name)
+    .map((field) => String(field.name));
+
+  return fieldPrimaryKeys.length ? fieldPrimaryKeys : undefined;
+}
+
+export function getCollectionRecordUniqueKey(collection: Record<string, unknown>, fields?: CollectionFieldRecord[]) {
+  return normalizeRecordUniqueKey(collection.filterTargetKey) || getCollectionPrimaryKey(collection, fields);
+}
+
+export function collectionNeedsRecordUniqueKey(collection: Record<string, unknown>, fields?: CollectionFieldRecord[]) {
+  return !getCollectionRecordUniqueKey(collection, fields);
+}
+
+function getCollectionUpdateActionUrl(dataSourceKey: string) {
+  return dataSourceKey === 'main' ? 'collections:update' : `dataSources/${dataSourceKey}/collections:update`;
+}
+
+export function RecordUniqueKeyPrompt(props: {
+  collection: Record<string, unknown>;
+  dataSourceKey: string;
+  fields?: CollectionFieldRecord[];
+  onSaved?: (values: { filterTargetKey: string[] }) => void;
+  size?: 'small';
+  style?: React.CSSProperties;
+}) {
+  const { collection, dataSourceKey, fields, onSaved, size, style } = props;
+  const t = useT();
+  const ctx = useFlowContext();
+  const { message, notification } = App.useApp();
+  const [filterTargetKey, setFilterTargetKey] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+  const dataSource = ctx.dataSourceManager.getDataSource(dataSourceKey);
+  const fieldInterfaceManager = ctx.dataSourceManager.collectionFieldInterfaceManager as FieldInterfaceManager;
+  const options = useMemo(
+    () =>
+      (fields || [])
+        .filter((field) => {
+          if (!field?.name || !field.interface) {
+            return false;
+          }
+          const fieldInterface = fieldInterfaceManager?.getFieldInterface?.(
+            String(field.interface),
+            dataSource?.options?.type,
+          );
+          return fieldInterface ? fieldInterface.titleUsable : true;
+        })
+        .map((field) => {
+          const title = field.uiSchema?.title || field.title || field.name;
+          return {
+            value: String(field.name),
+            label: compileLegacyTemplate(title, t),
+            title: compileLegacyTemplateText(title, t),
+          };
+        }),
+    [dataSource?.options?.type, fieldInterfaceManager, fields, t],
+  );
+  const selectedTitle = useMemo(
+    () => filterTargetKey.map((key) => options.find((option) => option.value === key)?.title || key).join(', '),
+    [filterTargetKey, options],
+  );
+
+  const handleConfirm = async () => {
+    if (!filterTargetKey.length) {
+      message.warning(t('Please select a field.'));
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await ctx.api.request({
+        url: getCollectionUpdateActionUrl(dataSourceKey),
+        method: 'post',
+        params: { filterByTk: String(collection.name) },
+        data: {
+          filterTargetKey,
+        },
+      });
+      dataSource?.collectionManager
+        ?.getCollection(String(collection.name))
+        ?.setOption?.('filterTargetKey', filterTargetKey);
+      onSaved?.({ filterTargetKey });
+      message.success(t('Saved successfully'));
+      await dataSource?.reload?.();
+    } catch (error) {
+      notification.error({
+        message: t('Save failed'),
+      });
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={style}>
+      {t(
+        'If a collection lacks a primary key, you must configure a unique record key to locate row records within a block, failure to configure this will prevent the creation of data blocks for the collection.',
+      )}
+      {size === 'small' ? <br /> : ' '}
+      <Space.Compact style={{ marginTop: 5 }}>
+        <Select
+          mode="multiple"
+          placeholder={t('Select field')}
+          options={options}
+          value={filterTargetKey}
+          loading={saving}
+          size="small"
+          style={{ minWidth: 200 }}
+          onChange={(value) => setFilterTargetKey(value.map(String))}
+        />
+        <Popconfirm
+          placement="bottom"
+          title={
+            <div style={{ width: '15em' }}>
+              {selectedTitle
+                ? t(
+                    'Are you sure you want to set the "{{title}}" field as a record unique key? This setting cannot be changed after it\'s been set.',
+                    { title: selectedTitle },
+                  )
+                : t('Please select a field.')}
+            </div>
+          }
+          onConfirm={handleConfirm}
+        >
+          <Button type="primary" size="small" loading={saving}>
+            {t('OK')}
+          </Button>
+        </Popconfirm>
+      </Space.Compact>
+    </div>
+  );
+}
+
+export function RecordUniqueKeyWarningIcon(props: {
+  collection: Record<string, unknown>;
+  dataSourceKey: string;
+  fields?: CollectionFieldRecord[];
+  onSaved?: (values: { filterTargetKey: string[] }) => void;
+}) {
+  const t = useT();
+
+  if (!collectionNeedsRecordUniqueKey(props.collection, props.fields)) {
+    return null;
+  }
+
+  return (
+    <Popover
+      trigger={['click']}
+      content={
+        <RecordUniqueKeyPrompt
+          collection={props.collection}
+          dataSourceKey={props.dataSourceKey}
+          fields={props.fields}
+          onSaved={props.onSaved}
+          size="small"
+          style={{ width: '20em' }}
+        />
+      }
+    >
+      <Button
+        aria-label={t('Record unique key')}
+        icon={<ExclamationCircleTwoTone twoToneColor="#faad14" />}
+        size="small"
+        type="text"
+        style={{ height: 20, marginRight: 2, padding: 0, width: 20 }}
+      />
+    </Popover>
+  );
+}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/RecordUniqueKey.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/RecordUniqueKey.tsx
@@ -30,6 +30,7 @@ type FieldInterfaceManager = {
 };
 
 type RecordUniqueKeyValue = string[] | undefined;
+type Translate = (key: string, options?: Record<string, unknown>) => string;
 
 function normalizeRecordUniqueKey(value: unknown): RecordUniqueKeyValue {
   if (Array.isArray(value)) {
@@ -61,8 +62,33 @@ export function collectionNeedsRecordUniqueKey(collection: Record<string, unknow
   return !getCollectionRecordUniqueKey(collection, fields);
 }
 
-function getCollectionUpdateActionUrl(dataSourceKey: string) {
+export function getCollectionUpdateActionUrl(dataSourceKey: string) {
   return dataSourceKey === 'main' ? 'collections:update' : `dataSources/${dataSourceKey}/collections:update`;
+}
+
+export function getRecordUniqueKeyFieldOptions(options: {
+  dataSourceType?: string;
+  fieldInterfaceManager?: FieldInterfaceManager;
+  fields?: CollectionFieldRecord[];
+  t: Translate;
+}) {
+  const { dataSourceType, fieldInterfaceManager, fields, t } = options;
+  return (fields || [])
+    .filter((field) => {
+      if (!field?.name || !field.interface) {
+        return false;
+      }
+      const fieldInterface = fieldInterfaceManager?.getFieldInterface?.(String(field.interface), dataSourceType);
+      return Boolean(fieldInterface?.titleUsable);
+    })
+    .map((field) => {
+      const title = field.uiSchema?.title || field.title || field.name;
+      return {
+        value: String(field.name),
+        label: compileLegacyTemplate(title, t),
+        title: compileLegacyTemplateText(title, t),
+      };
+    });
 }
 
 export function RecordUniqueKeyPrompt(props: {
@@ -83,25 +109,12 @@ export function RecordUniqueKeyPrompt(props: {
   const fieldInterfaceManager = ctx.dataSourceManager.collectionFieldInterfaceManager as FieldInterfaceManager;
   const options = useMemo(
     () =>
-      (fields || [])
-        .filter((field) => {
-          if (!field?.name || !field.interface) {
-            return false;
-          }
-          const fieldInterface = fieldInterfaceManager?.getFieldInterface?.(
-            String(field.interface),
-            dataSource?.options?.type,
-          );
-          return fieldInterface ? fieldInterface.titleUsable : true;
-        })
-        .map((field) => {
-          const title = field.uiSchema?.title || field.title || field.name;
-          return {
-            value: String(field.name),
-            label: compileLegacyTemplate(title, t),
-            title: compileLegacyTemplateText(title, t),
-          };
-        }),
+      getRecordUniqueKeyFieldOptions({
+        dataSourceType: dataSource?.options?.type,
+        fieldInterfaceManager,
+        fields,
+        t,
+      }),
     [dataSource?.options?.type, fieldInterfaceManager, fields, t],
   );
   const selectedTitle = useMemo(

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
@@ -9,7 +9,12 @@
 
 import { compileLegacyTemplate } from '../../../utils/compileLegacyTemplate';
 import { getPresetFieldRows } from '../CollectionsPage';
-import { collectionNeedsRecordUniqueKey, getCollectionRecordUniqueKey } from '../RecordUniqueKey';
+import {
+  collectionNeedsRecordUniqueKey,
+  getCollectionRecordUniqueKey,
+  getCollectionUpdateActionUrl,
+  getRecordUniqueKeyFieldOptions,
+} from '../RecordUniqueKey';
 
 describe('getPresetFieldRows', () => {
   it('uses the preset title template when preset field label is a raw translation key', () => {
@@ -67,5 +72,40 @@ describe('collection record unique key helpers', () => {
 
   it('requires a record unique key when no primary key is available', () => {
     expect(collectionNeedsRecordUniqueKey({}, [{ name: 'name' }])).toBe(true);
+  });
+});
+
+describe('record unique key quick setup helpers', () => {
+  const t = (key: string) => key;
+
+  it('only includes fields whose interface is title usable', () => {
+    const options = getRecordUniqueKeyFieldOptions({
+      dataSourceType: 'postgres',
+      fieldInterfaceManager: {
+        getFieldInterface: (name, dataSourceType) => {
+          if (name === 'input' && dataSourceType === 'postgres') {
+            return { titleUsable: true };
+          }
+          if (name === 'json') {
+            return { titleUsable: false };
+          }
+          return undefined;
+        },
+      },
+      fields: [
+        { name: 'name', interface: 'input', uiSchema: { title: 'Name' } },
+        { name: 'config', interface: 'json', uiSchema: { title: 'Config' } },
+        { name: 'legacy', interface: 'unknown', uiSchema: { title: 'Legacy' } },
+        { name: 'no_interface', uiSchema: { title: 'No interface' } },
+      ],
+      t,
+    });
+
+    expect(options).toEqual([{ value: 'name', label: 'Name', title: 'Name' }]);
+  });
+
+  it('uses the external data source collection update endpoint', () => {
+    expect(getCollectionUpdateActionUrl('main')).toBe('collections:update');
+    expect(getCollectionUpdateActionUrl('analytics')).toBe('dataSources/analytics/collections:update');
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
@@ -9,6 +9,7 @@
 
 import { compileLegacyTemplate } from '../../../utils/compileLegacyTemplate';
 import { getPresetFieldRows } from '../CollectionsPage';
+import { collectionNeedsRecordUniqueKey, getCollectionRecordUniqueKey } from '../RecordUniqueKey';
 
 describe('getPresetFieldRows', () => {
   it('uses the preset title template when preset field label is a raw translation key', () => {
@@ -44,5 +45,27 @@ describe('getPresetFieldRows', () => {
     };
 
     expect(compileLegacyTemplate(rows[0].field, t)).toBe('空间');
+  });
+});
+
+describe('collection record unique key helpers', () => {
+  it('uses filterTargetKey before field primary keys', () => {
+    expect(
+      getCollectionRecordUniqueKey(
+        {
+          filterTargetKey: ['code'],
+        },
+        [{ name: 'id', primaryKey: true }],
+      ),
+    ).toEqual(['code']);
+  });
+
+  it('treats field primary keys as configured record unique keys', () => {
+    expect(getCollectionRecordUniqueKey({}, [{ name: 'id', primaryKey: true }])).toEqual(['id']);
+    expect(collectionNeedsRecordUniqueKey({}, [{ name: 'id', primaryKey: true }])).toBe(false);
+  });
+
+  it('requires a record unique key when no primary key is available', () => {
+    expect(collectionNeedsRecordUniqueKey({}, [{ name: 'name' }])).toBe(true);
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 data source collection management was missing the v1 warning and quick setup flow for collections that do not have a primary key or configured record unique key. Without this, users may not notice that data blocks cannot be created reliably for those collections.

### Description 
- Added a reusable v2 record unique key warning and setup component for data source collections.
- Added the warning icon in the v2 collections list when a collection has no primary key and no `filterTargetKey`.
- Added the warning and quick setup control in the v2 configure fields drawer for both main and external data sources.
- Added unit coverage for record unique key detection.

Potential risk: limited to data source manager v2 collection and field configuration UI.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/RecordUniqueKey.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts --run --reporter=verbose`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added a warning and quick setup for v2 data source collections without a primary key or record unique key. |
| 🇨🇳 Chinese | 为 v2 数据源中没有主键或记录唯一标识的数据表增加提示和快捷设置。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
