### PR TITLE
Add support for Reply-To addresses (#9880)

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-email/src/client/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/client/MessageConfigForm.tsx
@@ -152,7 +152,7 @@ export const MessageConfigForm = ({ variableOptions }) => {
               },
             },
           },
-          repyTo: {
+          replyTo: {
             type: 'strin',
             required: false,
             title: `{{t("Reply To")}}`,

--- a/packages/plugins/@nocobase/plugin-notification-email/src/client/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/client/MessageConfigForm.tsx
@@ -152,6 +152,18 @@ export const MessageConfigForm = ({ variableOptions }) => {
               },
             },
           },
+          repyTo: {
+            type: 'strin',
+            required: false,
+            title: `{{t("Reply To")}}`,
+            'x-decorator': 'FormItem',
+            'x-component': 'Variable.TextArea',
+            'x-component-props': {
+              scope: variableOptions,
+              useTypedConstant: ['string'],
+              placeholder: `{{t("Email address")}}`,
+            },
+          },
           subject: {
             type: 'string',
             required: true,

--- a/packages/plugins/@nocobase/plugin-notification-email/src/locale/de-DE.json
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/locale/de-DE.json
@@ -19,5 +19,6 @@
   "Subject": "Betreff",
   "The email address that will be used as the sender": "Die E-Mail-Adresse, die als Absender verwendet wird",
   "To": "An",
+  "Reply To": "Antworten an",
   "Transport": "Transport"
 }

--- a/packages/plugins/@nocobase/plugin-notification-email/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/locale/en-US.json
@@ -21,6 +21,7 @@
   "The email address that will be used as the sender": "The email address that will be used as the sender",
   "The field value is required": "The field value is required",
   "To": "To",
+  "ReplyTo": "Reply To",
   "Transport": "Transport",
   "Yes": "Yes"
 }

--- a/packages/plugins/@nocobase/plugin-notification-email/src/locale/fr-FR.json
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/locale/fr-FR.json
@@ -19,5 +19,6 @@
   "Subject": "Subject",
   "The email address that will be used as the sender": "The email address that will be used as the sender",
   "To": "To",
+  "Reply To": "Répondre à",
   "Transport": "Transport"
 }

--- a/packages/plugins/@nocobase/plugin-notification-email/src/locale/nl-NL.json
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/locale/nl-NL.json
@@ -19,5 +19,6 @@
   "Subject": "Onderwerp",
   "The email address that will be used as the sender": "Het e-mailadres dat gebruikt wordt als verzender",
   "To": "Naar",
+  "Reply To": "Antwoord-op",
   "Transport": "Transport"
 }

--- a/packages/plugins/@nocobase/plugin-notification-email/src/server/mail-server.ts
+++ b/packages/plugins/@nocobase/plugin-notification-email/src/server/mail-server.ts
@@ -15,6 +15,7 @@ type Message = {
   cc?: string[];
   bcc?: string[];
   subject: string;
+  replyTo?: string | null;
 } & (
   | {
       contentType: 'html';
@@ -91,7 +92,7 @@ export class MailNotificationChannel extends BaseNotificationChannel {
 
     try {
       const transpoter: Transporter = this.getTransporter(channel);
-      const { subject, cc, bcc, to, contentType } = message;
+      const { subject, cc, bcc, replyTo, to, contentType } = message;
       if (receivers?.type === 'userId') {
         const users = await userRepo.find({
           filter: {
@@ -103,6 +104,7 @@ export class MailNotificationChannel extends BaseNotificationChannel {
         const payload = {
           to: usersEmail,
           from,
+          replyTo,
           subject,
           ...(contentType === 'html' ? { html: message.html } : { text: message.text }),
         };
@@ -128,6 +130,7 @@ export class MailNotificationChannel extends BaseNotificationChannel {
                 .map((item) => item?.trim())
                 .filter(Boolean)
             : undefined,
+          replyTo,
           subject,
           from,
           ...(contentType === 'html' ? { html: message.html } : { text: message.text }),


### PR DESCRIPTION
_-_ Add field "replyTo" in mail-server.ts

<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
See #9880 

### Description 
- Pass the data field into nodemailer
- Add config option in UI "MessageConfigForm.tsx" below bcc and above subject
- Add some translations for the new "Reply To" key (us, de, fr, nl)

### Related issues
Closes #9880 

### Showcase
<img width="939" height="602" alt="grafik" src="https://github.com/user-attachments/assets/d32e4508-381e-43c6-ac70-4c7a0a5b3646" />

Here is the Log of testing the Notification Node with sample settings:
```
2026-06-28 13:24:12 [info]  response /api/flow_nodes:test
method=POST
path=/api/flow_nodes:test res={"status":200}
action={"actionName":"test","resourceName":"flow_nodes","params":
{"resourceName":"flow_nodes","actionName":"test","values":
{"config":
{"channelName":"s_igpiu3f56c1",
"to":["user1@example.com","user2@example.com"],"cc":[],"bcc":[],
"contentType":"text","subject":"Reply-To Test","replyTo":"support@mycompany.test",
"text":"MAIL BODY. Reply-To Header should be set to support@mycompany.test"
},
"type":"notification"}}}
userId=1 username=nocobase status=200 cost=268 app=main reqId=11dbfe35-2f1d-4860-bb30-c4825adbe371 bodySize=573
```

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add support for reply-to address in  mail notifications    |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
