### PR TITLE
fix(notification): register content config form

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/registerType.test.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/registerType.test.ts
@@ -12,11 +12,13 @@ import NotificationManager from '../../../../plugin-notification-manager/src/cli
 describe('plugin-notification-in-app-message v2', () => {
   it('registers an in-app-message channel type on the v2 manager', () => {
     const manager = new NotificationManager();
+    const contentLoader = () => import('../components/ContentConfigForm');
     const messageLoader = () => import('../components/MessageConfigForm');
     manager.registerChannelType({
       type: 'in-app-message',
       title: '{{t("In-app message")}}',
       components: {
+        ContentConfigFormLoader: contentLoader,
         MessageConfigFormLoader: messageLoader,
       },
       meta: { creatable: true, editable: true, deletable: true },
@@ -25,6 +27,7 @@ describe('plugin-notification-in-app-message v2', () => {
     expect(registered).toBeDefined();
     expect(registered?.type).toBe('in-app-message');
     expect(registered?.meta?.creatable).toBe(true);
+    expect(registered?.components?.ContentConfigFormLoader).toBe(contentLoader);
     expect(registered?.components?.MessageConfigFormLoader).toBe(messageLoader);
   });
 
@@ -32,5 +35,11 @@ describe('plugin-notification-in-app-message v2', () => {
     const mod = await import('../components/MessageConfigForm');
     expect(typeof mod.default).toBe('function');
     expect(mod.MessageConfigForm).toBe(mod.default);
+  });
+
+  it('lazy-loads the ContentConfigForm module on demand', async () => {
+    const mod = await import('../components/ContentConfigForm');
+    expect(typeof mod.default).toBe('function');
+    expect(mod.ContentConfigForm).toBe(mod.default);
   });
 });

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/ContentConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/ContentConfigForm.tsx
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { ContentConfigFormProps } from '@nocobase/plugin-notification-manager/client-v2';
+import { WorkflowVariableInput, WorkflowVariableTextArea } from '@nocobase/plugin-workflow/client-v2';
+import { Form, InputNumber } from 'antd';
+import React from 'react';
+import { useInAppMessageTranslation, useT } from '../locale';
+
+function withPrefix(namePrefix: Array<string | number> | undefined, ...segments: Array<string | number>) {
+  return [...(namePrefix ?? []), ...segments];
+}
+
+export function ContentConfigForm(props: ContentConfigFormProps) {
+  const { t } = useInAppMessageTranslation();
+  const compileT = useT();
+
+  return (
+    <>
+      <Form.Item
+        name={withPrefix(props.namePrefix, 'title')}
+        label={t('Message title')}
+        rules={[{ required: true, message: t('The field value is required') }]}
+      >
+        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+      </Form.Item>
+      <Form.Item
+        name={withPrefix(props.namePrefix, 'content')}
+        label={t('Message content')}
+        rules={[{ required: true, message: t('The field value is required') }]}
+      >
+        <WorkflowVariableTextArea autoSize={{ minRows: 10 }} placeholder="Hi," delimiters={['{{{', '}}}']} />
+      </Form.Item>
+      <Form.Item
+        name={withPrefix(props.namePrefix, 'options', 'url')}
+        label={t('Details page for desktop')}
+        extra={compileT(
+          'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
+        )}
+      >
+        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+      </Form.Item>
+      <Form.Item
+        name={withPrefix(props.namePrefix, 'options', 'mobileUrl')}
+        label={t('Details page for mobile')}
+        extra={compileT(
+          'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/m". If using an external link, the link starts with "http", for example, "https://example.com".',
+        )}
+      >
+        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+      </Form.Item>
+      <Form.Item
+        name={withPrefix(props.namePrefix, 'options', 'duration')}
+        label={t('Close after')}
+        extra={compileT('Unit is second. Will not close automatically when set to empty.')}
+        initialValue={5}
+      >
+        <InputNumber />
+      </Form.Item>
+    </>
+  );
+}
+
+export default ContentConfigForm;

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/plugin.tsx
@@ -30,6 +30,7 @@ export class PluginNotificationInAppMessageClientV2 extends Plugin<Record<string
         type: IN_APP_TYPE,
         title: tExpr('In-app message'),
         components: {
+          ContentConfigFormLoader: () => import('./components/ContentConfigForm'),
           MessageConfigFormLoader: () => import('./components/MessageConfigForm'),
         },
         meta: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 v2 工作流里配置站内信通知时，通知渠道已经可以被选择，但站内信内容表单没有注册到通知管理器，导致标题、内容、详情页链接和自动关闭时间等内容无法按预期配置。

### Description
本次补充了站内信通知在 v2 中使用的内容配置表单，并把它注册到站内信渠道类型中。配置表单支持工作流变量输入，保留标题、内容、桌面详情页、移动端详情页和自动关闭时间等站内信常用配置项。

影响范围主要是 v2 工作流中的站内信通知配置。建议重点验证：在 v2 工作流通知配置中选择站内信渠道后，可以打开并保存内容配置；保存后再次进入配置页，标题、内容和链接等字段显示正常。

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where in-app message content cannot be configured in v2 workflows |
| 🇨🇳 Chinese | 修复 v2 工作流中无法配置站内信内容的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
