### PR TITLE
fix(plugin-workflow-custom-action-trigger): restore manual execute actor selects

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/triggers/TriggerCustomActionConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/triggers/TriggerCustomActionConfig.tsx
@@ -7,15 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { RemoteSelect, TypedVariableInput, type TypedVariableInputProps } from '@nocobase/client-v2';
+import { useDebounce } from 'ahooks';
+import { RemoteSelect } from '@nocobase/client-v2';
 import { FlowContextSelector, useFlowEngine, type MetaTreeNode } from '@nocobase/flow-engine';
 import {
   parseCollectionName,
   TriggerCollectionRecordSelect,
   useCurrentWorkflowContext,
   useWorkflowVariableOptions,
-  type CollectionTriggerField,
-  type UseWorkflowVariableOptions,
 } from '@nocobase/plugin-workflow/client-v2';
 import { Alert, Form, Input, Space, Typography } from 'antd';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -50,14 +49,6 @@ function getLabelValue(item: RecordValue, labelKey: string | string[]) {
       .join(' ');
   }
   return item?.[labelKey];
-}
-
-function WorkflowTypedVariableInput({
-  variableOptions,
-  ...props
-}: TypedVariableInputProps & { variableOptions?: UseWorkflowVariableOptions }) {
-  const metaTree = useWorkflowVariableOptions(variableOptions);
-  return <TypedVariableInput {...props} metaTree={metaTree} />;
 }
 
 function stringifyJsonValue(value: unknown) {
@@ -135,6 +126,75 @@ function WorkflowJsonInput({ value, onChange }: { value?: unknown; onChange?: (v
   );
 }
 
+type SearchableRemoteSelectProps<TRecord extends Record<string, unknown>, TValue extends string | number> = {
+  cacheKey: string;
+  labelKey: keyof TRecord & string;
+  resource: string;
+  value?: TValue | null;
+  valueKey: keyof TRecord & string;
+  onChange?: (value: TValue | null) => void;
+};
+
+function SearchableRemoteSelect<TRecord extends Record<string, unknown>, TValue extends string | number>({
+  cacheKey,
+  labelKey,
+  resource,
+  value,
+  valueKey,
+  onChange,
+}: SearchableRemoteSelectProps<TRecord, TValue>) {
+  const flowEngine = useFlowEngine();
+  const t = useT();
+  const [searchValue, setSearchValue] = useState('');
+  const debouncedSearchValue = useDebounce(searchValue, { wait: 300 });
+
+  return (
+    <RemoteSelect<TRecord, TRecord[], TValue>
+      cacheKey={cacheKey}
+      filterOption={false}
+      value={value == null ? undefined : value}
+      onChange={(nextValue) => onChange?.((nextValue as TValue | undefined) ?? null)}
+      onSearch={(nextValue) => {
+        setSearchValue(nextValue);
+      }}
+      request={async () => {
+        const response = await flowEngine.context.api.resource(resource).list({
+          pageSize: 200,
+          ...(debouncedSearchValue
+            ? {
+                filter: {
+                  [labelKey]: {
+                    $includes: debouncedSearchValue,
+                  },
+                },
+              }
+            : {}),
+        });
+        return response?.data?.data ?? [];
+      }}
+      refreshDeps={[debouncedSearchValue, resource, labelKey]}
+      mapOptions={(item) => {
+        const rawLabel = item[labelKey];
+        const rawValue = item[valueKey];
+        let label: React.ReactNode;
+
+        if (typeof rawLabel === 'string') {
+          label = t(rawLabel);
+        } else if (typeof rawLabel === 'number') {
+          label = rawLabel;
+        } else {
+          label = String(rawValue ?? '');
+        }
+
+        return {
+          label,
+          value: rawValue as TValue,
+        };
+      }}
+    />
+  );
+}
+
 function TriggerCollectionRecordMultiSelect({
   value,
   onChange,
@@ -200,8 +260,18 @@ function TriggerCollectionRecordMultiSelect({
       mapOptions={(item) => {
         const rawLabel =
           getLabelValue(item as RecordValue, labelKey) ?? getPrimaryValue(item as RecordValue, filterTargetKey);
+        let label: React.ReactNode;
+
+        if (typeof rawLabel === 'string') {
+          label = t(rawLabel);
+        } else if (typeof rawLabel === 'number') {
+          label = rawLabel;
+        } else {
+          label = t('Untitled');
+        }
+
         return {
-          label: typeof rawLabel === 'string' ? t(rawLabel) : rawLabel ?? t('Untitled'),
+          label,
           value: getPrimaryValue(item as RecordValue, filterTargetKey),
         };
       }}
@@ -251,28 +321,6 @@ function TriggerDataField() {
   );
 }
 
-const userVariableOptions: UseWorkflowVariableOptions = {
-  types: [
-    (field: CollectionTriggerField) => {
-      if (field.isForeignKey || field.type === 'context') {
-        return field.target === 'users';
-      }
-      return field.collectionName === 'users' && field.name === 'id';
-    },
-  ],
-};
-
-const roleVariableOptions: UseWorkflowVariableOptions = {
-  types: [
-    (field: CollectionTriggerField) => {
-      if (field.isForeignKey) {
-        return field.target === 'roles';
-      }
-      return field.collectionName === 'roles' && field.name === 'name';
-    },
-  ],
-};
-
 export function TriggerCustomActionConfig() {
   const t = useT();
 
@@ -280,10 +328,20 @@ export function TriggerCustomActionConfig() {
     <>
       <TriggerDataField />
       <Form.Item name="userId" label={t('User acted')} rules={[{ required: true }]}>
-        <WorkflowTypedVariableInput types={['number']} nullable={false} variableOptions={userVariableOptions} />
+        <SearchableRemoteSelect<{ id: number; nickname?: string }, number>
+          cacheKey="workflow-custom-action-trigger:users"
+          resource="users"
+          labelKey="nickname"
+          valueKey="id"
+        />
       </Form.Item>
       <Form.Item name="roleName" label={t('Role of user acted')}>
-        <WorkflowTypedVariableInput types={['string']} nullable={false} variableOptions={roleVariableOptions} />
+        <SearchableRemoteSelect<{ name: string; title?: string }, string>
+          cacheKey="workflow-custom-action-trigger:roles"
+          resource="roles"
+          labelKey="title"
+          valueKey="name"
+        />
       </Form.Item>
     </>
   );

--- a/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/triggers/__tests__/TriggerCustomActionConfig.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-custom-action-trigger/src/client-v2/triggers/__tests__/TriggerCustomActionConfig.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { Form } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { TriggerCustomActionConfig } from '../TriggerCustomActionConfig';
+
+const remoteSelectState = vi.hoisted(() => ({
+  propsList: [] as Array<{
+    cacheKey?: string;
+    onSearch?: (value: string) => void;
+    request: () => Promise<any[]>;
+  }>,
+}));
+
+const usersListMock = vi.fn();
+const rolesListMock = vi.fn();
+
+vi.mock('@nocobase/client-v2', () => ({
+  RemoteSelect: (props: any) => {
+    remoteSelectState.propsList.push(props);
+    return <div data-testid={`remote-select:${props.cacheKey}`} />;
+  },
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  FlowContextSelector: () => null,
+  useFlowEngine: () => ({
+    context: {
+      t: (key: string) => key,
+      api: {
+        resource: (name: string) => ({
+          list: name === 'users' ? usersListMock : rolesListMock,
+        }),
+      },
+      dataSourceManager: {
+        getDataSource: () => ({
+          collectionManager: {
+            getCollection: () => ({
+              filterTargetKey: 'id',
+              titleCollectionField: { name: 'title' },
+            }),
+          },
+        }),
+      },
+    },
+  }),
+}));
+
+vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
+  parseCollectionName: (value: string) => ['main', value],
+  TriggerCollectionRecordSelect: () => <div data-testid="trigger-collection-record-select" />,
+  useCurrentWorkflowContext: () => ({
+    config: { type: 0, collection: 'posts' },
+  }),
+  useWorkflowVariableOptions: () => [],
+}));
+
+vi.mock('../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+usersListMock.mockImplementation(async () => ({
+  data: {
+    data: [{ id: 1, nickname: 'NocoBase' }],
+  },
+}));
+
+rolesListMock.mockImplementation(async () => ({
+  data: {
+    data: [{ name: 'admin', title: 'Admin' }],
+  },
+}));
+
+describe('TriggerCustomActionConfig', () => {
+  it('uses searchable remote selects for actor and role with debounced 200-item requests', async () => {
+    vi.useFakeTimers();
+    usersListMock.mockClear();
+    rolesListMock.mockClear();
+    remoteSelectState.propsList = [];
+
+    try {
+      render(
+        <Form>
+          <TriggerCustomActionConfig />
+        </Form>,
+      );
+
+      expect(screen.getByTestId('remote-select:workflow-custom-action-trigger:users')).toBeInTheDocument();
+      expect(screen.getByTestId('remote-select:workflow-custom-action-trigger:roles')).toBeInTheDocument();
+
+      const getUserSelectProps = () =>
+        remoteSelectState.propsList.filter((props) => props.cacheKey === 'workflow-custom-action-trigger:users').at(-1);
+      const getRoleSelectProps = () =>
+        remoteSelectState.propsList.filter((props) => props.cacheKey === 'workflow-custom-action-trigger:roles').at(-1);
+
+      await getUserSelectProps()?.request();
+      await getRoleSelectProps()?.request();
+
+      expect(usersListMock).toHaveBeenLastCalledWith({ pageSize: 200 });
+      expect(rolesListMock).toHaveBeenLastCalledWith({ pageSize: 200 });
+
+      act(() => {
+        getUserSelectProps()?.onSearch?.('No');
+        getRoleSelectProps()?.onSearch?.('Ad');
+      });
+
+      await getUserSelectProps()?.request();
+      await getRoleSelectProps()?.request();
+
+      expect(usersListMock).toHaveBeenLastCalledWith({ pageSize: 200 });
+      expect(rolesListMock).toHaveBeenLastCalledWith({ pageSize: 200 });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await getUserSelectProps()?.request();
+      await getRoleSelectProps()?.request();
+
+      expect(usersListMock).toHaveBeenLastCalledWith({
+        pageSize: 200,
+        filter: {
+          nickname: {
+            $includes: 'No',
+          },
+        },
+      });
+      expect(rolesListMock).toHaveBeenLastCalledWith({
+        pageSize: 200,
+        filter: {
+          title: {
+            $includes: 'Ad',
+          },
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
- The v2 custom action trigger manual-execute form no longer matched the legacy workflow UI: the actor and role fields were rendered as variable inputs instead of searchable remote selects, and the remote query behavior no longer matched the previous 200-item fetch and debounced search flow.

### Description 
- restore searchable remote selects for `userId` and `roleName` in custom action trigger manual execution
- align user and role queries with the legacy behavior using `pageSize: 200` and `300ms` debounced remote search
- fix `RemoteSelect` option label typing in both actor selects and collection multi-select
- add regression coverage for the debounced remote query behavior

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
