### PR TITLE
fix(plugin-ai): support request token in MCP config

### DIFF
--- a/packages/core/ai/src/__tests__/mcp-user-context.test.ts
+++ b/packages/core/ai/src/__tests__/mcp-user-context.test.ts
@@ -20,6 +20,9 @@ const mcpClientMock = vi.hoisted(() => {
     }
 
     async initializeConnections() {
+      if (Object.values(this.connections).some((connection) => connection?.failInitialize)) {
+        throw new Error('initialize failed');
+      }
       return Object.fromEntries(
         Object.keys(this.connections).map((serverName) => [
           serverName,
@@ -250,6 +253,28 @@ describe('user-bound MCP clients', () => {
       },
     ]);
     expect(mcpClientMock.instances[0].connections.profile.url).toBe('https://mcp.example.test/11');
+  });
+
+  it('returns empty tools and logs warning when user-bound MCP initialization fails', async () => {
+    const app = createApp();
+    const manager = new UserContextMCPClientManager({
+      app,
+      listEntries: async () => [
+        {
+          name: 'profile',
+          enabled: true,
+          transport: 'http',
+          url: 'https://{{ $env.MCP_HOST }}/{{ currentUser.id }}',
+          headers: {},
+          useUserContext: true,
+        },
+      ],
+      buildConnection: () => ({ failInitialize: true }) as any,
+    });
+
+    await expect(manager.getToolsMap(createCtx(1))).resolves.toEqual({});
+    expect(app.log.warn).toHaveBeenCalledWith('fail to get user-bound mcp tools', expect.any(Error));
+    expect(mcpClientMock.instances[0].close).toHaveBeenCalledTimes(1);
   });
 
   it('reuses cached user-bound tools and refreshes them after TTL', async () => {

--- a/packages/core/ai/src/__tests__/mcp-user-context.test.ts
+++ b/packages/core/ai/src/__tests__/mcp-user-context.test.ts
@@ -84,6 +84,13 @@ describe('user-bound MCP clients', () => {
           findOne: vi.fn(),
         }),
       },
+      request: {
+        headers: {
+          authorization: 'Bearer request-token',
+          'x-role': 'admin',
+        },
+      },
+      getBearerToken: () => 'request-token',
     }) as any;
 
   beforeEach(() => {
@@ -136,6 +143,48 @@ describe('user-bound MCP clients', () => {
         'X-User': 'user-7',
       },
       useUserContext: true,
+    });
+  });
+
+  it('renders NocoBase request in MCP options', async () => {
+    const rendered = await renderMCPOptions(
+      {
+        transport: 'http',
+        url: 'https://{{ $env.MCP_HOST }}/mcp',
+        headers: {
+          Authorization: 'Bearer {{ request.token }}',
+          'X-Role': '{{ request.headers.x-role }}',
+        },
+        useUserContext: true,
+      },
+      createApp(),
+      createCtx(7),
+    );
+
+    expect(rendered).toMatchObject({
+      headers: {
+        Authorization: 'Bearer request-token',
+        'X-Role': 'admin',
+      },
+    });
+  });
+
+  it('does not render NocoBase request for shared MCP options', async () => {
+    const rendered = await renderMCPOptions(
+      {
+        transport: 'http',
+        url: 'https://{{ $env.MCP_HOST }}/mcp',
+        headers: {
+          Authorization: 'Bearer {{ request.token }}',
+        },
+        useUserContext: false,
+      },
+      createApp(),
+      createCtx(7),
+    );
+
+    expect(rendered.headers).toMatchObject({
+      Authorization: 'Bearer ',
     });
   });
 

--- a/packages/core/ai/src/mcp-manager/options-renderer.ts
+++ b/packages/core/ai/src/mcp-manager/options-renderer.ts
@@ -84,6 +84,16 @@ const stringifyArray = (value: unknown): string[] => {
   return value.filter((item) => item != null).map((item) => String(item));
 };
 
+const getRequestVariables = (ctx?: Context) => ({
+  headers: ctx?.request?.headers ?? {},
+  token: ctx?.getBearerToken?.() ?? '',
+});
+
+const emptyRequestVariables = {
+  headers: {},
+  token: '',
+};
+
 export const normalizeMCPOptions = (options: MCPOptions): MCPOptions => {
   const normalized: MCPOptions = {
     ...options,
@@ -106,12 +116,15 @@ export async function renderMCPOptions(
   ctx?: Context,
 ): Promise<MCPOptions> {
   const currentUser = options.useUserContext ? await getCurrentUser(ctx, options) : undefined;
+  const request = options.useUserContext ? getRequestVariables(ctx) : emptyRequestVariables;
   const variables = {
     $env: app.environment?.getVariables?.() ?? {},
     currentUser,
     $user: currentUser,
+    request,
     ctx: {
       currentUser,
+      request,
     },
   };
 

--- a/packages/core/ai/src/mcp-manager/user-context-client-manager.ts
+++ b/packages/core/ai/src/mcp-manager/user-context-client-manager.ts
@@ -46,52 +46,67 @@ export class UserContextMCPClientManager {
       return {};
     }
 
-    this.evictExpired();
+    let client: MultiServerMCPClient | null = null;
+    try {
+      this.evictExpired();
 
-    const entries = (await this.options.listEntries())
-      .filter((entry) => entry.enabled !== false && entry.useUserContext === true && entry.transport !== 'stdio')
-      .sort((left, right) => left.name.localeCompare(right.name));
-    if (!entries.length) {
+      const entries = (await this.options.listEntries())
+        .filter((entry) => entry.enabled !== false && entry.useUserContext === true && entry.transport !== 'stdio')
+        .sort((left, right) => left.name.localeCompare(right.name));
+      if (!entries.length) {
+        return {};
+      }
+
+      const cacheKey = String(currentUser.id);
+      const cached = this.cache.get(cacheKey);
+      const now = Date.now();
+      if (cached && cached.expiresAt > now) {
+        cached.lastAccessedAt = now;
+        return cached.toolsMap;
+      }
+
+      if (cached) {
+        await this.closeEntry(cached);
+        this.cache.delete(cacheKey);
+      }
+
+      const connections: Record<string, MCPConnection> = {};
+      for (const entry of entries) {
+        const rendered = await renderMCPOptions(entry, this.options.app, ctx);
+        connections[entry.name] = this.options.buildConnection(rendered);
+      }
+
+      client = new MultiServerMCPClient(connections);
+      const initializedToolsMap = await client.initializeConnections();
+      const toolsMap = Object.fromEntries(
+        Object.entries(initializedToolsMap).map(([serverName, tools]) => [
+          serverName,
+          tools as StructuredToolInterface[],
+        ]),
+      );
+
+      this.cache.set(cacheKey, {
+        client,
+        toolsMap,
+        expiresAt: now + this.ttlMs,
+        lastAccessedAt: now,
+      });
+      client = null;
+      await this.evictOversized();
+
+      return toolsMap;
+    } catch (error) {
+      if (client) {
+        await this.closeEntry({
+          client,
+          toolsMap: {},
+          expiresAt: 0,
+          lastAccessedAt: 0,
+        });
+      }
+      this.options.app?.log?.warn?.('fail to get user-bound mcp tools', error);
       return {};
     }
-
-    const cacheKey = String(currentUser.id);
-    const cached = this.cache.get(cacheKey);
-    const now = Date.now();
-    if (cached && cached.expiresAt > now) {
-      cached.lastAccessedAt = now;
-      return cached.toolsMap;
-    }
-
-    if (cached) {
-      await this.closeEntry(cached);
-      this.cache.delete(cacheKey);
-    }
-
-    const connections: Record<string, MCPConnection> = {};
-    for (const entry of entries) {
-      const rendered = await renderMCPOptions(entry, this.options.app, ctx);
-      connections[entry.name] = this.options.buildConnection(rendered);
-    }
-
-    const client = new MultiServerMCPClient(connections);
-    const initializedToolsMap = await client.initializeConnections();
-    const toolsMap = Object.fromEntries(
-      Object.entries(initializedToolsMap).map(([serverName, tools]) => [
-        serverName,
-        tools as StructuredToolInterface[],
-      ]),
-    );
-
-    this.cache.set(cacheKey, {
-      client,
-      toolsMap,
-      expiresAt: now + this.ttlMs,
-      lastAccessedAt: now,
-    });
-    await this.evictOversized();
-
-    return toolsMap;
   }
 
   async clear() {

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/admin/mcp/MCPSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/admin/mcp/MCPSettings.tsx
@@ -39,6 +39,19 @@ import { createMCPSchema, editMCPFormContentSchema, mcpSettingsSchema, viewMCPTo
 
 type MCPTransport = 'stdio' | 'http' | 'sse';
 
+type MCPVariableValue = NonNullable<DefaultOptionType['value']>;
+
+type MCPVariableOption = Omit<Partial<DefaultOptionType>, 'children' | 'label' | 'value'> & {
+  name?: MCPVariableValue;
+  title?: React.ReactNode;
+  value?: MCPVariableValue;
+  label?: React.ReactNode;
+  key?: React.Key;
+  children?: MCPVariableOption[];
+  loadChildren?: (option: MCPVariableOption, ...args: unknown[]) => Promise<void> | void;
+  [key: string]: unknown;
+};
+
 const transportOptions = [
   { label: 'Stdio', value: 'stdio' },
   { label: 'HTTP (Streamable)', value: 'http' },
@@ -50,6 +63,15 @@ const transportColorMap: Record<MCPTransport, string> = {
   http: 'green',
   sse: 'gold',
 };
+
+const requestHeaderVariables: MCPVariableOption[] = [
+  { name: 'x-app', title: 'X-App', value: 'x-app' },
+  { name: 'x-locale', title: 'X-Locale', value: 'x-locale' },
+  { name: 'x-hostname', title: 'X-Hostname', value: 'x-hostname' },
+  { name: 'x-timezone', title: 'X-Timezone', value: 'x-timezone' },
+  { name: 'x-role', title: 'X-Role', value: 'x-role' },
+  { name: 'x-authenticator', title: 'X-Authenticator', value: 'x-authenticator' },
+];
 
 const keyValueRowClassName = css`
   & > .ant-space-item:first-child,
@@ -465,6 +487,7 @@ const TestConnectionResult: React.FC = observer(
 );
 
 const useMCPVariableScope = (includeCurrentUser: boolean) => {
+  const t = useT();
   const environmentVariables = useGlobalVariable('$env');
   const { currentUserSettings } = useCurrentUserVariable({
     maxDepth: 3,
@@ -476,22 +499,29 @@ const useMCPVariableScope = (includeCurrentUser: boolean) => {
       [
         normalizeMCPVariableOption(environmentVariables),
         includeCurrentUser ? normalizeMCPVariableOption(currentUserSettings) : null,
+        includeCurrentUser
+          ? normalizeMCPVariableOption({
+              name: 'request',
+              title: t('NocoBase request'),
+              value: 'request',
+              children: [
+                {
+                  name: 'headers',
+                  title: 'headers',
+                  value: 'headers',
+                  children: requestHeaderVariables,
+                },
+                {
+                  name: 'token',
+                  title: 'Token',
+                  value: 'token',
+                },
+              ],
+            })
+          : null,
       ].filter(Boolean),
-    [currentUserSettings, environmentVariables, includeCurrentUser],
+    [currentUserSettings, environmentVariables, includeCurrentUser, t],
   );
-};
-
-type MCPVariableValue = NonNullable<DefaultOptionType['value']>;
-
-type MCPVariableOption = Omit<Partial<DefaultOptionType>, 'children' | 'label' | 'value'> & {
-  name?: MCPVariableValue;
-  title?: React.ReactNode;
-  value?: MCPVariableValue;
-  label?: React.ReactNode;
-  key?: React.Key;
-  children?: MCPVariableOption[];
-  loadChildren?: (option: MCPVariableOption, ...args: unknown[]) => Promise<void> | void;
-  [key: string]: unknown;
 };
 
 const normalizeMCPVariableOption = (option?: MCPVariableOption | null): MCPVariableOption | null => {
@@ -598,7 +628,13 @@ const AddNew = () => {
       </Button>
       <TestConnectionContext.Provider value={contextValue}>
         <SchemaComponent
-          components={{ TestConnectionButton, TestConnectionResult, Space, MCPVariableInput, UserContextCheckbox }}
+          components={{
+            TestConnectionButton,
+            TestConnectionResult,
+            Space,
+            MCPVariableInput,
+            UserContextCheckbox,
+          }}
           scope={{
             t,
             transportOptions,
@@ -634,7 +670,13 @@ const MCPEditDrawerContent: React.FC = () => {
     <CollectionRecordProvider record={record}>
       <TestConnectionContext.Provider value={contextValue}>
         <SchemaComponent
-          components={{ TestConnectionButton, TestConnectionResult, Space, MCPVariableInput, UserContextCheckbox }}
+          components={{
+            TestConnectionButton,
+            TestConnectionResult,
+            Space,
+            MCPVariableInput,
+            UserContextCheckbox,
+          }}
           scope={{
             t,
             transportOptions,

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/admin/mcp/schemas.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/admin/mcp/schemas.ts
@@ -76,7 +76,7 @@ const createMCPFormProperties = (options: {
     'x-component': 'UserContextCheckbox',
     'x-component-props': {
       tooltip:
-        '{{ t("When enabled, URL and headers can use current user variables, and the MCP server runs per current user. Stdio transport is not supported.") }}',
+        '{{ t("When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.") }}',
     },
   },
   command: {
@@ -421,18 +421,6 @@ export const mcpSettingsSchema = {
                 transport: {
                   type: 'string',
                   'x-component': 'TransportTag',
-                },
-              },
-            },
-            column5: {
-              type: 'void',
-              title: '{{ t("Depends on current user") }}',
-              'x-component': 'TableV2.Column',
-              properties: {
-                useUserContext: {
-                  type: 'boolean',
-                  'x-component': 'Checkbox',
-                  'x-read-pretty': true,
                 },
               },
             },

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -451,7 +451,9 @@
   "Restrict this AI employee to the selected models.": "Restrict this AI employee to the selected models.",
   "Models": "Models",
   "Depends on current user": "Depends on current user",
-  "When enabled, URL and headers can use current user variables, and the MCP server runs per current user. Stdio transport is not supported.": "When enabled, URL and headers can use current user variables, and the MCP server runs per current user. Stdio transport is not supported.",
+  "NocoBase request": "NocoBase request",
+  "When enabled, URL and headers can use current user variables. Stdio transport is not supported.": "When enabled, URL and headers can use current user variables. Stdio transport is not supported.",
+  "When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.": "When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.",
   "Connection test failed": "Connection test failed",
   "The MCP server uses current user variables and the connection test failed. Do you want to save it anyway?": "The MCP server uses current user variables and the connection test failed. Do you want to save it anyway?",
   "Save anyway": "Save anyway"

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -457,7 +457,9 @@
   "Restrict this AI employee to the selected models.": "限制该 AI 员工只能使用所选模型。",
   "Models": "模型",
   "Depends on current user": "依赖当前用户信息",
-  "When enabled, URL and headers can use current user variables, and the MCP server runs per current user. Stdio transport is not supported.": "启用后，可在 URL 和请求头中使用当前用户变量，并按当前用户运行 MCP 服务。Stdio 传输方式不支持。",
+  "NocoBase request": "NocoBase 请求",
+  "When enabled, URL and headers can use current user variables. Stdio transport is not supported.": "启用后，可在 URL 和请求头中使用当前用户变量。Stdio 传输方式不支持。",
+  "When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.": "启用后，可在 URL 和请求头中使用当前用户变量和 NocoBase 请求变量。Stdio 传输方式不支持。",
   "Connection test failed": "连接测试失败",
   "The MCP server uses current user variables and the connection test failed. Do you want to save it anyway?": "该 MCP 服务使用当前用户变量，且连接测试失败。是否仍然保存？",
   "Save anyway": "仍然保存"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
MCP servers configured for AI employees need to be able to reuse the current NocoBase request token when they are bound to the current user. User-bound MCP server connection failures should also not interrupt normal AI employee conversations.

### Description 
- Added NocoBase request variables, including request token and common request headers, to the MCP configuration variable picker when current user context is enabled.
- Rendered request token and request headers in user-bound MCP options on the server side, while keeping shared MCP options isolated from request variables.
- Prevented failures while loading user-bound MCP tools from propagating into AI employee conversations; failures are logged and an empty tools map is returned.
- Removed the "Depends on current user" column from the MCP settings table while keeping the setting available in create/edit forms.
- Added tests for request variable rendering and user-bound MCP load failure isolation.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added support for using NocoBase request variables in user-bound MCP configurations and prevented user-bound MCP connection failures from interrupting AI employee conversations. |
| 🇨🇳 Chinese | 支持在依赖当前用户的 MCP 配置中使用 NocoBase 请求变量，并避免用户态 MCP 连接失败影响 AI 员工正常对话。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
