### PR TITLE
fix(plugin-block-iframe): allow v2 iframe html access

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-iframe/src/client-v2/models/IframeBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-iframe/src/client-v2/models/IframeBlockModel.tsx
@@ -79,9 +79,11 @@ const Iframe: any = observer(
       const loadHtml = async () => {
         setLoading(true);
         try {
-          const res = await ctx.api.resource('iframeHtml').get({ filterByTk: htmlId });
+          const res = await ctx.api.request({
+            url: `iframeHtml:getHtml/${htmlId}`,
+          });
           if (!active) return;
-          setHtmlContent(res?.data?.data?.html || res?.data?.html || '');
+          setHtmlContent(typeof res?.data === 'string' ? res.data : '');
         } catch (error) {
           console.error(error);
         } finally {
@@ -91,7 +93,7 @@ const Iframe: any = observer(
         }
       };
 
-      void loadHtml();
+      loadHtml();
 
       return () => {
         active = false;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Normal users received 403 when opening v2 iframe blocks in HTML mode because the renderer requested the generic `iframeHtml:get` action, while the server only allows logged-in users to access the dedicated `iframeHtml:getHtml` action.

### Description 
Use the allowed `iframeHtml:getHtml/{htmlId}` endpoint when v2 iframe blocks load HTML content, matching the v1 rendering path and avoiding broader `iframeHtml:get` permissions.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-block-iframe/src/client-v2/models/IframeBlockModel.tsx`
- `git diff --check`
- pre-commit `lint-staged`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed 403 errors for normal users when viewing v2 iframe blocks in HTML mode. |
| 🇨🇳 Chinese | 修复普通用户查看 v2 iframe HTML 模式区块时报 403 的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |     |
| 🇨🇳 Chinese |     |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
