### PR TITLE
fix(client-v2): handle group route ids

### DIFF
--- a/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
+++ b/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
@@ -9,17 +9,20 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Router, Routes, useNavigate } from 'react-router-dom';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { FlowContextProvider, FlowEngine, FlowEngineProvider, type FlowModel } from '@nocobase/flow-engine';
 import FlowRoute from '../components/FlowRoute';
 import { RouteRepository } from '../../RouteRepository';
+import { NocoBaseDesktopRouteType } from '../../flow-compat';
 
 type MockAdminLayoutModel = FlowModel & {
   registerRoutePage: ReturnType<typeof vi.fn>;
   updateRoutePage: ReturnType<typeof vi.fn>;
   unregisterRoutePage: ReturnType<typeof vi.fn>;
 };
+
+type RouterNavigator = React.ComponentProps<typeof Router>['navigator'];
 
 const { hookState } = vi.hoisted(() => {
   return {
@@ -882,6 +885,548 @@ describe('FlowRoute', () => {
     render(
       <FlowEngineProvider engine={engine}>
         <MemoryRouter initialEntries={['/admin/admin-denied-page']}>
+          <Routes>
+            <Route path="/admin/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalled();
+  });
+
+  it('should render blank content when current admin route matches an accessible empty group id', async () => {
+    const engine = new FlowEngine();
+    const listAccessible = vi.fn(() => [
+      {
+        id: 371750686228480,
+        schemaUid: 'group-schema',
+        title: '789',
+        type: NocoBaseDesktopRouteType.group,
+      },
+    ]);
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn(() => undefined),
+        listAccessible,
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    const { container } = render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/371750686228480']}>
+          <Routes>
+            <Route path="/admin/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(listAccessible).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('404')).not.toBeInTheDocument();
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalled();
+  });
+
+  it('should navigate a current admin group route to its first accessible flow page', async () => {
+    const engine = new FlowEngine();
+    const childRoute = {
+      schemaUid: 'child-flow-page',
+      title: 'Child flow page',
+      type: NocoBaseDesktopRouteType.flowPage,
+    };
+    const groupRoute = {
+      id: 371750686228480,
+      schemaUid: 'group-schema',
+      title: 'Group with child',
+      type: NocoBaseDesktopRouteType.group,
+      children: [childRoute],
+    };
+    const getRouteBySchemaUid = vi.fn((schemaUid: string) =>
+      schemaUid === 'child-flow-page' ? childRoute : undefined,
+    );
+    const listAccessible = vi.fn(() => [groupRoute]);
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid,
+        listAccessible,
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/371750686228480']}>
+          <Routes>
+            <Route path="/admin/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(adminLayoutModel.registerRoutePage).toHaveBeenCalledWith('child-flow-page', expect.any(Object));
+    });
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalledWith('371750686228480', expect.any(Object));
+    expect(screen.queryByText('404')).not.toBeInTheDocument();
+  });
+
+  it('should keep rendering 404 when a group id is opened with a nested admin route path', async () => {
+    const engine = new FlowEngine();
+    const childRoute = {
+      schemaUid: 'child-flow-page',
+      title: 'Child flow page',
+      type: NocoBaseDesktopRouteType.flowPage,
+    };
+    const groupRoute = {
+      id: 371750686228480,
+      schemaUid: 'group-schema',
+      title: 'Group with child',
+      type: NocoBaseDesktopRouteType.group,
+      children: [childRoute],
+    };
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn((schemaUid: string) => (schemaUid === 'child-flow-page' ? childRoute : undefined)),
+        listAccessible: vi.fn(() => [groupRoute]),
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/371750686228480/view/not-exists']}>
+          <Routes>
+            <Route path="/admin/:name/view/*" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalledWith('child-flow-page', expect.any(Object));
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalledWith('371750686228480', expect.any(Object));
+  });
+
+  it('should keep rendering 404 when a group id is opened with a tab admin route path', async () => {
+    const engine = new FlowEngine();
+    const childRoute = {
+      schemaUid: 'child-flow-page',
+      title: 'Child flow page',
+      type: NocoBaseDesktopRouteType.flowPage,
+    };
+    const groupRoute = {
+      id: 371750686228480,
+      schemaUid: 'group-schema',
+      title: 'Group with child',
+      type: NocoBaseDesktopRouteType.group,
+      children: [childRoute],
+    };
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn((schemaUid: string) => (schemaUid === 'child-flow-page' ? childRoute : undefined)),
+        listAccessible: vi.fn(() => [groupRoute]),
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/371750686228480/tab/not-exists']}>
+          <Routes>
+            <Route path="/admin/:name/tab/:tabUid" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalledWith('child-flow-page', expect.any(Object));
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalledWith('371750686228480', expect.any(Object));
+  });
+
+  it('should keep blank content while a group child navigation is already pending for the current path', async () => {
+    const engine = new FlowEngine();
+    const childRoute = {
+      schemaUid: 'child-flow-page',
+      title: 'Child flow page',
+      type: NocoBaseDesktopRouteType.flowPage,
+    };
+    const groupRoute = {
+      id: 371750686228480,
+      schemaUid: 'group-schema',
+      title: 'Group with child',
+      type: NocoBaseDesktopRouteType.group,
+      children: [childRoute],
+    };
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn((schemaUid: string) => (schemaUid === 'child-flow-page' ? childRoute : undefined)),
+        listAccessible: vi.fn(() => [groupRoute]),
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const replace = vi.fn();
+    const navigator: RouterNavigator = {
+      createHref: (to: { pathname?: string; search?: string; hash?: string } | string) =>
+        typeof to === 'string' ? to : `${to.pathname || ''}${to.search || ''}${to.hash || ''}`,
+      go: vi.fn(),
+      push: vi.fn(),
+      replace,
+    };
+
+    const RerenderAfterReplace = () => {
+      const [rerendered, setRerendered] = React.useState(false);
+      React.useEffect(() => {
+        if (!rerendered && replace.mock.calls.length > 0) {
+          setRerendered(true);
+        }
+      }, [rerendered]);
+
+      return <FlowRoute legacyPageBehavior={rerendered ? 'bridge' : undefined} />;
+    };
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <Router location="/admin/371750686228480" navigator={navigator}>
+          <Routes>
+            <Route path="/admin/:name" element={<RerenderAfterReplace />} />
+          </Routes>
+        </Router>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(screen.queryByText('404')).not.toBeInTheDocument();
+  });
+
+  it('should reset group navigation guard when page uid changes in the same route instance', async () => {
+    const engine = new FlowEngine();
+    const childRoute1 = {
+      schemaUid: 'child-flow-page-1',
+      title: 'Child flow page 1',
+      type: NocoBaseDesktopRouteType.flowPage,
+    };
+    const childRoute2 = {
+      schemaUid: 'child-flow-page-2',
+      title: 'Child flow page 2',
+      type: NocoBaseDesktopRouteType.flowPage,
+    };
+    const groupRoute1 = {
+      id: 371750686228480,
+      schemaUid: 'group-schema-1',
+      title: 'Group with child 1',
+      type: NocoBaseDesktopRouteType.group,
+      children: [childRoute1],
+    };
+    const groupRoute2 = {
+      id: 371750755434496,
+      schemaUid: 'group-schema-2',
+      title: 'Group with child 2',
+      type: NocoBaseDesktopRouteType.group,
+      children: [childRoute2],
+    };
+    const routeMap: Record<string, typeof childRoute1 | typeof childRoute2> = {
+      'child-flow-page-1': childRoute1,
+      'child-flow-page-2': childRoute2,
+    };
+    const getRouteBySchemaUid = vi.fn((schemaUid: string) => routeMap[schemaUid]);
+    const listAccessible = vi.fn(() => [groupRoute1, groupRoute2]);
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid,
+        listAccessible,
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+    let navigateTo: (path: string) => void = () => {};
+    const CaptureNavigate = () => {
+      const navigate = useNavigate();
+      React.useEffect(() => {
+        navigateTo = navigate;
+      }, [navigate]);
+      return null;
+    };
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/371750686228480']}>
+          <CaptureNavigate />
+          <Routes>
+            <Route path="/admin/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(adminLayoutModel.registerRoutePage).toHaveBeenCalledWith('child-flow-page-1', expect.any(Object));
+    });
+
+    act(() => {
+      navigateTo('/admin/371750755434496');
+    });
+
+    await waitFor(() => {
+      expect(adminLayoutModel.registerRoutePage).toHaveBeenCalledWith('child-flow-page-2', expect.any(Object));
+    });
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalledWith('371750755434496', expect.any(Object));
+    expect(screen.queryByText('404')).not.toBeInTheDocument();
+  });
+
+  it('should keep rendering 404 when current admin route matches no accessible schema uid or id', async () => {
+    const engine = new FlowEngine();
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn(() => undefined),
+        listAccessible: vi.fn(() => [
+          {
+            id: 371750686228480,
+            schemaUid: 'group-schema',
+            title: '789',
+            type: NocoBaseDesktopRouteType.group,
+          },
+        ]),
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/not-exists-4822']}>
+          <Routes>
+            <Route path="/admin/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalled();
+  });
+
+  it('should keep rendering 404 when current admin route matches only a non-group route id', async () => {
+    const engine = new FlowEngine();
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn(() => undefined),
+        listAccessible: vi.fn(() => [
+          {
+            id: 10001,
+            schemaUid: 'flow-page-schema',
+            title: 'Flow page',
+            type: NocoBaseDesktopRouteType.flowPage,
+          },
+        ]),
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/10001']}>
+          <Routes>
+            <Route path="/admin/:name" element={<FlowRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </FlowEngineProvider>,
+    );
+
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(adminLayoutModel.registerRoutePage).not.toHaveBeenCalled();
+  });
+
+  it('should keep rendering 404 when current admin route matches only a group schema uid', async () => {
+    const engine = new FlowEngine();
+    const groupRoute = {
+      id: 371750686228480,
+      schemaUid: 'group-schema',
+      title: '789',
+      type: NocoBaseDesktopRouteType.group,
+    };
+    engine.context.defineProperty('routeRepository', {
+      value: {
+        refreshAccessible: hookState.refresh,
+        isAccessibleLoaded: () => true,
+        ensureAccessibleLoaded: vi.fn().mockResolvedValue([]),
+        getRouteBySchemaUid: vi.fn((schemaUid: string) => (schemaUid === 'group-schema' ? groupRoute : undefined)),
+        listAccessible: vi.fn(() => [groupRoute]),
+      },
+    });
+    engine.context.defineProperty('app', {
+      value: {
+        getPublicPath: () => '/v2/',
+        router: {
+          getBasename: () => '/v2',
+        },
+      },
+    });
+
+    const adminLayoutModel: MockAdminLayoutModel = Object.assign(
+      engine.createModel({ uid: 'admin-layout-model', use: 'FlowModel' }),
+      {
+        registerRoutePage: vi.fn(),
+        updateRoutePage: vi.fn(),
+        unregisterRoutePage: vi.fn(),
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <MemoryRouter initialEntries={['/admin/group-schema']}>
           <Routes>
             <Route path="/admin/:name" element={<FlowRoute />} />
           </Routes>

--- a/packages/core/client-v2/src/flow/components/FlowRoute.tsx
+++ b/packages/core/client-v2/src/flow/components/FlowRoute.tsx
@@ -10,10 +10,13 @@
 import { type FlowEngine, useFlowContext, useFlowEngine } from '@nocobase/flow-engine';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { deviceType } from 'react-device-detect';
-import { useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useApp } from '../../hooks/useApp';
-import { NocoBaseDesktopRouteType } from '../../flow-compat';
-import { resolveAdminRouteRuntimeTarget } from '../admin-shell/admin-layout/resolveAdminRouteRuntimeTarget';
+import { NocoBaseDesktopRouteType, type NocoBaseDesktopRoute } from '../../flow-compat';
+import {
+  resolveAdminRouteRuntimeTarget,
+  toRouterNavigationPath,
+} from '../admin-shell/admin-layout/resolveAdminRouteRuntimeTarget';
 import { getAdminLayoutModel, type AdminLayoutModel } from '../admin-shell/admin-layout/AdminLayoutModel';
 import { getLayoutModel, type BaseLayoutModel } from '../admin-shell/BaseLayoutModel';
 import { useLayoutRoutePage } from '../admin-shell/useLayoutRoutePage';
@@ -21,6 +24,7 @@ import { AppNotFound } from '../../components';
 import { useKeepAlive } from '../../components/KeepAlive';
 
 type FlowRouteGuardState = {
+  pageUid?: string;
   pending: boolean;
   allowBridge: boolean;
   notFound: boolean;
@@ -33,6 +37,14 @@ type FlowRouteLayoutContext = {
   routePath?: string;
   routeName?: string;
   uid?: string;
+};
+
+type FlowRouteRepositoryLike = {
+  refreshAccessible?: () => Promise<unknown>;
+  isAccessibleLoaded?: () => boolean;
+  ensureAccessibleLoaded?: () => Promise<unknown>;
+  getRouteBySchemaUid?: (schemaUid: string) => NocoBaseDesktopRoute | undefined;
+  listAccessible?: () => NocoBaseDesktopRoute[];
 };
 
 export type FlowRouteProps = {
@@ -69,6 +81,44 @@ const getDefaultLegacyPageBehavior = (
 };
 
 const shouldRequireAccessibleRoute = (contextLayout?: FlowRouteLayoutContext) => contextLayout?.authCheck !== false;
+
+const findAccessibleRouteByIdentity = (
+  routes: NocoBaseDesktopRoute[] | undefined,
+  pageUid: string,
+): NocoBaseDesktopRoute | undefined => {
+  if (!Array.isArray(routes)) {
+    return undefined;
+  }
+
+  for (const route of routes) {
+    if (
+      (route.type !== NocoBaseDesktopRouteType.group && route.schemaUid === pageUid) ||
+      (route.type === NocoBaseDesktopRouteType.group && route.id != null && String(route.id) === pageUid)
+    ) {
+      return route;
+    }
+
+    const matched = findAccessibleRouteByIdentity(route.children, pageUid);
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return undefined;
+};
+
+const getAccessibleRouteByPageUid = (
+  routeRepository: FlowRouteRepositoryLike | undefined,
+  pageUid: string,
+): NocoBaseDesktopRoute | undefined => {
+  const routeBySchemaUid = routeRepository?.getRouteBySchemaUid?.(pageUid);
+
+  if (routeBySchemaUid && routeBySchemaUid.type !== NocoBaseDesktopRouteType.group) {
+    return routeBySchemaUid;
+  }
+
+  return findAccessibleRouteByIdentity(routeRepository?.listAccessible?.(), pageUid);
+};
 
 const hasFlowModel = async (flowEngine: FlowEngine, pageUid: string) => {
   if (flowEngine.getModel(pageUid)) {
@@ -197,11 +247,15 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
   );
   const legacyPageBehavior = legacyPageBehaviorProp || getDefaultLegacyPageBehavior(flowEngine, routeLayout);
   const app = useApp();
-  const routeRepository = flowEngine.context.routeRepository;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const routeRepository = flowEngine.context.routeRepository as FlowRouteRepositoryLike | undefined;
   const params = useParams();
   const pageUid = pageUidProp || params?.name;
+  const hasNestedRoutePath = typeof params?.tabUid !== 'undefined' || typeof params?.['*'] !== 'undefined';
   const skipRouteRepositoryCheck = !routeRepository;
   const [guardState, setGuardState] = useState<FlowRouteGuardState>({
+    pageUid: undefined,
     pending: true,
     allowBridge: false,
     notFound: false,
@@ -214,18 +268,22 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
   }
 
   useEffect(() => {
+    replaceTriggeredRef.current = false;
+  }, [location.hash, location.pathname, location.search, pageUid]);
+
+  useEffect(() => {
     let active = true;
     const requestId = ++requestIdRef.current;
 
     const run = async () => {
-      setGuardState({ pending: true, allowBridge: false, notFound: false });
+      setGuardState({ pageUid, pending: true, allowBridge: false, notFound: false });
 
       if (!skipRouteRepositoryCheck && !routeRepository?.isAccessibleLoaded?.()) {
         try {
           await routeRepository?.ensureAccessibleLoaded?.();
         } catch (_error) {
           if (active && requestId === requestIdRef.current) {
-            setGuardState({ pending: false, allowBridge: true, notFound: false });
+            setGuardState({ pageUid, pending: false, allowBridge: true, notFound: false });
           }
           return;
         }
@@ -235,28 +293,64 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
         return;
       }
 
-      const route = skipRouteRepositoryCheck ? undefined : routeRepository?.getRouteBySchemaUid?.(pageUid);
+      const route = skipRouteRepositoryCheck ? undefined : getAccessibleRouteByPageUid(routeRepository, pageUid);
       if (!route && !skipRouteRepositoryCheck && shouldRequireAccessibleRoute(routeLayout)) {
-        setGuardState({ pending: false, allowBridge: false, notFound: true });
+        setGuardState({ pageUid, pending: false, allowBridge: false, notFound: true });
         return;
       }
 
       if (!route && legacyPageBehavior === 'notFound') {
         const flowModelExists = await hasFlowModel(flowEngine, pageUid);
         if (active && requestId === requestIdRef.current) {
-          setGuardState({ pending: false, allowBridge: flowModelExists, notFound: !flowModelExists });
+          setGuardState({ pageUid, pending: false, allowBridge: flowModelExists, notFound: !flowModelExists });
         }
+        return;
+      }
+
+      if (route?.type === NocoBaseDesktopRouteType.group) {
+        if (hasNestedRoutePath) {
+          setGuardState({ pageUid, pending: false, allowBridge: false, notFound: true });
+          return;
+        }
+
+        const target = resolveAdminRouteRuntimeTarget({
+          app,
+          route,
+          layout: routeLayout,
+        });
+
+        if (target.reason === 'emptyGroup') {
+          setGuardState({ pageUid, pending: false, allowBridge: false, notFound: false });
+          return;
+        }
+
+        if (target.runtimePath) {
+          if (replaceTriggeredRef.current) {
+            setGuardState({ pageUid, pending: false, allowBridge: false, notFound: false });
+            return;
+          }
+
+          replaceTriggeredRef.current = true;
+          if (target.navigationMode === 'document') {
+            window.location.replace(target.runtimePath);
+            return;
+          }
+          navigate(toRouterNavigationPath(target.runtimePath, app.router?.getBasename?.()), { replace: true });
+          return;
+        }
+
+        setGuardState({ pageUid, pending: false, allowBridge: false, notFound: true });
         return;
       }
 
       if (route?.type === NocoBaseDesktopRouteType.page) {
         if (legacyPageBehavior === 'notFound') {
-          setGuardState({ pending: false, allowBridge: false, notFound: true });
+          setGuardState({ pageUid, pending: false, allowBridge: false, notFound: true });
           return;
         }
 
         if (legacyPageBehavior === 'bridge') {
-          setGuardState({ pending: false, allowBridge: true, notFound: false });
+          setGuardState({ pageUid, pending: false, allowBridge: true, notFound: false });
           return;
         }
 
@@ -279,14 +373,14 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
 
         if (target.reason === 'unsupportedV2Runtime') {
           if (active && requestId === requestIdRef.current) {
-            setGuardState({ pending: false, allowBridge: false, notFound: true });
+            setGuardState({ pageUid, pending: false, allowBridge: false, notFound: true });
           }
           return;
         }
       }
 
       if (active && requestId === requestIdRef.current) {
-        setGuardState({ pending: false, allowBridge: true, notFound: false });
+        setGuardState({ pageUid, pending: false, allowBridge: true, notFound: false });
       }
     };
 
@@ -295,10 +389,20 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
     return () => {
       active = false;
     };
-  }, [app, flowEngine, legacyPageBehavior, pageUid, routeLayout, routeRepository, skipRouteRepositoryCheck]);
+  }, [
+    app,
+    flowEngine,
+    hasNestedRoutePath,
+    legacyPageBehavior,
+    navigate,
+    pageUid,
+    routeLayout,
+    routeRepository,
+    skipRouteRepositoryCheck,
+  ]);
 
   const content = useMemo(() => {
-    if (guardState.pending) {
+    if (guardState.pageUid !== pageUid || guardState.pending) {
       return null;
     }
 
@@ -311,7 +415,15 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
     }
 
     return <BridgeFlowRoute pageUid={pageUid} active={active} getLayoutModel={getLayoutModel} />;
-  }, [active, getLayoutModel, guardState.allowBridge, guardState.notFound, guardState.pending, pageUid]);
+  }, [
+    active,
+    getLayoutModel,
+    guardState.allowBridge,
+    guardState.notFound,
+    guardState.pageUid,
+    guardState.pending,
+    pageUid,
+  ]);
 
   return content;
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在 V2 管理端中新增 Group 类型菜单项后，点击该 Group 会直接进入 404 页面。实际这个 Group 已经存在，只是没有可打开的子页面，因此应该显示空白内容；同时真正不存在的页面仍然需要显示 404。

### Description
本次修复了 V2 管理端动态页面对 Group 菜单项的识别方式：

- Group 菜单项按菜单自身的路由 ID 打开，空 Group 会显示为空白页。
- 有可访问子页面的 Group 会继续跳转到第一个可打开的子页面。
- 不存在的页面、非 Group 的路由 ID、Group 的 schemaUid 直连，以及 Group 下不存在的深层链接仍显示 404。
- 补充了相关单元测试，覆盖空 Group、Group 子页面跳转、错误链接 404 和路由切换过程中的边界情况。

风险：变更集中在 V2 管理端动态路由守卫逻辑，已通过相关单元测试和浏览器回归验证。

### Showcase
不涉及界面样式变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where opening an empty V2 Group menu item shows 404 |
| 🇨🇳 Chinese | 修复打开 V2 空 Group 菜单项时显示 404 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
