### PR TITLE
refactor(plugin-workflow-json-query): migrate client to v2

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-json-query/client-v2.d.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/client-v2.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/client-v2';
+export { default } from './dist/client-v2';

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/client-v2.js
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/client-v2.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./dist/client-v2/index.js');

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/package.json
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/package.json
@@ -18,6 +18,7 @@
   },
   "peerDependencies": {
     "@nocobase/client": "2.x",
+    "@nocobase/client-v2": "2.x",
     "@nocobase/plugin-workflow": "2.x",
     "@nocobase/plugin-workflow-test": "2.x",
     "@nocobase/server": "2.x",

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/JSONQueryInstruction.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/JSONQueryInstruction.tsx
@@ -1,0 +1,73 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { NodeExpandOutlined } from '@ant-design/icons';
+import {
+  defaultFieldNames,
+  Instruction,
+  type UseVariableOptions,
+  type VariableOption,
+} from '@nocobase/plugin-workflow/client-v2';
+
+import { tExpr } from './locale';
+
+type JSONQueryModelItem = {
+  path: string;
+  alias?: string;
+  label: string;
+};
+
+type JSONQueryConfig = {
+  engine?: string;
+  source?: string;
+  expression?: string;
+  model?: JSONQueryModelItem[];
+};
+
+type JSONQueryNode = {
+  key: string;
+  title: string;
+  config?: JSONQueryConfig;
+};
+
+export default class JSONQueryInstruction extends Instruction {
+  title = tExpr('JSON calculation');
+  type = 'json-query';
+  group = 'calculation';
+  description = tExpr('Transforming or calculating values from complex JSON data.');
+  icon = (<NodeExpandOutlined />);
+  testable = true;
+  FieldsetLoader = () =>
+    import('./components/JSONQueryFieldset').then((module) => ({
+      default: module.JSONQueryFieldset,
+    }));
+
+  createDefaultConfig(): JSONQueryConfig {
+    return {
+      engine: 'jmespath',
+      model: [],
+    };
+  }
+
+  useVariables({ key, title, config }: JSONQueryNode, { fieldNames = defaultFieldNames }: UseVariableOptions = {}) {
+    return {
+      [fieldNames.value ?? defaultFieldNames.value]: key,
+      [fieldNames.label ?? defaultFieldNames.label]: title,
+      [fieldNames.children ?? defaultFieldNames.children]: config?.model?.length
+        ? config.model.map(
+            (item): VariableOption => ({
+              [fieldNames.value ?? defaultFieldNames.value]: item.alias || item.path,
+              [fieldNames.label ?? defaultFieldNames.label]: item.label,
+            }),
+          )
+        : null,
+    };
+  }
+}

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/__tests__/JSONQueryFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/__tests__/JSONQueryFieldset.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Form, Radio } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../locale', () => ({
+  NAMESPACE: 'workflow-json-query',
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
+  RadioWithTooltip: (props: {
+    options?: { value: string; label: string }[];
+    value?: string;
+    onChange?: (value: string) => void;
+  }) => (
+    <Radio.Group value={props.value} onChange={(event) => props.onChange?.(event.target.value)}>
+      {props.options?.map((option) => (
+        <Radio key={option.value} value={option.value}>
+          {option.label}
+        </Radio>
+      ))}
+    </Radio.Group>
+  ),
+  renderEngineReference: () => null,
+  WorkflowVariableInput: (props: { value?: string; onChange?: (value: string) => void }) => (
+    <input
+      aria-label="workflow-variable-input"
+      value={props.value ?? ''}
+      onChange={(event) => props.onChange?.(event.target.value)}
+    />
+  ),
+}));
+
+import { JSONQueryFieldset } from '../components/JSONQueryFieldset';
+
+function renderWithForm(initialValues: Record<string, unknown>) {
+  let formRef: ReturnType<typeof Form.useForm>[0] | undefined;
+
+  function Wrapper() {
+    const [form] = Form.useForm();
+    formRef = form;
+    return (
+      <Form form={form} initialValues={initialValues}>
+        <JSONQueryFieldset />
+      </Form>
+    );
+  }
+
+  render(<Wrapper />);
+
+  return () => formRef;
+}
+
+describe('JSONQueryFieldset', () => {
+  it('binds fields under config and edits property mappings', () => {
+    const getForm = renderWithForm({
+      config: {
+        engine: 'jmespath',
+        source: '{{$jobsMapByNodeKey.source}}',
+        expression: 'data.items',
+        model: [],
+      },
+    });
+
+    expect(screen.getByText('Query engine')).toBeInTheDocument();
+    expect(screen.getByText('Data source')).toBeInTheDocument();
+    expect(screen.getByText('Query expression')).toBeInTheDocument();
+    expect(screen.getByText('Properties mapping')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add property/ }));
+    fireEvent.change(screen.getByPlaceholderText('Property key'), { target: { value: 'user.name' } });
+    fireEvent.change(screen.getByPlaceholderText('Alias'), { target: { value: 'userName' } });
+    fireEvent.change(screen.getByPlaceholderText('Display label'), { target: { value: 'User name' } });
+
+    expect(getForm()?.getFieldValue(['config', 'model'])).toEqual([
+      {
+        path: 'user.name',
+        alias: 'userName',
+        label: 'User name',
+      },
+    ]);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/__tests__/JSONQueryInstruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/__tests__/JSONQueryInstruction.test.ts
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import JSONQueryInstruction from '../JSONQueryInstruction';
+
+describe('JSONQueryInstruction', () => {
+  it('registers the v2 fieldset through a lazy loader', async () => {
+    const instruction = new JSONQueryInstruction();
+
+    expect(instruction.type).toBe('json-query');
+    expect(instruction.group).toBe('calculation');
+    expect(instruction.testable).toBe(true);
+    expect(typeof instruction.FieldsetLoader).toBe('function');
+    expect(instruction.createDefaultConfig()).toEqual({
+      engine: 'jmespath',
+      model: [],
+    });
+
+    const loaded = await instruction.FieldsetLoader();
+    expect(loaded.default).toBeTypeOf('function');
+  });
+
+  it('preserves the v1 variable exposure contract', () => {
+    const instruction = new JSONQueryInstruction();
+
+    expect(
+      instruction.useVariables(
+        {
+          key: 'node-key',
+          title: 'JSON query',
+          config: {
+            model: [
+              {
+                path: 'user.name',
+                alias: 'userName',
+                label: 'User name',
+              },
+              {
+                path: 'user.age',
+                label: 'User age',
+              },
+            ],
+          },
+        },
+        {},
+      ),
+    ).toEqual({
+      value: 'node-key',
+      label: 'JSON query',
+      children: [
+        {
+          value: 'userName',
+          label: 'User name',
+        },
+        {
+          value: 'user.age',
+          label: 'User age',
+        },
+      ],
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/components/JSONQueryFieldset.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/components/JSONQueryFieldset.tsx
@@ -1,0 +1,141 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React, { useEffect } from 'react';
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button, Form, Input, Space } from 'antd';
+import {
+  RadioWithTooltip,
+  renderEngineReference,
+  WorkflowVariableInput,
+  type RadioWithTooltipOption,
+} from '@nocobase/plugin-workflow/client-v2';
+
+import { useT } from '../locale';
+
+type JSONQueryEngine = {
+  value: string;
+  label: string;
+  link: string;
+};
+
+const engines: JSONQueryEngine[] = [
+  {
+    value: 'jmespath',
+    label: 'JMESPath',
+    link: 'https://jmespath.org/',
+  },
+  {
+    value: 'jsonpathplus',
+    label: 'JSON Path Plus',
+    link: 'https://jsonpath-plus.github.io/JSONPath/docs/ts/',
+  },
+  {
+    value: 'jsonata',
+    label: 'JSONata',
+    link: 'https://jsonata.org/',
+  },
+];
+
+const engineOptions: RadioWithTooltipOption[] = engines.map(({ value, label }) => ({ value, label }));
+
+function renderJSONQueryEngineReference(engine: string | undefined, t: (text: string) => string) {
+  const item = engines.find((option) => option.value === engine);
+
+  if (!item) {
+    return null;
+  }
+
+  return (
+    renderEngineReference(item.value, t) ?? (
+      <>
+        {t('Syntax references')}:&nbsp;
+        <a href={item.link} target="_blank" rel="noreferrer">
+          {item.label}
+        </a>
+      </>
+    )
+  );
+}
+
+export function JSONQueryFieldset() {
+  const t = useT();
+  const form = Form.useFormInstance();
+  const engine = Form.useWatch(['config', 'engine']) ?? 'jmespath';
+
+  useEffect(() => {
+    if (typeof form.getFieldValue(['config', 'engine']) === 'undefined') {
+      form.setFieldValue(['config', 'engine'], 'jmespath');
+    }
+  }, [form]);
+
+  return (
+    <>
+      <Form.Item name={['config', 'engine']} label={t('Query engine')} rules={[{ required: true }]}>
+        <RadioWithTooltip options={engineOptions} />
+      </Form.Item>
+
+      <Form.Item name={['config', 'source']} label={t('Data source')} rules={[{ required: true }]}>
+        <WorkflowVariableInput />
+      </Form.Item>
+
+      <Form.Item
+        name={['config', 'expression']}
+        label={t('Query expression')}
+        rules={[{ required: true }]}
+        extra={renderJSONQueryEngineReference(engine, t)}
+      >
+        <WorkflowVariableInput />
+      </Form.Item>
+
+      <Form.Item
+        label={t('Properties mapping')}
+        extra={t(
+          'If the type of query result is object or array of object, could map the properties which to be accessed in subsequent nodes.',
+        )}
+      >
+        <Form.List name={['config', 'model']}>
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map((field) => (
+                <Space key={field.key} align="baseline">
+                  <Form.Item name={[field.name, 'path']} rules={[{ required: true }]}>
+                    <Input placeholder={t('Property key')} />
+                  </Form.Item>
+                  <Form.Item name={[field.name, 'alias']}>
+                    <Input placeholder={t('Alias')} />
+                  </Form.Item>
+                  <Form.Item name={[field.name, 'label']} rules={[{ required: true }]}>
+                    <Input placeholder={t('Display label')} />
+                  </Form.Item>
+                  <Form.Item>
+                    <Button
+                      aria-label={t('Delete')}
+                      icon={<DeleteOutlined />}
+                      size="small"
+                      type="text"
+                      onClick={() => remove(field.name)}
+                    />
+                  </Form.Item>
+                </Space>
+              ))}
+              <Form.Item>
+                <Button icon={<PlusOutlined />} size="small" type="dashed" onClick={() => add({})}>
+                  {t('Add property')}
+                </Button>
+              </Form.Item>
+            </>
+          )}
+        </Form.List>
+      </Form.Item>
+    </>
+  );
+}
+
+export default JSONQueryFieldset;

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/index.tsx
@@ -7,6 +7,4 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import V2JSONQueryInstruction from '../client-v2/JSONQueryInstruction';
-
-export default class JSONQueryInstruction extends V2JSONQueryInstruction {}
+export { default } from './plugin';

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/locale.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/locale.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { tExpr as flowTExpr, useFlowEngine } from '@nocobase/flow-engine';
+
+export const NAMESPACE = 'workflow-json-query';
+
+export function tExpr(key: string, options?: Record<string, unknown>) {
+  return flowTExpr(key, { ns: [NAMESPACE, 'client'], nsMode: 'fallback', ...options });
+}
+
+export function useT() {
+  const flowEngine = useFlowEngine();
+  return (key: string, options?: Record<string, unknown>) =>
+    flowEngine.context.t(key, { ns: [NAMESPACE, 'client'], nsMode: 'fallback', ...options });
+}

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client-v2/plugin.tsx
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Application, Plugin } from '@nocobase/client-v2';
+import type { PluginWorkflowClientV2 } from '@nocobase/plugin-workflow/client-v2';
+
+import JSONQueryInstruction from './JSONQueryInstruction';
+
+export class PluginWorkflowJSONQueryClientV2 extends Plugin<Record<string, never>, Application> {
+  async load() {
+    const workflow = this.app.pm.get('workflow') as PluginWorkflowClientV2;
+    workflow.registerInstruction('json-query', JSONQueryInstruction);
+  }
+}
+
+export default PluginWorkflowJSONQueryClientV2;

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/client/__tests__/JSONQueryInstruction.v1.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/client/__tests__/JSONQueryInstruction.v1.test.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import JSONQueryInstruction from '../instruction';
+import V2JSONQueryInstruction from '../../client-v2/JSONQueryInstruction';
+
+describe('JSONQueryInstruction v1 compatibility', () => {
+  it('keeps the v1 instruction as a compatibility entry over the v2 implementation', () => {
+    const instruction = new JSONQueryInstruction();
+
+    expect(instruction).toBeInstanceOf(V2JSONQueryInstruction);
+    expect(typeof instruction.FieldsetLoader).toBe('function');
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Migrate the workflow JSON calculation plugin client extension to the v2 workflow canvas/runtime while keeping the legacy v1 canvas compatible during the transition.

### Description
This PR adds a `client-v2` entry for `@nocobase/plugin-workflow-json-query`, registers the JSON calculation workflow instruction through the v2 workflow plugin API, and replaces the legacy Formily schema fieldset with an antd-based v2 fieldset loader.

The legacy `src/client/instruction.tsx` now reuses the v2 instruction implementation so v1 and v2 canvases share the same instruction metadata and variable exposure logic. Tests cover the v2 instruction loader, the fieldset value binding, and the v1 compatibility wrapper.

Potential risk: the node configuration UI has been rebuilt from Formily `ArrayTable` to antd `Form.List`, so manual verification should focus on editing existing JSON calculation nodes and saving property mappings.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Migrated the workflow JSON calculation node configuration UI to the v2 workflow canvas while preserving v1 canvas compatibility. |
| 🇨🇳 Chinese | 将工作流 JSON 计算节点配置界面迁移到 v2 工作流画布，并保留 v1 画布兼容性。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
