### PR TITLE
fix(plugin-action-custom-request): block runtime request target overrides

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/locale/en-US.json
@@ -24,6 +24,7 @@
   "Request settings": "Request settings",
   "Response type": "Response type",
   "Roles": "Roles",
+  "Runtime request options cannot override the request target": "Runtime request options cannot override the request target",
   "Stream": "Stream",
   "Timeout config": "Timeout config",
   "Title": "Title",

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/locale/zh-CN.json
@@ -24,6 +24,7 @@
   "Request settings": "请求设置",
   "Response type": "响应类型",
   "Roles": "角色",
+  "Runtime request options cannot override the request target": "运行时请求选项不能覆盖请求目标",
   "Stream": "流",
   "Timeout config": "超时设置",
   "Title": "标题",

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/server/__tests__/actions.test.ts
@@ -210,6 +210,28 @@ describe('actions', () => {
         b: '100 + order-100',
       });
     });
+
+    test('runtime options cannot override request target', async () => {
+      params = undefined;
+
+      const res = await resource.send({
+        filterByTk: 'test',
+        values: {
+          options: {
+            url: 'http://169.254.169.254/latest/meta-data/',
+            baseURL: 'http://169.254.169.254',
+            proxy: {
+              host: '169.254.169.254',
+              port: 80,
+            },
+            socketPath: '/var/run/docker.sock',
+          },
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(params).toBeUndefined();
+    });
   });
 
   describe('SSRF protection via SERVER_REQUEST_WHITELIST', () => {

--- a/packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts
+++ b/packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts
@@ -73,6 +73,24 @@ const omitNullAndUndefined = (obj: any) => {
   }, {});
 };
 
+const RuntimeTargetOptionKeys = new Set([
+  'url',
+  'baseURL',
+  'proxy',
+  'socketPath',
+  'transport',
+  'httpAgent',
+  'httpsAgent',
+]);
+
+const getForbiddenRuntimeTargetOptionKeys = (runtimeOptions: unknown) => {
+  if (!runtimeOptions || typeof runtimeOptions !== 'object' || Array.isArray(runtimeOptions)) {
+    return [];
+  }
+
+  return Object.keys(runtimeOptions).filter((key) => RuntimeTargetOptionKeys.has(key));
+};
+
 const CurrentUserVariableRegExp = /{{\s*(?:ctx\.)?(currentUser[^}]+)\s*}}/g;
 
 const getCurrentUserAppends = (str: string, user) => {
@@ -159,6 +177,14 @@ export async function send(this: CustomRequestPlugin, ctx: Context, next: Next) 
 
   if (!requestConfig) {
     ctx.throw(404, 'request config not found');
+  }
+
+  const forbiddenRuntimeOptionKeys = getForbiddenRuntimeTargetOptionKeys(runtimeOptions);
+  if (forbiddenRuntimeOptionKeys.length) {
+    return ctx.throw(
+      400,
+      ctx.t('Runtime request options cannot override the request target', { ns: 'action-custom-request' }),
+    );
   }
 
   ctx.withoutDataWrapping = true;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Prevent low-privileged users from changing the outbound target of a saved custom request at runtime through `customRequests:send`.

### Description 
This PR blocks runtime request options that can alter the actual server-side request target, including `url`, `baseURL`, `proxy`, `socketPath`, `transport`, `httpAgent`, and `httpsAgent`.

The saved custom request configuration remains the source of truth for the request target, while existing runtime values such as variables and request data continue to work.

Added a regression test to ensure runtime target overrides are rejected before the saved custom request is executed.

Tested with:

```bash
yarn eslint --fix packages/plugins/@nocobase/plugin-action-custom-request/src/server/actions/send.ts packages/plugins/@nocobase/plugin-action-custom-request/src/server/__tests__/actions.test.ts packages/plugins/@nocobase/plugin-action-custom-request/src/locale/en-US.json packages/plugins/@nocobase/plugin-action-custom-request/src/locale/zh-CN.json
yarn test packages/plugins/@nocobase/plugin-action-custom-request/src/server/__tests__/actions.test.ts
```

Note: the test run reports 3 obsolete snapshots that already existed in this test file; they are unrelated to this change.

### Related issues

Security advisory: GHSA-wrr5-j383-f7h2

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed custom requests allowing runtime options to override the saved request target. |
| 🇨🇳 Chinese | 修复自定义请求允许运行时选项覆盖已保存请求目标的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
