### PR TITLE
fix(client-v2): expose response record after form submit

### DIFF
--- a/packages/core/client-v2/src/flow/actions/__tests__/afterSuccess.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/afterSuccess.test.ts
@@ -7,9 +7,15 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import type { FlowRuntimeContext } from '@nocobase/flow-engine';
+import {
+  FlowEngine,
+  FlowModel,
+  FlowRuntimeContext,
+  setupRuntimeContextSteps,
+  type Collection,
+} from '@nocobase/flow-engine';
 import { describe, expect, it } from 'vitest';
-import { afterSuccess, getAfterSuccessResponseRecord } from '../afterSuccess';
+import { afterSuccess, getAfterSuccessResponseRecord, getMetaTreeWithResponseRecord } from '../afterSuccess';
 
 describe('afterSuccess response record variable', () => {
   it('reads the submit response record from the saveResource step', () => {
@@ -37,5 +43,31 @@ describe('afterSuccess response record variable', () => {
     const properties = await afterSuccess.defineProperties(sourceCtx as FlowRuntimeContext);
 
     expect(properties.responseRecord.get()).toBe(record);
+  });
+
+  it('shows responseRecord in the variable picker for settings context', () => {
+    const engine = new FlowEngine();
+    class SubmitActionModel extends FlowModel {}
+    engine.registerModels({ SubmitActionModel });
+    const model = engine.createModel<SubmitActionModel>({ use: 'SubmitActionModel' });
+    const collection = {
+      name: 'users',
+      dataSourceKey: 'main',
+      getFilterByTK: (record: { id?: number }) => record.id,
+    } as unknown as Collection;
+    model.context.defineProperty('collection', { value: collection });
+    const flow = model.registerFlow({
+      key: 'submitSettings',
+      steps: {
+        saveResource: { title: 'Save record', handler: () => undefined },
+        afterSuccess: { use: 'afterSuccess' },
+      },
+    });
+    const ctx = new FlowRuntimeContext(model, 'submitSettings', 'settings');
+    setupRuntimeContextSteps(ctx, flow.steps, model, 'submitSettings');
+
+    const metaTree = getMetaTreeWithResponseRecord(ctx);
+
+    expect(metaTree.find((node) => node.name === 'responseRecord')?.title).toBe('Response record');
   });
 });

--- a/packages/core/client-v2/src/flow/actions/__tests__/afterSuccess.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/afterSuccess.test.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { FlowRuntimeContext } from '@nocobase/flow-engine';
+import { describe, expect, it } from 'vitest';
+import { afterSuccess, getAfterSuccessResponseRecord } from '../afterSuccess';
+
+describe('afterSuccess response record variable', () => {
+  it('reads the submit response record from the saveResource step', () => {
+    const record = { id: 1, title: 'Saved' };
+
+    expect(
+      getAfterSuccessResponseRecord({
+        steps: {
+          confirm: { params: {}, result: undefined },
+          saveResource: { params: {}, result: record },
+          afterSuccess: { params: {} },
+        },
+      }),
+    ).toBe(record);
+  });
+
+  it('injects responseRecord into the afterSuccess runtime context', async () => {
+    const record = { id: 1, title: 'Saved' };
+    const sourceCtx = {
+      steps: {
+        saveResource: { params: {}, result: record },
+      },
+      t: (value: string) => value,
+    };
+    const properties = await afterSuccess.defineProperties(sourceCtx as FlowRuntimeContext);
+
+    expect(properties.responseRecord.get()).toBe(record);
+  });
+});

--- a/packages/core/client-v2/src/flow/actions/afterSuccess.tsx
+++ b/packages/core/client-v2/src/flow/actions/afterSuccess.tsx
@@ -7,13 +7,132 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { defineAction, tExpr } from '@nocobase/flow-engine';
+import {
+  FlowContext,
+  createRecordMetaFactory,
+  createRecordResolveOnServerWithLocal,
+  defineAction,
+  tExpr,
+  useFlowContext,
+  type Collection,
+  type FlowRuntimeContext,
+  type MetaTreeNode,
+  type PropertyMetaFactory,
+} from '@nocobase/flow-engine';
 import { isURL } from '@nocobase/utils/client';
-import { TextAreaWithContextSelector } from '../components/TextAreaWithContextSelector';
+import React, { useMemo } from 'react';
+import {
+  TextAreaWithContextSelector,
+  type TextAreaWithContextSelectorProps,
+} from '../components/TextAreaWithContextSelector';
+
+type ContextWithCollection = FlowRuntimeContext & {
+  blockModel?: { collection?: Collection };
+  collection?: Collection;
+  model?: FlowRuntimeContext['model'] & { collection?: Collection };
+};
+
+export function getAfterSuccessResponseRecord(ctx: Pick<FlowRuntimeContext, 'steps'>) {
+  const steps = ctx.steps || {};
+  const preferredStepKeys = ['saveResource', 'submit', 'request', 'apply', 'save'];
+
+  for (const stepKey of preferredStepKeys) {
+    if (Object.prototype.hasOwnProperty.call(steps, stepKey) && steps[stepKey]?.result != null) {
+      return steps[stepKey].result;
+    }
+  }
+
+  const results = Object.entries(steps)
+    .filter(([stepKey, step]) => stepKey !== 'afterSuccess' && step?.result != null)
+    .map(([, step]) => step.result);
+  return results[results.length - 1];
+}
+
+function getResponseRecordMeta(ctx: FlowRuntimeContext): PropertyMetaFactory | undefined {
+  if (!hasResponseRecordSource(ctx)) {
+    return;
+  }
+  const collectionAccessor = getResponseRecordCollectionAccessor(ctx);
+  if (!collectionAccessor()) {
+    return;
+  }
+  return createRecordMetaFactory(collectionAccessor, ctx.t('Response record'), () => {
+    const collection = collectionAccessor();
+    const record = getAfterSuccessResponseRecord(ctx);
+    if (!collection || !record) {
+      return;
+    }
+    try {
+      const filterByTk = collection.getFilterByTK(record);
+      if (filterByTk == null) {
+        return;
+      }
+      return {
+        collection: collection.name,
+        dataSourceKey: collection.dataSourceKey || 'main',
+        filterByTk,
+      };
+    } catch (error) {
+      return;
+    }
+  });
+}
+
+function hasResponseRecordSource(ctx: Pick<FlowRuntimeContext, 'steps'>) {
+  return Object.prototype.hasOwnProperty.call(ctx.steps || {}, 'saveResource');
+}
+
+function getResponseRecordCollectionAccessor(ctx: FlowRuntimeContext) {
+  const contextWithCollection = ctx as ContextWithCollection;
+  return () =>
+    contextWithCollection.blockModel?.collection ||
+    contextWithCollection.collection ||
+    contextWithCollection.model?.collection ||
+    null;
+}
+
+function getMetaTreeWithResponseRecord(ctx: FlowRuntimeContext): MetaTreeNode[] {
+  const responseRecordMeta = getResponseRecordMeta(ctx);
+  if (!responseRecordMeta) {
+    return ctx.getPropertyMetaTree?.() || [];
+  }
+
+  const scoped = new FlowContext();
+  scoped.addDelegate(ctx);
+  scoped.defineProperty('responseRecord', {
+    get: () => getAfterSuccessResponseRecord(ctx),
+    cache: false,
+    resolveOnServer: createRecordResolveOnServerWithLocal(getResponseRecordCollectionAccessor(ctx), () =>
+      getAfterSuccessResponseRecord(ctx),
+    ),
+    meta: responseRecordMeta,
+  });
+  return scoped.getPropertyMetaTree();
+}
+
+function AfterSuccessRedirectTextArea(props: TextAreaWithContextSelectorProps) {
+  const flowCtx = useFlowContext<FlowRuntimeContext>();
+  const metaTree = useMemo(() => () => getMetaTreeWithResponseRecord(flowCtx), [flowCtx]);
+
+  return <TextAreaWithContextSelector {...props} metaTree={metaTree} />;
+}
 
 export const afterSuccess = defineAction({
   name: 'afterSuccess',
   title: tExpr('After successful submission'),
+  defineProperties(ctx) {
+    const responseRecordMeta = getResponseRecordMeta(ctx);
+    return {
+      responseRecord: {
+        get: () => getAfterSuccessResponseRecord(ctx),
+        cache: false,
+        resolveOnServer: createRecordResolveOnServerWithLocal(getResponseRecordCollectionAccessor(ctx), () =>
+          getAfterSuccessResponseRecord(ctx),
+        ),
+        ...(responseRecordMeta ? { meta: responseRecordMeta } : {}),
+      },
+    };
+  },
   uiSchema: {
     successMessage: {
       type: 'string',
@@ -46,7 +165,7 @@ export const afterSuccess = defineAction({
       type: 'string',
       title: tExpr('Link'),
       'x-decorator': 'FormItem',
-      'x-component': TextAreaWithContextSelector,
+      'x-component': AfterSuccessRedirectTextArea,
       'x-reactions': {
         dependencies: ['actionAfterSuccess'],
         fulfill: {

--- a/packages/core/client-v2/src/flow/actions/afterSuccess.tsx
+++ b/packages/core/client-v2/src/flow/actions/afterSuccess.tsx
@@ -13,7 +13,7 @@ import {
   createRecordResolveOnServerWithLocal,
   defineAction,
   tExpr,
-  useFlowContext,
+  useFlowSettingsContext,
   type Collection,
   type FlowRuntimeContext,
   type MetaTreeNode,
@@ -28,6 +28,13 @@ import {
 
 type ResponseRecordPlainStepContext = {
   steps?: FlowRuntimeContext['steps'];
+};
+
+type ResponseRecordFlowDefinitionContext = {
+  flowKey?: string;
+  model?: {
+    getFlow?: (flowKey: string) => { steps?: Record<string, unknown> } | undefined;
+  };
 };
 
 type ResponseRecordContext = FlowContext &
@@ -88,14 +95,23 @@ function getResponseRecordMeta(ctx: ResponseRecordContext): PropertyMetaFactory 
 }
 
 function hasResponseRecordSource(ctx: FlowContext | ResponseRecordPlainStepContext) {
-  return Object.prototype.hasOwnProperty.call(getResponseRecordSteps(ctx), 'saveResource');
+  if (Object.prototype.hasOwnProperty.call(getResponseRecordSteps(ctx), 'saveResource')) {
+    return true;
+  }
+
+  const { model, flowKey } = ctx as ResponseRecordFlowDefinitionContext;
+  if (!model || typeof model.getFlow !== 'function' || !flowKey) {
+    return false;
+  }
+
+  return Object.prototype.hasOwnProperty.call(model.getFlow(flowKey)?.steps || {}, 'saveResource');
 }
 
 function getResponseRecordCollectionAccessor(ctx: ResponseRecordContext) {
   return () => ctx.blockModel?.collection || ctx.collection || ctx.model?.collection || null;
 }
 
-function getMetaTreeWithResponseRecord(ctx: FlowRuntimeContext): MetaTreeNode[] {
+export function getMetaTreeWithResponseRecord(ctx: FlowRuntimeContext): MetaTreeNode[] {
   const responseRecordMeta = getResponseRecordMeta(ctx);
   if (!responseRecordMeta) {
     return ctx.getPropertyMetaTree?.() || [];
@@ -115,7 +131,7 @@ function getMetaTreeWithResponseRecord(ctx: FlowRuntimeContext): MetaTreeNode[] 
 }
 
 function AfterSuccessRedirectTextArea(props: TextAreaWithContextSelectorProps) {
-  const flowCtx = useFlowContext<FlowRuntimeContext>();
+  const flowCtx = useFlowSettingsContext();
   const metaTree = useMemo(() => () => getMetaTreeWithResponseRecord(flowCtx), [flowCtx]);
 
   return <TextAreaWithContextSelector {...props} metaTree={metaTree} />;

--- a/packages/core/client-v2/src/flow/actions/afterSuccess.tsx
+++ b/packages/core/client-v2/src/flow/actions/afterSuccess.tsx
@@ -26,14 +26,23 @@ import {
   type TextAreaWithContextSelectorProps,
 } from '../components/TextAreaWithContextSelector';
 
-type ContextWithCollection = FlowRuntimeContext & {
-  blockModel?: { collection?: Collection };
-  collection?: Collection;
-  model?: FlowRuntimeContext['model'] & { collection?: Collection };
+type ResponseRecordPlainStepContext = {
+  steps?: FlowRuntimeContext['steps'];
 };
 
-export function getAfterSuccessResponseRecord(ctx: Pick<FlowRuntimeContext, 'steps'>) {
-  const steps = ctx.steps || {};
+type ResponseRecordContext = FlowContext &
+  ResponseRecordPlainStepContext & {
+    blockModel?: { collection?: Collection };
+    collection?: Collection;
+    model?: FlowRuntimeContext['model'] & { collection?: Collection };
+  };
+
+function getResponseRecordSteps(ctx: FlowContext | ResponseRecordPlainStepContext): FlowRuntimeContext['steps'] {
+  return 'steps' in ctx ? ctx.steps || {} : {};
+}
+
+export function getAfterSuccessResponseRecord(ctx: FlowContext | ResponseRecordPlainStepContext) {
+  const steps = getResponseRecordSteps(ctx);
   const preferredStepKeys = ['saveResource', 'submit', 'request', 'apply', 'save'];
 
   for (const stepKey of preferredStepKeys) {
@@ -48,7 +57,7 @@ export function getAfterSuccessResponseRecord(ctx: Pick<FlowRuntimeContext, 'ste
   return results[results.length - 1];
 }
 
-function getResponseRecordMeta(ctx: FlowRuntimeContext): PropertyMetaFactory | undefined {
+function getResponseRecordMeta(ctx: ResponseRecordContext): PropertyMetaFactory | undefined {
   if (!hasResponseRecordSource(ctx)) {
     return;
   }
@@ -78,17 +87,12 @@ function getResponseRecordMeta(ctx: FlowRuntimeContext): PropertyMetaFactory | u
   });
 }
 
-function hasResponseRecordSource(ctx: Pick<FlowRuntimeContext, 'steps'>) {
-  return Object.prototype.hasOwnProperty.call(ctx.steps || {}, 'saveResource');
+function hasResponseRecordSource(ctx: FlowContext | ResponseRecordPlainStepContext) {
+  return Object.prototype.hasOwnProperty.call(getResponseRecordSteps(ctx), 'saveResource');
 }
 
-function getResponseRecordCollectionAccessor(ctx: FlowRuntimeContext) {
-  const contextWithCollection = ctx as ContextWithCollection;
-  return () =>
-    contextWithCollection.blockModel?.collection ||
-    contextWithCollection.collection ||
-    contextWithCollection.model?.collection ||
-    null;
+function getResponseRecordCollectionAccessor(ctx: ResponseRecordContext) {
+  return () => ctx.blockModel?.collection || ctx.collection || ctx.model?.collection || null;
 }
 
 function getMetaTreeWithResponseRecord(ctx: FlowRuntimeContext): MetaTreeNode[] {

--- a/packages/core/client-v2/src/flow/actions/index.ts
+++ b/packages/core/client-v2/src/flow/actions/index.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-export * from './afterSuccess';
+export { afterSuccess } from './afterSuccess';
 export * from './confirm';
 export * from './dataScope';
 export * from './openView';

--- a/packages/core/client-v2/src/flow/models/blocks/form/FormActionModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/FormActionModel.tsx
@@ -117,7 +117,7 @@ FormSubmitActionModel.registerFlow({
         try {
           ctx.model.setProps('loading', true);
           const { submitHandler } = await import('./submitHandler');
-          await submitHandler(ctx, params);
+          return await submitHandler(ctx, params);
         } catch (error) {
           ctx.model.setProps('loading', false);
           if (error instanceof FlowExitAllException) {

--- a/packages/core/client-v2/src/flow/models/blocks/form/__tests__/submitHandler.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/__tests__/submitHandler.test.ts
@@ -52,13 +52,14 @@ describe('submitHandler', () => {
       t: (value: string) => value,
     };
 
-    await submitHandler(ctx, {
+    const responseRecord = await submitHandler(ctx, {
       assignedValues: {
         status: 'published',
         reviewer: 'Alice',
       },
     });
 
+    expect(responseRecord).toEqual({ id: 1 });
     expect(resource.save).toHaveBeenCalledWith(
       {
         title: 'Draft title',

--- a/packages/core/client-v2/src/flow/models/blocks/form/__tests__/submitHandler.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/__tests__/submitHandler.test.ts
@@ -9,6 +9,7 @@
 
 import { SingleRecordResource } from '@nocobase/flow-engine';
 import { describe, expect, it, vi } from 'vitest';
+import { EditFormModel } from '../EditFormModel';
 import { submitHandler } from '../submitHandler';
 
 describe('submitHandler', () => {
@@ -68,5 +69,56 @@ describe('submitHandler', () => {
       },
       undefined,
     );
+  });
+
+  it('returns the refreshed record for edit forms when the save response is empty', async () => {
+    const refreshedRecord = { id: 2, title: 'Updated title' };
+    const resource = Object.create(SingleRecordResource.prototype);
+    resource.getMeta = vi.fn((key: string) => (key === 'currentFilterByTk' ? 2 : undefined));
+    resource.setFilterByTk = vi.fn(() => resource);
+    resource.save = vi.fn(async () => undefined);
+    resource.refresh = vi.fn(async () => undefined);
+    resource.getData = vi.fn(() => refreshedRecord);
+
+    const blockModel = Object.create(EditFormModel.prototype);
+    const form = {
+      validateFields: vi.fn(async () => undefined),
+      getFieldsValue: vi.fn(() => ({
+        title: 'Updated title',
+      })),
+    };
+    Object.defineProperty(blockModel, 'context', { value: { form } });
+    Object.defineProperty(blockModel, 'collection', {
+      value: {
+        name: 'posts',
+        getFilterByTK: (record: { id?: number }) => record.id,
+      },
+    });
+    blockModel.resetUserModifiedFields = vi.fn();
+
+    const responseRecord = await submitHandler(
+      {
+        resource,
+        blockModel,
+        model: {
+          getStepParams: vi.fn(),
+        },
+        message: {
+          error: vi.fn(),
+        },
+        t: (value: string) => value,
+      },
+      {},
+    );
+
+    expect(responseRecord).toBe(refreshedRecord);
+    expect(resource.setFilterByTk).toHaveBeenCalledWith(2);
+    expect(resource.save).toHaveBeenCalledWith(
+      {
+        title: 'Updated title',
+      },
+      undefined,
+    );
+    expect(resource.refresh).toHaveBeenCalled();
   });
 });

--- a/packages/core/client-v2/src/flow/models/blocks/form/submitHandler.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/submitHandler.ts
@@ -12,6 +12,16 @@ import { mergeAssignFieldValues, resolveAssignFieldValues } from '../assign-form
 import type { FormBlockModel } from './FormBlockModel';
 import { omitHiddenModelValuesFromSubmit, shouldSkipSubmitValidation, validateSubmitForm } from './submitValues';
 
+function getResponseRecord(response: unknown) {
+  if (!response || typeof response !== 'object') {
+    return response;
+  }
+  if ('data' in response) {
+    return (response as { data?: unknown }).data;
+  }
+  return response;
+}
+
 export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?: any) => void) {
   const resource = ctx.resource;
   const blockModel = ctx.blockModel as FormBlockModel;
@@ -41,7 +51,8 @@ export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?
         resource.setFilterByTk(currentFilterByTk);
       }
     }
-    const data: any = cb ? await cb(values) : await resource.save(values, params.requestConfig);
+    const data: unknown = cb ? await cb(values) : await resource.save(values, params.requestConfig);
+    const responseRecord = getResponseRecord(data);
     if (isEditFormModel) {
       resource.isNewRecord = false;
       // 编辑表单保存成功后，表单应回到“已同步”状态：下一次刷新应允许覆盖为服务端值
@@ -53,18 +64,20 @@ export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?
       blockModel.resetUserModifiedFields?.();
       blockModel.formValueRuntime?.resetAfterFormReset?.();
       if (ctx.view.inputArgs.collectionName === blockModel.collection.name && ctx.view.inputArgs.onChange) {
-        ctx.view.inputArgs.onChange(data?.data);
+        ctx.view.inputArgs.onChange(responseRecord);
       }
     }
+    return responseRecord;
   } else if (resource instanceof MultiRecordResource) {
     const currentFilterByTk = resource.getMeta('currentFilterByTk');
     if (!currentFilterByTk) {
       ctx.message.error(ctx.t('No filterByTk found for multi-record resource.'));
       return;
     }
-    (await cb)
+    const data = cb
       ? await cb(values, currentFilterByTk)
       : await resource.update(currentFilterByTk, values, params.requestConfig);
     blockModel.resetUserModifiedFields?.();
+    return getResponseRecord(data);
   }
 }

--- a/packages/core/client-v2/src/flow/models/blocks/form/submitHandler.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/submitHandler.ts
@@ -52,12 +52,13 @@ export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?
       }
     }
     const data: unknown = cb ? await cb(values) : await resource.save(values, params.requestConfig);
-    const responseRecord = getResponseRecord(data);
+    let responseRecord = getResponseRecord(data);
     if (isEditFormModel) {
       resource.isNewRecord = false;
       // 编辑表单保存成功后，表单应回到“已同步”状态：下一次刷新应允许覆盖为服务端值
       blockModel.resetUserModifiedFields?.();
       await resource.refresh();
+      responseRecord = responseRecord ?? resource.getData?.();
     } else {
       blockModel.form.resetFields();
       blockModel.emitter.emit('onFieldReset');
@@ -78,6 +79,6 @@ export async function submitHandler(ctx, params, cb?: (values?: any, filterByTk?
       ? await cb(values, currentFilterByTk)
       : await resource.update(currentFilterByTk, values, params.requestConfig);
     blockModel.resetUserModifiedFields?.();
-    return getResponseRecord(data);
+    return getResponseRecord(data) ?? blockModel.getCurrentRecord?.();
   }
 }

--- a/packages/core/flow-engine/src/locale/en-US.json
+++ b/packages/core/flow-engine/src/locale/en-US.json
@@ -56,6 +56,7 @@
   "Replace current block with template?": "Replace current block with template?",
   "Replaced with template block": "Replaced with template block",
   "Render failed": "Render failed",
+  "Response record": "Response record",
   "Step configuration": "Step configuration",
   "Step parameter configuration": "Step parameter configuration",
   "Step with key {{stepKey}} not found": "Step with key {{stepKey}} not found",

--- a/packages/core/flow-engine/src/locale/zh-CN.json
+++ b/packages/core/flow-engine/src/locale/zh-CN.json
@@ -60,6 +60,7 @@
   "Other blocks": "其他区块",
   "Previous step": "上一步",
   "Render failed": "渲染失败",
+  "Response record": "响应结果记录",
   "Step configuration": "步骤配置",
   "Step parameter configuration": "步骤参数配置",
   "Step with key {{stepKey}} not found": "未找到key为 {{stepKey}} 的步骤",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

V2 form submit actions expose the submitted response record differently from v1, so redirect links configured after successful submission cannot reliably reference the saved response record.

### Description 

- Return the saved response record from the v2 form submit handler and propagate it through the `saveResource` flow step.
- Expose `responseRecord` in the `afterSuccess` action context so redirect links can use the submitted record, aligned with v1 behavior.
- Show the response record variable only for flows that include a `saveResource` step to avoid misleading variable options in other `afterSuccess` usage scenarios.
- Add coverage for response record lookup and submit handler return values.

Risk: Low. The change is scoped to v2 form submit success flows and keeps existing fallback behavior for other step results. The variable tree entry is gated by `saveResource`, while the runtime property remains non-cached and resolves from the current flow context.

Testing suggestions: Verify creating and editing records with a v2 form submit action, especially redirect URLs that reference response record fields.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed v2 form submit success redirects so they can reference the saved response record. |
| 🇨🇳 Chinese | 修复 v2 表单提交成功后跳转链接无法引用已保存响应结果记录的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
