### PR TITLE
fix(plugin-backups): align v2 settings label styles

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -112,8 +112,6 @@ const BackupCron = ({ onChange, value, ...props }: BackupCronProps) => {
   );
 };
 
-const label = (text: string) => <strong>{text}:</strong>;
-
 const BackupSettings = () => {
   const ctx = useFlowContext();
   const t = useT();
@@ -188,7 +186,7 @@ const BackupSettings = () => {
         initialValues={DEFAULT_FORM_VALUES}
         disabled={settingsRequest.loading}
       >
-        <Form.Item label={label(t('Automatic backup'))}>
+        <Form.Item label={t('Automatic backup')}>
           <Space direction="vertical" style={{ width: '100%' }}>
             <Form.Item name="scheduled" valuePropName="checked" noStyle>
               <Checkbox>{t('Run automatic backup on the cron schedule')}</Checkbox>
@@ -205,7 +203,7 @@ const BackupSettings = () => {
 
         <Form.Item
           name="keep"
-          label={label(t('Maximum number of backups'))}
+          label={t('Maximum number of backups')}
           extra={t('The maximum number of backups to keep, older backups are automatically deleted.')}
           required
           rules={[{ required: true, message: t('The field value is required') }]}
@@ -213,17 +211,17 @@ const BackupSettings = () => {
           <InputNumber min={1} style={{ width: '100%' }} />
         </Form.Item>
 
-        <Form.Item name="storageId" label={label(t('Sync backups to cloud storage'))}>
+        <Form.Item name="storageId" label={t('Sync backups to cloud storage')}>
           <Select loading={storagesRequest.loading} options={storageOptions} style={{ width: '100%' }} />
         </Form.Item>
 
-        <Form.Item name="enableFilesBackup" label={label(t('Backup local storage files'))} valuePropName="checked">
+        <Form.Item name="enableFilesBackup" label={t('Backup local storage files')} valuePropName="checked">
           <Switch />
         </Form.Item>
 
         <Form.Item
           name="encryptionPassword"
-          label={label(t('Restore password'))}
+          label={t('Restore password')}
           extra={t('If a restore password is set, it must be entered when restoring the backup.')}
         >
           <Input.Password autoComplete="new-password" style={{ width: '100%' }} />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 Backup manager settings page rendered form labels with a custom `<strong>` wrapper, making the label font weight inconsistent with other v2 settings pages.

### Description 
Removed the custom strong label wrapper from the v2 Backup manager settings form and let Ant Design `Form.Item` render labels with the default settings-page style.

Potential risk is low because this only changes label rendering on the v2 Backup manager settings page.

Testing suggestions:
- Open the v2 Backup manager settings page and verify form labels match other settings pages.
- Confirm automatic backup settings can still be edited and submitted.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed inconsistent bold labels on the v2 Backup manager settings page. |
| 🇨🇳 Chinese | 修复 v2 备份管理器设置页标签异常加粗、与其他设置页样式不一致的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
