### PR TITLE
Fix Swagger schema example typo

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-schema-storage/src/swagger/index.ts
+++ b/packages/plugins/@nocobase/plugin-ui-schema-storage/src/swagger/index.ts
@@ -316,7 +316,7 @@ export default {
           },
           'x-index': {
             type: 'integer',
-            exmaple: 1,
+            example: 1,
             description: "ui schema's order index",
           },
           'x-async': {


### PR DESCRIPTION
Summary:
- Fixes `exmaple` to `example` in the UI schema storage Swagger definition so the OpenAPI example field is recognized.

Testing:
- Verified there are no remaining `exmaple` matches in the touched file.
- Minimal schema typo fix; full project tests were not run.

AI assistance: This small schema typo fix was prepared with AI assistance and reviewed before submission.