### PR TITLE
fix(plugin-users): remove default password for new users

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx
@@ -143,6 +143,43 @@ vi.mock('../locale', () => ({
   useT: () => (value: string) => value,
 }));
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getByPath(source: unknown, path: string[]) {
+  let current = source;
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+function findPasswordItem(source: unknown): Record<string, unknown> | undefined {
+  if (Array.isArray(source)) {
+    for (const item of source) {
+      const matched = findPasswordItem(item);
+      if (matched) {
+        return matched;
+      }
+    }
+    return;
+  }
+
+  if (!isRecord(source)) {
+    return;
+  }
+
+  if (getByPath(source, ['stepParams', 'fieldSettings', 'init', 'fieldPath']) === 'password') {
+    return source;
+  }
+
+  return findPasswordItem(Object.values(source));
+}
+
 describe('UserFormDrawer', () => {
   beforeEach(() => {
     const model = {
@@ -249,46 +286,31 @@ describe('UserFormDrawer', () => {
     });
   });
 
-  it('should persist the create form model with password defaults', async () => {
+  it('should persist the create form model without password defaults', async () => {
     findOne.mockResolvedValueOnce(null);
 
     render(<UserFormDrawer onSubmitted={() => undefined} />);
 
     await waitFor(() => {
-      expect(save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          values: expect.objectContaining({
-            uid: ADMIN_PROFILE_CREATE_FORM_MODEL_UID,
-            use: 'UserCreateFormModel',
-            subModels: expect.objectContaining({
-              grid: expect.objectContaining({
-                subModels: expect.objectContaining({
-                  items: expect.arrayContaining([
-                    expect.objectContaining({
-                      stepParams: expect.objectContaining({
-                        fieldSettings: expect.objectContaining({
-                          init: expect.objectContaining({
-                            fieldPath: 'password',
-                          }),
-                        }),
-                      }),
-                      subModels: expect.objectContaining({
-                        field: expect.objectContaining({
-                          props: expect.objectContaining({
-                            checkStrength: false,
-                            initialValue: 'admin123',
-                          }),
-                        }),
-                      }),
-                    }),
-                  ]),
-                }),
-              }),
-            }),
-          }),
-        }),
-      );
+      expect(save).toHaveBeenCalled();
     });
+
+    const savedValues = getByPath(save.mock.calls[0]?.[0], ['values']);
+    expect(savedValues).toEqual(
+      expect.objectContaining({
+        uid: ADMIN_PROFILE_CREATE_FORM_MODEL_UID,
+        use: 'UserCreateFormModel',
+      }),
+    );
+    const passwordItem = findPasswordItem(savedValues);
+    expect(passwordItem).toBeTruthy();
+    expect(getByPath(passwordItem, ['stepParams', 'editItemSettings', 'initialValue'])).toBeUndefined();
+    expect(getByPath(passwordItem, ['subModels', 'field', 'props'])).toEqual(
+      expect.objectContaining({
+        checkStrength: false,
+      }),
+    );
+    expect(getByPath(passwordItem, ['subModels', 'field', 'props', 'initialValue'])).toBeUndefined();
 
     expect(createModelAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -296,5 +318,56 @@ describe('UserFormDrawer', () => {
         use: expect.any(Function),
       }),
     );
+  });
+
+  it('should remove legacy password defaults from a persisted create form model', async () => {
+    findOne.mockResolvedValueOnce({
+      uid: ADMIN_PROFILE_CREATE_FORM_MODEL_UID,
+      use: 'UserCreateFormModel',
+      subModels: {
+        grid: {
+          subModels: {
+            items: [
+              {
+                use: 'FormItemModel',
+                stepParams: {
+                  fieldSettings: {
+                    init: {
+                      fieldPath: 'password',
+                    },
+                  },
+                  editItemSettings: {
+                    initialValue: {
+                      defaultValue: 'admin123',
+                    },
+                  },
+                },
+                subModels: {
+                  field: {
+                    use: 'UserPasswordFieldModel',
+                    props: {
+                      checkStrength: false,
+                      initialValue: 'admin123',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    render(<UserFormDrawer onSubmitted={() => undefined} />);
+
+    await waitFor(() => {
+      expect(createModelAsync).toHaveBeenCalled();
+    });
+
+    const createdModelTree = createModelAsync.mock.calls[0]?.[0];
+    const passwordItem = findPasswordItem(createdModelTree);
+    expect(passwordItem).toBeTruthy();
+    expect(getByPath(passwordItem, ['stepParams', 'editItemSettings', 'initialValue'])).toBeUndefined();
+    expect(getByPath(passwordItem, ['subModels', 'field', 'props', 'initialValue'])).toBeUndefined();
   });
 });

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx
@@ -82,6 +82,52 @@ function withPrivateUserFormModel(tree: PersistedFlowModelTree, uid: string): Pe
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneWithoutCreatePasswordDefaults(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(cloneWithoutCreatePasswordDefaults);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const next = Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, cloneWithoutCreatePasswordDefaults(item)]),
+  );
+  const stepParams = next.stepParams;
+  const fieldSettings = isRecord(stepParams) ? stepParams.fieldSettings : undefined;
+  const init = isRecord(fieldSettings) ? fieldSettings.init : undefined;
+  const fieldPath = isRecord(init) ? init.fieldPath : undefined;
+  if (fieldPath !== 'password') {
+    return next;
+  }
+
+  const editItemSettings = isRecord(stepParams) ? stepParams.editItemSettings : undefined;
+  if (isRecord(editItemSettings)) {
+    delete editItemSettings.initialValue;
+  }
+  const subModels = next.subModels;
+  const fieldModel = isRecord(subModels) ? subModels.field : undefined;
+  const fieldProps = isRecord(fieldModel) ? fieldModel.props : undefined;
+  if (isRecord(fieldProps)) {
+    delete fieldProps.initialValue;
+    delete fieldProps.defaultValue;
+    delete fieldProps.value;
+  }
+
+  return next;
+}
+
+function normalizePersistedUserFormModel(tree: PersistedFlowModelTree, uid: string): PersistedFlowModelTree {
+  if (uid !== ADMIN_PROFILE_CREATE_FORM_MODEL_UID) {
+    return tree;
+  }
+  return cloneWithoutCreatePasswordDefaults(tree) as PersistedFlowModelTree;
+}
+
 async function ensurePersistedUserFormModel(options: {
   flowEngine: ReturnType<typeof useFlowEngine>;
   api: FlowEngineContext['api'];
@@ -97,6 +143,7 @@ async function ensurePersistedUserFormModel(options: {
     });
     modelTree = fallbackTree;
   }
+  modelTree = normalizePersistedUserFormModel(modelTree, uid);
   return (await flowEngine.createModelAsync(withPrivateUserFormModel(modelTree, uid))) as LoadedUserFormModel;
 }
 

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/shared/adminProfileFormModels.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/shared/adminProfileFormModels.ts
@@ -62,9 +62,6 @@ function buildPasswordFieldItem(): FlowModelTree {
         required: {
           required: true,
         },
-        initialValue: {
-          defaultValue: 'admin123',
-        },
       },
     },
     subModels: {
@@ -73,7 +70,6 @@ function buildPasswordFieldItem(): FlowModelTree {
         props: {
           autoComplete: 'new-password',
           checkStrength: false,
-          initialValue: 'admin123',
         },
       },
     },


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When adding users from the Users & Permissions page, the password field should be empty by default. The previous v2 create-user form model still provided `admin123` as a default password, and persisted legacy form models could keep that old default even after the source model changed.

### Description

- Removed the default password value from the v2 create-user form model.
- Stripped legacy persisted `admin123` password defaults when loading the create-user form model in the drawer.
- Updated tests to cover both the default form model and legacy persisted model sanitization.

Risk is low. The change is scoped to the client-v2 Users & Permissions create-user drawer form model.

Testing:

- `yarn eslint --fix packages/plugins/@nocobase/plugin-users/src/client-v2/shared/adminProfileFormModels.ts packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx`
- `yarn test packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Removed the default password from the add-user form in Users & Permissions. |
| 🇨🇳 Chinese | 移除“用户和权限”新增用户表单中的默认密码。 |

### Docs

N/A

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, docs are updated, translation files are updated and changelog is provided
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
