### PR TITLE
fix(client): avoid no-pages tip flash in UI editor mode

### DIFF
--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutComponent.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutComponent.tsx
@@ -718,6 +718,7 @@ export const AdminLayoutComponent = observer((props: any) => {
                       <ConfigProvider theme={isMobile ? mobileTheme : theme}>
                         <GlobalStyle />
                         <AdminLayoutContent
+                          designable={designable}
                           layout={adminLayoutModel?.layout}
                           onContentElementChange={handleLayoutContentElementChange}
                         />

--- a/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutSlotModels.tsx
+++ b/packages/core/client-v2/src/flow/admin-shell/admin-layout/AdminLayoutSlotModels.tsx
@@ -26,6 +26,7 @@ import {
 type AdminLayoutContentProps = {
   onContentElementChange?: (element: HTMLDivElement | null) => void;
   layout?: (AdminLayoutRoutePathLike & { routeName?: string }) | null;
+  designable?: boolean;
 };
 
 const layoutContentClass = css`
@@ -70,7 +71,7 @@ function isDvhSupported() {
   return testEl.style.height === '1dvh';
 }
 
-const ShowTipWhenNoPages = observer((props: { layout?: AdminLayoutRoutePathLike | null }) => {
+const ShowTipWhenNoPages = observer((props: { designable?: boolean; layout?: AdminLayoutRoutePathLike | null }) => {
   const flowEngine = useFlowEngine();
   const { token } = antdTheme.useToken();
   const { t } = useTranslation();
@@ -79,7 +80,7 @@ const ShowTipWhenNoPages = observer((props: { layout?: AdminLayoutRoutePathLike 
   const visibleRoutes = isV2AdminRuntime(flowEngine.context.app)
     ? allAccessRoutes.filter((route) => isV2MenuRoute(route))
     : allAccessRoutes;
-  const designable = !!flowEngine.context.flowSettingsEnabled;
+  const designable = !!props.designable || !!flowEngine.context.flowSettingsEnabled;
   const layoutRoutePath = getAdminLayoutRoutePath(props.layout);
 
   if (
@@ -104,7 +105,7 @@ const ShowTipWhenNoPages = observer((props: { layout?: AdminLayoutRoutePathLike 
  *
  * 内容区不再依赖独立 FlowModel，而是通过回调把挂载目标同步给 root model。
  */
-export const AdminLayoutContent: FC<AdminLayoutContentProps> = ({ onContentElementChange, layout }) => {
+export const AdminLayoutContent: FC<AdminLayoutContentProps> = ({ designable, onContentElementChange, layout }) => {
   const style = useMemo(() => (isDvhSupported() ? mobileHeight : undefined), []);
   const params = useParams();
   const matches = useMatches();
@@ -131,7 +132,7 @@ export const AdminLayoutContent: FC<AdminLayoutContentProps> = ({ onContentEleme
     >
       <div style={pageContentStyle}>
         {shouldKeepAlive && pageUid ? <KeepAlive uid={pageUid}>{() => <Outlet />}</KeepAlive> : <Outlet />}
-        <ShowTipWhenNoPages layout={layout} />
+        <ShowTipWhenNoPages designable={designable} layout={layout} />
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When UI Editor mode is enabled and the admin page is refreshed with no pages configured, the empty-page prompt can briefly flash before the asynchronous flow settings state finishes syncing.

### Description 
This PR passes the already-known AdminLayout designable state into the content slot and lets the no-pages prompt treat either the layout preference state or the flow engine state as design mode.

Potential risk is low: the change only affects whether the empty-page prompt renders, keeps the previous flow engine fallback, and does not change routes, permissions, menu data, persistence, or i18n strings.

Testing suggestions:
- Refresh an admin page while UI Editor mode is enabled and no pages are configured.
- Confirm the "No pages yet, please configure first" prompt does not flash.
- Confirm the prompt still appears when UI Editor mode is disabled and no pages are configured.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed a brief no-pages prompt flash when refreshing in UI Editor mode. |
| 🇨🇳 Chinese | 修复界面配置模式下刷新页面时短暂闪现暂无页面提示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
