### PR TITLE
fix(plugin-workflow): address workflow v2 selector and appends regressions

### DIFF
--- a/packages/core/client-v2/src/components/form/__tests__/TypedVariableInput.test.tsx
+++ b/packages/core/client-v2/src/components/form/__tests__/TypedVariableInput.test.tsx
@@ -64,6 +64,7 @@ describe('TypedVariableInput - constant rendering', () => {
       const item = screen.getByText('True');
       expect(item).toBeInTheDocument();
     });
+    expect(screen.getByRole('button', { name: 'variable-switcher' }).className).not.toContain('ant-btn-primary');
   });
 
   it('renders the Null placeholder when value=null and nullable=true', async () => {
@@ -77,6 +78,7 @@ describe('TypedVariableInput - constant rendering', () => {
     const nullInput = await screen.findByPlaceholderText('<Null>');
     expect(nullInput).toBeInTheDocument();
     expect(nullInput.getAttribute('readonly')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'variable-switcher' }).className).not.toContain('ant-btn-primary');
   });
 
   it('defaults undefined to the first constant type', async () => {

--- a/packages/core/flow-engine/src/components/FlowContextSelector.tsx
+++ b/packages/core/flow-engine/src/components/FlowContextSelector.tsx
@@ -85,6 +85,7 @@ const FlowContextSelectorComponent: React.FC<FlowContextSelectorProps> = ({
   value,
   onChange,
   children,
+  active,
   metaTree,
   showSearch = false,
   parseValueToPath: customParseValueToPath = parseValueToPath,
@@ -266,13 +267,13 @@ const FlowContextSelectorComponent: React.FC<FlowContextSelectorProps> = ({
 
   // 默认按钮组件
   const defaultChildren = useMemo(() => {
-    const hasSelected = currentPath && currentPath.length > 0;
+    const hasSelected = active ?? Boolean(currentPath && currentPath.length > 0);
     return (
       <Button type={hasSelected ? 'primary' : 'default'} style={defaultButtonStyle}>
         x
       </Button>
     );
-  }, [currentPath]);
+  }, [active, currentPath]);
 
   // 处理选择变化事件
   const handleChange = useCallback(

--- a/packages/core/flow-engine/src/components/variables/VariableInput.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableInput.tsx
@@ -192,7 +192,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
     };
 
     restoreFromValue();
-  }, [resolvedMetaTree, innerValue, resolvePathFromValue, currentMetaTreeNode]);
+  }, [resolvedMetaTree, innerValue, resolvePathFromValue, currentMetaTreeNode, value]);
 
   const ValueComponent = useMemo(() => {
     const Component = renderInputComponent?.(resolvedMetaTreeNode);
@@ -356,6 +356,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
       <FlowContextSelector
         metaTree={resolvedMetaTree}
         value={innerValue}
+        active={isVariableValue(innerValue)}
         onChange={handleVariableSelect}
         parseValueToPath={resolvePathFromValue}
         formatPathToValue={resolveValueFromPath}

--- a/packages/core/flow-engine/src/components/variables/__tests__/FlowContextSelector.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/FlowContextSelector.test.tsx
@@ -67,6 +67,23 @@ describe('FlowContextSelector', () => {
     });
   });
 
+  it('uses explicit active=false to keep the default trigger unhighlighted even when value parses to a path', async () => {
+    const flowContext = createTestFlowContext();
+
+    render(
+      <TestFlowContextWrapper context={flowContext}>
+        <FlowContextSelector
+          metaTree={() => flowContext.getPropertyMetaTree()}
+          value="{{ ctx.user.name }}"
+          active={false}
+        />
+      </TestFlowContextWrapper>,
+    );
+
+    const button = await screen.findByRole('button');
+    expect(button.className).not.toContain('ant-btn-primary');
+  });
+
   it('should support function metaTree loading', async () => {
     const flowContext = createTestFlowContext();
     const metaTreeFn = vi.fn(() => flowContext.getPropertyMetaTree());
@@ -405,10 +422,13 @@ describe('FlowContextSelector', () => {
 
     const clearIcon = document.querySelector('.ant-input-clear-icon') as HTMLElement | null;
     expect(clearIcon).toBeInTheDocument();
+    if (!clearIcon) {
+      throw new Error('Expected inline clear icon to be present');
+    }
 
-    fireEvent.mouseDown(clearIcon!);
-    fireEvent.mouseUp(clearIcon!);
-    fireEvent.click(clearIcon!);
+    fireEvent.mouseDown(clearIcon);
+    fireEvent.mouseUp(clearIcon);
+    fireEvent.click(clearIcon);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith('', undefined);

--- a/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Input } from 'antd';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ContextSelectorItem } from '../types';
@@ -112,6 +113,50 @@ describe('VariableInput', () => {
     expect(selectorButton).toBeInTheDocument();
   });
 
+  it('should not highlight the selector button for synthetic constant/null paths', async () => {
+    const flowContext = createTestFlowContext();
+
+    render(
+      <TestFlowContextWrapper context={flowContext}>
+        <VariableInput
+          value=""
+          metaTree={[
+            { name: 'constant', title: 'Constant', type: 'string', paths: ['constant'] },
+            { name: 'null', title: 'Null', type: 'object', paths: ['null'] },
+            ...flowContext.getPropertyMetaTree(),
+          ]}
+          converters={{
+            renderInputComponent: (meta) => {
+              const first = meta?.paths?.[0];
+              if (first === 'constant') {
+                return (props: any) => <input aria-label="constant-value" {...props} />;
+              }
+              if (first === 'null') {
+                return () => <Input placeholder="<Null>" readOnly />;
+              }
+              return null;
+            },
+            resolveValueFromPath: (meta) => {
+              const first = meta?.paths?.[0];
+              if (first === 'constant') return '';
+              if (first === 'null') return null;
+              return undefined;
+            },
+            resolvePathFromValue: (currentValue) => {
+              if (currentValue === null) return ['null'];
+              const trimmed = typeof currentValue === 'string' ? currentValue.trim() : currentValue;
+              if (trimmed === '') return ['constant'];
+              return undefined;
+            },
+          }}
+        />
+      </TestFlowContextWrapper>,
+    );
+
+    const selectorButton = await screen.findByRole('button');
+    expect(selectorButton.className).not.toContain('ant-btn-primary');
+  });
+
   it('should handle onChange from Input', async () => {
     const onChange = vi.fn();
     const flowContext = createTestFlowContext();
@@ -195,20 +240,21 @@ describe('VariableInput', () => {
 
     const selectElement = container.querySelector('.ant-select');
     expect(selectElement).toBeInTheDocument();
+    if (!selectElement) {
+      throw new Error('Expected variable tag select wrapper to be present');
+    }
 
     // 触发鼠标悬停以显示清除按钮
-    fireEvent.mouseEnter(selectElement!);
+    fireEvent.mouseEnter(selectElement);
 
     // 尝试触发清除功能
     // 方法1: 直接触发 Select 组件的 onClear 事件
-    const selectInstance = selectElement as any;
-
     // 尝试通过键盘事件触发清除
-    fireEvent.keyDown(selectElement!, { key: 'Backspace', code: 'Backspace' });
+    fireEvent.keyDown(selectElement, { key: 'Backspace', code: 'Backspace' });
 
     // 或者尝试触发自定义的清除逻辑
     const clearEvents = new CustomEvent('clear');
-    selectElement!.dispatchEvent(clearEvents);
+    selectElement.dispatchEvent(clearEvents);
 
     // 检查是否调用了清除功能（可能需要调整期望）
     // 如果清除按钮不能直接测试，我们验证组件支持清除功能

--- a/packages/core/flow-engine/src/components/variables/types.ts
+++ b/packages/core/flow-engine/src/components/variables/types.ts
@@ -16,6 +16,16 @@ export interface FlowContextSelectorProps
   value?: string;
   onChange?: (value: string, metaTreeNode?: MetaTreeNode) => void;
   children?: CascaderProps<ContextSelectorItem>['children'];
+  /**
+   * Controls whether the default `x` trigger button is rendered as active
+   * (`type="primary"`). When omitted, the selector falls back to its parsed
+   * `value` path (`true` iff a valid variable path is currently selected).
+   *
+   * Use this when callers intentionally feed synthetic paths such as
+   * `['constant']` / `['null']` into the cascader to keep menu state aligned,
+   * but only want real variable references to show the blue active button.
+   */
+  active?: boolean;
   metaTree?: MetaTreeNode[] | (() => MetaTreeNode[] | Promise<MetaTreeNode[]>);
   parseValueToPath?: (value: string) => string[] | undefined;
   formatPathToValue?: (item: MetaTreeNode) => string;

--- a/packages/plugins/@nocobase/plugin-workflow-json-variable-mapping/src/client-v2/__tests__/JSONVariableMappingFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-variable-mapping/src/client-v2/__tests__/JSONVariableMappingFieldset.test.tsx
@@ -18,9 +18,9 @@ vi.mock('../locale', () => ({
 }));
 
 vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
-  WorkflowVariableInput: (props: { value?: string; onChange?: (value: string) => void }) => (
+  WorkflowVariableSelect: (props: { value?: string; onChange?: (value: string) => void }) => (
     <input
-      aria-label="workflow-variable-input"
+      aria-label="workflow-variable-select"
       value={props.value ?? ''}
       onChange={(event) => props.onChange?.(event.target.value)}
     />

--- a/packages/plugins/@nocobase/plugin-workflow-json-variable-mapping/src/client-v2/components/JSONVariableMappingFieldset.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-json-variable-mapping/src/client-v2/components/JSONVariableMappingFieldset.tsx
@@ -11,7 +11,7 @@ import React, { useCallback } from 'react';
 import { DeleteOutlined } from '@ant-design/icons';
 import { Button, Checkbox, Form, Input, Popconfirm, Space } from 'antd';
 import { JsonTextArea } from '@nocobase/client-v2';
-import { WorkflowVariableInput } from '@nocobase/plugin-workflow/client-v2';
+import { WorkflowVariableSelect } from '@nocobase/plugin-workflow/client-v2';
 
 import { useT } from '../locale';
 import { parseJsonVariables } from '../utils/parseJsonVariables';
@@ -34,7 +34,7 @@ export function JSONVariableMappingFieldset() {
   return (
     <>
       <Form.Item name={['config', 'dataSource']} label={t('JSON data source')} rules={[{ required: true }]}>
-        <WorkflowVariableInput />
+        <WorkflowVariableSelect />
       </Form.Item>
 
       <Form.Item name={['config', 'example']} label={t('Input example')}>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableSelect.tsx
@@ -7,14 +7,13 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useMemo, useState } from 'react';
-import { CloseCircleFilled } from '@ant-design/icons';
-import { FlowContextSelector, loadMetaTreeChildren, useFlowContext, type MetaTreeNode } from '@nocobase/flow-engine';
-import { Button, Input, Space, Tag, theme } from 'antd';
-import { css } from '@emotion/css';
+import React, { useMemo } from 'react';
+import { FlowContextSelector } from '@nocobase/flow-engine';
+import { Input, Space } from 'antd';
 import { formatWorkflowPathToValue, parseWorkflowValueToPath } from './workflowVariableConverters';
 import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from './useWorkflowVariableOptions';
 import { useHideVariable } from '../components/HideVariableContext';
+import { WorkflowVariableTag, isWorkflowVariableValue, type WorkflowVariableTagProps } from './WorkflowVariableTag';
 
 export type WorkflowVariableSelectProps = {
   value?: string | null;
@@ -23,33 +22,9 @@ export type WorkflowVariableSelectProps = {
   placeholder?: string;
   className?: string;
   style?: React.CSSProperties;
-  status?: 'error' | 'warning';
+  status?: WorkflowVariableTagProps['status'];
   variableOptions?: UseWorkflowVariableOptions;
 };
-
-function isWorkflowVariableValue(value: unknown): value is string {
-  return typeof value === 'string' && /^\{\{\s*[^{}]+?\s*\}\}$/.test(value);
-}
-
-function resolveVariableLabels(path: string[], metaTree: MetaTreeNode[], t: (text: string) => string): string[] {
-  const labels: string[] = [];
-  let nodes: MetaTreeNode[] | undefined = metaTree;
-  for (const segment of path) {
-    if (!nodes) {
-      break;
-    }
-    const matched = nodes.find((node) => node.name === segment);
-    if (!matched) {
-      labels.push(segment);
-      nodes = undefined;
-      continue;
-    }
-    const title = typeof matched.title === 'string' && matched.title ? matched.title : matched.name;
-    labels.push(t(title));
-    nodes = Array.isArray(matched.children) ? matched.children : undefined;
-  }
-  return labels;
-}
 
 /**
  * Pure workflow variable selector: the left side is read-only and only shows
@@ -64,141 +39,18 @@ export function WorkflowVariableSelect(props: WorkflowVariableSelectProps) {
   const translatedMetaTree = useMemo(() => metaTree, [metaTree]);
   const isVariable = isWorkflowVariableValue(value);
   const hasVariableOptions = !hideVariable && translatedMetaTree.length > 0;
-  const { token } = theme.useToken();
-  const ctx = useFlowContext();
-  const t = useMemo(() => (typeof ctx?.t === 'function' ? ctx.t : (text: string) => text), [ctx]);
-  const variablePath = useMemo(() => (isVariable ? parseWorkflowValueToPath(value) : undefined), [isVariable, value]);
-  const [updateFlag, setUpdateFlag] = useState(0);
-
-  React.useEffect(() => {
-    if (!isVariable || !variablePath?.length) {
-      return;
-    }
-    let cancelled = false;
-    const run = async () => {
-      let nodes: MetaTreeNode[] | undefined = translatedMetaTree;
-      let didLoad = false;
-      for (const segment of variablePath) {
-        if (!nodes) {
-          break;
-        }
-        const matched = nodes.find((node) => node.name === segment);
-        if (!matched) {
-          break;
-        }
-        if (typeof matched.children === 'function') {
-          const resolved = await loadMetaTreeChildren(matched);
-          if (cancelled) {
-            return;
-          }
-          matched.children = resolved;
-          didLoad = true;
-        }
-        nodes = Array.isArray(matched.children) ? matched.children : undefined;
-      }
-      if (didLoad && !cancelled) {
-        setUpdateFlag((prev) => prev + 1);
-      }
-    };
-    run();
-    return () => {
-      cancelled = true;
-    };
-  }, [isVariable, translatedMetaTree, variablePath]);
-
-  const variableLabels = useMemo(() => {
-    void updateFlag;
-    return isVariable && variablePath ? resolveVariableLabels(variablePath, translatedMetaTree, t) : [];
-  }, [isVariable, translatedMetaTree, t, updateFlag, variablePath]);
-
-  const variableValueClassName = useMemo(
-    () => css`
-      &:hover .clear-button,
-      &:focus-within .clear-button {
-        visibility: visible;
-        pointer-events: auto;
-        opacity: 1;
-      }
-
-      .clear-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: ${token.fontSizeIcon}px;
-        height: ${token.fontSizeIcon}px;
-        padding: 0;
-        color: ${token.colorTextQuaternary};
-        background: transparent;
-        cursor: pointer;
-        visibility: hidden;
-        pointer-events: none;
-        opacity: 0;
-        transition:
-          visibility ${token.motionDurationMid} ease,
-          color ${token.motionDurationMid} ease,
-          opacity ${token.motionDurationSlow} ease;
-
-        &:hover {
-          color: ${token.colorTextTertiary};
-          background: transparent;
-        }
-      }
-    `,
-    [token],
-  );
 
   return (
     <Space.Compact block className={className} style={style}>
       <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
         {isVariable ? (
-          <div
-            className={variableValueClassName}
-            role="button"
-            aria-label="workflow-variable-select-value"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: token.marginXXS,
-              padding: `0 ${token.paddingSM}px`,
-              minHeight: token.controlHeight,
-              border: `1px solid ${
-                status === 'error' ? token.colorError : status === 'warning' ? token.colorWarning : token.colorBorder
-              }`,
-              borderRadius: token.borderRadius,
-              borderTopRightRadius: 0,
-              borderBottomRightRadius: 0,
-              background: disabled ? token.colorBgContainerDisabled : token.colorBgContainer,
-              overflow: 'hidden',
-            }}
-          >
-            <Tag
-              color="blue"
-              style={{
-                marginInlineEnd: 0,
-                maxWidth: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {variableLabels.map((label, index) => (
-                <React.Fragment key={`${label}-${index}`}>
-                  {index ? ' / ' : ''}
-                  {label}
-                </React.Fragment>
-              ))}
-            </Tag>
-            {!disabled ? (
-              <Button
-                type="text"
-                size="small"
-                className="clear-button"
-                aria-label="workflow-variable-select-clear"
-                onClick={() => onChange?.(null)}
-                icon={<CloseCircleFilled />}
-              />
-            ) : null}
-          </div>
+          <WorkflowVariableTag
+            value={value}
+            metaTree={translatedMetaTree}
+            disabled={disabled}
+            status={status}
+            onClear={() => onChange?.(null)}
+          />
         ) : (
           <Input
             value={undefined}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableSelect.tsx
@@ -1,0 +1,230 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React, { useMemo, useState } from 'react';
+import { CloseCircleFilled } from '@ant-design/icons';
+import { FlowContextSelector, loadMetaTreeChildren, useFlowContext, type MetaTreeNode } from '@nocobase/flow-engine';
+import { Button, Input, Space, Tag, theme } from 'antd';
+import { css } from '@emotion/css';
+import { formatWorkflowPathToValue, parseWorkflowValueToPath } from './workflowVariableConverters';
+import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from './useWorkflowVariableOptions';
+import { useHideVariable } from '../components/HideVariableContext';
+
+export type WorkflowVariableSelectProps = {
+  value?: string | null;
+  onChange?: (value: string | null) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  status?: 'error' | 'warning';
+  variableOptions?: UseWorkflowVariableOptions;
+};
+
+function isWorkflowVariableValue(value: unknown): value is string {
+  return typeof value === 'string' && /^\{\{\s*[^{}]+?\s*\}\}$/.test(value);
+}
+
+function resolveVariableLabels(path: string[], metaTree: MetaTreeNode[], t: (text: string) => string): string[] {
+  const labels: string[] = [];
+  let nodes: MetaTreeNode[] | undefined = metaTree;
+  for (const segment of path) {
+    if (!nodes) {
+      break;
+    }
+    const matched = nodes.find((node) => node.name === segment);
+    if (!matched) {
+      labels.push(segment);
+      nodes = undefined;
+      continue;
+    }
+    const title = typeof matched.title === 'string' && matched.title ? matched.title : matched.name;
+    labels.push(t(title));
+    nodes = Array.isArray(matched.children) ? matched.children : undefined;
+  }
+  return labels;
+}
+
+/**
+ * Pure workflow variable selector: the left side is read-only and only shows
+ * the selected variable tag (with clear) or an empty placeholder input. Users
+ * must select from the workflow variable cascader and cannot type freeform
+ * content after choosing a variable.
+ */
+export function WorkflowVariableSelect(props: WorkflowVariableSelectProps) {
+  const { value, onChange, disabled, placeholder, className, style, status, variableOptions } = props;
+  const hideVariable = useHideVariable();
+  const metaTree = useWorkflowVariableOptions(variableOptions);
+  const translatedMetaTree = useMemo(() => metaTree, [metaTree]);
+  const isVariable = isWorkflowVariableValue(value);
+  const hasVariableOptions = !hideVariable && translatedMetaTree.length > 0;
+  const { token } = theme.useToken();
+  const ctx = useFlowContext();
+  const t = useMemo(() => (typeof ctx?.t === 'function' ? ctx.t : (text: string) => text), [ctx]);
+  const variablePath = useMemo(() => (isVariable ? parseWorkflowValueToPath(value) : undefined), [isVariable, value]);
+  const [updateFlag, setUpdateFlag] = useState(0);
+
+  React.useEffect(() => {
+    if (!isVariable || !variablePath?.length) {
+      return;
+    }
+    let cancelled = false;
+    const run = async () => {
+      let nodes: MetaTreeNode[] | undefined = translatedMetaTree;
+      let didLoad = false;
+      for (const segment of variablePath) {
+        if (!nodes) {
+          break;
+        }
+        const matched = nodes.find((node) => node.name === segment);
+        if (!matched) {
+          break;
+        }
+        if (typeof matched.children === 'function') {
+          const resolved = await loadMetaTreeChildren(matched);
+          if (cancelled) {
+            return;
+          }
+          matched.children = resolved;
+          didLoad = true;
+        }
+        nodes = Array.isArray(matched.children) ? matched.children : undefined;
+      }
+      if (didLoad && !cancelled) {
+        setUpdateFlag((prev) => prev + 1);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isVariable, translatedMetaTree, variablePath]);
+
+  const variableLabels = useMemo(() => {
+    void updateFlag;
+    return isVariable && variablePath ? resolveVariableLabels(variablePath, translatedMetaTree, t) : [];
+  }, [isVariable, translatedMetaTree, t, updateFlag, variablePath]);
+
+  const variableValueClassName = useMemo(
+    () => css`
+      &:hover .clear-button,
+      &:focus-within .clear-button {
+        visibility: visible;
+        pointer-events: auto;
+        opacity: 1;
+      }
+
+      .clear-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: ${token.fontSizeIcon}px;
+        height: ${token.fontSizeIcon}px;
+        padding: 0;
+        color: ${token.colorTextQuaternary};
+        background: transparent;
+        cursor: pointer;
+        visibility: hidden;
+        pointer-events: none;
+        opacity: 0;
+        transition:
+          visibility ${token.motionDurationMid} ease,
+          color ${token.motionDurationMid} ease,
+          opacity ${token.motionDurationSlow} ease;
+
+        &:hover {
+          color: ${token.colorTextTertiary};
+          background: transparent;
+        }
+      }
+    `,
+    [token],
+  );
+
+  return (
+    <Space.Compact block className={className} style={style}>
+      <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+        {isVariable ? (
+          <div
+            className={variableValueClassName}
+            role="button"
+            aria-label="workflow-variable-select-value"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: token.marginXXS,
+              padding: `0 ${token.paddingSM}px`,
+              minHeight: token.controlHeight,
+              border: `1px solid ${
+                status === 'error' ? token.colorError : status === 'warning' ? token.colorWarning : token.colorBorder
+              }`,
+              borderRadius: token.borderRadius,
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
+              background: disabled ? token.colorBgContainerDisabled : token.colorBgContainer,
+              overflow: 'hidden',
+            }}
+          >
+            <Tag
+              color="blue"
+              style={{
+                marginInlineEnd: 0,
+                maxWidth: '100%',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {variableLabels.map((label, index) => (
+                <React.Fragment key={`${label}-${index}`}>
+                  {index ? ' / ' : ''}
+                  {label}
+                </React.Fragment>
+              ))}
+            </Tag>
+            {!disabled ? (
+              <Button
+                type="text"
+                size="small"
+                className="clear-button"
+                aria-label="workflow-variable-select-clear"
+                onClick={() => onChange?.(null)}
+                icon={<CloseCircleFilled />}
+              />
+            ) : null}
+          </div>
+        ) : (
+          <Input
+            value={undefined}
+            readOnly
+            disabled={disabled}
+            placeholder={placeholder}
+            status={status}
+            style={{ width: '100%' }}
+          />
+        )}
+      </div>
+      {hasVariableOptions ? (
+        <FlowContextSelector
+          metaTree={translatedMetaTree}
+          value={isVariable ? value : undefined}
+          active={isVariable}
+          disabled={disabled}
+          parseValueToPath={parseWorkflowValueToPath}
+          formatPathToValue={formatWorkflowPathToValue}
+          onChange={(nextValue, _metaTreeNode) => {
+            onChange?.(nextValue || null);
+          }}
+        />
+      ) : null}
+    </Space.Compact>
+  );
+}
+
+export default WorkflowVariableSelect;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableTag.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableTag.tsx
@@ -1,0 +1,202 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { CloseCircleFilled } from '@ant-design/icons';
+import { loadMetaTreeChildren, useFlowContext, type MetaTreeNode } from '@nocobase/flow-engine';
+import { Button, Tag, theme } from 'antd';
+import { css } from '@emotion/css';
+import { parseWorkflowValueToPath } from './workflowVariableConverters';
+
+export type WorkflowVariableTagProps = {
+  value?: string | null;
+  metaTree: MetaTreeNode[];
+  onClear?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+  status?: 'error' | 'warning';
+  disabled?: boolean;
+};
+
+export function isWorkflowVariableValue(value: unknown): value is string {
+  return typeof value === 'string' && /^\{\{\s*[^{}]+?\s*\}\}$/.test(value);
+}
+
+function resolveVariableLabels(path: string[], metaTree: MetaTreeNode[], t: (text: string) => string): string[] {
+  const labels: string[] = [];
+  let nodes: MetaTreeNode[] | undefined = metaTree;
+  for (const segment of path) {
+    if (!nodes) {
+      break;
+    }
+    const matched = nodes.find((node) => node.name === segment);
+    if (!matched) {
+      labels.push(segment);
+      nodes = undefined;
+      continue;
+    }
+    const title = typeof matched.title === 'string' && matched.title ? matched.title : matched.name;
+    labels.push(t(title));
+    nodes = Array.isArray(matched.children) ? matched.children : undefined;
+  }
+  return labels;
+}
+
+export function WorkflowVariableTag({
+  value,
+  metaTree,
+  onClear,
+  className,
+  style,
+  status,
+  disabled,
+}: WorkflowVariableTagProps) {
+  const { token } = theme.useToken();
+  const ctx = useFlowContext();
+  const t = useMemo(() => (typeof ctx?.t === 'function' ? ctx.t : (text: string) => text), [ctx]);
+  const variablePath = useMemo(
+    () => (isWorkflowVariableValue(value) ? parseWorkflowValueToPath(value) : undefined),
+    [value],
+  );
+  const [updateFlag, setUpdateFlag] = useState(0);
+
+  useEffect(() => {
+    if (!variablePath?.length) {
+      return;
+    }
+    let cancelled = false;
+    const run = async () => {
+      let nodes: MetaTreeNode[] | undefined = metaTree;
+      let didLoad = false;
+      for (const segment of variablePath) {
+        if (!nodes) {
+          break;
+        }
+        const matched = nodes.find((node) => node.name === segment);
+        if (!matched) {
+          break;
+        }
+        if (typeof matched.children === 'function') {
+          const resolved = await loadMetaTreeChildren(matched);
+          if (cancelled) {
+            return;
+          }
+          matched.children = resolved;
+          didLoad = true;
+        }
+        nodes = Array.isArray(matched.children) ? matched.children : undefined;
+      }
+      if (didLoad && !cancelled) {
+        setUpdateFlag((prev) => prev + 1);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [metaTree, variablePath]);
+
+  const variableLabels = useMemo(() => {
+    void updateFlag;
+    return variablePath ? resolveVariableLabels(variablePath, metaTree, t) : [];
+  }, [metaTree, t, updateFlag, variablePath]);
+
+  const variableValueClassName = useMemo(
+    () => css`
+      &:hover .clear-button,
+      &:focus-within .clear-button {
+        visibility: visible;
+        pointer-events: auto;
+        opacity: 1;
+      }
+
+      .clear-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: ${token.fontSizeIcon}px;
+        height: ${token.fontSizeIcon}px;
+        padding: 0;
+        color: ${token.colorTextQuaternary};
+        background: transparent;
+        cursor: pointer;
+        visibility: hidden;
+        pointer-events: none;
+        opacity: 0;
+        transition:
+          visibility ${token.motionDurationMid} ease,
+          color ${token.motionDurationMid} ease,
+          opacity ${token.motionDurationSlow} ease;
+
+        &:hover {
+          color: ${token.colorTextTertiary};
+          background: transparent;
+        }
+      }
+    `,
+    [token],
+  );
+
+  return (
+    <div
+      className={css(variableValueClassName, className)}
+      role="button"
+      aria-label="workflow-variable-tag"
+      style={{
+        width: '100%',
+        minWidth: 0,
+        flex: '1 1 auto',
+        display: 'flex',
+        alignItems: 'center',
+        gap: token.marginXXS,
+        padding: `0 ${token.paddingSM}px`,
+        minHeight: token.controlHeight,
+        border: `1px solid ${
+          status === 'error' ? token.colorError : status === 'warning' ? token.colorWarning : token.colorBorder
+        }`,
+        borderRadius: token.borderRadius,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        background: disabled ? token.colorBgContainerDisabled : token.colorBgContainer,
+        overflow: 'hidden',
+        ...style,
+      }}
+    >
+      <Tag
+        color="blue"
+        style={{
+          marginInlineEnd: 0,
+          maxWidth: '100%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {variableLabels.map((label, index) => (
+          <React.Fragment key={`${label}-${index}`}>
+            {index ? ' / ' : ''}
+            {label}
+          </React.Fragment>
+        ))}
+      </Tag>
+      {!disabled && onClear ? (
+        <Button
+          type="text"
+          size="small"
+          className="clear-button"
+          aria-label="workflow-variable-tag-clear"
+          onClick={onClear}
+          icon={<CloseCircleFilled />}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export default WorkflowVariableTag;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowVariableSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowVariableSelect.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  selectorProps: null as any,
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  FlowContextSelector: (props: any) => {
+    holder.selectorProps = props;
+    return (
+      <button
+        type="button"
+        aria-label="workflow-variable-select-trigger"
+        onClick={() => props.onChange?.('{{$context.id}}')}
+      >
+        x
+      </button>
+    );
+  },
+  loadMetaTreeChildren: vi.fn(async (meta: any) => meta?.children?.() ?? []),
+  useFlowContext: () => ({
+    t: (text: string) => text,
+  }),
+}));
+
+vi.mock('../useWorkflowVariableOptions', () => ({
+  useWorkflowVariableOptions: vi.fn(() => [
+    {
+      name: '$context',
+      title: 'Trigger variables',
+      type: 'object',
+      paths: ['$context'],
+      children: [{ name: 'id', title: 'id', type: 'string', paths: ['$context', 'id'] }],
+    },
+  ]),
+}));
+
+import { WorkflowVariableSelect } from '../WorkflowVariableSelect';
+
+describe('WorkflowVariableSelect', () => {
+  it('renders a readonly placeholder input before a variable is selected', () => {
+    render(<WorkflowVariableSelect placeholder="Select variable" />);
+
+    const input = screen.getByPlaceholderText('Select variable');
+    expect(input).toHaveAttribute('readonly');
+    expect(screen.queryByRole('button', { name: 'workflow-variable-select-value' })).toBeNull();
+    expect(holder.selectorProps?.active).toBe(false);
+  });
+
+  it('renders the variable tag and keeps the selector active only for variable values', () => {
+    render(<WorkflowVariableSelect value="{{$context.id}}" />);
+
+    expect(screen.getByRole('button', { name: 'workflow-variable-select-value' })).toHaveTextContent(
+      'Trigger variables / id',
+    );
+    expect(holder.selectorProps?.active).toBe(true);
+    expect(holder.selectorProps?.value).toBe('{{$context.id}}');
+  });
+
+  it('clears the selected variable to null through the tag clear handler', () => {
+    const onChange = vi.fn();
+    render(<WorkflowVariableSelect value="{{$context.id}}" onChange={onChange} />);
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'workflow-variable-select-value' }));
+    fireEvent.click(screen.getByLabelText('workflow-variable-select-clear'));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('propagates selected workflow variables from the selector', () => {
+    const onChange = vi.fn();
+    render(<WorkflowVariableSelect onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'workflow-variable-select-trigger' }));
+
+    expect(onChange).toHaveBeenCalledWith('{{$context.id}}');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowVariableSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowVariableSelect.test.tsx
@@ -54,16 +54,14 @@ describe('WorkflowVariableSelect', () => {
 
     const input = screen.getByPlaceholderText('Select variable');
     expect(input).toHaveAttribute('readonly');
-    expect(screen.queryByRole('button', { name: 'workflow-variable-select-value' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'workflow-variable-tag' })).toBeNull();
     expect(holder.selectorProps?.active).toBe(false);
   });
 
   it('renders the variable tag and keeps the selector active only for variable values', () => {
     render(<WorkflowVariableSelect value="{{$context.id}}" />);
 
-    expect(screen.getByRole('button', { name: 'workflow-variable-select-value' })).toHaveTextContent(
-      'Trigger variables / id',
-    );
+    expect(screen.getByRole('button', { name: 'workflow-variable-tag' })).toHaveTextContent('Trigger variables / id');
     expect(holder.selectorProps?.active).toBe(true);
     expect(holder.selectorProps?.value).toBe('{{$context.id}}');
   });
@@ -72,8 +70,8 @@ describe('WorkflowVariableSelect', () => {
     const onChange = vi.fn();
     render(<WorkflowVariableSelect value="{{$context.id}}" onChange={onChange} />);
 
-    fireEvent.mouseEnter(screen.getByRole('button', { name: 'workflow-variable-select-value' }));
-    fireEvent.click(screen.getByLabelText('workflow-variable-select-clear'));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'workflow-variable-tag' }));
+    fireEvent.click(screen.getByLabelText('workflow-variable-tag-clear'));
 
     expect(onChange).toHaveBeenCalledWith(null);
   });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowVariableWrapper.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/WorkflowVariableWrapper.tsx
@@ -7,12 +7,13 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useMemo, useState } from 'react';
-import { FlowContextSelector, VariableTag, type MetaTreeNode } from '@nocobase/flow-engine';
+import React, { useMemo } from 'react';
+import { FlowContextSelector } from '@nocobase/flow-engine';
 import type { FlowContextSelectorProps } from '@nocobase/flow-engine';
 import { Space } from 'antd';
 import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from '../canvas/useWorkflowVariableOptions';
 import { formatWorkflowPathToValue, parseWorkflowValueToPath } from '../canvas/workflowVariableConverters';
+import { WorkflowVariableTag, isWorkflowVariableValue } from '../canvas/WorkflowVariableTag';
 import { useHideVariable } from './HideVariableContext';
 
 type BaseWrapperRenderProps<TValue> = {
@@ -29,10 +30,6 @@ export type WorkflowVariableWrapperProps<TValue> = {
   selectorProps?: Partial<FlowContextSelectorProps>;
 };
 
-function isWorkflowVariableValue(value: unknown): value is string {
-  return typeof value === 'string' && /^\{\{\s*[^{}]+?\s*\}\}$/.test(value);
-}
-
 export function WorkflowVariableWrapper<TValue>({
   value,
   onChange,
@@ -43,7 +40,6 @@ export function WorkflowVariableWrapper<TValue>({
 }: WorkflowVariableWrapperProps<TValue>) {
   const hideVariable = useHideVariable();
   const metaTree = useWorkflowVariableOptions(variableOptions);
-  const [selectedMetaTreeNode, setSelectedMetaTreeNode] = useState<MetaTreeNode | undefined>();
   const isVariable = isWorkflowVariableValue(value);
   const translatedMetaTree = useMemo(() => metaTree, [metaTree]);
   const hasVariableOptions = !hideVariable && translatedMetaTree.length > 0;
@@ -62,12 +58,7 @@ export function WorkflowVariableWrapper<TValue>({
   return (
     <Space.Compact block>
       {isVariable ? (
-        <VariableTag
-          value={value}
-          metaTree={translatedMetaTree}
-          metaTreeNode={selectedMetaTreeNode}
-          onClear={() => onChange?.(clearValue)}
-        />
+        <WorkflowVariableTag value={value} metaTree={translatedMetaTree} onClear={() => onChange?.(clearValue)} />
       ) : (
         render({
           value: (value as TValue | null | undefined) ?? undefined,
@@ -79,8 +70,7 @@ export function WorkflowVariableWrapper<TValue>({
         value={isVariable ? value : undefined}
         parseValueToPath={parseWorkflowValueToPath}
         formatPathToValue={formatWorkflowPathToValue}
-        onChange={(nextValue, metaTreeNode) => {
-          setSelectedMetaTreeNode(metaTreeNode);
+        onChange={(nextValue) => {
           onChange?.(nextValue);
         }}
         {...selectorProps}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/AppendsSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/AppendsSelect.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { AppendsSelect } from '../collection/AppendsSelect';
 
 const treeSelectState = vi.hoisted(() => ({
@@ -33,25 +33,43 @@ vi.mock('@nocobase/flow-engine', () => ({
       dataSourceManager: {
         getDataSource: () => ({
           collectionManager: {
-            getCollection: () => ({
-              getFields: () => [
-                {
-                  options: {
-                    name: 'createdBy',
-                    type: 'belongsTo',
-                    target: 'users',
-                    uiSchema: { title: '{{t("Created by")}}' },
-                  },
-                },
-                {
-                  options: {
-                    name: 'role',
-                    type: 'belongsTo',
-                    target: 'roles',
-                    uiSchema: { title: '{{t("Role")}}' },
-                  },
-                },
-              ],
+            getCollection: (collectionName: string) => ({
+              getFields: () =>
+                (
+                  ({
+                    users: [
+                      {
+                        options: {
+                          name: 'createdBy',
+                          type: 'belongsTo',
+                          target: 'users',
+                          interface: 'm2o',
+                          uiSchema: { title: '{{t("Created by")}}' },
+                        },
+                      },
+                      {
+                        options: {
+                          name: 'role',
+                          type: 'belongsTo',
+                          target: 'roles',
+                          interface: 'm2o',
+                          uiSchema: { title: '{{t("Role")}}' },
+                        },
+                      },
+                    ],
+                    roles: [
+                      {
+                        options: {
+                          name: 'createdBy',
+                          type: 'belongsTo',
+                          target: 'users',
+                          interface: 'm2o',
+                          uiSchema: { title: '{{t("Created by")}}' },
+                        },
+                      },
+                    ],
+                  }) as Record<string, Array<{ options: Record<string, any> }>>
+                )[collectionName] ?? [],
             }),
           },
         }),
@@ -90,7 +108,7 @@ describe('AppendsSelect', () => {
 
     expect(treeSelectState.props?.treeCheckStrictly).toBe(true);
     expect(treeSelectState.props?.showCheckedStrategy).toBe('SHOW_ALL');
-    expect(treeSelectState.props?.value).toEqual([{ value: 'createdBy.role', label: 'createdBy.role' }]);
+    expect(treeSelectState.props?.value).toMatchObject([{ value: 'createdBy.role', label: 'createdBy.role' }]);
 
     const tag = treeSelectState.props?.tagRender?.({
       value: 'createdBy.role',
@@ -115,5 +133,49 @@ describe('AppendsSelect', () => {
 
     treeSelectState.props?.onChange?.([{ value: 'createdBy.role', label: 'createdBy.role' }]);
     expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('continues loading deeper association levels on demand', async () => {
+    render(<AppendsSelect collection="users" value={[]} />);
+
+    await act(async () => {
+      await treeSelectState.props?.loadData?.(
+        treeSelectState.props?.treeData?.find((item) => item.value === 'createdBy'),
+      );
+    });
+
+    await waitFor(() => {
+      expect(treeSelectState.props?.treeData).toEqual(
+        expect.arrayContaining([expect.objectContaining({ value: 'createdBy.createdBy' })]),
+      );
+    });
+
+    await act(async () => {
+      await treeSelectState.props?.loadData?.(
+        treeSelectState.props?.treeData?.find((item) => item.value === 'createdBy.createdBy'),
+      );
+    });
+
+    await waitFor(() => {
+      expect(treeSelectState.props?.treeData).toEqual(
+        expect.arrayContaining([expect.objectContaining({ value: 'createdBy.createdBy.createdBy' })]),
+      );
+    });
+  });
+
+  it('preloads nested value paths so deep selections can be displayed', async () => {
+    render(<AppendsSelect collection="users" value={['createdBy.createdBy.role']} />);
+
+    await waitFor(() => {
+      expect(treeSelectState.props?.value).toMatchObject([{ value: 'createdBy.createdBy.role' }]);
+    });
+
+    const tag = treeSelectState.props?.tagRender?.({
+      value: 'createdBy.createdBy.role',
+      closable: true,
+      onClose: vi.fn(),
+    });
+    const { container } = render(tag);
+    expect(container).toHaveTextContent('Created by / Created by / Role');
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/WorkflowVariableWrapper.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/WorkflowVariableWrapper.test.tsx
@@ -15,7 +15,7 @@ import { WorkflowVariableWrapper } from '../WorkflowVariableWrapper';
 
 const holder = vi.hoisted(() => ({
   selectorProps: null as null | Record<string, unknown>,
-  variableTagProps: null as null | Record<string, unknown>,
+  workflowVariableTagProps: null as null | Record<string, unknown>,
 }));
 
 vi.mock('@nocobase/flow-engine', () => ({
@@ -27,18 +27,22 @@ vi.mock('@nocobase/flow-engine', () => ({
       </button>
     );
   },
-  VariableTag: (props: any) => {
-    holder.variableTagProps = props;
-    return (
-      <button type="button" aria-label="variable-tag" onClick={() => props.onClear?.()}>
-        {props.value}
-      </button>
-    );
-  },
 }));
 
 vi.mock('../../canvas/useWorkflowVariableOptions', () => ({
   useWorkflowVariableOptions: vi.fn(),
+}));
+
+vi.mock('../../canvas/WorkflowVariableTag', () => ({
+  isWorkflowVariableValue: (value: unknown) => typeof value === 'string' && /^\{\{\s*[^{}]+?\s*\}\}$/.test(value),
+  WorkflowVariableTag: (props: any) => {
+    holder.workflowVariableTagProps = props;
+    return (
+      <button type="button" aria-label="workflow-variable-tag" onClick={() => props.onClear?.()}>
+        {props.value}
+      </button>
+    );
+  },
 }));
 
 describe('WorkflowVariableWrapper', () => {
@@ -82,8 +86,8 @@ describe('WorkflowVariableWrapper', () => {
     );
 
     expect(screen.queryByTestId('wrapped-field')).toBeNull();
-    expect(screen.getByRole('button', { name: 'variable-tag' })).toHaveTextContent('{{$context.user.id}}');
-    expect(holder.variableTagProps?.metaTree).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'workflow-variable-tag' })).toHaveTextContent('{{$context.user.id}}');
+    expect(holder.workflowVariableTagProps?.metaTree).toBeTruthy();
   });
 
   it('clears the selected variable back to null by default', async () => {
@@ -101,9 +105,42 @@ describe('WorkflowVariableWrapper', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'variable-tag' }));
+    fireEvent.click(screen.getByRole('button', { name: 'workflow-variable-tag' }));
 
     expect(handleChange).toHaveBeenCalledWith(null);
+  });
+
+  it('re-renders a saved workflow variable through the workflow-aware tag path on reopen', async () => {
+    const { useWorkflowVariableOptions } = await import('../../canvas/useWorkflowVariableOptions');
+    vi.mocked(useWorkflowVariableOptions).mockReturnValue([
+      {
+        name: '$jobsMapByNodeKey',
+        title: 'Node result',
+        type: 'object',
+        paths: ['$jobsMapByNodeKey'],
+        children: [
+          {
+            name: 'jsonCalc',
+            title: 'JSON calc',
+            type: 'object',
+            paths: ['$jobsMapByNodeKey', 'jsonCalc'],
+            children: [{ name: 'id', title: 'ID', type: 'string', paths: ['$jobsMapByNodeKey', 'jsonCalc', 'id'] }],
+          },
+        ],
+      },
+    ] as any);
+
+    render(
+      <WorkflowVariableWrapper
+        value="{{$jobsMapByNodeKey.jsonCalc.id}}"
+        render={() => <div data-testid="wrapped-field" />}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'workflow-variable-tag' })).toHaveTextContent(
+      '{{$jobsMapByNodeKey.jsonCalc.id}}',
+    );
+    expect(holder.workflowVariableTagProps?.metaTree).toBeTruthy();
   });
 
   it('falls back to the wrapped field when the hide-variable context is enabled', async () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AppendsSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AppendsSelect.tsx
@@ -22,7 +22,7 @@ import {
   type CollectionTriggerField,
 } from './utils';
 
-type AppendsTreeNode = {
+type AppendsTreeNode = LegacyDataNode & {
   pId: string | null;
   id: string;
   title: string;
@@ -38,15 +38,6 @@ type AppendsTreeScope = {
   compile: (value: string) => string;
   getCollectionFields: CollectionFieldGetter;
 };
-
-function isAppendsTreeNode(dataNode: LegacyDataNode): dataNode is LegacyDataNode & AppendsTreeNode {
-  return (
-    typeof dataNode?.value === 'string' &&
-    typeof (dataNode as Partial<AppendsTreeNode>)?.id === 'string' &&
-    Array.isArray((dataNode as Partial<AppendsTreeNode>)?.fullTitle) &&
-    typeof (dataNode as Partial<AppendsTreeNode>)?.field?.name === 'string'
-  );
-}
 
 function isAssociation(field: CollectionTriggerField) {
   return isAssociationField(field) && Boolean(field.target) && Boolean(field.interface);
@@ -82,6 +73,7 @@ function getCollectionFieldOptions(
     const isLeaf = !this.getCollectionFields(field.target).filter(isAssociation).length;
 
     return {
+      props: undefined,
       pId: parentNode?.key ?? null,
       id: key,
       key,
@@ -202,10 +194,7 @@ export function AppendsSelect({
   }, [optionsMap, treeData.length, value]);
 
   const loadData = useMemoizedFn(async (dataNode: LegacyDataNode) => {
-    if (!isAppendsTreeNode(dataNode)) {
-      return;
-    }
-    const option = dataNode;
+    const option = dataNode as AppendsTreeNode;
     if (!option.isLeaf && option.loadChildren) {
       const children = option.loadChildren(option);
       setOptionsMap((prev) => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AppendsSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AppendsSelect.tsx
@@ -10,6 +10,7 @@
 import { useFlowEngine } from '@nocobase/flow-engine';
 import { useMemoizedFn } from 'ahooks';
 import { Tag, TreeSelect } from 'antd';
+import type { LegacyDataNode } from 'rc-tree-select/lib/interface';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useT } from '../../locale';
 import {
@@ -37,6 +38,15 @@ type AppendsTreeScope = {
   compile: (value: string) => string;
   getCollectionFields: CollectionFieldGetter;
 };
+
+function isAppendsTreeNode(dataNode: LegacyDataNode): dataNode is LegacyDataNode & AppendsTreeNode {
+  return (
+    typeof dataNode?.value === 'string' &&
+    typeof (dataNode as Partial<AppendsTreeNode>)?.id === 'string' &&
+    Array.isArray((dataNode as Partial<AppendsTreeNode>)?.fullTitle) &&
+    typeof (dataNode as Partial<AppendsTreeNode>)?.field?.name === 'string'
+  );
+}
 
 function isAssociation(field: CollectionTriggerField) {
   return isAssociationField(field) && Boolean(field.target) && Boolean(field.interface);
@@ -104,7 +114,7 @@ export function AppendsSelect({
     () => parseCollectionName(collection) as [string, string],
     [collection],
   );
-  const treeData = useMemo(() => Object.values(optionsMap), [optionsMap]);
+  const treeData = useMemo<AppendsTreeNode[]>(() => Object.values(optionsMap), [optionsMap]);
   const treeValue = useMemo<TreeSelectValue[]>(
     () =>
       (value ?? [])
@@ -135,7 +145,7 @@ export function AppendsSelect({
       return;
     }
 
-    const options = getCollectionFieldOptions.call(
+    const options: AppendsTreeNode[] = getCollectionFieldOptions.call(
       { compile, getCollectionFields: getCollectionFieldsByName },
       collectionName,
     );
@@ -191,7 +201,11 @@ export function AppendsSelect({
     });
   }, [optionsMap, treeData.length, value]);
 
-  const loadData = useMemoizedFn(async (option: AppendsTreeNode) => {
+  const loadData = useMemoizedFn(async (dataNode: LegacyDataNode) => {
+    if (!isAppendsTreeNode(dataNode)) {
+      return;
+    }
+    const option = dataNode;
     if (!option.isLeaf && option.loadChildren) {
       const children = option.loadChildren(option);
       setOptionsMap((prev) => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AppendsSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AppendsSelect.tsx
@@ -10,70 +10,82 @@
 import { useFlowEngine } from '@nocobase/flow-engine';
 import { useMemoizedFn } from 'ahooks';
 import { Tag, TreeSelect } from 'antd';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useT } from '../../locale';
 import {
   getCollectionFields,
   hasFieldName,
   isAssociationField,
+  joinCollectionName,
   parseCollectionName,
   type CollectionTriggerField,
 } from './utils';
 
 type AppendsTreeNode = {
+  pId: string | null;
+  id: string;
   title: string;
   value: string;
   key: string;
+  isLeaf: boolean;
+  field: CollectionTriggerField & { name: string };
   fullTitle: string[];
-  children?: AppendsTreeNode[];
+  loadChildren: ((option: AppendsTreeNode) => AppendsTreeNode[]) | null;
 };
-type CollectionDataSourceManager = Parameters<typeof getCollectionFields>[0];
+type CollectionFieldGetter = (collectionName?: string) => Array<CollectionTriggerField & { name: string }>;
+type AppendsTreeScope = {
+  compile: (value: string) => string;
+  getCollectionFields: CollectionFieldGetter;
+};
 
-function buildAssociationTree(
-  dataSourceManager: CollectionDataSourceManager,
-  compile: (value: string) => string,
-  collectionValue?: string,
-  prefix = '',
-  depth = 2,
-  parentTitles: string[] = [],
+function isAssociation(field: CollectionTriggerField) {
+  return isAssociationField(field) && Boolean(field.target) && Boolean(field.interface);
+}
+
+function getFieldTitle(compile: (value: string) => string, field: CollectionTriggerField & { name: string }) {
+  return field.uiSchema?.title ? compile(field.uiSchema.title) : field.name;
+}
+
+function loadChildren(this: AppendsTreeScope, option: AppendsTreeNode) {
+  const result = getCollectionFieldOptions.call(this, option.field.target, option);
+  if (result.length) {
+    if (!result.some((item) => isAssociation(item.field))) {
+      option.isLeaf = true;
+    }
+  } else {
+    option.isLeaf = true;
+  }
+  return result;
+}
+
+function getCollectionFieldOptions(
+  this: AppendsTreeScope,
+  collectionName?: string,
+  parentNode?: Pick<AppendsTreeNode, 'key' | 'value' | 'fullTitle'>,
 ): AppendsTreeNode[] {
-  const fields = getCollectionFields(dataSourceManager, collectionValue);
-  return fields
-    .filter(hasFieldName)
-    .filter(isAssociationField)
-    .map((field: CollectionTriggerField & { name: string }) => {
-      const value = prefix ? `${prefix}.${field.name}` : field.name;
-      const title = field.uiSchema?.title ? compile(field.uiSchema.title) : field.name;
-      const fullTitle = [...parentTitles, title];
-      const [dataSourceKey] = parseCollectionName(collectionValue) as [string, string];
-      const targetCollection = field.target
-        ? `${dataSourceKey && dataSourceKey !== 'main' ? `${dataSourceKey}:` : ''}${field.target}`
-        : undefined;
-      const children =
-        depth > 1 && targetCollection
-          ? buildAssociationTree(dataSourceManager, compile, targetCollection, value, depth - 1, fullTitle)
-          : [];
-      return {
-        title,
-        value,
-        key: value,
-        fullTitle,
-        children: children.length ? children : undefined,
-      };
-    });
+  const fields = this.getCollectionFields(collectionName);
+  const boundLoadChildren = loadChildren.bind(this);
+
+  return fields.filter(isAssociation).map((field) => {
+    const key = parentNode ? `${parentNode.value ? `${parentNode.value}.` : ''}${field.name}` : field.name;
+    const title = getFieldTitle(this.compile, field);
+    const isLeaf = !this.getCollectionFields(field.target).filter(isAssociation).length;
+
+    return {
+      pId: parentNode?.key ?? null,
+      id: key,
+      key,
+      value: key,
+      title,
+      isLeaf,
+      loadChildren: isLeaf ? null : boundLoadChildren,
+      field,
+      fullTitle: parentNode ? [...parentNode.fullTitle, title] : [title],
+    };
+  });
 }
 
 type TreeSelectValue = { value: string; label?: React.ReactNode };
-
-function flattenTree(treeData: AppendsTreeNode[]): Record<string, AppendsTreeNode> {
-  return treeData.reduce<Record<string, AppendsTreeNode>>((result, node) => {
-    result[node.value] = node;
-    if (node.children?.length) {
-      Object.assign(result, flattenTree(node.children));
-    }
-    return result;
-  }, {});
-}
 
 export function AppendsSelect({
   collection,
@@ -86,15 +98,111 @@ export function AppendsSelect({
 }) {
   const flowEngine = useFlowEngine();
   const t = useT();
-  const treeData = useMemo(
-    () => buildAssociationTree(flowEngine.context.dataSourceManager, t, collection),
-    [flowEngine, t, collection],
+  const compile = useMemoizedFn((text: string) => t(text));
+  const [optionsMap, setOptionsMap] = useState<Record<string, AppendsTreeNode>>({});
+  const [dataSourceKey, collectionName] = useMemo(
+    () => parseCollectionName(collection) as [string, string],
+    [collection],
   );
-  const optionsMap = useMemo(() => flattenTree(treeData), [treeData]);
+  const treeData = useMemo(() => Object.values(optionsMap), [optionsMap]);
   const treeValue = useMemo<TreeSelectValue[]>(
-    () => (value ?? []).map((item) => ({ value: item, label: item })).filter((item) => item.value in optionsMap),
+    () =>
+      (value ?? [])
+        .map((item) => optionsMap[item])
+        .filter(Boolean)
+        .map((item) => ({ value: item.value, label: item.value })),
     [optionsMap, value],
   );
+  const valueKeys = value ?? [];
+
+  const getCollectionFieldsByName = useMemoizedFn((targetCollectionName?: string) => {
+    if (!targetCollectionName) {
+      return [];
+    }
+
+    const resolvedCollection = targetCollectionName.includes(':')
+      ? targetCollectionName
+      : joinCollectionName(dataSourceKey || 'main', targetCollectionName);
+
+    return getCollectionFields(flowEngine.context.dataSourceManager, resolvedCollection).filter(hasFieldName) as Array<
+      CollectionTriggerField & { name: string }
+    >;
+  });
+
+  useEffect(() => {
+    if (!collectionName) {
+      setOptionsMap({});
+      return;
+    }
+
+    const options = getCollectionFieldOptions.call(
+      { compile, getCollectionFields: getCollectionFieldsByName },
+      collectionName,
+    );
+    const nextOptionsMap = options.reduce<Record<string, AppendsTreeNode>>((result, item) => {
+      result[item.value] = item;
+      return result;
+    }, {});
+    setOptionsMap(nextOptionsMap);
+  }, [collectionName, compile, getCollectionFieldsByName]);
+
+  useEffect(() => {
+    const pathsToLoad = value ?? [];
+    if (!pathsToLoad.length || pathsToLoad.every((item) => Boolean(optionsMap[item]))) {
+      return;
+    }
+
+    const loaded: AppendsTreeNode[] = [];
+    pathsToLoad.forEach((item) => {
+      const paths = item.split('.');
+      let option = optionsMap[paths[0]];
+
+      for (let i = 1; i < paths.length; i++) {
+        if (!option) {
+          break;
+        }
+
+        const nextPath = paths.slice(0, i + 1).join('.');
+        if (optionsMap[nextPath]) {
+          option = optionsMap[nextPath];
+          continue;
+        }
+
+        if (!option.isLeaf && option.loadChildren) {
+          const children = option.loadChildren(option);
+          if (children?.length) {
+            loaded.push(...children);
+            option = children.find((child) => child.value === nextPath);
+          }
+        }
+      }
+    });
+
+    if (!loaded.length) {
+      return;
+    }
+
+    setOptionsMap((prev) => {
+      const next = { ...prev };
+      loaded.forEach((item) => {
+        next[item.value] = item;
+      });
+      return next;
+    });
+  }, [optionsMap, treeData.length, value]);
+
+  const loadData = useMemoizedFn(async (option: AppendsTreeNode) => {
+    if (!option.isLeaf && option.loadChildren) {
+      const children = option.loadChildren(option);
+      setOptionsMap((prev) => {
+        const next = { ...prev };
+        children.forEach((item) => {
+          next[item.value] = item;
+        });
+        return next;
+      });
+    }
+  });
 
   const handleChange = useMemoizedFn((next: TreeSelectValue | TreeSelectValue[] | undefined) => {
     const nextItems = Array.isArray(next) ? next : next ? [next] : [];
@@ -139,10 +247,13 @@ export function AppendsSelect({
     <TreeSelect
       treeData={treeData}
       value={treeValue}
+      treeDataSimpleMode
+      loadData={loadData}
       onChange={handleChange}
       treeCheckable
       treeCheckStrictly
       showCheckedStrategy={TreeSelect.SHOW_ALL}
+      treeDefaultExpandedKeys={valueKeys}
       placeholder={t('Preload associations')}
       treeNodeFilterProp="title"
       tagRender={tagRender}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
@@ -23,6 +23,8 @@ export { WorkflowVariableInput } from './canvas/WorkflowVariableInput';
 export type { WorkflowVariableInputProps } from './canvas/WorkflowVariableInput';
 export { WorkflowVariableSelect } from './canvas/WorkflowVariableSelect';
 export type { WorkflowVariableSelectProps } from './canvas/WorkflowVariableSelect';
+export { WorkflowVariableTag } from './canvas/WorkflowVariableTag';
+export type { WorkflowVariableTagProps } from './canvas/WorkflowVariableTag';
 export { WorkflowVariableTextArea } from './canvas/WorkflowVariableTextArea';
 export type { WorkflowVariableTextAreaProps } from './canvas/WorkflowVariableTextArea';
 export { WorkflowVariableJsonTextArea } from './canvas/WorkflowVariableJsonTextArea';

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/index.tsx
@@ -21,6 +21,8 @@ export type { CanvasNode } from './canvas/contexts';
 export { default as useStyles } from './canvas/style';
 export { WorkflowVariableInput } from './canvas/WorkflowVariableInput';
 export type { WorkflowVariableInputProps } from './canvas/WorkflowVariableInput';
+export { WorkflowVariableSelect } from './canvas/WorkflowVariableSelect';
+export type { WorkflowVariableSelectProps } from './canvas/WorkflowVariableSelect';
 export { WorkflowVariableTextArea } from './canvas/WorkflowVariableTextArea';
 export type { WorkflowVariableTextAreaProps } from './canvas/WorkflowVariableTextArea';
 export { WorkflowVariableJsonTextArea } from './canvas/WorkflowVariableJsonTextArea';


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow v2 still had a few regressions after the migration path: preloaded associations stopped expanding recursively, non-variable states could still highlight the variable selector button, and the JSON variable mapping data source field still allowed free typing after selecting a variable.

### Description 
- Restore recursive lazy loading and saved-path preloading for workflow appends selection so deep associations match v1 behavior.
- Keep variable selector highlight state aligned with actual variable values instead of constant or null pseudo-paths.
- Add `WorkflowVariableSelect` as a pure workflow variable picker and switch JSON variable mapping to it so selected values are read-only and clearable.
- Add regression tests for the selector/highlight behaviors and the JSON variable mapping fieldset.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |    |
| 🇨🇳 Chinese |    |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
