### PR TITLE
fix(client-v2): show action title when icon is missing

### DIFF
--- a/packages/core/client-v2/src/flow/models/base/ActionModelCore.tsx
+++ b/packages/core/client-v2/src/flow/models/base/ActionModelCore.tsx
@@ -25,7 +25,7 @@ export function ActionWithoutPermission(props) {
     const dataSourcePrefix = `${t(dataSource.displayName || dataSource.key)} > `;
     const collectionPrefix = collection ? `${t(collection.title) || collection.name || collection.tableName} ` : '';
     return `${dataSourcePrefix}${collectionPrefix}`;
-  }, []);
+  }, [collection, dataSource.displayName, dataSource.key, t]);
   const { actionName } = props?.forbidden || model.forbidden;
   const messageValue = useMemo(() => {
     return t(
@@ -143,10 +143,11 @@ export class ActionModel<T extends DefaultStructure = DefaultStructure> extends 
   renderButton() {
     const { iconOnly, ...props } = this.props;
     const icon = this.getIcon() ? <Icon type={this.getIcon() as any} /> : undefined;
+    const titleContent = iconOnly && icon ? null : props.children || this.getTitle();
 
     return (
       <Button {...props} onClick={this.onClick.bind(this)} icon={icon}>
-        {iconOnly ? null : props.children || this.getTitle()}
+        {titleContent}
       </Button>
     );
   }
@@ -162,11 +163,12 @@ export class ActionModel<T extends DefaultStructure = DefaultStructure> extends 
   renderHiddenInConfig(): React.ReactNode | undefined {
     const { iconOnly, ...props } = this.props;
     const icon = this.getIcon() ? <Icon type={this.getIcon() as any} /> : undefined;
+    const titleContent = iconOnly && icon ? null : props.children || this.getTitle();
     if (this.forbidden) {
       return (
         <ActionWithoutPermission>
           <Button {...props} onClick={this.onClick.bind(this)} icon={icon} style={{ opacity: '0.3' }}>
-            {iconOnly ? null : props.children || this.getTitle()}
+            {titleContent}
           </Button>
         </ActionWithoutPermission>
       );
@@ -174,7 +176,7 @@ export class ActionModel<T extends DefaultStructure = DefaultStructure> extends 
     return (
       <Tooltip title={this.context.t('The button is hidden and only visible when the UI Editor is active')}>
         <Button {...props} onClick={this.onClick.bind(this)} icon={icon} style={{ opacity: '0.3' }}>
-          {iconOnly ? null : props.children || this.getTitle()}
+          {titleContent}
         </Button>
       </Tooltip>
     );

--- a/packages/core/client-v2/src/flow/models/base/__tests__/ActionModelCore.render.test.tsx
+++ b/packages/core/client-v2/src/flow/models/base/__tests__/ActionModelCore.render.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@nocobase/test/client';
+import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
+import { App, ConfigProvider } from 'antd';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { ActionModel } from '../ActionModel';
+
+class NoIconActionModel extends ActionModel {
+  defaultProps = {
+    type: 'link' as const,
+    title: 'Open details',
+  };
+}
+
+describe('ActionModel rendering', () => {
+  it('shows the title when iconOnly is true but no icon is configured', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ NoIconActionModel });
+    const model = engine.createModel<NoIconActionModel>({
+      use: 'NoIconActionModel',
+      props: {
+        title: 'Open details',
+        iconOnly: true,
+      },
+    });
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <App>{model.render()}</App>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Open details' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
On embedded pages rendered in mobile layout, a link action could keep `iconOnly=true` after its icon was removed. The button still existed in the DOM with a title, but had no visible text, so users could not see the "enter details" action.

### Description 
This PR updates the shared v2 action button renderer to hide the title only when `iconOnly=true` and an icon is actually rendered. If an action has no icon, it now falls back to showing the action title. The same fallback is applied to hidden-in-config rendering for consistency.

Risk is low: this only affects the inconsistent state where an action is configured as icon-only without an icon. Existing icon-only actions with icons keep the previous behavior.

Testing suggestions:
- Verify a mobile embedded list page shows link action text when the action has no icon.
- Verify existing icon-only actions with icons still render as icon-only buttons.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed link actions becoming invisible on mobile embedded pages when icon-only mode is enabled but no icon is configured. |
| 🇨🇳 Chinese | 修复移动端嵌入页中操作启用纯图标模式但未配置图标时，链接操作文字不可见的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
