### PR TITLE
fix(client): preserve table datetime display format

### DIFF
--- a/packages/core/client-v2/src/flow/actions/dateTimeFormat.tsx
+++ b/packages/core/client-v2/src/flow/actions/dateTimeFormat.tsx
@@ -28,11 +28,11 @@ const isTableColumnFieldSubModel = (model) => {
 
 const syncTableColumnDateTimeFormatProps = (ctx, props) => {
   const model = ctx.model;
-  if (!isTableColumnFieldSubModel(model) || !model?.parent?.collectionField?.isAssociationField?.()) {
+  if (!isTableColumnFieldSubModel(model)) {
     return;
   }
 
-  model.parent.setProps(props);
+  model.parent?.setProps?.(props);
 };
 
 export const dateTimeFormat = defineAction({

--- a/packages/core/client-v2/src/flow/models/blocks/table/TableColumnModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableColumnModel.tsx
@@ -373,14 +373,18 @@ TableColumnModel.registerFlow({
               currentProps: ctx.model.props,
             })
           : undefined;
+        const collectionFieldComponentProps = collectionField.getComponentProps();
         const componentProps =
           collectionField.isAssociationField() && titleField
             ? {
-                ...collectionField.getComponentProps(),
+                ...collectionFieldComponentProps,
                 ...targetCollectionField?.getComponentProps?.(),
                 ...savedDateTimeDisplayProps,
               }
-            : collectionField.getComponentProps();
+            : {
+                ...collectionFieldComponentProps,
+                ...savedDateTimeDisplayProps,
+              };
         ctx.model.setProps('title', collectionField.title);
         ctx.model.setProps('dataIndex', collectionField.name);
         // for quick edit

--- a/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableColumnModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableColumnModel.test.tsx
@@ -327,6 +327,57 @@ describe('TableColumnModel sorter settings', () => {
     );
   });
 
+  it('keeps saved ordinary datetime format when table column initializes again', async () => {
+    const engine = new FlowEngine();
+    const model = new TableColumnModel({
+      uid: 'table-column-saved-datetime-format',
+      flowEngine: engine,
+    } as any);
+    const initStep = model.getFlow('tableColumnSettings')?.steps?.init as any;
+    const setProps = vi.fn();
+
+    await initStep.handler({
+      model: {
+        context: {
+          collectionField: {
+            title: 'Datetime',
+            name: 'datetime',
+            isAssociationField: () => false,
+            getComponentProps: () => ({
+              dateFormat: 'YYYY-MM-DD',
+              showTime: false,
+            }),
+          },
+        },
+        props: {},
+        subModels: {
+          field: {
+            getStepParams: (flowKey, stepKey) =>
+              flowKey === 'datetimeSettings' && stepKey === 'dateFormat'
+                ? {
+                    picker: 'date',
+                    dateFormat: 'YYYY-MM-DD',
+                    showTime: true,
+                    timeFormat: 'HH:mm:ss',
+                  }
+                : undefined,
+          },
+        },
+        applySubModelsBeforeRenderFlows: vi.fn(),
+        setProps,
+      },
+    });
+
+    expect(setProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dateFormat: 'YYYY-MM-DD',
+        format: 'YYYY-MM-DD HH:mm:ss',
+        showTime: true,
+        timeFormat: 'HH:mm:ss',
+      }),
+    );
+  });
+
   it('does not update field component setting when title field refresh fails', async () => {
     const engine = new FlowEngine();
     const model = new TableColumnModel({ uid: 'table-column-title-field-component-failed', flowEngine: engine } as any);

--- a/packages/core/client-v2/src/flow/utils/__tests__/dateTimeFormat.test.ts
+++ b/packages/core/client-v2/src/flow/utils/__tests__/dateTimeFormat.test.ts
@@ -207,6 +207,48 @@ describe('dateTimeFormat', () => {
     expect(save).toHaveBeenCalled();
   });
 
+  it('syncs ordinary table column props when date time format settings are saved', async () => {
+    const setProps = vi.fn();
+    const save = vi.fn();
+    const setParentProps = vi.fn();
+    const model = {
+      context: {
+        collectionField: {
+          type: 'datetime',
+          interface: 'datetime',
+        },
+      },
+      setProps,
+      save,
+      parent: {
+        use: 'TableColumnModel',
+        setProps: setParentProps,
+      },
+    };
+    model.parent['subModels'] = {
+      field: model,
+    };
+
+    await dateTimeFormat.beforeParamsSave(
+      { model },
+      {
+        picker: 'date',
+        dateFormat: 'YYYY-MM-DD',
+        showTime: true,
+        timeFormat: 'HH:mm:ss',
+      },
+    );
+
+    expect(setParentProps).toHaveBeenCalledWith({
+      picker: 'date',
+      dateFormat: 'YYYY-MM-DD',
+      showTime: true,
+      timeFormat: 'HH:mm:ss',
+      format: 'YYYY-MM-DD HH:mm:ss',
+    });
+    expect(save).toHaveBeenCalled();
+  });
+
   it('hides time format for association title date-only fields', () => {
     const ctx = {
       model: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Table datetime columns could lose their configured display format after pagination, refresh, or quick edit related rerenders. When "Show time" was enabled in Date display format, the table could still fall back to the collection field's default date-only display.

### Description
This PR keeps table datetime display format settings synchronized between the table column model and its field sub-model. It also restores saved datetime display settings when ordinary table columns initialize again, so pagination and data refreshes keep the configured `showTime`, `timeFormat`, and final `format`.

Potential risk is low because the change only applies when the Date display format action is used on a `TableColumnModel` field sub-model, and saved datetime props are only merged when the field model has persisted datetime/time format step params.

Testing suggestions:
- Configure Date display format for a table datetime column with Show time enabled, then paginate or refresh the table.
- Repeat with quick edit enabled on the same column.
- Check association title datetime columns still keep their configured format.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed table datetime columns losing their configured time display after pagination or refresh. |
| 🇨🇳 Chinese | 修复表格日期时间列在分页或刷新后丢失已配置时分秒显示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
