### PR TITLE
fix(plugin-workflow-cc): remove legacy variable

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/UserSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/UserSelect.tsx
@@ -16,12 +16,15 @@ import {
   type MetaTreeNode,
   useFlowContext,
   useResolvedMetaTree,
-  VariableTag,
 } from '@nocobase/flow-engine';
 import { useMemoizedFn } from 'ahooks';
 import { Button, Cascader, Space, theme, Tooltip } from 'antd';
 import React, { useMemo, useState } from 'react';
-import { FilterDynamicComponent, useWorkflowVariableOptions } from '@nocobase/plugin-workflow/client-v2';
+import {
+  FilterDynamicComponent,
+  WorkflowVariableTag,
+  useWorkflowVariableOptions,
+} from '@nocobase/plugin-workflow/client-v2';
 import { useNotificationTranslation } from '../../locale';
 
 type UserOption = { id: number | string; nickname?: string };
@@ -223,7 +226,7 @@ function WorkflowUserVariableInput(props: {
   );
 
   const valueNode = isVariableValue ? (
-    <VariableTag
+    <WorkflowVariableTag
       value={value ?? ''}
       onClear={() => onChange?.('')}
       metaTree={resolvedMetaTree ?? metaTree}

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/__tests__/UserSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/__tests__/UserSelect.test.tsx
@@ -22,8 +22,15 @@ const workflow = vi.hoisted(() => ({
       {JSON.stringify(props.value ?? {})}
     </div>
   )),
+  WorkflowVariableTag: vi.fn(),
   useWorkflowVariableOptions: vi.fn(() => []),
 }));
+
+type TestMetaNode = {
+  name: string;
+  title?: string;
+  children?: TestMetaNode[];
+};
 
 vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -40,7 +47,19 @@ vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   };
 });
 
-vi.mock('@nocobase/plugin-workflow/client-v2', () => workflow);
+vi.mock('@nocobase/plugin-workflow/client-v2', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    FilterDynamicComponent: workflow.FilterDynamicComponent,
+    useWorkflowVariableOptions: workflow.useWorkflowVariableOptions,
+    WorkflowVariableTag: (props: { metaTree?: TestMetaNode[]; onClear?: () => void; value?: string }) => {
+      workflow.WorkflowVariableTag(props);
+      const WorkflowVariableTag = actual.WorkflowVariableTag as React.ComponentType<typeof props>;
+      return <WorkflowVariableTag {...props} />;
+    },
+  };
+});
 
 vi.mock('../../../locale', () => ({
   useNotificationTranslation: () => ({ t: (key: string) => key }),
@@ -270,6 +289,51 @@ describe('UserSelect', () => {
 
     fireEvent.click(screen.getByText('Instance ID'));
     expect(onChange).toHaveBeenLastCalledWith('{{$system.instanceId}}');
+  });
+
+  it('renders selected workflow receiver variables with workflow variable labels', async () => {
+    workflow.useWorkflowVariableOptions.mockReturnValue([
+      {
+        name: '$context',
+        title: 'Trigger variables',
+        type: '',
+        paths: ['$context'],
+        children: [
+          {
+            name: 'data',
+            title: 'Trigger data',
+            type: '',
+            paths: ['$context', 'data'],
+            children: [{ name: 'id', title: 'ID', type: 'string', paths: ['$context', 'data', 'id'] }],
+          },
+        ],
+      },
+    ]);
+    holder.ctx = {
+      api: {
+        resource: () => ({
+          list: vi.fn().mockResolvedValue({ data: { data: [] } }),
+        }),
+      },
+    };
+
+    const onChange = vi.fn();
+    render(<UserSelect value="{{$context.data.id}}" onChange={onChange} />);
+
+    expect(await screen.findByRole('button', { name: 'workflow-variable-tag' })).toHaveTextContent(
+      'Trigger variables / Trigger data / ID',
+    );
+    expect(workflow.WorkflowVariableTag).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: '{{$context.data.id}}',
+        metaTree: expect.any(Array),
+      }),
+    );
+
+    const clearButton = document.querySelector('[aria-label="workflow-variable-tag-clear"]') as HTMLElement;
+    expect(clearButton).toBeInTheDocument();
+    fireEvent.click(clearButton);
+    expect(onChange).toHaveBeenLastCalledWith('');
   });
 
   it('uses the workflow variable-aware filter for query receiver mode', () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/useWorkflowVariableOptions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/useWorkflowVariableOptions.test.tsx
@@ -186,26 +186,36 @@ describe('useWorkflowVariableOptions — runtime-neutral resolution', () => {
     expect(triggerData?.children?.map((child: any) => child.name)).toContain('title');
   });
 
-  it('includes the legacy workflow title context path for saved trigger task titles', () => {
+  it('does not add the legacy workflow title context path to trigger variables', () => {
     setupEngine(makeV1ShapedPlugin());
     holder.currentNode = { key: 'n1', type: 'condition', upstream: null };
-    holder.workflow = { id: 7, type: 'approval', config: {} };
+    holder.workflow = { id: 7, type: 'collection', config: { collection: 'posts' } };
 
     const { result } = renderHook(() => useWorkflowVariableOptions());
     const trigger = result.current.find((n) => n.name === '$context');
     const workflow = trigger?.children?.find((c: any) => c.name === 'workflow');
-    const title = workflow?.children?.find((c: any) => c.name === 'title');
 
     expect(trigger?.title).toBe('Trigger variables');
-    expect(workflow?.title).toBe('Workflow');
-    expect(title?.title).toBe('Workflow title');
-    expect(title?.paths).toEqual(['useFlowContext()', 'workflow', 'title']);
+    expect(trigger?.children?.map((child: any) => child.name)).toEqual(['data']);
+    expect(workflow).toBeUndefined();
   });
 
   it('omits the trigger scope when no workflow is in context (drawer without workflow)', () => {
     setupEngine(makeV1ShapedPlugin());
     holder.currentNode = { key: 'n1', type: 'condition', upstream: null };
     holder.workflow = null;
+
+    const { result } = renderHook(() => useWorkflowVariableOptions());
+    expect(result.current.find((n) => n.name === '$context')).toBeUndefined();
+  });
+
+  it('omits the trigger scope when trigger variables are empty', () => {
+    setupEngine({
+      ...makeV1ShapedPlugin(),
+      triggers: { get: () => ({ useVariables: () => [] }) },
+    });
+    holder.currentNode = { key: 'n1', type: 'condition', upstream: null };
+    holder.workflow = { id: 7, type: 'collection', config: { collection: 'posts' } };
 
     const { result } = renderHook(() => useWorkflowVariableOptions());
     expect(result.current.find((n) => n.name === '$context')).toBeUndefined();

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/useWorkflowVariableOptions.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/useWorkflowVariableOptions.tsx
@@ -25,8 +25,7 @@
  *     read from `getPropertyMetaTree()`. Independent of any node/trigger
  *     migration. Serialized as `{{$env.x.y}}` (no inner spaces, workflow style).
  *   - `$context` (Trigger variables)     — trigger outputs from
- *     `useVariables`, plus the legacy workflow-title context path used by
- *     saved trigger task titles.
+ *     `useVariables`.
  *   - `$system` (System variables)       — **stub**: lit when the v2 plugin
  *     gains a `systemVariables` registry.
  *   - `$scopes` (Scope variables)        — **stub**: lit when branch nodes
@@ -50,7 +49,6 @@ const ENV_ROOT = '$env';
 const SYSTEM_ROOT = '$system';
 const TRIGGER_ROOT = '$context';
 const SCOPES_ROOT = '$scopes';
-const LEGACY_FLOW_CONTEXT_ROOT = 'useFlowContext()';
 
 /**
  * A system variable as held by either runtime's `systemVariables` registry.
@@ -106,8 +104,7 @@ function extractTooltipFromReactNode(node: React.ReactNode): string {
 /**
  * A trigger as held by either runtime's `triggers` registry. v1 stores a
  * `Trigger` instance carrying a `useVariables(config, options)` hook; v2 stores
- * a plain options object with no `useVariables` (so only the workflow-title
- * fallback is available until the trigger variable migration reaches v2).
+ * a plain options object with no `useVariables`.
  */
 type TriggerLike = { useVariables?(config: any, options?: any): any[] | null | undefined };
 
@@ -234,60 +231,15 @@ function useEnvScope(): MetaTreeNode | null {
   return env ?? null;
 }
 
-function createLegacyWorkflowTitleNode(t: (key: string) => string): MetaTreeNode {
-  return {
-    name: 'workflow',
-    title: t('Workflow'),
-    type: '',
-    paths: [LEGACY_FLOW_CONTEXT_ROOT, 'workflow'],
-    children: [
-      {
-        name: 'title',
-        title: t('Workflow title'),
-        type: 'string',
-        paths: [LEGACY_FLOW_CONTEXT_ROOT, 'workflow', 'title'],
-      },
-    ],
-  };
-}
-
-function appendLegacyWorkflowTitleNode(children: MetaTreeNode[], t: (key: string) => string): MetaTreeNode[] {
-  const workflowNode = children.find((node) => node.name === 'workflow');
-  if (!workflowNode) {
-    return [...children, createLegacyWorkflowTitleNode(t)];
-  }
-  const workflowChildren = workflowNode.children;
-  const legacyWorkflowTitleChildren = createLegacyWorkflowTitleNode(t).children;
-  if (!Array.isArray(workflowChildren) || !Array.isArray(legacyWorkflowTitleChildren)) {
-    return children;
-  }
-  const hasTitle = workflowChildren.some((node) => node.name === 'title');
-  if (hasTitle) {
-    return children;
-  }
-  return children.map((node) =>
-    node === workflowNode
-      ? {
-          ...node,
-          children: [...workflowChildren, ...legacyWorkflowTitleChildren],
-        }
-      : node,
-  );
-}
-
 /**
  * "Trigger variables" (`$context`) — the workflow trigger's output. Resolves the
  * current workflow (threaded into the config drawer via `CurrentWorkflowContext`,
  * since the drawer renders at the React root, outside the canvas `FlowContext`),
  * looks up its trigger, and calls the trigger's `useVariables(config, options)`.
- * Also exposes the legacy `useFlowContext().workflow.title` path so saved
- * trigger task titles render as a readable token instead of raw `{{...}}`.
  *
  * Runtime-neutral, mirroring `useNodeResultScope`: a v1 trigger
  * (`PluginWorkflowClient.triggers`) implements `useVariables` so the scope lights
- * up; a v2 trigger may have no `useVariables`, but still gets the workflow-title
- * fallback while a workflow is in context. Returns null when no workflow is in
- * context.
+ * up. Returns null when no workflow is in context.
  */
 function useTriggerScope(options: UseWorkflowVariableOptions): MetaTreeNode | null {
   const flowEngine = useFlowEngine();
@@ -302,7 +254,10 @@ function useTriggerScope(options: UseWorkflowVariableOptions): MetaTreeNode | nu
   const trigger = workflow?.type ? plugin?.triggers?.get(workflow.type) : undefined;
   const subOptions = trigger?.useVariables?.(workflow?.config, options);
   const list = Array.isArray(subOptions) ? subOptions.filter(Boolean) : [];
-  const children = appendLegacyWorkflowTitleNode(adaptVariableOptionsToMetaTree(list, [TRIGGER_ROOT]), t);
+  const children = adaptVariableOptionsToMetaTree(list, [TRIGGER_ROOT]);
+  if (!children.length) {
+    return null;
+  }
   return {
     name: TRIGGER_ROOT,
     title: t('Trigger variables'),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
审批工作流的 CC 节点配置中，变量菜单会显示不应出现的旧版 Workflow 变量；同时 Recipients 已选工作流变量时会直接显示原始表达式，用户难以确认当前选中的变量含义。

### Description
本次移除了工作流变量菜单里旧版 Workflow title 变量的注入逻辑，使 CC 节点里的 Recipients、Query users 条件值和 Task title 变量入口都只展示当前触发器真实提供的变量。

同时，Recipients 已选工作流变量时改用工作流变量标签展示标题链，避免显示原始表达式。若触发器变量经过过滤后没有可用子项，也不会再显示一个可选的空 Trigger variables 根节点。

测试覆盖了变量菜单、已选变量标签展示、CC 节点配置字段以及旧表达式不再可读化展示的相关路径。

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect workflow variables shown in CC configuration |
| 🇨🇳 Chinese | 修复 CC 配置中显示错误工作流变量的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
