### PR TITLE
fix: improve v2 workflow field selection

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/interface.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/interface.tsx
@@ -33,7 +33,7 @@ export class MarkdownVditorFieldInterface extends CollectionFieldInterface {
   group = 'media';
   order = 1;
   title = 'Markdown(Vditor)';
-  sortable = true;
+  sortable = false;
   default = {
     interface: 'vditor',
     type: 'text',

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client-v2/__tests__/AssociatedConfig.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client-v2/__tests__/AssociatedConfig.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
+import type { CascaderProps } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AssociatedConfig } from '../components/AssociatedConfig';
+
+type MockField = {
+  collectionName?: string;
+  dataSourceKey?: string;
+  name: string;
+  primaryKey?: boolean;
+  target?: string;
+  type: string;
+};
+
+type MockOption = {
+  appends?: string[] | null;
+  children?: MockOption[];
+  depth?: number;
+  field?: MockField;
+  isLeaf?: boolean;
+  key: string;
+  label: string;
+  loadChildren?: (option: MockOption) => void;
+  types?: Array<(field: MockField) => boolean>;
+  value: string;
+};
+
+type MockCascaderProps = CascaderProps<MockOption, 'value', false>;
+
+const { cascaderProps, mockWorkflowPlugin } = vi.hoisted(() => {
+  const cascaderProps: { current?: MockCascaderProps } = {};
+
+  const makeFieldOption = (
+    field: MockField,
+    options: {
+      depth?: number;
+      label: string;
+      loadChildren?: (option: MockOption) => void;
+      types?: MockOption['types'];
+    },
+  ): MockOption => ({
+    depth: options.depth,
+    field,
+    isLeaf: !options.loadChildren,
+    key: field.name,
+    label: options.label,
+    loadChildren: options.loadChildren,
+    types: options.types,
+    value: field.name,
+  });
+
+  const filterFieldOptions = (target: MockOption, options: MockOption[]) => {
+    if (!target.types?.length) {
+      return options;
+    }
+
+    return options.filter((option) => {
+      const { field } = option;
+      if (!field) {
+        return false;
+      }
+      return target.types?.some((type) => type(field)) || Boolean(option.loadChildren);
+    });
+  };
+
+  const loadAuthorChildren = (target: MockOption) => {
+    target.children = filterFieldOptions(target, [
+      makeFieldOption(
+        {
+          collectionName: 'users',
+          dataSourceKey: 'main',
+          name: 'tasks',
+          target: 'tasks',
+          type: 'hasMany',
+        },
+        { depth: (target.depth ?? 1) - 1, label: 'Tasks', types: target.types },
+      ),
+      makeFieldOption(
+        {
+          collectionName: 'users',
+          dataSourceKey: 'main',
+          name: 'nickname',
+          type: 'string',
+        },
+        { depth: (target.depth ?? 1) - 1, label: 'Nickname', types: target.types },
+      ),
+    ]);
+  };
+
+  const loadTriggerDataChildren = (target: MockOption) => {
+    target.children = filterFieldOptions(target, [
+      makeFieldOption(
+        {
+          collectionName: 'posts',
+          dataSourceKey: 'main',
+          name: 'comments',
+          target: 'comments',
+          type: 'hasMany',
+        },
+        { depth: (target.depth ?? 1) - 1, label: 'Comments', types: target.types },
+      ),
+      makeFieldOption(
+        {
+          collectionName: 'posts',
+          dataSourceKey: 'main',
+          name: 'author',
+          target: 'users',
+          type: 'belongsTo',
+        },
+        {
+          depth: (target.depth ?? 1) - 1,
+          label: 'Author',
+          loadChildren: loadAuthorChildren,
+          types: target.types,
+        },
+      ),
+      makeFieldOption(
+        {
+          collectionName: 'posts',
+          dataSourceKey: 'main',
+          name: 'title',
+          type: 'string',
+        },
+        { depth: (target.depth ?? 1) - 1, label: 'Title', types: target.types },
+      ),
+    ]);
+  };
+
+  const mockWorkflowPlugin = {
+    instructions: { get: vi.fn() },
+    triggers: {
+      get: vi.fn(() => ({
+        useVariables: vi.fn((_config, options) => [
+          {
+            appends: options?.appends,
+            depth: options?.depth,
+            field: {
+              collectionName: 'posts',
+              dataSourceKey: 'main',
+              name: 'data',
+              target: 'posts',
+              type: 'hasOne',
+            },
+            isLeaf: false,
+            key: 'data',
+            label: 'Trigger data',
+            loadChildren: loadTriggerDataChildren,
+            types: options?.types,
+            value: 'data',
+          },
+        ]),
+      })),
+    },
+  };
+
+  return { cascaderProps, mockWorkflowPlugin };
+});
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+  return {
+    ...actual,
+    Cascader: (props: MockCascaderProps) => {
+      cascaderProps.current = props;
+      return <div data-testid="associated-cascader" />;
+    },
+  };
+});
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const actual = await vi.importActual<typeof import('@nocobase/flow-engine')>('@nocobase/flow-engine');
+  return {
+    ...actual,
+    useFlowEngine: () => ({
+      context: {
+        app: {
+          pm: {
+            get: vi.fn(() => mockWorkflowPlugin),
+          },
+        },
+        dataSourceManager: {},
+        t: (key: string) => key,
+      },
+    }),
+  };
+});
+
+vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
+  getCollection: (_dataSourceManager: unknown, collection: string) => ({
+    fields: [{ name: 'id', primaryKey: true }],
+    name: collection,
+  }),
+  joinCollectionName: (dataSourceKey: string, collectionName: string) =>
+    dataSourceKey === 'main' ? collectionName : `${dataSourceKey}:${collectionName}`,
+  parseCollectionName: (value?: string) => {
+    if (!value) {
+      return [];
+    }
+    const parts = value.split(':');
+    const collectionName = parts.pop();
+    return [parts[0] ?? 'main', collectionName];
+  },
+  useAvailableUpstreams: () => [],
+  useCurrentWorkflowContext: () => ({ config: { collection: 'posts' }, type: 'collection' }),
+  useNodeContext: () => ({ id: 1 }),
+}));
+
+function renderWithForm(initialValues: unknown) {
+  let formRef: ReturnType<typeof Form.useForm>[0] | undefined;
+
+  function Wrapper() {
+    const [form] = Form.useForm();
+    formRef = form;
+    return (
+      <Form form={form} initialValues={initialValues}>
+        <Form.Item name={['config', 'association']}>
+          <AssociatedConfig />
+        </Form.Item>
+      </Form>
+    );
+  }
+
+  render(<Wrapper />);
+  return () => formRef;
+}
+
+async function loadChildren(path: MockOption[]) {
+  await act(async () => {
+    await cascaderProps.current?.loadData?.(path);
+  });
+}
+
+function getCascaderOptions() {
+  const options = cascaderProps.current?.options as MockOption[] | undefined;
+  expect(options).toBeTruthy();
+  return options ?? [];
+}
+
+function getTriggerOptions() {
+  const triggerRoot = getCascaderOptions()[1];
+  expect(triggerRoot).toBeTruthy();
+  const triggerData = triggerRoot?.children?.[0];
+  expect(triggerData).toBeTruthy();
+  return { triggerRoot, triggerData, triggerDataOptions: triggerData?.children ?? [] };
+}
+
+function findOption(options: MockOption[], value: string) {
+  const option = options.find((item) => item.value === value);
+  expect(option).toBeTruthy();
+  return option as MockOption;
+}
+
+describe('AssociatedConfig', () => {
+  beforeEach(() => {
+    cascaderProps.current = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('keeps only to-many relation fields and branches that can reach to-many relation fields', async () => {
+    renderWithForm({ config: { association: null } });
+
+    await waitFor(() => {
+      expect(cascaderProps.current?.options).toBeTruthy();
+    });
+
+    const { triggerRoot, triggerData } = getTriggerOptions();
+
+    await loadChildren([triggerRoot, triggerData]);
+
+    const { triggerDataOptions } = getTriggerOptions();
+    expect(triggerDataOptions.map((option) => option.value)).toEqual(['comments', 'author']);
+
+    const author = findOption(triggerDataOptions, 'author');
+    await loadChildren([triggerRoot, triggerData, author]);
+
+    const authorOptions = findOption(getTriggerOptions().triggerDataOptions, 'author').children ?? [];
+    expect(authorOptions.map((option) => option.value)).toEqual(['tasks']);
+  });
+
+  it('resets aggregate field and filter when selecting or clearing an associated collection', async () => {
+    const getForm = renderWithForm({
+      config: {
+        association: null,
+        collection: 'posts',
+        params: {
+          field: 'amount',
+          filter: { amount: { $gt: 1 } },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(cascaderProps.current?.options).toBeTruthy();
+    });
+
+    const { triggerRoot, triggerData } = getTriggerOptions();
+    await loadChildren([triggerRoot, triggerData]);
+    const comments = findOption(getTriggerOptions().triggerDataOptions, 'comments');
+
+    act(() => {
+      cascaderProps.current?.onChange?.(
+        [triggerRoot.value, triggerData.value, comments.value],
+        [triggerRoot, triggerData, comments],
+      );
+    });
+
+    await waitFor(() => {
+      expect(getForm()?.getFieldValue(['config', 'collection'])).toBe('comments');
+      expect(getForm()?.getFieldValue(['config', 'association'])).toEqual({
+        associatedCollection: 'posts',
+        associatedKey: '{{$context.data.id}}',
+        name: 'comments',
+      });
+      expect(getForm()?.getFieldValue(['config', 'params', 'field'])).toBeNull();
+      expect(getForm()?.getFieldValue(['config', 'params', 'filter'])).toBeNull();
+    });
+
+    getForm()?.setFieldValue(['config', 'params'], {
+      field: 'amount',
+      filter: { amount: { $gt: 1 } },
+    });
+
+    act(() => {
+      cascaderProps.current?.onChange?.([], []);
+    });
+
+    await waitFor(() => {
+      expect(getForm()?.getFieldValue(['config', 'collection'])).toBeNull();
+      expect(getForm()?.getFieldValue(['config', 'association'])).toEqual({});
+      expect(getForm()?.getFieldValue(['config', 'params', 'field'])).toBeNull();
+      expect(getForm()?.getFieldValue(['config', 'params', 'filter'])).toBeNull();
+    });
+  });
+
+  it('keeps intermediate relation navigation local until a to-many relation is selected', async () => {
+    const getForm = renderWithForm({
+      config: {
+        association: {
+          associatedCollection: 'posts',
+          associatedKey: '{{$context.data.id}}',
+          name: 'comments',
+        },
+        collection: 'comments',
+      },
+    });
+
+    await waitFor(() => {
+      expect(cascaderProps.current?.options).toBeTruthy();
+    });
+
+    const { triggerRoot, triggerData } = getTriggerOptions();
+    await loadChildren([triggerRoot, triggerData]);
+    const author = findOption(getTriggerOptions().triggerDataOptions, 'author');
+
+    act(() => {
+      cascaderProps.current?.onChange?.(
+        [triggerRoot.value, triggerData.value, author.value],
+        [triggerRoot, triggerData, author],
+      );
+    });
+
+    await waitFor(() => {
+      expect(cascaderProps.current?.value).toEqual([triggerRoot.value, triggerData.value, author.value]);
+      expect(getForm()?.getFieldValue(['config', 'collection'])).toBe('comments');
+      expect(getForm()?.getFieldValue(['config', 'association'])).toEqual({
+        associatedCollection: 'posts',
+        associatedKey: '{{$context.data.id}}',
+        name: 'comments',
+      });
+    });
+
+    act(() => {
+      cascaderProps.current?.onDropdownVisibleChange?.(false);
+    });
+
+    await waitFor(() => {
+      expect(cascaderProps.current?.value).toEqual([triggerRoot.value, triggerData.value, 'comments']);
+    });
+  });
+
+  it('clears existing associated values that resolve to a non-to-many relation field', async () => {
+    const getForm = renderWithForm({
+      config: {
+        association: {
+          associatedCollection: 'posts',
+          associatedKey: '{{$context.data.id}}',
+          name: 'author',
+        },
+        collection: 'users',
+        params: {
+          field: 'score',
+          filter: { score: { $gt: 1 } },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(getForm()?.getFieldValue(['config', 'collection'])).toBeNull();
+      expect(getForm()?.getFieldValue(['config', 'association'])).toEqual({});
+      expect(getForm()?.getFieldValue(['config', 'params', 'field'])).toBeNull();
+      expect(getForm()?.getFieldValue(['config', 'params', 'filter'])).toBeNull();
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client-v2/components/AssociatedConfig.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-aggregate/src/client-v2/components/AssociatedConfig.tsx
@@ -45,13 +45,16 @@ type WorkflowPluginLike = {
 };
 
 type AssociatedCascaderOption = {
+  appends?: string[] | null;
+  depth?: number;
   key?: string;
   value: string;
   label?: React.ReactNode;
   disabled?: boolean;
   isLeaf?: boolean;
   field?: FieldWithDataSource;
-  loadChildren?: (option: AssociatedCascaderOption) => Promise<void> | void;
+  loadChildren?: ((option: AssociatedCascaderOption) => Promise<void> | void) | null;
+  types?: UseVariableOptions['types'];
   children?: AssociatedCascaderOption[];
 };
 
@@ -107,6 +110,8 @@ function toCascaderOption(
       : undefined;
 
   return {
+    appends: option.appends as string[] | null | undefined,
+    depth: option.depth as number | undefined,
     key: option.key,
     value: getOptionValue(option),
     label: compileLabel(option.label, compile),
@@ -114,6 +119,7 @@ function toCascaderOption(
     isLeaf: Boolean(option.isLeaf),
     field,
     loadChildren,
+    types: option.types as UseVariableOptions['types'] | undefined,
     children: Array.isArray(option.children)
       ? option.children.map((child) => toCascaderOption(child, compile, nextFallbackDataSourceKey))
       : undefined,
@@ -203,9 +209,24 @@ async function loadOptionChildren(option: AssociatedCascaderOption) {
   }
 }
 
+function clearAggregateParams(form: ReturnType<typeof Form.useFormInstance>) {
+  form.setFieldValue(['config', 'params', 'field'], null);
+  form.setFieldValue(['config', 'params', 'filter'], null);
+}
+
+function clearAssociatedSelection(
+  form: ReturnType<typeof Form.useFormInstance>,
+  onChange?: (value: AggregateAssociationConfig) => void,
+) {
+  form.setFieldValue(['config', 'collection'], null);
+  clearAggregateParams(form);
+  onChange?.({});
+}
+
 export function AssociatedConfig({
   value,
   onChange,
+  onDropdownVisibleChange,
   ...props
 }: Omit<
   CascaderProps<AssociatedCascaderOption, 'value', false>,
@@ -221,11 +242,17 @@ export function AssociatedConfig({
   const [options, setOptions] = useState(baseOptions);
   const selectedPath = getAssociatedPath(value);
   const selectedPathSignature = selectedPath.join('.');
+  const [activePath, setActivePath] = useState<string[]>(selectedPath);
 
   useEffect(() => {
     setOptions(baseOptions);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset when the selectable variable tree changes.
   }, [baseOptionsSignature]);
+
+  useEffect(() => {
+    setActivePath(selectedPath);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedPathSignature is the stable value identity.
+  }, [selectedPathSignature]);
 
   useEffect(() => {
     let cancelled = false;
@@ -237,18 +264,27 @@ export function AssociatedConfig({
 
       let currentOptions = options;
       let currentOption: AssociatedCascaderOption | undefined;
+      let resolved = true;
       for (const key of selectedPath) {
         currentOption = currentOptions.find((option) => option.value === key);
         if (!currentOption) {
+          resolved = false;
           break;
         }
         await loadOptionChildren(currentOption);
         currentOptions = currentOption.children ?? [];
       }
 
-      if (!cancelled) {
-        setOptions([...options]);
+      if (cancelled) {
+        return;
       }
+
+      if (resolved && currentOption?.field && !matchToManyField(currentOption.field)) {
+        clearAssociatedSelection(form, onChange);
+        return;
+      }
+
+      setOptions([...options]);
     };
 
     loadSelectedPath();
@@ -261,7 +297,7 @@ export function AssociatedConfig({
   return (
     <Cascader
       {...props}
-      value={selectedPath}
+      value={activePath}
       options={options}
       changeOnSelect
       loadData={async (selectedOptions) => {
@@ -272,10 +308,16 @@ export function AssociatedConfig({
         await loadOptionChildren(option);
         setOptions([...options]);
       }}
+      onDropdownVisibleChange={(open) => {
+        if (!open) {
+          setActivePath(selectedPath);
+        }
+        onDropdownVisibleChange?.(open);
+      }}
       onChange={(path, selectedOptions) => {
+        setActivePath(path as string[]);
         if (!path?.length) {
-          form.setFieldValue(['config', 'collection'], null);
-          onChange?.({});
+          clearAssociatedSelection(form, onChange);
           return;
         }
 
@@ -294,6 +336,7 @@ export function AssociatedConfig({
         );
 
         form.setFieldValue(['config', 'collection'], joinCollectionName(dataSourceKey, field.target));
+        clearAggregateParams(form);
         onChange?.({
           name: field.name,
           associatedKey: `{{${path.slice(0, -1).join('.')}.${primaryKeyName}}}`,

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
@@ -16,11 +16,18 @@ import { Button, Dropdown, Empty, Form } from 'antd';
 import type { MenuProps } from 'antd';
 import { useWorkflowVariableOptions } from '../../canvas/useWorkflowVariableOptions';
 import { useT } from '../../locale';
-import { getCollection, getCollectionFields, hasFieldName, parseCollectionName } from './utils';
+import {
+  getCollection,
+  getCollectionFields,
+  hasFieldName,
+  parseCollectionName,
+  type CollectionTriggerField,
+} from './utils';
 
 type AssignedValues = Record<string, unknown>;
 type AssignedField = ReturnType<typeof getCollectionFields>[number] & { name: string };
 type WorkflowVariableTree = ReturnType<typeof useWorkflowVariableOptions>;
+export type AssignedFieldFilter = (field: AssignedField) => boolean;
 
 const fieldItemClassName = css`
   position: relative;
@@ -81,26 +88,35 @@ function getFieldTitle(field: AssignedField, t: (key: string) => string) {
   return t(field.uiSchema?.title ?? field.name);
 }
 
+function defaultFieldFilter(_field: CollectionTriggerField) {
+  return true;
+}
+
 export function AssignedFieldsEditor({
   collection,
   value,
   onChange,
+  fieldFilter = defaultFieldFilter,
+  pruneFilteredValues,
 }: {
   collection?: string;
   value?: AssignedValues;
   onChange?: (value: AssignedValues) => void;
+  fieldFilter?: AssignedFieldFilter;
+  pruneFilteredValues?: boolean;
 }) {
   const flowEngine = useFlowEngine();
   const t = useT();
   const workflowVariableTree = useWorkflowVariableOptions();
   const contextModel = useCollectionContextModel(collection, workflowVariableTree);
-  const fields = useMemo(
+  const allFields = useMemo(
     () =>
       getCollectionFields(flowEngine.context.dataSourceManager, collection)
         .filter(hasFieldName)
         .filter((field) => !field.hidden && Boolean(field.uiSchema)) as AssignedField[],
     [collection, flowEngine],
   );
+  const fields = useMemo(() => allFields.filter(fieldFilter), [allFields, fieldFilter]);
   const normalizedValue = useMemo(() => normalizeAssignedValues(value), [value]);
   const assignedFields = useMemo(() => {
     const fieldsByName = new Map(fields.map((field) => [field.name, field]));
@@ -112,6 +128,21 @@ export function AssignedFieldsEditor({
     () => fields.filter((field) => !Object.prototype.hasOwnProperty.call(normalizedValue, field.name)),
     [fields, normalizedValue],
   );
+
+  useEffect(() => {
+    if (!pruneFilteredValues) {
+      return;
+    }
+
+    const fieldNames = new Set(fields.map((field) => field.name));
+    const entries = Object.entries(normalizedValue);
+    const nextEntries = entries.filter(([fieldName]) => fieldNames.has(fieldName));
+    if (nextEntries.length === entries.length) {
+      return;
+    }
+
+    onChange?.(Object.fromEntries(nextEntries));
+  }, [fields, normalizedValue, onChange, pruneFilteredValues]);
 
   const updateValue = (fieldName: string, nextValue: unknown) => {
     onChange?.({ ...normalizedValue, [fieldName]: nextValue === undefined ? '' : nextValue });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
@@ -19,8 +19,10 @@ const { collection, createModel, mockFieldAssignValueInput, mockFlowEngine, work
     dataSourceKey: 'main',
     getField: vi.fn((name: string) => collection.getFields().find((field) => field.name === name)),
     getFields: vi.fn(() => [
-      { name: 'title', uiSchema: { title: 'Title' }, interface: 'input' },
-      { name: 'status', uiSchema: { title: 'Status' }, interface: 'select' },
+      { name: 'title', type: 'string', uiSchema: { title: 'Title' }, interface: 'input' },
+      { name: 'status', type: 'string', uiSchema: { title: 'Status' }, interface: 'select' },
+      { name: 'author', type: 'belongsTo', uiSchema: { title: 'Author' }, interface: 'm2o' },
+      { name: 'comments', type: 'hasMany', uiSchema: { title: 'Comments' }, interface: 'o2m' },
     ]),
   };
   const createModel = vi.fn((options) => ({
@@ -127,5 +129,27 @@ describe('AssignedFieldsEditor', () => {
 
     expect(onChange).toHaveBeenLastCalledWith({ title: 'old', status: '' });
     expect(collection.getFields).toHaveBeenCalled();
+  });
+
+  it('filters selectable fields and prunes filtered assigned values', async () => {
+    const onChange = vi.fn();
+
+    render(
+      <AssignedFieldsEditor
+        collection="posts"
+        value={{ title: 'old', comments: [1] }}
+        onChange={onChange}
+        fieldFilter={(field) => field.type !== 'hasMany'}
+        pruneFilteredValues
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ title: 'old' });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    expect(await screen.findByText('Status')).toBeTruthy();
+    expect(screen.queryByText('Comments')).toBeNull();
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/updateFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/updateFieldset.test.tsx
@@ -19,7 +19,11 @@ vi.mock('../../locale', () => ({
   useT: () => (key: string) => key,
 }));
 
+type MockAssignedField = { name: string; type?: string };
+
 vi.mock('../../components/collection', () => ({
+  isAssociationField: (field: MockAssignedField) =>
+    ['belongsTo', 'hasOne', 'hasMany', 'belongsToMany', 'belongsToArray'].includes(field.type ?? ''),
   CollectionCascader: ({
     value,
     onChange,
@@ -40,9 +44,34 @@ vi.mock('../../components/collection', () => ({
       <option value="comments">Comments</option>
     </select>
   ),
-  AssignedFieldsEditor: ({ collection }: { collection?: string }) => (
-    <div data-testid="assigned-fields" data-collection={collection ?? ''} />
-  ),
+  AssignedFieldsEditor: ({
+    collection,
+    fieldFilter,
+    pruneFilteredValues,
+  }: {
+    collection?: string;
+    fieldFilter?: (field: MockAssignedField) => boolean;
+    pruneFilteredValues?: boolean;
+  }) => {
+    const fields: MockAssignedField[] = [
+      { name: 'title', type: 'string' },
+      { name: 'author', type: 'belongsTo' },
+      { name: 'comments', type: 'hasMany' },
+      { name: 'tags', type: 'belongsToMany' },
+    ];
+
+    return (
+      <div
+        data-testid="assigned-fields"
+        data-collection={collection ?? ''}
+        data-fields={fields
+          .filter((field) => fieldFilter?.(field) ?? true)
+          .map((field) => field.name)
+          .join(',')}
+        data-prune-filtered-values={String(Boolean(pruneFilteredValues))}
+      />
+    );
+  },
 }));
 
 vi.mock('../../components/FilterDynamicComponent', () => ({
@@ -141,6 +170,40 @@ describe('UpdateFieldset', () => {
       expect(getForm()?.getFieldValue(['config', 'params', 'values'])).toEqual({});
       expect(getForm()?.getFieldValue(['config', 'usingAssignFormSchema'])).toBeUndefined();
       expect(getForm()?.getFieldValue(['config', 'assignFormSchema'])).toBeUndefined();
+    });
+  });
+
+  it('limits batch update assigned fields to non-association and belongsTo fields', async () => {
+    renderWithForm(
+      { id: 1, config: { collection: 'posts' } },
+      {
+        config: {
+          collection: 'posts',
+          params: { individualHooks: false, values: {} },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-fields', 'title,author');
+      expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-prune-filtered-values', 'true');
+    });
+  });
+
+  it('allows all assigned fields when updating one by one', async () => {
+    renderWithForm(
+      { id: 1, config: { collection: 'posts' } },
+      {
+        config: {
+          collection: 'posts',
+          params: { individualHooks: true, values: {} },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-fields', 'title,author,comments,tags');
+      expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-prune-filtered-values', 'false');
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/update.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/update.tsx
@@ -10,11 +10,13 @@
 import React, { useEffect } from 'react';
 import { Form } from 'antd';
 import { useNodeContext } from '../../canvas/contexts';
-import { AssignedFieldsEditor } from '../../components/collection';
+import { AssignedFieldsEditor, isAssociationField, type AssignedFieldFilter } from '../../components/collection';
 import { RadioWithTooltip, type RadioWithTooltipOption } from '../../components/RadioWithTooltip';
 import { useT } from '../../locale';
 import { NodeCollectionField } from './collection';
 import { NodeFilterField } from './filter';
+
+const batchUpdateFieldFilter: AssignedFieldFilter = (field) => !isAssociationField(field) || field.type === 'belongsTo';
 
 function useUpdateModeOptions(): RadioWithTooltipOption[] {
   const t = useT();
@@ -41,7 +43,9 @@ function UpdateFields() {
   const t = useT();
   const form = Form.useFormInstance();
   const collection = Form.useWatch(['config', 'collection']);
+  const individualHooks = Form.useWatch(['config', 'params', 'individualHooks'], form);
   const updateModeOptions = useUpdateModeOptions();
+  const isBatchUpdateMode = individualHooks !== true;
 
   useEffect(() => {
     if (!collection) {
@@ -67,7 +71,11 @@ function UpdateFields() {
       <NodeFilterField collection={collection} label={t('Only update records matching conditions')} />
 
       <Form.Item name={['config', 'params', 'values']} label={t('Fields values')}>
-        <AssignedFieldsEditor collection={collection} />
+        <AssignedFieldsEditor
+          collection={collection}
+          fieldFilter={isBatchUpdateMode ? batchUpdateFieldFilter : undefined}
+          pruneFilteredValues={isBatchUpdateMode}
+        />
       </Form.Item>
     </>
   );


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Improve v2 workflow field selection behavior and keep migrated workflow configuration consistent with legacy expectations.

### Description
This PR updates several v2 workflow field selectors:

- Disable sorting for vditor fields.
- In update nodes, batch update mode now restricts relation field selection to `belongsTo` relations.
- In aggregate query nodes, associated collection mode now only allows to-many relation fields, while still allowing intermediate relation branches that can reach to-many fields.
- Fix the associated collection Cascader state so browsing intermediate branches does not overwrite the saved association until a valid to-many relation is selected.
- Reset aggregate field and filter values when the associated collection target changes.
- Add tests for associated collection filtering, selection reset, intermediate navigation, and invalid legacy association cleanup.

Potential risk: existing aggregate query node configurations that point to a non-to-many associated field are cleared by the v2 UI after the path resolves, which matches the new selection rule.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved v2 workflow field selection for update and aggregate query nodes, including safer associated collection selection in aggregate query nodes. |
| 🇨🇳 Chinese | 优化 v2 工作流更新节点和聚合查询节点的字段选择逻辑，并修复聚合查询节点关联数据表选择的切换异常。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
