### PR TITLE
fix(data-source-manager): respect non-deletable v2 template fields

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldForm.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldForm.tsx
@@ -66,6 +66,7 @@ interface FieldFormProps {
   collection: Record<string, any>;
   interfaceName?: string;
   field?: Record<string, any>;
+  override?: boolean;
   onSubmitted: () => void;
 }
 
@@ -1811,9 +1812,11 @@ export function FieldForm(props: FieldFormProps) {
       createMainOnly: props.mode === 'create' && props.dataSourceKey === 'main',
       disabledJSONB: props.mode === 'edit',
       isDialect: (dialect: string) => databaseDialect === dialect,
+      isOverride: !!props.override,
+      override: !!props.override,
       primaryKeyOnly: false,
     }),
-    [databaseDialect, props.dataSourceKey, props.mode],
+    [databaseDialect, props.dataSourceKey, props.mode, props.override],
   );
   const previousWatchedValuesRef = useRef<Record<string, any>>();
   const pendingInitialValuesRef = useRef<Record<string, any>>();
@@ -2047,7 +2050,9 @@ export function FieldForm(props: FieldFormProps) {
   ]);
 
   const collectionTitle = compileLegacyTemplateText(get(props.collection, 'title') || props.collection.name, t);
-  const title = `${collectionTitle} - ${props.mode === 'create' ? t('Add field') : t('Edit field')}`;
+  const title = `${collectionTitle} - ${
+    props.override ? t('Override field') : props.mode === 'create' ? t('Add field') : t('Edit field')
+  }`;
   const existingFieldNames = new Set((props.collection.fields || []).map((field: Record<string, any>) => field.name));
 
   return (
@@ -2102,7 +2107,10 @@ export function FieldForm(props: FieldFormProps) {
           ]}
           extra={t(fieldNameDescription)}
         >
-          <Input autoComplete="off" disabled={props.mode === 'edit' || interfaceName === 'tableoid'} />
+          <Input
+            autoComplete="off"
+            disabled={props.mode === 'edit' || props.override || interfaceName === 'tableoid'}
+          />
         </Form.Item>
         <FieldConfigureItemsRenderer
           items={mainConfigureItems}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -1307,6 +1307,16 @@ export default function FieldsPage(props: FieldsPageProps) {
     [ctx, message, notification, props, t],
   );
 
+  const syncFieldsVisible = isSyncFieldsVisible(props.dataSourceKey, props.collection, ctx);
+  const configureFieldsDisabled = Boolean(dataSourceType?.disableConfigureFields);
+  const fieldDeletionVisible = isMainDataSource && !configureFieldsDisabled;
+  const addFieldVisible = isAddFieldVisible({
+    collection: props.collection,
+    ctx,
+    dataSourceType: dataSource?.options?.type,
+    fieldInterfaceGroups,
+  });
+
   const inheritedFieldColumns = useMemo<ColumnsType<Record<string, any>>>(
     () => [
       {
@@ -1434,16 +1444,6 @@ export default function FieldsPage(props: FieldsPageProps) {
     TemplateSyncFieldsDrawer,
     t,
   ]);
-
-  const syncFieldsVisible = isSyncFieldsVisible(props.dataSourceKey, props.collection, ctx);
-  const configureFieldsDisabled = Boolean(dataSourceType?.disableConfigureFields);
-  const fieldDeletionVisible = isMainDataSource && !configureFieldsDisabled;
-  const addFieldVisible = isAddFieldVisible({
-    collection: props.collection,
-    ctx,
-    dataSourceType: dataSource?.options?.type,
-    fieldInterfaceGroups,
-  });
 
   useEffect(() => {
     if (!fieldDeletionVisible) {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -26,6 +26,7 @@ import {
   Table as AntdTable,
   Tag,
   Tooltip,
+  Typography,
 } from 'antd';
 import type { MenuProps } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -386,6 +387,20 @@ function isSyncFieldsVisible(dataSourceKey: string, collection: Record<string, a
   }
 
   return dataSourceKey === 'main';
+}
+
+function getCollectionTemplateFields(collectionTemplate?: Record<string, any>) {
+  const fields = collectionTemplate?.collection?.fields;
+  return typeof fields === 'function' ? fields() : Array.isArray(fields) ? fields : [];
+}
+
+export function isFieldDeleteDisabled(record: Record<string, any>, collectionTemplate?: Record<string, any>) {
+  if (record.deletable === false) {
+    return true;
+  }
+  return getCollectionTemplateFields(collectionTemplate).some(
+    (field: Record<string, any>) => field?.name === record.name && field.deletable === false,
+  );
 }
 
 function isAddFieldVisible(options: {
@@ -926,6 +941,10 @@ export default function FieldsPage(props: FieldsPageProps) {
     }, {});
   }, [databaseDialect, ctx, dataSource?.options?.type, props.collection]);
   const presetFieldInterfaces = useMemo(() => getCollectionPresetFieldInterfaces(ctx), [ctx]);
+  const collectionTemplate = useMemo(() => getCollectionTemplate(ctx, props.collection), [ctx, props.collection]);
+  const currentFieldsByName = useMemo(() => {
+    return new Map((request.data || []).map((field: Record<string, any>) => [String(field.name), field]));
+  }, [request.data]);
 
   const openFieldForm = useCallback(
     (mode: 'create' | 'edit', field?: Record<string, any>, interfaceName?: string) => {
@@ -967,7 +986,6 @@ export default function FieldsPage(props: FieldsPageProps) {
     [fieldInterfaceGroups, openFieldForm, t],
   );
 
-  const collectionTemplate = useMemo(() => getCollectionTemplate(ctx, props.collection), [ctx, props.collection]);
   const TemplateSyncFieldsDrawer = collectionTemplate?.configure?.syncFields?.Component;
 
   const openTemplateSyncFieldsDrawer = useCallback(() => {
@@ -1009,12 +1027,18 @@ export default function FieldsPage(props: FieldsPageProps) {
 
   const handleDelete = useCallback(
     (filterByTk: React.Key | React.Key[]) => {
+      const keys = (Array.isArray(filterByTk) ? filterByTk : [filterByTk]).filter((key) => {
+        const record = currentFieldsByName.get(String(key));
+        return record && !isFieldDeleteDisabled(record, collectionTemplate);
+      });
+      if (!keys.length) {
+        return;
+      }
       modal.confirm({
         title: t('Delete record'),
         content: t('Are you sure you want to delete it?'),
         async onOk() {
           try {
-            const keys = Array.isArray(filterByTk) ? filterByTk : [filterByTk];
             await Promise.all(
               keys.map((key) =>
                 ctx.api.request({
@@ -1035,7 +1059,18 @@ export default function FieldsPage(props: FieldsPageProps) {
         },
       });
     },
-    [ctx.api, ctx.dataSourceManager, modal, notification, props.collection.name, props.dataSourceKey, request, t],
+    [
+      collectionTemplate,
+      ctx.api,
+      ctx.dataSourceManager,
+      currentFieldsByName,
+      modal,
+      notification,
+      props.collection.name,
+      props.dataSourceKey,
+      request,
+      t,
+    ],
   );
 
   const handleFieldInterfaceChange = useCallback(
@@ -1292,7 +1327,14 @@ export default function FieldsPage(props: FieldsPageProps) {
         render: (_, record) => (
           <Space>
             <a onClick={() => openFieldForm('edit', record)}>{t('Edit')}</a>
-            {fieldDeletionVisible ? <a onClick={() => handleDelete(record.name)}>{t('Delete')}</a> : null}
+            {fieldDeletionVisible ? (
+              <Typography.Link
+                disabled={isFieldDeleteDisabled(record, collectionTemplate)}
+                onClick={() => handleDelete(record.name)}
+              >
+                {t('Delete')}
+              </Typography.Link>
+            ) : null}
           </Space>
         ),
       });
@@ -1303,6 +1345,7 @@ export default function FieldsPage(props: FieldsPageProps) {
     allFieldInterfaceGroups,
     configureFieldsDisabled,
     fieldDeletionVisible,
+    collectionTemplate,
     ctx.dataSourceManager,
     dataSourceType,
     fieldInterfacesByName,
@@ -1357,6 +1400,9 @@ export default function FieldsPage(props: FieldsPageProps) {
             ? {
                 selectedRowKeys,
                 onChange: setSelectedRowKeys,
+                getCheckboxProps: (record) => ({
+                  disabled: isFieldDeleteDisabled(record, collectionTemplate),
+                }),
               }
             : undefined
         }

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -16,6 +16,7 @@ import {
   App,
   Button,
   Cascader,
+  Descriptions,
   Dropdown,
   Form,
   Input,
@@ -76,6 +77,13 @@ type ViewFieldRecord = {
   type?: string;
   uiSchema?: Record<string, any>;
   [key: string]: any;
+};
+
+type InheritedFieldGroup = {
+  collectionName: string;
+  fields: Record<string, any>[];
+  key: string;
+  title?: React.ReactNode;
 };
 
 type ViewFieldsResponse = {
@@ -294,6 +302,30 @@ function EditableFieldDisplayNameCell(props: {
   );
 }
 
+function InheritedFieldDetails(props: { field: Record<string, any>; fieldInterface?: FieldInterfaceOption }) {
+  const t = useT();
+  const field = props.field;
+  const fieldInterfaceTitle = getFieldInterfaceLabel(props.fieldInterface, field.interface);
+
+  return (
+    <Descriptions column={1} bordered size="small">
+      <Descriptions.Item label={t('Field display name')}>
+        {compileLegacyTemplate(getEditableFieldDisplayName(field), t)}
+      </Descriptions.Item>
+      <Descriptions.Item label={t('Field name')}>{field.name}</Descriptions.Item>
+      <Descriptions.Item label={t('Field type')}>
+        <Tag>{field.type}</Tag>
+      </Descriptions.Item>
+      <Descriptions.Item label={t('Field interface')}>
+        <Tag>{compileLegacyTemplate(fieldInterfaceTitle, t)}</Tag>
+      </Descriptions.Item>
+      {field.description ? (
+        <Descriptions.Item label={t('Description')}>{compileLegacyTemplate(field.description, t)}</Descriptions.Item>
+      ) : null}
+    </Descriptions>
+  );
+}
+
 function isReadOnlyFieldInterface(
   record: Record<string, any>,
   options: {
@@ -401,6 +433,68 @@ export function isFieldDeleteDisabled(record: Record<string, any>, collectionTem
   return getCollectionTemplateFields(collectionTemplate).some(
     (field: Record<string, any>) => field?.name === record.name && field.deletable === false,
   );
+}
+
+function normalizeRuntimeField(field: any, collectionName?: string) {
+  const options = field?.options || field || {};
+  return {
+    ...options,
+    collectionName: options.collectionName || field?.collectionName || field?.collection?.name || collectionName,
+  };
+}
+
+function getRuntimeCollectionOwnFields(collection: any) {
+  if (!collection) {
+    return [];
+  }
+  if (collection.fields instanceof Map) {
+    return Array.from(collection.fields.values()).map((field) => normalizeRuntimeField(field, collection.name));
+  }
+  return Array.isArray(collection.fields)
+    ? collection.fields.map((field) => normalizeRuntimeField(field, collection.name))
+    : [];
+}
+
+export function getInheritedFieldGroups(collection: any) {
+  const groups: InheritedFieldGroup[] = [];
+  const visitedCollections = new Set<string>();
+
+  const visitParentCollections = (currentCollection: any) => {
+    const parentCollections =
+      currentCollection?.inherits instanceof Map ? Array.from(currentCollection.inherits.values()) : [];
+    parentCollections.forEach((parentCollection: any) => {
+      if (!parentCollection?.name || visitedCollections.has(parentCollection.name)) {
+        return;
+      }
+      visitedCollections.add(parentCollection.name);
+      groups.push({
+        collectionName: parentCollection.name,
+        fields: getRuntimeCollectionOwnFields(parentCollection),
+        key: parentCollection.name,
+        title: parentCollection.title || parentCollection.options?.title || parentCollection.name,
+      });
+      visitParentCollections(parentCollection);
+    });
+  };
+
+  visitParentCollections(collection);
+  return groups;
+}
+
+export function isInheritedFieldOverridden(
+  record: Record<string, any>,
+  currentCollectionName: string,
+  currentFieldsByName: Map<string, Record<string, any>>,
+) {
+  const currentField = currentFieldsByName.get(record.name);
+  return Boolean(
+    currentField && (!currentField.collectionName || currentField.collectionName === currentCollectionName),
+  );
+}
+
+function getOverrideInitialField(record: Record<string, any>) {
+  const { collectionName, key, sort, uiSchemaUid, ...rest } = record;
+  return rest;
 }
 
 function isAddFieldVisible(options: {
@@ -947,7 +1041,12 @@ export default function FieldsPage(props: FieldsPageProps) {
   }, [request.data]);
 
   const openFieldForm = useCallback(
-    (mode: 'create' | 'edit', field?: Record<string, any>, interfaceName?: string) => {
+    (
+      mode: 'create' | 'edit',
+      field?: Record<string, any>,
+      interfaceName?: string,
+      options?: { override?: boolean },
+    ) => {
       ctx.viewer.drawer({
         width: 800,
         closable: true,
@@ -958,6 +1057,7 @@ export default function FieldsPage(props: FieldsPageProps) {
             collection={props.collection}
             interfaceName={interfaceName}
             field={field}
+            override={options?.override}
             onSubmitted={() => request.refresh()}
           />
         ),
@@ -987,6 +1087,8 @@ export default function FieldsPage(props: FieldsPageProps) {
   );
 
   const TemplateSyncFieldsDrawer = collectionTemplate?.configure?.syncFields?.Component;
+  const runtimeCollection = dataSource?.collectionManager?.getCollection?.(props.collection.name);
+  const inheritedFieldGroups = getInheritedFieldGroups(runtimeCollection);
 
   const openTemplateSyncFieldsDrawer = useCallback(() => {
     if (!TemplateSyncFieldsDrawer) {
@@ -1024,6 +1126,31 @@ export default function FieldsPage(props: FieldsPageProps) {
       ),
     });
   }, [allFieldInterfaceGroups, ctx.viewer, fieldInterfacesByName, props.collection, request]);
+
+  const openInheritedFieldView = useCallback(
+    (record: Record<string, any>, parentTitle?: React.ReactNode) => {
+      const fieldInterface = record.interface ? fieldInterfacesByName[record.interface] : undefined;
+      ctx.viewer.drawer({
+        title: `${compileLegacyTemplate(parentTitle || record.collectionName || props.collection.name, t)} - ${t(
+          'View',
+        )}`,
+        width: 520,
+        closable: true,
+        content: () => <InheritedFieldDetails field={record} fieldInterface={fieldInterface} />,
+      });
+    },
+    [ctx.viewer, fieldInterfacesByName, props.collection.name, t],
+  );
+
+  const openInheritedFieldOverride = useCallback(
+    (record: Record<string, any>) => {
+      if (isInheritedFieldOverridden(record, props.collection.name, currentFieldsByName)) {
+        return;
+      }
+      openFieldForm('create', getOverrideInitialField(record), record.interface, { override: true });
+    },
+    [currentFieldsByName, openFieldForm, props.collection.name],
+  );
 
   const handleDelete = useCallback(
     (filterByTk: React.Key | React.Key[]) => {
@@ -1178,6 +1305,92 @@ export default function FieldsPage(props: FieldsPageProps) {
       }
     },
     [ctx, message, notification, props, t],
+  );
+
+  const inheritedFieldColumns = useMemo<ColumnsType<Record<string, any>>>(
+    () => [
+      {
+        title: t('Field display name'),
+        dataIndex: ['uiSchema', 'title'],
+        width: 240,
+        render: (_, record) => compileLegacyTemplate(getEditableFieldDisplayName(record), t),
+      },
+      { title: t('Field name'), dataIndex: 'name' },
+      { title: t('Field type'), dataIndex: 'type', render: (value) => <Tag>{value}</Tag> },
+      {
+        title: t('Field interface'),
+        dataIndex: 'interface',
+        width: 180,
+        render: (value) => (
+          <Tag>{compileLegacyTemplate(getFieldInterfaceLabel(fieldInterfacesByName[value], value), t)}</Tag>
+        ),
+      },
+      {
+        title: t('Title field'),
+        dataIndex: 'titleField',
+        width: 120,
+        render: (_, record) =>
+          isTitleField(ctx.dataSourceManager, record) ? (
+            <Tooltip title={t('Default title for each record')} placement="right">
+              <Switch
+                aria-label={`switch-title-field-${record.name}`}
+                size="small"
+                disabled={configureFieldsDisabled}
+                loading={record.name === titleFieldLoadingKey}
+                checked={record.name === (titleField || 'id')}
+                onChange={(checked) => handleTitleFieldChange(record, checked)}
+              />
+            </Tooltip>
+          ) : null,
+      },
+      { title: t('Description'), dataIndex: 'description', ellipsis: true },
+      {
+        title: t('Actions'),
+        width: 160,
+        render: (_, record) => {
+          const overridden = isInheritedFieldOverridden(record, props.collection.name, currentFieldsByName);
+          return (
+            <Space>
+              {configureFieldsDisabled ? null : (
+                <Typography.Link disabled={overridden} onClick={() => openInheritedFieldOverride(record)}>
+                  {t('Override')}
+                </Typography.Link>
+              )}
+              <Typography.Link onClick={() => openInheritedFieldView(record, record.__parentTitle)}>
+                {t('View')}
+              </Typography.Link>
+            </Space>
+          );
+        },
+      },
+    ],
+    [
+      configureFieldsDisabled,
+      ctx.dataSourceManager,
+      currentFieldsByName,
+      fieldInterfacesByName,
+      handleTitleFieldChange,
+      openInheritedFieldOverride,
+      openInheritedFieldView,
+      props.collection.name,
+      t,
+      titleField,
+      titleFieldLoadingKey,
+    ],
+  );
+
+  const inheritedGroupColumns = useMemo<ColumnsType<InheritedFieldGroup>>(
+    () => [
+      {
+        dataIndex: 'title',
+        render: (_, record) => (
+          <strong>
+            {t('Inherited fields')} - {compileLegacyTemplate(record.title || record.collectionName, t)}
+          </strong>
+        ),
+      },
+    ],
+    [t],
   );
 
   const handleSyncFields = useCallback(async () => {
@@ -1407,6 +1620,32 @@ export default function FieldsPage(props: FieldsPageProps) {
             : undefined
         }
       />
+      {inheritedFieldGroups.some((group) => group.fields.length) ? (
+        <AntdTable<InheritedFieldGroup>
+          style={{ marginTop: 16 }}
+          rowKey="key"
+          columns={inheritedGroupColumns}
+          dataSource={inheritedFieldGroups.filter((group) => group.fields.length)}
+          pagination={false}
+          showHeader={false}
+          expandable={{
+            defaultExpandAllRows: true,
+            defaultExpandedRowKeys: inheritedFieldGroups.map((group) => group.key),
+            expandedRowRender: (record) => (
+              <AntdTable<Record<string, any>>
+                rowKey="name"
+                columns={inheritedFieldColumns}
+                dataSource={record.fields.map((field) => ({
+                  ...field,
+                  __parentTitle: record.title,
+                }))}
+                pagination={false}
+                showHeader={false}
+              />
+            ),
+          }}
+        />
+      ) : null}
     </>
   );
 }

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { compileLegacyTemplate } from '../../../utils/compileLegacyTemplate';
-import { isFieldDeleteDisabled } from '../FieldsPage';
+import { getInheritedFieldGroups, isFieldDeleteDisabled, isInheritedFieldOverridden } from '../FieldsPage';
 import { getPresetFieldRows } from '../CollectionsPage';
 
 describe('getPresetFieldRows', () => {
@@ -66,5 +66,43 @@ describe('field delete helpers', () => {
   it('disables deleting fields whose record metadata is non-deletable', () => {
     expect(isFieldDeleteDisabled({ name: 'title', deletable: false })).toBe(true);
     expect(isFieldDeleteDisabled({ name: 'title', deletable: true })).toBe(false);
+  });
+});
+
+describe('inherited field helpers', () => {
+  function createCollection(name: string, fields: Array<Record<string, unknown>>, inherits: unknown[] = []) {
+    return {
+      name,
+      title: name,
+      fields: new Map(fields.map((field) => [field.name, { options: field }])),
+      inherits: new Map(inherits.map((collection: { name: string }) => [collection.name, collection])),
+    };
+  }
+
+  it('returns direct and ancestor inherited field groups using each parent collection own fields', () => {
+    const grandparent = createCollection('grandparent', [{ name: 'grandparentField', interface: 'input' }]);
+    const parent = createCollection('parent', [{ name: 'parentField', interface: 'input' }], [grandparent]);
+    const child = createCollection('child', [{ name: 'childField', interface: 'input' }], [parent]);
+
+    expect(
+      getInheritedFieldGroups(child).map((group) => ({
+        collectionName: group.collectionName,
+        fields: group.fields.map((field) => field.name),
+      })),
+    ).toEqual([
+      { collectionName: 'parent', fields: ['parentField'] },
+      { collectionName: 'grandparent', fields: ['grandparentField'] },
+    ]);
+  });
+
+  it('treats a same-name current collection field as an overridden inherited field', () => {
+    const currentFieldsByName = new Map([
+      ['title', { name: 'title', collectionName: 'orders-1' }],
+      ['status', { name: 'status', collectionName: 'orders' }],
+    ]);
+
+    expect(isInheritedFieldOverridden({ name: 'title' }, 'orders-1', currentFieldsByName)).toBe(true);
+    expect(isInheritedFieldOverridden({ name: 'status' }, 'orders-1', currentFieldsByName)).toBe(false);
+    expect(isInheritedFieldOverridden({ name: 'amount' }, 'orders-1', currentFieldsByName)).toBe(false);
   });
 });

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { compileLegacyTemplate } from '../../../utils/compileLegacyTemplate';
+import { isFieldDeleteDisabled } from '../FieldsPage';
 import { getPresetFieldRows } from '../CollectionsPage';
 
 describe('getPresetFieldRows', () => {
@@ -44,5 +45,26 @@ describe('getPresetFieldRows', () => {
     };
 
     expect(compileLegacyTemplate(rows[0].field, t)).toBe('空间');
+  });
+});
+
+describe('field delete helpers', () => {
+  it('disables deleting fields marked as non-deletable by the collection template', () => {
+    const fileTemplate = {
+      collection: {
+        fields: [
+          { name: 'title', deletable: false },
+          { name: 'filename', deletable: false },
+        ],
+      },
+    };
+
+    expect(isFieldDeleteDisabled({ name: 'title' }, fileTemplate)).toBe(true);
+    expect(isFieldDeleteDisabled({ name: 'customName' }, fileTemplate)).toBe(false);
+  });
+
+  it('disables deleting fields whose record metadata is non-deletable', () => {
+    expect(isFieldDeleteDisabled({ name: 'title', deletable: false })).toBe(true);
+    expect(isFieldDeleteDisabled({ name: 'title', deletable: true })).toBe(false);
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 collection field management did not fully match v1 behavior for template fields and inherited fields. File collection template fields should not be removable, and inherited fields should be shown separately with view / override actions instead of being treated as normal current collection fields.

### Description
This PR updates the v2 data source field management page to align these behaviors with v1.

Key changes:
- Disable the row Delete action for fields marked as non-deletable by record metadata or the collection template.
- Disable row selection for non-deletable fields so they cannot be included in bulk delete.
- Filter non-deletable fields again before sending delete requests.
- Show inherited fields in separate inherited-field groups.
- Provide inherited field View and Override actions. Override creates a same-name field in the current collection and is disabled once that field has already been overridden.
- Keep the inherited-field View action read-only to avoid accidentally editing parent collection fields from the child collection drawer.
- Add unit coverage for template-level non-deletable fields and inherited-field helper behavior.

Potential risk:
- The non-deletable behavior now applies to any v2 collection template that declares same-name fields with `deletable: false`, which matches the existing template contract.
- The inherited-field UI reads from the client runtime collection inheritance chain and keeps the change scoped to the data source manager field configuration page.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts --run --reporter=verbose`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed v2 collection field management so template-protected fields cannot be deleted and inherited fields support view / override behavior consistent with v1. |
| 🇨🇳 Chinese | 修复 v2 数据表字段管理中，模板保护字段仍可删除，以及继承字段展示、查看和重写行为与 v1 不一致的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
