### PR TITLE
fix(plugin-ai): recover workflow tasks after graph recursion

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -366,7 +366,7 @@ export class AIEmployee {
       const { threadId } = await this.getCurrentThread();
       const invokeConfig = {
         context: { ctx: this.ctx, decisions: chatContext.decisions, ...context },
-        recursionLimit: 100,
+        recursionLimit: 200,
         configurable: this.from === 'main-agent' ? { thread_id: threadId } : undefined,
         writer,
         signal,
@@ -480,7 +480,7 @@ export class AIEmployee {
           streamMode: ['updates', 'messages', 'custom'],
           configurable: this.from === 'main-agent' ? { thread_id: threadId } : undefined,
           context: { ctx: this.ctx, decisions: chatContext.decisions },
-          recursionLimit: 100,
+          recursionLimit: 200,
           ...config,
         },
         state,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
@@ -102,27 +102,30 @@ Do not treat **${toolName}** as optional, and do not finish the task without cal
         const plugin = this.workflow.app.pm.get('ai') as PluginAIServer;
         const resolvedModel = await plugin.aiEmployeesManager.resolveModel(employee, model);
 
+        const aiEmployeeContext = {
+          app: this.workflow.app,
+          db: this.workflow.app.db,
+          log: this.workflow.app.log,
+          logger: this.workflow.app.log,
+          state: { currentRoles },
+          auth: {
+            user: {
+              id: input?.result?.user?.id ?? userId,
+            },
+          },
+          action: {
+            params: {
+              values: {
+                sessionId: conversation.sessionId,
+                model: resolvedModel,
+              },
+            },
+          },
+        } as any;
+        const aiEmployeeActionValues = aiEmployeeContext.action.params.values;
+
         const aiEmployee = new AIEmployee({
-          ctx: {
-            app: this.workflow.app,
-            db: this.workflow.app.db,
-            log: this.workflow.app.log,
-            logger: this.workflow.app.log,
-            state: { currentRoles },
-            auth: {
-              user: {
-                id: input?.result?.user?.id ?? userId,
-              },
-            },
-            action: {
-              params: {
-                values: {
-                  sessionId: conversation.sessionId,
-                  model: resolvedModel,
-                },
-              },
-            },
-          } as any,
+          ctx: aiEmployeeContext,
           employee,
           sessionId: conversation.sessionId,
           systemMessage,
@@ -142,6 +145,7 @@ Do not treat **${toolName}** as optional, and do not finish the task without cal
 
         let result;
         let isToolInvoke = false;
+        let recoveredFromGraphRecursion = false;
         let retry = 0;
         do {
           const userMessages = [
@@ -154,38 +158,80 @@ Do not treat **${toolName}** as optional, and do not finish the task without cal
               ...attachmentPart,
             },
           ];
-          if (retry > 0) {
-            if (retry < 2) {
-              abortHandle.throwIfAborted();
-              const firstUserMessage = await this.workflow.db
-                .getRepository('aiConversations.messages', conversation.sessionId)
-                .findOne({
-                  filter: {
-                    role: 'user',
-                  },
-                  sort: ['messageId'],
-                });
-              const messageId = firstUserMessage?.messageId;
-              result = await aiEmployee.invoke({ messageId, userMessages, signal: abortHandle.signal });
-            } else {
-              result = await aiEmployee.invoke({
-                signal: abortHandle.signal,
-                userMessages: [
-                  {
-                    role: 'user',
-                    content: {
-                      type: 'text',
-                      content: `You failed to call the required tool "${SYSTEM_TOOLS.WORK_FLOW_TASK_OUTPUT}" in your previous response.
-Call "${SYSTEM_TOOLS.WORK_FLOW_TASK_OUTPUT}" now to submit the workflow outcome.
+          try {
+            if (retry > 0) {
+              if (retry < 2) {
+                abortHandle.throwIfAborted();
+                const firstUserMessage = await this.workflow.db
+                  .getRepository('aiConversations.messages', conversation.sessionId)
+                  .findOne({
+                    filter: {
+                      role: 'user',
+                    },
+                    sort: ['messageId'],
+                  });
+                const messageId = firstUserMessage?.messageId;
+                result = await aiEmployee.invoke({ messageId, userMessages, signal: abortHandle.signal });
+              } else {
+                result = await aiEmployee.invoke({
+                  signal: abortHandle.signal,
+                  userMessages: [
+                    {
+                      role: 'user',
+                      content: {
+                        type: 'text',
+                        content: `You failed to call the required tool "${toolName}" in your previous response.
+Call "${toolName}" now to submit the workflow outcome.
 Do not send another normal assistant response without invoking it.
                   `,
+                      },
+                    },
+                  ],
+                });
+              }
+            } else {
+              result = await aiEmployee.invoke({ userMessages, signal: abortHandle.signal });
+            }
+          } catch (error) {
+            if (!isGraphRecursionError(error) || recoveredFromGraphRecursion) {
+              throw error;
+            }
+            recoveredFromGraphRecursion = true;
+            processor.logger.warn(`ai employee invoke reached graph recursion limit, trying workflow output recovery`, {
+              node: node.id,
+              stack: error.stack,
+              chatOptions: node.config,
+            });
+            const latestMessage = await this.workflow.db
+              .getRepository('aiConversations.messages', conversation.sessionId)
+              .findOne({
+                sort: ['-messageId'],
+              });
+            const recoveryAIEmployee = new AIEmployee({
+              ctx: {
+                ...aiEmployeeContext,
+                action: {
+                  params: {
+                    values: {
+                      ...aiEmployeeActionValues,
+                      important: 'GraphRecursionError',
                     },
                   },
-                ],
-              });
-            }
-          } else {
-            result = await aiEmployee.invoke({ userMessages, signal: abortHandle.signal });
+                },
+              } as any,
+              employee,
+              sessionId: conversation.sessionId,
+              systemMessage,
+              skillSettings,
+              webSearch,
+              model: resolvedModel,
+              tools: [{ name: toolName }],
+            });
+            abortHandle.throwIfAborted();
+            result = await recoveryAIEmployee.invoke({
+              messageId: latestMessage?.messageId,
+              signal: abortHandle.signal,
+            });
           }
 
           abortHandle.throwIfAborted();
@@ -499,6 +545,16 @@ async function parseAssignees(node, processor): Promise<number[]> {
   }
 
   return assignees;
+}
+
+function isGraphRecursionError(error: unknown): error is Error {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    ('name' in error || 'lc_error_code' in error) &&
+    ((error as { name?: unknown }).name === 'GraphRecursionError' ||
+      (error as { lc_error_code?: unknown }).lc_error_code === 'GRAPH_RECURSION_LIMIT')
+  );
 }
 
 export * from './handler';


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow AI employee nodes can hit the LangGraph recursion limit after repeated tool calls. When this happens, the workflow task fails before the employee can recover and submit the expected workflow output.

### Description 
This PR increases the AI employee recursion limit to 200 for both invoke and stream paths, and handles `GraphRecursionError` / `GRAPH_RECURSION_LIMIT` in workflow AI employee nodes. When the limit is reached, the workflow path creates a recovery AI employee inside the error handler, preserves the original skills and tools context, excludes the incomplete latest tool-call message by invoking from the latest persisted conversation message, and adds a recovery important prompt so the employee can complete the workflow task.

Testing suggestions:
- Run related plugin-ai server tests.
- Verify a workflow AI employee node can repeatedly call Document search and still finish after recursion-limit recovery.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow AI employee tasks failing after repeated tool calls reached the graph recursion limit. |
| 🇨🇳 Chinese | 修复工作流 AI 员工任务连续调用工具达到图递归限制后执行失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Self-tested:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts`
- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-employee-skill-binding.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/__tests__/skill-tool-binding-middleware.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/__tests__/tool-call-sanitizer-middleware.test.ts --run --reporter=verbose`
- Live workflow test on server 13007 with 10 consecutive Document search calls; recovery was triggered and the workflow resolved successfully.