### PR TITLE
fix(plugin-backups): use spawn args for postgres restore

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/adapters/database.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/adapters/database.test.ts
@@ -23,13 +23,28 @@ vi.mock('child_process', async (importOriginal) => {
   return {
     ...actual,
     execSync: vi.fn(),
-    exec: vi.fn(),
-    spawn: vi.fn().mockImplementation(() => {
-      const stdout = new Readable({
-        read() {
-          this.push(null);
-        },
-      });
+    exec: vi.fn().mockImplementation((_command, _options, callback) => {
+      callback(null, { stdout: '' });
+    }),
+    spawnSync: vi.fn().mockReturnValue({ status: 0, stdout: 'PostgreSQL 16.1', stderr: '' }),
+    spawn: vi.fn().mockImplementation((command, args = []) => {
+      const stdoutText =
+        (String(command).includes('pg_restore') || String(command).includes('sys_restore')) &&
+        Array.isArray(args) &&
+        args.includes('--list')
+          ? [
+              '; Archive created at 2026-06-18 00:00:00',
+              '123; 2615 2200 SCHEMA - public test',
+              '124; 0 0 COMMENT - SCHEMA public test',
+              '125; 0 0 ACL - SCHEMA public test',
+              '126; 1259 2201 TABLE public users test',
+            ].join('\n')
+          : (String(command).includes('psql') || String(command).includes('ksql')) &&
+              Array.isArray(args) &&
+              args.some((arg) => String(arg).includes('pg_depend'))
+            ? 'public.logs_id_seq\n'
+            : '';
+      const stdout = Readable.from(stdoutText ? [stdoutText] : []);
       const stderr = new Readable({
         read() {
           this.push(null);
@@ -75,10 +90,7 @@ describe('DatabaseAdapter', () => {
 
   describe('PostgresAdapter', () => {
     it('check function without client installed', async () => {
-      // mock the child_process.execSync function
-      (cp.execSync as Mock).mockImplementation((_command, _callback) => {
-        throw new Error('Command not found');
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ error: new Error('Command not found'), status: 1 });
 
       const adapter = getDBAdapter(dbOpts);
       await expect(adapter.check('backup')).rejects.toThrowError('Command pg_dump not found, please install it first');
@@ -86,10 +98,7 @@ describe('DatabaseAdapter', () => {
     });
 
     it('check function with client installed', async () => {
-      // mock the child_process.execSync function
-      (cp.execSync as Mock).mockImplementation((_command, _callback) => {
-        return 'PostgreSQL 16.1';
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ status: 0, stdout: 'PostgreSQL 16.1', stderr: '' });
 
       const adapter = getDBAdapter(dbOpts);
       expect(adapter.check('backup')).resolves.toBeUndefined();
@@ -97,22 +106,20 @@ describe('DatabaseAdapter', () => {
     });
 
     it('backup function', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const dir = os.tmpdir();
       await adapter.backup({ dir });
-      expect(mockedExec.mock.lastCall[0]).toContain('pg_dump');
+      expect(mockedSpawn.mock.lastCall[0]).toBe('pg_dump');
+      expect(mockedSpawn.mock.lastCall[1]).toEqual(
+        expect.arrayContaining(['-U', 'test', '-h', 'localhost', '-p', '5432', '-F', 'c', '-f', `${dir}/data`, 'test']),
+      );
     });
 
     it('backup function with included and excluded tables', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const dir = os.tmpdir();
       await adapter.backup({
@@ -120,18 +127,16 @@ describe('DatabaseAdapter', () => {
         includeTables: ['users', 'posts'],
         excludeTables: ['logs', 'audit_logs'],
       });
-      const command = mockedExec.mock.lastCall[0];
-      expect(command).toContain('pg_dump');
-      expect(command).toContain(`-t '"users"' -t '"posts"'`);
-      expect(command).toContain(`-T '"logs"' -T '"audit_logs"'`);
+      const [command, args] = mockedSpawn.mock.lastCall;
+      expect(command).toBe('pg_dump');
+      expect(args).toEqual(
+        expect.arrayContaining(['-t', '"users"', '-t', '"posts"', '-T', '"logs"', '-T', '"audit_logs"']),
+      );
     });
 
     it('backup function should quote mixed-case included and excluded tables', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const dir = os.tmpdir();
       await adapter.backup({
@@ -139,18 +144,22 @@ describe('DatabaseAdapter', () => {
         includeTables: ['applicationPlugins', 'public.rolesUsers'],
         excludeTables: ['dataSourcesCollections'],
       });
-      const command = mockedExec.mock.lastCall[0];
-      expect(command).toContain(`-t '"applicationPlugins"'`);
-      expect(command).toContain(`-t '"public"."rolesUsers"'`);
-      expect(command).toContain(`-T '"dataSourcesCollections"'`);
+      const args = mockedSpawn.mock.lastCall[1];
+      expect(args).toEqual(
+        expect.arrayContaining([
+          '-t',
+          '"applicationPlugins"',
+          '-t',
+          '"public"."rolesUsers"',
+          '-T',
+          '"dataSourcesCollections"',
+        ]),
+      );
     });
 
     it('backup function should qualify included and excluded tables with configured schema', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter({
         ...dbOpts,
         schema: 'test_version_control',
@@ -161,100 +170,81 @@ describe('DatabaseAdapter', () => {
         includeTables: ['applicationPlugins', 'public.rolesUsers'],
         excludeTables: ['dataSourcesCollections'],
       });
-      const command = mockedExec.mock.lastCall[0];
-      expect(command).toContain(`-t '"test_version_control"."applicationPlugins"'`);
-      expect(command).toContain(`-t '"public"."rolesUsers"'`);
-      expect(command).toContain(`-T '"test_version_control"."dataSourcesCollections"'`);
-      expect(command).toContain(`--schema=test_version_control`);
+      const args = mockedSpawn.mock.lastCall[1];
+      expect(args).toEqual(
+        expect.arrayContaining([
+          '-t',
+          '"test_version_control"."applicationPlugins"',
+          '-t',
+          '"public"."rolesUsers"',
+          '-T',
+          '"test_version_control"."dataSourcesCollections"',
+          '--schema=test_version_control',
+        ]),
+      );
     });
 
     it('backup function should exclude owned sequences for excluded tables', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((command, _options, callback) => {
-        if (command.includes('pg_depend')) {
-          callback(null, 'public.logs_id_seq\n', '');
-          return;
-        }
-        callback(null, 'done', '');
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const dir = os.tmpdir();
       await adapter.backup({
         dir,
         excludeTables: ['logs'],
       });
-      const command = mockedExec.mock.lastCall[0];
-      expect(command).toContain(`-T '"logs"'`);
-      expect(command).toContain(`-T '"public"."logs_id_seq"'`);
+      const [sequenceCommand, sequenceArgs] = mockedSpawn.mock.calls[0];
+      expect(sequenceCommand).toBe('psql');
+      expect(sequenceArgs).toEqual(expect.arrayContaining(['-At', '-c']));
+      expect(sequenceArgs[sequenceArgs.indexOf('-c') + 1]).toContain('pg_depend');
+
+      const args = mockedSpawn.mock.lastCall[1];
+      expect(args).toEqual(expect.arrayContaining(['-T', '"logs"', '-T', '"public"."logs_id_seq"']));
     });
 
     it('restore function', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const filePath = os.tmpdir();
       await adapter.restore({ filePath });
-      expect(mockedExec.mock.lastCall[0]).toContain('pg_restore');
+      expect(mockedSpawn.mock.lastCall[0]).toBe('pg_restore');
+      expect(mockedSpawn.mock.lastCall[1]).toEqual(expect.arrayContaining(['-d', 'test', '--clean', filePath]));
     });
 
     it('restore function should skip dropping all tables when skipDropAllTables is true', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const filePath = os.tmpdir();
       await adapter.restore({ filePath, skipDropAllTables: true });
 
-      const commands = mockedExec.mock.calls.map(([command]) => command);
-      expect(commands).toHaveLength(1);
-      expect(commands[0]).toContain('pg_restore');
-      expect(commands.some((command) => command.includes('DROP TABLE IF EXISTS'))).toBe(false);
-      expect(commands.some((command) => command.includes('DROP VIEW IF EXISTS'))).toBe(false);
-      expect(commands.some((command) => command.includes('DROP TRIGGER IF EXISTS'))).toBe(false);
+      expect(mockedSpawn).toHaveBeenCalledTimes(1);
+      expect(mockedSpawn.mock.calls[0][0]).toBe('pg_restore');
     });
 
     it('restore function should preserve tables and drop views when restoreMode is preserveTables', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
+      const mockedSpawn = cp.spawn as unknown as Mock;
       const mockedWriteFile = fsPromises.writeFile as Mock;
       const mockedUnlink = fsPromises.unlink as Mock;
-      mockedExec.mockClear();
+      mockedSpawn.mockClear();
       mockedWriteFile.mockClear();
       mockedUnlink.mockClear();
-      mockedExec.mockImplementation((command, _options, callback) => {
-        if (String(command).includes('--list')) {
-          callback(null, {
-            stdout: [
-              '; Archive created at 2026-06-18 00:00:00',
-              '123; 2615 2200 SCHEMA - public test',
-              '124; 0 0 COMMENT - SCHEMA public test',
-              '125; 0 0 ACL - SCHEMA public test',
-              '126; 1259 2201 TABLE public users test',
-            ].join('\n'),
-          });
-          return;
-        }
-        callback(null, { stdout: 'done' });
-      });
       const adapter = getDBAdapter(dbOpts);
       const filePath = os.tmpdir();
       await adapter.restore({ filePath, restoreMode: 'preserveTables' });
 
-      const commands = mockedExec.mock.calls.map(([command]) => command);
-      expect(commands).toHaveLength(3);
-      expect(commands[0]).toContain('DROP VIEW IF EXISTS');
-      expect(commands[0]).toContain('DROP MATERIALIZED VIEW IF EXISTS');
-      expect(commands[0]).not.toContain('DROP TABLE IF EXISTS');
-      expect(commands[0]).not.toContain('DROP SEQUENCE IF EXISTS');
-      expect(commands[0]).not.toContain('DROP TRIGGER IF EXISTS');
-      expect(commands[1]).toContain('pg_restore');
-      expect(commands[1]).toContain('--list');
-      expect(commands[2]).toContain('pg_restore');
-      expect(commands[2]).toContain('-L');
+      expect(mockedSpawn).toHaveBeenCalledTimes(3);
+      const dropQuery = mockedSpawn.mock.calls[0][1][mockedSpawn.mock.calls[0][1].indexOf('-c') + 1];
+      expect(dropQuery).toContain('DROP VIEW IF EXISTS');
+      expect(dropQuery).toContain('DROP MATERIALIZED VIEW IF EXISTS');
+      expect(dropQuery).not.toContain('DROP TABLE IF EXISTS');
+      expect(dropQuery).not.toContain('DROP SEQUENCE IF EXISTS');
+      expect(dropQuery).not.toContain('DROP TRIGGER IF EXISTS');
+      expect(mockedSpawn.mock.calls[1][0]).toBe('pg_restore');
+      expect(mockedSpawn.mock.calls[1][1]).toEqual(['--list', filePath]);
+      expect(mockedSpawn.mock.calls[2][0]).toBe('pg_restore');
+      expect(mockedSpawn.mock.calls[2][1]).toEqual(expect.arrayContaining(['-L', expect.any(String), filePath]));
       expect(mockedWriteFile).toHaveBeenCalledTimes(1);
       expect(mockedWriteFile.mock.calls[0][1]).not.toContain('SCHEMA - public');
       expect(mockedWriteFile.mock.calls[0][1]).toContain('COMMENT - SCHEMA public');
@@ -264,11 +254,8 @@ describe('DatabaseAdapter', () => {
     });
 
     it('restore function should sync collection schema metadata when schema is renamed', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter({
         ...dbOpts,
         schema: 'public',
@@ -277,21 +264,16 @@ describe('DatabaseAdapter', () => {
 
       await adapter.restore({ filePath: os.tmpdir(), schema: 'source_schema' });
 
-      const commands = mockedExec.mock.calls.map(([command]) => command);
-      expect(commands.some((command) => command.includes('jsonb_set') && command.includes('nb_collections'))).toBe(
-        true,
-      );
-      expect(commands.some((command) => command.includes("'public'") && command.includes("'source_schema'"))).toBe(
-        true,
-      );
+      const queries = mockedSpawn.mock.calls
+        .filter(([command]) => command === 'psql')
+        .map(([, args]) => args[args.indexOf('-c') + 1]);
+      expect(queries.some((query) => query.includes('jsonb_set') && query.includes('nb_collections'))).toBe(true);
+      expect(queries.some((query) => query.includes("'public'") && query.includes("'source_schema'"))).toBe(true);
     });
 
     it('restore function should reject unsafe source schema names before running commands', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter({
         ...dbOpts,
         schema: 'target_schema',
@@ -305,15 +287,12 @@ describe('DatabaseAdapter', () => {
         }),
       ).rejects.toThrow(/invalid PostgreSQL schema/i);
 
-      expect(mockedExec).not.toHaveBeenCalled();
+      expect(mockedSpawn).not.toHaveBeenCalled();
     });
 
     it('restore function should reject unsafe target schema names before running commands', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter({
         ...dbOpts,
         schema: 'target; touch /tmp/nocobase-cve-marker #',
@@ -327,15 +306,12 @@ describe('DatabaseAdapter', () => {
         }),
       ).rejects.toThrow(/invalid PostgreSQL schema/i);
 
-      expect(mockedExec).not.toHaveBeenCalled();
+      expect(mockedSpawn).not.toHaveBeenCalled();
     });
 
     it('restore function should not sync collection schema metadata when schema is unchanged', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter({
         ...dbOpts,
         schema: 'public',
@@ -343,8 +319,10 @@ describe('DatabaseAdapter', () => {
 
       await adapter.restore({ filePath: os.tmpdir(), schema: 'public' });
 
-      const commands = mockedExec.mock.calls.map(([command]) => command);
-      expect(commands.some((command) => command.includes('jsonb_set'))).toBe(false);
+      const queries = mockedSpawn.mock.calls
+        .filter(([command]) => command === 'psql')
+        .map(([, args]) => args[args.indexOf('-c') + 1]);
+      expect(queries.some((query) => query.includes('jsonb_set'))).toBe(false);
     });
   });
 
@@ -359,11 +337,9 @@ describe('DatabaseAdapter', () => {
     } as DatabaseOptions;
 
     it('uses Kingbase client tools by default', async () => {
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ status: 0, stdout: 'KingbaseES V009R001C010', stderr: '' });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
       const dir = os.tmpdir();
 
@@ -371,46 +347,40 @@ describe('DatabaseAdapter', () => {
       await adapter.restore({ filePath: os.tmpdir(), skipDropAllTables: true });
 
       expect(adapter.backupToolchain).toBe('kingbase');
-      expect(mockedExec.mock.calls[0][0]).toContain('sys_dump');
-      expect(mockedExec.mock.calls[0][0]).toContain('--schema=public');
-      expect(mockedExec.mock.calls[0][1].env).toEqual(expect.objectContaining({ KINGBASE_PASSWORD: 'secret' }));
-      expect(mockedExec.mock.calls[1][0]).toContain('sys_restore');
-      expect(mockedExec.mock.calls[1][1].env).toEqual(expect.objectContaining({ KINGBASE_PASSWORD: 'secret' }));
+      expect(mockedSpawn.mock.calls[0][0]).toBe('sys_dump');
+      expect(mockedSpawn.mock.calls[0][1]).toContain('--schema=public');
+      expect(mockedSpawn.mock.calls[0][2].env).toEqual(expect.objectContaining({ KINGBASE_PASSWORD: 'secret' }));
+      expect(mockedSpawn.mock.calls[1][0]).toBe('sys_restore');
+      expect(mockedSpawn.mock.calls[1][2].env).toEqual(expect.objectContaining({ KINGBASE_PASSWORD: 'secret' }));
     });
 
     it('falls back to PostgreSQL client tools when Kingbase tools are missing', async () => {
-      (cp.execSync as Mock).mockImplementation((command) => {
+      (cp.spawnSync as Mock).mockImplementation((command) => {
         if (
           String(command).includes('sys_dump') ||
           String(command).includes('sys_restore') ||
           String(command).includes('ksql')
         ) {
-          throw new Error('Command not found');
+          return { error: new Error('Command not found'), status: 1 };
         }
-        return 'PostgreSQL 16.1';
+        return { status: 0, stdout: 'PostgreSQL 16.1', stderr: '' };
       });
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter(dbOpts);
 
       await adapter.backup({ dir: os.tmpdir() });
       await adapter.restore({ filePath: os.tmpdir(), skipDropAllTables: true });
 
       expect(adapter.backupToolchain).toBe('postgres');
-      expect(mockedExec.mock.calls[0][0]).toContain('pg_dump');
-      expect(mockedExec.mock.calls[1][0]).toContain('pg_restore');
+      expect(mockedSpawn.mock.calls[0][0]).toBe('pg_dump');
+      expect(mockedSpawn.mock.calls[1][0]).toBe('pg_restore');
     });
 
     it('uses sys_restore schema remapping for Kingbase backup toolchain', async () => {
-      (cp.execSync as Mock).mockImplementation(() => 'KingbaseES V009R001C010');
-      const mockedExec = cp.exec as unknown as Mock;
-      mockedExec.mockClear();
-      mockedExec.mockImplementation((_command, _options, callback) => {
-        callback(null, { stdout: 'done' });
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ status: 0, stdout: 'KingbaseES V009R001C010', stderr: '' });
+      const mockedSpawn = cp.spawn as unknown as Mock;
+      mockedSpawn.mockClear();
       const adapter = getDBAdapter({
         ...dbOpts,
         schema: 'target_schema',
@@ -418,15 +388,13 @@ describe('DatabaseAdapter', () => {
 
       await adapter.restore({ filePath: os.tmpdir(), schema: 'source_schema', skipDropAllTables: true });
 
-      const commands = mockedExec.mock.calls.map(([command]) => command);
-      expect(commands.some((command) => command.includes('CREATE SCHEMA IF NOT EXISTS \\"target_schema\\"'))).toBe(
-        true,
-      );
-      expect(commands.some((command) => command.includes('sys_restore') && command.includes('-g source_schema'))).toBe(
-        true,
-      );
-      expect(commands.some((command) => command.includes('-G target_schema'))).toBe(true);
-      expect(commands.some((command) => command.includes('jsonb_set'))).toBe(true);
+      const queries = mockedSpawn.mock.calls
+        .filter(([command]) => command === 'ksql')
+        .map(([, args]) => args[args.indexOf('-c') + 1]);
+      const restoreCall = mockedSpawn.mock.calls.find(([command]) => command === 'sys_restore');
+      expect(queries.some((query) => query.includes('CREATE SCHEMA IF NOT EXISTS "target_schema"'))).toBe(true);
+      expect(restoreCall?.[1]).toEqual(expect.arrayContaining(['-g', 'source_schema', '-G', 'target_schema']));
+      expect(queries.some((query) => query.includes('jsonb_set'))).toBe(true);
     });
   });
 
@@ -441,10 +409,7 @@ describe('DatabaseAdapter', () => {
     };
 
     it('check function without client installed', async () => {
-      // mock the child_process.execSync function
-      (cp.execSync as Mock).mockImplementation((_command, _callback) => {
-        throw new Error('Command not found');
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ error: new Error('Command not found'), status: 1 });
 
       const adapter = getDBAdapter(dbOpts);
       await expect(adapter.check('backup')).rejects.toThrowError(
@@ -454,10 +419,7 @@ describe('DatabaseAdapter', () => {
     });
 
     it('check function with client installed', async () => {
-      // mock the child_process.execSync function
-      (cp.execSync as Mock).mockImplementation((_command, _callback) => {
-        return 'MySQL 8.0';
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ status: 0, stdout: 'MySQL 8.0', stderr: '' });
 
       const adapter = getDBAdapter(dbOpts);
       expect(adapter.check('backup')).resolves.toBeUndefined();
@@ -556,10 +518,7 @@ describe('DatabaseAdapter', () => {
     };
 
     it('check function without client installed', async () => {
-      // mock the child_process.execSync function
-      (cp.execSync as Mock).mockImplementation((_command, _callback) => {
-        throw new Error('Command not found');
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ error: new Error('Command not found'), status: 1 });
 
       const adapter = getDBAdapter(dbOpts);
       await expect(adapter.check('backup')).rejects.toThrowError(
@@ -569,10 +528,7 @@ describe('DatabaseAdapter', () => {
     });
 
     it('check function with client installed', async () => {
-      // mock the child_process.execSync function
-      (cp.execSync as Mock).mockImplementation((_command, _callback) => {
-        return 'MariaDB 10.6';
-      });
+      (cp.spawnSync as Mock).mockReturnValue({ status: 0, stdout: 'MariaDB 10.6', stderr: '' });
 
       const adapter = getDBAdapter(dbOpts);
       expect(adapter.check('backup')).resolves.toBeUndefined();

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
@@ -25,6 +25,7 @@ vi.mock('child_process', async (importOriginal) => {
   return {
     ...actual,
     execSync: vi.fn(),
+    spawnSync: vi.fn().mockReturnValue({ status: 0, stdout: 'PostgreSQL 16.1', stderr: '' }),
     exec: vi.fn().mockImplementation((command, _options, callback) => {
       if (command.includes(' > ')) {
         // mock the command to create a backup file

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
@@ -50,6 +50,7 @@ vi.mock('child_process', async (importOriginal) => {
   return {
     ...actual,
     execSync: vi.fn(),
+    spawnSync: vi.fn().mockReturnValue({ status: 0, stdout: 'PostgreSQL 16.1', stderr: '' }),
     exec: vi
       .fn()
       .mockImplementation((command, options, callback) => mockExecImplementation(command, options, callback)),

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
@@ -26,7 +26,7 @@ let mockExecImplementation = (command, _options, callback) => {
   callback(null, 'done');
 };
 
-let mockSpawnImplementation = () => {
+let mockSpawnImplementation = (_command?: string, _args?: string[]) => {
   const stdout = Readable.from(['mocked database backup']);
   const stderr = Readable.from([]);
   const stdin = new Writable({
@@ -128,7 +128,21 @@ describe('RestoreManager', () => {
       callback(null, 'done');
     };
 
-    mockSpawnImplementation = () => {
+    mockSpawnImplementation = (command) => {
+      if (
+        ['psql', 'pg_restore', 'ksql', 'sys_restore', 'mysql'].some((restoreCommand) =>
+          String(command).includes(restoreCommand),
+        )
+      ) {
+        // simulate restore side effect: clear the encryption password
+        app.db
+          .getRepository(SETTINGS)
+          .update({
+            values: { encryptionPassword: '' },
+            filter: { id: 1 },
+          })
+          .catch(() => {});
+      }
       const stdout = Readable.from(['mocked database backup']);
       const stderr = Readable.from([]);
       const stdin = new Writable({
@@ -433,8 +447,8 @@ describe('RestoreManager', () => {
         backupClientVersion: 'pg_dump (PostgreSQL) 17.2',
       }),
     );
-    const mockedExec = cp.exec as unknown as Mock;
-    mockedExec.mockClear();
+    const mockedSpawn = cp.spawn as unknown as Mock;
+    mockedSpawn.mockClear();
     const restoreManager = new RestoreManager(createCtx(), {
       dialect: 'kingbase',
       username: 'test',
@@ -448,9 +462,9 @@ describe('RestoreManager', () => {
     await restoreManager.restore(backupFilePath, 'task_id', undefined, true, true);
 
     await vi.waitFor(() => {
-      expect(mockedExec.mock.calls.some(([command]) => command.includes('pg_restore'))).toBe(true);
+      expect(mockedSpawn.mock.calls.some(([command]) => String(command).includes('pg_restore'))).toBe(true);
     });
-    expect(mockedExec.mock.calls.some(([, options]) => options.env?.PGPASSWORD === 'test')).toBe(true);
+    expect(mockedSpawn.mock.calls.some(([, , options]) => options.env?.PGPASSWORD === 'test')).toBe(true);
   });
 
   it('does not ignore dialect mismatch with force schema restore', async () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/adapters/database.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/adapters/database.ts
@@ -8,8 +8,8 @@
  */
 
 import { DatabaseOptions } from '@nocobase/database';
-import { exec as execCallback, execSync, spawn } from 'child_process';
-import { createReadStream, createWriteStream } from 'fs';
+import { exec as execCallback, execSync, spawn, spawnSync } from 'child_process';
+import { createWriteStream } from 'fs';
 import * as fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -18,7 +18,6 @@ import { promisify } from 'util';
 import { EscapeQuoteTransform } from '../utils';
 
 const exec = promisify(execCallback);
-const D$$ = os.platform() === 'win32' ? '$$' : '\\$\\$';
 
 const STREAM_BUFFER_SIZE = 2 * 1024 * 1024; // 2MB buffer for better IO performance
 
@@ -69,16 +68,47 @@ const run = async (command: string, envVars: NodeJS.ProcessEnv = {}) => {
   }
 };
 
+const runSpawn = async (command: string, args: string[], envVars: NodeJS.ProcessEnv = {}) => {
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: { ...process.env, ...envVars },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let settled = false;
+
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on('error', (error) => {
+      settled = true;
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      if (code === 0) {
+        settled = true;
+        resolve(Buffer.concat(stdout).toString());
+        return;
+      }
+      const errorMessage = Buffer.concat(stderr).toString().trim() || `${command} exited with code ${code}`;
+      settled = true;
+      reject(new Error(errorMessage));
+    });
+  });
+};
+
 const formatPathInEnv = (path?: string) => {
-  if (path && /\s/.test(path) && !/^".*"$/.test(path) && !/^'.*'$/.test(path)) {
-    return `"${path}"`;
+  if ((path?.startsWith('"') && path.endsWith('"')) || (path?.startsWith("'") && path.endsWith("'"))) {
+    return path.slice(1, -1);
   }
   return path;
 };
 const escapeStringLiteral = (value: string) => String(value).replace(/'/g, "''");
 const quotePgIdentifier = (value: string) => `"${String(value).replace(/"/g, '""')}"`;
-const quoteShellArg = (value: string) => `'${String(value).replace(/'/g, "'\\''")}'`;
-const quotePgTablePattern = (table: string) => quoteShellArg(String(table).split('.').map(quotePgIdentifier).join('.'));
+const quotePgTablePattern = (table: string) => String(table).split('.').map(quotePgIdentifier).join('.');
 const isPgRestoreSchemaTocEntry = (line: string) => /^\d+;\s+\d+\s+\d+\s+SCHEMA\s+-\s+/.test(line);
 const parsePgTableReference = (table: string, defaultSchema?: string) => {
   const parts = String(table).split('.');
@@ -118,9 +148,8 @@ abstract class BaseDBAdapter implements DBAdapter {
   async clientVersion(_: 'backup' | 'restore'): Promise<string | void> {}
 
   protected assertCommand = (command: string) => {
-    try {
-      execSync(`${command} --version`);
-    } catch (error) {
+    const result = spawnSync(command, ['--version'], { encoding: 'utf8' });
+    if (result.error || result.status !== 0) {
       throw new Error(
         `Command ${command} not found, please install it first. Check reference here: https://docs.nocobase.com/ops-management/backup-manager/`,
       );
@@ -128,12 +157,8 @@ abstract class BaseDBAdapter implements DBAdapter {
   };
 
   protected hasCommand(command: string) {
-    try {
-      execSync(`${command} --version`);
-      return true;
-    } catch (_error) {
-      return false;
-    }
+    const result = spawnSync(command, ['--version'], { encoding: 'utf8' });
+    return !result.error && result.status === 0;
   }
 }
 
@@ -502,36 +527,43 @@ class PostgresAdapter extends BaseDBAdapter {
   async clientVersion(op: 'backup' | 'restore'): Promise<string | void> {
     const cmd = op === 'backup' ? this.getBackupCommandName() : this.getRestoreCommandName();
     try {
-      return execSync(`${cmd} --version`).toString();
+      return await runSpawn(cmd, ['--version']);
     } catch (_error) {
       return undefined;
     }
   }
 
   async backup({ dir, includeTables, excludeTables }: DBBackupOptions): Promise<void> {
-    const { username, host, port, database, password } = this.dbOpts;
+    const { database, password } = this.dbOpts;
     const filePath = `${dir}/data`;
     const backupSchema = this.getBackupSchema();
-    const schemaOption = backupSchema ? `--schema=${backupSchema}` : '';
     const expandedExcludeTables = Array.isArray(excludeTables)
       ? [...new Set([...excludeTables, ...(await this.getOwnedSequenceTables(excludeTables, backupSchema))])]
       : [];
-    const includeOption =
+    const includeArgs =
       Array.isArray(includeTables) && includeTables.length
-        ? includeTables
-            .map((table) => `-t ${quotePgTablePattern(qualifyPgTablePattern(table, backupSchema))}`)
-            .join(' ')
-        : '';
-    const excludeOption = expandedExcludeTables.length
-      ? expandedExcludeTables
-          .map((table) => `-T ${quotePgTablePattern(qualifyPgTablePattern(table, backupSchema))}`)
-          .join(' ')
-      : '';
-    // set the password in the environment variable, so we don't need to pass it in the command
-    const command = `${this.getBackupCommandName()} ${includeOption} ${excludeOption} -U ${username} -h ${host} ${
-      port ? `-p ${port}` : ''
-    } -F c -b --quote-all-identifiers ${schemaOption} -f ${filePath} ${database}`;
-    await run(command, this.getPasswordEnvVars(password));
+        ? includeTables.flatMap((table) => ['-t', quotePgTablePattern(qualifyPgTablePattern(table, backupSchema))])
+        : [];
+    const excludeArgs = expandedExcludeTables.length
+      ? expandedExcludeTables.flatMap((table) => [
+          '-T',
+          quotePgTablePattern(qualifyPgTablePattern(table, backupSchema)),
+        ])
+      : [];
+    const args = [
+      ...includeArgs,
+      ...excludeArgs,
+      ...this.getConnectionArgs(false),
+      '-F',
+      'c',
+      '-b',
+      '--quote-all-identifiers',
+      ...(backupSchema ? [`--schema=${backupSchema}`] : []),
+      '-f',
+      filePath,
+      database,
+    ];
+    await runSpawn(this.getBackupCommandName(), args, this.getPasswordEnvVars(password));
   }
 
   protected async getOwnedSequenceTables(
@@ -542,7 +574,6 @@ class PostgresAdapter extends BaseDBAdapter {
       return [];
     }
 
-    const { username, host, port, database, password } = this.dbOpts;
     const tableRefs = excludeTables
       .map((table) => parsePgTableReference(table, backupSchema))
       .filter((ref) => ref.table);
@@ -569,14 +600,41 @@ class PostgresAdapter extends BaseDBAdapter {
         AND dep.deptype IN ('a', 'i')
         AND (excluded.schema_name IS NULL OR tbl_ns.nspname = excluded.schema_name)
     `;
-    const command = `${this.getSqlCommandName()} -U ${username} -h ${host} ${
-      port ? `-p ${port}` : ''
-    } -d ${database} -At -c ${quoteShellArg(query)}`;
-    const output = String(await run(command, this.getPasswordEnvVars(password)));
+    const output = String(await this.runSql(query, ['-At']));
     return output
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
+  }
+
+  protected getConnectionArgs(includeDatabase = true): string[] {
+    const { username, host, port, database } = this.dbOpts;
+    return [
+      '-U',
+      username,
+      '-h',
+      host,
+      ...(port ? ['-p', String(port)] : []),
+      ...(includeDatabase ? ['-d', database] : []),
+    ];
+  }
+
+  protected runSql(
+    query: string,
+    extraArgs: string[] = [],
+    toolchain: DBBackupToolchain = this.backupToolchain,
+  ): Promise<string> {
+    const { password } = this.dbOpts;
+    return runSpawn(
+      this.getSqlCommandName(toolchain),
+      [...this.getConnectionArgs(), ...extraArgs, '-c', query],
+      this.getPasswordEnvVars(password, toolchain),
+    );
+  }
+
+  protected runRestore(args: string[], toolchain: DBBackupToolchain = this.backupToolchain): Promise<string> {
+    const { password } = this.dbOpts;
+    return runSpawn(this.getRestoreCommandName(toolchain), args, this.getPasswordEnvVars(password, toolchain));
   }
 
   async restore({
@@ -586,7 +644,6 @@ class PostgresAdapter extends BaseDBAdapter {
     restoreMode,
     toolchain = this.backupToolchain,
   }: DBRestoreOptions): Promise<void> {
-    const { username, host, port, database, password } = this.dbOpts;
     let schemaOption = this.dbOpts.schema;
     if (schema && !schemaOption) {
       schemaOption = 'public'; // if schema is provided, but schemaOption is not, set it to public
@@ -606,10 +663,8 @@ class PostgresAdapter extends BaseDBAdapter {
       ? `WHERE relnamespace = '${schemaOption}'::regnamespace`
       : `WHERE tgrelid IN (SELECT oid FROM pg_class WHERE relnamespace NOT IN (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname IN ('pg_catalog', 'information_schema')))`;
     if (restoreMode === 'preserveTables') {
-      const dropViewsCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
-        port ? `-p ${port}` : ''
-      } -d ${database} -c "
-    DO ${D$$} DECLARE r RECORD;
+      const dropViewsQuery = `
+    DO $$ DECLARE r RECORD;
     BEGIN
     FOR r IN (
       SELECT schemaname, viewname, false AS materialized FROM pg_views ${schemaNameCondition}
@@ -626,14 +681,12 @@ class PostgresAdapter extends BaseDBAdapter {
         WHEN OTHERS THEN
       END;
     END LOOP;
-    END ${D$$};"`.replace(/\n/g, ' ');
+    END $$;`;
 
-      await run(dropViewsCommand, this.getPasswordEnvVars(password, toolchain));
+      await this.runSql(dropViewsQuery, [], toolchain);
     } else if (!skipDropAllTables) {
-      const dropDataCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
-        port ? `-p ${port}` : ''
-      } -d ${database} -c "
-    DO ${D$$} DECLARE r RECORD;
+      const dropDataQuery = `
+    DO $$ DECLARE r RECORD;
     BEGIN
     FOR r IN (SELECT viewname,schemaname FROM pg_views ${schemaNameCondition}) LOOP
         BEGIN
@@ -671,10 +724,10 @@ class PostgresAdapter extends BaseDBAdapter {
       END;
     END LOOP;
 
-    END ${D$$};"`.replace(/\n/g, ' ');
+    END $$;`;
 
       // Run the command to drop all existing data
-      await run(dropDataCommand, this.getPasswordEnvVars(password, toolchain));
+      await this.runSql(dropDataQuery, [], toolchain);
     }
 
     if (schema === schemaOption || !schemaOption) {
@@ -690,11 +743,18 @@ class PostgresAdapter extends BaseDBAdapter {
       // SCHEMA.
       const restoreList =
         restoreMode === 'preserveTables' ? await this.createRestoreListWithoutSchema(filePath, toolchain) : undefined;
-      const pgRestoreCommand = `${this.getRestoreCommandName(toolchain)} -U ${username} -h ${host} ${
-        port ? `-p ${port}` : ''
-      } -d ${database} --clean --if-exists --no-owner -j ${j} ${restoreList?.option ?? ''} ${filePath}`;
+      const restoreArgs = [
+        ...this.getConnectionArgs(),
+        '--clean',
+        '--if-exists',
+        '--no-owner',
+        '-j',
+        String(j),
+        ...(restoreList ? ['-L', restoreList.filePath] : []),
+        filePath,
+      ];
       try {
-        await run(pgRestoreCommand, this.getPasswordEnvVars(password, toolchain));
+        await this.runRestore(restoreArgs, toolchain);
       } finally {
         if (restoreList) {
           await fsPromises.unlink(restoreList.filePath).catch(() => {});
@@ -702,16 +762,16 @@ class PostgresAdapter extends BaseDBAdapter {
       }
     } else {
       const srcSchema = schema || 'public';
-      const pgRestoreCommand = this.buildSchemaRestoreCommand(srcSchema, schemaOption, filePath, j, toolchain);
-      await this.restoreSchema(srcSchema, schemaOption, pgRestoreCommand, toolchain);
+      const pgRestoreArgs = this.buildSchemaRestoreArgs(srcSchema, schemaOption, filePath, j, toolchain);
+      await this.restoreSchema(srcSchema, schemaOption, pgRestoreArgs, toolchain);
     }
   }
 
   protected async createRestoreListWithoutSchema(
     filePath: string,
     toolchain: DBBackupToolchain = this.backupToolchain,
-  ): Promise<{ option: string; filePath: string }> {
-    const listOutput = String(await run(`${this.getRestoreCommandName(toolchain)} --list ${quoteShellArg(filePath)}`));
+  ): Promise<{ filePath: string }> {
+    const listOutput = String(await this.runRestore(['--list', filePath], toolchain));
     const filteredList = listOutput
       .split('\n')
       .filter((line) => !isPgRestoreSchemaTocEntry(line))
@@ -722,57 +782,61 @@ class PostgresAdapter extends BaseDBAdapter {
     );
     await fsPromises.writeFile(listFilePath, filteredList);
     return {
-      option: `-L ${quoteShellArg(listFilePath)}`,
       filePath: listFilePath,
     };
   }
 
-  protected buildSchemaRestoreCommand(
+  protected buildSchemaRestoreArgs(
     srcSchema: string,
     _targetSchema: string,
     filePath: string,
     jobs: number,
-    toolchain: DBBackupToolchain = this.backupToolchain,
+    _toolchain: DBBackupToolchain = this.backupToolchain,
   ) {
-    const { username, host, port, database } = this.dbOpts;
-    return `${this.getRestoreCommandName(toolchain)} -U ${username} -h ${host} ${
-      port ? `-p ${port}` : ''
-    } -n ${srcSchema} -d ${database} --clean --if-exists --no-owner -j ${jobs} ${filePath}`;
+    return [
+      ...this.getConnectionArgs(),
+      '-n',
+      srcSchema,
+      '--clean',
+      '--if-exists',
+      '--no-owner',
+      '-j',
+      String(jobs),
+      filePath,
+    ];
   }
 
   protected async restoreSchema(
     srcSchema: string,
     targetSchema: string,
-    pgRestoreCommand: string,
+    pgRestoreArgs: string[],
     toolchain: DBBackupToolchain = this.backupToolchain,
   ) {
-    const { username, host, port, database, password } = this.dbOpts;
     const ts = Date.now();
     // 1. backup current schema to srcSchema_ts if exists and create new schema (same name as srcSchema)
-    const sqlCommandName = this.getSqlCommandName(toolchain);
-    const preCommand = `${sqlCommandName} -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
-    DO ${D$$}
+    const preQuery = `
+    DO $$
     BEGIN
         IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '${srcSchema}') THEN
             EXECUTE 'ALTER SCHEMA ${srcSchema} RENAME TO ${srcSchema}_${ts}';
         END IF;
         EXECUTE 'CREATE SCHEMA ${srcSchema}';
-    END ${D$$};"`.replace(/\n/g, ' ');
-    const postCommand = `${sqlCommandName} -U ${username} -h ${host} ${port ? `-p ${port}` : ''} -d ${database} -c "
-    DO ${D$$}
+    END $$;`;
+    const postQuery = `
+    DO $$
     BEGIN
         EXECUTE 'DROP SCHEMA ${targetSchema} CASCADE';
         EXECUTE 'ALTER SCHEMA ${srcSchema} RENAME TO ${targetSchema}';
         IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '${srcSchema}_${ts}') THEN
             EXECUTE 'ALTER SCHEMA ${srcSchema}_${ts} RENAME TO ${srcSchema}';
         END IF;
-    END ${D$$};"`.replace(/\n/g, ' ');
+    END $$;`;
 
-    await run(preCommand, this.getPasswordEnvVars(password, toolchain));
+    await this.runSql(preQuery, [], toolchain);
     try {
-      await run(pgRestoreCommand, this.getPasswordEnvVars(password, toolchain));
+      await this.runRestore(pgRestoreArgs, toolchain);
     } finally {
-      await run(postCommand, this.getPasswordEnvVars(password, toolchain));
+      await this.runSql(postQuery, [], toolchain);
     }
     await this.syncCollectionSchemaMetadata(srcSchema, targetSchema, toolchain);
   }
@@ -782,15 +846,13 @@ class PostgresAdapter extends BaseDBAdapter {
     targetSchema: string,
     toolchain: DBBackupToolchain = this.backupToolchain,
   ) {
-    const { username, host, port, database, password, tablePrefix } = this.dbOpts;
+    const { tablePrefix } = this.dbOpts;
     const collectionsTable = `${tablePrefix || ''}collections`;
     const targetSchemaLiteral = escapeStringLiteral(targetSchema);
     const srcSchemaLiteral = escapeStringLiteral(srcSchema);
     const collectionsTableLiteral = escapeStringLiteral(collectionsTable);
-    const updateCollectionSchemaCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
-      port ? `-p ${port}` : ''
-    } -d ${database} -c "
-    DO ${D$$}
+    const updateCollectionSchemaQuery = `
+    DO $$
     DECLARE
         collections_table text := '${collectionsTableLiteral}';
     BEGIN
@@ -808,8 +870,8 @@ class PostgresAdapter extends BaseDBAdapter {
               '${srcSchemaLiteral}'
             );
         END IF;
-    END ${D$$};"`.replace(/\n/g, ' ');
-    await run(updateCollectionSchemaCommand, this.getPasswordEnvVars(password, toolchain));
+    END $$;`;
+    await this.runSql(updateCollectionSchemaQuery, [], toolchain);
   }
 }
 
@@ -864,7 +926,7 @@ class KingbaseAdapter extends PostgresAdapter {
     return this.dbOpts.schema || 'public';
   }
 
-  protected buildSchemaRestoreCommand(
+  protected buildSchemaRestoreArgs(
     srcSchema: string,
     targetSchema: string,
     filePath: string,
@@ -872,33 +934,38 @@ class KingbaseAdapter extends PostgresAdapter {
     toolchain: DBBackupToolchain = this.backupToolchain,
   ) {
     if (toolchain === 'postgres') {
-      return super.buildSchemaRestoreCommand(srcSchema, targetSchema, filePath, jobs, toolchain);
+      return super.buildSchemaRestoreArgs(srcSchema, targetSchema, filePath, jobs, toolchain);
     }
-    const { username, host, port, database } = this.dbOpts;
-    return `${this.getRestoreCommandName(toolchain)} -U ${username} -h ${host} ${
-      port ? `-p ${port}` : ''
-    } -g ${srcSchema} -G ${targetSchema} -d ${database} --clean --if-exists --no-owner -j ${jobs} ${filePath}`;
+    return [
+      ...this.getConnectionArgs(),
+      '-g',
+      srcSchema,
+      '-G',
+      targetSchema,
+      '--clean',
+      '--if-exists',
+      '--no-owner',
+      '-j',
+      String(jobs),
+      filePath,
+    ];
   }
 
   protected async restoreSchema(
     srcSchema: string,
     targetSchema: string,
-    restoreCommand: string,
+    restoreArgs: string[],
     toolchain: DBBackupToolchain = this.backupToolchain,
   ) {
     if (toolchain === 'postgres') {
-      await super.restoreSchema(srcSchema, targetSchema, restoreCommand, toolchain);
+      await super.restoreSchema(srcSchema, targetSchema, restoreArgs, toolchain);
       return;
     }
 
-    const { username, host, port, database, password } = this.dbOpts;
-    const targetSchemaIdentifier = quotePgIdentifier(targetSchema).replace(/"/g, '\\"');
-    const createSchemaCommand = `${this.getSqlCommandName(toolchain)} -U ${username} -h ${host} ${
-      port ? `-p ${port}` : ''
-    } -d ${database} -c "CREATE SCHEMA IF NOT EXISTS ${targetSchemaIdentifier};"`;
+    const targetSchemaIdentifier = quotePgIdentifier(targetSchema);
 
-    await run(createSchemaCommand, this.getPasswordEnvVars(password, toolchain));
-    await run(restoreCommand, this.getPasswordEnvVars(password, toolchain));
+    await this.runSql(`CREATE SCHEMA IF NOT EXISTS ${targetSchemaIdentifier};`, [], toolchain);
+    await this.runRestore(restoreArgs, toolchain);
     await this.syncCollectionSchemaMetadata(srcSchema, targetSchema, toolchain);
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
PostgreSQL and Kingbase backup restore commands were assembled as shell strings. Paths, schema names, table patterns, and SQL blocks could be interpreted by the shell, which made restore behavior fragile for spaces and special characters.

### Description 
This PR changes PostgreSQL and Kingbase backup/restore command execution to pass command arguments through `spawn` arrays instead of shell-assembled strings. It also updates command availability checks to use `spawnSync`, keeps SQL execution and restore command helpers centralized, and adjusts backup restore tests to assert spawned command arguments and environment variables.

Potential risk is limited to backup and restore command invocation for PostgreSQL and Kingbase. Related adapter and restore manager tests were updated and run.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed PostgreSQL and Kingbase backup restore command execution when paths or arguments contain spaces or special characters. |
| 🇨🇳 Chinese | 修复 PostgreSQL 和 Kingbase 备份恢复命令在路径或参数包含空格、特殊字符时执行异常的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary