### PR TITLE
fix(plugin-ui-layout): support scrolling crowded mobile tabs

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
@@ -3334,11 +3334,14 @@ describe('plugin-ui-layout mobile models', () => {
 
     expect(tabbarRule).toMatch(/display:\s*flex/);
     expect(tabbarRule).toMatch(/min-height:\s*48px/);
+    expect(tabbarRule).toMatch(/overflow-x:\s*auto/);
+    expect(tabbarRule).toMatch(/scrollbar-width:\s*thin/);
     expect(tabbarRule).not.toMatch(/grid-template-columns/);
-    expect(tabbarChildRule).toMatch(/flex:\s*1 1 0%/);
-    expect(tabbarChildRule).toMatch(/min-width:\s*0/);
-    expect(itemShellRule).toMatch(/flex:\s*1 1 0%/);
-    expect(itemShellRule).toMatch(/width:\s*100%/);
+    expect(tabbarChildRule).toMatch(/flex:\s*1 0 64px/);
+    expect(tabbarChildRule).toMatch(/min-width:\s*64px/);
+    expect(itemShellRule).toMatch(/flex:\s*1 0 64px/);
+    expect(itemShellRule).toMatch(/width:\s*auto/);
+    expect(itemShellRule).toMatch(/min-width:\s*64px/);
     expect(itemShellRule).toMatch(/min-height:\s*48px/);
     expect(itemRule).toMatch(/min-height:\s*48px/);
     expect(itemRule).toMatch(/padding:\s*4px 8px/);
@@ -3563,7 +3566,7 @@ describe('plugin-ui-layout mobile models', () => {
     expect(activeTabRule).toContain('#642ab5');
   });
 
-  it('should let mobile tabs share the tab bar width like antd-mobile', async () => {
+  it('should let crowded mobile tabs scroll horizontally', async () => {
     renderMobileLayoutWithRouteRepository({
       listAccessible: () =>
         Array.from({ length: 10 }, (_, index) => ({
@@ -3585,12 +3588,17 @@ describe('plugin-ui-layout mobile models', () => {
     const tabbarRule = styleText.match(/\.nb-ui-layout-mobile-home-tabbar\s*\{[^}]+\}/)?.[0];
     const tabbarChildRule = styleText.match(/\.nb-ui-layout-mobile-home-tabbar\s*>\s*div\s*\{[^}]+\}/)?.[0];
     const itemShellRule = styleText.match(/\.nb-ui-layout-mobile-home-tabbar-item-shell\s*\{[^}]+\}/)?.[0];
+    const addRule = styleText.match(/\.nb-ui-layout-mobile-home-tabbar-add\s*\{[^}]+\}/)?.[0];
 
     expect(tabbarRule).toMatch(/display:\s*flex/);
-    expect(tabbarRule).not.toMatch(/overflow-x:\s*auto/);
-    expect(tabbarChildRule).toMatch(/flex:\s*1 1 0%/);
-    expect(itemShellRule).toMatch(/flex:\s*1 1 0%/);
-    expect(itemShellRule).toMatch(/min-width:\s*0/);
+    expect(tabbarRule).toMatch(/overflow-x:\s*auto/);
+    expect(tabbarRule).toMatch(/overflow-y:\s*hidden/);
+    expect(tabbarChildRule).toMatch(/flex:\s*1 0 64px/);
+    expect(tabbarChildRule).toMatch(/min-width:\s*64px/);
+    expect(itemShellRule).toMatch(/flex:\s*1 0 64px/);
+    expect(itemShellRule).toMatch(/min-width:\s*64px/);
+    expect(addRule).toMatch(/position:\s*sticky/);
+    expect(addRule).toMatch(/right:\s*8px/);
   });
 
   it('should register mobile route pages with the mobile root page model', () => {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
@@ -1810,22 +1810,40 @@ const MobileHomePlaceholder = observer(
           padding: 0 0 env(safe-area-inset-bottom);
           background: ${token.colorBgContainer};
           border-top: 1px solid ${token.colorBorderSecondary};
-          overflow-x: hidden;
+          overflow-x: auto;
           overflow-y: hidden;
+          overscroll-behavior-x: contain;
+          -webkit-overflow-scrolling: touch;
+          scrollbar-width: thin;
+          scrollbar-color: ${token.colorFillSecondary} transparent;
+        }
+
+        .nb-ui-layout-mobile-home-tabbar::-webkit-scrollbar {
+          height: 6px;
+        }
+
+        .nb-ui-layout-mobile-home-tabbar::-webkit-scrollbar-track {
+          background: transparent;
+        }
+
+        .nb-ui-layout-mobile-home-tabbar::-webkit-scrollbar-thumb {
+          border-radius: ${token.borderRadiusSM}px;
+          background: ${token.colorFillSecondary};
         }
 
         .nb-ui-layout-mobile-home-tabbar > div {
-          flex: 1 1 0%;
-          min-width: 0;
+          flex: 1 0 64px;
+          width: auto;
+          min-width: 64px;
           min-height: 48px;
           display: flex;
         }
 
         .nb-ui-layout-mobile-home-tabbar-item-shell {
           position: relative;
-          flex: 1 1 0%;
-          width: 100%;
-          min-width: 0;
+          flex: 1 0 64px;
+          width: auto;
+          min-width: 64px;
           min-height: 48px;
           display: flex;
           align-items: stretch;
@@ -1866,6 +1884,9 @@ const MobileHomePlaceholder = observer(
           display: inline-flex;
           align-self: center;
           flex: 0 0 32px;
+          position: sticky;
+          right: 8px;
+          z-index: 1;
           margin: 8px;
           width: 32px;
           height: 32px;
@@ -1876,7 +1897,7 @@ const MobileHomePlaceholder = observer(
           align-items: center;
           justify-content: center;
           color: ${colorSettings};
-          background: transparent;
+          background: ${token.colorBgContainer};
           cursor: pointer;
           font-size: ${token.fontSize}px;
         }
@@ -1936,6 +1957,7 @@ const MobileHomePlaceholder = observer(
         token.colorBgContainer,
         token.colorBgLayout,
         token.colorBorderSecondary,
+        token.colorFillSecondary,
         token.colorFillTertiary,
         token.colorPrimary,
         token.colorPrimaryBg,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 mobile tab bar can become crowded when many tabs are configured. The existing flex layout allowed each tab to shrink too far, causing icons and labels to overlap instead of remaining usable.

### Description
This PR updates the v2 mobile tab bar layout so crowded tabs can scroll horizontally while keeping normal tab counts evenly distributed.

- Allows horizontal scrolling on the v2 mobile home tab bar.
- Keeps each tab at a minimum usable width while still letting tabs share available space when there are only a few items.
- Keeps the design-mode add button available with sticky positioning.
- Updates the v2 mobile model tests to cover the crowded tab bar behavior.

Potential risk: the design-mode add button is sticky and may visually overlap the far-right edge of the scrollable tab area on very narrow screens. It only appears in design mode and keeps the add action reachable.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts --run --reporter=verbose`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved the v2 mobile tab bar so crowded tabs scroll horizontally instead of overlapping. |
| 🇨🇳 Chinese | 优化 v2 移动端标签栏，标签过多时可横向滚动，避免图标重叠。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
