### PR TITLE
fix(client): correct Japanese translation of "Tag" (currently shows "Tab")

### DIFF
--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -1319,7 +1319,7 @@
     "Table size": "テーブルサイズ",
     "Tablet": "Tablet",
     "Tablet device": "タブレットデバイス",
-    "Tag": "タブ",
+    "Tag": "タグ",
     "Tag color field": "ラベルの色フィールド",
     "Target": "ターゲット",
     "Target block UID": "Target block UID",


### PR DESCRIPTION
In `locales/ja-JP.json`, the `Tag` string under `@nocobase/client` is translated as `タブ`, which is the Japanese word for "Tab". The Japanese word for "Tag" is `タグ`.

The same namespace also has a separate `Tab` key whose value is `タブ`, so right now both "Tag" and "Tab" show up as `タブ` in Japanese. That makes the tag label read as "Tab" to Japanese users.

The other locales keep the two distinct: Korean uses `태그` for Tag and `탭` for Tab, and Chinese uses `标签` for Tag. Only Japanese collapsed them into the same word.

This fixes the single value:

```
"Tag": "タブ"  ->  "Tag": "タグ"
```
