### PR TITLE
fix(plugin-workflow): align v2 request and mailer fields

### DIFF
--- a/packages/core/flow-engine/src/components/variables/VariableHybridInput.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableHybridInput.tsx
@@ -36,6 +36,7 @@ export interface VariableHybridInputProps {
   value?: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  readOnly?: boolean;
   placeholder?: string;
   addonBefore?: React.ReactNode;
   metaTree?: MetaTreeNode[] | (() => MetaTreeNode[] | Promise<MetaTreeNode[]>);
@@ -295,7 +296,7 @@ function getCurrentRange(element: HTMLElement): RangeIndexes {
 }
 
 const VariableHybridInputComponent: React.FC<VariableHybridInputProps> = (props) => {
-  const { addonBefore, className, converters, disabled, metaTree, onChange, placeholder, style } = props;
+  const { addonBefore, className, converters, disabled, metaTree, onChange, placeholder, readOnly, style } = props;
   const { token } = theme.useToken();
   const ctx = useFlowContext();
   const { resolvedMetaTree } = useResolvedMetaTree(metaTree);
@@ -458,12 +459,13 @@ const VariableHybridInputComponent: React.FC<VariableHybridInputProps> = (props)
 
   const handleInput = useCallback(
     ({ currentTarget }: React.FormEvent<HTMLDivElement>) => {
+      if (readOnly) return;
       if (isComposing) return;
       setChanged(true);
       setRange(getCurrentRange(currentTarget));
       emitChange(currentTarget);
     },
-    [emitChange, isComposing],
+    [emitChange, isComposing, readOnly],
   );
 
   const handleBlur = useCallback(({ currentTarget }: React.FocusEvent<HTMLDivElement>) => {
@@ -479,6 +481,7 @@ const VariableHybridInputComponent: React.FC<VariableHybridInputProps> = (props)
   const handlePaste = useCallback(
     (event: React.ClipboardEvent<HTMLDivElement>) => {
       event.preventDefault();
+      if (readOnly) return;
       // Paste as plain text only; variable tags must be inserted via the picker.
       const text = event.clipboardData.getData('text/plain').replace(/\n/g, ' ');
       if (!text) return;
@@ -487,18 +490,19 @@ const VariableHybridInputComponent: React.FC<VariableHybridInputProps> = (props)
       setRange(getCurrentRange(event.currentTarget));
       emitChange(event.currentTarget);
     },
-    [emitChange],
+    [emitChange, readOnly],
   );
 
   const handleCompositionStart = useCallback(() => setIsComposing(true), []);
   const handleCompositionEnd = useCallback(
     ({ currentTarget }: React.CompositionEvent<HTMLDivElement>) => {
       setIsComposing(false);
+      if (readOnly) return;
       setChanged(true);
       setRange(getCurrentRange(currentTarget));
       emitChange(currentTarget);
     },
-    [emitChange],
+    [emitChange, readOnly],
   );
 
   const wrapperClassName = useMemo(
@@ -620,6 +624,14 @@ const VariableHybridInputComponent: React.FC<VariableHybridInputProps> = (props)
         }
       }
 
+      &.is-readonly {
+        cursor: default;
+
+        &:hover {
+          border-color: ${token.colorBorder};
+        }
+      }
+
       &.is-error {
         border-color: ${token.colorError};
 
@@ -660,10 +672,12 @@ const VariableHybridInputComponent: React.FC<VariableHybridInputProps> = (props)
           aria-label="textbox"
           className={cx(editorClassName, {
             'is-disabled': disabled,
+            'is-readonly': readOnly,
             'is-error': effectiveStatus === 'error',
             'is-warning': effectiveStatus === 'warning',
           })}
-          contentEditable={!disabled}
+          contentEditable={!disabled && !readOnly}
+          aria-readonly={readOnly}
           data-placeholder={placeholder}
           onInput={handleInput}
           onBlur={handleBlur}

--- a/packages/core/flow-engine/src/components/variables/__tests__/VariableHybridInput.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/VariableHybridInput.test.tsx
@@ -14,7 +14,7 @@
  * Plus the top-level (already-loaded) and not-in-tree (raw-token fallback) cases.
  */
 
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { VariableHybridInput, type VariableHybridInputConverters } from '../VariableHybridInput';
@@ -174,5 +174,39 @@ describe('VariableHybridInput — saved reference labels', () => {
       const tag = document.querySelector(TAG_SELECTOR);
       expect(tag?.textContent).toBe('{{$missing.field}}');
     });
+  });
+
+  it('keeps the selector enabled when only the editor is read-only', async () => {
+    const flowContext = createTestFlowContext();
+    const onChange = vi.fn();
+    const metaTree: MetaTreeNode[] = [
+      {
+        name: '$user',
+        title: 'User',
+        type: '',
+        paths: ['$user'],
+        children: [{ name: 'name', title: 'Name', type: 'string', paths: ['$user', 'name'] }],
+      },
+    ];
+
+    render(
+      <TestFlowContextWrapper context={flowContext}>
+        <VariableHybridInput
+          readOnly
+          value=""
+          onChange={onChange}
+          metaTree={metaTree}
+          converters={workflowConverters}
+        />
+      </TestFlowContextWrapper>,
+    );
+
+    const editor = screen.getByRole('textbox');
+    expect(editor).toHaveAttribute('contenteditable', 'false');
+    expect(editor).toHaveAttribute('aria-readonly', 'true');
+
+    fireEvent.input(editor, { currentTarget: { textContent: 'manual' } });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button')).not.toBeDisabled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/client-v2/components/CodeEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/client-v2/components/CodeEditor.tsx
@@ -29,6 +29,8 @@ export default function CodeEditor({ value = '', onChange, disabled = false }: C
   const readOnlyCompartmentRef = useRef(new Compartment());
   const themeCompartmentRef = useRef(new Compartment());
   const onChangeRef = useRef(onChange);
+  const initialValueRef = useRef(value);
+  const initialDisabledRef = useRef(disabled);
 
   onChangeRef.current = onChange;
 
@@ -84,6 +86,7 @@ export default function CodeEditor({ value = '', onChange, disabled = false }: C
       }),
     [disabled, token.colorBgContainer, token.colorBgContainerDisabled, token.fontFamilyCode, token.fontSize],
   );
+  const initialEditorThemeRef = useRef(editorTheme);
 
   useEffect(() => {
     if (!containerRef.current || editorRef.current) {
@@ -92,13 +95,13 @@ export default function CodeEditor({ value = '', onChange, disabled = false }: C
 
     const editor = new EditorView({
       state: EditorState.create({
-        doc: value,
+        doc: initialValueRef.current,
         extensions: [
           basicSetup,
           javascript(),
-          editableCompartmentRef.current.of(EditorView.editable.of(!disabled)),
-          readOnlyCompartmentRef.current.of(EditorState.readOnly.of(disabled)),
-          themeCompartmentRef.current.of(editorTheme),
+          editableCompartmentRef.current.of(EditorView.editable.of(!initialDisabledRef.current)),
+          readOnlyCompartmentRef.current.of(EditorState.readOnly.of(initialDisabledRef.current)),
+          themeCompartmentRef.current.of(initialEditorThemeRef.current),
           EditorView.updateListener.of((update) => {
             if (!update.docChanged) {
               return;
@@ -116,7 +119,7 @@ export default function CodeEditor({ value = '', onChange, disabled = false }: C
       editor.destroy();
       editorRef.current = null;
     };
-  }, [disabled, editorTheme, value]);
+  }, []);
 
   useEffect(() => {
     const editor = editorRef.current;

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/client-v2/components/__tests__/CodeEditor.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/client-v2/components/__tests__/CodeEditor.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CodeEditor from '../CodeEditor';
+
+type MockEditorState = {
+  doc: {
+    toString: () => string;
+  };
+  extensions: unknown[];
+};
+
+type MockEditorViewConfig = {
+  state: MockEditorState;
+  parent: HTMLElement;
+};
+
+const mocks = vi.hoisted(() => {
+  class MockCompartment {
+    of = vi.fn((extension: unknown) => ({ compartment: this, extension }));
+    reconfigure = vi.fn((extension: unknown) => ({ compartment: this, extension, type: 'reconfigure' }));
+  }
+
+  class MockEditorView {
+    static editable = { of: vi.fn((value: boolean) => ({ kind: 'editable', value })) };
+    static updateListener = { of: vi.fn((listener: unknown) => ({ kind: 'updateListener', listener })) };
+    static theme = vi.fn((themeConfig: unknown) => ({ kind: 'theme', themeConfig }));
+
+    state: MockEditorState;
+    parent: HTMLElement;
+    dispatch = vi.fn((transaction: { changes?: { insert: string } }) => {
+      if (!transaction.changes) {
+        return;
+      }
+
+      const value = transaction.changes.insert;
+      this.state = {
+        ...this.state,
+        doc: {
+          toString: () => value,
+        },
+      };
+    });
+    destroy = vi.fn();
+
+    constructor(config: MockEditorViewConfig) {
+      this.state = config.state;
+      this.parent = config.parent;
+      mocks.editorViews.push(this);
+    }
+  }
+
+  return {
+    compartmentClass: MockCompartment,
+    editorStateCreate: vi.fn((config: { doc: string; extensions: unknown[] }) => ({
+      doc: {
+        toString: () => config.doc,
+      },
+      extensions: config.extensions,
+    })),
+    editorViews: [] as MockEditorView[],
+    editorViewClass: MockEditorView,
+  };
+});
+
+vi.mock('antd', () => ({
+  theme: {
+    useToken: () => ({
+      token: {
+        borderRadiusLG: 6,
+        colorBgContainer: '#fff',
+        colorBgContainerDisabled: '#f5f5f5',
+        colorBorder: '#d9d9d9',
+        colorPrimary: '#1677ff',
+        colorPrimaryHover: '#4096ff',
+        controlHeight: 32,
+        fontFamilyCode: 'monospace',
+        fontSize: 14,
+      },
+    }),
+  },
+}));
+
+vi.mock('@codemirror/lang-javascript', () => ({
+  javascript: vi.fn(() => ({ kind: 'javascript' })),
+}));
+
+vi.mock('@codemirror/state', () => ({
+  Compartment: mocks.compartmentClass,
+  EditorState: {
+    create: mocks.editorStateCreate,
+    readOnly: { of: vi.fn((value: boolean) => ({ kind: 'readOnly', value })) },
+  },
+}));
+
+vi.mock('@codemirror/view', () => ({
+  EditorView: mocks.editorViewClass,
+}));
+
+vi.mock('codemirror', () => ({
+  basicSetup: { kind: 'basicSetup' },
+}));
+
+describe('CodeEditor', () => {
+  it('keeps the CodeMirror view mounted when the controlled value changes', () => {
+    const { rerender, unmount } = render(<CodeEditor value="const a = 1;" />);
+
+    expect(mocks.editorViews).toHaveLength(1);
+
+    const editor = mocks.editorViews[0];
+
+    rerender(<CodeEditor value="const a = 12;" />);
+
+    expect(mocks.editorViews).toHaveLength(1);
+    expect(editor.destroy).not.toHaveBeenCalled();
+    expect(editor.dispatch).toHaveBeenCalledWith({
+      changes: {
+        from: 0,
+        to: 'const a = 1;'.length,
+        insert: 'const a = 12;',
+      },
+    });
+
+    unmount();
+
+    expect(editor.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow-mailer/src/client-v2/__tests__/MailerFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-mailer/src/client-v2/__tests__/MailerFieldset.test.tsx
@@ -84,6 +84,7 @@ vi.mock('@nocobase/plugin-workflow/client-v2', () => {
     onChange?: (value: unknown) => void;
     defaultToFirstConstantTypeWhenUndefined?: boolean;
     placeholder?: string;
+    readOnly?: boolean;
     types?: unknown;
   };
 
@@ -111,7 +112,14 @@ vi.mock('@nocobase/plugin-workflow/client-v2', () => {
   }
 
   function WorkflowVariableInput(props: InputProps) {
-    return <input aria-label={props.placeholder ?? 'workflow-variable-input'} readOnly value="" />;
+    return (
+      <input
+        aria-label={props.placeholder ?? 'workflow-variable-input'}
+        readOnly
+        value=""
+        data-read-only={String(!!props.readOnly)}
+      />
+    );
   }
 
   function WorkflowVariableTextArea(props: InputProps) {
@@ -252,6 +260,31 @@ describe('MailerFieldset', () => {
         '{{$jobsMapByNodeKey.query.files.1}}',
         '{{$jobsMapByNodeKey.query.files.0}}',
       ]);
+    });
+  });
+
+  it('renders attachment inputs as variable-only and array add buttons as dashed additions', async () => {
+    dndState.contexts = [];
+    dndState.pendingDragEndHandlers = [];
+    renderWithForm();
+
+    expect(dndState.contexts).toHaveLength(0);
+
+    const addButtons = [
+      ...screen.getAllByRole('button', { name: /Add email address/ }),
+      screen.getByRole('button', { name: /Add attachment/ }),
+    ];
+
+    for (const button of addButtons) {
+      expect(button).toHaveClass('ant-btn-dashed');
+      expect(button).toHaveClass('ant-btn-block');
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: /Add attachment/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('File record')).toHaveAttribute('data-read-only', 'true');
+      expect(dndState.contexts).toHaveLength(1);
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow-mailer/src/client-v2/components/MailerFieldset.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-mailer/src/client-v2/components/MailerFieldset.tsx
@@ -87,6 +87,14 @@ function SortableRow({ children, disabled, id }: { children: React.ReactNode; di
   );
 }
 
+function ArrayAddButton({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
+  return (
+    <Button block icon={<PlusOutlined />} onClick={onClick} type="dashed">
+      {children}
+    </Button>
+  );
+}
+
 function AddressListField({ name, label, required }: { name: NamePath; label: React.ReactNode; required?: boolean }) {
   const t = useT();
   const form = Form.useFormInstance();
@@ -136,34 +144,34 @@ function AddressListField({ name, label, required }: { name: NamePath; label: Re
 
           return (
             <Space direction="vertical" style={{ width: '100%' }}>
-              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-                <SortableContext items={items} strategy={verticalListSortingStrategy}>
-                  <Space direction="vertical" style={{ width: '100%' }}>
-                    {fields.map((field) => (
-                      <SortableRow key={field.key} id={String(field.key)} disabled={fields.length < 2}>
-                        <Col>
-                          <SortHandle disabled={fields.length < 2} />
-                        </Col>
-                        <Col flex="auto">
-                          <Form.Item name={field.name} noStyle>
-                            <WorkflowTypedVariableInput types={EMAIL_VALUE_TYPES} placeholder={t('Email address')} />
-                          </Form.Item>
-                        </Col>
-                        <Col>
-                          <Button
-                            aria-label={t('Delete')}
-                            icon={<DeleteOutlined />}
-                            onClick={() => remove(field.name)}
-                          />
-                        </Col>
-                      </SortableRow>
-                    ))}
-                  </Space>
-                </SortableContext>
-              </DndContext>
-              <Button
-                block
-                icon={<PlusOutlined />}
+              {fields.length ? (
+                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                  <SortableContext items={items} strategy={verticalListSortingStrategy}>
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                      {fields.map((field) => (
+                        <SortableRow key={field.key} id={String(field.key)} disabled={fields.length < 2}>
+                          <Col>
+                            <SortHandle disabled={fields.length < 2} />
+                          </Col>
+                          <Col flex="auto">
+                            <Form.Item name={field.name} noStyle>
+                              <WorkflowTypedVariableInput types={EMAIL_VALUE_TYPES} placeholder={t('Email address')} />
+                            </Form.Item>
+                          </Col>
+                          <Col>
+                            <Button
+                              aria-label={t('Delete')}
+                              icon={<DeleteOutlined />}
+                              onClick={() => remove(field.name)}
+                            />
+                          </Col>
+                        </SortableRow>
+                      ))}
+                    </Space>
+                  </SortableContext>
+                </DndContext>
+              ) : null}
+              <ArrayAddButton
                 onClick={() => {
                   skipNextEmptyValidation();
                   add('');
@@ -171,7 +179,7 @@ function AddressListField({ name, label, required }: { name: NamePath; label: Re
                 }}
               >
                 {t('Add email address')}
-              </Button>
+              </ArrayAddButton>
               <Form.ErrorList errors={errors} />
             </Space>
           );
@@ -211,34 +219,38 @@ function AttachmentListField() {
 
           return (
             <Space direction="vertical" style={{ width: '100%' }}>
-              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-                <SortableContext items={items} strategy={verticalListSortingStrategy}>
-                  <Space direction="vertical" style={{ width: '100%' }}>
-                    {fields.map((field) => (
-                      <SortableRow key={field.key} id={String(field.key)} disabled={fields.length < 2}>
-                        <Col>
-                          <SortHandle disabled={fields.length < 2} />
-                        </Col>
-                        <Col flex="auto">
-                          <Form.Item name={field.name} noStyle>
-                            <WorkflowVariableInput variableOptions={variableOptions} placeholder={t('File record')} />
-                          </Form.Item>
-                        </Col>
-                        <Col>
-                          <Button
-                            aria-label={t('Delete')}
-                            icon={<DeleteOutlined />}
-                            onClick={() => remove(field.name)}
-                          />
-                        </Col>
-                      </SortableRow>
-                    ))}
-                  </Space>
-                </SortableContext>
-              </DndContext>
-              <Button block icon={<PlusOutlined />} onClick={() => add(null)}>
-                {t('Add attachment')}
-              </Button>
+              {fields.length ? (
+                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                  <SortableContext items={items} strategy={verticalListSortingStrategy}>
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                      {fields.map((field) => (
+                        <SortableRow key={field.key} id={String(field.key)} disabled={fields.length < 2}>
+                          <Col>
+                            <SortHandle disabled={fields.length < 2} />
+                          </Col>
+                          <Col flex="auto">
+                            <Form.Item name={field.name} noStyle>
+                              <WorkflowVariableInput
+                                readOnly
+                                variableOptions={variableOptions}
+                                placeholder={t('File record')}
+                              />
+                            </Form.Item>
+                          </Col>
+                          <Col>
+                            <Button
+                              aria-label={t('Delete')}
+                              icon={<DeleteOutlined />}
+                              onClick={() => remove(field.name)}
+                            />
+                          </Col>
+                        </SortableRow>
+                      ))}
+                    </Space>
+                  </SortableContext>
+                </DndContext>
+              ) : null}
+              <ArrayAddButton onClick={() => add(null)}>{t('Add attachment')}</ArrayAddButton>
             </Space>
           );
         }}

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/client-v2/__tests__/RequestFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/client-v2/__tests__/RequestFieldset.test.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { Form } from 'antd';
 import type { FormInstance } from 'antd';
 import React, { Suspense, useEffect } from 'react';
@@ -125,5 +125,20 @@ describe('RequestFieldset', () => {
       expect(getForm()?.getFieldValue(['config', 'method'])).toBe(DEFAULT_REQUEST_METHOD);
       expect(getForm()?.getFieldValue(['config', 'data'])).toBe('');
     });
+  });
+
+  it('renders boolean options inline and keeps timeout input compact', async () => {
+    const { resolveFieldset } = renderLazyFieldset({});
+
+    await resolveFieldset();
+
+    const onlyDataLabel = screen.getByText('Only return response data').closest('label');
+    const ignoreFailLabel = screen.getByText('Ignore failed request and continue workflow').closest('label');
+
+    expect(onlyDataLabel?.querySelector('input[type="checkbox"]')).toBeTruthy();
+    expect(ignoreFailLabel?.querySelector('input[type="checkbox"]')).toBeTruthy();
+    expect(screen.getByRole('spinbutton').closest('.ant-input-number')?.getAttribute('style') ?? '').not.toContain(
+      'width: 100%',
+    );
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/client-v2/components/RequestFieldset.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/client-v2/components/RequestFieldset.tsx
@@ -280,27 +280,22 @@ export function RequestFieldset() {
       <RequestBodyField />
 
       <Form.Item name={['config', 'timeout']} label={t('Timeout config')} initialValue={DEFAULT_TIMEOUT}>
-        <InputNumber addonAfter={t('ms')} min={1} step={1000} style={{ width: '100%' }} />
+        <InputNumber addonAfter={t('ms')} min={1} step={1000} />
       </Form.Item>
 
       <Form.Item
         name={['config', 'onlyData']}
-        label={t('Only return response data')}
         valuePropName="checked"
         extra={t(
           'If enabled, only the response data will be saved into result, and the status code and headers will be ignored.',
         )}
         initialValue={true}
       >
-        <Checkbox />
+        <Checkbox>{t('Only return response data')}</Checkbox>
       </Form.Item>
 
-      <Form.Item
-        name={['config', 'ignoreFail']}
-        label={t('Ignore failed request and continue workflow')}
-        valuePropName="checked"
-      >
-        <Checkbox />
+      <Form.Item name={['config', 'ignoreFail']} valuePropName="checked">
+        <Checkbox>{t('Ignore failed request and continue workflow')}</Checkbox>
       </Form.Item>
     </>
   );

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
@@ -31,6 +31,7 @@ export type WorkflowVariableInputProps = {
   value?: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  readOnly?: boolean;
   placeholder?: string;
   className?: string;
   style?: React.CSSProperties;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 workflow request and mailer node configuration forms had several UI parity gaps with the legacy form behavior. Boolean options, timeout width, mailer array additions, and mailer attachment input behavior did not match the existing v1 interaction patterns.

### Description
This PR aligns the v2 workflow request and mailer node fieldsets with the expected legacy behavior:

- Renders request node boolean options inline with their checkboxes.
- Keeps the request timeout input compact instead of full width.
- Makes mailer attachment inputs read-only for manual typing while keeping variable selection available.
- Uses dashed block add buttons for mailer array fields.
- Avoids rendering empty sortable row containers when mailer array fields have no rows, reducing the extra gap between labels and add buttons.
- Adds regression coverage for request field layout, mailer array/attachment behavior, and read-only variable input behavior.

Potential risk: `WorkflowVariableInput` now forwards a `readOnly` prop to `VariableHybridInput`. Existing callers do not pass this prop, so default behavior is unchanged.

Testing suggestions:

- Open the v2 workflow request node configuration form and verify boolean options stay inline and timeout is compact.
- Open the v2 mailer node configuration form and verify empty array fields show dashed add buttons close to their labels.
- Add mailer attachment rows and verify manual typing is disabled while selecting variables still works.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Aligned v2 workflow request and mailer node configuration fields with legacy layout and attachment variable behavior. |
| 🇨🇳 Chinese | 调整 v2 工作流请求节点和邮件节点配置字段，使其布局和附件变量选择行为与旧版保持一致。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
