### PR TITLE
fix(plugin-workflow): reduce dispatcher db fetch retries

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -68,7 +68,7 @@ export default class Dispatcher {
     const execution: ExecutionModel = await ExecutionRepo.findOne({
       filterByTk: event.executionId,
     });
-    if (!execution || execution.dispatched) {
+    if (!execution || execution.dispatched || execution.status !== EXECUTION_STATUS.QUEUEING) {
       return;
     }
     this.plugin
@@ -432,8 +432,7 @@ export default class Dispatcher {
     // the transaction boundary is managed externally, so run once without retry.
     if (options.transaction) {
       try {
-        const { execution } = await this.acquireExecution(input, options, options.transaction);
-        return execution;
+        return await this.acquireExecution(input, options, options.transaction);
       } catch (error) {
         if (error instanceof Error) {
           logger.error(`entering execution failed: ${error.message}`, { error });
@@ -455,13 +454,12 @@ export default class Dispatcher {
         async () => {
           const tx = await this.plugin.db.sequelize.transaction({
             isolationLevel:
-              this.plugin.db.options.dialect === 'sqlite' ? undefined : Transaction.ISOLATION_LEVELS.REPEATABLE_READ,
+              this.plugin.db.options.dialect === 'sqlite' ? undefined : Transaction.ISOLATION_LEVELS.READ_COMMITTED,
           });
           try {
-            const { execution, shouldRetry } = await this.acquireExecution(input, options, tx);
+            const execution = await this.acquireExecution(input, options, tx);
             await tx.commit();
             result = execution;
-            return shouldRetry;
           } catch (error) {
             await tx.rollback();
             if (this.isConcurrentAcquireError(error)) {
@@ -471,7 +469,6 @@ export default class Dispatcher {
               logger.error(`entering execution failed: ${error.message}`, { error });
             }
             result = null;
-            return false;
           }
         },
         {
@@ -497,17 +494,25 @@ export default class Dispatcher {
     input: ExecutionModel | null,
     options: { immediate?: boolean },
     transaction: Transaction,
-  ): Promise<{ execution: ExecutionModel | null; shouldRetry: boolean }> {
+  ): Promise<ExecutionModel | null> {
     let execution: ExecutionModel | null = input;
     if (execution) {
       if (!options.immediate || execution.status !== EXECUTION_STATUS.QUEUEING) {
         await execution.reload({ transaction });
       }
     } else {
+      const workflowIds = [...this.plugin.enabledCache.keys()];
+      if (!workflowIds.length) {
+        this.plugin.getLogger('dispatcher').debug(`no enabled workflow to process`);
+        return null;
+      }
+
       execution = (await this.plugin.db.getRepository('executions').findOne({
         filter: {
           dispatched: false,
-          'workflow.enabled': true,
+          status: EXECUTION_STATUS.QUEUEING,
+          startedAt: null,
+          workflowId: workflowIds,
         },
         sort: 'id',
         transaction,
@@ -522,18 +527,14 @@ export default class Dispatcher {
     }
 
     if (!execution) {
-      return { execution: null, shouldRetry: false };
+      return null;
     }
 
-    const entered = await this.enter(execution, transaction);
-    // NOTE: a queued execution was fetched but acquired by another worker first
-    // (conditional update affected 0 rows), retry to pick the next one.
-    const shouldRetry = !input && !entered;
-    return { execution: entered, shouldRetry };
+    return this.enter(execution, transaction);
   }
 
   private async acquireWithRetry(
-    acquire: () => Promise<boolean>,
+    acquire: () => Promise<void>,
     options: {
       logger: AcquireRetryLogger;
       conflictMessage: string;
@@ -541,22 +542,18 @@ export default class Dispatcher {
     },
   ) {
     for (let attempt = 1; attempt <= EXECUTION_ACQUIRE_MAX_ATTEMPTS; attempt++) {
-      let shouldRetry = false;
       try {
-        shouldRetry = await acquire();
+        await acquire();
+        break;
       } catch (error) {
         if (!this.isConcurrentAcquireError(error)) {
           throw error;
         }
-        shouldRetry = true;
         options.logger.warn(options.conflictMessage, { error });
-      }
-      if (!shouldRetry) {
-        break;
-      }
-      if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
-        options.logger.warn(options.maxAttemptsMessage);
-        break;
+        if (attempt >= EXECUTION_ACQUIRE_MAX_ATTEMPTS) {
+          options.logger.warn(options.maxAttemptsMessage);
+          break;
+        }
       }
     }
   }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -548,6 +548,60 @@ describe('workflow > Plugin', () => {
       },
     );
 
+    it('should skip non-queueing undispatched executions when fetching from db', async () => {
+      type DbFetchDispatcher = {
+        dispatch(): void;
+        executing: Promise<unknown> | null;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: DbFetchDispatcher }).dispatcher;
+
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await w1.createNode({
+        type: 'echo',
+      });
+      const aborted = await w1.createExecution({
+        key: w1.key,
+        context: { aborted: true },
+        dispatched: false,
+        status: EXECUTION_STATUS.ABORTED,
+      });
+
+      const w2 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await w2.createNode({
+        type: 'echo',
+      });
+      const queueing = await w2.createExecution({
+        key: w2.key,
+        context: { queueing: true },
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+
+      dispatcher.dispatch();
+
+      for (let i = 0; i < 20; i++) {
+        await queueing.reload();
+        if (queueing.status === EXECUTION_STATUS.RESOLVED) {
+          break;
+        }
+        await sleep(50);
+      }
+
+      await aborted.reload();
+      expect(aborted.status).toBe(EXECUTION_STATUS.ABORTED);
+      expect(aborted.dispatched).toBe(false);
+      expect(queueing.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(queueing.dispatched).toBe(true);
+
+      await dispatcher.executing?.catch(() => null);
+    });
+
     it('multiple triggers in same event', async () => {
       const w1 = await WorkflowModel.create({
         enabled: true,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow dispatcher DB fetch can perform excessive retries under contention. The previous queue acquisition query joined workflows through `workflow.enabled`, and acquiring queueing executions used repeatable-read transactions. In high-concurrency queue claiming, this can increase lock conflicts and serialization retries.

### Description 
This PR tightens workflow dispatcher queue acquisition:

- Only queueing, undispatched executions are accepted from queue messages.
- DB fetch now limits candidates to queueing, undispatched, not-yet-started executions for currently enabled workflows from the runtime enabled cache.
- Queue acquisition uses `READ COMMITTED` instead of `REPEATABLE READ`, which is better suited to `SELECT ... FOR UPDATE SKIP LOCKED` queue claiming.
- Removed the unused `shouldRetry` path so acquire retries only handle concurrent database errors.
- Added a regression test ensuring non-queueing undispatched executions do not block later queueing executions.

Potential risk: enabled workflow filtering now uses the runtime enabled workflow cache instead of a workflow table join. This matches dispatcher runtime semantics and avoids locking workflow rows during execution claiming.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reduced unnecessary workflow dispatcher DB fetch retries under concurrent queue processing. |
| 🇨🇳 Chinese | 减少并发队列处理时工作流调度器不必要的数据库拉取重试。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
