### PR TITLE
feat(plugin-block-comment): improve comment block configuration

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/RecordCommentsBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/RecordCommentsBlockModel.tsx
@@ -80,11 +80,13 @@ const getFieldMappingDefaults = (
       : undefined;
   const associationName =
     resourceSettingsInit?.associationName || ctx.view?.inputArgs?.associationName || ctx.inputArgs?.associationName;
+  const sourceId = resourceSettingsInit?.sourceId;
   const association = (model?.context?.association as RecordCommentAssociationLike | undefined) || ctx.association;
   const associationMapping = getAssociationRecordCommentFieldMapping({
     collection: model?.collection || ctx.collection,
     association,
     associationName,
+    sourceId,
   });
 
   if (associationMapping.ownerField) {
@@ -233,8 +235,9 @@ export class RecordCommentsBlockModel extends CollectionBlockModel<RecordComment
 
     resource.setPageSize(this.props.pageSize || DEFAULT_PAGE_SIZE);
 
-    if (mapping.dateField) {
-      resource.setSort([mapping.dateField]);
+    const sort = this.props.globalSort?.length ? this.props.globalSort : mapping.dateField ? [mapping.dateField] : [];
+    if (sort.length) {
+      resource.setSort(sort);
     }
 
     if (mapping.ownerField) {
@@ -259,9 +262,17 @@ export class RecordCommentsBlockModel extends CollectionBlockModel<RecordComment
     return Math.max(Math.ceil(count / pageSize), 1);
   }
 
+  shouldAutoJumpToLastPage() {
+    return this.props.autoJumpToLastPage === true;
+  }
+
   isPreparingLastPageLoad() {
     if (this.loadingLastPage.value) {
       return true;
+    }
+
+    if (!this.shouldAutoJumpToLastPage()) {
+      return false;
     }
 
     const count = this.resource.getCount() || 0;
@@ -288,6 +299,10 @@ export class RecordCommentsBlockModel extends CollectionBlockModel<RecordComment
       } finally {
         this.loadingLastPage.value = false;
       }
+      return;
+    }
+
+    if (!this.shouldAutoJumpToLastPage()) {
       return;
     }
 
@@ -421,7 +436,7 @@ RecordCommentsBlockModel.registerFlow({
                 'x-decorator': 'FormItem',
                 'x-component': RecordCommentFieldSelect,
                 'x-component-props': {
-                  fieldFilter: 'belongsTo',
+                  fieldFilter: 'owner',
                 },
               },
           ownerValueField: shouldHideOwnerMappingFields
@@ -487,11 +502,18 @@ RecordCommentsBlockModel.registerFlow({
     },
     pageSize: {
       title: tExpr('Page size'),
-      uiSchema: {
-        pageSize: {
-          'x-component': 'Select',
-          'x-decorator': 'FormItem',
-          enum: [5, 10, 20, 50, 100].map((value) => ({ label: String(value), value })),
+      uiMode: {
+        type: 'select',
+        key: 'pageSize',
+        props: {
+          options: [
+            { label: '5', value: 5 },
+            { label: '10', value: 10 },
+            { label: '20', value: 20 },
+            { label: '50', value: 50 },
+            { label: '100', value: 100 },
+            { label: '200', value: 200 },
+          ],
         },
       },
       defaultParams: {
@@ -504,7 +526,29 @@ RecordCommentsBlockModel.registerFlow({
           pageSize,
         });
         model.resource.setPageSize(pageSize);
-        model.resource.setPage(model.getLastPage(pageSize));
+        model.resource.setPage(model.shouldAutoJumpToLastPage() ? model.getLastPage(pageSize) : 1);
+      },
+    },
+    dataScope: {
+      use: 'dataScope',
+      title: tExpr('Data scope'),
+    },
+    defaultSorting: {
+      use: 'sortingRule',
+      title: tExpr('Default sorting'),
+    },
+    autoJumpToLastPage: {
+      title: tExpr('Jump to last page by default'),
+      uiMode: { type: 'switch', key: 'autoJumpToLastPage' },
+      defaultParams: {
+        autoJumpToLastPage: false,
+      },
+      handler(ctx, params) {
+        const model = ctx.model as RecordCommentsBlockModel;
+        model.setProps({
+          autoJumpToLastPage: params.autoJumpToLastPage !== false,
+        });
+        model.resource.setPage(params.autoJumpToLastPage === false ? 1 : model.getLastPage());
       },
     },
   },

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockModel.test.ts
@@ -64,6 +64,44 @@ describe('RecordCommentsBlockModel field mapping settings', () => {
     });
   });
 
+  test('hides owner mapping fields using the selected association foreign key when available', () => {
+    const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
+    const step: any = flow?.steps?.fieldMapping;
+    const ctx = {
+      model: {
+        props: {},
+        collection: {
+          fields: [
+            { name: 'postId', type: 'bigInt', interface: 'integer', title: 'Post ID' },
+            { name: 'post', type: 'belongsTo', interface: 'm2o', title: 'Post', target: 'posts' },
+          ],
+        },
+        context: {
+          association: {
+            collection: {
+              name: 'posts',
+            },
+            foreignKey: 'postId',
+          },
+        },
+        getResourceSettingsInitParams: () => ({
+          associationName: 'posts.comments',
+          sourceId: '{{ ctx.popup.record.uuid }}',
+        }),
+      },
+    };
+
+    const schema = step.uiSchema(ctx);
+    const params = step.defaultParams(ctx);
+
+    expect(schema.ownerField).toBeUndefined();
+    expect(schema.ownerValueField).toBeUndefined();
+    expect(params).toMatchObject({
+      ownerField: 'postId',
+      ownerValueField: '{{ ctx.popup.record.uuid }}',
+    });
+  });
+
   test('keeps owner mapping fields visible for direct comment collection blocks', () => {
     const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
     const step: any = flow?.steps?.fieldMapping;
@@ -124,6 +162,35 @@ describe('RecordCommentsBlockModel pagination and sorting', () => {
     RecordCommentsBlockModel.prototype.createResource.call(model);
 
     expect(fakeResource.setSort).toHaveBeenCalledWith(['createdAt']);
+  });
+
+  test('prefers configured default sorting over the date field sorting', () => {
+    const fakeResource = {
+      setPageSize: vi.fn(),
+      setSort: vi.fn(),
+      addFilterGroup: vi.fn(),
+      addAppends: vi.fn(),
+    };
+
+    const model = {
+      props: {
+        pageSize: 20,
+        globalSort: ['-createdAt'],
+      },
+      mapping: {
+        dateField: 'createdAt',
+        commenterField: 'createdBy',
+      },
+      context: {
+        createResource: () => fakeResource,
+      },
+      ownerValue: undefined,
+      collection: {},
+    };
+
+    RecordCommentsBlockModel.prototype.createResource.call(model);
+
+    expect(fakeResource.setSort).toHaveBeenCalledWith(['-createdAt']);
   });
 
   test('uses normalized owner values when creating owner filters', () => {
@@ -204,7 +271,7 @@ describe('RecordCommentsBlockModel pagination and sorting', () => {
     expect(fakeResource.addFilterGroup).not.toHaveBeenCalled();
   });
 
-  test('page size handler keeps the list on the last page', () => {
+  test('page size handler returns to the first page by default', () => {
     const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
     const step: any = flow?.steps?.pageSize;
     const resource = {
@@ -218,12 +285,86 @@ describe('RecordCommentsBlockModel pagination and sorting', () => {
       resource,
       setProps: vi.fn(),
       getLastPage: RecordCommentsBlockModel.prototype.getLastPage,
+      shouldAutoJumpToLastPage: RecordCommentsBlockModel.prototype.shouldAutoJumpToLastPage,
+    };
+
+    step.handler({ model } as any, { pageSize: 10 });
+
+    expect(resource.setPageSize).toHaveBeenCalledWith(10);
+    expect(resource.setPage).toHaveBeenCalledWith(1);
+  });
+
+  test('page size handler keeps the list on the last page when auto jump to last page is enabled', () => {
+    const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
+    const step: any = flow?.steps?.pageSize;
+    const resource = {
+      setPageSize: vi.fn(),
+      setPage: vi.fn(),
+      getCount: vi.fn(() => 41),
+      getPageSize: vi.fn(() => 20),
+    };
+    const model = {
+      props: {
+        autoJumpToLastPage: true,
+      },
+      resource,
+      setProps: vi.fn(),
+      getLastPage: RecordCommentsBlockModel.prototype.getLastPage,
+      shouldAutoJumpToLastPage: RecordCommentsBlockModel.prototype.shouldAutoJumpToLastPage,
     };
 
     step.handler({ model } as any, { pageSize: 10 });
 
     expect(resource.setPageSize).toHaveBeenCalledWith(10);
     expect(resource.setPage).toHaveBeenCalledWith(5);
+  });
+
+  test('auto jump to last page setting moves between the last page and first page', () => {
+    const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
+    const step: any = flow?.steps?.autoJumpToLastPage;
+    const resource = {
+      setPage: vi.fn(),
+      getCount: vi.fn(() => 41),
+      getPageSize: vi.fn(() => 20),
+    };
+    const model = {
+      props: {},
+      resource,
+      setProps: vi.fn(),
+      getLastPage: RecordCommentsBlockModel.prototype.getLastPage,
+    };
+
+    step.handler({ model } as any, { autoJumpToLastPage: false });
+    step.handler({ model } as any, { autoJumpToLastPage: true });
+
+    expect(model.setProps).toHaveBeenNthCalledWith(1, { autoJumpToLastPage: false });
+    expect(model.setProps).toHaveBeenNthCalledWith(2, { autoJumpToLastPage: true });
+    expect(resource.setPage).toHaveBeenNthCalledWith(1, 1);
+    expect(resource.setPage).toHaveBeenNthCalledWith(2, 3);
+  });
+
+  test('settings expose data scope, default sorting, last-page jump, and select-mode page size controls', () => {
+    const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
+    const settingKeys = Object.keys(flow?.steps || {});
+
+    expect(flow?.steps?.dataScope).toMatchObject({
+      use: 'dataScope',
+    });
+    expect(flow?.steps?.defaultSorting).toMatchObject({
+      use: 'sortingRule',
+    });
+    expect(flow?.steps?.pageSize?.uiMode).toMatchObject({
+      type: 'select',
+      key: 'pageSize',
+    });
+    expect(flow?.steps?.autoJumpToLastPage?.uiMode).toMatchObject({
+      type: 'switch',
+      key: 'autoJumpToLastPage',
+    });
+    expect(flow?.steps?.autoJumpToLastPage?.defaultParams).toMatchObject({
+      autoJumpToLastPage: false,
+    });
+    expect(settingKeys.indexOf('autoJumpToLastPage')).toBeGreaterThan(settingKeys.indexOf('defaultSorting'));
   });
 
   test('ensureLastPageLoaded snaps back when the current page is larger than the last page', async () => {
@@ -253,7 +394,7 @@ describe('RecordCommentsBlockModel pagination and sorting', () => {
     expect(model.refresh).toHaveBeenCalled();
   });
 
-  test('reports preparing state before the initial last page is loaded', () => {
+  test('does not report preparing state before the initial last page is loaded by default', () => {
     const resource = {
       getPage: vi.fn(() => 1),
       getCount: vi.fn(() => 41),
@@ -269,6 +410,30 @@ describe('RecordCommentsBlockModel pagination and sorting', () => {
         pageSize: 20,
       },
       getLastPage: RecordCommentsBlockModel.prototype.getLastPage,
+      shouldAutoJumpToLastPage: RecordCommentsBlockModel.prototype.shouldAutoJumpToLastPage,
+    };
+
+    expect(RecordCommentsBlockModel.prototype.isPreparingLastPageLoad.call(model)).toBe(false);
+  });
+
+  test('reports preparing state before the initial last page is loaded when auto jump is enabled', () => {
+    const resource = {
+      getPage: vi.fn(() => 1),
+      getCount: vi.fn(() => 41),
+      getPageSize: vi.fn(() => 20),
+    };
+    const model = {
+      shouldLoadLastPage: true,
+      loadingLastPage: {
+        value: false,
+      },
+      resource,
+      props: {
+        autoJumpToLastPage: true,
+        pageSize: 20,
+      },
+      getLastPage: RecordCommentsBlockModel.prototype.getLastPage,
+      shouldAutoJumpToLastPage: RecordCommentsBlockModel.prototype.shouldAutoJumpToLastPage,
     };
 
     expect(RecordCommentsBlockModel.prototype.isPreparingLastPageLoad.call(model)).toBe(true);
@@ -293,11 +458,13 @@ describe('RecordCommentsBlockModel pagination and sorting', () => {
       },
       resource,
       props: {
+        autoJumpToLastPage: true,
         pageSize: 20,
       },
       refresh: vi.fn(() => refreshPromise),
       getLastPage: RecordCommentsBlockModel.prototype.getLastPage,
       isPreparingLastPageLoad: RecordCommentsBlockModel.prototype.isPreparingLastPageLoad,
+      shouldAutoJumpToLastPage: RecordCommentsBlockModel.prototype.shouldAutoJumpToLastPage,
     };
 
     const ensurePromise = RecordCommentsBlockModel.prototype.ensureLastPageLoaded.call(model);

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockView.test.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockView.test.tsx
@@ -244,6 +244,7 @@ describe('RecordCommentsBlockView', () => {
         fields: [{ name: 'commentedAt', type: 'datetime', interface: 'datetime' }],
       },
       resource,
+      shouldAutoJumpToLastPage: vi.fn(() => true),
       isPreparingLastPageLoad: vi.fn(() => false),
       ensureLastPageLoaded: vi.fn(async () => undefined),
       mapSubModels: vi.fn(() => []),
@@ -272,5 +273,56 @@ describe('RecordCommentsBlockView', () => {
         },
       );
     });
+  });
+
+  it('does not jump to the last page after creating comments when auto jump is disabled', async () => {
+    const create = vi.fn(async () => undefined);
+    const setPage = vi.fn();
+    const resource = {
+      loading: false,
+      create,
+      refresh: vi.fn(async () => undefined),
+      setPage,
+      getPage: vi.fn(() => 1),
+      getPageSize: vi.fn(() => 20),
+      getCount: vi.fn(() => 41),
+    };
+    const model = {
+      uid: 'block-1',
+      mapping: {
+        contentField: 'content',
+        ownerField: 'post',
+        dateField: 'commentedAt',
+      },
+      ownerValue: 12,
+      context: {
+        defineMethod: vi.fn(),
+        flowSettingsEnabled: false,
+      },
+      collection: {
+        fields: [{ name: 'commentedAt', type: 'datetime', interface: 'datetime' }],
+      },
+      resource,
+      shouldAutoJumpToLastPage: vi.fn(() => false),
+      isPreparingLastPageLoad: vi.fn(() => false),
+      ensureLastPageLoaded: vi.fn(async () => undefined),
+      mapSubModels: vi.fn(() => []),
+    } as unknown as RecordCommentsBlockModel;
+
+    render(
+      <App>
+        <RecordCommentsBlockView model={model} dataSource={[]} onPageChange={vi.fn()} />
+      </App>,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Comment content' }), {
+      target: { value: 'A new comment' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalled();
+    });
+    expect(setPage).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/utils.test.ts
@@ -204,16 +204,22 @@ describe('record comments owner value utils', () => {
     expect(resolveCommentOwnerValueFromFilterByTk(true, 100)).toBe(true);
   });
 
-  it('only exposes many-to-one fields as owner field options', () => {
+  it('exposes scalar fields and excludes association fields as owner field options', () => {
     expect(
       getCommentOwnerFieldOptions({
         fields: [
           { name: 'content', type: 'text', title: 'Content' },
+          { name: 'postId', type: 'bigInt', interface: 'integer', title: 'Post ID' },
           { name: 'task', type: 'belongsTo', interface: 'm2o', title: 'Task' },
+          { name: 'profile', type: 'hasOne', interface: 'oho', title: 'Profile' },
           { name: 'tags', type: 'belongsToMany', interface: 'm2m', title: 'Tags' },
+          { name: 'children', type: 'hasMany', interface: 'o2m', title: 'Children' },
         ],
       }),
-    ).toEqual([{ label: 'Task', value: 'task' }]);
+    ).toEqual([
+      { label: 'Content', value: 'content' },
+      { label: 'Post ID', value: 'postId' },
+    ]);
   });
 
   it('defaults comment owner mapping to the current popup collection relation', () => {
@@ -279,6 +285,30 @@ describe('record comments owner value utils', () => {
     ).toEqual({
       ownerField: 'post',
       ownerValueField: COMMENT_OWNER_FILTER_BY_TK_VARIABLE,
+    });
+  });
+
+  it('defaults comment owner mapping from the selected association foreign key first', () => {
+    expect(
+      getAssociationRecordCommentFieldMapping({
+        associationName: 'posts.comments',
+        sourceId: '{{ ctx.popup.record.uuid }}',
+        association: {
+          collection: {
+            name: 'posts',
+          },
+          foreignKey: 'postId',
+        },
+        collection: {
+          fields: [
+            { name: 'postId', type: 'bigInt', interface: 'integer', title: 'Post ID' },
+            { name: 'post', type: 'belongsTo', interface: 'm2o', title: 'Post', target: 'posts' },
+          ],
+        },
+      }),
+    ).toEqual({
+      ownerField: 'postId',
+      ownerValueField: '{{ ctx.popup.record.uuid }}',
     });
   });
 
@@ -376,6 +406,21 @@ describe('record comments owner value utils', () => {
           ],
         },
         'task',
+        '123',
+      ),
+    ).toEqual({
+      compatible: true,
+      value: 123,
+    });
+  });
+
+  it('normalizes owner values by a scalar owner field type', () => {
+    expect(
+      normalizeOwnerFilterValue(
+        {
+          fields: [{ name: 'postId', type: 'bigInt', interface: 'integer' }],
+        },
+        'postId',
         '123',
       ),
     ).toEqual({

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentFieldSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentFieldSelect.tsx
@@ -24,7 +24,7 @@ import {
 type RecordCommentFieldSelectProps = Omit<SelectProps<string | string[]>, 'options'> & {
   value?: string | string[];
   onChange?: (value: string | string[] | undefined) => void;
-  fieldFilter?: 'belongsTo' | 'content' | 'date' | 'user';
+  fieldFilter?: 'content' | 'date' | 'owner' | 'user';
 };
 
 export const RecordCommentFieldSelect = observer((props: RecordCommentFieldSelectProps) => {
@@ -34,7 +34,7 @@ export const RecordCommentFieldSelect = observer((props: RecordCommentFieldSelec
   const model = settingsContext?.model as { collection?: unknown } | undefined;
   const collection = model?.collection || settingsContext?.collection;
   const options = useMemo(() => {
-    if (fieldFilter === 'belongsTo') {
+    if (fieldFilter === 'owner') {
       return getCommentOwnerFieldOptions(collection);
     }
 

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentsBlockView.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentsBlockView.tsx
@@ -353,9 +353,11 @@ const SubmitBox = observer(({ model, forkKeyPrefix }: { model: RecordCommentsBlo
         },
       );
       setContent('');
-      const count = model.resource.getCount() || 0;
-      const pageSize = model.resource.getPageSize() || 10;
-      model.resource.setPage(Math.max(Math.ceil((count + 1) / pageSize), 1));
+      if (model.shouldAutoJumpToLastPage()) {
+        const count = model.resource.getCount() || 0;
+        const pageSize = model.resource.getPageSize() || 10;
+        model.resource.setPage(Math.max(Math.ceil((count + 1) / pageSize), 1));
+      }
       await model.resource.refresh();
     } catch (error) {
       message.error(getErrorMessage(error, t('Failed to create comment')));

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/utils.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/utils.ts
@@ -26,6 +26,8 @@ export type RecordCommentAssociationLike = {
   collection?: {
     name?: string;
   };
+  foreignKey?: string;
+  sourceKey?: string;
 };
 
 export type RecordCommentCollection = {
@@ -178,13 +180,36 @@ export const isBelongsToField = (field?: RecordCommentCollectionField) => {
   return field?.type === 'belongsTo' || field?.interface === 'm2o';
 };
 
+const multiValueAssociationTypes = new Set(['belongsToArray', 'belongsToMany', 'hasMany', 'hasOne']);
+const multiValueAssociationInterfaces = new Set(['m2m', 'o2m', 'oho', 'obo']);
+
+export const isCommentOwnerField = (field?: RecordCommentCollectionField) => {
+  if (!field?.name) {
+    return false;
+  }
+
+  if (field.type && multiValueAssociationTypes.has(field.type)) {
+    return false;
+  }
+
+  if (field.interface && multiValueAssociationInterfaces.has(field.interface)) {
+    return false;
+  }
+
+  if (isBelongsToField(field)) {
+    return false;
+  }
+
+  return true;
+};
+
 export const isUserField = (field?: RecordCommentCollectionField) => {
   return isBelongsToField(field) && (field?.target === 'users' || field?.targetCollection?.name === 'users');
 };
 
 export const getCommentOwnerFieldOptions = (collection?: unknown) => {
   return getCollectionFields(collection)
-    .filter((field) => field.name && isBelongsToField(field))
+    .filter(isCommentOwnerField)
     .map((field) => ({
       label: field.title || field.uiSchema?.title || field.name,
       value: field.name,
@@ -250,13 +275,31 @@ export const getAssociationRecordCommentFieldMapping = (options: {
   collection?: unknown;
   association?: RecordCommentAssociationLike;
   associationName?: string;
+  sourceId?: unknown;
 }): DefaultRecordCommentFieldMapping => {
+  const foreignKey = options.association?.foreignKey;
+  if (foreignKey && getCollectionField(options.collection, foreignKey)) {
+    return {
+      ownerField: foreignKey,
+      ownerValueField: options.sourceId ?? COMMENT_OWNER_FILTER_BY_TK_VARIABLE,
+    };
+  }
+
   const sourceCollectionName = getAssociationSourceCollectionName(options);
 
-  return getDefaultRecordCommentFieldMapping({
+  const mapping = getDefaultRecordCommentFieldMapping({
     collection: options.collection,
     currentCollectionName: sourceCollectionName,
   });
+
+  if (mapping.ownerField) {
+    return {
+      ...mapping,
+      ownerValueField: options.sourceId ?? mapping.ownerValueField,
+    };
+  }
+
+  return {};
 };
 
 export const getCollectionFilterTargetKey = (collection?: unknown) => {
@@ -457,10 +500,10 @@ const normalizeFilterValueByFieldType = (value: string | number | boolean, field
   };
 };
 
-const getOwnerTargetField = (collection: unknown, ownerFieldName: string) => {
+const getOwnerValueField = (collection: unknown, ownerFieldName: string) => {
   const ownerField = getCollectionField(collection, ownerFieldName);
   if (!isBelongsToField(ownerField)) {
-    return undefined;
+    return ownerField;
   }
 
   const targetKey =
@@ -473,7 +516,7 @@ export const normalizeOwnerFilterValue = (
   ownerFieldName: string,
   ownerValue: string | number | boolean,
 ) => {
-  return normalizeFilterValueByFieldType(ownerValue, getOwnerTargetField(collection, ownerFieldName));
+  return normalizeFilterValueByFieldType(ownerValue, getOwnerValueField(collection, ownerFieldName));
 };
 
 const extractCurrentRecordVariablePath = (value?: unknown) => {

--- a/packages/plugins/@nocobase/plugin-block-comment/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/locale/en-US.json
@@ -1,5 +1,6 @@
 {
   "Actions": "Actions",
+  "Auto jump to last page": "Auto jump to last page",
   "Are you sure you want to delete it?": "Are you sure you want to delete it?",
   "Cancel": "Cancel",
   "Comment": "Comment",
@@ -18,8 +19,9 @@
   "Failed to delete comment": "Failed to delete comment",
   "Failed to update comment": "Failed to update comment",
   "Field mapping": "Field mapping",
+  "Jump to last page by default": "Jump to last page by default",
   "Record comment action": "Comment action",
-  "Comments": "Comment",
+  "Comments": "Comments",
   "Record comments settings": "Block: Comment settings",
   "No comments": "No comments",
   "No resource or record selected for deletion": "No resource or record selected for deletion",

--- a/packages/plugins/@nocobase/plugin-block-comment/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/locale/zh-CN.json
@@ -1,5 +1,6 @@
 {
   "Actions": "操作",
+  "Auto jump to last page": "自动跳转到最后一页",
   "Are you sure you want to delete it?": "确定要删除吗？",
   "Cancel": "取消",
   "Comment": "评论",
@@ -18,6 +19,7 @@
   "Failed to delete comment": "删除评论失败",
   "Failed to update comment": "更新评论失败",
   "Field mapping": "字段映射",
+  "Jump to last page by default": "默认跳转到最后一页",
   "Record comment action": "评论操作",
   "Comments": "评论",
   "Record comments settings": "区块：评论设置",

--- a/packages/plugins/@nocobase/plugin-comments/src/client-v2/models/CommentsBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-comments/src/client-v2/models/CommentsBlockModel.tsx
@@ -119,6 +119,7 @@ CommentsBlockModel.registerFlow({
 
 CommentsBlockModel.define({
   label: tExpr('Comments'),
+  hide: true,
   searchable: true,
   searchPlaceholder: tExpr('Search'),
   createModelOptions: {

--- a/packages/plugins/@nocobase/plugin-comments/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-comments/src/client/index.tsx
@@ -16,14 +16,11 @@
  * For more information, see <https://www.nocobase.com/agreement>
  */
 
-import { canMakeAssociationBlock, Plugin, useCollection, useCollectionManager } from '@nocobase/client';
-import { useMemo } from 'react';
+import { Plugin } from '@nocobase/client';
 import { CommentCollectionTemplate } from './collection-templates/comment';
 import { Comment } from './comment';
 import { commentBlockSettings } from './comment/Comment.Settings';
 import { useCommentBlockDecoratorProps } from './hooks/useCommentBlockDecoratorProps';
-import { generateNTemplate } from './locale';
-import { CommentBlockInitializer } from './schema-initializer/initializers';
 import {
   commentItemActionInitializers,
   QuoteReplyCommentActionButton,
@@ -43,57 +40,7 @@ export class PluginCommentClient extends Plugin {
   // You can get and modify the app instance here
   async load() {
     this.app.dataSourceManager.addCollectionTemplates([CommentCollectionTemplate]);
-    this.app.schemaInitializerManager.addItem('page:addBlock', 'dataBlocks.comment', {
-      title: generateNTemplate('Comment'),
-      Component: 'CommentBlockInitializer',
-      useComponentProps() {
-        return {
-          filterCollections({ collection }) {
-            return collection.template === 'comment';
-          },
-        };
-      },
-    });
-
-    this.app.schemaInitializerManager.addItem('popup:common:addBlock', 'dataBlocks.comment', {
-      title: generateNTemplate('Comment'),
-      Component: 'CommentBlockInitializer',
-      useVisible() {
-        const collection = useCollection();
-        return useMemo(
-          () =>
-            collection.fields.some(
-              (field) => canMakeAssociationBlock(field) && ['hasMany', 'belongsToMany'].includes(field.type),
-            ),
-          [collection.fields],
-        );
-      },
-      useComponentProps() {
-        const cm = useCollectionManager();
-        return {
-          onlyCurrentDataSource: true,
-          filterCollections({ associationField }) {
-            if (associationField) {
-              if (!['hasMany', 'belongsToMany'].includes(associationField.type)) {
-                return false;
-              }
-              const collection = cm.getCollection(associationField.target);
-              return collection?.template === 'comment';
-            }
-            return false;
-          },
-          filterOtherRecordsCollection(collection) {
-            return collection?.template === 'comment';
-          },
-          showAssociationFields: true,
-          hideOtherRecordsInPopup: false,
-          hideSearch: true,
-        };
-      },
-    });
-
     this.app.addComponents({
-      CommentBlockInitializer: CommentBlockInitializer as any,
       Comment,
       UpdateCommentActionInitializer,
       UpdateCommentActionButton,

--- a/packages/plugins/@nocobase/plugin-comments/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-comments/src/client/index.tsx
@@ -16,11 +16,14 @@
  * For more information, see <https://www.nocobase.com/agreement>
  */
 
-import { Plugin } from '@nocobase/client';
+import { canMakeAssociationBlock, Plugin, useCollection, useCollectionManager } from '@nocobase/client';
+import { useMemo } from 'react';
 import { CommentCollectionTemplate } from './collection-templates/comment';
 import { Comment } from './comment';
 import { commentBlockSettings } from './comment/Comment.Settings';
 import { useCommentBlockDecoratorProps } from './hooks/useCommentBlockDecoratorProps';
+import { generateNTemplate } from './locale';
+import { CommentBlockInitializer } from './schema-initializer/initializers';
 import {
   commentItemActionInitializers,
   QuoteReplyCommentActionButton,
@@ -40,7 +43,57 @@ export class PluginCommentClient extends Plugin {
   // You can get and modify the app instance here
   async load() {
     this.app.dataSourceManager.addCollectionTemplates([CommentCollectionTemplate]);
+    this.app.schemaInitializerManager.addItem('page:addBlock', 'dataBlocks.comment', {
+      title: generateNTemplate('Comment'),
+      Component: 'CommentBlockInitializer',
+      useComponentProps() {
+        return {
+          filterCollections({ collection }) {
+            return collection.template === 'comment';
+          },
+        };
+      },
+    });
+
+    this.app.schemaInitializerManager.addItem('popup:common:addBlock', 'dataBlocks.comment', {
+      title: generateNTemplate('Comment'),
+      Component: 'CommentBlockInitializer',
+      useVisible() {
+        const collection = useCollection();
+        return useMemo(
+          () =>
+            collection.fields.some(
+              (field) => canMakeAssociationBlock(field) && ['hasMany', 'belongsToMany'].includes(field.type),
+            ),
+          [collection.fields],
+        );
+      },
+      useComponentProps() {
+        const cm = useCollectionManager();
+        return {
+          onlyCurrentDataSource: true,
+          filterCollections({ associationField }) {
+            if (associationField) {
+              if (!['hasMany', 'belongsToMany'].includes(associationField.type)) {
+                return false;
+              }
+              const collection = cm.getCollection(associationField.target);
+              return collection?.template === 'comment';
+            }
+            return false;
+          },
+          filterOtherRecordsCollection(collection) {
+            return collection?.template === 'comment';
+          },
+          showAssociationFields: true,
+          hideOtherRecordsInPopup: false,
+          hideSearch: true,
+        };
+      },
+    });
+
     this.app.addComponents({
+      CommentBlockInitializer: CommentBlockInitializer as any,
       Comment,
       UpdateCommentActionInitializer,
       UpdateCommentActionButton,

--- a/packages/plugins/@nocobase/plugin-comments/src/client/models/CommentsBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-comments/src/client/models/CommentsBlockModel.tsx
@@ -125,6 +125,7 @@ CommentsBlockModel.registerFlow({
 
 CommentsBlockModel.define({
   label: escapeT('Comments', { ns: 'comments' }),
+  hide: true,
   searchable: true,
   searchPlaceholder: escapeT('Search'),
   createModelOptions: {


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Improve the new comment block configuration and keep legacy comment blocks compatible while preventing new legacy comment block creation.

### Description
- Hide add-block entries for the legacy comments plugin while keeping existing configured blocks working.
- Add data scope and default sorting settings to the new comment block.
- Change page size to select mode.
- Add an optional auto-jump-to-last-page setting, disabled by default.
- Refine comment owner mapping so association-created blocks can use association foreign keys, while manual owner field selection only exposes scalar fields such as FK fields.
- Update English and Chinese labels, including using `Comments` for the add-block label.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved comment block settings with data scope, default sorting, selectable page size, optional last-page jumping, and scalar owner field mapping. |
| 🇨🇳 Chinese | 优化评论区块设置，支持数据范围、默认排序、下拉选择分页大小、可选跳转最后一页，以及基于标量字段的归属字段配置。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary