### PR TITLE
fix(plugin-ai): handle blank LLM provider base URL

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/llm-services/utils.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/llm-services/utils.test.ts
@@ -1,0 +1,50 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeLLMServiceFormValues, normalizeLLMServiceOptions } from '../../llm-services/utils';
+
+describe('LLM service utils', () => {
+  it('removes blank baseURL from provider options', () => {
+    expect(normalizeLLMServiceOptions({ apiKey: 'test-key', baseURL: '' })).toEqual({
+      apiKey: 'test-key',
+    });
+    expect(normalizeLLMServiceOptions({ apiKey: 'test-key', baseURL: '   ' })).toEqual({
+      apiKey: 'test-key',
+    });
+  });
+
+  it('trims non-blank baseURL from provider options', () => {
+    expect(normalizeLLMServiceOptions({ apiKey: 'test-key', baseURL: ' https://api.example.com/v1/ ' })).toEqual({
+      apiKey: 'test-key',
+      baseURL: 'https://api.example.com/v1/',
+    });
+  });
+
+  it('normalizes form values without mutating the original values', () => {
+    const values = {
+      name: 'test-service',
+      options: {
+        apiKey: 'test-key',
+        baseURL: '',
+      },
+    };
+
+    expect(normalizeLLMServiceFormValues(values)).toEqual({
+      name: 'test-service',
+      options: {
+        apiKey: 'test-key',
+      },
+    });
+    expect(values.options).toEqual({
+      apiKey: 'test-key',
+      baseURL: '',
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/LLMServices.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/LLMServices.tsx
@@ -44,6 +44,7 @@ import { LLMTestFlight } from './component/LLMTestFlight';
 import { EnabledModelsSelect } from './component/EnabledModelsSelect';
 import { ModelOptionsSettings } from './component/ModelOptionsSettings';
 import { useAIConfigRepository } from '../repositories/hooks/useAIConfigRepository';
+import { normalizeLLMServiceFormValues } from './utils';
 
 const useCreateFormProps = () => {
   const form = useMemo(
@@ -97,7 +98,7 @@ const useCreateActionProps = () => {
     type: 'primary',
     async onClick() {
       await form.submit();
-      const values = form.values;
+      const values = normalizeLLMServiceFormValues(form.values);
       await resource.create({
         values,
       });
@@ -124,7 +125,7 @@ const useEditActionProps = () => {
     type: 'primary',
     async onClick() {
       await form.submit();
-      const values = form.values;
+      const values = normalizeLLMServiceFormValues(form.values);
       await resource.update({
         values,
         filterByTk: values[filterTk],

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/component/LLMTestFlight.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/component/LLMTestFlight.tsx
@@ -15,6 +15,7 @@ import { RocketOutlined } from '@ant-design/icons';
 import { getRecommendedModels } from '../../../common/recommended-models';
 import { normalizeEnabledModels } from './EnabledModelsSelect';
 import { useT } from '../../locale';
+import { normalizeLLMServiceOptions } from '../utils';
 
 export const LLMTestFlight: React.FC = observer(() => {
   const t = useT();
@@ -57,7 +58,7 @@ export const LLMTestFlight: React.FC = observer(() => {
       const res = await api.resource('ai').testFlight({
         values: {
           provider,
-          options,
+          options: normalizeLLMServiceOptions(options),
           model,
         },
       });

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/utils.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/utils.ts
@@ -28,7 +28,7 @@ export const normalizeLLMServiceOptions = <T extends LLMServiceOptions | null | 
     return options;
   }
 
-  const nextOptions = { ...options };
+  const nextOptions: LLMServiceOptions = { ...options };
   const baseURL = nextOptions.baseURL;
   if (typeof baseURL === 'string') {
     if (baseURL.trim() === '') {

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/utils.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/utils.ts
@@ -21,6 +21,37 @@ export type ProviderOption = {
   label: string;
 };
 
+export type LLMServiceOptions = Record<string, unknown>;
+
+export const normalizeLLMServiceOptions = <T extends LLMServiceOptions | null | undefined>(options: T): T => {
+  if (!options || Array.isArray(options)) {
+    return options;
+  }
+
+  const nextOptions = { ...options };
+  const baseURL = nextOptions.baseURL;
+  if (typeof baseURL === 'string') {
+    if (baseURL.trim() === '') {
+      delete nextOptions.baseURL;
+    } else {
+      nextOptions.baseURL = baseURL.trim();
+    }
+  }
+
+  return nextOptions as T;
+};
+
+export const normalizeLLMServiceFormValues = <T extends { options?: LLMServiceOptions | null }>(values: T): T => {
+  if (!values.options || Array.isArray(values.options)) {
+    return values;
+  }
+
+  return {
+    ...values,
+    options: normalizeLLMServiceOptions(values.options),
+  };
+};
+
 export const getServiceByOverride = (services: LLMServiceItem[], override?: { llmService?: string } | null) => {
   if (!override?.llmService) {
     return undefined;

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts
@@ -73,6 +73,18 @@ describe('LLM provider baseURL guard', () => {
     expect(provider.buildURL('models')).toBe('https://api.example.com/v1/models');
   });
 
+  it('treats blank rendered baseURL as unset for LLM providers', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    const provider = new TestLLMProvider({
+      app: createApp({ baseURL: '  ' }),
+    });
+
+    expect(provider.serviceOptions.baseURL).toBeUndefined();
+    expect(provider.getResolvedURL()).toBe('https://api.example.com/v1');
+    expect(provider.buildURL('models')).toBe('https://api.example.com/v1/models');
+  });
+
   it('validates provider default baseURL against the global whitelist', () => {
     process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
 
@@ -81,6 +93,16 @@ describe('LLM provider baseURL guard', () => {
     });
 
     expect(provider.getResolvedURL()).toBe('https://api.example.com/v1');
+  });
+
+  it('trims rendered baseURL before validation', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    const provider = new TestLLMProvider({
+      app: createApp({ baseURL: ' https://api.example.com/v1/ ' }),
+    });
+
+    expect(provider.serviceOptions.baseURL).toBe('https://api.example.com/v1');
   });
 
   it('rejects rendered baseURL values blocked by the global whitelist', () => {
@@ -99,6 +121,17 @@ describe('LLM provider baseURL guard', () => {
 
     const provider = new TestEmbeddingProvider({
       app: createApp({ baseURL: 'https://api.example.com/v1/' }),
+      modelOptions: { model: 'text-embedding-3-small' },
+    });
+
+    expect(provider.getResolvedURL()).toBe('https://api.example.com/v1');
+  });
+
+  it('treats blank rendered baseURL as unset for embedding providers', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.example.com';
+
+    const provider = new TestEmbeddingProvider({
+      app: createApp({ baseURL: '' }),
       modelOptions: { model: 'text-embedding-3-small' },
     });
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -52,16 +52,38 @@ export interface LLMProviderOptions {
   modelOptions?: Record<string, any>;
 }
 
-function normalizeBaseURL(baseURL: string): string {
-  checkUrlAgainstWhitelist(baseURL);
-  return new URL(baseURL).toString().replace(/\/$/, '');
+function assertBaseURLString(baseURL: unknown): asserts baseURL is string {
+  if (typeof baseURL !== 'string') {
+    throw new Error('baseURL must be a string');
+  }
+}
+
+function normalizeBaseURL(baseURL: unknown): string {
+  assertBaseURLString(baseURL);
+  const trimmedBaseURL = baseURL.trim();
+  checkUrlAgainstWhitelist(trimmedBaseURL);
+  return new URL(trimmedBaseURL).toString().replace(/\/$/, '');
+}
+
+function isBlankBaseURL(baseURL: string): boolean {
+  return baseURL.trim() === '';
+}
+
+function getServiceBaseURL(serviceOptions?: Record<string, any>): unknown {
+  const baseURL = serviceOptions?.baseURL;
+  if (typeof baseURL === 'string' && isBlankBaseURL(baseURL)) {
+    return null;
+  }
+  return baseURL;
 }
 
 function resolveServiceOptions(serviceOptions: Record<string, any> | undefined, app: Application) {
   const rendered = app.environment.renderJsonTemplate(serviceOptions ?? {});
   if (rendered?.baseURL != null) {
-    if (typeof rendered.baseURL !== 'string') {
-      throw new Error('baseURL must be a string');
+    assertBaseURLString(rendered.baseURL);
+    if (isBlankBaseURL(rendered.baseURL)) {
+      delete rendered.baseURL;
+      return rendered;
     }
     rendered.baseURL = normalizeBaseURL(rendered.baseURL);
   }
@@ -370,12 +392,9 @@ export abstract class LLMProvider {
   }
 
   protected getResolvedBaseURL(): string {
-    const baseURL = this.serviceOptions?.baseURL ?? this.baseURL;
+    const baseURL = getServiceBaseURL(this.serviceOptions) ?? this.baseURL;
     if (!baseURL) {
       throw new Error('baseURL is required');
-    }
-    if (typeof baseURL !== 'string') {
-      throw new Error('baseURL must be a string');
     }
     return normalizeBaseURL(baseURL);
   }
@@ -419,12 +438,9 @@ export abstract class EmbeddingProvider {
   }
 
   protected get baseURL() {
-    const baseURL = this.serviceOptions?.baseURL ?? this.getDefaultUrl();
+    const baseURL = getServiceBaseURL(this.serviceOptions) ?? this.getDefaultUrl();
     if (!baseURL) {
       throw new Error('baseURL is required');
-    }
-    if (typeof baseURL !== 'string') {
-      throw new Error('baseURL must be a string');
     }
     return normalizeBaseURL(baseURL);
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Clearing the Base URL field for an LLM provider saved an empty `baseURL` value. That empty value could override the provider default URL and cause model listing and AI employee message requests to fail.

### Description 
- Treat blank LLM provider `baseURL` values as unset on the server, so providers fall back to their default URLs.
- Normalize LLM service form values before create/update/test requests, removing blank Base URL values and trimming non-blank values.
- Add server and client tests for blank Base URL handling.

Potential risk is low. The change only affects blank or whitespace-only Base URL values; non-blank custom Base URLs continue to be normalized and validated as before.

Testing suggestions:
- Configure an LLM provider, clear the Base URL field, save it, and verify model listing works.
- Send a message through an AI employee using that provider and verify the request uses the default provider URL.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed LLM providers falling back to their default Base URL when the custom Base URL field is cleared. |
| 🇨🇳 Chinese | 修复清空自定义 Base URL 后，LLM 提供商无法回退到默认 Base URL 的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
