### PR TITLE
fix: ctx.setFormValues not working for textarea field

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/TextareaFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/TextareaFieldModel.tsx
@@ -9,54 +9,77 @@
 
 import { Input } from 'antd';
 import type { TextAreaProps } from 'antd/es/input';
-import type { TextAreaRef } from 'antd/es/input/TextArea';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { largeField, EditableItemModel } from '@nocobase/flow-engine';
 import { FieldModel } from '../base/FieldModel';
 
 function IMESafeTextArea(props: TextAreaProps) {
   const { value, onChange, onCompositionStart, onCompositionEnd, ...rest } = props;
-  const textAreaRef = useRef<TextAreaRef>(null);
-  const previousValueRef = useRef(value);
-  const defaultValue = typeof value === 'bigint' ? String(value) : value;
+  const [textAreaValue, setTextAreaValue] = useState<TextAreaProps['value']>(() => normalizeTextAreaValue(value));
+  const textAreaValueRef = useRef<TextAreaProps['value']>(textAreaValue);
+  const pendingLocalValuesRef = useRef<TextAreaProps['value'][]>([]);
 
   useEffect(() => {
-    if (Object.is(previousValueRef.current, value)) {
-      return;
-    }
-    previousValueRef.current = value;
+    const nextValue = normalizeTextAreaValue(value);
+    const pendingValues = pendingLocalValuesRef.current;
+    const pendingIndex = pendingValues.findIndex((item) => Object.is(item, nextValue));
 
-    const textArea = textAreaRef.current?.resizableTextArea?.textArea;
-    if (textArea) {
-      const nextValue = value == null ? '' : String(value);
-      if (textArea.value !== nextValue) {
-        textArea.value = nextValue;
+    if (pendingIndex >= 0) {
+      pendingValues.splice(0, pendingIndex + 1);
+      if (!Object.is(textAreaValueRef.current, nextValue)) {
+        return;
       }
     }
+
+    pendingValues.length = 0;
+    if (Object.is(textAreaValueRef.current, nextValue)) {
+      return;
+    }
+
+    textAreaValueRef.current = nextValue;
+    setTextAreaValue(nextValue);
   }, [value]);
 
   const getEventValue = (event: React.ChangeEvent<HTMLTextAreaElement> | React.CompositionEvent<HTMLTextAreaElement>) =>
     event.currentTarget.value;
 
+  const recordLocalValue = (
+    event: React.ChangeEvent<HTMLTextAreaElement> | React.CompositionEvent<HTMLTextAreaElement>,
+  ) => {
+    const nextValue = getEventValue(event);
+    const pendingValues = pendingLocalValuesRef.current;
+    pendingValues.push(nextValue);
+    if (pendingValues.length > 20) {
+      pendingValues.shift();
+    }
+    textAreaValueRef.current = nextValue;
+    setTextAreaValue(nextValue);
+  };
+
   return (
     <Input.TextArea
       {...rest}
-      ref={textAreaRef}
-      defaultValue={defaultValue}
+      value={textAreaValue}
       onChange={(event) => {
-        previousValueRef.current = getEventValue(event);
+        recordLocalValue(event);
         onChange?.(event);
       }}
       onCompositionStart={(event) => {
-        previousValueRef.current = getEventValue(event);
+        recordLocalValue(event);
         onCompositionStart?.(event);
       }}
       onCompositionEnd={(event) => {
-        previousValueRef.current = getEventValue(event);
+        recordLocalValue(event);
         onCompositionEnd?.(event);
       }}
     />
   );
+}
+
+function normalizeTextAreaValue(nextValue: unknown): TextAreaProps['value'] {
+  if (typeof nextValue === 'bigint') return String(nextValue);
+  if (nextValue == null) return '';
+  return nextValue as TextAreaProps['value'];
 }
 
 @largeField()

--- a/packages/core/client-v2/src/flow/models/fields/__tests__/TextareaFieldModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/__tests__/TextareaFieldModel.test.tsx
@@ -7,8 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { FlowEngine } from '@nocobase/flow-engine';
+import { FieldModelRenderer, FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { TextareaFieldModel } from '../TextareaFieldModel';
@@ -23,6 +24,36 @@ function createTextareaFieldModel(props?: Record<string, unknown>) {
 }
 
 describe('TextareaFieldModel', () => {
+  it('syncs multiline values assigned through the form renderer', async () => {
+    const flowEngine = new FlowEngine();
+    const model = createTextareaFieldModel();
+    model.dispatchEvent = vi.fn().mockResolvedValue([]);
+
+    function FormHost() {
+      const [form] = Form.useForm();
+
+      React.useEffect(() => {
+        form.setFieldsValue({ address: 'aaaaaa\nbbbbbb' });
+      }, [form]);
+
+      return (
+        <FlowEngineProvider engine={flowEngine}>
+          <Form form={form}>
+            <Form.Item name="address">
+              <FieldModelRenderer model={model} />
+            </Form.Item>
+          </Form>
+        </FlowEngineProvider>
+      );
+    }
+
+    render(<FormHost />);
+
+    await waitFor(() => {
+      expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('aaaaaa\nbbbbbb');
+    });
+  });
+
   it('keeps IME composition text visible before the parent value is committed', () => {
     const onChange = vi.fn();
     const onCompositionStart = vi.fn();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where multiline text field values could not be set via ctx.setFormValues. |
| 🇨🇳 Chinese | 无法通过 ctx.setFormValues 设置多行文本字段值。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
