### PR TITLE
fix: popup sub table should not show popup template

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/__tests__/menuExtensions.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/__tests__/menuExtensions.test.ts
@@ -113,6 +113,27 @@ describe('registerMenuExtensions', () => {
       label: 'Convert reference to duplicate',
       sort: -8,
     });
+
+    class PopupSubTableEditActionModel extends FlowModel {}
+    PopupSubTableEditActionModel.registerFlow({
+      key: 'popupSettings',
+      title: 'Popup settings',
+      steps: {
+        openView: {
+          title: 'Open view',
+          use: 'openView',
+        },
+      },
+    });
+    const popupSubTableEdit = new PopupSubTableEditActionModel({
+      uid: 'popup-sub-table-edit',
+      use: 'PopupSubTableEditActionModel',
+      flowEngine: engine,
+    });
+    popupSubTableEdit.setStepParams('popupSettings', 'openView', { popupTemplateUid: 'tpl-popup' });
+    const popupSubTableEditItems = await PopupSubTableEditActionModel.getExtraMenuItems(popupSubTableEdit, t);
+    expect(findItem(popupSubTableEditItems, 'block-reference:save-popup-as-template')).toBeUndefined();
+    expect(findItem(popupSubTableEditItems, 'block-reference:convert-popup-template-to-copy')).toBeUndefined();
   });
 
   it('keeps popup template context when converting popup template to copy mode', async () => {

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/__tests__/openViewActionExtensions.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/__tests__/openViewActionExtensions.test.ts
@@ -63,6 +63,36 @@ describe('openViewActionExtensions (popup template)', () => {
     expect(merged.map((item) => item.value)).toEqual(['disabled-1', 'disabled-2', 'enabled-later']);
   });
 
+  it('omits popup template settings for popup sub table internal openView models', async () => {
+    const engine = new FlowEngine();
+    const baseOpenView: ActionDefinition = {
+      name: 'openView',
+      title: 'openView',
+      uiSchema: {
+        mode: { type: 'string' },
+        size: { type: 'string' },
+        uid: { type: 'string' },
+      },
+      handler: vi.fn(async () => undefined) as any,
+    };
+    engine.registerActions({ openView: baseOpenView });
+
+    registerOpenViewPopupTemplateAction(engine);
+    const enhanced = engine.getAction('openView') as any;
+    const schema = await enhanced.uiSchema({
+      model: { use: 'PopupSubTableEditActionModel' },
+    });
+    expect(schema).toHaveProperty('mode');
+    expect(schema).toHaveProperty('size');
+    expect(schema).toHaveProperty('uid');
+    expect(schema).not.toHaveProperty('popupTemplateUid');
+
+    const normalSchema = await enhanced.uiSchema({
+      model: { use: 'PopupActionModel' },
+    });
+    expect(normalSchema).toHaveProperty('popupTemplateUid');
+  });
+
   it('resolves popupTemplateUid to uid and delegates to base', async () => {
     const engine = new FlowEngine();
     const baseBefore = vi.fn(async () => {});

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/menuExtensions.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/menuExtensions.tsx
@@ -48,6 +48,7 @@ let unregisterMenuExtensions: (() => void) | undefined;
 
 const GRID_REF_FLOW_KEY = 'referenceSettings';
 const GRID_REF_STEP_KEY = 'useTemplate';
+const POPUP_SUB_TABLE_INTERNAL_OPEN_VIEW_MODELS = new Set(['PopupSubTableFieldModel', 'PopupSubTableEditActionModel']);
 
 type ReferenceFormGridTargetSettings = {
   templateUid: string;
@@ -964,6 +965,11 @@ function isReferenceTarget(model: FlowModel): boolean {
   return false;
 }
 
+function isPopupSubTableInternalOpenViewModel(model: FlowModel): boolean {
+  const useKey = normalizeStr((model as any)?.use) || normalizeStr((model as any)?.constructor?.name);
+  return POPUP_SUB_TABLE_INTERNAL_OPEN_VIEW_MODELS.has(useKey);
+}
+
 export function registerMenuExtensions() {
   if (unregisterMenuExtensions) {
     return unregisterMenuExtensions;
@@ -1077,6 +1083,9 @@ export function registerMenuExtensions() {
         const hasTemplate = !!templateUid;
         const disablePopupTemplateMenu = !!(openViewParams as any)?.disablePopupTemplateMenu;
         const pluginT = getPluginT(model);
+        if (isPopupSubTableInternalOpenViewModel(model)) {
+          return [];
+        }
         if (hasTemplate) {
           return [
             {

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/openViewActionExtensions.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/openViewActionExtensions.tsx
@@ -983,6 +983,13 @@ const persistCurrentOpenViewParams = (ctx: FlowSettingsContext, params: any) => 
   ctx.model?.setStepParams?.(flowKey, { [stepKey]: params });
 };
 
+const POPUP_SUB_TABLE_INTERNAL_OPEN_VIEW_MODELS = new Set(['PopupSubTableFieldModel', 'PopupSubTableEditActionModel']);
+
+const isPopupSubTableInternalOpenViewModel = (model: any) => {
+  const useKey = normalizeStr(model?.use) || normalizeStr(model?.constructor?.name);
+  return POPUP_SUB_TABLE_INTERNAL_OPEN_VIEW_MODELS.has(useKey);
+};
+
 const hasOwnParam = (params: any, key: string) => {
   return !!params && typeof params === 'object' && Object.prototype.hasOwnProperty.call(params, key);
 };
@@ -996,17 +1003,23 @@ export function registerOpenViewPopupTemplateAction(flowEngine: FlowEngine) {
 
   const enhanced: ActionDefinition = {
     ...(base as any),
-    uiSchema: {
-      ...(mode ? { mode } : {}),
-      ...(size ? { size } : {}),
-      popupTemplateUid: {
-        type: 'string',
-        title: `{{t("Popup template", { ns: ['${NAMESPACE}', 'client'], nsMode: 'fallback' })}}`,
-        'x-decorator': 'FormItem',
-        'x-component': PopupTemplateSelect,
-      },
-      ...(uid ? { uid } : {}),
-      ...rest,
+    uiSchema(ctx: FlowSettingsContext) {
+      return {
+        ...(mode ? { mode } : {}),
+        ...(size ? { size } : {}),
+        ...(isPopupSubTableInternalOpenViewModel(ctx?.model)
+          ? {}
+          : {
+              popupTemplateUid: {
+                type: 'string',
+                title: `{{t("Popup template", { ns: ['${NAMESPACE}', 'client'], nsMode: 'fallback' })}}`,
+                'x-decorator': 'FormItem',
+                'x-component': PopupTemplateSelect,
+              },
+            }),
+        ...(uid ? { uid } : {}),
+        ...rest,
+      };
     },
 
     async beforeParamsSave(ctx: FlowSettingsContext, params: any, previousParams: any) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the save as template menu was incorrectly displayed for sub-table fields in popup. |
| 🇨🇳 Chinese | 修复弹窗子表格字段错误的显示另存为模板菜单的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
