### PR TITLE
fix: unnecessary chart block auto refresh

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -14,7 +14,6 @@ import {
   SQLResource,
   useFlowContext,
 } from '@nocobase/flow-engine';
-import type { Collection, CollectionField, FlowEngine } from '@nocobase/flow-engine';
 import React, { createRef } from 'react';
 import _ from 'lodash';
 import { Button, Space } from 'antd';
@@ -29,6 +28,11 @@ import { configStore } from './config-store';
 import PluginDataVisualizationClient from '../../plugin';
 import { DaraButton } from '../components/DaraButton';
 import { useChatBoxStore, useChatMessagesStore } from '@nocobase/plugin-ai/client-v2';
+import {
+  getChartDirtyRefreshSnapshot,
+  shouldRefreshChartOnActive,
+  type ChartDirtyRefreshSnapshot,
+} from './chartDirtyTracking';
 
 const NO_PREVIEW_SNAPSHOT = Symbol('NO_PREVIEW_SNAPSHOT');
 
@@ -43,24 +47,6 @@ type ChartProps = {
     optionRaw?: string;
     Component?: React.FC<any>;
   };
-};
-
-type ChartDirtyTarget = {
-  dataSourceKey: string;
-  collectionName: string;
-};
-
-type ChartQueryForDirtyTracking = {
-  mode?: string;
-  collectionPath?: unknown[];
-  measures?: ChartQueryFieldItem[];
-  dimensions?: ChartQueryFieldItem[];
-  orders?: ChartQueryFieldItem[];
-  filter?: unknown;
-};
-
-type ChartQueryFieldItem = {
-  field?: unknown;
 };
 
 const toFieldPath = (field: string | string[] | undefined) => {
@@ -105,144 +91,29 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
   // 统一管理 refresh 监听引用，便于 off 解绑
   private __onResourceRefresh = () => this.renderChart();
-  private lastSeenDirtyVersion: number | null = null;
-  private lastSeenDirtyTargetKey: string | null = null;
+  private lastRefreshSnapshot: ChartDirtyRefreshSnapshot | null = null;
   private dirtyRefreshing = false;
 
-  private getDirtyTargetKey(target: ChartDirtyTarget): string {
-    return `${target.dataSourceKey}:${target.collectionName}`;
-  }
-
-  private addDirtyTarget(targets: Map<string, ChartDirtyTarget>, dataSourceKey: string, collectionName: string) {
-    if (!collectionName) return;
-    const target = {
-      dataSourceKey: dataSourceKey || DEFAULT_DATA_SOURCE_KEY,
-      collectionName,
-    };
-    targets.set(this.getDirtyTargetKey(target), target);
-  }
-
-  private normalizeFieldSegments(field: unknown): string[] {
-    if (Array.isArray(field)) {
-      return field.filter((segment): segment is string => typeof segment === 'string' && !!segment);
-    }
-    if (typeof field === 'string') {
-      return field.split('.').filter(Boolean);
-    }
-    return [];
-  }
-
-  private collectFilterFieldSegments(filter: unknown, result: string[][]) {
-    if (!filter) return;
-    if (Array.isArray(filter)) {
-      filter.forEach((item) => this.collectFilterFieldSegments(item, result));
-      return;
-    }
-    if (typeof filter !== 'object') return;
-
-    const item = filter as Record<string, unknown>;
-    const pathSegments = this.normalizeFieldSegments(item.path);
-    if (pathSegments.length) {
-      result.push(pathSegments);
-    }
-
-    this.collectFilterFieldSegments(item.items, result);
-    this.collectFilterFieldSegments(item.$and, result);
-    this.collectFilterFieldSegments(item.$or, result);
-  }
-
-  private collectQueryFieldSegments(query: ChartQueryForDirtyTracking): string[][] {
-    const result: string[][] = [];
-    [query.measures, query.dimensions, query.orders].forEach((items) => {
-      items?.forEach((item) => {
-        const fieldSegments = this.normalizeFieldSegments(item?.field);
-        if (fieldSegments.length) {
-          result.push(fieldSegments);
-        }
-      });
+  private getCurrentRefreshSnapshot(): ChartDirtyRefreshSnapshot | null {
+    return getChartDirtyRefreshSnapshot({
+      engine: this.context.engine,
+      dataSourceManager: this.context.dataSourceManager,
+      query: this.getResourceSettingsInitParams()?.query,
     });
-    this.collectFilterFieldSegments(query.filter, result);
-    return result;
   }
 
-  private addRelatedDirtyTargets(
-    targets: Map<string, ChartDirtyTarget>,
-    dataSourceKey: string,
-    collectionName: string,
-    fieldSegments: string[],
-  ) {
-    let collection = this.context.dataSourceManager.getCollection(dataSourceKey, collectionName) as Collection;
-    if (!collection) return;
-
-    for (const fieldName of fieldSegments) {
-      const collectionField = collection.getField(fieldName) as CollectionField | undefined;
-      if (!collectionField) return;
-
-      const targetCollection = collectionField.targetCollection;
-      if (!targetCollection) {
-        continue;
-      }
-
-      this.addDirtyTarget(targets, targetCollection.dataSourceKey || dataSourceKey, targetCollection.name);
-      collection = targetCollection;
-    }
+  private rememberRefreshSnapshot() {
+    this.lastRefreshSnapshot = this.getCurrentRefreshSnapshot();
   }
 
-  private getDirtyTrackingTargets(): ChartDirtyTarget[] | null {
-    const query = this.getResourceSettingsInitParams()?.query as ChartQueryForDirtyTracking | undefined;
-    if (!query || query.mode === 'sql') {
-      return null;
-    }
-
-    const [rawDataSourceKey = DEFAULT_DATA_SOURCE_KEY, rawCollectionName] = query.collectionPath || [];
-    if (typeof rawCollectionName !== 'string' || !rawCollectionName) {
-      return null;
-    }
-
-    const dataSourceKey =
-      typeof rawDataSourceKey === 'string' && rawDataSourceKey ? rawDataSourceKey : DEFAULT_DATA_SOURCE_KEY;
-    const targets = new Map<string, ChartDirtyTarget>();
-    this.addDirtyTarget(targets, dataSourceKey, rawCollectionName);
-    this.collectQueryFieldSegments(query).forEach((fieldSegments) => {
-      this.addRelatedDirtyTargets(targets, dataSourceKey, rawCollectionName, fieldSegments);
-    });
-
-    return Array.from(targets.values()).sort(
-      (a, b) => a.dataSourceKey.localeCompare(b.dataSourceKey) || a.collectionName.localeCompare(b.collectionName),
-    );
-  }
-
-  private getDirtyTrackingVersion(engine: FlowEngine, targets: ChartDirtyTarget[]): number {
-    return targets.reduce(
-      (version, target) => version + engine.getDataSourceDirtyVersion(target.dataSourceKey, target.collectionName),
-      0,
-    );
-  }
-
-  private getDirtyTargetsKey(targets: ChartDirtyTarget[]): string {
-    return targets.map((target) => this.getDirtyTargetKey(target)).join('|');
-  }
-
-  private rememberDirtyVersion(targets = this.getDirtyTrackingTargets()) {
-    if (!targets) {
-      this.lastSeenDirtyVersion = null;
-      this.lastSeenDirtyTargetKey = null;
-      return;
-    }
-
-    const engine = this.context.engine as FlowEngine;
-    this.lastSeenDirtyVersion = this.getDirtyTrackingVersion(engine, targets);
-    this.lastSeenDirtyTargetKey = this.getDirtyTargetsKey(targets);
-  }
-
-  private async refreshAndRememberDirtyVersion(targets: ChartDirtyTarget[] | null): Promise<void> {
+  private async refreshAndRememberSnapshot(): Promise<void> {
     if (this.dirtyRefreshing) return;
     this.dirtyRefreshing = true;
     try {
       await this.resource.refresh();
-      this.rememberDirtyVersion(targets);
+      this.rememberRefreshSnapshot();
     } catch {
-      // Keep lastSeenDirtyVersion unchanged so the next activate can retry.
+      // Keep lastRefreshSnapshot unchanged so the next activate can retry.
     } finally {
       this.dirtyRefreshing = false;
     }
@@ -251,29 +122,17 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
   async onActive(forceRefresh = false) {
     if (this.hidden) return;
 
-    const targets = this.getDirtyTrackingTargets();
-    if (!targets) {
-      await this.refreshAndRememberDirtyVersion(null);
+    const currentSnapshot = this.getCurrentRefreshSnapshot();
+    if (!shouldRefreshChartOnActive({ forceRefresh, currentSnapshot, lastSnapshot: this.lastRefreshSnapshot })) {
       return;
     }
 
-    const engine = this.context.engine as FlowEngine;
-    const currentVersion = this.getDirtyTrackingVersion(engine, targets);
-    const targetKey = this.getDirtyTargetsKey(targets);
-    const shouldRefresh =
-      forceRefresh ||
-      this.lastSeenDirtyVersion === null ||
-      this.lastSeenDirtyTargetKey !== targetKey ||
-      currentVersion !== this.lastSeenDirtyVersion;
-
-    if (!shouldRefresh) return;
-
-    await this.refreshAndRememberDirtyVersion(targets);
+    await this.refreshAndRememberSnapshot();
   }
 
   async refresh() {
     await this.resource.refresh();
-    this.rememberDirtyVersion();
+    this.rememberRefreshSnapshot();
   }
 
   // 初始化注册 ChartResource | SQLResource

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -14,6 +14,7 @@ import {
   SQLResource,
   useFlowContext,
 } from '@nocobase/flow-engine';
+import type { Collection, CollectionField, FlowEngine } from '@nocobase/flow-engine';
 import React, { createRef } from 'react';
 import _ from 'lodash';
 import { Button, Space } from 'antd';
@@ -42,6 +43,24 @@ type ChartProps = {
     optionRaw?: string;
     Component?: React.FC<any>;
   };
+};
+
+type ChartDirtyTarget = {
+  dataSourceKey: string;
+  collectionName: string;
+};
+
+type ChartQueryForDirtyTracking = {
+  mode?: string;
+  collectionPath?: unknown[];
+  measures?: ChartQueryFieldItem[];
+  dimensions?: ChartQueryFieldItem[];
+  orders?: ChartQueryFieldItem[];
+  filter?: unknown;
+};
+
+type ChartQueryFieldItem = {
+  field?: unknown;
 };
 
 const toFieldPath = (field: string | string[] | undefined) => {
@@ -86,13 +105,175 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
   // 统一管理 refresh 监听引用，便于 off 解绑
   private __onResourceRefresh = () => this.renderChart();
+  private lastSeenDirtyVersion: number | null = null;
+  private lastSeenDirtyTargetKey: string | null = null;
+  private dirtyRefreshing = false;
 
-  onActive() {
-    this.resource.refresh();
+  private getDirtyTargetKey(target: ChartDirtyTarget): string {
+    return `${target.dataSourceKey}:${target.collectionName}`;
   }
 
-  refresh() {
-    return this.resource.refresh();
+  private addDirtyTarget(targets: Map<string, ChartDirtyTarget>, dataSourceKey: string, collectionName: string) {
+    if (!collectionName) return;
+    const target = {
+      dataSourceKey: dataSourceKey || DEFAULT_DATA_SOURCE_KEY,
+      collectionName,
+    };
+    targets.set(this.getDirtyTargetKey(target), target);
+  }
+
+  private normalizeFieldSegments(field: unknown): string[] {
+    if (Array.isArray(field)) {
+      return field.filter((segment): segment is string => typeof segment === 'string' && !!segment);
+    }
+    if (typeof field === 'string') {
+      return field.split('.').filter(Boolean);
+    }
+    return [];
+  }
+
+  private collectFilterFieldSegments(filter: unknown, result: string[][]) {
+    if (!filter) return;
+    if (Array.isArray(filter)) {
+      filter.forEach((item) => this.collectFilterFieldSegments(item, result));
+      return;
+    }
+    if (typeof filter !== 'object') return;
+
+    const item = filter as Record<string, unknown>;
+    const pathSegments = this.normalizeFieldSegments(item.path);
+    if (pathSegments.length) {
+      result.push(pathSegments);
+    }
+
+    this.collectFilterFieldSegments(item.items, result);
+    this.collectFilterFieldSegments(item.$and, result);
+    this.collectFilterFieldSegments(item.$or, result);
+  }
+
+  private collectQueryFieldSegments(query: ChartQueryForDirtyTracking): string[][] {
+    const result: string[][] = [];
+    [query.measures, query.dimensions, query.orders].forEach((items) => {
+      items?.forEach((item) => {
+        const fieldSegments = this.normalizeFieldSegments(item?.field);
+        if (fieldSegments.length) {
+          result.push(fieldSegments);
+        }
+      });
+    });
+    this.collectFilterFieldSegments(query.filter, result);
+    return result;
+  }
+
+  private addRelatedDirtyTargets(
+    targets: Map<string, ChartDirtyTarget>,
+    dataSourceKey: string,
+    collectionName: string,
+    fieldSegments: string[],
+  ) {
+    let collection = this.context.dataSourceManager.getCollection(dataSourceKey, collectionName) as Collection;
+    if (!collection) return;
+
+    for (const fieldName of fieldSegments) {
+      const collectionField = collection.getField(fieldName) as CollectionField | undefined;
+      if (!collectionField) return;
+
+      const targetCollection = collectionField.targetCollection;
+      if (!targetCollection) {
+        continue;
+      }
+
+      this.addDirtyTarget(targets, targetCollection.dataSourceKey || dataSourceKey, targetCollection.name);
+      collection = targetCollection;
+    }
+  }
+
+  private getDirtyTrackingTargets(): ChartDirtyTarget[] | null {
+    const query = this.getResourceSettingsInitParams()?.query as ChartQueryForDirtyTracking | undefined;
+    if (!query || query.mode === 'sql') {
+      return null;
+    }
+
+    const [rawDataSourceKey = DEFAULT_DATA_SOURCE_KEY, rawCollectionName] = query.collectionPath || [];
+    if (typeof rawCollectionName !== 'string' || !rawCollectionName) {
+      return null;
+    }
+
+    const dataSourceKey =
+      typeof rawDataSourceKey === 'string' && rawDataSourceKey ? rawDataSourceKey : DEFAULT_DATA_SOURCE_KEY;
+    const targets = new Map<string, ChartDirtyTarget>();
+    this.addDirtyTarget(targets, dataSourceKey, rawCollectionName);
+    this.collectQueryFieldSegments(query).forEach((fieldSegments) => {
+      this.addRelatedDirtyTargets(targets, dataSourceKey, rawCollectionName, fieldSegments);
+    });
+
+    return Array.from(targets.values()).sort(
+      (a, b) => a.dataSourceKey.localeCompare(b.dataSourceKey) || a.collectionName.localeCompare(b.collectionName),
+    );
+  }
+
+  private getDirtyTrackingVersion(engine: FlowEngine, targets: ChartDirtyTarget[]): number {
+    return targets.reduce(
+      (version, target) => version + engine.getDataSourceDirtyVersion(target.dataSourceKey, target.collectionName),
+      0,
+    );
+  }
+
+  private getDirtyTargetsKey(targets: ChartDirtyTarget[]): string {
+    return targets.map((target) => this.getDirtyTargetKey(target)).join('|');
+  }
+
+  private rememberDirtyVersion(targets = this.getDirtyTrackingTargets()) {
+    if (!targets) {
+      this.lastSeenDirtyVersion = null;
+      this.lastSeenDirtyTargetKey = null;
+      return;
+    }
+
+    const engine = this.context.engine as FlowEngine;
+    this.lastSeenDirtyVersion = this.getDirtyTrackingVersion(engine, targets);
+    this.lastSeenDirtyTargetKey = this.getDirtyTargetsKey(targets);
+  }
+
+  private async refreshAndRememberDirtyVersion(targets: ChartDirtyTarget[] | null): Promise<void> {
+    if (this.dirtyRefreshing) return;
+    this.dirtyRefreshing = true;
+    try {
+      await this.resource.refresh();
+      this.rememberDirtyVersion(targets);
+    } catch {
+      // Keep lastSeenDirtyVersion unchanged so the next activate can retry.
+    } finally {
+      this.dirtyRefreshing = false;
+    }
+  }
+
+  async onActive(forceRefresh = false) {
+    if (this.hidden) return;
+
+    const targets = this.getDirtyTrackingTargets();
+    if (!targets) {
+      await this.refreshAndRememberDirtyVersion(null);
+      return;
+    }
+
+    const engine = this.context.engine as FlowEngine;
+    const currentVersion = this.getDirtyTrackingVersion(engine, targets);
+    const targetKey = this.getDirtyTargetsKey(targets);
+    const shouldRefresh =
+      forceRefresh ||
+      this.lastSeenDirtyVersion === null ||
+      this.lastSeenDirtyTargetKey !== targetKey ||
+      currentVersion !== this.lastSeenDirtyVersion;
+
+    if (!shouldRefresh) return;
+
+    await this.refreshAndRememberDirtyVersion(targets);
+  }
+
+  async refresh() {
+    await this.resource.refresh();
+    this.rememberDirtyVersion();
   }
 
   // 初始化注册 ChartResource | SQLResource
@@ -182,7 +363,7 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
       const initQuery = initParams?.query;
       if (initQuery) {
         this.applyQuery(await this.buildQueryRequest(initQuery));
-        await this.resource.refresh();
+        await this.refresh();
       }
     } catch (e) {
       const message = (e as any)?.message || String(e);
@@ -476,7 +657,7 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
       try {
         // 等待确保 stepParams 已更新
         await sleep(200);
-        await this.resource.refresh();
+        await this.refresh();
         this.setDataResult();
       } finally {
         if (isSQL) {
@@ -497,7 +678,7 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
       // 等待确保 stepParams 已更新
       await sleep(100);
       // 重新请求数据，并刷新图表
-      await this.resource.refresh();
+      await this.refresh();
     }
   }
 }

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -134,6 +134,34 @@ describe('ChartBlockModel onActive dirty refresh', () => {
     expect(resource.refreshCalls).toBe(0);
   });
 
+  it('refreshes builder charts when the query changes for the same collection', async () => {
+    const { model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+      measures: [{ field: ['amount'] }],
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+    model.setStepParams('chartSettings', 'configure', {
+      query: {
+        mode: 'builder',
+        collectionPath: ['main', 'orders'],
+        measures: [{ field: ['id'] }],
+        filter: {
+          logic: '$and',
+          items: [{ path: 'amount', operator: '$gt', value: 100 }],
+        },
+        orders: [{ field: ['amount'] }],
+      },
+    });
+
+    await model.onActive();
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(1);
+  });
+
   it('refreshes builder charts when a dimension reads a dirty associated collection', async () => {
     const { engine, model, resource } = setupModel({
       mode: 'builder',

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -134,6 +134,20 @@ describe('ChartBlockModel onActive dirty refresh', () => {
     expect(resource.refreshCalls).toBe(0);
   });
 
+  it('refreshes builder charts when activation is forced', async () => {
+    const { model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+
+    await model.onActive(true);
+
+    expect(resource.refreshCalls).toBe(1);
+  });
+
   it('refreshes builder charts when the query changes for the same collection', async () => {
     const { model, resource } = setupModel({
       mode: 'builder',

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -1,0 +1,187 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it } from 'vitest';
+import { ChartBlockModel } from '../ChartBlockModel';
+
+type ChartQuery = {
+  mode?: string;
+  collectionPath?: string[];
+  measures?: { field?: string | string[] }[];
+  dimensions?: { field?: string | string[] }[];
+  orders?: { field?: string | string[] }[];
+  filter?: unknown;
+  sql?: string;
+  sqlDatasource?: string;
+};
+
+class DummyChartResource {
+  refreshCalls = 0;
+
+  async refresh(): Promise<void> {
+    this.refreshCalls += 1;
+  }
+}
+
+class DummyChartBlockModel extends ChartBlockModel {
+  readonly testResource = new DummyChartResource();
+
+  override async onInit(_options: unknown): Promise<void> {
+    this.context.defineProperty('resource', {
+      get: () => this.testResource,
+    });
+  }
+}
+
+function setupModel(query: ChartQuery) {
+  const engine = new FlowEngine();
+  engine.registerModels({ DummyChartBlockModel });
+  addChartCollections(engine);
+
+  const model = engine.createModel<DummyChartBlockModel>({
+    uid: 'chart-block',
+    use: 'DummyChartBlockModel',
+    stepParams: {
+      chartSettings: {
+        configure: {
+          query,
+        },
+      },
+    },
+  });
+
+  return { engine, model, resource: model.testResource };
+}
+
+function addChartCollections(engine: FlowEngine) {
+  const dataSource = engine.dataSourceManager.getDataSource('main');
+  dataSource.addCollection({
+    name: 'customers',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'name', type: 'string', interface: 'input' },
+    ],
+  });
+  dataSource.addCollection({
+    name: 'orders',
+    filterTargetKey: 'id',
+    fields: [
+      { name: 'id', type: 'integer', interface: 'number' },
+      { name: 'amount', type: 'double', interface: 'number' },
+      {
+        name: 'customer',
+        title: 'Customer',
+        type: 'belongsTo',
+        target: 'customers',
+        interface: 'm2o',
+        foreignKey: 'customer_id',
+      },
+    ],
+  });
+}
+
+describe('ChartBlockModel onActive dirty refresh', () => {
+  it('does not refresh builder charts when the configured collection is clean', async () => {
+    const { model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(0);
+  });
+
+  it('refreshes builder charts when the configured collection becomes dirty', async () => {
+    const { engine, model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+    engine.markDataSourceDirty('main', 'orders');
+
+    await model.onActive();
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(1);
+  });
+
+  it('does not refresh builder charts for unrelated dirty collections', async () => {
+    const { engine, model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+    engine.markDataSourceDirty('main', 'customers');
+
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(0);
+  });
+
+  it('refreshes builder charts when a dimension reads a dirty associated collection', async () => {
+    const { engine, model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+      measures: [{ field: ['amount'] }],
+      dimensions: [{ field: ['customer', 'name'] }],
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+    engine.markDataSourceDirty('main', 'customers');
+
+    await model.onActive();
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(1);
+  });
+
+  it('refreshes builder charts when a filter reads a dirty associated collection', async () => {
+    const { engine, model, resource } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+      measures: [{ field: ['amount'] }],
+      filter: {
+        logic: '$and',
+        items: [{ path: 'customer.name', operator: '$eq', value: 'Acme' }],
+      },
+    });
+
+    await model.refresh();
+    resource.refreshCalls = 0;
+    engine.markDataSourceDirty('main', 'customers');
+
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(1);
+  });
+
+  it('keeps refreshing SQL charts on active because no collection target is available', async () => {
+    const { model, resource } = setupModel({
+      mode: 'sql',
+      sql: 'select 1',
+      sqlDatasource: 'main',
+    });
+
+    await model.onActive();
+    await model.onActive();
+
+    expect(resource.refreshCalls).toBe(2);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/chartDirtyTracking.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/chartDirtyTracking.ts
@@ -1,0 +1,190 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { DEFAULT_DATA_SOURCE_KEY } from '@nocobase/client-v2';
+import type { Collection, CollectionField, FlowEngine } from '@nocobase/flow-engine';
+import _ from 'lodash';
+
+type ChartDirtyTarget = {
+  dataSourceKey: string;
+  collectionName: string;
+};
+
+type ChartQueryFieldItem = {
+  field?: unknown;
+};
+
+export type ChartQueryForDirtyTracking = {
+  mode?: string;
+  collectionPath?: unknown[];
+  measures?: ChartQueryFieldItem[];
+  dimensions?: ChartQueryFieldItem[];
+  orders?: ChartQueryFieldItem[];
+  filter?: unknown;
+};
+
+export type ChartDirtyRefreshSnapshot = {
+  query: ChartQueryForDirtyTracking;
+  targetKey: string;
+  dirtyVersion: number;
+};
+
+type DataSourceManagerLike = {
+  getCollection?: (dataSourceKey: string, collectionName: string) => Collection | undefined;
+};
+
+function getDirtyTargetKey(target: ChartDirtyTarget): string {
+  return `${target.dataSourceKey}:${target.collectionName}`;
+}
+
+function addDirtyTarget(targets: Map<string, ChartDirtyTarget>, dataSourceKey: string, collectionName: string) {
+  if (!collectionName) return;
+  const target = {
+    dataSourceKey: dataSourceKey || DEFAULT_DATA_SOURCE_KEY,
+    collectionName,
+  };
+  targets.set(getDirtyTargetKey(target), target);
+}
+
+function normalizeFieldSegments(field: unknown): string[] {
+  if (Array.isArray(field)) {
+    return field.filter((segment): segment is string => typeof segment === 'string' && !!segment);
+  }
+  if (typeof field === 'string') {
+    return field.split('.').filter(Boolean);
+  }
+  return [];
+}
+
+function collectFilterFieldSegments(filter: unknown, result: string[][]) {
+  if (!filter) return;
+  if (Array.isArray(filter)) {
+    filter.forEach((item) => collectFilterFieldSegments(item, result));
+    return;
+  }
+  if (typeof filter !== 'object') return;
+
+  const item = filter as Record<string, unknown>;
+  const pathSegments = normalizeFieldSegments(item.path);
+  if (pathSegments.length) {
+    result.push(pathSegments);
+  }
+
+  collectFilterFieldSegments(item.items, result);
+  collectFilterFieldSegments(item.$and, result);
+  collectFilterFieldSegments(item.$or, result);
+}
+
+function collectQueryFieldSegments(query: ChartQueryForDirtyTracking): string[][] {
+  const result: string[][] = [];
+  [query.measures, query.dimensions, query.orders].forEach((items) => {
+    items?.forEach((item) => {
+      const fieldSegments = normalizeFieldSegments(item?.field);
+      if (fieldSegments.length) {
+        result.push(fieldSegments);
+      }
+    });
+  });
+  collectFilterFieldSegments(query.filter, result);
+  return result;
+}
+
+function addRelatedDirtyTargets(
+  targets: Map<string, ChartDirtyTarget>,
+  dataSourceManager: DataSourceManagerLike,
+  dataSourceKey: string,
+  collectionName: string,
+  fieldSegments: string[],
+) {
+  let collection = dataSourceManager.getCollection?.(dataSourceKey, collectionName);
+  if (!collection) return;
+
+  for (const fieldName of fieldSegments) {
+    const collectionField = collection.getField(fieldName) as CollectionField | undefined;
+    if (!collectionField) return;
+
+    const targetCollection = collectionField.targetCollection;
+    if (!targetCollection) {
+      continue;
+    }
+
+    addDirtyTarget(targets, targetCollection.dataSourceKey || dataSourceKey, targetCollection.name);
+    collection = targetCollection;
+  }
+}
+
+function getDirtyTrackingTargets(
+  dataSourceManager: DataSourceManagerLike,
+  query?: ChartQueryForDirtyTracking,
+): ChartDirtyTarget[] | null {
+  if (!query || query.mode === 'sql') {
+    return null;
+  }
+
+  const [rawDataSourceKey = DEFAULT_DATA_SOURCE_KEY, rawCollectionName] = query.collectionPath || [];
+  if (typeof rawCollectionName !== 'string' || !rawCollectionName) {
+    return null;
+  }
+
+  const dataSourceKey =
+    typeof rawDataSourceKey === 'string' && rawDataSourceKey ? rawDataSourceKey : DEFAULT_DATA_SOURCE_KEY;
+  const targets = new Map<string, ChartDirtyTarget>();
+  addDirtyTarget(targets, dataSourceKey, rawCollectionName);
+  collectQueryFieldSegments(query).forEach((fieldSegments) => {
+    addRelatedDirtyTargets(targets, dataSourceManager, dataSourceKey, rawCollectionName, fieldSegments);
+  });
+
+  return Array.from(targets.values()).sort(
+    (a, b) => a.dataSourceKey.localeCompare(b.dataSourceKey) || a.collectionName.localeCompare(b.collectionName),
+  );
+}
+
+function getDirtyTrackingVersion(engine: FlowEngine, targets: ChartDirtyTarget[]): number {
+  return targets.reduce(
+    (version, target) => version + engine.getDataSourceDirtyVersion(target.dataSourceKey, target.collectionName),
+    0,
+  );
+}
+
+function getDirtyTargetsKey(targets: ChartDirtyTarget[]): string {
+  return targets.map((target) => getDirtyTargetKey(target)).join('|');
+}
+
+export function getChartDirtyRefreshSnapshot(options: {
+  engine: FlowEngine;
+  dataSourceManager: DataSourceManagerLike;
+  query?: ChartQueryForDirtyTracking;
+}): ChartDirtyRefreshSnapshot | null {
+  const targets = getDirtyTrackingTargets(options.dataSourceManager, options.query);
+  if (!targets) {
+    return null;
+  }
+
+  return {
+    query: _.cloneDeep(options.query || {}),
+    targetKey: getDirtyTargetsKey(targets),
+    dirtyVersion: getDirtyTrackingVersion(options.engine, targets),
+  };
+}
+
+export function shouldRefreshChartOnActive(options: {
+  forceRefresh?: boolean;
+  currentSnapshot: ChartDirtyRefreshSnapshot | null;
+  lastSnapshot: ChartDirtyRefreshSnapshot | null;
+}): boolean {
+  const { forceRefresh, currentSnapshot, lastSnapshot } = options;
+  if (!currentSnapshot) return true;
+  if (forceRefresh || !lastSnapshot) return true;
+
+  return (
+    currentSnapshot.targetKey !== lastSnapshot.targetKey ||
+    currentSnapshot.dirtyVersion !== lastSnapshot.dirtyVersion ||
+    !_.isEqual(currentSnapshot.query, lastSnapshot.query)
+  );
+}

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/resources/ChartResource.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/resources/ChartResource.ts
@@ -16,6 +16,7 @@ export class ChartResource<TData = any> extends BaseRecordResource<TData> {
   resourceName = 'charts';
 
   private refreshTimer: NodeJS.Timeout | null = null;
+  private refreshWaiters: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
 
   protected request = {
     url: 'charts:queryData',
@@ -169,7 +170,11 @@ export class ChartResource<TData = any> extends BaseRecordResource<TData> {
       clearTimeout(this.refreshTimer);
     }
     return new Promise<void>((resolve, reject) => {
+      this.refreshWaiters.push({ resolve, reject });
       this.refreshTimer = setTimeout(async () => {
+        const waiters = this.refreshWaiters;
+        this.refreshWaiters = [];
+        this.refreshTimer = null;
         try {
           this.clearError();
           this.loading = true;
@@ -179,12 +184,12 @@ export class ChartResource<TData = any> extends BaseRecordResource<TData> {
           this.setData(data).setMeta(meta);
           this.loading = false;
           this.emit('refresh');
-          resolve();
+          waiters.forEach((waiter) => waiter.resolve());
         } catch (error) {
           this.setError(error);
-          reject(error instanceof Error ? error : new Error(String(error)));
+          const err = error instanceof Error ? error : new Error(String(error));
+          waiters.forEach((waiter) => waiter.reject(err));
         } finally {
-          this.refreshTimer = null;
           this.loading = false;
         }
       });

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/resources/__tests__/ChartResource.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/resources/__tests__/ChartResource.test.ts
@@ -11,6 +11,15 @@ import { FlowContext } from '@nocobase/flow-engine';
 
 import { ChartResource } from '../ChartResource';
 
+class TestChartResource extends ChartResource<any[]> {
+  runCalls = 0;
+
+  override async run() {
+    this.runCalls += 1;
+    return { data: [], meta: {} };
+  }
+}
+
 describe('client-v2 ChartResource', () => {
   test('fills aggregated order alias from selected query fields', () => {
     const resource = new ChartResource(new FlowContext());
@@ -44,5 +53,13 @@ describe('client-v2 ChartResource', () => {
     expect((resource as any).request.data.filter).toEqual({
       $and: [{ status: { $eq: 'paid' } }, { amount: { $gt: 0 } }],
     });
+  });
+
+  test('settles all callers when rapid refresh calls are debounced', async () => {
+    const resource = new TestChartResource(new FlowContext());
+
+    await expect(Promise.all([resource.refresh(), resource.refresh()])).resolves.toEqual([undefined, undefined]);
+
+    expect(resource.runCalls).toBe(1);
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where chart blocks would trigger unnecessary refreshes when closing a popup. |
| 🇨🇳 Chinese | 修复图表区块在关闭弹窗时会触发不必要的刷新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
