### PR TITLE
test(plugin-users): improve client-v2 coverage

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ChangeUserPasswordDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ChangeUserPasswordDrawer.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import ChangeUserPasswordDrawer from '../pages/ChangeUserPasswordDrawer';
+
+const { formItems, setFieldsValue, update, success, onSubmitted } = vi.hoisted(() => ({
+  formItems: [] as Array<Record<string, any>>,
+  setFieldsValue: vi.fn(),
+  update: vi.fn(),
+  success: vi.fn(),
+  onSubmitted: vi.fn(),
+}));
+
+vi.mock('antd', async () => {
+  const React = await import('react');
+
+  return {
+    Button: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) =>
+      React.createElement('button', { onClick }, children),
+    Col: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
+    Row: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
+    Form: {
+      Item: (props: Record<string, any>) => {
+        formItems.push(props);
+        return React.createElement('div', null, props.children);
+      },
+    },
+  };
+});
+
+vi.mock('@nocobase/client-v2', async () => {
+  const React = await import('react');
+
+  return {
+    Plugin: class Plugin {},
+    PasswordInput: (props: Record<string, unknown>) =>
+      React.createElement('input', {
+        'data-testid': 'password-input',
+        autoComplete: props.autoComplete,
+      }),
+  };
+});
+
+vi.mock('@nocobase/plugin-acl/client-v2', () => ({
+  default: class PluginAclClientV2 {},
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    app: {
+      pm: {
+        get: () => ({
+          getPasswordValidators: () => [
+            async (value: string, ctx: { username?: string }) =>
+              value.includes(ctx.username || '') ? 'Password cannot include username' : null,
+          ],
+        }),
+      },
+    },
+    api: {
+      resource: () => ({
+        update,
+      }),
+    },
+    message: {
+      success,
+    },
+  }),
+}));
+
+vi.mock('../components/resource', async () => {
+  const React = await import('react');
+
+  return {
+    ResourceFormDrawer: ({
+      children,
+      onSubmit,
+      onSubmitted: handleSubmitted,
+    }: {
+      children: (args: { form: { setFieldsValue: typeof setFieldsValue } }) => React.ReactNode;
+      onSubmit: (values: { password: string }) => Promise<void>;
+      onSubmitted: () => Promise<void>;
+    }) =>
+      React.createElement(
+        'div',
+        null,
+        children({ form: { setFieldsValue } }),
+        React.createElement(
+          'button',
+          {
+            onClick: async () => {
+              await onSubmit({ password: 'New-password-1' });
+              await handleSubmitted();
+            },
+          },
+          'Submit drawer',
+        ),
+      ),
+  };
+});
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+}));
+
+vi.mock('../shared/generatePassword', () => ({
+  generatePassword: () => 'Generated-password-1',
+}));
+
+describe('ChangeUserPasswordDrawer', () => {
+  beforeEach(() => {
+    formItems.length = 0;
+    setFieldsValue.mockReset();
+    update.mockReset();
+    success.mockReset();
+    onSubmitted.mockReset();
+  });
+
+  it('generates a password into the form', () => {
+    render(
+      <ChangeUserPasswordDrawer
+        user={{
+          id: 1,
+          username: 'alice',
+        }}
+        onSubmitted={onSubmitted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Random password' }));
+
+    expect(setFieldsValue).toHaveBeenCalledWith({ password: 'Generated-password-1' });
+  });
+
+  it('runs registered password validators with the target username', async () => {
+    render(
+      <ChangeUserPasswordDrawer
+        user={{
+          id: 1,
+          username: 'alice',
+        }}
+        onSubmitted={onSubmitted}
+      />,
+    );
+
+    const passwordItem = formItems.find((item) => item.name === 'password');
+    const validator = passwordItem.rules.find((rule: Record<string, any>) => rule.validator).validator;
+
+    await expect(validator({}, 'alice-secret')).rejects.toThrow('Password cannot include username');
+    await expect(validator({}, 'secure-secret')).resolves.toBeUndefined();
+  });
+
+  it('updates user password and runs submitted side effects', async () => {
+    render(
+      <ChangeUserPasswordDrawer
+        user={{
+          id: 18,
+          username: 'alice',
+        }}
+        onSubmitted={onSubmitted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit drawer' }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith({
+        filterByTk: 18,
+        values: {
+          password: 'New-password-1',
+        },
+      });
+    });
+    expect(success).toHaveBeenCalledWith('Saved successfully');
+    expect(onSubmitted).toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ResourceComponents.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ResourceComponents.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Input, Form } from 'antd';
+import React from 'react';
+import { ResourceFormDrawer, ResourcePickerView, ResourceTablePage, SettingsActionCell } from '../components/resource';
+
+const { latestTableProps, close } = vi.hoisted(() => ({
+  latestTableProps: {
+    current: null as null | Record<string, unknown>,
+  },
+  close: vi.fn(),
+}));
+
+vi.mock('@nocobase/client-v2', async () => {
+  const React = await import('react');
+
+  return {
+    DEFAULT_PAGE_SIZE: 20,
+    CollectionFilter: ({ onChange }: { onChange: (filter: Record<string, unknown>) => void }) =>
+      React.createElement(
+        'button',
+        {
+          onClick: () => onChange({ username: { $includes: 'alice' } }),
+        },
+        'Filter',
+      ),
+    DrawerFormLayout: ({
+      children,
+      onSubmit,
+      submitting,
+    }: {
+      children?: React.ReactNode;
+      onSubmit?: () => Promise<void>;
+      submitting?: boolean;
+    }) =>
+      React.createElement(
+        'div',
+        null,
+        children,
+        React.createElement(
+          'button',
+          {
+            disabled: submitting,
+            onClick: async () => {
+              await onSubmit?.();
+            },
+          },
+          'Submit drawer',
+        ),
+      ),
+    Table: (props: Record<string, unknown>) => {
+      latestTableProps.current = props;
+      const dataSource = Array.isArray(props.dataSource) ? props.dataSource : [];
+      return React.createElement(
+        'div',
+        { 'data-testid': 'resource-table' },
+        dataSource.map((record: Record<string, unknown>) =>
+          React.createElement('div', { key: String(record.id) }, String(record.username ?? record.name ?? record.id)),
+        ),
+      );
+    },
+  };
+});
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const React = await import('react');
+
+  return {
+    useFlowView: () => ({
+      close,
+      Header: ({ title }: { title: React.ReactNode }) => React.createElement('div', null, title),
+      Footer: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
+    }),
+  };
+});
+
+describe('plugin-users client-v2 resource components', () => {
+  beforeEach(() => {
+    latestTableProps.current = null;
+    close.mockReset();
+  });
+
+  it('submits ResourceFormDrawer values after validation', async () => {
+    const onSubmit = vi.fn();
+    const onSubmitted = vi.fn();
+
+    render(
+      <ResourceFormDrawer
+        title="Edit"
+        initialValues={{ username: 'alice' }}
+        onSubmit={onSubmit}
+        onSubmitted={onSubmitted}
+      >
+        <Form.Item name="username">
+          <Input aria-label="Username" />
+        </Form.Item>
+      </ResourceFormDrawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Username')).toHaveValue('alice');
+    });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'bob' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit drawer' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ username: 'bob' }, expect.anything());
+    });
+    expect(onSubmitted).toHaveBeenCalledWith({ username: 'bob' });
+  });
+
+  it('loads ResourceTablePage data and refreshes when filter changes', async () => {
+    const request = vi.fn().mockResolvedValue({
+      data: [{ id: 1, username: 'alice' }],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+
+    render(
+      <ResourceTablePage
+        collection={{} as never}
+        rowKey="id"
+        columns={[]}
+        request={request}
+        toolbar={({ refresh }) => <button onClick={refresh}>Refresh table</button>}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument();
+    });
+    expect(request).toHaveBeenLastCalledWith({ filter: undefined, page: 1, pageSize: 20 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
+
+    await waitFor(() => {
+      expect(request).toHaveBeenLastCalledWith({
+        filter: { username: { $includes: 'alice' } },
+        page: 1,
+        pageSize: 20,
+      });
+    });
+  });
+
+  it('renders visible SettingsActionCell actions and invokes handlers with the record', () => {
+    const edit = vi.fn();
+    const hidden = vi.fn();
+
+    render(
+      <SettingsActionCell
+        record={{ id: 1 }}
+        actions={[
+          {
+            key: 'edit',
+            label: 'Edit',
+            onClick: edit,
+          },
+          {
+            key: 'hidden',
+            label: 'Hidden',
+            hidden: true,
+            onClick: hidden,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Hidden' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(edit).toHaveBeenCalledWith({ id: 1 });
+    expect(hidden).not.toHaveBeenCalled();
+  });
+
+  it('submits ResourcePickerView selection and closes with selected rows', async () => {
+    const onSubmit = vi.fn();
+    const request = vi.fn().mockResolvedValue({
+      data: [{ id: 7, username: 'alice' }],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+
+    render(
+      <ResourcePickerView
+        title="Pick users"
+        rowKey="id"
+        columns={[]}
+        request={request}
+        onSubmit={onSubmit}
+        t={(key) => key}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument();
+    });
+
+    const rowSelection = latestTableProps.current?.rowSelection as {
+      onChange: (keys: React.Key[], rows: Array<Record<string, unknown>>) => void;
+    };
+    act(() => {
+      rowSelection.onChange([7], [{ id: 7, username: 'alice' }]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith([{ id: 7, username: 'alice' }], [7]);
+    });
+    expect(close).toHaveBeenCalledWith({
+      selectedRows: [{ id: 7, username: 'alice' }],
+      selectedRowKeys: [7],
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/RoleUsersManager.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/RoleUsersManager.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import RoleUsersManager from '../pages/RoleUsersManager';
+
+const { open, list, listExcludeRole, add, remove, success, tableProps, pickerProps } = vi.hoisted(() => ({
+  open: vi.fn(),
+  list: vi.fn(),
+  listExcludeRole: vi.fn(),
+  add: vi.fn(),
+  remove: vi.fn(),
+  success: vi.fn(),
+  tableProps: {
+    current: null as null | Record<string, any>,
+  },
+  pickerProps: {
+    current: null as null | Record<string, any>,
+  },
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    dataSourceManager: {
+      getDataSource: () => ({
+        getCollection: () => ({}),
+      }),
+    },
+    viewer: {
+      open,
+    },
+    api: {
+      resource: (name: string) => {
+        if (name === 'users') {
+          return {
+            listExcludeRole,
+          };
+        }
+        return {
+          list,
+          add,
+          remove,
+        };
+      },
+    },
+    message: {
+      success,
+    },
+  }),
+}));
+
+vi.mock('../components/resource', () => ({
+  ResourceTablePage: (props: Record<string, any>) => {
+    tableProps.current = props;
+    return <div>{props.toolbar({ refreshAsync: vi.fn().mockResolvedValue(undefined) })}</div>;
+  },
+  ResourcePickerView: (props: Record<string, any>) => {
+    pickerProps.current = props;
+    return <div>ResourcePickerView</div>;
+  },
+  SettingsActionCell: ({ record, actions }: { record: Record<string, any>; actions: Array<Record<string, any>> }) => (
+    <div>
+      {actions
+        .filter((action) => !action.hidden)
+        .map((action) => (
+          <button key={action.key} onClick={() => action.onClick?.(record)}>
+            {action.label}
+          </button>
+        ))}
+    </div>
+  ),
+}));
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+}));
+
+describe('RoleUsersManager', () => {
+  beforeEach(() => {
+    open.mockReset();
+    list.mockResolvedValue({
+      data: {
+        data: [{ id: 1, username: 'alice' }],
+        meta: {
+          page: 1,
+          pageSize: 20,
+          total: 1,
+        },
+      },
+    });
+    listExcludeRole.mockResolvedValue({
+      data: {
+        data: [{ id: 2, username: 'bob' }],
+        meta: {
+          page: 1,
+          pageSize: 20,
+          count: 1,
+        },
+      },
+    });
+    add.mockReset();
+    remove.mockReset();
+    success.mockReset();
+    tableProps.current = null;
+    pickerProps.current = null;
+  });
+
+  it('shows empty state when no role is selected', () => {
+    render(<RoleUsersManager role={null as never} />);
+
+    expect(screen.getByText('Select a role to configure permissions')).toBeInTheDocument();
+  });
+
+  it('loads users for the selected role', async () => {
+    render(<RoleUsersManager role={{ name: 'admin', title: 'Admin' } as never} />);
+
+    const response = await tableProps.current?.request({
+      filter: { username: { $includes: 'a' } },
+      page: 2,
+      pageSize: 10,
+    });
+
+    expect(list).toHaveBeenCalledWith({
+      page: 2,
+      pageSize: 10,
+      filter: { username: { $includes: 'a' } },
+    });
+    expect(response).toEqual({
+      data: [{ id: 1, username: 'alice' }],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+  });
+
+  it('opens picker and adds selected users to the role', async () => {
+    render(<RoleUsersManager role={{ name: 'admin', title: 'Admin' } as never} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add users/ }));
+
+    expect(open).toHaveBeenCalledWith(expect.objectContaining({ type: 'drawer', width: '50%' }));
+
+    const drawer = open.mock.calls[0][0];
+    render(drawer.content());
+
+    const pickerResponse = await pickerProps.current?.request({
+      filter: { username: { $includes: 'b' } },
+      page: 3,
+      pageSize: 20,
+    });
+
+    expect(listExcludeRole).toHaveBeenCalledWith({
+      page: 3,
+      pageSize: 20,
+      roleName: 'admin',
+      filter: { username: { $includes: 'b' } },
+    });
+    expect(pickerResponse).toEqual({
+      data: [{ id: 2, username: 'bob' }],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+
+    await pickerProps.current?.onSubmit([{ id: 2, username: 'bob' }]);
+
+    await waitFor(() => {
+      expect(add).toHaveBeenCalledWith({ values: [2] });
+    });
+    expect(success).toHaveBeenCalledWith('Saved successfully');
+  });
+
+  it('removes a user from row actions', async () => {
+    render(<RoleUsersManager role={{ name: 'admin', title: 'Admin' } as never} />);
+
+    const actionsColumn = tableProps.current?.columns.find((column: Record<string, any>) => column.key === 'actions');
+    render(actionsColumn.render(null, { id: 2, username: 'alice' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(remove).toHaveBeenCalledWith({ values: [2] });
+    });
+    expect(success).toHaveBeenCalledWith('Removed successfully');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserCenterDrawerContent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserCenterDrawerContent.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockClient } from '@nocobase/client-v2';
+import type { FlowContext } from '@nocobase/flow-engine';
+import React from 'react';
+import PluginUsersClientV2 from '../plugin';
+
+const { changePassword, currentContext, redirectToV2Signin, updateProfile } = vi.hoisted(() => ({
+  changePassword: vi.fn(),
+  currentContext: {
+    value: null as FlowContext | null,
+  },
+  redirectToV2Signin: vi.fn(),
+  updateProfile: vi.fn(),
+}));
+
+vi.mock('@nocobase/client-v2', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nocobase/client-v2')>();
+  const React = await import('react');
+
+  return {
+    ...actual,
+    DrawerFormLayout: ({
+      children,
+      onSubmit,
+      submitText,
+      title,
+    }: {
+      children?: React.ReactNode;
+      onSubmit?: () => Promise<void>;
+      submitText?: React.ReactNode;
+      title?: React.ReactNode;
+    }) =>
+      React.createElement(
+        'div',
+        null,
+        React.createElement('h1', null, title),
+        children,
+        React.createElement(
+          'button',
+          {
+            onClick: async () => {
+              try {
+                await onSubmit?.();
+              } catch {
+                // DrawerFormLayout keeps the drawer mounted on submit errors; tests assert the visible error state.
+              }
+            },
+          },
+          submitText,
+        ),
+      ),
+    PasswordInput: ({
+      checkStrength: _checkStrength,
+      value,
+      ...props
+    }: React.InputHTMLAttributes<HTMLInputElement> & { checkStrength?: boolean }) =>
+      React.createElement('input', { ...props, value: value ?? '' }),
+    redirectToV2Signin,
+  };
+});
+
+vi.mock('@nocobase/flow-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nocobase/flow-engine')>();
+
+  return {
+    ...actual,
+    useFlowEngine: () => ({
+      context: {
+        t: (key: string) => key,
+      },
+    }),
+    useFlowContext: () => currentContext.value,
+  };
+});
+
+function setupChangePasswordContext() {
+  changePassword.mockReset();
+  redirectToV2Signin.mockReset();
+  currentContext.value = null;
+}
+
+function setupEditProfileContext(
+  user = { nickname: 'Alice', username: 'alice', email: 'alice@example.com', phone: '1' },
+) {
+  updateProfile.mockReset();
+  currentContext.value = null;
+  return user;
+}
+
+type UserCenterDrawerModel = {
+  context: FlowContext;
+  onClick: () => Promise<void>;
+};
+
+type MockClientApplication = ReturnType<typeof createMockClient>;
+
+async function renderModelContent(
+  use: 'ChangePasswordItemModel' | 'EditProfileItemModel',
+  configureContext?: (context: FlowContext, app: MockClientApplication) => void,
+) {
+  const app = createMockClient({});
+  await app.pm.add(PluginUsersClientV2);
+  await app.load();
+  await app.flowEngine.getModelClassAsync(use);
+
+  const model = app.flowEngine.createModel({
+    use,
+    uid: `${use}-test`,
+  }) as unknown as UserCenterDrawerModel;
+  const open = vi.fn();
+
+  model.context.defineProperty('viewer', {
+    value: {
+      open,
+    },
+  });
+  configureContext?.(model.context, app);
+  currentContext.value = model.context;
+
+  await model.onClick();
+  const content = open.mock.calls[0][0].content;
+  render(content());
+
+  return { app, model };
+}
+
+describe('plugin-users client-v2 user center drawer content', () => {
+  it('submits change password and redirects to signin', async () => {
+    setupChangePasswordContext();
+    changePassword.mockResolvedValue({});
+
+    const { app } = await renderModelContent('ChangePasswordItemModel', (context, app) => {
+      context.defineProperty('app', { value: app });
+      context.defineProperty('api', {
+        value: {
+          resource: () => ({
+            changePassword,
+          }),
+        },
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText('Old password'), { target: { value: 'old-password' } });
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'New-password-1' } });
+    fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'New-password-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(changePassword).toHaveBeenCalledWith({
+        values: {
+          oldPassword: 'old-password',
+          newPassword: 'New-password-1',
+          confirmPassword: 'New-password-1',
+        },
+      });
+    });
+    expect(redirectToV2Signin).toHaveBeenCalledWith(
+      app,
+      expect.any(String),
+      expect.objectContaining({ replace: true }),
+    );
+  });
+
+  it('shows change password validation errors from registered password validators', async () => {
+    setupChangePasswordContext();
+
+    await renderModelContent('ChangePasswordItemModel', (context, app) => {
+      const plugin = app.pm.get(PluginUsersClientV2) as PluginUsersClientV2;
+      plugin.registerPasswordValidator('weak-password-test', async (value) =>
+        value === 'weak-password' ? 'Password is too weak' : null,
+      );
+      context.defineProperty('app', { value: app });
+      context.defineProperty('api', {
+        value: {
+          resource: () => ({
+            changePassword,
+          }),
+        },
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText('Old password'), { target: { value: 'old-password' } });
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'weak-password' } });
+    fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'weak-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Password is too weak')).toBeInTheDocument();
+    expect(changePassword).not.toHaveBeenCalled();
+  });
+
+  it('shows change password API errors inline', async () => {
+    setupChangePasswordContext();
+    changePassword.mockRejectedValue({
+      response: {
+        data: {
+          errors: [{ message: 'Old password is incorrect' }],
+        },
+      },
+    });
+
+    await renderModelContent('ChangePasswordItemModel', (context, app) => {
+      context.defineProperty('app', { value: app });
+      context.defineProperty('api', {
+        value: {
+          resource: () => ({
+            changePassword,
+          }),
+        },
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText('Old password'), { target: { value: 'old-password' } });
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'New-password-1' } });
+    fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'New-password-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Old password is incorrect')).toBeInTheDocument();
+  });
+
+  it('submits edit profile values and updates current user context', async () => {
+    const user = setupEditProfileContext();
+    updateProfile.mockResolvedValue({});
+
+    await renderModelContent('EditProfileItemModel', (context) => {
+      context.defineProperty('api', {
+        value: {
+          resource: () => ({
+            updateProfile,
+          }),
+        },
+      });
+      context.defineProperty('user', { value: user });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Username')).toHaveValue('alice');
+    });
+
+    fireEvent.change(screen.getByLabelText('Nickname'), { target: { value: 'Bob' } });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'bob' } });
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'bob@example.com' } });
+    fireEvent.change(screen.getByLabelText('Phone'), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalledWith({
+        values: {
+          nickname: 'Bob',
+          username: 'bob',
+          email: 'bob@example.com',
+          phone: '2',
+        },
+      });
+    });
+    expect(user).toEqual({
+      nickname: 'Bob',
+      username: 'bob',
+      email: 'bob@example.com',
+      phone: '2',
+    });
+  });
+
+  it('shows edit profile username validation errors', async () => {
+    setupEditProfileContext();
+
+    await renderModelContent('EditProfileItemModel', (context) => {
+      context.defineProperty('api', {
+        value: {
+          resource: () => ({
+            updateProfile,
+          }),
+        },
+      });
+      context.defineProperty('user', {
+        value: { nickname: 'Alice', username: 'alice', email: 'alice@example.com', phone: '1' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Username')).toHaveValue('alice');
+    });
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'bad@name' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Must be 1-50 characters in length (excluding @.<>"\'/)')).toBeInTheDocument();
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('shows edit profile API errors inline', async () => {
+    setupEditProfileContext();
+    updateProfile.mockRejectedValue(new Error('Username already exists'));
+
+    await renderModelContent('EditProfileItemModel', (context) => {
+      context.defineProperty('api', {
+        value: {
+          resource: () => ({
+            updateProfile,
+          }),
+        },
+      });
+      context.defineProperty('user', {
+        value: { nickname: 'Alice', username: 'alice', email: 'alice@example.com', phone: '1' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Username')).toHaveValue('alice');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Username already exists')).toBeInTheDocument();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserCenterItemModels.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserCenterItemModels.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createMockClient } from '@nocobase/client-v2';
+import PluginUsersClientV2 from '../plugin';
+
+describe('plugin-users client-v2 user center item models', () => {
+  it('registers and hides change password when system settings disable it', async () => {
+    const app = createMockClient({});
+    await app.pm.add(PluginUsersClientV2);
+    await app.load();
+
+    const ChangePasswordItemModel = await app.flowEngine.getModelClassAsync('ChangePasswordItemModel');
+    const model = app.flowEngine.createModel({ use: 'ChangePasswordItemModel', uid: 'change-password' }) as any;
+
+    expect(ChangePasswordItemModel).toBeTruthy();
+
+    model.context.defineProperty('systemSettings', {
+      value: {
+        load: vi.fn().mockResolvedValue({ data: { enableChangePassword: false } }),
+      },
+    });
+
+    await model.prepare();
+
+    expect(model.ready).toBe(false);
+  });
+
+  it('opens change password drawer when clicked', async () => {
+    const app = createMockClient({});
+    await app.pm.add(PluginUsersClientV2);
+    await app.load();
+
+    await app.flowEngine.getModelClassAsync('ChangePasswordItemModel');
+    const model = app.flowEngine.createModel({ use: 'ChangePasswordItemModel', uid: 'change-password' }) as any;
+    const open = vi.fn();
+
+    model.context.defineProperty('viewer', {
+      value: {
+        open,
+      },
+    });
+
+    await model.onClick();
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'drawer',
+        width: '50%',
+        closable: true,
+      }),
+    );
+  });
+
+  it('uses nickname, username, then email for current user summary', async () => {
+    const app = createMockClient({});
+    await app.pm.add(PluginUsersClientV2);
+    await app.load();
+
+    await app.flowEngine.getModelClassAsync('CurrentUserSummaryItemModel');
+    const model = app.flowEngine.createModel({
+      use: 'CurrentUserSummaryItemModel',
+      uid: 'current-user-summary',
+    }) as any;
+
+    model.context.defineProperty('user', {
+      value: {
+        nickname: '',
+        username: 'alice',
+        email: 'alice@example.com',
+      },
+    });
+
+    await model.prepare();
+
+    expect(model.label).toBe('alice');
+    expect(model.value).toBeUndefined();
+    expect(model.description).toBeUndefined();
+    expect(model.ready).toBe(true);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFieldModels.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFieldModels.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MultiRecordResource } from '@nocobase/flow-engine';
+import { UserPasswordFieldModel } from '../models/UserPasswordFieldModel';
+import { UserCreateFormModel, UserEditFormModel } from '../models/UserProfileFormModels';
+import { UserRolesSelectFieldModel } from '../models/UserRolesSelectFieldModel';
+
+const { dispatchEventDeep, formBlockContentProps, recordSelectRender } = vi.hoisted(() => ({
+  dispatchEventDeep: vi.fn(),
+  formBlockContentProps: [] as Array<Record<string, any>>,
+  recordSelectRender: vi.fn(),
+}));
+
+vi.mock('@nocobase/client-v2', async () => {
+  const React = await import('react');
+
+  return {
+    Plugin: class Plugin {},
+    CreateFormModel: class CreateFormModel {
+      props: Record<string, unknown> = {};
+      decoratorProps: Record<string, any> = {};
+      subModels = {
+        grid: {
+          uid: 'grid',
+        },
+      };
+
+      onInit() {}
+
+      setDecoratorProps(props: Record<string, any>) {
+        this.decoratorProps = props;
+      }
+    },
+    EditFormModel: class EditFormModel {
+      props: Record<string, unknown> = {};
+      decoratorProps: Record<string, any> = {};
+      subModels = {
+        grid: {
+          uid: 'grid',
+        },
+      };
+      resource: Record<string, any> = {
+        loading: false,
+        getMeta: () => 0,
+      };
+      context = {
+        themeToken: {
+          colorTextDescription: '#999',
+        },
+      };
+
+      onInit() {}
+
+      setDecoratorProps(props: Record<string, any>) {
+        this.decoratorProps = props;
+      }
+
+      hasAvailableData() {
+        return true;
+      }
+
+      isMultiRecordResource() {
+        return Boolean(this.resource?.__isMultiRecordResource);
+      }
+
+      translate(value: string) {
+        return value;
+      }
+    },
+    FormBlockContent: (props: Record<string, unknown>) => {
+      formBlockContentProps.push(props);
+      return React.createElement('div', { 'data-testid': 'form-block-content' }, props.footer as React.ReactNode);
+    },
+    dispatchEventDeep,
+    PasswordFieldModel: class PasswordFieldModel {
+      props: Record<string, unknown> = {};
+      context: Record<string, any> = {};
+      parent?: {
+        getProps: () => Record<string, unknown>;
+        setProps: (props: Record<string, unknown>) => void;
+      };
+    },
+    PasswordInput: (props: { checkStrength?: boolean }) =>
+      React.createElement('input', {
+        'data-testid': 'password-input',
+        'data-check-strength': String(props.checkStrength),
+      }),
+    RecordSelectFieldModel: class RecordSelectFieldModel {
+      resource?: {
+        addRequestParameter: (key: string, value: unknown) => void;
+        addFilterGroup: (key: string, value: unknown) => void;
+      };
+
+      render() {
+        recordSelectRender();
+        return React.createElement('div', { 'data-testid': 'record-select-field' });
+      }
+    },
+  };
+});
+
+vi.mock('@nocobase/flow-engine', async () => {
+  const React = await import('react');
+
+  class MockMultiRecordResource {
+    __isMultiRecordResource = true;
+    loading = false;
+    page = 1;
+    totalPage = 3;
+    meta: Record<string, unknown> = {
+      count: 3,
+    };
+    setPage = vi.fn((page: number) => {
+      this.page = page;
+    });
+    refresh = vi.fn();
+    getPage = vi.fn(() => this.page);
+    getTotalPage = vi.fn(() => this.totalPage);
+    getMeta = vi.fn((key: string) => this.meta[key]);
+  }
+
+  return {
+    FlowModelRenderer: ({ model }: { model: { uid?: string } }) =>
+      React.createElement('div', { 'data-testid': 'flow-model-renderer' }, model.uid),
+    MultiRecordResource: MockMultiRecordResource,
+  };
+});
+
+vi.mock('@nocobase/plugin-acl/client-v2', () => ({
+  default: class PluginAclClientV2 {},
+}));
+
+describe('plugin-users client-v2 field models', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    formBlockContentProps.length = 0;
+  });
+
+  it('renders password input with strength disabled by default', () => {
+    const model = new UserPasswordFieldModel();
+    model.props = {};
+
+    render(model.render());
+
+    expect(screen.getByTestId('password-input')).toHaveAttribute('data-check-strength', 'false');
+  });
+
+  it('injects the password policy validator once and passes username context', async () => {
+    const validator = vi.fn().mockResolvedValue('policy failed');
+    const setProps = vi.fn();
+    const model = new UserPasswordFieldModel();
+    let parentProps = {
+      rules: [{ required: true, message: 'required' }],
+    };
+    model.parent = {
+      getProps: () => parentProps,
+      setProps: (props) => {
+        parentProps = {
+          ...parentProps,
+          ...props,
+        };
+        setProps(props);
+      },
+    };
+    model.context = {
+      app: {
+        pm: {
+          get: () => ({
+            getPasswordValidators: () => [validator],
+          }),
+        },
+      },
+      form: {
+        getFieldValue: () => 'alice',
+      },
+    };
+
+    render(model.render());
+    render(model.render());
+
+    expect(setProps).toHaveBeenCalledTimes(1);
+    const injectedRules = setProps.mock.calls[0][0].rules as Array<Record<string, any>>;
+    expect(injectedRules).toHaveLength(2);
+    expect(injectedRules[1].__pluginUsersPasswordPolicy).toBe(true);
+
+    await expect(injectedRules[1].validator({}, 'alice-password')).rejects.toThrow('policy failed');
+    expect(validator).toHaveBeenCalledWith('alice-password', { username: 'alice' });
+  });
+
+  it('adds role select resource defaults before rendering', () => {
+    const model = new UserRolesSelectFieldModel();
+    const addRequestParameter = vi.fn();
+    const addFilterGroup = vi.fn();
+    model.resource = {
+      addRequestParameter,
+      addFilterGroup,
+    };
+
+    render(model.render());
+
+    expect(addRequestParameter).toHaveBeenCalledWith('showAnonymous', true);
+    expect(addFilterGroup).toHaveBeenCalledWith('__plugin_users__exclude_root_role__', {
+      'name.$ne': 'root',
+    });
+    expect(recordSelectRender).toHaveBeenCalled();
+    expect(screen.getByTestId('record-select-field')).toBeInTheDocument();
+  });
+
+  it('initializes create profile form with borderless decorator and renders grid content', () => {
+    const model = new UserCreateFormModel();
+    model.props = {
+      colon: false,
+      labelAlign: 'left',
+      labelWidth: 120,
+      labelWrap: true,
+      layout: 'vertical',
+    };
+
+    model.onInit({});
+    render(model.renderComponent());
+
+    expect(model.decoratorProps).toEqual(
+      expect.objectContaining({
+        bordered: false,
+        className: expect.any(String),
+      }),
+    );
+    expect(screen.getByTestId('form-block-content')).toBeInTheDocument();
+    expect(formBlockContentProps[0]).toEqual(
+      expect.objectContaining({
+        model,
+        gridModel: model.subModels.grid,
+        layoutProps: {
+          colon: false,
+          labelAlign: 'left',
+          labelWidth: 120,
+          labelWrap: true,
+          layout: 'vertical',
+        },
+      }),
+    );
+  });
+
+  it('renders edit profile empty state when no data is available', () => {
+    const model = new UserEditFormModel();
+    model.hasAvailableData = () => false;
+    model.resource = {
+      loading: false,
+      getMeta: () => 0,
+    };
+
+    render(model.renderComponent());
+
+    expect(screen.getByText('No available data currently')).toBeInTheDocument();
+  });
+
+  it('refreshes multi-record edit profile resource on pagination change', async () => {
+    const model = new UserEditFormModel();
+    const resource = new MultiRecordResource() as MultiRecordResource & {
+      setPage: ReturnType<typeof vi.fn>;
+      refresh: ReturnType<typeof vi.fn>;
+    };
+    model.resource = resource;
+
+    await model.handlePageChange(2);
+
+    expect(resource.setPage).toHaveBeenCalledWith(2);
+    expect(resource.loading).toBe(true);
+    expect(resource.refresh).toHaveBeenCalled();
+    expect(dispatchEventDeep).toHaveBeenCalledWith(model, 'paginationChange');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersManagementPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersManagementPage.test.tsx
@@ -7,17 +7,24 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import UsersManagementPage from '../pages/UsersManagementPage';
 
-const { open } = vi.hoisted(() => ({
+const { open, destroy, list, success, deniedActions, resourceTableProps } = vi.hoisted(() => ({
   open: vi.fn(),
+  destroy: vi.fn(),
+  list: vi.fn(),
+  success: vi.fn(),
+  deniedActions: new Set<string>(),
+  resourceTableProps: {
+    current: null as null | Record<string, any>,
+  },
 }));
 
 vi.mock('@nocobase/client-v2', () => ({
   useACLRoleContext: () => ({
-    parseAction: (action: string) => (action === 'users:create' ? null : {}),
+    parseAction: (action: string) => (deniedActions.has(action) ? null : {}),
   }),
 }));
 
@@ -33,23 +40,32 @@ vi.mock('@nocobase/flow-engine', () => ({
     },
     api: {
       resource: () => ({
-        destroy: vi.fn(),
-        list: vi.fn().mockResolvedValue({ data: { data: [], meta: {} } }),
+        destroy,
+        list,
       }),
     },
     message: {
-      success: vi.fn(),
+      success,
     },
   }),
 }));
 
 vi.mock('../components/resource', () => ({
-  ResourceTablePage: ({
-    toolbar,
-  }: {
-    toolbar: (args: { refresh: () => void; refreshAsync: () => Promise<void> }) => React.ReactNode;
-  }) => <div>{toolbar({ refresh: vi.fn(), refreshAsync: vi.fn().mockResolvedValue(undefined) })}</div>,
-  SettingsActionCell: () => null,
+  ResourceTablePage: (props: Record<string, any>) => {
+    resourceTableProps.current = props;
+    return <div>{props.toolbar({ refresh: vi.fn(), refreshAsync: vi.fn().mockResolvedValue(undefined) })}</div>;
+  },
+  SettingsActionCell: ({ record, actions }: { record: Record<string, any>; actions: Array<Record<string, any>> }) => (
+    <div>
+      {actions
+        .filter((action) => !action.hidden)
+        .map((action) => (
+          <button key={action.key} onClick={() => action.onClick?.(record)}>
+            {action.label}
+          </button>
+        ))}
+    </div>
+  ),
 }));
 
 vi.mock('../locale', () => ({
@@ -69,9 +85,131 @@ vi.mock('../pages/UsersSettingsForm', () => ({
 }));
 
 describe('UsersManagementPage', () => {
+  beforeEach(() => {
+    deniedActions.clear();
+    open.mockReset();
+    destroy.mockReset();
+    list.mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: 1,
+            username: 'root',
+            roles: [{ name: 'root', title: 'Root' }],
+          },
+        ],
+        meta: {
+          page: 2,
+          pageSize: 10,
+          count: 1,
+        },
+      },
+    });
+    success.mockReset();
+    resourceTableProps.current = null;
+  });
+
   it('shows the add user action even when users:create is not granted', () => {
+    deniedActions.add('users:create');
+
     render(<UsersManagementPage />);
 
     expect(screen.getByRole('button', { name: /Add new/ })).toBeInTheDocument();
+  });
+
+  it('requests users with roles append and maps list payload', async () => {
+    render(<UsersManagementPage />);
+
+    const response = await resourceTableProps.current?.request({
+      filter: { username: { $includes: 'a' } },
+      page: 2,
+      pageSize: 10,
+    });
+
+    expect(list).toHaveBeenCalledWith({
+      page: 2,
+      pageSize: 10,
+      filter: { username: { $includes: 'a' } },
+      appends: ['roles'],
+      sort: ['id'],
+    });
+    expect(response).toEqual({
+      data: [
+        {
+          id: 1,
+          username: 'root',
+          roles: [{ name: 'root', title: 'Root' }],
+        },
+      ],
+      page: 2,
+      pageSize: 10,
+      total: 1,
+    });
+  });
+
+  it('disables root user selection and deletes selected users', async () => {
+    render(<UsersManagementPage />);
+
+    const rowSelection = resourceTableProps.current?.tableProps.rowSelection;
+    expect(rowSelection.getCheckboxProps({ id: 1, roles: [{ name: 'root', title: 'Root' }] }).disabled).toBe(true);
+    expect(rowSelection.getCheckboxProps({ id: 2, roles: [{ name: 'member', title: 'Member' }] }).disabled).toBe(false);
+
+    act(() => {
+      rowSelection.onChange([2]);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
+    fireEvent.click(await screen.findByText('OK'));
+
+    await waitFor(() => {
+      expect(destroy).toHaveBeenCalledWith({ filterByTk: [2] });
+    });
+    expect(success).toHaveBeenCalledWith('Deleted successfully');
+  });
+
+  it('hides destructive controls when destroy permission is denied', () => {
+    deniedActions.add('users:destroy');
+
+    render(<UsersManagementPage />);
+
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    expect(resourceTableProps.current?.tableProps.rowSelection).toBeUndefined();
+  });
+
+  it('opens edit and password drawers from row actions while hiding delete for root', async () => {
+    render(<UsersManagementPage />);
+
+    const actionsColumn = resourceTableProps.current?.columns.find(
+      (column: Record<string, any>) => column.key === 'actions',
+    );
+    const rootCell = actionsColumn.render(null, {
+      id: 1,
+      username: 'root',
+      roles: [{ name: 'root', title: 'Root' }],
+    });
+    const memberCell = actionsColumn.render(null, {
+      id: 2,
+      username: 'alice',
+      roles: [{ name: 'member', title: 'Member' }],
+    });
+
+    const { rerender } = render(rootCell);
+    expect(screen.getByRole('button', { name: 'Edit profile' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Change password' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+    expect(open).toHaveBeenLastCalledWith(
+      expect.objectContaining({ inputArgs: expect.objectContaining({ filterByTk: 1 }) }),
+    );
+
+    rerender(memberCell);
+    fireEvent.click(screen.getByRole('button', { name: 'Change password' }));
+    expect(open).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'drawer', width: '50%' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(destroy).toHaveBeenCalledWith({ filterByTk: 2 });
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersSettingsForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersSettingsForm.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import UsersSettingsForm from '../pages/UsersSettingsForm';
+
+const { getSystemSettings, updateSystemSettings, success } = vi.hoisted(() => ({
+  getSystemSettings: vi.fn(),
+  updateSystemSettings: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    api: {
+      resource: () => ({
+        getSystemSettings,
+        updateSystemSettings,
+      }),
+    },
+    message: {
+      success,
+    },
+  }),
+}));
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+}));
+
+describe('UsersSettingsForm', () => {
+  const originalLocation = globalThis.window.location;
+
+  beforeEach(() => {
+    getSystemSettings.mockResolvedValue({
+      data: {
+        data: {
+          enableEditProfile: false,
+          enableChangePassword: true,
+        },
+      },
+    });
+    updateSystemSettings.mockReset();
+    success.mockReset();
+    Object.defineProperty(globalThis.window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        reload: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis.window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.clearAllMocks();
+  });
+
+  it('loads system settings and submits normalized checkbox values', async () => {
+    render(<UsersSettingsForm />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Allow edit profile')).not.toBeChecked();
+    });
+    expect(screen.getByLabelText('Allow change password')).toBeChecked();
+
+    fireEvent.click(screen.getByLabelText('Allow edit profile'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateSystemSettings).toHaveBeenCalledWith({
+        values: {
+          enableEditProfile: true,
+          enableChangePassword: true,
+        },
+      });
+    });
+    expect(success).toHaveBeenCalledWith('Saved successfully');
+    expect(globalThis.window.location.reload).toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/plugin.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { createMockClient } from '@nocobase/client-v2';
+import PluginAclClientV2 from '@nocobase/plugin-acl/client-v2';
 import PluginUsersClientV2 from '../plugin';
 
 describe('plugin-users client-v2', () => {
@@ -34,6 +35,54 @@ describe('plugin-users client-v2', () => {
     );
     expect(registeredLoaders).not.toHaveProperty('UserCreateFormModel');
     expect(registeredLoaders).not.toHaveProperty('UserEditFormModel');
+  });
+
+  it('registers settings menu, users tab, settings link, and user center model loaders in the real client runtime', async () => {
+    const app = createMockClient({ publicPath: '/v2/' });
+
+    await app.pm.add(PluginUsersClientV2);
+    await app.load();
+
+    expect(app.pluginSettingsManager.get('users-permissions')).toMatchObject({
+      title: 'Users & Permissions',
+      isPinned: true,
+      sort: 200,
+      showTabs: true,
+    });
+    expect(app.pluginSettingsManager.get('users-permissions.users')).toMatchObject({
+      title: 'Users',
+      aclSnippet: 'pm.users',
+      sort: 2,
+    });
+    expect(app.pluginSettingsManager.getPluginSettingsName('users')).toBe('users-permissions.users');
+    expect(app.pluginSettingsManager.getPluginSettingsRoutePath('users')).toBe(
+      '/admin/settings/users-permissions/users',
+    );
+
+    await expect(app.flowEngine.getModelClassAsync('EditProfileItemModel')).resolves.toBeTruthy();
+    await expect(app.flowEngine.getModelClassAsync('ChangePasswordItemModel')).resolves.toBeTruthy();
+    await expect(app.flowEngine.getModelClassAsync('CurrentUserSummaryItemModel')).resolves.toBeTruthy();
+    await expect(app.flowEngine.getModelClassAsync('SignOutItemModel')).resolves.toBeTruthy();
+    await expect(app.flowEngine.getModelClassAsync('UserPasswordFieldModel')).resolves.toBeTruthy();
+    await expect(app.flowEngine.getModelClassAsync('UserRolesSelectFieldModel')).resolves.toBeTruthy();
+  });
+
+  it('registers the users role tab when the ACL plugin is loaded', async () => {
+    const app = createMockClient({ publicPath: '/v2/' });
+
+    await app.pm.add(PluginAclClientV2);
+    await app.pm.add(PluginUsersClientV2);
+    await app.load();
+
+    const aclPlugin = app.pm.get(PluginAclClientV2) as PluginAclClientV2;
+    const usersRoleTab = aclPlugin.rolesManager.list().find(([key]) => key === 'users');
+
+    expect(usersRoleTab).toBeTruthy();
+    expect(usersRoleTab?.[1]).toMatchObject({
+      title: 'Users',
+      sort: 10,
+    });
+    await expect(usersRoleTab?.[1].componentLoader()).resolves.toHaveProperty('default');
   });
 
   it('should use same-origin signin redirect returned by server when whitelisted', async () => {

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/sharedHelpers.test.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/sharedHelpers.test.ts
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import {
+  ADMIN_PROFILE_CREATE_FORM_MODEL_UID,
+  ADMIN_PROFILE_EDIT_FORM_MODEL_UID,
+  buildAdminProfileCreateFormModel,
+  buildAdminProfileEditFormModel,
+} from '../shared/adminProfileFormModels';
+import { generatePassword } from '../shared/generatePassword';
+import { toListPayload } from '../pages/types';
+
+function getItems(model: Record<string, any>) {
+  return model.subModels.grid.subModels.items as Record<string, any>[];
+}
+
+function getFieldPath(item: Record<string, any>) {
+  return item.stepParams.fieldSettings.init.fieldPath;
+}
+
+describe('plugin-users client-v2 shared helpers', () => {
+  it('builds the default create profile form model', () => {
+    const model = buildAdminProfileCreateFormModel();
+    const items = getItems(model);
+
+    expect(model).toEqual(
+      expect.objectContaining({
+        uid: ADMIN_PROFILE_CREATE_FORM_MODEL_UID,
+        use: 'UserCreateFormModel',
+      }),
+    );
+    expect(items.map(getFieldPath)).toEqual(['nickname', 'username', 'email', 'phone', 'password', 'roles']);
+    expect(items.find((item) => getFieldPath(item) === 'username')?.stepParams.editItemSettings.required).toEqual({
+      required: true,
+    });
+    expect(items.find((item) => getFieldPath(item) === 'password')?.subModels.field).toEqual(
+      expect.objectContaining({
+        use: 'UserPasswordFieldModel',
+        props: expect.objectContaining({
+          autoComplete: 'new-password',
+          checkStrength: false,
+        }),
+      }),
+    );
+    expect(items.find((item) => getFieldPath(item) === 'roles')?.subModels.field).toEqual(
+      expect.objectContaining({
+        use: 'UserRolesSelectFieldModel',
+      }),
+    );
+  });
+
+  it('builds the default edit profile form model without password field', () => {
+    const model = buildAdminProfileEditFormModel();
+    const items = getItems(model);
+
+    expect(model).toEqual(
+      expect.objectContaining({
+        uid: ADMIN_PROFILE_EDIT_FORM_MODEL_UID,
+        use: 'UserEditFormModel',
+      }),
+    );
+    expect(model.stepParams.resourceSettings.init.filterByTk).toBe('{{ctx.view.inputArgs.filterByTk}}');
+    expect(items.map(getFieldPath)).toEqual(['nickname', 'username', 'email', 'phone', 'roles']);
+  });
+
+  it('generates passwords with required character categories', () => {
+    const password = generatePassword();
+
+    expect(password).toHaveLength(10);
+    expect(password).toMatch(/[A-Z]/);
+    expect(password).toMatch(/[a-z]/);
+    expect(password).toMatch(/[0-9]/);
+    expect(password).toMatch(/[!#$%^&*\-_+=]/);
+  });
+
+  it('normalizes list payloads', () => {
+    expect(toListPayload(null)).toEqual({});
+    expect(toListPayload({ data: 'invalid', meta: { count: 3 } })).toEqual({
+      data: [],
+      meta: { count: 3 },
+    });
+    expect(toListPayload<{ id: number }>({ data: [{ id: 1 }], meta: { total: 1 } })).toEqual({
+      data: [{ id: 1 }],
+      meta: { total: 1 },
+    });
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Improve behavior-driven test coverage for `@nocobase/plugin-users` client-v2 so coverage remains green while protecting the main user management, role management, settings, user-center, and field-model flows.

### Description
This PR adds client-v2 tests for:

- user management list requests, permissions, root-user protection, edit/change-password actions, and delete flows
- role users management list/add/remove flows
- shared resource table/form/picker/action components used by the users plugin
- user settings load/save behavior
- change user password behavior, random password generation, and password validator integration
- user-center item model behavior
- password and roles field model behavior
- default admin profile form model builders, password generation, and list payload normalization
- real `createMockClient()` runtime registration of settings pages, model loaders, plugin settings link, and ACL role tab registration

Potential risk is limited to test code. The tests use focused mocks only where API/viewer/FlowEngine context is otherwise unstable to construct in jsdom, while keeping the tested business logic real.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve client-v2 test coverage for the users plugin. |
| 🇨🇳 Chinese | 完善用户插件 client-v2 测试覆盖率。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

### Tests

```bash
yarn eslint --fix packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/plugin.test.ts packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/sharedHelpers.test.ts packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFieldModels.test.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserCenterItemModels.test.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ChangeUserPasswordDrawer.test.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersSettingsForm.test.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UsersManagementPage.test.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ResourceComponents.test.tsx packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/RoleUsersManager.test.tsx
yarn test:client packages/plugins/@nocobase/plugin-users/src/client-v2 --run --reporter=verbose
yarn test:client packages/plugins/@nocobase/plugin-users/src/client-v2 --coverage --run --reporter=verbose
```
