### PR TITLE
fix(plugin-block-comment): adjust comment action order

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/RecordCommentsBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/RecordCommentsBlockModel.tsx
@@ -570,10 +570,10 @@ RecordCommentsBlockModel.define({
                 use: 'QuoteReplyRecordCommentActionModel',
               },
               {
-                use: 'DeleteRecordCommentActionModel',
+                use: 'EditRecordCommentActionModel',
               },
               {
-                use: 'EditRecordCommentActionModel',
+                use: 'DeleteRecordCommentActionModel',
               },
             ],
             bodyFields: {

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockModel.test.ts
@@ -18,6 +18,9 @@ describe('RecordCommentsBlockModel field mapping settings', () => {
       subModels?: {
         items?: Array<{
           subModels?: {
+            actions?: Array<{
+              use?: string;
+            }>;
             bodyFields?: {
               use?: string;
             };
@@ -29,6 +32,26 @@ describe('RecordCommentsBlockModel field mapping settings', () => {
     expect(createModelOptions.subModels?.items?.[0]?.subModels?.bodyFields).toEqual({
       use: 'DetailsGridModel',
     });
+  });
+
+  test('creates comment record actions in quote, edit, delete order', () => {
+    const createModelOptions = RecordCommentsBlockModel.meta.createModelOptions as {
+      subModels?: {
+        items?: Array<{
+          subModels?: {
+            actions?: Array<{
+              use?: string;
+            }>;
+          };
+        }>;
+      };
+    };
+
+    expect(createModelOptions.subModels?.items?.[0]?.subModels?.actions?.map((action) => action.use)).toEqual([
+      'QuoteReplyRecordCommentActionModel',
+      'EditRecordCommentActionModel',
+      'DeleteRecordCommentActionModel',
+    ]);
   });
 
   test('hides owner mapping fields when the block is created from an association field', () => {

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentActions.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentActions.tsx
@@ -20,7 +20,7 @@ import {
 } from '@nocobase/flow-engine';
 import { css } from '@emotion/css';
 import { Space } from 'antd';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import type { RecordCommentsBlockModel } from '../RecordCommentsBlockModel';
 import type { RecordCommentRecord } from '../utils';
@@ -35,21 +35,10 @@ type FlowModelWithForkId = FlowModel & {
   forkId?: string | number;
 };
 
-type FlowEngineLookup = {
-  getModelClass?: (modelName: string) => unknown;
-  getModelClassAsync?: (modelName: string) => Promise<unknown>;
-};
-
 const getFlowModelRenderKey = (model: FlowModel, fallback: string) => {
   const forkId = (model as FlowModelWithForkId).forkId;
   return `${model.uid}:${forkId ?? fallback}`;
 };
-
-const defaultRecordActionModels = [
-  'QuoteReplyRecordCommentActionModel',
-  'DeleteRecordCommentActionModel',
-  'EditRecordCommentActionModel',
-];
 
 const recordCommentActionsClassName = css`
   .ant-btn-link {
@@ -57,10 +46,6 @@ const recordCommentActionsClassName = css`
     padding: 0;
   }
 `;
-
-const getModelName = (model: FlowModel) => {
-  return (model as FlowModel & { use?: string }).use || model.constructor.name;
-};
 
 export const RecordCommentActions = observer(
   ({
@@ -77,39 +62,6 @@ export const RecordCommentActions = observer(
     setEditing: () => void;
   }) => {
     const recordKey = getRecordPrimaryKeyValue(record, blockModel.collection);
-
-    useEffect(() => {
-      let disposed = false;
-      const actions = itemModel.subModels.actions
-        ? ([] as FlowModel[]).concat(itemModel.subModels.actions as FlowModel | FlowModel[])
-        : [];
-
-      async function ensureDefaultActions() {
-        const flowEngine = (itemModel as FlowModel & { flowEngine?: FlowEngineLookup }).flowEngine;
-
-        for (const [index, use] of defaultRecordActionModels.entries()) {
-          const existing = actions.find((action) => getModelName(action) === use);
-          if (existing) {
-            existing.sortIndex = index;
-            continue;
-          }
-
-          const ModelClass = (await flowEngine?.getModelClassAsync?.(use)) || flowEngine?.getModelClass?.(use);
-          if (!ModelClass || disposed) {
-            continue;
-          }
-
-          const added = itemModel.addSubModel('actions', { use });
-          added.sortIndex = index;
-        }
-      }
-
-      ensureDefaultActions();
-
-      return () => {
-        disposed = true;
-      };
-    }, [itemModel]);
 
     return (
       <DndProvider>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
New Comment blocks should show record actions in this order: quote, edit, delete.

### Description
- Adjusts the default action order for newly created Comment blocks to quote, edit, delete.
- Stops the renderer from automatically backfilling or reordering default actions, so existing Comment blocks are not changed.
- Adds a focused test for the default action order.

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjusted the default action order for new Comment blocks. |
| 🇨🇳 Chinese | 调整新评论区块的默认操作顺序。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
