### PR TITLE
fix(plugin-file-manager): hide attachments list API

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
@@ -67,6 +67,58 @@ describe('file manager > server', () => {
         expect(model.toJSON()).toMatchObject(matcher);
       });
 
+      it('should hide attachments list even when role strategy allows file actions', async () => {
+        await app.destroy();
+        app = await getApp({ acl: true });
+        agent = app.agent();
+        db = app.db;
+
+        AttachmentRepo = db.getCollection('attachments').repository;
+        StorageRepo = db.getCollection('storages').repository;
+        defaultStorage = await StorageRepo.findOne();
+
+        app.acl.define({
+          role: 'attachment-manager',
+          strategy: {
+            actions: '*',
+          },
+        });
+        app.resourcer.use(
+          async (ctx, next) => {
+            ctx.state.currentRole = 'attachment-manager';
+            ctx.state.currentRoles = ['attachment-manager'];
+            await next();
+          },
+          {
+            tag: 'setAttachmentManagerRole',
+            after: 'auth',
+            before: 'acl',
+          },
+        );
+
+        const user = await db.getRepository('users').findOne();
+        const userAgent = await agent.login(user.id);
+        const attachment = await AttachmentRepo.create({
+          values: {
+            title: 'acl-test',
+            filename: 'acl-test.txt',
+            extname: '.txt',
+            path: '',
+            mimetype: 'text/plain',
+            storageId: defaultStorage.id,
+            createdById: user.id,
+          },
+        });
+
+        const getResponse = await userAgent.resource('attachments').get({
+          filterByTk: attachment.id,
+        });
+        expect(getResponse.statusCode).toBe(200);
+
+        const listResponse = await userAgent.resource('attachments').list();
+        expect(listResponse.statusCode).toBe(404);
+      });
+
       it('should be local2 storage', async () => {
         const storage = await StorageRepo.create({
           values: {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts
@@ -309,6 +309,14 @@ export class PluginFileManagerServer extends Plugin {
     this.app.acl.addFixedParams('attachments', 'update', ownMerger);
     this.app.acl.addFixedParams('attachments', 'create', ownMerger);
     this.app.acl.addFixedParams('attachments', 'destroy', ownMerger);
+    this.app.resourcer.define({
+      name: 'attachments',
+      actions: {
+        list(ctx) {
+          ctx.throw(404);
+        },
+      },
+    });
 
     this.app.db.interfaceManager.registerInterfaceType('attachment', AttachmentInterface);
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The attachments resource should not expose the generic list API from the file manager plugin. Hiding this endpoint avoids exposing attachment records through a broad list action, even when a role strategy allows file resource actions.

### Description
This PR overrides `attachments:list` in the file manager server plugin and returns 404 so the endpoint is hidden.

It also adds a server test with ACL enabled and a role strategy that allows all actions. The test verifies that `attachments:get` still works while `attachments:list` returns 404.

Tests run:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-file-manager/src/server/server.ts packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts`
- `TZ=Asia/Shanghai yarn test packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts`

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hidden the file manager attachments list API and return 404 when it is requested. |
| 🇨🇳 Chinese | 隐藏文件管理器的附件列表接口，请求该接口时返回 404。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
