### PR TITLE
fix(plugin-ai): isolate workflow AI employee resume context

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
@@ -321,7 +321,7 @@ Do not send another normal assistant response without invoking it.
           username,
         },
         title: userMessage.slice(0, 30),
-        from: 'sub-agent',
+        from: 'main-agent',
         options: {
           systemMessage,
           skillSettings,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/tools.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/tools.ts
@@ -9,6 +9,7 @@
 
 import type { Context } from '@nocobase/actions';
 import type { DynamicToolsProvider } from '@nocobase/ai';
+import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import PluginWorkflowServer, { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
 import type { Plugin } from '@nocobase/server';
 import { AI_WORKFLOW_TASK_STATUS, REQUIRES_APPROVAL } from './constants';
@@ -140,7 +141,18 @@ export const getWorkflowTasks: WorkflowTaskToolProvider = (plugin) => async (reg
         status: JOB_STATUS.RESOLVED,
         result: args.result,
       });
-      await workflowPlugin.resume(job);
+      // This tool runs inside LangGraph's tool runnable context. If workflow resume is called directly here,
+      // the next AI employee node inherits the current checkpoint namespace and is treated as a nested graph,
+      // causing its interrupt to throw GraphInterrupt instead of returning a root-level __interrupt__ result.
+      // More importantly, later aiEmployee.invoke({ userDecisions, signal }) resumes the wrong graph context
+      // instead of the next employee's own root checkpoint.
+      setImmediate(() => {
+        AsyncLocalStorageProviderSingleton.getInstance().run(undefined, () => {
+          workflowPlugin.resume(job).catch((error) => {
+            plugin.app.logger.error(error);
+          });
+        });
+      });
 
       return {
         status: 'success',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow AI employee nodes can run in loops where one AI employee completes a workflow-output tool call and immediately resumes the workflow. With newer LangGraph config merging behavior, resuming the workflow directly inside the tool runnable context can make the next AI employee inherit the previous tool checkpoint namespace and behave like a nested graph.

### Description 
This PR updates workflow AI employee execution so task conversations are treated as main-agent conversations with their own checkpoints, and defers workflow resume outside LangChain's runnable context after the workflow-output tool completes.

This prevents later workflow AI employee calls from inheriting the previous tool's LangGraph checkpoint namespace, which could cause interrupts to be handled as nested graph interrupts and make `aiEmployee.invoke({ userDecisions, signal })` resume the wrong graph context.

Testing suggestions:
- Run an AI employee workflow node inside a loop where `requiresApproval` is `false` and confirm every iteration completes.
- Confirm checkpoint writes for subsequent AI employee sessions use the root checkpoint namespace rather than `tools:...`.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI employee workflow nodes failing to resume correctly in loops after a previous AI employee tool call. |
| 🇨🇳 Chinese | 修复 AI 员工工作流节点在循环中前一次工具调用后无法正确恢复后续节点的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
