### PR TITLE
fix(plugin-ai): resolve checkpoint cleanup message id column

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/checkpoints/cleaner.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/checkpoints/cleaner.ts
@@ -42,7 +42,10 @@ export class CheckpointCleaner {
 
     const sessionIds = outdatedConversations.map((conversation) => conversation.sessionId);
     const latestMessageRefs = await this.aiMessagesModel.findAll({
-      attributes: ['sessionId', [this.sequelize.fn('MAX', this.sequelize.col('messageId')), 'messageId']],
+      attributes: [
+        'sessionId',
+        [this.sequelize.fn('MAX', this.sequelize.col(this.aiMessagesMessageIdColumn)), 'messageId'],
+      ],
       where: {
         sessionId: {
           [Op.in]: sessionIds,
@@ -126,6 +129,16 @@ export class CheckpointCleaner {
 
   private get aiMessagesModel() {
     return this.collectionManager.getCollection('aiMessages').model;
+  }
+
+  private get aiMessagesMessageIdColumn() {
+    return (
+      this.aiMessagesModel.rawAttributes.messageId?.field || (this.isUnderscoredDatabase ? 'message_id' : 'messageId')
+    );
+  }
+
+  private get isUnderscoredDatabase() {
+    return this.collectionManager.db.options.underscored === true || process.env.DB_UNDERSCORED === 'true';
   }
 
   private get sequelize() {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI checkpoint cleanup failed in underscored database environments because the aggregate query referenced the JavaScript attribute name `messageId` directly instead of the actual database column name.

### Description 
- Resolve the `aiMessages.messageId` database column through the Sequelize model metadata before building the `MAX()` aggregate expression.
- Fall back to `message_id` when the database is configured with underscored column names, otherwise fall back to `messageId`.
- This prevents checkpoint cleanup from querying a non-existent `"messageId"` column in underscored schemas.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI checkpoint cleanup failures in underscored database environments. |
| 🇨🇳 Chinese | 修复下划线数据库命名环境中 AI checkpoint 清理失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
