### PR TITLE
fix(plugins): align external data source and backup UI

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
@@ -95,14 +95,14 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
         <Form layout="vertical" autoComplete="off">
           {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
-              label={<strong>{t('Confirm the application database schema')}</strong>}
+              label={t('Confirm the application database schema')}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}
             >
               <Input autoComplete="new-password" value={dbSchema} onChange={(e) => setDbSchema(e.target.value)} />
             </Form.Item>
           )}
 
-          <Form.Item colon label={<strong>{t('Restore password')}</strong>}>
+          <Form.Item colon label={t('Restore password')}>
             <Input.Password
               value={password}
               autoComplete="new-password"

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
@@ -131,13 +131,13 @@ export const RestoreFromLocal = () => {
           </Form.Item>
           {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
-              label={<strong>{t('Confirm the application database schema')}</strong>}
+              label={t('Confirm the application database schema')}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}
             >
               <Input autoComplete="new-password" value={dbSchema} onChange={(e) => setDbSchema(e.target.value)} />
             </Form.Item>
           )}
-          <Form.Item colon label={<strong>{t('Restore password')}</strong>}>
+          <Form.Item colon label={t('Restore password')}>
             <Input.Password
               autoComplete="new-password"
               value={password}

--- a/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromBackup.tsx
@@ -86,14 +86,14 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
         <Form layout={'vertical'} autoComplete="off">
           {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
-              label={<strong>{t('Confirm the application database schema')}</strong>}
+              label={t('Confirm the application database schema')}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}
             >
               <Input autoComplete="new-password" value={dbSchema} onChange={(e) => setDbSchema(e.target.value)} />
             </Form.Item>
           )}
 
-          <Form.Item colon={true} label={<strong>{t('Restore password')}</strong>}>
+          <Form.Item colon={true} label={t('Restore password')}>
             <Input.Password
               value={password}
               autoComplete="new-password"

--- a/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromLocal.tsx
@@ -121,13 +121,13 @@ export const RestoreFromLocal = () => {
           </Form.Item>
           {['postgres', 'kingbase'].includes(dialect) && (
             <Form.Item
-              label={<strong>{t('Confirm the application database schema')}</strong>}
+              label={t('Confirm the application database schema')}
               help={t('Required if application database schema is different with the backup', { currentDbSchemaTips })}
             >
               <Input autoComplete="new-password" value={dbSchema} onChange={(e) => setDbSchema(e.target.value)} />
             </Form.Item>
           )}
-          <Form.Item colon={true} label={<strong>{t('Restore password')}</strong>}>
+          <Form.Item colon={true} label={t('Restore password')}>
             <Input.Password
               autoComplete="new-password"
               value={password}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -44,6 +44,7 @@ import {
 } from './collectionTemplateFieldInterfaces';
 import { FieldForm } from './FieldForm';
 import { collectionNeedsRecordUniqueKey, RecordUniqueKeyPrompt } from './RecordUniqueKey';
+import { UnsupportedFields } from './UnsupportedFields';
 
 interface FieldsPageProps {
   dataSourceKey: string;
@@ -946,14 +947,7 @@ function ViewSyncFieldsDrawer(props: {
               />
             </Form.Item>
           ) : null}
-          {unsupportedFields.length ? (
-            <Alert
-              showIcon
-              type="warning"
-              message={t('Unsupported fields')}
-              description={unsupportedFields.map((field) => field.name).join(', ')}
-            />
-          ) : null}
+          <UnsupportedFields dataSource={unsupportedFields} style={{ marginBottom: 24 }} />
           <Form.Item label={t('Preview')}>
             <Spin spinning={previewLoading}>
               <AntdTable
@@ -1102,6 +1096,7 @@ export default function FieldsPage(props: FieldsPageProps) {
   const TemplateSyncFieldsDrawer = collectionTemplate?.configure?.syncFields?.Component;
   const runtimeCollection = dataSource?.collectionManager?.getCollection?.(props.collection.name);
   const inheritedFieldGroups = getInheritedFieldGroups(runtimeCollection);
+  const unsupportedFields = Array.isArray(props.collection.unsupportedFields) ? props.collection.unsupportedFields : [];
 
   const openTemplateSyncFieldsDrawer = useCallback(() => {
     if (!TemplateSyncFieldsDrawer) {
@@ -1651,6 +1646,7 @@ export default function FieldsPage(props: FieldsPageProps) {
             : undefined
         }
       />
+      <UnsupportedFields dataSource={unsupportedFields} />
       {inheritedFieldGroups.some((group) => group.fields.length) ? (
         <AntdTable<InheritedFieldGroup>
           style={{ marginTop: 16 }}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/UnsupportedFields.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/UnsupportedFields.tsx
@@ -1,0 +1,66 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Table } from '@nocobase/client-v2';
+import { Divider } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import React, { useMemo } from 'react';
+import { useT } from '../../locale';
+
+export type UnsupportedFieldRecord = Record<string, unknown>;
+
+function getFieldValue(record: UnsupportedFieldRecord, key: 'field' | 'name' | 'rawType' | 'type') {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function UnsupportedFields(props: { dataSource?: UnsupportedFieldRecord[]; style?: React.CSSProperties }) {
+  const t = useT();
+  const dataSource = Array.isArray(props.dataSource) ? props.dataSource : [];
+  const columns = useMemo<ColumnsType<UnsupportedFieldRecord>>(
+    () => [
+      {
+        title: t('Field name'),
+        render: (_, record) => getFieldValue(record, 'name') || getFieldValue(record, 'field'),
+      },
+      {
+        title: t('Field database type'),
+        render: (_, record) => getFieldValue(record, 'rawType') || getFieldValue(record, 'type'),
+      },
+    ],
+    [t],
+  );
+
+  if (!dataSource.length) {
+    return null;
+  }
+
+  return (
+    <div style={props.style}>
+      <Divider plain orientation="left" orientationMargin="0">
+        <h3>{t('Unknown field type')}</h3>
+      </Divider>
+      <div style={{ marginBottom: 15 }}>
+        {t('The following field types are not compatible and do not support output and display')}
+      </div>
+      <Table<UnsupportedFieldRecord>
+        columns={columns}
+        dataSource={dataSource}
+        pagination={false}
+        rowKey={(record) =>
+          getFieldValue(record, 'name') ||
+          getFieldValue(record, 'field') ||
+          getFieldValue(record, 'rawType') ||
+          getFieldValue(record, 'type') ||
+          ''
+        }
+      />
+    </div>
+  );
+}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/ViewCollectionConfigure.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/ViewCollectionConfigure.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { CollectionTemplateConfigureItemProps } from '../../plugin';
 import { useT } from '../../locale';
 import { compileLegacyTemplate } from '../../utils/compileLegacyTemplate';
+import { UnsupportedFields } from './UnsupportedFields';
 
 type ViewRecord = {
   name: string;
@@ -589,15 +590,7 @@ export function ViewFieldsConfigureItem(props: CollectionTemplateConfigureItemPr
           <Alert showIcon message={t('Please select a database view')} />
         </Form.Item>
       )}
-      {unsupportedFields?.length ? (
-        <Alert
-          showIcon
-          type="warning"
-          message={t('Unsupported fields')}
-          description={unsupportedFields.map((field) => field.name).join(', ')}
-          style={{ marginBottom: 24 }}
-        />
-      ) : null}
+      <UnsupportedFields dataSource={unsupportedFields} style={{ marginBottom: 24 }} />
     </>
   );
 }

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/UnsupportedFields.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/UnsupportedFields.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { UnsupportedFields } from '../UnsupportedFields';
+
+vi.mock('../../../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+describe('UnsupportedFields', () => {
+  it('renders unsupported field names and database raw types', () => {
+    render(<UnsupportedFields dataSource={[{ name: 'point', rawType: 'POINT' }]} />);
+
+    expect(screen.getByText('Unknown field type')).toBeInTheDocument();
+    expect(screen.getByText('Field name')).toBeInTheDocument();
+    expect(screen.getByText('Field database type')).toBeInTheDocument();
+    expect(screen.getByText('point')).toBeInTheDocument();
+    expect(screen.getByText('POINT')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 external data source collections already receive `unsupportedFields` from the collection list API, but the Configure fields drawer did not render this information like the V1 external data source UI does. As a result, unsupported database fields, such as unknown raw field types, were invisible in the V2 field configuration drawer.

The backup restore dialogs also had manually bolded Form.Item labels, which made `Confirm the application database schema` and `Restore password` visually inconsistent with the surrounding Ant Design form style.

### Description 
- Added a reusable V2 `UnsupportedFields` component for external data source unsupported fields.
  - Renders the `Unknown field type` section.
  - Shows the incompatible-field description.
  - Displays `Field name` and `Field database type` in a table.
  - Supports both `name` / `field` and `rawType` / `type` payload shapes.
- Rendered `collection.unsupportedFields` in the V2 Configure fields drawer for external data source collections.
- Reused the same unsupported-fields table in V2 view field sync/configuration flows instead of showing only a warning with field names.
- Removed the extra `<strong>` wrapper from backup restore form labels in both V1 and V2 backup restore dialogs, keeping the default Ant Design label style.

Potential risks are low: this PR does not change APIs, persistence, migrations, or restore behavior. Empty or missing `unsupportedFields` continues to render nothing.

Testing performed:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/UnsupportedFields.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/UnsupportedFields.test.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/ViewCollectionConfigure.tsx`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/UnsupportedFields.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromLocal.tsx packages/plugins/@nocobase/plugin-backups/src/client/components/RestoreFromBackup.tsx`
- `yarn test packages/plugins/@nocobase/plugin-backups/src/client/__tests__/BackupSettings.test.tsx --run --reporter=verbose`

Note: the backup settings test still emits existing antd/act warnings, but all tests pass.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Display unsupported external data source fields in V2 Configure fields, and align backup restore form label styles. |
| 🇨🇳 Chinese | V2 配置字段中展示外部数据源不支持的字段，并统一备份恢复表单标签样式。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
