### PR TITLE
Remove deprecated AI employee datasource registration from v2

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/settings-registration.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/settings-registration.test.ts
@@ -7,8 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { createMockClient } from '@nocobase/client-v2';
 import { describe, expect, it, vi } from 'vitest';
-import { registerPluginAIPermissionsTab, registerPluginAISettingsPages } from '../plugin';
+import PluginAIClientV2, { registerPluginAIPermissionsTab, registerPluginAISettingsPages } from '../plugin';
 
 describe('plugin-ai v2 settings registration', () => {
   it('registers AI settings menu and page tabs', () => {
@@ -32,12 +33,11 @@ describe('plugin-ai v2 settings registration', () => {
       sort: 400,
       showTabs: true,
     });
-    expect(addPageTabItem).toHaveBeenCalledTimes(5);
+    expect(addPageTabItem).toHaveBeenCalledTimes(4);
     expect(addPageTabItem.mock.calls.map(([item]) => [item.menuKey, item.key, item.aclSnippet])).toEqual([
       ['ai', 'employees', 'pm.ai.employees'],
       ['ai', 'llm-services', 'pm.ai.llm-services'],
       ['ai', 'mcp-settings', 'pm.ai.mcp-settings'],
-      ['ai', 'datasource', 'pm.ai.datasource'],
       ['ai', 'settings', 'pm.ai.settings'],
     ]);
     addPageTabItem.mock.calls.forEach(([item]) => {
@@ -80,5 +80,17 @@ describe('plugin-ai v2 settings registration', () => {
         (key) => key,
       ),
     ).not.toThrow();
+  });
+
+  it('does not register the deprecated datasource work context in v2', async () => {
+    const app = createMockClient({ publicPath: '/v/' });
+
+    await app.pm.add(PluginAIClientV2);
+    await app.load();
+
+    const plugin = app.pm.get(PluginAIClientV2) as PluginAIClientV2;
+
+    expect(plugin.aiManager.getWorkContext('flow-model')).toBeDefined();
+    expect(plugin.aiManager.getWorkContext('datasource')).toBeUndefined();
   });
 });

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/plugin.tsx
@@ -14,7 +14,6 @@ import { registerPluginAIClientV2BuiltinTools } from './ai-employees/tools';
 import { FlowModelsContext } from './ai-employees/context/flow-models';
 import { chartConfigWorkContext } from './ai-employees/context/chart-config';
 import { CodeEditorContext } from './ai-employees/context/code-editor';
-import { DatasourceContext } from './ai-employees/context/datasource';
 import { AIManager } from './manager/ai-manager';
 import { AIPluginFeatureManagerImpl } from './manager/ai-feature-manager';
 import { AIConfigRepository } from './repositories/AIConfigRepository';
@@ -94,15 +93,6 @@ export const registerPluginAISettingsPages = (
   });
   pluginSettingsManager.addPageTabItem({
     menuKey: 'ai',
-    key: 'datasource',
-    icon: 'CloudServerOutlined',
-    title: t('Datasource'),
-    aclSnippet: 'pm.ai.datasource',
-    componentLoader: () => import('./pages/DatasourceSettingsPage'),
-    sort: 40,
-  });
-  pluginSettingsManager.addPageTabItem({
-    menuKey: 'ai',
     key: 'settings',
     icon: 'SettingOutlined',
     title: t('Settings'),
@@ -133,7 +123,6 @@ export class PluginAIClientV2 extends Plugin<object, Application> {
     });
     registerPluginAIClientV2BuiltinTools(this.ai.toolsManager);
     this.aiManager.registerWorkContext('flow-model', FlowModelsContext);
-    this.aiManager.registerWorkContext('datasource', DatasourceContext);
     this.aiManager.registerWorkContext('code-editor', CodeEditorContext);
     this.aiManager.registerWorkContext('chart-config', chartConfigWorkContext);
     setupAICoding();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The AI employee Datasource feature is being deprecated in the v2 UI, so the v2 settings page and chat context selector should no longer expose Datasource entries while v1 keeps the existing behavior.

### Description 
- Removed the Datasource tab registration from the AI employee settings menu in client-v2.
- Removed the Datasource work context registration from the AI employee chat context selector in client-v2.
- Kept the v1 registrations unchanged.
- Updated v2 registration coverage to verify the deprecated Datasource entry is not registered.

Potential risk: existing v2 users will no longer see the Datasource setting tab or context selector entry. Existing backend APIs and v1 UI registrations are unchanged.

Testing suggestions: verify the AI employee settings tabs and chat context menu in v2 no longer include Datasource, and verify v1 still exposes it.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Removed the deprecated Datasource entry from AI employee settings and context selection in the v2 UI. |
| 🇨🇳 Chinese | 在 v2 界面中移除了已废弃的 AI 员工 Datasource 设置入口和上下文选择入口。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
