### PR TITLE
fix(cli): use rabbitmq-safe revision event names

### DIFF
--- a/packages/core/cli/src/commands/revision/create.ts
+++ b/packages/core/cli/src/commands/revision/create.ts
@@ -126,7 +126,7 @@ export default class RevisionCreate extends Command {
       path: '/app:publishEvent',
       body: {
         plugin: 'plugin-version-control',
-        command: 'revision:create',
+        command: 'revision.create',
         payload: {
           description,
         },

--- a/packages/plugins/@nocobase/plugin-client/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/server.ts
@@ -148,7 +148,7 @@ export class PluginClientServer extends Plugin {
           const { id, username } = ctx.auth?.user ?? {};
           const user = id ? { id, username } : undefined;
 
-          const eventName = `${command}@${plugin}`;
+          const eventName = `${command.replaceAll(':', '.')}.${plugin}`;
           try {
             await ctx.app.eventQueue.publish(eventName, {
               plugin,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Some RabbitMQ brokers only allow queue names to contain letters, numbers, underscores, dots, and hyphens. The revision creation event previously used `:` and `@`, which could cause queue declaration failures on these brokers.

### Description 
- Update the revision CLI command payload to use `revision.create`.
- Update `app:publishEvent` to join command and plugin names with `.`.
- Keep compatibility with older CLI versions by normalizing `:` in incoming commands to `.` before publishing the event.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed revision creation events failing on RabbitMQ brokers that reject `:` and `@` in queue names. |
| 🇨🇳 Chinese | 修复部分 RabbitMQ 服务不允许队列名包含 `:` 和 `@` 时，创建版本事件发布失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
