### PR TITLE
fix(plugin-workflow): update job modal loading state reactively

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/ExecutionCanvas.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Breadcrumb, Button, Dropdown, message, Modal, Result, Space, Spin, Tag, Tooltip, Typography } from 'antd';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import {
@@ -84,7 +84,22 @@ function useJobData(id) {
   );
 }
 
-function JobResult({ jobData, loading, ...props }) {
+type JobModalContextValue = {
+  jobData: Record<string, unknown>;
+  loading: boolean;
+};
+
+const JobModalContext = createContext<JobModalContextValue>({
+  jobData: {},
+  loading: false,
+});
+
+function useJobModalContext() {
+  return useContext(JobModalContext);
+}
+
+function JobResult(props) {
+  const { jobData, loading } = useJobModalContext();
   if (loading) {
     return <Spin />;
   }
@@ -92,7 +107,8 @@ function JobResult({ jobData, loading, ...props }) {
   return <Input.JSON {...props} value={result} disabled />;
 }
 
-function JobLog({ jobData, loading }) {
+function JobLog() {
+  const { jobData, loading } = useJobModalContext();
   if (loading) {
     return null;
   }
@@ -109,82 +125,85 @@ function JobModalContent({ job, setViewJob }) {
   const latestJob = get(data, 'data') ?? job;
   const { node = {} } = job ?? {};
   const instruction = instructions.get(node.type);
+  const jobModalContextValue = useMemo(
+    () => ({
+      jobData: latestJob,
+      loading,
+    }),
+    [latestJob, loading],
+  );
 
   return (
     <ActionContextProvider value={{ visible: Boolean(job), setVisible: setViewJob }}>
-      <SchemaComponent
-        components={{
-          JobResult,
-          JobLog,
-        }}
-        schema={{
-          type: 'void',
-          properties: {
-            [`${latestJob.id}-${latestJob.updatedAt}-modal`]: {
-              type: 'void',
-              'x-decorator': 'Form',
-              'x-decorator-props': {
-                initialValue: {
-                  ...job,
-                  ...latestJob,
-                  node,
-                },
-              },
-              'x-component': 'Action.Modal',
-              title: (
-                <div className={styles.nodeTitleClass}>
-                  <Tag>{compile(instruction?.title)}</Tag>
-                  <strong>{node.title}</strong>
-                  <span className="workflow-node-id">#{node.id}</span>
-                </div>
-              ),
-              properties: {
-                status: {
-                  type: 'number',
-                  title: `{{t("Status", { ns: "${NAMESPACE}" })}}`,
-                  'x-decorator': 'FormItem',
-                  'x-component': 'Select',
-                  enum: JobStatusOptions,
-                  'x-read-pretty': true,
-                },
-                updatedAt: {
-                  type: 'string',
-                  title: `{{t("Executed at", { ns: "${NAMESPACE}" })}}`,
-                  'x-decorator': 'FormItem',
-                  'x-component': 'DatePicker',
-                  'x-component-props': {
-                    showTime: true,
+      <JobModalContext.Provider value={jobModalContextValue}>
+        <SchemaComponent
+          components={{
+            JobResult,
+            JobLog,
+          }}
+          schema={{
+            type: 'void',
+            properties: {
+              [`${latestJob.id}-${latestJob.updatedAt}-modal`]: {
+                type: 'void',
+                'x-decorator': 'Form',
+                'x-decorator-props': {
+                  initialValue: {
+                    ...job,
+                    ...latestJob,
+                    node,
                   },
-                  'x-read-pretty': true,
                 },
-                result: {
-                  type: 'object',
-                  title: `{{t("Node result", { ns: "${NAMESPACE}" })}}`,
-                  'x-decorator': 'FormItem',
-                  'x-component': 'JobResult',
-                  'x-component-props': {
-                    jobData: latestJob,
-                    loading,
-                    className: styles.nodeJobResultClass,
-                    autoSize: {
-                      minRows: 4,
-                      maxRows: 32,
+                'x-component': 'Action.Modal',
+                title: (
+                  <div className={styles.nodeTitleClass}>
+                    <Tag>{compile(instruction?.title)}</Tag>
+                    <strong>{node.title}</strong>
+                    <span className="workflow-node-id">#{node.id}</span>
+                  </div>
+                ),
+                properties: {
+                  status: {
+                    type: 'number',
+                    title: `{{t("Status", { ns: "${NAMESPACE}" })}}`,
+                    'x-decorator': 'FormItem',
+                    'x-component': 'Select',
+                    enum: JobStatusOptions,
+                    'x-read-pretty': true,
+                  },
+                  updatedAt: {
+                    type: 'string',
+                    title: `{{t("Executed at", { ns: "${NAMESPACE}" })}}`,
+                    'x-decorator': 'FormItem',
+                    'x-component': 'DatePicker',
+                    'x-component-props': {
+                      showTime: true,
+                    },
+                    'x-read-pretty': true,
+                  },
+                  result: {
+                    type: 'object',
+                    title: `{{t("Node result", { ns: "${NAMESPACE}" })}}`,
+                    'x-decorator': 'FormItem',
+                    'x-component': 'JobResult',
+                    'x-component-props': {
+                      className: styles.nodeJobResultClass,
+                      autoSize: {
+                        minRows: 4,
+                        maxRows: 32,
+                      },
                     },
                   },
-                },
-                log: {
-                  type: 'string',
-                  'x-component': 'JobLog',
-                  'x-component-props': {
-                    jobData: latestJob,
-                    loading,
+                  log: {
+                    type: 'string',
+                    'x-component': 'JobLog',
                   },
                 },
               },
             },
-          },
-        }}
-      />
+          }}
+        />
+      </JobModalContext.Provider>
     </ActionContextProvider>
   );
 }
@@ -344,7 +363,7 @@ export function ExecutionCanvas() {
           });
       },
     });
-  }, [data?.data]);
+  }, [apiClient, data?.data.id, refresh, t]);
 
   const onBack = useCallback(() => {
     history.back();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The workflow execution job modal passed request state such as `loading` and job data through static schema component props. In some cases, the Formily field could keep using stale cached props, leaving the node result area stuck on the loading spinner even after the job result had loaded.

### Description
This PR moves the job modal's dynamic request state into React context so `JobResult` and `JobLog` subscribe to the latest `loading` and job data directly. The schema now only keeps stable UI configuration such as class names and textarea sizing.

It also fixes the existing hook dependency warning in the execution cancel callback.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where workflow execution node results could remain stuck in a loading state. |
| 🇨🇳 Chinese | 修复工作流执行记录中节点结果可能一直显示加载中的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
