### PR TITLE
fix(plugin-action-export): preload selected export field paths

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
@@ -26,17 +26,12 @@ const exportFieldNames = {
 
 const ExportFieldsCascader = (props) => {
   const { optionsCache, value, onChange, onDropdownVisibleChange, ...others } = props;
-  const [cascaderOptions, setCascaderOptions] = React.useState(() => createExportFieldsOptionsSnapshot(optionsCache));
-  const lastPreloadedValueRef = React.useRef<string | null>(null);
-  const cascaderValue = React.useMemo(() => normalizeExportFieldValue(value) || undefined, [value]);
+  const [optionsVersion, setOptionsVersion] = React.useState(0);
+  const cascaderValue = React.useMemo(() => normalizeExportFieldValue(value), [value]);
 
   const refreshOptions = React.useCallback(() => {
-    setCascaderOptions(createExportFieldsOptionsSnapshot(optionsCache));
-  }, [optionsCache]);
-
-  React.useEffect(() => {
-    refreshOptions();
-  }, [refreshOptions]);
+    setOptionsVersion((version) => version + 1);
+  }, []);
 
   const getValueKey = React.useCallback((path) => {
     if (!Array.isArray(path)) {
@@ -44,6 +39,9 @@ const ExportFieldsCascader = (props) => {
     }
     return path.map((item) => item?.name ?? item).join('.');
   }, []);
+
+  optionsCache.preloadPath(cascaderValue);
+  const cascaderOptions = createExportFieldsOptionsSnapshot(optionsCache);
 
   const loadData = React.useCallback(
     (selectedOptions) => {
@@ -60,26 +58,14 @@ const ExportFieldsCascader = (props) => {
     [optionsCache, refreshOptions],
   );
 
-  const preloadSelectedPath = React.useCallback(() => {
-    const valueKey = getValueKey(value);
-    if (!valueKey || lastPreloadedValueRef.current === valueKey) {
-      return;
-    }
-    lastPreloadedValueRef.current = valueKey;
-    const changed = optionsCache.preloadPath(value);
-    if (changed) {
-      refreshOptions();
-    }
-  }, [getValueKey, optionsCache, refreshOptions, value]);
-
   const handleDropdownVisibleChange = React.useCallback(
     (open) => {
       if (open) {
-        preloadSelectedPath();
+        refreshOptions();
       }
       onDropdownVisibleChange?.(open);
     },
-    [onDropdownVisibleChange, preloadSelectedPath],
+    [onDropdownVisibleChange, refreshOptions],
   );
 
   const handleChange = React.useCallback(
@@ -107,7 +93,7 @@ const ExportFieldsCascader = (props) => {
   return (
     <Cascader
       {...others}
-      value={cascaderValue}
+      value={cascaderValue || undefined}
       fieldNames={exportFieldNames}
       options={cascaderOptions}
       loadData={loadData}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Dragging exportable fields in the v2 export action settings could crash after selecting a relation field. The selected relation path could be present in the Cascader value while its lazy-loaded option path was not present in the current options tree, causing rc-cascader to throw `Cannot read properties of undefined (reading 'nodes')`.

### Description 
Preload the currently selected export field path before rendering the v2 export fields Cascader, so relation paths are available in the options tree after drag sorting. Lazy loading for browsing relation field options is kept unchanged.

Risk is low. The change is scoped to the v2 export action settings Cascader and does not alter export API payloads, field option rules, or ArrayItems sorting behavior.

Testing performed:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx`
- `yarn test packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/buildExportFieldOptions.test.ts --run --reporter=verbose`

### Related issues

None.

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed a crash when dragging v2 exportable fields after selecting relation fields. |
| 🇨🇳 Chinese | 修复 v2 可导出字段选择关系字段后拖拽导致页面崩溃的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary