### PR TITLE
feat(plugin-ai): optimize web search reasoning

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/ai/tools/subAgentWebSearch.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/ai/tools/subAgentWebSearch.ts
@@ -36,6 +36,7 @@ export default defineTools({
     const { provider } = await pluginAI.aiManager.getLLMService({
       ...model,
       webSearch: true,
+      reasoning: { mode: 'off' },
     });
     if (!args.query?.length) {
       return {

--- a/packages/plugins/@nocobase/plugin-ai/src/ai/tools/subAgentWebSearch.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/ai/tools/subAgentWebSearch.ts
@@ -21,9 +21,13 @@ export default defineTools({
   },
   definition: {
     name: 'subAgentWebSearch',
-    description: 'Use the query to search the web and return concise, relevant findings with source links.',
+    description:
+      'Search the web for current information. Put all independent search queries needed for this turn into one call so they can run in parallel. Do not call this tool repeatedly with similar queries unless the previous results are clearly insufficient for a critical missing fact.',
     schema: z.object({
-      query: z.array(z.string(), 'A clear and specific web search query describing the information to retrieve.'),
+      query: z.array(
+        z.string(),
+        'A list of clear, specific, non-overlapping web search queries. Include all independent queries needed for this answer in a single tool call so they can run in parallel.',
+      ),
     }),
   },
   invoke: async (ctx: Context, args: { query: string[] }, id) => {
@@ -71,19 +75,20 @@ export default defineTools({
   },
 });
 
-const WEB_SEARCH_SYSTEM_PROMPT = `You are a web search assistant.
+const WEB_SEARCH_SYSTEM_PROMPT = `You are a web search retrieval assistant.
 
-Your primary task is to retrieve up-to-date information from the internet based on the user's input query.
+Your output is for another AI model, not the final user-facing answer.
 
 Requirements:
-1. Actively attempt web retrieval first. Use internet search to find relevant and recent information.
-2. Summarize and synthesize findings clearly and concisely.
-3. Explicitly cite sources for key points whenever possible (for example: website/publication name, article title, and URL if available).
-4. Distinguish confirmed facts from uncertain or incomplete information.
-5. Do not fabricate search results, sources, or real-time data.
-6. If you cannot access reliable real-time information from the internet, clearly and honestly state that real-time retrieval was not possible, then provide the best available general information with that limitation noted.
+1. Retrieve current, relevant information for the query.
+2. Return concise findings only. Do not write a polished final answer.
+3. Include source title, publisher/site, URL, and publication or update date when available.
+4. Prefer authoritative and recent sources.
+5. Distinguish confirmed facts from uncertain or incomplete information.
+6. Do not fabricate results, sources, dates, or URLs.
+7. If results are weak, say exactly what is missing instead of broadening the search yourself.
 
-Output style:
-- Start with a brief direct answer.
-- Then provide a structured summary of findings.
-- End with a "Sources" section listing the origin of the information used.`;
+Output format:
+- Findings: 3-6 concise bullet points.
+- Sources: numbered list with title, site, URL, and date when available.
+- Gaps: one short sentence if important information could not be verified.`;

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/ai-employee.ts
@@ -892,6 +892,7 @@ export class AIEmployee {
       knowledgeBase,
       availableSkills,
       availableAIEmployees,
+      webSearch: this.webSearch,
     });
 
     const { important } = this.ctx.action?.params?.values || {};

--- a/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/ai-employees/prompts.ts
@@ -15,12 +15,14 @@ export function getSystemPrompt({
   knowledgeBase,
   availableSkills,
   availableAIEmployees,
+  webSearch,
 }: {
   aiEmployee: { nickname: string; about: string };
   personal?: string;
   task: { background: string; context?: string };
   environment: { database: string; locale: string; currentDateTime?: string; timezone?: string };
   knowledgeBase?: string;
+  webSearch?: boolean;
   availableSkills?: { name: string; description: string; content?: string }[];
   availableAIEmployees?: {
     username: string;
@@ -51,6 +53,14 @@ export function getSystemPrompt({
 
   const quotingRules = getDatabaseQuotingRules();
   const isUnderscored = process.env.DB_UNDERSCORED === 'true';
+  const webSearchInstructions =
+    webSearch === true
+      ? `
+   - When using web search, batch all independent search queries needed for this turn into one tool call whenever possible so they can run in parallel.
+   - Do not make repeated web search calls with the same or similar queries in the same turn.
+   - After receiving usable web search results, synthesize an answer from those results instead of searching again.
+   - Search again only when a critical fact is still missing and the new query is materially different from previous queries.`
+      : '';
 
   return `You are **${aiEmployee.nickname}**, an AI employee working in **NocoBase**, the leading no-code platform.
 
@@ -116,7 +126,7 @@ This prompt uses a structured tag system to organize your operational framework:
 5. **Tool Integration**
    - Utilize system-provided tools to enhance response quality
    - **NEVER refer to tool names when speaking to the USER.** Instead, just say what the tool is doing in natural language.
-   - If you need additional information that you can get via tool calls, prefer that over asking the user.
+   - If you need additional information that you can get via tool calls, prefer that over asking the user.${webSearchInstructions}
 </global>
 
 <ai_employee>

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts
@@ -11,9 +11,13 @@ import { describe, expect, it, afterEach } from 'vitest';
 import type { Application } from '@nocobase/server';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
-import { EmbeddingProvider, LLMProvider } from '../provider';
+import { EmbeddingProvider, LLMProvider, ReasoningOptions, ResolvedReasoningOptions } from '../provider';
 import { injectMistralReasoningEffort, MistralProvider } from '../mistral';
 import type { AIMessageInput } from '../../types';
+import { KimiProvider } from '../kimi/provider';
+import { DeepSeekProvider } from '../deepseek';
+import { OpenAICompletionsProvider } from '../openai/completions';
+import { OpenAIResponsesProvider } from '../openai/responses';
 
 class TestLLMProvider extends LLMProvider {
   get baseURL(): string {
@@ -44,6 +48,30 @@ class TestEmbeddingProvider extends EmbeddingProvider {
 
   getResolvedURL() {
     return this.baseURL;
+  }
+}
+
+class CapturingReasoningProvider extends LLMProvider {
+  createModel() {
+    return {
+      modelOptions: this.modelOptions,
+      reasoningOptions: this.resolveReasoningOptions(this.modelReasoningOptions),
+    };
+  }
+
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (reasoning?.mode !== 'off') {
+      return {};
+    }
+    return {
+      modelKwargs: {
+        providerOnly: true,
+        shared: 'provider',
+      },
+      modelRequestParams: {
+        providerParam: 'off',
+      },
+    };
   }
 }
 
@@ -138,6 +166,81 @@ describe('LLM provider baseURL guard', () => {
     expect(provider.getResolvedURL()).toBe('https://api.example.com/v1');
   });
 
+  it('extracts model reasoning options without leaking them to provider model options', () => {
+    const provider = new CapturingReasoningProvider({
+      app: createApp(),
+      modelOptions: {
+        model: 'test-model',
+        temperature: 0.1,
+        _reasoning: { mode: 'off' },
+      },
+    });
+
+    expect(provider.chatModel.modelOptions).toEqual({
+      model: 'test-model',
+      temperature: 0.1,
+    });
+    expect(provider.chatModel.reasoningOptions).toEqual({
+      modelKwargs: {
+        providerOnly: true,
+        shared: 'provider',
+      },
+      modelRequestParams: {
+        providerParam: 'off',
+      },
+    });
+  });
+
+  it('maps OpenAI chat completions reasoning off to reasoning_effort none', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.openai.com';
+
+    const provider = new OpenAICompletionsProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'gpt-5', _reasoning: { mode: 'off' } },
+    });
+
+    expect(provider.chatModel.invocationParams()).toMatchObject({
+      reasoning_effort: 'none',
+    });
+  });
+
+  it('maps OpenAI responses reasoning off to reasoning effort none', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.openai.com';
+
+    const provider = new OpenAIResponsesProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'gpt-5', _reasoning: { mode: 'off' } },
+    });
+
+    expect(provider.chatModel.invocationParams()).toMatchObject({
+      reasoning: {
+        effort: 'none',
+      },
+    });
+  });
+
+  it('maps OpenAI reasoning effort values for chat completions and responses', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.openai.com';
+
+    const completionsProvider = new OpenAICompletionsProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'gpt-5', _reasoning: { mode: 'minimal' } },
+    });
+    const responsesProvider = new OpenAIResponsesProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'gpt-5', _reasoning: { mode: 'xhigh' } },
+    });
+
+    expect(completionsProvider.chatModel.invocationParams()).toMatchObject({
+      reasoning_effort: 'minimal',
+    });
+    expect(responsesProvider.chatModel.invocationParams()).toMatchObject({
+      reasoning: {
+        effort: 'xhigh',
+      },
+    });
+  });
+
   it('normalizes Mistral SDK serverURL to the API root', () => {
     process.env.SERVER_REQUEST_WHITELIST = 'api.mistral.ai';
 
@@ -167,6 +270,124 @@ describe('LLM provider baseURL guard', () => {
     expect(body).toMatchObject({
       reasoning_effort: 'high',
       model: 'mistral-small-latest',
+    });
+  });
+
+  it('disables Mistral reasoning effort when reasoning mode is off', async () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.mistral.ai';
+
+    const provider = new MistralProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'mistral-small-latest', _reasoning: { mode: 'off' } },
+    });
+    const params = provider.chatModel.invocationParams();
+    const request = new Request('https://api.mistral.ai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...params,
+        reasoning_effort: 'high',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const nextRequest = await injectMistralReasoningEffort(request);
+    const body = await (nextRequest as Request).json();
+
+    expect(body).toMatchObject({
+      model: 'mistral-small-latest',
+    });
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.__nb_reasoning_mode).toBeUndefined();
+  });
+
+  it('honors requested Mistral reasoning effort', async () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.mistral.ai';
+
+    const provider = new MistralProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'mistral-small-latest', _reasoning: { mode: 'low' } },
+    });
+    const params = provider.chatModel.invocationParams();
+    const request = new Request('https://api.mistral.ai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...params,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const nextRequest = await injectMistralReasoningEffort(request);
+    const body = await (nextRequest as Request).json();
+
+    expect(body).toMatchObject({
+      reasoning_effort: 'low',
+      model: 'mistral-small-latest',
+    });
+    expect(body.__nb_reasoning_mode).toBeUndefined();
+  });
+
+  it('disables Kimi thinking for models that support the thinking switch', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.moonshot.cn';
+
+    const provider = new KimiProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'kimi-k2.5', _reasoning: { mode: 'off' } },
+    });
+
+    expect(provider.chatModel.invocationParams()).toMatchObject({
+      thinking: {
+        type: 'disabled',
+      },
+    });
+  });
+
+  it('skips Kimi thinking switch for models that do not support disabling thinking', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.moonshot.cn';
+
+    const provider = new KimiProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'kimi-k2.7-code', _reasoning: { mode: 'off' } },
+    });
+
+    expect(provider.chatModel.invocationParams().thinking).toBeUndefined();
+  });
+
+  it('maps DeepSeek reasoning off to disabled thinking without reasoning effort', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.deepseek.com';
+
+    const provider = new DeepSeekProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'deepseek-v4-pro', _reasoning: { mode: 'off' } },
+    });
+    const params = provider.chatModel.invocationParams();
+
+    expect(params).toMatchObject({
+      thinking: {
+        type: 'disabled',
+      },
+    });
+    expect(params.reasoning_effort).toBeUndefined();
+  });
+
+  it('maps DeepSeek reasoning effort when thinking is enabled', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.deepseek.com';
+
+    const provider = new DeepSeekProvider({
+      app: createApp({ apiKey: 'test-key' }),
+      modelOptions: { model: 'deepseek-v4-pro', _reasoning: { mode: 'high' } },
+    });
+
+    expect(provider.chatModel.invocationParams()).toMatchObject({
+      thinking: {
+        type: 'enabled',
+      },
+      reasoning_effort: 'high',
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/dashscope.ts
@@ -9,7 +9,7 @@
 
 import { AIMessageChunk } from '@langchain/core/messages';
 import { OpenAIEmbeddings } from '@langchain/openai';
-import { EmbeddingProvider, LLMProvider } from './provider';
+import { EmbeddingProvider, LLMProvider, ReasoningOptions, ResolvedReasoningOptions } from './provider';
 import { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { SupportedModel } from '../manager/ai-manager';
 import { Context } from '@nocobase/actions';
@@ -33,6 +33,7 @@ export class DashscopeProvider extends LLMProvider {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { name, schema } = structuredOutput || {};
+    const reasoningOptions = this.resolveReasoningOptions(this.modelReasoningOptions);
 
     const modelKwargs: Record<string, any> = {};
 
@@ -61,7 +62,11 @@ export class DashscopeProvider extends LLMProvider {
       topP: 0.8,
       temperature: 0.7,
       ...this.modelOptions,
-      modelKwargs,
+      ...(reasoningOptions.modelRequestParams || {}),
+      modelKwargs: {
+        ...modelKwargs,
+        ...(reasoningOptions.modelKwargs || {}),
+      },
       configuration: {
         baseURL: this.getResolvedBaseURL(),
       },
@@ -79,6 +84,17 @@ export class DashscopeProvider extends LLMProvider {
     } else {
       return toolDefinitions;
     }
+  }
+
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (reasoning?.mode !== 'off') {
+      return {};
+    }
+    return {
+      modelKwargs: {
+        enable_thinking: false,
+      },
+    };
   }
 
   parseResponseMessage(message: Model) {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/deepseek.ts
@@ -9,7 +9,7 @@
 
 import { ChatDeepSeek } from '@langchain/deepseek';
 import { AIMessageChunk, BaseMessage } from '@langchain/core/messages';
-import { LLMProvider, ParsedAttachmentResult } from './provider';
+import { LLMProvider, ParsedAttachmentResult, ReasoningOptions, ResolvedReasoningOptions } from './provider';
 import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
 import { Model } from '@nocobase/database';
 import _ from 'lodash';
@@ -25,6 +25,8 @@ import { Context } from '@nocobase/actions';
 import PluginAIServer from '../plugin';
 import path from 'node:path';
 import { AttachmentModel } from '@nocobase/plugin-file-manager';
+
+const DEEPSEEK_REASONING_EFFORTS = new Set(['low', 'medium', 'high']);
 
 class ReasoningDeepSeek extends ChatDeepSeek {
   async _generate(messages: BaseMessage[], options: any, runManager?: any) {
@@ -81,6 +83,7 @@ export class DeepSeekProvider extends LLMProvider {
   createModel() {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat } = this.modelOptions || {};
+    const reasoningOptions = this.resolveReasoningOptions(this.modelReasoningOptions);
 
     const modelKwargs: Record<string, any> = {};
 
@@ -94,7 +97,11 @@ export class DeepSeekProvider extends LLMProvider {
     return new ReasoningDeepSeek({
       apiKey,
       ...this.modelOptions,
-      modelKwargs,
+      ...(reasoningOptions.modelRequestParams || {}),
+      modelKwargs: {
+        ...modelKwargs,
+        ...(reasoningOptions.modelKwargs || {}),
+      },
       configuration: {
         baseURL: this.getResolvedBaseURL(),
       },
@@ -130,6 +137,32 @@ export class DeepSeekProvider extends LLMProvider {
     return null;
   }
 
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (!reasoning || reasoning.mode === 'default') {
+      return {};
+    }
+    if (reasoning.mode === 'off') {
+      return {
+        modelKwargs: {
+          thinking: {
+            type: 'disabled',
+          },
+        },
+      };
+    }
+    if (!DEEPSEEK_REASONING_EFFORTS.has(reasoning.mode)) {
+      return {};
+    }
+    return {
+      modelKwargs: {
+        thinking: {
+          type: 'enabled',
+        },
+        reasoning_effort: reasoning.mode,
+      },
+    };
+  }
+
   protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
     return false;
   }
@@ -139,7 +172,7 @@ export const deepseekProviderOptions: LLMProviderMeta = {
   title: 'DeepSeek',
   supportedModel: [SupportedModel.LLM],
   models: {
-    [SupportedModel.LLM]: ['deepseek-chat', 'deepseek-reasoner'],
+    [SupportedModel.LLM]: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-reasoner'],
   },
   provider: DeepSeekProvider,
 };

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/kimi/provider.ts
@@ -10,12 +10,14 @@
 import { AIMessageChunk } from '@langchain/core/messages';
 import { Model } from '@nocobase/database';
 import _ from 'lodash';
-import { LLMProvider } from '../provider';
+import { LLMProvider, ReasoningOptions, ResolvedReasoningOptions } from '../provider';
 import { LLMProviderMeta, SupportedModel } from '../../manager/ai-manager';
 import { CachedDocumentLoader } from '../../document-loader';
 import { KimiDocumentLoader } from './document-loader';
 import { ReasoningChatOpenAI } from '../common/reasoning';
 import { AttachmentModel } from '@nocobase/plugin-file-manager';
+
+const KIMI_THINKING_SWITCH_MODELS = new Set(['kimi-k2.5', 'kimi-k2.6']);
 
 export class KimiProvider extends LLMProvider {
   declare chatModel: ReasoningChatOpenAI;
@@ -29,6 +31,7 @@ export class KimiProvider extends LLMProvider {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { name, schema } = structuredOutput || {};
+    const reasoningOptions = this.resolveReasoningOptions(this.modelReasoningOptions);
     const responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
@@ -40,7 +43,9 @@ export class KimiProvider extends LLMProvider {
       ...this.modelOptions,
       modelKwargs: {
         response_format: responseFormatOptions,
+        ...(reasoningOptions.modelKwargs || {}),
       },
+      ...(reasoningOptions.modelRequestParams || {}),
       configuration: {
         baseURL: this.getResolvedBaseURL(),
       },
@@ -75,6 +80,22 @@ export class KimiProvider extends LLMProvider {
     return null;
   }
 
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (!reasoning || reasoning.mode === 'default') {
+      return {};
+    }
+    if (!KIMI_THINKING_SWITCH_MODELS.has(this.modelOptions?.model)) {
+      return {};
+    }
+    return {
+      modelKwargs: {
+        thinking: {
+          type: reasoning.mode === 'off' ? 'disabled' : 'enabled',
+        },
+      },
+    };
+  }
+
   protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
     return attachment.mimetype?.startsWith('image/') ?? false;
   }
@@ -102,7 +123,7 @@ export const kimiProviderOptions: LLMProviderMeta = {
   title: 'Kimi',
   supportedModel: [SupportedModel.LLM],
   models: {
-    [SupportedModel.LLM]: ['kimi-k2.5', 'kimi-k2-0905-Preview', 'kimi-k2-turbo-preview'],
+    [SupportedModel.LLM]: ['kimi-k2.7-code', 'kimi-k2.7-code-highspeed', 'kimi-k2.6', 'kimi-k2.5'],
   },
   provider: KimiProvider,
 };

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/mistral.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/mistral.ts
@@ -12,7 +12,14 @@ import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import { ChatMistralAI, MistralAIEmbeddings } from '@langchain/mistralai';
 import { checkUrlAgainstWhitelist, serverRequest } from '@nocobase/utils';
 import { AttachmentModel } from '@nocobase/plugin-file-manager';
-import { EmbeddingProvider, LLMProvider, LLMProviderInvokeOptions } from './provider';
+import {
+  EmbeddingProvider,
+  LLMProvider,
+  LLMProviderInvokeOptions,
+  ReasoningMode,
+  ReasoningOptions,
+  ResolvedReasoningOptions,
+} from './provider';
 import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
 import { AIChatContext, AIMessageInput } from '../types/ai-chat-conversation.type';
 import { Model } from '@nocobase/database';
@@ -20,11 +27,19 @@ import { Model } from '@nocobase/database';
 const MISTRAL_URL = 'https://api.mistral.ai';
 const MISTRAL_REASONING_EFFORT = 'high';
 const MISTRAL_REASONING_MODELS = new Set(['mistral-small-latest', 'mistral-medium-3-5']);
+const MISTRAL_REASONING_EFFORTS = new Set<ReasoningMode>(['off', 'low', 'medium', 'high']);
+const MISTRAL_REASONING_MODE_KEY = '__nb_reasoning_mode';
 
 type MistralCallOptions = LLMProviderInvokeOptions & {
   response_format?: {
     type: 'text' | 'json_object';
   };
+};
+
+type MistralRequestBody = Record<string, unknown> & {
+  model?: string;
+  reasoning_effort?: string;
+  [MISTRAL_REASONING_MODE_KEY]?: ReasoningMode;
 };
 
 type MistralBeforeRequestHook = (request: Request) => Request | void | Promise<Request | void>;
@@ -33,6 +48,10 @@ type MistralContentChunk = {
   type?: string;
   text?: string;
   thinking?: MistralContentChunk[];
+};
+
+type ReasoningChatMistralAIFields = ConstructorParameters<typeof ChatMistralAI>[0] & {
+  [MISTRAL_REASONING_MODE_KEY]?: ReasoningMode;
 };
 
 function omitDisabledNumberOptions(options: Record<string, unknown>) {
@@ -79,23 +98,69 @@ export const injectMistralReasoningEffort: MistralBeforeRequestHook = async (req
   const body = (await request
     .clone()
     .json()
-    .catch(() => null)) as Record<string, unknown> | null;
+    .catch(() => null)) as MistralRequestBody | null;
   if (!body || typeof body !== 'object') {
     return;
   }
+  const reasoningMode = body[MISTRAL_REASONING_MODE_KEY];
+  delete body[MISTRAL_REASONING_MODE_KEY];
+  const shouldRewriteBody = reasoningMode != null;
   if (typeof body.model !== 'string' || !MISTRAL_REASONING_MODELS.has(body.model)) {
+    if (shouldRewriteBody) {
+      const headers = new Headers(request.headers);
+      headers.delete('content-length');
+      return new Request(request, {
+        headers,
+        body: JSON.stringify(body),
+      });
+    }
     return;
   }
+  if (reasoningMode === 'off') {
+    delete body.reasoning_effort;
+    const headers = new Headers(request.headers);
+    headers.delete('content-length');
+    return new Request(request, {
+      headers,
+      body: JSON.stringify(body),
+    });
+  }
+  if (body.reasoning_effort && !shouldRewriteBody) {
+    return;
+  }
+  const reasoningEffort = reasoningMode && reasoningMode !== 'default' ? reasoningMode : MISTRAL_REASONING_EFFORT;
   const headers = new Headers(request.headers);
   headers.delete('content-length');
   return new Request(request, {
     headers,
     body: JSON.stringify({
       ...body,
-      reasoning_effort: MISTRAL_REASONING_EFFORT,
+      reasoning_effort: reasoningEffort,
     }),
   });
 };
+
+class ReasoningChatMistralAI extends ChatMistralAI {
+  private readonly reasoningMode?: ReasoningMode;
+
+  constructor(fields: ReasoningChatMistralAIFields) {
+    const { [MISTRAL_REASONING_MODE_KEY]: reasoningMode, ...modelFields } = fields;
+    super(modelFields);
+    this.reasoningMode = reasoningMode;
+  }
+
+  invocationParams(options?: MistralCallOptions) {
+    const params = super.invocationParams(options);
+    const mode = this.reasoningMode;
+    if (!mode || mode === 'default') {
+      return params;
+    }
+    return {
+      ...params,
+      [MISTRAL_REASONING_MODE_KEY]: mode,
+    };
+  }
+}
 
 export class MistralProvider extends LLMProvider {
   declare chatModel: ChatMistralAI;
@@ -111,14 +176,30 @@ export class MistralProvider extends LLMProvider {
     const beforeRequestHooks = Array.isArray(modelOptions.beforeRequestHooks)
       ? ([injectMistralReasoningEffort, ...modelOptions.beforeRequestHooks] as MistralBeforeRequestHook[])
       : [injectMistralReasoningEffort];
+    const reasoningOptions = this.resolveReasoningOptions(this.modelReasoningOptions);
 
-    return new ChatMistralAI({
+    return new ReasoningChatMistralAI({
       apiKey,
       ...modelOptions,
+      ...(reasoningOptions.modelRequestParams || {}),
       beforeRequestHooks,
       serverURL: this.getResolvedServerURL(),
       verbose: false,
     });
+  }
+
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (!reasoning || reasoning.mode === 'default') {
+      return {};
+    }
+    if (!MISTRAL_REASONING_EFFORTS.has(reasoning.mode)) {
+      return {};
+    }
+    return {
+      modelRequestParams: {
+        [MISTRAL_REASONING_MODE_KEY]: reasoning.mode,
+      },
+    };
   }
 
   async stream(context: AIChatContext, options?: MistralCallOptions) {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/completions.ts
@@ -8,7 +8,7 @@
  */
 
 import { ChatOpenAI } from '@langchain/openai';
-import { LLMProvider } from '../provider';
+import { LLMProvider, ReasoningOptions, ResolvedReasoningOptions } from '../provider';
 
 export class OpenAICompletionsProvider extends LLMProvider {
   declare chatModel: ChatOpenAI;
@@ -21,6 +21,7 @@ export class OpenAICompletionsProvider extends LLMProvider {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { name, schema } = structuredOutput || {};
+    const reasoningOptions = this.resolveReasoningOptions(this.modelReasoningOptions);
     const responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
@@ -30,12 +31,28 @@ export class OpenAICompletionsProvider extends LLMProvider {
     return new ChatOpenAI({
       apiKey,
       ...this.modelOptions,
+      ...(reasoningOptions.modelRequestParams || {}),
       modelKwargs: {
         response_format: responseFormatOptions,
+        ...(reasoningOptions.modelKwargs || {}),
       },
       configuration: {
         baseURL: this.getResolvedBaseURL(),
       },
     });
+  }
+
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (!reasoning || reasoning.mode === 'default') {
+      return {};
+    }
+    const effort = reasoning.mode === 'off' ? 'none' : reasoning.mode;
+    return {
+      modelRequestParams: {
+        reasoning: {
+          effort,
+        },
+      },
+    };
   }
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/responses.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/openai/responses.ts
@@ -8,7 +8,7 @@
  */
 
 import { ChatOpenAI } from '@langchain/openai';
-import { LLMProvider } from '../provider';
+import { LLMProvider, ReasoningOptions, ResolvedReasoningOptions } from '../provider';
 import { Model } from '@nocobase/database';
 import { stripToolCallTags } from '../../utils';
 import { AIMessageChunk } from '@langchain/core/messages';
@@ -25,6 +25,7 @@ export class OpenAIResponsesProvider extends LLMProvider {
     const { apiKey } = this.serviceOptions || {};
     const { responseFormat, structuredOutput } = this.modelOptions || {};
     const { name, schema, strict } = structuredOutput || {};
+    const reasoningOptions = this.resolveReasoningOptions(this.modelReasoningOptions);
     let responseFormatOptions: Record<string, any> = {
       type: responseFormat ?? 'text',
     };
@@ -39,10 +40,12 @@ export class OpenAIResponsesProvider extends LLMProvider {
     return new ChatOpenAI({
       apiKey,
       ...this.modelOptions,
+      ...(reasoningOptions.modelRequestParams || {}),
       modelKwargs: {
         text: {
           format: responseFormatOptions,
         },
+        ...(reasoningOptions.modelKwargs || {}),
       },
       configuration: {
         baseURL: this.getResolvedBaseURL(),
@@ -120,6 +123,20 @@ export class OpenAIResponsesProvider extends LLMProvider {
       return [webSearchTool];
     }
     return [];
+  }
+
+  protected resolveReasoningOptions(reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    if (!reasoning || reasoning.mode === 'default') {
+      return {};
+    }
+    const effort = reasoning.mode === 'off' ? 'none' : reasoning.mode;
+    return {
+      modelRequestParams: {
+        reasoning: {
+          effort,
+        },
+      },
+    };
   }
 
   isToolConflict(): boolean {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/provider.ts
@@ -36,6 +36,14 @@ export type LLMProviderInvokeOptions = {
   [key: string]: any;
 };
 
+export type ReasoningMode = 'default' | 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export type ReasoningOptions = {
+  mode: ReasoningMode;
+};
+
+export type ResolvedReasoningOptions = Pick<LLMProviderInvokeOptions, 'modelKwargs' | 'modelRequestParams'>;
+
 export type LLMModelRequestBuilderResult = {
   context: AIChatContext;
   options?: LLMProviderInvokeOptions;
@@ -95,6 +103,7 @@ export abstract class LLMProvider {
   serviceOptions: Record<string, any>;
   modelOptions: Record<string, any> | undefined;
   chatModel: any;
+  protected modelReasoningOptions: ReasoningOptions | undefined;
 
   abstract createModel(): BaseChatModel | any;
 
@@ -107,13 +116,19 @@ export abstract class LLMProvider {
     this.app = app;
     this.serviceOptions = resolveServiceOptions(serviceOptions, app);
     if (modelOptions) {
-      this.modelOptions = modelOptions;
+      const { _reasoning, ...restModelOptions } = modelOptions;
+      this.modelReasoningOptions = _reasoning;
+      this.modelOptions = restModelOptions;
       this.chatModel = this.createModel();
     }
   }
 
   protected getModelRequestBuilder(_model?: string): LLMModelRequestBuilder | null {
     return null;
+  }
+
+  protected resolveReasoningOptions(_reasoning?: ReasoningOptions): ResolvedReasoningOptions {
+    return {};
   }
 
   prepareChain(context: AIChatContext) {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-manager.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-manager.ts
@@ -12,6 +12,7 @@ import {
   LLMProviderOptions,
   EmbeddingProvider,
   EmbeddingProviderOptions,
+  ReasoningOptions,
 } from '../llm-providers/provider';
 import PluginAIServer from '../plugin';
 import _ from 'lodash';
@@ -37,6 +38,7 @@ export type LLMModelOptions = {
   llmService: string;
   model: string;
   webSearch?: boolean;
+  reasoning?: ReasoningOptions;
 };
 
 export type EnabledLLMModel = {
@@ -157,7 +159,7 @@ export class AIManager {
   }
 
   async getLLMService(options: LLMModelOptions) {
-    const { llmService, model, webSearch } = options ?? {};
+    const { llmService, model, webSearch, reasoning } = options ?? {};
 
     // model is required - it's set by the frontend ModelSwitcher
     if (!llmService || !model) {
@@ -172,6 +174,10 @@ export class AIManager {
 
     if (webSearch === true) {
       modelOptions.builtIn = { webSearch: true };
+    }
+
+    if (reasoning) {
+      modelOptions._reasoning = reasoning;
     }
 
     const service = await this.plugin.db.getRepository('llmServices').findOne({


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

AI employee web search can spend extra time on reasoning before retrieving and summarizing current information. The web search sub-agent should prefer retrieval-focused behavior and avoid provider reasoning when the selected model/provider supports controlling it.

### Description

This PR updates the AI employee web search prompt to encourage single-call, retrieval-focused search behavior.

It also adds provider construction-time reasoning options so AI employee web search can request reasoning to be disabled through `aiManager.getLLMService({ reasoning })`. The internal provider option is kept as `_reasoning` and stripped before SDK model options are passed through. Provider mappings are added for OpenAI Completions, OpenAI Responses, DashScope, Mistral, Kimi, and DeepSeek, with tests covering supported mappings and unsupported-model fallbacks.

Potential risks: reasoning controls are provider and model dependent, so unsupported values are intentionally ignored by some providers instead of being forced into API requests.

Testing suggestions: verify AI employee web search with reasoning-capable OpenAI, DashScope, Kimi, DeepSeek, and Mistral services, especially provider-specific models where thinking controls differ.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved AI employee web search to reduce unnecessary model reasoning and better use provider-specific thinking controls. |
| 🇨🇳 Chinese | 优化 AI 员工网页搜索，减少不必要的模型推理，并更好地使用各 Provider 的思考控制参数。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Tested with:

```bash
yarn test packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/provider.test.ts --run --reporter=verbose
```
