### PR TITLE
refactor(cli): reuse app start during setup and improve proxy configuration

### DIFF
--- a/packages/core/cli/src/__tests__/auth-store.test.ts
+++ b/packages/core/cli/src/__tests__/auth-store.test.ts
@@ -18,9 +18,11 @@ import {
   loadAuthConfig,
   replaceEnvConfig,
   removeEnv,
+  resolveEnvProxyEntry,
   saveAuthConfig,
   setCurrentEnv,
   setEnvOauthSession,
+  setEnvProxyEntry,
   updateEnvConnection,
   upsertEnv,
 } from '../lib/auth-store.js';
@@ -131,6 +133,83 @@ test('clearEnvRootSetup removes saved root setup fields while preserving other e
     expect(env).not.toHaveProperty('rootEmail');
     expect(env).not.toHaveProperty('rootPassword');
     expect(env).not.toHaveProperty('rootNickname');
+  });
+});
+
+test('setEnvProxyEntry stores shared proxy host and port', async () => {
+  await withTempCliHome(async () => {
+    await saveAuthConfig(
+      {
+        lastEnv: 'test',
+        envs: {
+          test: {
+            baseUrl: 'http://localhost:13000/api',
+          },
+        },
+      },
+      { scope: 'global' },
+    );
+
+    await setEnvProxyEntry(
+      'test',
+      'nginx',
+      {
+        host: 'c.local.nocobase.com',
+        port: 80,
+      },
+      { scope: 'global' },
+    );
+
+    const env = await getEnv('test', { scope: 'global' });
+    expect(env?.config.proxy).toEqual({
+      host: 'c.local.nocobase.com',
+      port: 80,
+    });
+    expect(resolveEnvProxyEntry(env?.config, 'nginx')).toEqual({
+      host: 'c.local.nocobase.com',
+      port: 80,
+    });
+  });
+});
+
+test('setEnvProxyEntry keeps shared proxy host and port alongside provider-specific settings', async () => {
+  await withTempCliHome(async () => {
+    await saveAuthConfig(
+      {
+        lastEnv: 'test',
+        envs: {
+          test: {
+            baseUrl: 'http://localhost:13000/api',
+          },
+        },
+      },
+      { scope: 'global' },
+    );
+
+    await setEnvProxyEntry(
+      'test',
+      'nginx',
+      {
+        host: 'c.local.nocobase.com',
+        port: 80,
+        ssl: false,
+      },
+      { scope: 'global' },
+    );
+
+    const env = await getEnv('test', { scope: 'global' });
+    expect(env?.config.proxy).toEqual({
+      host: 'c.local.nocobase.com',
+      port: 80,
+      nginx: {
+        ssl: false,
+      },
+    });
+    expect(resolveEnvProxyEntry(env?.config, 'nginx')).toEqual({
+      host: 'c.local.nocobase.com',
+      port: 80,
+      ssl: false,
+    });
   });
 });
 

--- a/packages/core/cli/src/__tests__/env-proxy.test.ts
+++ b/packages/core/cli/src/__tests__/env-proxy.test.ts
@@ -162,6 +162,11 @@ test('buildEnvProxyNginxBundle renders app.conf and index HTML with CDN-prefixed
   expect(bundle.appConfigContent).toContain('# BEGIN NocoBase managed config');
   expect(bundle.appConfigContent).toContain('location / {');
   expect(bundle.appConfigContent).toContain('return 302 /console$uri$is_args$args;');
+  expect(bundle.appConfigContent).toContain('location = /console/api {');
+  expect(bundle.appConfigContent).toContain('return 308 /console/api/$is_args$args;');
+  expect(bundle.appConfigContent.indexOf('location = /console/api {')).toBeLessThan(
+    bundle.appConfigContent.indexOf('location ^~ /console/api/ {'),
+  );
   expect(bundle.appConfigContent).toContain('location ^~ /console/admin/ {');
   expect(bundle.appConfigContent).toContain('alias /workspace/.nocobase/proxy/nginx/demo/public/;');
   expect(bundle.appConfigContent).toContain('try_files $uri /index-v2.html =404;');

--- a/packages/core/cli/src/__tests__/install-resume.test.ts
+++ b/packages/core/cli/src/__tests__/install-resume.test.ts
@@ -205,12 +205,6 @@ test('install syncs oauth env connection after the app becomes ready', async () 
   const saveInstalledEnv = vi.fn(async () => undefined);
   const waitForAppHealthCheck = vi.fn(async () => undefined);
   const downloadManagedSource = vi.fn(async () => undefined);
-  const installDockerApp = vi.fn(async () => ({
-    containerName: 'nb-chen-app1-app',
-    appPort: '13080',
-    appKey: 'app-key',
-    timeZone: 'Asia/Shanghai',
-  }));
   const runCommand = vi.fn(async () => undefined);
   const collectPromptResults = vi.fn(async () => ({
     envName: 'app1',
@@ -244,34 +238,27 @@ test('install syncs oauth env connection after the app becomes ready', async () 
     saveInstalledEnv,
     waitForAppHealthCheck,
     downloadManagedSource,
-    installDockerApp,
     commandStdio: vi.fn(() => 'ignore'),
     config: { runCommand },
   });
 
   await Install.prototype.run.call(command);
 
-  expect(waitForAppHealthCheck).toHaveBeenCalledTimes(1);
+  expect(waitForAppHealthCheck).not.toHaveBeenCalled();
   expect(runCommand.mock.calls).toEqual([
+    ['app:start', ['--env', 'app1', '--yes', '--no-sync-licensed-plugins', '--hook-command', 'init']],
     ['env:auth', ['app1']],
     ['env:update', ['app1']],
   ]);
 });
 
-test('install prints the resolved app url when the app becomes ready', async () => {
+test('install saves the resolved app url before delegating startup', async () => {
   const { default: Install } = await import('../commands/install.js');
 
   await setCliConfigValue('default-api-host', '192.168.1.10');
 
-  const saveInstalledEnv = vi.fn(async () => undefined);
   const waitForAppHealthCheck = vi.fn(async () => undefined);
   const downloadManagedSource = vi.fn(async () => undefined);
-  const installDockerApp = vi.fn(async () => ({
-    containerName: 'nb-chen-app1-app',
-    appPort: '13080',
-    appKey: 'app-key',
-    timeZone: 'Asia/Shanghai',
-  }));
   const runCommand = vi.fn(async () => undefined);
   const collectPromptResults = vi.fn(async () => ({
     envName: 'app1',
@@ -301,17 +288,22 @@ test('install prints the resolved app url when the app becomes ready', async () 
       },
     })),
     collectPromptResults,
-    saveInstalledEnv,
     waitForAppHealthCheck,
     downloadManagedSource,
-    installDockerApp,
     commandStdio: vi.fn(() => 'ignore'),
     config: { runCommand },
   });
 
   await Install.prototype.run.call(command);
 
-  expect(mocks.printInfo).toHaveBeenCalledWith('NocoBase is ready at http://192.168.1.10:13080/');
+  expect(mocks.upsertEnv.mock.calls.at(-1)?.[1]).toMatchObject({
+    apiBaseUrl: 'http://192.168.1.10:13080/api',
+    appPort: '13080',
+  });
+  expect(runCommand.mock.calls[0]).toEqual([
+    'app:start',
+    ['--env', 'app1', '--yes', '--no-sync-licensed-plugins', '--hook-command', 'init'],
+  ]);
 });
 
 test('install syncs token env connection after the app becomes ready without oauth login', async () => {
@@ -320,11 +312,6 @@ test('install syncs token env connection after the app becomes ready without oau
   const saveInstalledEnv = vi.fn(async () => undefined);
   const waitForAppHealthCheck = vi.fn(async () => undefined);
   const downloadLocalApp = vi.fn(async () => '/tmp/app1/source');
-  const startLocalApp = vi.fn(async () => ({
-    appPort: '13080',
-    appKey: 'app-key',
-    timeZone: 'Asia/Shanghai',
-  }));
   const runCommand = vi.fn(async () => undefined);
   const collectPromptResults = vi.fn(async () => ({
     envName: 'app1',
@@ -359,14 +346,16 @@ test('install syncs token env connection after the app becomes ready without oau
     saveInstalledEnv,
     waitForAppHealthCheck,
     downloadLocalApp,
-    startLocalApp,
     commandStdio: vi.fn(() => 'ignore'),
     config: { runCommand },
   });
 
   await Install.prototype.run.call(command);
 
-  expect(runCommand.mock.calls).toEqual([['env:update', ['app1']]]);
+  expect(runCommand.mock.calls).toEqual([
+    ['app:start', ['--env', 'app1', '--yes', '--no-sync-licensed-plugins', '--hook-command', 'init']],
+    ['env:update', ['app1']],
+  ]);
   expect(mocks.clearEnvRootSetup).toHaveBeenCalledWith('app1', { scope: 'global' });
 });
 
@@ -675,12 +664,7 @@ test('install reuses saved appKey and timezone before resuming docker startup', 
   const saveInstalledEnv = vi.fn(async () => undefined);
   const waitForAppHealthCheck = vi.fn(async () => undefined);
   const downloadManagedSource = vi.fn(async () => undefined);
-  const installDockerApp = vi.fn(async () => ({
-    containerName: 'nb-chen-app1-app',
-    appPort: '13080',
-    appKey: 'saved-app-key',
-    timeZone: 'Asia/Shanghai',
-  }));
+  const runCommand = vi.fn(async () => undefined);
 
   const command = Object.assign(Object.create(Install.prototype), {
     parse: vi.fn(async () => ({
@@ -712,17 +696,20 @@ test('install reuses saved appKey and timezone before resuming docker startup', 
     saveInstalledEnv,
     waitForAppHealthCheck,
     downloadManagedSource,
-    installDockerApp,
     commandStdio: vi.fn(() => 'ignore'),
-    config: { runCommand: vi.fn(async () => undefined) },
+    config: { runCommand },
   });
 
   await Install.prototype.run.call(command);
 
-  expect(installDockerApp.mock.calls[0]?.[0].appResults).toMatchObject({
+  expect(saveInstalledEnv.mock.calls.at(-1)?.[0].appResults).toMatchObject({
     appKey: 'saved-app-key',
     timeZone: 'Asia/Shanghai',
   });
+  expect(runCommand.mock.calls[0]).toEqual([
+    'app:start',
+    ['--env', 'app1', '--yes', '--no-sync-licensed-plugins', '--hook-command', 'init'],
+  ]);
 });
 
 test('install --resume keeps saved basic auth credentials editable in prompts', async () => {

--- a/packages/core/cli/src/__tests__/proxy-caddy-command.test.ts
+++ b/packages/core/cli/src/__tests__/proxy-caddy-command.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   resolveManagedAppRuntime: vi.fn(),
+  resolveEnvProxyEntry: vi.fn(),
+  setEnvProxyEntry: vi.fn(),
   setCaddyProxyDriver: vi.fn(),
   getCaddyProxyDriver: vi.fn(),
   resolveCaddyProxyRuntimeContext: vi.fn(),
@@ -35,6 +37,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../lib/app-runtime.js', () => ({
   resolveManagedAppRuntime: mocks.resolveManagedAppRuntime,
   formatMissingManagedAppEnvMessage: vi.fn((envName?: string) => `missing:${envName ?? ''}`),
+}));
+
+vi.mock('../lib/auth-store.js', () => ({
+  resolveEnvProxyEntry: mocks.resolveEnvProxyEntry,
+  setEnvProxyEntry: mocks.setEnvProxyEntry,
 }));
 
 vi.mock('../lib/proxy-caddy.js', () => ({
@@ -77,6 +84,10 @@ vi.mock('../lib/env-proxy.js', () => ({
   mapProxyPathFromCliRoot: mocks.mapProxyPathFromCliRoot,
 }));
 
+vi.mock('../lib/cli-home.js', () => ({
+  resolveDefaultConfigScope: vi.fn(() => 'local'),
+}));
+
 vi.mock('../lib/cli-config.js', async () => {
   const actual = await vi.importActual<typeof import('../lib/cli-config.js')>('../lib/cli-config.js');
   return {
@@ -87,6 +98,8 @@ vi.mock('../lib/cli-config.js', async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.resolveEnvProxyEntry.mockReturnValue(undefined);
+  mocks.setEnvProxyEntry.mockResolvedValue(undefined);
   mocks.setCaddyProxyDriver.mockResolvedValue('docker');
   mocks.getCaddyProxyDriver.mockResolvedValue('local');
   mocks.resolveCaddyProxyRuntimeContext.mockResolvedValue({
@@ -199,6 +212,15 @@ test('proxy caddy generate writes proxy files with the current runtime context',
       cdnBaseUrl: 'https://cdn.example.com/ui/',
     },
   );
+  expect(mocks.setEnvProxyEntry).toHaveBeenCalledWith(
+    'test2',
+    'caddy',
+    {
+      host: 'c.local.nocobase.com',
+      port: undefined,
+    },
+    { scope: 'local' },
+  );
   expect(mocks.succeedTask).toHaveBeenCalledWith(
     'Saved caddy proxy files for env "test2" under /Users/chen/test4/.nocobase/proxy/caddy/test2, and created app.caddy at /Users/chen/test4/.nocobase/proxy/caddy/test2/app.caddy.',
   );
@@ -244,6 +266,59 @@ test('proxy caddy generate defaults to the current env when --env is omitted', a
     {
       cdnBaseUrl: undefined,
     },
+  );
+});
+
+test('proxy caddy generate falls back to saved env proxy settings when flags are omitted', async () => {
+  const { default: ProxyCaddyGenerate } = await import('../commands/proxy/caddy/generate.js');
+  mocks.resolveManagedAppRuntime.mockResolvedValue({
+    kind: 'local',
+    envName: 'current-env',
+    env: { config: {} },
+  });
+  mocks.resolveEnvProxyEntry.mockReturnValue({
+    host: 'saved.local.nocobase.com',
+    port: 8080,
+  });
+  mocks.writeCaddyProxyBundle.mockResolvedValue({
+    status: 'updated',
+    bundle: {
+      entryDir: '/Users/chen/test4/.nocobase/proxy/caddy/current-env',
+      appConfigPath: '/Users/chen/test4/.nocobase/proxy/caddy/current-env/app.caddy',
+    },
+  });
+
+  const command = Object.assign(Object.create(ProxyCaddyGenerate.prototype), {
+    parse: vi.fn(async () => ({
+      flags: {},
+    })),
+  });
+
+  await ProxyCaddyGenerate.prototype.run.call(command);
+
+  expect(mocks.writeCaddyProxyBundle).toHaveBeenCalledWith(
+    expect.objectContaining({ envName: 'current-env' }),
+    {
+      host: 'saved.local.nocobase.com',
+      port: '8080',
+    },
+    {
+      driver: 'local',
+      runtimeCliRoot: '/Users/chen/test4',
+      upstreamHost: '127.0.0.1',
+    },
+    {
+      cdnBaseUrl: undefined,
+    },
+  );
+  expect(mocks.setEnvProxyEntry).toHaveBeenCalledWith(
+    'current-env',
+    'caddy',
+    {
+      host: 'saved.local.nocobase.com',
+      port: 8080,
+    },
+    { scope: 'local' },
   );
 });
 

--- a/packages/core/cli/src/__tests__/proxy-caddy-runtime.test.ts
+++ b/packages/core/cli/src/__tests__/proxy-caddy-runtime.test.ts
@@ -1,0 +1,162 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dockerContainerExists: vi.fn(),
+  dockerContainerIsRunning: vi.fn(),
+  startDockerContainer: vi.fn(),
+  stopDockerContainer: vi.fn(),
+  loadAuthConfig: vi.fn(),
+  getCliConfigValue: vi.fn(),
+  resolveDockerContainerPrefix: vi.fn(),
+  setCliConfigValue: vi.fn(),
+  buildEnvProxyMainConfig: vi.fn(),
+  mapProxyPathFromCliRoot: vi.fn(),
+  resolveEnvProxyMainOutputPath: vi.fn(),
+  commandOutput: vi.fn(),
+  run: vi.fn(),
+}));
+
+vi.mock('../lib/app-runtime.js', () => ({
+  dockerContainerExists: mocks.dockerContainerExists,
+  dockerContainerIsRunning: mocks.dockerContainerIsRunning,
+  startDockerContainer: mocks.startDockerContainer,
+  stopDockerContainer: mocks.stopDockerContainer,
+}));
+
+vi.mock('../lib/auth-store.js', () => ({
+  loadAuthConfig: mocks.loadAuthConfig,
+}));
+
+vi.mock('../lib/cli-config.js', () => ({
+  CADDY_PROXY_DRIVER_OPTIONS: ['local', 'docker'],
+  DEFAULT_CADDY_PROXY_DRIVER: 'local',
+  getCliConfigValue: mocks.getCliConfigValue,
+  normalizeCaddyProxyDriver: vi.fn(),
+  resolveDockerContainerPrefix: mocks.resolveDockerContainerPrefix,
+  setCliConfigValue: mocks.setCliConfigValue,
+}));
+
+vi.mock('../lib/env-proxy.js', () => ({
+  applyEnvProxyAppEntryOptions: vi.fn(),
+  buildManualEnvProxyCaddyBundle: vi.fn(),
+  buildEnvProxyCaddyBundle: vi.fn(),
+  buildEnvProxyMainConfig: mocks.buildEnvProxyMainConfig,
+  mapProxyPathFromCliRoot: mocks.mapProxyPathFromCliRoot,
+  resolveEnvProxyMainOutputPath: mocks.resolveEnvProxyMainOutputPath,
+}));
+
+vi.mock('../lib/run-npm.js', () => ({
+  commandOutput: mocks.commandOutput,
+  run: mocks.run,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NB_CLI_ROOT = '/tmp/nocobase-cli-proxy-caddy-runtime';
+  mocks.dockerContainerExists.mockResolvedValue(false);
+  mocks.dockerContainerIsRunning.mockResolvedValue(false);
+  mocks.resolveDockerContainerPrefix.mockResolvedValue('nb');
+  mocks.resolveEnvProxyMainOutputPath.mockReturnValue(
+    '/tmp/nocobase-cli-proxy-caddy-runtime/.nocobase/proxy/caddy/nocobase.caddy',
+  );
+  mocks.buildEnvProxyMainConfig.mockResolvedValue('import /apps/.nocobase/proxy/caddy/*/app.caddy');
+  mocks.loadAuthConfig.mockResolvedValue({
+    lastEnv: 'app1',
+    envs: {
+      app1: {
+        proxy: {
+          host: 'a.local.nocobase.com',
+          port: 8080,
+        },
+      },
+      app2: {
+        proxy: {
+          host: 'b.local.nocobase.com',
+          port: 80,
+        },
+      },
+      app3: {
+        proxy: {
+          host: 'c.local.nocobase.com',
+          port: 8443,
+        },
+      },
+    },
+  });
+  mocks.commandOutput.mockResolvedValue('{}');
+  mocks.run.mockResolvedValue(undefined);
+});
+
+test('startCaddyProxy publishes docker ports 80, 443, and saved env proxy ports', async () => {
+  const { startCaddyProxy } = await import('../lib/proxy-caddy.js');
+
+  await startCaddyProxy({
+    driver: 'docker',
+    runtimeCliRoot: '/apps',
+    upstreamHost: 'host.docker.internal',
+  });
+
+  expect(mocks.run).toHaveBeenCalledWith(
+    'docker',
+    [
+      'run',
+      '-d',
+      '--name',
+      'nb-caddy-proxy',
+      '--add-host',
+      'host.docker.internal:host-gateway',
+      '-p',
+      '80:80',
+      '-p',
+      '443:443',
+      '-p',
+      '8080:8080',
+      '-p',
+      '8443:8443',
+      '-v',
+      '/tmp/nocobase-cli-proxy-caddy-runtime:/apps',
+      '-v',
+      '/tmp/nocobase-cli-proxy-caddy-runtime/.nocobase/proxy/caddy/nocobase.caddy:/etc/caddy/Caddyfile:ro',
+      'caddy:latest',
+    ],
+    {
+      errorName: 'docker run',
+      stdio: 'ignore',
+    },
+  );
+});
+
+test('startCaddyProxy recreates the docker container when published ports changed', async () => {
+  mocks.dockerContainerExists.mockResolvedValue(true);
+  mocks.commandOutput.mockResolvedValueOnce('{"80/tcp":[{"HostPort":"80"}]}');
+
+  const { startCaddyProxy } = await import('../lib/proxy-caddy.js');
+
+  await startCaddyProxy({
+    driver: 'docker',
+    runtimeCliRoot: '/apps',
+    upstreamHost: 'host.docker.internal',
+  });
+
+  expect(mocks.run).toHaveBeenCalledWith('docker', ['rm', '-f', 'nb-caddy-proxy'], {
+    errorName: 'docker rm',
+    stdio: 'ignore',
+  });
+  expect(mocks.run).toHaveBeenCalledWith(
+    'docker',
+    expect.arrayContaining(['run', '-d', '--name', 'nb-caddy-proxy']),
+    {
+      errorName: 'docker run',
+      stdio: 'ignore',
+    },
+  );
+});

--- a/packages/core/cli/src/__tests__/proxy-nginx-command.test.ts
+++ b/packages/core/cli/src/__tests__/proxy-nginx-command.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   resolveManagedAppRuntime: vi.fn(),
+  resolveEnvProxyEntry: vi.fn(),
+  setEnvProxyEntry: vi.fn(),
   setNginxProxyDriver: vi.fn(),
   getNginxProxyDriver: vi.fn(),
   resolveNginxProxyRuntimeContext: vi.fn(),
@@ -35,6 +37,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../lib/app-runtime.js', () => ({
   resolveManagedAppRuntime: mocks.resolveManagedAppRuntime,
   formatMissingManagedAppEnvMessage: vi.fn((envName?: string) => `missing:${envName ?? ''}`),
+}));
+
+vi.mock('../lib/auth-store.js', () => ({
+  resolveEnvProxyEntry: mocks.resolveEnvProxyEntry,
+  setEnvProxyEntry: mocks.setEnvProxyEntry,
 }));
 
 vi.mock('../lib/proxy-nginx.js', () => ({
@@ -75,6 +82,10 @@ vi.mock('../lib/env-proxy.js', () => ({
   mapProxyPathFromCliRoot: mocks.mapProxyPathFromCliRoot,
 }));
 
+vi.mock('../lib/cli-home.js', () => ({
+  resolveDefaultConfigScope: vi.fn(() => 'local'),
+}));
+
 vi.mock('../lib/cli-config.js', async () => {
   const actual = await vi.importActual<typeof import('../lib/cli-config.js')>('../lib/cli-config.js');
   return {
@@ -85,6 +96,8 @@ vi.mock('../lib/cli-config.js', async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.resolveEnvProxyEntry.mockReturnValue(undefined);
+  mocks.setEnvProxyEntry.mockResolvedValue(undefined);
   mocks.setNginxProxyDriver.mockResolvedValue('docker');
   mocks.getNginxProxyDriver.mockResolvedValue('local');
   mocks.resolveNginxProxyRuntimeContext.mockResolvedValue({
@@ -200,6 +213,15 @@ test('proxy nginx generate writes proxy files with the current runtime context',
       force: false,
     },
   );
+  expect(mocks.setEnvProxyEntry).toHaveBeenCalledWith(
+    'test2',
+    'nginx',
+    {
+      host: 'c.local.nocobase.com',
+      port: undefined,
+    },
+    { scope: 'local' },
+  );
   expect(mocks.succeedTask).toHaveBeenCalledWith(
     'Saved nginx proxy files for env "test2" under /Users/chen/test4/.nocobase/proxy/nginx/test2, and created editable app entry config at /Users/chen/test4/.nocobase/proxy/nginx/test2/app.conf.',
   );
@@ -246,6 +268,61 @@ test('proxy nginx generate defaults to the current env when --env is omitted', a
     {
       force: false,
     },
+  );
+});
+
+test('proxy nginx generate falls back to saved env proxy settings when flags are omitted', async () => {
+  const { default: ProxyNginxGenerate } = await import('../commands/proxy/nginx/generate.js');
+  mocks.resolveManagedAppRuntime.mockResolvedValue({
+    kind: 'local',
+    envName: 'current-env',
+    env: { config: {} },
+  });
+  mocks.resolveEnvProxyEntry.mockReturnValue({
+    host: 'saved.local.nocobase.com',
+    port: 8080,
+  });
+  mocks.writeNginxProxyBundle.mockResolvedValue({
+    status: 'updated',
+    bundle: {
+      entryDir: '/Users/chen/test4/.nocobase/proxy/nginx/current-env',
+      appConfigPath: '/Users/chen/test4/.nocobase/proxy/nginx/current-env/app.conf',
+    },
+  });
+
+  const command = Object.assign(Object.create(ProxyNginxGenerate.prototype), {
+    parse: vi.fn(async () => ({
+      flags: {
+        force: false,
+      },
+    })),
+  });
+
+  await ProxyNginxGenerate.prototype.run.call(command);
+
+  expect(mocks.writeNginxProxyBundle).toHaveBeenCalledWith(
+    expect.objectContaining({ envName: 'current-env' }),
+    {
+      host: 'saved.local.nocobase.com',
+      port: '8080',
+    },
+    {
+      driver: 'local',
+      runtimeCliRoot: '/Users/chen/test4',
+      upstreamHost: '127.0.0.1',
+    },
+    {
+      force: false,
+    },
+  );
+  expect(mocks.setEnvProxyEntry).toHaveBeenCalledWith(
+    'current-env',
+    'nginx',
+    {
+      host: 'saved.local.nocobase.com',
+      port: 8080,
+    },
+    { scope: 'local' },
   );
 });
 

--- a/packages/core/cli/src/__tests__/proxy-nginx-runtime.test.ts
+++ b/packages/core/cli/src/__tests__/proxy-nginx-runtime.test.ts
@@ -1,0 +1,172 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dockerContainerExists: vi.fn(),
+  dockerContainerIsRunning: vi.fn(),
+  startDockerContainer: vi.fn(),
+  stopDockerContainer: vi.fn(),
+  loadAuthConfig: vi.fn(),
+  getCliConfigValue: vi.fn(),
+  resolveDockerContainerPrefix: vi.fn(),
+  setCliConfigValue: vi.fn(),
+  buildEnvProxyMainConfig: vi.fn(),
+  installEnvProxyProvider: vi.fn(),
+  mapProxyPathFromCliRoot: vi.fn(),
+  reloadEnvProxyProvider: vi.fn(),
+  resolveEnvProxyMainOutputPath: vi.fn(),
+  syncEnvProxyNginxSnippets: vi.fn(),
+  commandOutput: vi.fn(),
+  run: vi.fn(),
+}));
+
+vi.mock('../lib/app-runtime.js', () => ({
+  dockerContainerExists: mocks.dockerContainerExists,
+  dockerContainerIsRunning: mocks.dockerContainerIsRunning,
+  startDockerContainer: mocks.startDockerContainer,
+  stopDockerContainer: mocks.stopDockerContainer,
+}));
+
+vi.mock('../lib/auth-store.js', () => ({
+  loadAuthConfig: mocks.loadAuthConfig,
+}));
+
+vi.mock('../lib/cli-config.js', () => ({
+  DEFAULT_NGINX_PROXY_DRIVER: 'local',
+  NGINX_PROXY_DRIVER_OPTIONS: ['local', 'docker'],
+  getCliConfigValue: mocks.getCliConfigValue,
+  normalizeNginxProxyDriver: vi.fn(),
+  resolveDockerContainerPrefix: mocks.resolveDockerContainerPrefix,
+  setCliConfigValue: mocks.setCliConfigValue,
+}));
+
+vi.mock('../lib/env-proxy.js', () => ({
+  applyEnvProxyAppEntryOptions: vi.fn(),
+  appConfigHasManagedNginxBlock: vi.fn(),
+  buildManualEnvProxyNginxBundle: vi.fn(),
+  buildEnvProxyMainConfig: mocks.buildEnvProxyMainConfig,
+  buildEnvProxyNginxBundle: vi.fn(),
+  extractManagedNginxConfigBlock: vi.fn(),
+  installEnvProxyProvider: mocks.installEnvProxyProvider,
+  mapProxyPathFromCliRoot: mocks.mapProxyPathFromCliRoot,
+  reloadEnvProxyProvider: mocks.reloadEnvProxyProvider,
+  resolveEnvProxyMainOutputPath: mocks.resolveEnvProxyMainOutputPath,
+  replaceManagedNginxConfigBlock: vi.fn(),
+  syncEnvProxyNginxSnippets: mocks.syncEnvProxyNginxSnippets,
+}));
+
+vi.mock('../lib/run-npm.js', () => ({
+  commandOutput: mocks.commandOutput,
+  run: mocks.run,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NB_CLI_ROOT = '/tmp/nocobase-cli-proxy-nginx-runtime';
+  mocks.dockerContainerExists.mockResolvedValue(false);
+  mocks.dockerContainerIsRunning.mockResolvedValue(false);
+  mocks.resolveDockerContainerPrefix.mockResolvedValue('nb');
+  mocks.resolveEnvProxyMainOutputPath.mockReturnValue(
+    '/tmp/nocobase-cli-proxy-nginx-runtime/.nocobase/proxy/nginx/nocobase.conf',
+  );
+  mocks.buildEnvProxyMainConfig.mockResolvedValue('include /apps/.nocobase/proxy/nginx/*/app.conf;');
+  mocks.syncEnvProxyNginxSnippets.mockResolvedValue(undefined);
+  mocks.loadAuthConfig.mockResolvedValue({
+    lastEnv: 'app1',
+    envs: {
+      app1: {
+        proxy: {
+          host: 'a.local.nocobase.com',
+          port: 8080,
+        },
+      },
+      app2: {
+        proxy: {
+          host: 'b.local.nocobase.com',
+          port: 80,
+        },
+      },
+      app3: {
+        proxy: {
+          host: 'c.local.nocobase.com',
+          port: 8443,
+        },
+      },
+    },
+  });
+  mocks.commandOutput.mockResolvedValue('{}');
+  mocks.run.mockResolvedValue(undefined);
+});
+
+test('startNginxProxy publishes docker ports 80, 443, and saved env proxy ports', async () => {
+  const { startNginxProxy } = await import('../lib/proxy-nginx.js');
+
+  await startNginxProxy({
+    driver: 'docker',
+    runtimeCliRoot: '/apps',
+    upstreamHost: 'host.docker.internal',
+  });
+
+  expect(mocks.run).toHaveBeenCalledWith(
+    'docker',
+    [
+      'run',
+      '-d',
+      '--name',
+      'nb-nginx-proxy',
+      '--add-host',
+      'host.docker.internal:host-gateway',
+      '-p',
+      '80:80',
+      '-p',
+      '443:443',
+      '-p',
+      '8080:8080',
+      '-p',
+      '8443:8443',
+      '-v',
+      '/tmp/nocobase-cli-proxy-nginx-runtime:/apps',
+      '-v',
+      '/tmp/nocobase-cli-proxy-nginx-runtime/.nocobase/proxy/nginx/nocobase.conf:/etc/nginx/conf.d/default.conf:ro',
+      'nginx:latest',
+    ],
+    {
+      errorName: 'docker run',
+      stdio: 'ignore',
+    },
+  );
+});
+
+test('startNginxProxy recreates the docker container when published ports changed', async () => {
+  mocks.dockerContainerExists.mockResolvedValue(true);
+  mocks.commandOutput.mockResolvedValueOnce('{"80/tcp":[{"HostPort":"80"}]}');
+
+  const { startNginxProxy } = await import('../lib/proxy-nginx.js');
+
+  await startNginxProxy({
+    driver: 'docker',
+    runtimeCliRoot: '/apps',
+    upstreamHost: 'host.docker.internal',
+  });
+
+  expect(mocks.run).toHaveBeenCalledWith('docker', ['rm', '-f', 'nb-nginx-proxy'], {
+    errorName: 'docker rm',
+    stdio: 'ignore',
+  });
+  expect(mocks.run).toHaveBeenCalledWith(
+    'docker',
+    expect.arrayContaining(['run', '-d', '--name', 'nb-nginx-proxy']),
+    {
+      errorName: 'docker run',
+      stdio: 'ignore',
+    },
+  );
+});

--- a/packages/core/cli/src/commands/app/start.ts
+++ b/packages/core/cli/src/commands/app/start.ts
@@ -73,6 +73,9 @@ function buildLicenseSyncArgv(
 
 function resolveHookCommand(value: unknown): HookCommand {
   const text = String(value ?? '').trim();
+  if (text === 'init') {
+    return text;
+  }
   if (text === 'app:restart' || text === 'app:upgrade') {
     return text;
   }
@@ -302,7 +305,7 @@ export default class AppStart extends Command {
     }),
     'hook-command': Flags.string({
       hidden: true,
-      options: ['app:start', 'app:restart', 'app:upgrade'],
+      options: ['init', 'app:start', 'app:restart', 'app:upgrade'],
     }),
   };
 

--- a/packages/core/cli/src/commands/install.ts
+++ b/packages/core/cli/src/commands/install.ts
@@ -3007,6 +3007,14 @@ export default class Install extends Command {
     await this.config.runCommand('env:update', [params.envName]);
   }
 
+  private buildAppStartArgv(params: { envName: string; verbose?: boolean }): string[] {
+    const argv = ['--env', params.envName, '--yes', '--no-sync-licensed-plugins', '--hook-command', 'init'];
+    if (params.verbose) {
+      argv.push('--verbose');
+    }
+    return argv;
+  }
+
   private async runInstallHookIfNeeded(params: {
     hookName: HookName;
     envName: string;
@@ -3296,7 +3304,6 @@ export default class Install extends Command {
     const parsed = {
       ...(flags as unknown as InstallParsedFlags & DownloadParsedFlags),
     } as InstallParsedFlags & DownloadParsedFlags;
-    const defaultApiHost = await resolveDefaultApiHost();
     if (parsed['skip-auth'] && (parsed['access-token'] !== undefined || parsed.token !== undefined)) {
       this.error('--skip-auth cannot be used with --access-token or --token.');
     }
@@ -3384,8 +3391,7 @@ export default class Install extends Command {
       dbResults.dbPassword = builtinDbPlan.dbPassword;
     }
 
-    let dockerAppPlan: DockerAppPlan | undefined;
-    let localAppPlan: LocalAppPlan | undefined;
+    let shouldStartApp = false;
     if (source === 'docker' || source === 'npm' || source === 'git') {
       this.logStage('Preparing application');
       if (source === 'docker') {
@@ -3397,115 +3403,27 @@ export default class Install extends Command {
           printInfo('Application image ready.');
         }
         if (!parsed['prepare-only']) {
-          await this.runInstallHookIfNeeded({
-            hookName: 'beforeAppInstall',
-            envName,
-            source,
-            appResults,
-            downloadResults,
-            dbResults,
-            rootResults,
-            envAddResults,
-            defaultApiHost,
-          });
-          dockerAppPlan = await this.installDockerApp({
-            envName,
-            dockerNetworkName,
-            dockerContainerPrefix,
-            appResults,
-            downloadResults,
-            dbResults,
-            rootResults,
-            builtinDbPlan,
-            force: parsed.force,
-            commandStdio,
-          });
-          appResults.appKey = dockerAppPlan.appKey;
-          appResults.timeZone = dockerAppPlan.timeZone;
+          shouldStartApp = true;
         }
       } else if (source === 'npm' || source === 'git') {
-        const localSource: 'npm' | 'git' = source === 'npm' ? 'npm' : 'git';
-        const projectRoot =
-          parsed['skip-download'] || parsed['prepare-only']
-            ? Install.resolveLocalProjectRoot({
-                envName,
-                appResults,
-                downloadResults,
-              })
-            : await this.downloadLocalApp({
-                envName,
-                appResults,
-                downloadResults,
-                verbose: parsed.verbose,
-              });
         if (!parsed['skip-download'] && !parsed['prepare-only']) {
+          await this.downloadLocalApp({
+            envName,
+            appResults,
+            downloadResults,
+            verbose: parsed.verbose,
+          });
           printInfo('Application files ready.');
         }
         if (!parsed['prepare-only']) {
-          await this.runInstallHookIfNeeded({
-            hookName: 'beforeAppInstall',
-            envName,
-            source,
-            appResults,
-            downloadResults,
-            dbResults,
-            rootResults,
-            envAddResults,
-            projectRoot,
-            defaultApiHost,
-          });
-          localAppPlan = await this.startLocalApp({
-            envName,
-            source: localSource,
-            projectRoot,
-            appResults,
-            dbResults,
-            rootResults,
-            commandStdio,
-          });
-          appResults.appKey = localAppPlan.appKey;
-          appResults.timeZone = localAppPlan.timeZone;
+          shouldStartApp = true;
         }
       }
     } else {
       this.logDetail('Skipped app download and install.');
     }
 
-    if (dockerAppPlan || localAppPlan) {
-      this.logStage('Starting NocoBase');
-      await this.waitForAppHealthCheck(
-        Install.resolveApiBaseUrl({
-          appResults,
-          envAddResults,
-          defaultApiHost,
-        }),
-        {
-          containerName: dockerAppPlan?.containerName,
-          verbose: parsed.verbose,
-        },
-      );
-      const displayApiBaseUrl = Install.resolveApiBaseUrl({
-        appResults,
-        envAddResults,
-        defaultApiHost,
-      });
-      printInfo(`NocoBase is ready at ${formatInstallDisplayUrl(displayApiBaseUrl)}`);
-      appResults.setupState = 'installed';
-      await this.runInstallHookIfNeeded({
-        hookName: 'afterAppStart',
-        envName,
-        source,
-        appResults,
-        downloadResults,
-        dbResults,
-        rootResults,
-        envAddResults,
-        projectRoot: localAppPlan?.projectRoot,
-        defaultApiHost,
-      });
-    }
-
-    if (dockerAppPlan || localAppPlan || builtinDbPlan) {
+    if (shouldStartApp || builtinDbPlan) {
       await this.saveInstalledEnv({
         envName,
         appResults,
@@ -3516,10 +3434,15 @@ export default class Install extends Command {
       });
     }
 
+    if (shouldStartApp) {
+      this.logStage('Starting NocoBase');
+      await this.config.runCommand('app:start', this.buildAppStartArgv({ envName, verbose: parsed.verbose }));
+    }
+
     await this.syncInstalledEnvConnection({
       envName,
       envAddResults,
-      appReady: Boolean(dockerAppPlan || localAppPlan),
+      appReady: shouldStartApp,
       skipAuth: Boolean(parsed['skip-auth']),
     });
     if (!parsed['prepare-only']) {
@@ -3530,7 +3453,7 @@ export default class Install extends Command {
       printInfo(
         `Preparation complete for "${envName}". Activate the license, then run \`nb app start --env ${envName}\`.`,
       );
-    } else if (!dockerAppPlan && !localAppPlan) {
+    } else if (!shouldStartApp) {
       printInfo(`Install config for "${envName}" has been saved.`);
     }
   }

--- a/packages/core/cli/src/commands/proxy/caddy/generate.ts
+++ b/packages/core/cli/src/commands/proxy/caddy/generate.ts
@@ -13,6 +13,8 @@ import {
   resolveManagedAppRuntime,
   type ManagedAppRuntime,
 } from '../../../lib/app-runtime.js';
+import { resolveEnvProxyEntry, setEnvProxyEntry } from '../../../lib/auth-store.js';
+import { resolveDefaultConfigScope } from '../../../lib/cli-home.js';
 import {
   getCaddyProxyDriver,
   writeManualCaddyProxyBundle,
@@ -170,16 +172,27 @@ export default class ProxyCaddyGenerate extends Command {
     startTask(`Generating caddy proxy config for env "${runtime.envName}" with the ${driver} driver...`);
 
     try {
+      const savedAppEntryOptions = resolveEnvProxyEntry(runtime.env.config, 'caddy');
+      const appEntryOptions = {
+        host: flags.host?.trim() || savedAppEntryOptions?.host,
+        port: normalizedPort ?? (savedAppEntryOptions?.port !== undefined ? String(savedAppEntryOptions.port) : undefined),
+      };
       const { bundle, status } = await writeCaddyProxyBundle(
         runtime as WritableProxyRuntime,
-        {
-          host: flags.host?.trim() || undefined,
-          port: normalizedPort,
-        },
+        appEntryOptions,
         runtimeContext,
         {
           cdnBaseUrl: flags['cdn-base-url']?.trim() || undefined,
         },
+      );
+      await setEnvProxyEntry(
+        runtime.envName,
+        'caddy',
+        {
+          host: appEntryOptions.host,
+          port: appEntryOptions.port ? Number(appEntryOptions.port) : undefined,
+        },
+        { scope: resolveDefaultConfigScope() },
       );
       succeedTask(
         status === 'created'

--- a/packages/core/cli/src/commands/proxy/nginx/generate.ts
+++ b/packages/core/cli/src/commands/proxy/nginx/generate.ts
@@ -13,6 +13,7 @@ import {
   resolveManagedAppRuntime,
   type ManagedAppRuntime,
 } from '../../../lib/app-runtime.js';
+import { resolveDefaultConfigScope } from '../../../lib/cli-home.js';
 import {
   getNginxProxyDriver,
   normalizeProxyListenPort,
@@ -20,6 +21,7 @@ import {
   writeManualNginxProxyBundle,
   writeNginxProxyBundle,
 } from '../../../lib/proxy-nginx.js';
+import { resolveEnvProxyEntry, setEnvProxyEntry } from '../../../lib/auth-store.js';
 import { announceTargetEnv, failTask, startTask, succeedTask } from '../../../lib/ui.js';
 
 type WritableProxyRuntime = Extract<ManagedAppRuntime, { kind: 'local' | 'docker' }>;
@@ -174,17 +176,28 @@ export default class ProxyNginxGenerate extends Command {
     startTask(`Generating nginx proxy config for env "${runtime.envName}" with the ${driver} driver...`);
 
     try {
+      const savedAppEntryOptions = resolveEnvProxyEntry(runtime.env.config, 'nginx');
+      const appEntryOptions = {
+        host: flags.host?.trim() || savedAppEntryOptions?.host,
+        port: normalizedPort ?? (savedAppEntryOptions?.port !== undefined ? String(savedAppEntryOptions.port) : undefined),
+      };
       const { bundle, status } = await writeNginxProxyBundle(
         runtime as WritableProxyRuntime,
-        {
-          host: flags.host?.trim() || undefined,
-          port: normalizedPort,
-        },
+        appEntryOptions,
         runtimeContext,
         {
           cdnBaseUrl: flags['cdn-base-url']?.trim() || undefined,
           force: flags.force,
         },
+      );
+      await setEnvProxyEntry(
+        runtime.envName,
+        'nginx',
+        {
+          host: appEntryOptions.host,
+          port: appEntryOptions.port ? Number(appEntryOptions.port) : undefined,
+        },
+        { scope: resolveDefaultConfigScope() },
       );
       succeedTask(
         status === 'created'

--- a/packages/core/cli/src/lib/auth-store.ts
+++ b/packages/core/cli/src/lib/auth-store.ts
@@ -19,6 +19,7 @@ import {
   type EnvProxyConfig,
   type EnvProxyProvider,
   type EnvProxyProviderConfig,
+  type EnvResolvedProxyEntry,
 } from './env-proxy-config.js';
 import {
   inferConfiguredAppPathFromLegacyConfig,
@@ -847,13 +848,14 @@ export async function setEnvRuntime(
 export function resolveEnvProxyEntry(
   config: Pick<EnvConfigEntry, 'proxy'> | undefined,
   provider: EnvProxyProvider,
-): EnvProxyProviderConfig | undefined {
+): EnvResolvedProxyEntry | undefined {
   const proxy = normalizeEnvProxyConfig(config?.proxy);
-  return {
+  const resolved: EnvResolvedProxyEntry = {
     ...(proxy?.host ? { host: proxy.host } : {}),
     ...(proxy?.port !== undefined ? { port: proxy.port } : {}),
     ...((provider === 'nginx' ? proxy?.nginx : proxy?.caddy) ?? {}),
   };
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 
 export async function setEnvProxyEntry(

--- a/packages/core/cli/src/lib/auth-store.ts
+++ b/packages/core/cli/src/lib/auth-store.ts
@@ -14,6 +14,13 @@ import { resolveAppPublicPath } from './app-public-path.js';
 import { resolveCliHomeDir, resolveConfiguredEnvPath, resolveEnvRelativePath } from './cli-home.js';
 import { normalizeCliLocale } from './cli-locale.js';
 import {
+  normalizeEnvProxyConfig,
+  normalizeEnvProxyProviderConfig,
+  type EnvProxyConfig,
+  type EnvProxyProvider,
+  type EnvProxyProviderConfig,
+} from './env-proxy-config.js';
+import {
   inferConfiguredAppPathFromLegacyConfig,
   resolveConfiguredAppPath,
   resolveConfiguredSourcePath,
@@ -123,6 +130,7 @@ export interface EnvConfigEntry {
     schemaHash?: string;
     generatedAt?: string;
   };
+  proxy?: EnvProxyConfig;
 }
 
 export interface AuthConfig {
@@ -270,12 +278,14 @@ function normalizeEnvConfigEntry(entry: EnvConfigEntry | undefined): EnvConfigEn
   const normalizedKind = resolveEnvKind(entry);
   const apiBaseUrl = readEnvApiBaseUrl(entry);
   const schemaVersion = normalizeEnvConfigSchemaVersion(entry.schemaVersion);
+  const proxy = normalizeEnvProxyConfig(entry.proxy);
   return {
     ...rest,
     ...(schemaVersion ? { schemaVersion } : {}),
     ...(normalizedKind ? { kind: normalizedKind } : {}),
     ...(apiBaseUrl !== undefined ? { apiBaseUrl } : {}),
     ...(normalizeOptionalString(entry.appPublicPath) ? { appPublicPath: resolveAppPublicPath(entry.appPublicPath) } : {}),
+    ...(proxy ? { proxy } : {}),
   };
 }
 
@@ -832,6 +842,79 @@ export async function setEnvRuntime(
     runtime,
   };
   await saveAuthConfig(config, options);
+}
+
+export function resolveEnvProxyEntry(
+  config: Pick<EnvConfigEntry, 'proxy'> | undefined,
+  provider: EnvProxyProvider,
+): EnvProxyProviderConfig | undefined {
+  const proxy = normalizeEnvProxyConfig(config?.proxy);
+  return {
+    ...(proxy?.host ? { host: proxy.host } : {}),
+    ...(proxy?.port !== undefined ? { port: proxy.port } : {}),
+    ...((provider === 'nginx' ? proxy?.nginx : proxy?.caddy) ?? {}),
+  };
+}
+
+export async function setEnvProxyEntry(
+  envName: string,
+  provider: EnvProxyProvider,
+  entry: EnvProxyProviderConfig | undefined,
+  options: AuthStoreOptions = {},
+) {
+  await writeEnv(
+    envName,
+    (previous) => {
+      const currentProxy = normalizeEnvProxyConfig(previous?.proxy) ?? {};
+      const nextEntry = normalizeEnvProxyProviderConfig(entry);
+      const nextProxy: EnvProxyConfig = { ...currentProxy };
+
+      if (nextEntry && 'host' in nextEntry) {
+        const host = normalizeOptionalString(nextEntry.host);
+        if (host) {
+          nextProxy.host = host;
+        } else {
+          delete nextProxy.host;
+        }
+      }
+
+      if (nextEntry && 'port' in nextEntry) {
+        const portValue = nextEntry.port;
+        const port =
+          typeof portValue === 'number' && Number.isInteger(portValue) && portValue >= 1 && portValue <= 65535
+            ? portValue
+            : undefined;
+        if (port !== undefined) {
+          nextProxy.port = port;
+        } else {
+          delete nextProxy.port;
+        }
+      }
+
+      const providerConfig =
+        nextEntry && Object.keys(nextEntry).some((key) => key !== 'host' && key !== 'port')
+          ? Object.fromEntries(Object.entries(nextEntry).filter(([key]) => key !== 'host' && key !== 'port'))
+          : undefined;
+
+      if (provider === 'nginx') {
+        if (providerConfig && Object.keys(providerConfig).length > 0) {
+          nextProxy.nginx = providerConfig;
+        } else {
+          delete nextProxy.nginx;
+        }
+      } else if (providerConfig && Object.keys(providerConfig).length > 0) {
+        nextProxy.caddy = providerConfig;
+      } else {
+        delete nextProxy.caddy;
+      }
+
+      return {
+        ...previous,
+        proxy: nextProxy,
+      };
+    },
+    options,
+  );
 }
 
 export async function clearEnvRootSetup(

--- a/packages/core/cli/src/lib/env-config.ts
+++ b/packages/core/cli/src/lib/env-config.ts
@@ -8,6 +8,7 @@
  */
 
 import type { EnvConfigEntry } from './auth-store.js';
+import { normalizeEnvProxyConfig } from './env-proxy-config.js';
 import { resolveAppPublicPath } from './app-public-path.js';
 
 const STRING_ENV_CONFIG_KEYS = [
@@ -63,6 +64,7 @@ export type StoredEnvConfigInput = {
   accessToken?: unknown;
   setupState?: unknown;
   schemaVersion?: unknown;
+  proxy?: unknown;
 } & Partial<Record<StringEnvConfigKey | BooleanEnvConfigKey, unknown>>;
 
 export type StoredEnvConfig = Partial<
@@ -145,6 +147,11 @@ export function buildStoredEnvConfig(input: StoredEnvConfigInput): StoredEnvConf
   const accessToken = trimConfigValue(input.accessToken);
   if ((authType === 'basic' || authType === 'token') && accessToken) {
     envConfig.accessToken = accessToken;
+  }
+
+  const proxy = normalizeEnvProxyConfig(input.proxy);
+  if (proxy) {
+    envConfig.proxy = proxy;
   }
 
   return envConfig;

--- a/packages/core/cli/src/lib/env-proxy-config.ts
+++ b/packages/core/cli/src/lib/env-proxy-config.ts
@@ -13,6 +13,11 @@ export interface EnvProxyProviderConfig {
   [key: string]: unknown;
 }
 
+export interface EnvResolvedProxyEntry extends EnvProxyProviderConfig {
+  host?: string;
+  port?: number;
+}
+
 export interface EnvProxyConfig {
   host?: string;
   port?: number;

--- a/packages/core/cli/src/lib/env-proxy-config.ts
+++ b/packages/core/cli/src/lib/env-proxy-config.ts
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export type EnvProxyProvider = 'nginx' | 'caddy';
+
+export interface EnvProxyProviderConfig {
+  [key: string]: unknown;
+}
+
+export interface EnvProxyConfig {
+  host?: string;
+  port?: number;
+  nginx?: EnvProxyProviderConfig;
+  caddy?: EnvProxyProviderConfig;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  const normalized = String(value ?? '').trim();
+  return normalized || undefined;
+}
+
+function normalizeOptionalPort(value: unknown): number | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized || !/^\d+$/.test(normalized)) {
+    return undefined;
+  }
+
+  const port = Number(normalized);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return undefined;
+  }
+
+  return port;
+}
+
+export function normalizeEnvProxyProviderConfig(value: unknown): EnvProxyProviderConfig | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+export function normalizeEnvProxyConfig(value: unknown): EnvProxyConfig | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const proxy = value as { host?: unknown; port?: unknown; nginx?: unknown; caddy?: unknown };
+  const host = normalizeOptionalString(proxy.host);
+  const port = normalizeOptionalPort(proxy.port);
+  const nginx = normalizeEnvProxyProviderConfig(proxy.nginx);
+  const caddy = normalizeEnvProxyProviderConfig(proxy.caddy);
+
+  if (!host && port === undefined && !nginx && !caddy) {
+    return undefined;
+  }
+
+  return {
+    ...(host ? { host } : {}),
+    ...(port !== undefined ? { port } : {}),
+    ...(nginx ? { nginx } : {}),
+    ...(caddy ? { caddy } : {}),
+  };
+}

--- a/packages/core/cli/src/lib/env-proxy.ts
+++ b/packages/core/cli/src/lib/env-proxy.ts
@@ -794,6 +794,7 @@ type EnvProxyCaddyRenderContext = EnvProxyNginxRenderContext;
 
 function buildNginxManagedConfigBlock(context: EnvProxyNginxRenderContext): string {
   const v2PublicPathNoTrailingSlash = trimTrailingSlash(context.v2PublicPath);
+  const apiBasePathNoTrailingSlash = trimTrailingSlash(context.apiBasePath);
   const appPublicPathNoTrailingSlash = trimTrailingSlash(context.appPublicPath);
   const isRootMounted = context.appPublicPath === '/';
   const appPublicPathRedirectBlock = isRootMounted
@@ -831,6 +832,10 @@ function buildNginxManagedConfigBlock(context: EnvProxyNginxRenderContext): stri
     '',
     `        proxy_pass ${context.backendUrl};`,
     `        include ${context.snippetsDir}/proxy-location.conf;`,
+    '    }',
+    '',
+    `    location = ${apiBasePathNoTrailingSlash} {`,
+    `        return 308 ${context.apiBasePath}$is_args$args;`,
     '    }',
     '',
     `    location ^~ ${context.apiBasePath} {`,
@@ -1429,6 +1434,7 @@ function buildNginxOtherLocation(appPublicPath: string, v2PublicPath: string, mo
 function renderNginxLocationTemplate(context: EnvProxyTemplateContext): string {
   const proxyPassBlock = buildNginxProxyPassBlock(context.proxyHost, context.apiPort);
   const wsProxyPassTarget = `http://${context.proxyHost}:${context.apiPort}${context.wsPath}`;
+  const apiBasePathNoTrailingSlash = trimTrailingSlash(context.apiBasePath);
 
   return `    location ~* ^${context.appPublicPath}storage/uploads/(.*\\.md)$ {
         alias ${context.uploadsPath}/$1;
@@ -1474,6 +1480,10 @@ function renderNginxLocationTemplate(context: EnvProxyTemplateContext): string {
         rewrite ^/\\.well-known/openid-configuration/(.+)$ /$1/.well-known/openid-configuration break;
         ${proxyPassBlock}
     }${context.otherLocation}
+
+    location = ${apiBasePathNoTrailingSlash} {
+        return 308 ${context.apiBasePath}$is_args$args;
+    }
 
     location ^~ ${context.apiBasePath} {
         ${proxyPassBlock}

--- a/packages/core/cli/src/lib/proxy-caddy.ts
+++ b/packages/core/cli/src/lib/proxy-caddy.ts
@@ -16,6 +16,7 @@ import {
   startDockerContainer,
   stopDockerContainer,
 } from './app-runtime.js';
+import { loadAuthConfig } from './auth-store.js';
 import {
   CADDY_PROXY_DRIVER_OPTIONS,
   DEFAULT_CADDY_PROXY_DRIVER,
@@ -37,12 +38,14 @@ import {
   type EnvProxyCaddyBundle,
   type ManualEnvProxyNginxInput,
 } from './env-proxy.js';
-import { run } from './run-npm.js';
+import { normalizeEnvProxyConfig } from './env-proxy-config.js';
+import { commandOutput, run } from './run-npm.js';
 
 const DOCKER_CADDY_PROXY_CONTAINER_SUFFIX = 'caddy-proxy';
 const DOCKER_CADDY_PROXY_IMAGE = 'caddy:latest';
 const DOCKER_CADDY_PROXY_RUNTIME_ROOT = '/apps';
 const DOCKER_CADDY_PROXY_CONF_DESTINATION = '/etc/caddy/Caddyfile';
+const DEFAULT_DOCKER_CADDY_PROXY_PUBLISHED_PORTS = [80, 443] as const;
 
 type WritableProxyRuntime = Extract<ManagedAppRuntime, { kind: 'local' | 'docker' }>;
 
@@ -268,12 +271,18 @@ async function reloadLocalCaddyProxy(runtimeContext: CaddyProxyRuntimeContext): 
 
 async function ensureDockerCaddyProxyContainer(runtimeContext: CaddyProxyRuntimeContext): Promise<void> {
   const containerName = await resolveCaddyProxyContainerName();
+  const mainConfigPath = await ensureCaddyProxyMainConfig(runtimeContext);
+  const publishedPorts = await resolveDockerCaddyPublishedPorts();
   if (await dockerContainerExists(containerName)) {
-    return;
+    if (await dockerCaddyProxyContainerMatchesPublishedPorts(containerName, publishedPorts)) {
+      return;
+    }
+
+    await removeDockerCaddyProxyContainer(containerName);
   }
 
   const hostCliRoot = String(process.env.NB_CLI_ROOT ?? resolveCliHomeRoot()).trim() || resolveCliHomeRoot();
-  const mainConfigPath = await ensureCaddyProxyMainConfig(runtimeContext);
+  const dockerPortArgs = publishedPorts.flatMap((port) => ['-p', `${port}:${port}`]);
 
   await run(
     'docker',
@@ -284,8 +293,7 @@ async function ensureDockerCaddyProxyContainer(runtimeContext: CaddyProxyRuntime
       containerName,
       '--add-host',
       'host.docker.internal:host-gateway',
-      '-p',
-      '80:80',
+      ...dockerPortArgs,
       '-v',
       `${hostCliRoot}:${DOCKER_CADDY_PROXY_RUNTIME_ROOT}`,
       '-v',
@@ -299,16 +307,71 @@ async function ensureDockerCaddyProxyContainer(runtimeContext: CaddyProxyRuntime
   );
 }
 
+async function resolveDockerCaddyPublishedPorts(): Promise<number[]> {
+  const config = await loadAuthConfig();
+  const ports = new Set<number>(DEFAULT_DOCKER_CADDY_PROXY_PUBLISHED_PORTS);
+
+  for (const envConfig of Object.values(config.envs)) {
+    const port = normalizeEnvProxyConfig(envConfig.proxy)?.port;
+    if (port !== undefined) {
+      ports.add(port);
+    }
+  }
+
+  return Array.from(ports).sort((left, right) => left - right);
+}
+
+async function readDockerCaddyPublishedPorts(containerName: string): Promise<number[]> {
+  const output = await commandOutput(
+    'docker',
+    ['inspect', '--format', '{{json .HostConfig.PortBindings}}', containerName],
+    { errorName: 'docker inspect' },
+  );
+  const parsed = JSON.parse(output.trim() || '{}') as Record<string, Array<{ HostPort?: string }> | null>;
+  const ports = new Set<number>();
+
+  for (const bindings of Object.values(parsed)) {
+    if (!Array.isArray(bindings)) {
+      continue;
+    }
+
+    for (const binding of bindings) {
+      const port = Number.parseInt(String(binding?.HostPort ?? '').trim(), 10);
+      if (Number.isInteger(port) && port > 0) {
+        ports.add(port);
+      }
+    }
+  }
+
+  return Array.from(ports).sort((left, right) => left - right);
+}
+
+async function dockerCaddyProxyContainerMatchesPublishedPorts(
+  containerName: string,
+  expectedPorts: number[],
+): Promise<boolean> {
+  const currentPorts = await readDockerCaddyPublishedPorts(containerName);
+  return currentPorts.length === expectedPorts.length && currentPorts.every((port, index) => port === expectedPorts[index]);
+}
+
+async function removeDockerCaddyProxyContainer(containerName: string): Promise<void> {
+  await run('docker', ['rm', '-f', containerName], {
+    errorName: 'docker rm',
+    stdio: 'ignore',
+  });
+}
+
 async function startDockerCaddyProxy(runtimeContext: CaddyProxyRuntimeContext): Promise<CaddyProxyLifecycleResult> {
   const containerName = await resolveCaddyProxyContainerName();
   await ensureCaddyProxyMainConfig(runtimeContext);
+  const existedBeforeEnsure = await dockerContainerExists(containerName);
+  await ensureDockerCaddyProxyContainer(runtimeContext);
 
-  if (await dockerContainerExists(containerName)) {
+  if (existedBeforeEnsure && (await dockerContainerExists(containerName))) {
     const state = await startDockerContainer(containerName, { stdio: 'ignore' });
     return state === 'already-running' ? 'already-running' : 'started';
   }
 
-  await ensureDockerCaddyProxyContainer(runtimeContext);
   return 'started';
 }
 

--- a/packages/core/cli/src/lib/proxy-nginx.ts
+++ b/packages/core/cli/src/lib/proxy-nginx.ts
@@ -16,6 +16,7 @@ import {
   startDockerContainer,
   stopDockerContainer,
 } from './app-runtime.js';
+import { loadAuthConfig } from './auth-store.js';
 import {
   DEFAULT_NGINX_PROXY_DRIVER,
   getCliConfigValue,
@@ -43,12 +44,14 @@ import {
   type EnvProxyNginxBundle,
   type ManualEnvProxyNginxInput,
 } from './env-proxy.js';
-import { run } from './run-npm.js';
+import { normalizeEnvProxyConfig } from './env-proxy-config.js';
+import { commandOutput, run } from './run-npm.js';
 
 const DOCKER_NGINX_PROXY_CONTAINER_SUFFIX = 'nginx-proxy';
 const DOCKER_NGINX_PROXY_IMAGE = 'nginx:latest';
 const DOCKER_NGINX_PROXY_RUNTIME_ROOT = '/apps';
 const DOCKER_NGINX_PROXY_CONF_DESTINATION = '/etc/nginx/conf.d/default.conf';
+const DEFAULT_DOCKER_NGINX_PROXY_PUBLISHED_PORTS = [80, 443] as const;
 
 type WritableProxyRuntime = Extract<ManagedAppRuntime, { kind: 'local' | 'docker' }>;
 
@@ -366,12 +369,18 @@ async function reloadLocalNginxProxy(runtimeContext: NginxProxyRuntimeContext): 
 
 async function ensureDockerNginxProxyContainer(runtimeContext: NginxProxyRuntimeContext): Promise<void> {
   const containerName = await resolveNginxProxyContainerName();
+  const mainConfigPath = await ensureNginxProxyMainConfig(runtimeContext);
+  const publishedPorts = await resolveDockerNginxPublishedPorts();
   if (await dockerContainerExists(containerName)) {
-    return;
+    if (await dockerNginxProxyContainerMatchesPublishedPorts(containerName, publishedPorts)) {
+      return;
+    }
+
+    await removeDockerNginxProxyContainer(containerName);
   }
 
   const hostCliRoot = String(process.env.NB_CLI_ROOT ?? resolveCliHomeRoot()).trim() || resolveCliHomeRoot();
-  const mainConfigPath = await ensureNginxProxyMainConfig(runtimeContext);
+  const dockerPortArgs = publishedPorts.flatMap((port) => ['-p', `${port}:${port}`]);
 
   await run('docker', [
     'run',
@@ -380,8 +389,7 @@ async function ensureDockerNginxProxyContainer(runtimeContext: NginxProxyRuntime
     containerName,
     '--add-host',
     'host.docker.internal:host-gateway',
-    '-p',
-    '80:80',
+    ...dockerPortArgs,
     '-v',
     `${hostCliRoot}:${DOCKER_NGINX_PROXY_RUNTIME_ROOT}`,
     '-v',
@@ -393,16 +401,71 @@ async function ensureDockerNginxProxyContainer(runtimeContext: NginxProxyRuntime
   });
 }
 
+async function resolveDockerNginxPublishedPorts(): Promise<number[]> {
+  const config = await loadAuthConfig();
+  const ports = new Set<number>(DEFAULT_DOCKER_NGINX_PROXY_PUBLISHED_PORTS);
+
+  for (const envConfig of Object.values(config.envs)) {
+    const port = normalizeEnvProxyConfig(envConfig.proxy)?.port;
+    if (port !== undefined) {
+      ports.add(port);
+    }
+  }
+
+  return Array.from(ports).sort((left, right) => left - right);
+}
+
+async function readDockerNginxPublishedPorts(containerName: string): Promise<number[]> {
+  const output = await commandOutput(
+    'docker',
+    ['inspect', '--format', '{{json .HostConfig.PortBindings}}', containerName],
+    { errorName: 'docker inspect' },
+  );
+  const parsed = JSON.parse(output.trim() || '{}') as Record<string, Array<{ HostPort?: string }> | null>;
+  const ports = new Set<number>();
+
+  for (const bindings of Object.values(parsed)) {
+    if (!Array.isArray(bindings)) {
+      continue;
+    }
+
+    for (const binding of bindings) {
+      const port = Number.parseInt(String(binding?.HostPort ?? '').trim(), 10);
+      if (Number.isInteger(port) && port > 0) {
+        ports.add(port);
+      }
+    }
+  }
+
+  return Array.from(ports).sort((left, right) => left - right);
+}
+
+async function dockerNginxProxyContainerMatchesPublishedPorts(
+  containerName: string,
+  expectedPorts: number[],
+): Promise<boolean> {
+  const currentPorts = await readDockerNginxPublishedPorts(containerName);
+  return currentPorts.length === expectedPorts.length && currentPorts.every((port, index) => port === expectedPorts[index]);
+}
+
+async function removeDockerNginxProxyContainer(containerName: string): Promise<void> {
+  await run('docker', ['rm', '-f', containerName], {
+    errorName: 'docker rm',
+    stdio: 'ignore',
+  });
+}
+
 async function startDockerNginxProxy(runtimeContext: NginxProxyRuntimeContext): Promise<NginxProxyLifecycleResult> {
   const containerName = await resolveNginxProxyContainerName();
   await ensureNginxProxyMainConfig(runtimeContext);
+  const existedBeforeEnsure = await dockerContainerExists(containerName);
+  await ensureDockerNginxProxyContainer(runtimeContext);
 
-  if (await dockerContainerExists(containerName)) {
+  if (existedBeforeEnsure && (await dockerContainerExists(containerName))) {
     const state = await startDockerContainer(containerName, { stdio: 'ignore' });
     return state === 'already-running' ? 'already-running' : 'started';
   }
 
-  await ensureDockerNginxProxyContainer(runtimeContext);
   return 'started';
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Refactor CLI setup startup to reuse `nb app start`, normalize API base path redirects, persist shared env proxy defaults, and rebuild Docker proxy containers when published ports change. |
| 🇨🇳 Chinese | 重构 CLI 的 setup 启动流程以复用 `nb app start`，统一 API base path 的重定向行为，持久化 env 的共享代理默认配置，并在 Docker 代理端口变化时自动重建容器。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
