### PR TITLE
fix(plugin-block-comment): support configurable comment submit actions

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/RecordCommentsBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/RecordCommentsBlockModel.tsx
@@ -582,7 +582,11 @@ RecordCommentsBlockModel.define({
           },
         },
       ],
-      submitActions: [],
+      submitActions: [
+        {
+          use: 'RecordCommentSubmitActionModel',
+        },
+      ],
     },
   },
   sort: 552,

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentActionGroupModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentActionGroupModel.test.ts
@@ -8,14 +8,33 @@
  */
 
 import { ActionModel, ActionSceneEnum, RecordActionGroupModel } from '@nocobase/client-v2';
-import { FlowEngine } from '@nocobase/flow-engine';
-import { afterEach, describe, expect, test } from 'vitest';
+import { FlowEngine, type FlowModelContext } from '@nocobase/flow-engine';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   RecordCommentActionGroupModel,
   RecordCommentActionModel,
   RecordCommentSubmitActionGroupModel,
 } from '../actions/RecordCommentActionGroupModel';
+import { RecordCommentSubmitActionModel } from '../actions/RecordCommentSubmitActionModel';
+
+type TestFlowStep = {
+  defaultParams?: Record<string, unknown>;
+  handler?: (ctx: unknown, params?: unknown) => unknown;
+};
+
+type TestFlow = {
+  steps?: Record<string, TestFlowStep>;
+};
+
+type TestFlowModelClass = typeof RecordCommentSubmitActionModel & {
+  globalFlowRegistry: {
+    getFlow: (key: string) => TestFlow | undefined;
+  };
+};
+
+const getRecordCommentSubmitFlow = (key: string) =>
+  (RecordCommentSubmitActionModel as unknown as TestFlowModelClass).globalFlowRegistry.getFlow(key);
 
 describe('RecordCommentSubmitActionGroupModel', () => {
   const originalAIEmployeeActionModel = RecordActionGroupModel.currentModels.get('AIEmployeeActionModel');
@@ -45,15 +64,138 @@ describe('RecordCommentSubmitActionGroupModel', () => {
     const engine = new FlowEngine();
     engine.registerModels({
       RecordCommentSubmitActionGroupModel,
+      RecordCommentSubmitActionModel,
     });
 
     const items = await RecordCommentSubmitActionGroupModel.defineChildren({
       engine,
       dataSourceManager: engine.dataSourceManager,
       model: { uid: 'comments-submit-actions' },
-    } as any);
+    } as unknown as FlowModelContext);
 
-    expect(items.map((item) => item.useModel)).toEqual(['AIEmployeeActionModel', 'JSItemActionModel', 'JSActionModel']);
+    expect(items.map((item) => item.useModel)).toEqual([
+      'RecordCommentSubmitActionModel',
+      'AIEmployeeActionModel',
+      'JSItemActionModel',
+      'JSActionModel',
+    ]);
+  });
+});
+
+describe('RecordCommentSubmitActionModel', () => {
+  test('stays on the current page without a default popup message after successful submission', () => {
+    const flow = getRecordCommentSubmitFlow('submitSettings');
+
+    expect(flow?.steps?.afterSuccess?.defaultParams?.successMessage).toBe('');
+    expect(flow?.steps?.afterSuccess?.defaultParams?.actionAfterSuccess).toBe('stay');
+  });
+
+  test('passes assigned field values to the comment submit handler', async () => {
+    const flow = getRecordCommentSubmitFlow('submitSettings');
+    const saveResource = flow?.steps?.saveResource;
+    const submitComment = vi.fn(async (params) => params);
+    const model = {
+      setProps: vi.fn(),
+    };
+
+    if (!saveResource?.handler) {
+      throw new Error('saveResource handler is not registered');
+    }
+
+    const result = await saveResource.handler(
+      {
+        model,
+        submitComment,
+        t: (message: string) => message,
+      },
+      {
+        assignedValues: {
+          status: 'published',
+        },
+        requestConfig: {
+          params: {
+            triggerWorkflows: 'comment-workflow',
+          },
+        },
+      },
+    );
+
+    expect(submitComment).toHaveBeenCalledWith({
+      assignedValues: {
+        status: 'published',
+      },
+      requestConfig: {
+        params: {
+          triggerWorkflows: 'comment-workflow',
+        },
+      },
+    });
+    expect(result).toEqual({
+      assignedValues: {
+        status: 'published',
+      },
+      requestConfig: {
+        params: {
+          triggerWorkflows: 'comment-workflow',
+        },
+      },
+    });
+    expect(model.setProps).toHaveBeenNthCalledWith(1, 'loading', true);
+    expect(model.setProps).toHaveBeenNthCalledWith(2, 'loading', false);
+  });
+
+  test('does not submit when the comment content is empty', async () => {
+    const flow = getRecordCommentSubmitFlow('submitSettings');
+    const validateCommentContent = flow?.steps?.validateCommentContent;
+    const saveResource = flow?.steps?.saveResource;
+    const exit = vi.fn();
+    const submitComment = vi.fn();
+    const model = {
+      setProps: vi.fn(),
+    };
+
+    validateCommentContent?.handler?.({
+      commentCanSubmit: false,
+      exit,
+    });
+
+    if (!saveResource?.handler) {
+      throw new Error('saveResource handler is not registered');
+    }
+
+    await saveResource.handler({
+      commentCanSubmit: false,
+      exit,
+      model,
+      submitComment,
+      t: (message: string) => message,
+    });
+
+    expect(exit).toHaveBeenCalledTimes(2);
+    expect(submitComment).not.toHaveBeenCalled();
+    expect(model.setProps).not.toHaveBeenCalled();
+  });
+
+  test('binds workflow settings without workflow plugin model registration changes', () => {
+    const flow = getRecordCommentSubmitFlow('recordCommentTriggerWorkflowsActionSettings');
+    const model = {
+      setSaveRequestConfig: vi.fn(),
+    };
+
+    flow?.steps?.setTriggerWorkflows?.handler?.(
+      { model },
+      {
+        group: [{ workflowKey: 'comment-workflow' }, { workflowKey: undefined }],
+      },
+    );
+
+    expect(flow).toBeTruthy();
+    expect(flow?.steps?.setTriggerWorkflows).toBeTruthy();
+    expect(model.setSaveRequestConfig).toHaveBeenCalledWith({
+      params: {
+        triggerWorkflows: 'comment-workflow',
+      },
+    });
   });
 });
 
@@ -92,7 +234,7 @@ describe('RecordCommentActionGroupModel', () => {
       engine,
       dataSourceManager: engine.dataSourceManager,
       model: { uid: 'comment-record-actions' },
-    } as any);
+    } as unknown as FlowModelContext);
 
     expect(items.map((item) => item.useModel)).toContain('AIEmployeeActionModel');
   });

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentActions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentActions.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FlowModel } from '@nocobase/flow-engine';
+
+import type { RecordCommentsBlockModel } from '../RecordCommentsBlockModel';
+import { RecordCommentActions } from '../components/RecordCommentActions';
+
+vi.mock('@nocobase/flow-engine', () => ({
+  AddSubModelButton: ({ children, model }: { children: React.ReactNode; model: { uid: string } }) => (
+    <button data-testid="settings-target" type="button">
+      {model.uid}
+      {children}
+    </button>
+  ),
+  DndProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DragHandler: () => null,
+  Droppable: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  FlowModelRenderer: ({ model }: { model: { constructor: { name: string } } }) => (
+    <button type="button">{model.constructor.name}</button>
+  ),
+  FlowSettingsButton: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  observer: <T extends React.ComponentType>(component: T) => component,
+}));
+
+type FakeFlowContext = Record<string, unknown> & {
+  flowSettingsEnabled?: boolean;
+  defineProperty: (name: string, descriptor: PropertyDescriptor) => void;
+  defineMethod: (name: string, value: unknown) => void;
+};
+
+type FakeAction = {
+  uid: string;
+  context: FakeFlowContext;
+  createFork: (params: Record<string, unknown>, forkKey: string) => FakeAction;
+};
+
+function createContext(flowSettingsEnabled = false): FakeFlowContext {
+  return {
+    flowSettingsEnabled,
+    defineProperty(name, descriptor) {
+      Object.defineProperty(this, name, descriptor);
+    },
+    defineMethod(name, value) {
+      this[name] = value;
+    },
+  };
+}
+
+function createAction(ActionClass: new (uid: string) => FakeAction, uid: string) {
+  return new ActionClass(uid);
+}
+
+class DeleteRecordCommentActionModel implements FakeAction {
+  context = createContext();
+
+  constructor(public uid: string) {}
+
+  createFork(_params: Record<string, unknown>, forkKey: string) {
+    return createAction(DeleteRecordCommentActionModel, forkKey);
+  }
+}
+
+class EditRecordCommentActionModel implements FakeAction {
+  context = createContext();
+
+  constructor(public uid: string) {}
+
+  createFork(_params: Record<string, unknown>, forkKey: string) {
+    return createAction(EditRecordCommentActionModel, forkKey);
+  }
+}
+
+class QuoteReplyRecordCommentActionModel implements FakeAction {
+  context = createContext();
+
+  constructor(public uid: string) {}
+
+  createFork(_params: Record<string, unknown>, forkKey: string) {
+    return createAction(QuoteReplyRecordCommentActionModel, forkKey);
+  }
+}
+
+function createItemModel(actions: FakeAction[], flowSettingsEnabled = false) {
+  return {
+    uid: flowSettingsEnabled ? 'fork-item' : 'item',
+    context: createContext(flowSettingsEnabled),
+    translate: (value: string) => value,
+    mapSubModels(_key: string, renderItem: (action: FakeAction, index: number) => React.ReactNode) {
+      return actions.map(renderItem);
+    },
+  } as unknown as FlowModel;
+}
+
+const blockModel = {
+  collection: {
+    filterTargetKey: 'id',
+  },
+  resource: {},
+} as unknown as RecordCommentsBlockModel;
+
+describe('RecordCommentActions', () => {
+  it('renders only one built-in action for duplicated historical action models', () => {
+    const itemModel = createItemModel([
+      createAction(QuoteReplyRecordCommentActionModel, 'quote-1'),
+      createAction(DeleteRecordCommentActionModel, 'delete-1'),
+      createAction(DeleteRecordCommentActionModel, 'delete-2'),
+      createAction(EditRecordCommentActionModel, 'edit-1'),
+      createAction(EditRecordCommentActionModel, 'edit-2'),
+    ]);
+
+    render(
+      <RecordCommentActions
+        blockModel={blockModel}
+        record={{ id: 1 }}
+        itemModel={itemModel}
+        forkKeyPrefix="comment_item_1"
+        setEditing={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole('button', { name: 'QuoteReplyRecordCommentActionModel' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'DeleteRecordCommentActionModel' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'EditRecordCommentActionModel' })).toHaveLength(1);
+  });
+
+  it('uses the template item model for action settings instead of the per-record fork', () => {
+    const itemModel = createItemModel([], true);
+    const actionSettingsModel = {
+      ...createItemModel([], true),
+      uid: 'template-item',
+    } as FlowModel;
+
+    render(
+      <RecordCommentActions
+        blockModel={blockModel}
+        record={{ id: 1 }}
+        itemModel={itemModel}
+        actionSettingsModel={actionSettingsModel}
+        forkKeyPrefix="comment_item_1"
+        setEditing={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('settings-target')).toHaveTextContent('template-item');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/__tests__/RecordCommentsBlockModel.test.ts
@@ -54,6 +54,20 @@ describe('RecordCommentsBlockModel field mapping settings', () => {
     ]);
   });
 
+  test('creates a configurable comment submit action by default', () => {
+    const createModelOptions = RecordCommentsBlockModel.meta.createModelOptions as {
+      subModels?: {
+        submitActions?: Array<{
+          use?: string;
+        }>;
+      };
+    };
+
+    expect(createModelOptions.subModels?.submitActions?.map((action) => action.use)).toEqual([
+      'RecordCommentSubmitActionModel',
+    ]);
+  });
+
   test('hides owner mapping fields when the block is created from an association field', () => {
     const flow: any = (RecordCommentsBlockModel as any).globalFlowRegistry.getFlow('recordCommentsSettings');
     const step: any = flow?.steps?.fieldMapping;

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/actions/RecordCommentActionGroupModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/actions/RecordCommentActionGroupModel.tsx
@@ -19,8 +19,14 @@ import {
 import { buildSubModelItem, type FlowModelContext } from '@nocobase/flow-engine';
 
 import { tExpr } from '../../locale';
+import { RecordCommentSubmitActionModel } from './RecordCommentSubmitActionModel';
 
-const ALLOWED_RECORD_COMMENT_SUBMIT_ACTIONS = ['AIEmployeeActionModel', 'JSItemActionModel', 'JSActionModel'];
+const ALLOWED_RECORD_COMMENT_SUBMIT_ACTIONS = [
+  'RecordCommentSubmitActionModel',
+  'AIEmployeeActionModel',
+  'JSItemActionModel',
+  'JSActionModel',
+];
 const ALLOWED_RECORD_COMMENT_RECORD_ACTIONS = ['AIEmployeeActionModel'];
 
 const getRecordCommentActionModelClass = (
@@ -103,6 +109,7 @@ RecordCommentActionGroupModel.registerActionModels({
 });
 
 RecordCommentSubmitActionGroupModel.registerActionModels({
+  RecordCommentSubmitActionModel,
   JSActionModel,
   JSItemActionModel,
 });

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/actions/RecordCommentSubmitActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/actions/RecordCommentSubmitActionModel.tsx
@@ -1,0 +1,454 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import {
+  ActionModel,
+  createAssignFieldValuesStep,
+  createAssignFormSubModelOptions,
+  getAssignFieldValuesDefaultParams,
+  resolveAssignFieldValues,
+  type AssignFormModel,
+} from '@nocobase/client-v2';
+import { useFlowContext, type FlowRuntimeContext } from '@nocobase/flow-engine';
+import { Alert, Select, Space } from 'antd';
+import type { SelectProps } from 'antd';
+import type { AxiosRequestConfig } from 'axios';
+import type { ButtonProps } from 'antd/es/button';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { tExpr, useT } from '../../locale';
+
+const SETTINGS_FLOW_KEY = 'submitSettings';
+
+type WorkflowCollection = {
+  name?: string;
+  dataSourceKey?: string;
+  dataSource?: {
+    key?: string;
+    name?: string;
+  };
+};
+
+type WorkflowOption = {
+  title?: string;
+  key?: string;
+  type?: string;
+  config?: Record<string, unknown> | null;
+};
+
+type TriggerWorkflowBinding = {
+  workflowKey?: string;
+};
+
+type ActionTriggerableTrigger = {
+  actionTriggerableScope?: boolean | ((config: Record<string, unknown>, scope: string) => boolean);
+};
+
+type WorkflowPlugin = {
+  getTriggerOptions?: (type?: string) => ActionTriggerableTrigger | undefined;
+  triggers?: {
+    get(type: string): ActionTriggerableTrigger | undefined;
+  };
+};
+
+type PluginManagerLike = {
+  get(name: string): unknown;
+};
+
+type RecordCommentSubmitContext = {
+  commentCanSubmit?: boolean;
+  commentSubmitting?: boolean;
+  submitComment?: (params?: RecordCommentSubmitParams) => Promise<unknown>;
+  exit?: () => void;
+  message?: { error?: (message: string) => void };
+  model: RecordCommentSubmitActionModel;
+  t: (message: string) => string;
+};
+
+type RecordCommentSubmitParams = {
+  assignedValues?: Record<string, unknown>;
+  requestConfig?: AxiosRequestConfig;
+};
+
+function isWorkflowPlugin(plugin: unknown): plugin is WorkflowPlugin {
+  if (typeof plugin !== 'object' || plugin === null) {
+    return false;
+  }
+  const workflowPlugin = plugin as WorkflowPlugin;
+  return typeof workflowPlugin.getTriggerOptions === 'function' || typeof workflowPlugin.triggers?.get === 'function';
+}
+
+function getWorkflowPlugin(pm: PluginManagerLike): WorkflowPlugin | undefined {
+  const plugins = [pm.get('workflow'), pm.get('@nocobase/plugin-workflow')];
+  return plugins.find(isWorkflowPlugin);
+}
+
+function getTriggerOptions(plugin: WorkflowPlugin | undefined, type?: string) {
+  if (!type) {
+    return undefined;
+  }
+  return plugin?.getTriggerOptions?.(type) ?? plugin?.triggers?.get(type);
+}
+
+function joinWorkflowCollectionName(dataSourceKey: string | undefined, collectionName: string | undefined) {
+  if (!collectionName) {
+    return undefined;
+  }
+  if (!dataSourceKey || dataSourceKey === 'main') {
+    return collectionName;
+  }
+  return `${dataSourceKey}:${collectionName}`;
+}
+
+function getWorkflowCollectionName(collection?: WorkflowCollection | null) {
+  return joinWorkflowCollectionName(collection?.dataSourceKey || collection?.dataSource?.key, collection?.name);
+}
+
+function buildTriggerWorkflows(group?: TriggerWorkflowBinding[]) {
+  const workflowKeys = group?.map((row) => row.workflowKey).filter((key): key is string => Boolean(key));
+  return workflowKeys?.length ? workflowKeys.join(',') : undefined;
+}
+
+function shouldBlockEmptyCommentSubmit(ctx: Pick<RecordCommentSubmitContext, 'commentCanSubmit'>) {
+  return ctx.commentCanSubmit === false;
+}
+
+function getWorkflowOptionFilter(plugin: unknown, currentValue?: string) {
+  const workflowPlugin = isWorkflowPlugin(plugin) ? plugin : undefined;
+
+  return (option: WorkflowOption) => {
+    if (option.key && option.key === currentValue) {
+      return true;
+    }
+    const trigger = getTriggerOptions(workflowPlugin, option.type);
+    if (!trigger) {
+      return false;
+    }
+    if (trigger.actionTriggerableScope === true) {
+      return true;
+    }
+    if (typeof trigger.actionTriggerableScope === 'function') {
+      return trigger.actionTriggerableScope(option.config || {}, 'form');
+    }
+    return false;
+  };
+}
+
+function useWorkflowOptions(filter?: Record<string, unknown>) {
+  const ctx = useFlowContext();
+  const [options, setOptions] = useState<WorkflowOption[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadWorkflows() {
+      setLoading(true);
+      try {
+        const response = await ctx.api.request({
+          url: 'workflows:list',
+          method: 'get',
+          params: {
+            paginate: false,
+            filter: {
+              enabled: true,
+              ...filter,
+            },
+          },
+        });
+        if (mounted) {
+          setOptions(response?.data?.data || []);
+        }
+      } catch (error) {
+        console.error('Error loading workflows:', error);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadWorkflows();
+
+    return () => {
+      mounted = false;
+    };
+  }, [ctx.api, filter]);
+
+  return { options, loading };
+}
+
+function WorkflowSelect({
+  value,
+  onChange,
+  filter,
+  ...props
+}: Omit<SelectProps<string>, 'options'> & {
+  value?: string;
+  onChange?: (value?: string) => void;
+  filter?: Record<string, unknown>;
+}) {
+  const ctx = useFlowContext();
+  const t = useT();
+  const plugin = getWorkflowPlugin(ctx.app.pm);
+  const { options, loading } = useWorkflowOptions(filter);
+  const optionFilter = useMemo(() => getWorkflowOptionFilter(plugin, value), [plugin, value]);
+  const selectOptions = useMemo<SelectProps['options']>(
+    () =>
+      options
+        .filter((option): option is WorkflowOption & { key: string } => Boolean(option.key) && optionFilter(option))
+        .map((option) => {
+          const title = option.title ? t(option.title) : option.key;
+          return {
+            label: title,
+            value: option.key,
+            searchText: title,
+          };
+        }),
+    [optionFilter, options, t],
+  );
+
+  return (
+    <Select
+      allowClear
+      showSearch
+      loading={loading}
+      placeholder={t('Select workflow')}
+      {...props}
+      filterOption={(input, option) =>
+        String((option as { searchText?: string })?.searchText || '')
+          .toLowerCase()
+          .includes(input.toLowerCase())
+      }
+      value={value}
+      options={selectOptions}
+      onChange={onChange}
+    />
+  );
+}
+
+function getWorkflowCollectionFilter(ctx: FlowRuntimeContext) {
+  const collection = ctx.blockModel?.collection || ctx.model?.context?.blockModel?.collection;
+  const workflowCollection = getWorkflowCollectionName(collection);
+  return workflowCollection ? { 'config.collection': workflowCollection } : undefined;
+}
+
+function createTriggerWorkflowsSchema(description: string) {
+  return (ctx: FlowRuntimeContext) => {
+    const filter = getWorkflowCollectionFilter(ctx);
+
+    return {
+      description: {
+        type: 'void',
+        'x-component': Alert,
+        'x-component-props': {
+          type: 'info',
+          showIcon: true,
+          message: description,
+          style: {
+            marginBottom: '1em',
+          },
+        },
+      },
+      group: {
+        type: 'array',
+        'x-component': 'ArrayItems',
+        'x-decorator': 'FormItem',
+        items: {
+          type: 'object',
+          properties: {
+            space: {
+              type: 'void',
+              'x-component': Space,
+              'x-component-props': {
+                align: 'center',
+                style: {
+                  display: 'flex',
+                  width: '100%',
+                  gap: 8,
+                },
+              },
+              properties: {
+                sort: {
+                  type: 'void',
+                  'x-decorator': 'FormItem',
+                  'x-component': 'ArrayItems.SortHandle',
+                },
+                workflowKey: {
+                  type: 'string',
+                  'x-decorator': 'FormItem',
+                  'x-component': WorkflowSelect,
+                  'x-component-props': {
+                    filter,
+                    placeholder: tExpr('Select workflow'),
+                    style: {
+                      width: 320,
+                      maxWidth: '100%',
+                    },
+                  },
+                  required: true,
+                },
+                remove: {
+                  type: 'void',
+                  'x-decorator': 'FormItem',
+                  'x-component': 'ArrayItems.Remove',
+                },
+              },
+            },
+          },
+        },
+        properties: {
+          add: {
+            type: 'void',
+            title: tExpr('Add workflow'),
+            'x-component': 'ArrayItems.Addition',
+          },
+        },
+      },
+    };
+  };
+}
+
+export class RecordCommentSubmitActionModel extends ActionModel<{
+  subModels: {
+    assignForm: AssignFormModel;
+  };
+}> {
+  assignFormUid?: string;
+
+  defaultProps: ButtonProps = {
+    title: tExpr('Comment'),
+    type: 'primary',
+  };
+
+  getAclActionName() {
+    return 'create';
+  }
+
+  setSaveRequestConfig(requestConfig?: AxiosRequestConfig) {
+    this.setStepParams('submitSettings', 'saveResource', {
+      requestConfig,
+    });
+  }
+
+  renderButton() {
+    const disabledByContent = !this.context.commentCanSubmit;
+    const submitting = Boolean(this.context.commentSubmitting);
+    const previousDisabled = this.props.disabled;
+    const previousLoading = this.props.loading;
+
+    this.props.disabled = previousDisabled || disabledByContent;
+    this.props.loading = previousLoading || submitting;
+
+    const button = super.renderButton();
+
+    this.props.disabled = previousDisabled;
+    this.props.loading = previousLoading;
+    return button;
+  }
+}
+
+RecordCommentSubmitActionModel.define({
+  label: tExpr('Comment'),
+  sort: 10,
+  createModelOptions: (ctx) => ({
+    subModels: {
+      assignForm: createAssignFormSubModelOptions(ctx),
+    },
+  }),
+});
+
+RecordCommentSubmitActionModel.registerFlow({
+  key: SETTINGS_FLOW_KEY,
+  on: 'click',
+  title: tExpr('Submit action settings'),
+  steps: {
+    validateCommentContent: {
+      hideInSettings: true,
+      handler(ctx: RecordCommentSubmitContext) {
+        if (shouldBlockEmptyCommentSubmit(ctx)) {
+          ctx.exit?.();
+        }
+      },
+    },
+    confirm: {
+      use: 'confirm',
+      defaultParams: {
+        enable: false,
+        title: tExpr('Submit comment'),
+        content: tExpr('Are you sure you want to submit this comment?'),
+      },
+    },
+    assignFieldValues: createAssignFieldValuesStep({
+      settingsFlowKey: SETTINGS_FLOW_KEY,
+      title: tExpr('Assign field values'),
+    }),
+    saveResource: {
+      async defaultParams(ctx) {
+        return getAssignFieldValuesDefaultParams(ctx, SETTINGS_FLOW_KEY);
+      },
+      async handler(ctx: RecordCommentSubmitContext, params?: RecordCommentSubmitParams) {
+        if (shouldBlockEmptyCommentSubmit(ctx)) {
+          ctx.exit?.();
+          return;
+        }
+
+        const assignedValues = await resolveAssignFieldValues(ctx, params?.assignedValues, 'RecordCommentSubmitAction');
+        if (!assignedValues) {
+          ctx.exit?.();
+          return;
+        }
+        if (!ctx.submitComment) {
+          ctx.message?.error?.(ctx.t('Failed to create comment'));
+          return;
+        }
+
+        try {
+          ctx.model.setProps('loading', true);
+          return await ctx.submitComment({
+            ...params,
+            assignedValues,
+          });
+        } catch {
+          ctx.exit?.();
+          return;
+        } finally {
+          ctx.model.setProps('loading', false);
+        }
+      },
+    },
+    afterSuccess: {
+      use: 'afterSuccess',
+      defaultParams: {
+        successMessage: '',
+        actionAfterSuccess: 'stay',
+      },
+    },
+  },
+});
+
+RecordCommentSubmitActionModel.registerFlow({
+  key: 'recordCommentTriggerWorkflowsActionSettings',
+  title: tExpr('Workflow'),
+  steps: {
+    setTriggerWorkflows: {
+      title: tExpr('Bind workflows'),
+      uiSchema: createTriggerWorkflowsSchema(
+        tExpr('Support pre-action event (local mode), post-action event (local mode), and approval event here.'),
+      ),
+      handler(ctx, params: { group?: TriggerWorkflowBinding[] }) {
+        ctx.model.setSaveRequestConfig({
+          params: {
+            triggerWorkflows: buildTriggerWorkflows(params.group),
+          },
+        });
+      },
+    },
+  },
+});

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/actions/index.ts
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/actions/index.ts
@@ -10,4 +10,5 @@
 export * from './DeleteRecordCommentActionModel';
 export * from './EditRecordCommentActionModel';
 export * from './RecordCommentActionGroupModel';
+export * from './RecordCommentSubmitActionModel';
 export * from './QuoteReplyRecordCommentActionModel';

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentActions.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentActions.tsx
@@ -47,26 +47,43 @@ const recordCommentActionsClassName = css`
   }
 `;
 
+const UNIQUE_RECORD_COMMENT_ACTION_MODELS = new Set([
+  'QuoteReplyRecordCommentActionModel',
+  'EditRecordCommentActionModel',
+  'DeleteRecordCommentActionModel',
+]);
+
 export const RecordCommentActions = observer(
   ({
     blockModel,
     record,
     itemModel,
+    actionSettingsModel = itemModel,
     forkKeyPrefix,
     setEditing,
   }: {
     blockModel: RecordCommentsBlockModel;
     record: RecordCommentRecord;
     itemModel: FlowModel;
+    actionSettingsModel?: FlowModel;
     forkKeyPrefix: string;
     setEditing: () => void;
   }) => {
     const recordKey = getRecordPrimaryKeyValue(record, blockModel.collection);
+    const renderedUniqueActionModels = new Set<string>();
 
     return (
       <DndProvider>
         <Space size={4} className={recordCommentActionsClassName}>
           {itemModel.mapSubModels('actions', (action, index) => {
+            const actionModelName = action.constructor.name;
+            if (UNIQUE_RECORD_COMMENT_ACTION_MODELS.has(actionModelName)) {
+              if (renderedUniqueActionModels.has(actionModelName)) {
+                return null;
+              }
+              renderedUniqueActionModels.add(actionModelName);
+            }
+
             const forkKey = [forkKeyPrefix, recordKey || 'record', action.uid, index]
               .map(normalizeForkKeyPart)
               .join('_');
@@ -104,11 +121,13 @@ export const RecordCommentActions = observer(
           {itemModel.context.flowSettingsEnabled ? (
             <AddSubModelButton
               key="record-comment-actions-add"
-              model={itemModel}
+              model={actionSettingsModel}
               subModelKey="actions"
               subModelBaseClasses={['RecordCommentActionGroupModel']}
             >
-              <FlowSettingsButton icon={<SettingOutlined />}>{itemModel.translate('Actions')}</FlowSettingsButton>
+              <FlowSettingsButton icon={<SettingOutlined />}>
+                {actionSettingsModel.translate('Actions')}
+              </FlowSettingsButton>
             </AddSubModelButton>
           ) : null}
         </Space>

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentsBlockView.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/models/components/RecordCommentsBlockView.tsx
@@ -8,6 +8,7 @@
  */
 
 import { SettingOutlined } from '@ant-design/icons';
+import type { AxiosRequestConfig } from 'axios';
 import {
   AddSubModelButton,
   DndProvider,
@@ -133,6 +134,11 @@ type FlowModelWithForkId = FlowModel & {
 
 type DetailsGridForkModel = ReturnType<DetailsGridModel['createFork']> & {
   gridContainerRef: React.RefObject<HTMLDivElement>;
+};
+
+type SubmitCommentParams = {
+  assignedValues?: Record<string, unknown>;
+  requestConfig?: AxiosRequestConfig;
 };
 
 const getFlowModelRenderKey = (model: FlowModel, fallback: string) => {
@@ -269,11 +275,13 @@ const RecordCommentBodyFields = observer(
   ({
     blockModel,
     itemModel,
+    actionSettingsModel,
     record,
     forkKeyPrefix,
   }: {
     blockModel: RecordCommentsBlockModel;
     itemModel: FlowModel;
+    actionSettingsModel?: FlowModel;
     record: RecordCommentRecord;
     forkKeyPrefix: string;
   }) => {
@@ -334,37 +342,50 @@ const SubmitBox = observer(({ model, forkKeyPrefix }: { model: RecordCommentsBlo
     setContent(value);
   });
 
-  const submit = useCallback(async () => {
-    if (!mapping.contentField || !mapping.ownerField || model.ownerValue === undefined) {
-      return;
-    }
+  const submit = useCallback(
+    async (params?: SubmitCommentParams): Promise<unknown> => {
+      if (!mapping.contentField || !mapping.ownerField || model.ownerValue === undefined) {
+        return;
+      }
 
-    setSubmitting(true);
-    try {
-      await model.resource.create(
-        {
+      setSubmitting(true);
+      try {
+        const values = {
           [mapping.contentField]: content,
           [mapping.ownerField]: model.ownerValue,
           ...getCommenterCreatePayload(model),
           ...getDateCreatePayload(model),
-        } as RecordCommentRecord,
-        {
+          ...(params?.assignedValues || {}),
+        } as RecordCommentRecord;
+
+        const response = await model.resource.create(values, {
+          ...(params?.requestConfig || {}),
           refresh: false,
-        },
-      );
-      setContent('');
-      if (model.shouldAutoJumpToLastPage()) {
-        const count = model.resource.getCount() || 0;
-        const pageSize = model.resource.getPageSize() || 10;
-        model.resource.setPage(Math.max(Math.ceil((count + 1) / pageSize), 1));
+        });
+        setContent('');
+        if (model.shouldAutoJumpToLastPage()) {
+          const count = model.resource.getCount() || 0;
+          const pageSize = model.resource.getPageSize() || 10;
+          model.resource.setPage(Math.max(Math.ceil((count + 1) / pageSize), 1));
+        }
+        await model.resource.refresh();
+        return response;
+      } catch (error) {
+        message.error(getErrorMessage(error, t('Failed to create comment')));
+        throw error;
+      } finally {
+        setSubmitting(false);
       }
-      await model.resource.refresh();
-    } catch (error) {
-      message.error(getErrorMessage(error, t('Failed to create comment')));
-    } finally {
-      setSubmitting(false);
+    },
+    [content, mapping.contentField, mapping.ownerField, message, model, t],
+  );
+  const handleFallbackSubmit = useCallback(async () => {
+    try {
+      await submit();
+    } catch {
+      // The submit helper already shows the localized error message.
     }
-  }, [content, mapping.contentField, mapping.ownerField, message, model, t]);
+  }, [submit]);
 
   return (
     <div style={{ marginTop: 10 }}>
@@ -387,13 +408,13 @@ const SubmitBox = observer(({ model, forkKeyPrefix }: { model: RecordCommentsBlo
         />
       )}
       <div style={submitButtonAreaStyle}>
-        <Button disabled={!canSubmit} loading={submitting} onClick={submit} type="primary">
-          {t('Comment')}
-        </Button>
         <RecordCommentSubmitActions
           model={model}
           content={content}
+          canSubmit={canSubmit}
+          submitting={submitting}
           setContent={setContent}
+          handleFallbackSubmit={handleFallbackSubmit}
           submit={submit}
           forkKeyPrefix={forkKeyPrefix}
         />
@@ -406,19 +427,36 @@ const RecordCommentSubmitActions = observer(
   ({
     model,
     content,
+    canSubmit,
+    submitting,
     setContent,
+    handleFallbackSubmit,
     submit,
     forkKeyPrefix,
   }: {
     model: RecordCommentsBlockModel;
     content: string;
+    canSubmit: boolean;
+    submitting: boolean;
     setContent: (value: string) => void;
-    submit: () => Promise<void>;
+    handleFallbackSubmit: () => Promise<void>;
+    submit: (params?: SubmitCommentParams) => Promise<unknown>;
     forkKeyPrefix: string;
   }) => {
+    const t = useT();
+    const submitActions = model.subModels?.submitActions || [];
+    const hasCommentSubmitAction = submitActions.some(
+      (action) => action.constructor.name === 'RecordCommentSubmitActionModel',
+    );
+
     return (
       <DndProvider>
-        <Space size={0} style={{ gap: 0 }}>
+        <Space size={8} wrap>
+          {!hasCommentSubmitAction ? (
+            <Button disabled={!canSubmit} loading={submitting} onClick={handleFallbackSubmit} type="primary">
+              {t('Comment')}
+            </Button>
+          ) : null}
           {model.mapSubModels('submitActions', (action, index) => {
             const fork = action.createFork({}, `${forkKeyPrefix}_submit_${normalizeForkKeyPart(action.uid)}_${index}`);
             fork.context.defineProperty('resource', {
@@ -432,6 +470,14 @@ const RecordCommentSubmitActions = observer(
             });
             fork.context.defineProperty('commentContent', {
               get: () => content,
+              cache: false,
+            });
+            fork.context.defineProperty('commentCanSubmit', {
+              get: () => canSubmit,
+              cache: false,
+            });
+            fork.context.defineProperty('commentSubmitting', {
+              get: () => submitting,
               cache: false,
             });
             fork.context.defineMethod('setCommentContent', setContent);
@@ -473,11 +519,13 @@ const RecordCommentItemView = observer(
   ({
     blockModel,
     itemModel,
+    actionSettingsModel,
     record,
     forkKeyPrefix,
   }: {
     blockModel: RecordCommentsBlockModel;
     itemModel: FlowModel;
+    actionSettingsModel?: FlowModel;
     record: RecordCommentRecord;
     forkKeyPrefix: string;
   }) => {
@@ -546,6 +594,7 @@ const RecordCommentItemView = observer(
                   blockModel={blockModel}
                   record={record}
                   itemModel={itemModel}
+                  actionSettingsModel={actionSettingsModel}
                   forkKeyPrefix={forkKeyPrefix}
                   setEditing={() => {
                     setEditing(true);
@@ -678,6 +727,7 @@ export const RecordCommentsBlockView = Object.assign(
                       <RecordCommentItemView
                         blockModel={model}
                         itemModel={itemModel}
+                        actionSettingsModel={model.subModels.items[0]}
                         record={record}
                         forkKeyPrefix={`${blockForkKeyPrefix}_item_${recordForkKey}`}
                       />

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client-v2/plugin.tsx
@@ -30,6 +30,9 @@ export class PluginRecordCommentsClientV2 extends Plugin {
       RecordCommentSubmitActionGroupModel: {
         loader: () => import('./models/actions'),
       },
+      RecordCommentSubmitActionModel: {
+        loader: () => import('./models/actions'),
+      },
       EditRecordCommentActionModel: {
         loader: () => import('./models/actions'),
       },

--- a/packages/plugins/@nocobase/plugin-block-comment/src/client/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/client/plugin.tsx
@@ -30,6 +30,9 @@ export class PluginRecordCommentsClient extends Plugin {
       RecordCommentSubmitActionGroupModel: {
         loader: () => import('../client-v2/models/actions'),
       },
+      RecordCommentSubmitActionModel: {
+        loader: () => import('../client-v2/models/actions'),
+      },
       EditRecordCommentActionModel: {
         loader: () => import('../client-v2/models/actions'),
       },

--- a/packages/plugins/@nocobase/plugin-block-comment/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/locale/en-US.json
@@ -1,6 +1,9 @@
 {
   "Actions": "Actions",
+  "Add workflow": "Add workflow",
+  "Assign field values": "Assign field values",
   "Auto jump to last page": "Auto jump to last page",
+  "Are you sure you want to submit this comment?": "Are you sure you want to submit this comment?",
   "Are you sure you want to delete it?": "Are you sure you want to delete it?",
   "Cancel": "Cancel",
   "Comment": "Comment",
@@ -33,8 +36,14 @@
   "Render error": "Render error",
   "Search": "Search",
   "Select field": "Select field",
+  "Select workflow": "Select workflow",
   "Specify the associated business record value, for example the current record ID.": "Specify the associated business record value, for example the current record ID.",
+  "Submit action settings": "Submit action settings",
+  "Submit comment": "Submit comment",
+  "Support pre-action event (local mode), post-action event (local mode), and approval event here.": "Support pre-action event (local mode), post-action event (local mode), and approval event here.",
   "The comment owner field value type does not match the comment owner field. Please reconfigure the field mapping.": "The comment owner field value type does not match the comment owner field. Please reconfigure the field mapping.",
   "The current record value is empty, so comments cannot be loaded.": "The current record value is empty, so comments cannot be loaded.",
-  "Update Comment": "Update Comment"
+  "Update Comment": "Update Comment",
+  "Workflow": "Workflow",
+  "Bind workflows": "Bind workflows"
 }

--- a/packages/plugins/@nocobase/plugin-block-comment/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-block-comment/src/locale/zh-CN.json
@@ -1,6 +1,9 @@
 {
   "Actions": "操作",
+  "Add workflow": "添加工作流",
+  "Assign field values": "字段赋值",
   "Auto jump to last page": "自动跳转到最后一页",
+  "Are you sure you want to submit this comment?": "确定要提交这条评论吗？",
   "Are you sure you want to delete it?": "确定要删除吗？",
   "Cancel": "取消",
   "Comment": "评论",
@@ -33,8 +36,14 @@
   "Render error": "渲染错误",
   "Search": "搜索",
   "Select field": "选择字段",
+  "Select workflow": "选择工作流",
   "Specify the associated business record value, for example the current record ID.": "指定关联业务记录值，例如当前记录 ID。",
+  "Submit action settings": "提交按钮设置",
+  "Submit comment": "提交评论",
+  "Support pre-action event (local mode), post-action event (local mode), and approval event here.": "这里支持操作前事件（本地模式）、操作后事件（本地模式）和审批事件。",
   "The comment owner field value type does not match the comment owner field. Please reconfigure the field mapping.": "评论归属字段值的数据类型与评论归属字段不匹配，请重新配置字段映射。",
   "The current record value is empty, so comments cannot be loaded.": "当前记录值为空，无法加载评论。",
-  "Update Comment": "更新评论"
+  "Update Comment": "更新评论",
+  "Workflow": "工作流",
+  "Bind workflows": "绑定工作流"
 }

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx
@@ -79,8 +79,12 @@ vi.mock('@nocobase/client-v2', async () => {
         {children}
         <button
           onClick={async () => {
-            await onSubmit?.();
-            await close();
+            try {
+              await onSubmit?.();
+              await close();
+            } catch {
+              // Keep the drawer open when validation or submit flow interrupts submission.
+            }
           }}
         >
           {submitText ?? 'Submit'}
@@ -284,6 +288,29 @@ describe('UserFormDrawer', () => {
         },
       });
     });
+  });
+
+  it('should keep the drawer open and avoid refresh when the submit flow does not save values', async () => {
+    submit.mockResolvedValue(undefined);
+    const onSubmitted = vi.fn();
+
+    render(<UserFormDrawer onSubmitted={onSubmitted} />);
+
+    await waitFor(() => {
+      expect(createModelAsync).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalled();
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(success).not.toHaveBeenCalled();
+    expect(onSubmitted).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
   });
 
   it('should persist the create form model without password defaults', async () => {

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx
@@ -45,6 +45,13 @@ type FlowModelsResource = {
   save: (params: { values: Record<string, unknown> }) => Promise<unknown>;
 };
 
+class UserFormSubmitInterruptedError extends Error {
+  constructor() {
+    super('User form submission was interrupted.');
+    this.name = 'UserFormSubmitInterruptedError';
+  }
+}
+
 const userFormBlockClassName = css`
   width: 100%;
   border: none !important;
@@ -225,6 +232,7 @@ export default function UserFormDrawer(props: UserFormDrawerProps) {
     }
     setSubmitting(true);
     try {
+      let submitted = false;
       await model.submit({}, async (values) => {
         const nextValues = normalizeSubmitValues(values || {});
         if (isEdit && user?.id != null) {
@@ -232,10 +240,15 @@ export default function UserFormDrawer(props: UserFormDrawerProps) {
             filterByTk: user.id,
             values: nextValues,
           });
+          submitted = true;
           return;
         }
         await ctx.api.resource('users').create({ values: nextValues });
+        submitted = true;
       });
+      if (!submitted) {
+        throw new UserFormSubmitInterruptedError();
+      }
       ctx.message.success(t('Saved successfully'));
       await onSubmitted();
     } finally {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The new comment block submit action should support the same configuration capabilities as normal submit actions, including button settings, linkage rules, assign fields, workflow binding, and after-success behavior.


### Description 

This PR adds a dedicated configurable comment submit action model for the comment block. The submit action now supports button settings, linkage rules, assign fields, workflow binding, and after-success settings without changing workflow plugin code.


### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved comment submit actions and fixed related comment/user form submission issues. |
| 🇨🇳 Chinese | 改进评论提交按钮配置，并修复相关的评论和用户表单提交问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
