### PR TITLE
feat(ai): record AI usage events

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-usage-events.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-usage-events.test.ts
@@ -1,0 +1,220 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Context } from '@nocobase/actions';
+import { describe, expect, it, vi } from 'vitest';
+import { AIMessage } from '../types';
+import {
+  AIUsageEventValues,
+  buildAIUsageEventValues,
+  normalizeUsageMetadata,
+  recordAIUsageEventsForMessages,
+} from '../manager/ai-usage-events';
+
+describe('AI usage events', () => {
+  it('normalizes provider token usage variants', () => {
+    expect(
+      normalizeUsageMetadata({
+        prompt_tokens: '12',
+        completion_tokens: 8.7,
+        prompt_tokens_details: {
+          cached_tokens: 3,
+        },
+        completion_tokens_details: {
+          reasoning_tokens: 2,
+        },
+      }),
+    ).toEqual({
+      inputTokens: 12,
+      outputTokens: 8,
+      totalTokens: 20,
+      cachedTokens: 3,
+      reasoningTokens: 2,
+    });
+  });
+
+  it('builds an LLM usage event from an AI message and conversation', () => {
+    const event = buildAIUsageEventValues(
+      'session-1',
+      {
+        messageId: '1001',
+        sessionId: 'session-1',
+        role: 'nathan',
+        createdAt: '2026-07-06T01:02:03.004Z',
+        content: {
+          type: 'text',
+          content: 'Done',
+        },
+        toolCalls: [{ id: 'tool-1', name: 'search', type: 'function', args: {} }],
+        metadata: {
+          provider: 'openai',
+          llmService: 'primary-openai',
+          model: 'gpt-5.2',
+          usage_metadata: {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+          },
+          response_metadata: {
+            id: 'response-1',
+          },
+          autoCallTools: ['search'],
+        },
+      },
+      {
+        userId: 7,
+        aiEmployeeUsername: 'nathan',
+        from: 'main-agent',
+        category: 'chat',
+      },
+    );
+
+    expect(event).toMatchObject({
+      sessionId: 'session-1',
+      messageId: '1001',
+      userId: 7,
+      aiEmployeeUsername: 'nathan',
+      from: 'main-agent',
+      category: 'chat',
+      eventType: 'llm_message',
+      role: 'nathan',
+      provider: 'openai',
+      llmService: 'primary-openai',
+      model: 'gpt-5.2',
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      toolCallCount: 1,
+      autoToolCallCount: 1,
+      status: 'success',
+      rawResponseMetadata: {
+        id: 'response-1',
+      },
+    });
+    expect(event?.occurredAt.toISOString()).toBe('2026-07-06T01:02:03.004Z');
+  });
+
+  it('skips user messages', () => {
+    expect(
+      buildAIUsageEventValues(
+        'session-1',
+        {
+          messageId: '1002',
+          sessionId: 'session-1',
+          role: 'user',
+          content: {
+            type: 'text',
+            content: 'Hello',
+          },
+          metadata: {
+            provider: 'openai',
+            model: 'gpt-5.2',
+          },
+        },
+        {},
+      ),
+    ).toBeNull();
+  });
+
+  it('records usage events with conversation dimensions', async () => {
+    const updateOrCreate = vi.fn().mockResolvedValue(undefined);
+    const findOne = vi.fn().mockResolvedValue({
+      userId: 9,
+      aiEmployeeUsername: 'lina',
+      from: 'sub-agent',
+      category: 'task',
+    });
+    const getRepository = vi.fn((name: string) => {
+      if (name === 'aiConversations') {
+        return { findOne };
+      }
+      if (name === 'aiUsageEvents') {
+        return { updateOrCreate };
+      }
+      throw new Error(`Unexpected repository: ${name}`);
+    });
+    const ctx = {
+      db: {
+        getRepository,
+      },
+    } as unknown as Context;
+    const messages: AIMessage[] = [
+      {
+        messageId: '2001',
+        sessionId: 'session-2',
+        role: 'lina',
+        createdAt: new Date('2026-07-06T02:03:04.005Z'),
+        content: {
+          type: 'text',
+          content: 'Translated',
+        },
+        metadata: {
+          provider: 'dashscope',
+          model: 'qwen3-max',
+          usage_metadata: {},
+        },
+      },
+    ];
+
+    await recordAIUsageEventsForMessages(ctx, 'session-2', messages);
+
+    expect(findOne).toHaveBeenCalledWith({
+      filter: {
+        sessionId: 'session-2',
+      },
+      transaction: undefined,
+    });
+    expect(updateOrCreate).toHaveBeenCalledTimes(1);
+    const call = updateOrCreate.mock.calls[0]?.[0] as {
+      filterKeys: string[];
+      values: AIUsageEventValues;
+    };
+    expect(call.filterKeys).toEqual(['messageId', 'eventType']);
+    expect(call.values).toMatchObject({
+      sessionId: 'session-2',
+      messageId: '2001',
+      userId: 9,
+      aiEmployeeUsername: 'lina',
+      from: 'sub-agent',
+      category: 'task',
+      provider: 'dashscope',
+      model: 'qwen3-max',
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
+  });
+
+  it('does not query repositories when messages are not LLM usage events', async () => {
+    const getRepository = vi.fn();
+    const ctx = {
+      db: {
+        getRepository,
+      },
+    } as unknown as Context;
+
+    await recordAIUsageEventsForMessages(ctx, 'session-3', [
+      {
+        messageId: '3001',
+        sessionId: 'session-3',
+        role: 'user',
+        content: {
+          type: 'text',
+          content: 'Hello',
+        },
+        metadata: {
+          provider: 'openai',
+          model: 'gpt-5.2',
+        },
+      },
+    ]);
+
+    expect(getRepository).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/collections/ai-usage-events.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/collections/ai-usage-events.ts
@@ -1,0 +1,162 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { defineCollection } from '@nocobase/database';
+
+export default defineCollection({
+  migrationRules: ['schema-only'],
+  name: 'aiUsageEvents',
+  dataCategory: 'business',
+  timestamps: false,
+  createdAt: false,
+  updatedAt: false,
+  createdBy: false,
+  updatedBy: false,
+  fields: [
+    {
+      name: 'occurredAt',
+      type: 'unixTimestamp',
+      accuracy: 'millisecond',
+      allowNull: false,
+    },
+    {
+      name: 'sessionId',
+      type: 'uuid',
+      allowNull: false,
+    },
+    {
+      name: 'messageId',
+      type: 'bigInt',
+      allowNull: false,
+    },
+    {
+      name: 'user',
+      type: 'belongsTo',
+      target: 'users',
+      targetKey: 'id',
+      foreignKey: 'userId',
+    },
+    {
+      name: 'aiEmployee',
+      type: 'belongsTo',
+      target: 'aiEmployees',
+      targetKey: 'username',
+      foreignKey: 'aiEmployeeUsername',
+    },
+    {
+      name: 'from',
+      type: 'string',
+      allowNull: false,
+      defaultValue: 'main-agent',
+    },
+    {
+      name: 'category',
+      type: 'string',
+      allowNull: false,
+      defaultValue: 'chat',
+    },
+    {
+      name: 'eventType',
+      type: 'string',
+      allowNull: false,
+      defaultValue: 'llm_message',
+    },
+    {
+      name: 'role',
+      type: 'string',
+      allowNull: false,
+    },
+    {
+      name: 'provider',
+      type: 'string',
+    },
+    {
+      name: 'llmService',
+      type: 'string',
+    },
+    {
+      name: 'model',
+      type: 'string',
+    },
+    {
+      name: 'inputTokens',
+      type: 'bigInt',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'outputTokens',
+      type: 'bigInt',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'totalTokens',
+      type: 'bigInt',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'cachedTokens',
+      type: 'bigInt',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'reasoningTokens',
+      type: 'bigInt',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'toolCallCount',
+      type: 'integer',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'autoToolCallCount',
+      type: 'integer',
+      allowNull: false,
+      defaultValue: 0,
+    },
+    {
+      name: 'status',
+      type: 'string',
+      allowNull: false,
+      defaultValue: 'success',
+    },
+    {
+      name: 'rawUsageMetadata',
+      type: 'jsonb',
+    },
+    {
+      name: 'rawResponseMetadata',
+      type: 'jsonb',
+    },
+  ],
+  indexes: [
+    {
+      fields: ['messageId', 'eventType'],
+      unique: true,
+    },
+    {
+      fields: ['occurredAt'],
+    },
+    {
+      fields: ['userId', 'occurredAt'],
+    },
+    {
+      fields: ['aiEmployeeUsername', 'occurredAt'],
+    },
+    {
+      fields: ['sessionId'],
+    },
+  ],
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-chat-conversation.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-chat-conversation.ts
@@ -20,6 +20,7 @@ import {
 import { Context } from '@nocobase/actions';
 import PluginAIServer from '../plugin';
 import { Filter, Transaction } from '@nocobase/database';
+import { recordAIUsageEventsForMessages } from './ai-usage-events';
 export const createAIChatConversation = (ctx: Context, sessionId: string): AIChatConversation => {
   return new AIChatConversationImpl(ctx, sessionId);
 };
@@ -68,6 +69,7 @@ class AIChatConversationImpl implements AIChatConversation {
       ),
       transaction: this.transaction,
     });
+    await recordAIUsageEventsForMessages(this.ctx, this.sessionId, instances, this.transaction);
     return isArray ? instances : instances[0];
   }
   async removeMessages({ messageId }: AIMessageRemoveOptions): Promise<void> {

--- a/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-usage-events.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/manager/ai-usage-events.ts
@@ -1,0 +1,249 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Context } from '@nocobase/actions';
+import { Transaction } from '@nocobase/database';
+import { AIMessage } from '../types';
+
+const SKIPPED_MESSAGE_ROLES = new Set(['user', 'tool', 'system']);
+
+type RecordLike = Record<string, unknown> & {
+  get?: (key: string) => unknown;
+};
+
+export type NormalizedUsageMetadata = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cachedTokens: number;
+  reasoningTokens: number;
+};
+
+export type AIUsageEventValues = {
+  occurredAt: Date;
+  sessionId: string;
+  messageId: string;
+  userId?: unknown;
+  aiEmployeeUsername?: unknown;
+  from: string;
+  category: string;
+  eventType: 'llm_message';
+  role: string;
+  provider: string;
+  llmService?: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cachedTokens: number;
+  reasoningTokens: number;
+  toolCallCount: number;
+  autoToolCallCount: number;
+  status: 'success';
+  rawUsageMetadata: Record<string, unknown>;
+  rawResponseMetadata?: Record<string, unknown>;
+};
+
+export function normalizeUsageMetadata(usageMetadata: Record<string, unknown>): NormalizedUsageMetadata {
+  const inputTokens =
+    getNumericValue(usageMetadata, ['input_tokens', 'prompt_tokens', 'inputTokens', 'promptTokens']) ?? 0;
+  const outputTokens =
+    getNumericValue(usageMetadata, ['output_tokens', 'completion_tokens', 'outputTokens', 'completionTokens']) ?? 0;
+  const totalTokens = getNumericValue(usageMetadata, ['total_tokens', 'totalTokens']) ?? inputTokens + outputTokens;
+  const cachedTokens =
+    getNumericValue(usageMetadata, ['cached_tokens', 'cachedTokens']) ??
+    getNestedNumericValue(usageMetadata, ['input_token_details', 'cache_read']) ??
+    getNestedNumericValue(usageMetadata, ['input_token_details', 'cached_tokens']) ??
+    getNestedNumericValue(usageMetadata, ['prompt_tokens_details', 'cached_tokens']) ??
+    0;
+  const reasoningTokens =
+    getNumericValue(usageMetadata, ['reasoning_tokens', 'reasoningTokens']) ??
+    getNestedNumericValue(usageMetadata, ['output_token_details', 'reasoning']) ??
+    getNestedNumericValue(usageMetadata, ['completion_tokens_details', 'reasoning_tokens']) ??
+    0;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedTokens,
+    reasoningTokens,
+  };
+}
+
+export function buildAIUsageEventValues(
+  sessionId: string,
+  message: AIMessage,
+  conversation: RecordLike,
+): AIUsageEventValues | null {
+  const role = readString(message, 'role');
+  if (!role || SKIPPED_MESSAGE_ROLES.has(role)) {
+    return null;
+  }
+
+  const metadata = readRecord(message, 'metadata');
+  const provider = readString(metadata, 'provider');
+  const model = readString(metadata, 'model');
+  if (!provider || !model) {
+    return null;
+  }
+
+  const usageMetadata = readRecord(metadata, 'usage_metadata') ?? {};
+  const responseMetadata = readRecord(metadata, 'response_metadata');
+  const normalizedUsage = normalizeUsageMetadata(usageMetadata);
+  const toolCalls = readArray(message, 'toolCalls');
+  const autoCallTools = readArray(metadata, 'autoCallTools');
+  const llmService = readString(metadata, 'llmService');
+
+  return {
+    occurredAt: normalizeDate(readValue(message, 'createdAt')),
+    sessionId,
+    messageId: String(readValue(message, 'messageId') ?? ''),
+    userId: readValue(conversation, 'userId'),
+    aiEmployeeUsername: readValue(conversation, 'aiEmployeeUsername'),
+    from: readString(conversation, 'from') ?? 'main-agent',
+    category: readString(conversation, 'category') ?? 'chat',
+    eventType: 'llm_message',
+    role,
+    provider,
+    ...(llmService ? { llmService } : {}),
+    model,
+    ...normalizedUsage,
+    toolCallCount: toolCalls?.length ?? 0,
+    autoToolCallCount: autoCallTools?.length ?? 0,
+    status: 'success',
+    rawUsageMetadata: usageMetadata,
+    ...(responseMetadata ? { rawResponseMetadata: responseMetadata } : {}),
+  };
+}
+
+export async function recordAIUsageEventsForMessages(
+  ctx: Context,
+  sessionId: string,
+  messages: AIMessage[],
+  transaction?: Transaction,
+) {
+  const recordableMessages = messages.filter(isRecordableLLMMessage);
+  if (recordableMessages.length === 0) {
+    return;
+  }
+
+  const conversation = await ctx.db.getRepository('aiConversations').findOne({
+    filter: {
+      sessionId,
+    },
+    transaction,
+  });
+  if (!conversation) {
+    return;
+  }
+
+  const usageEvents = recordableMessages
+    .map((message) => buildAIUsageEventValues(sessionId, message, conversation as RecordLike))
+    .filter(isUsageEventValues);
+  if (usageEvents.length === 0) {
+    return;
+  }
+
+  const usageEventsRepo = ctx.db.getRepository('aiUsageEvents');
+  for (const values of usageEvents) {
+    await usageEventsRepo.updateOrCreate({
+      filterKeys: ['messageId', 'eventType'],
+      values,
+      transaction,
+    });
+  }
+}
+
+function isUsageEventValues(value: AIUsageEventValues | null): value is AIUsageEventValues {
+  return value !== null && value.messageId !== '';
+}
+
+function isRecordableLLMMessage(message: AIMessage): boolean {
+  const role = readString(message, 'role');
+  if (!role || SKIPPED_MESSAGE_ROLES.has(role)) {
+    return false;
+  }
+  const metadata = readRecord(message, 'metadata');
+  return Boolean(readString(metadata, 'provider') && readString(metadata, 'model'));
+}
+
+function isRecord(value: unknown): value is RecordLike {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readValue(source: unknown, key: string): unknown {
+  if (!isRecord(source)) {
+    return undefined;
+  }
+  const value = source[key];
+  if (value !== undefined) {
+    return value;
+  }
+  if (typeof source.get === 'function') {
+    return source.get(key);
+  }
+  return undefined;
+}
+
+function readString(source: unknown, key: string): string | undefined {
+  const value = readValue(source, key);
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function readRecord(source: unknown, key: string): Record<string, unknown> | undefined {
+  const value = readValue(source, key);
+  return isRecord(value) ? value : undefined;
+}
+
+function readArray(source: unknown, key: string): unknown[] | undefined {
+  const value = readValue(source, key);
+  return Array.isArray(value) ? value : undefined;
+}
+
+function getNumericValue(source: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const normalized = normalizeNumber(source[key]);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+  }
+}
+
+function getNestedNumericValue(source: Record<string, unknown>, path: string[]): number | undefined {
+  let current: unknown = source;
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return normalizeNumber(current);
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  const numeric = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(numeric)) {
+    return undefined;
+  }
+  return Math.max(0, Math.trunc(numeric));
+}
+
+function normalizeDate(value: unknown): Date {
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    if (Number.isFinite(date.getTime())) {
+      return date;
+    }
+  }
+  return new Date();
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
AI conversation usage facts were only available inside message metadata, making common usage statistics such as user rankings, AI employee rankings, model usage, and token totals harder to query directly.

### Description 
Added an `aiUsageEvents` collection that records structured LLM usage facts when AI messages are saved.

Key changes:
- Records LLM usage events with conversation, user, AI employee, model, token, tool-call, status, and raw metadata fields.
- Uses `occurredAt` as a millisecond Unix timestamp for event time.
- Keeps system audit fields disabled for the usage facts table.
- Adds token usage normalization for common provider metadata variants.
- Adds focused unit tests for usage normalization and event recording.

Potential risks:
- The first version only records successful LLM message events; failed LLM calls and historical backfill are not included.

Testing:
- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-usage-events.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-ai/src/server/__tests__/mcp-client-events.test.ts`

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added structured AI usage records for usage statistics |
| 🇨🇳 Chinese | 新增结构化 AI 使用记录，便于统计使用情况 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
