### PR TITLE
fix(plugin-auth): allow public auth routes

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/client/__tests__/routes.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/__tests__/routes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import PluginAuthClient from '../index';
+
+vi.mock('@nocobase/client', () => ({
+  Plugin: class {
+    app: { router: unknown };
+    router: unknown;
+
+    constructor(_options: unknown, app: { router: unknown }) {
+      this.app = app;
+      this.router = app.router;
+    }
+  },
+  lazy: (_loader: () => Promise<unknown>, ...names: string[]) =>
+    names.reduce<Record<string, string>>((components, name) => {
+      components[name] = name;
+      return components;
+    }, {}),
+}));
+
+vi.mock('@nocobase/utils/client', () => ({
+  Registry: class {
+    register = vi.fn();
+  },
+}));
+
+vi.mock('../interceptors', () => ({
+  authCheckMiddleware: vi.fn(() => [vi.fn(), vi.fn()]),
+}));
+
+describe('PluginAuthClient routes', () => {
+  it('should skip auth check for v1 public auth pages without silencing signin errors', async () => {
+    const app = {
+      router: {
+        add: vi.fn(),
+      },
+      pluginSettingsManager: {
+        add: vi.fn(),
+      },
+      addComponents: vi.fn(),
+      providers: {
+        unshift: vi.fn(),
+      },
+      apiClient: {
+        axios: {
+          interceptors: {
+            response: {
+              handlers: {
+                unshift: vi.fn(),
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const plugin = new PluginAuthClient({}, app as ConstructorParameters<typeof PluginAuthClient>[1]);
+
+    await plugin.load();
+
+    const getRouteOptions = (routeName: string) => {
+      const matchingCall = app.router.add.mock.calls.find(([name]) => name === routeName) as
+        | [string, { path?: string; skipAuthCheck?: boolean }]
+        | undefined;
+      expect(matchingCall).toBeDefined();
+      return matchingCall?.[1];
+    };
+
+    expect(getRouteOptions('auth.signin')).toEqual(expect.objectContaining({ path: '/signin' }));
+    expect(getRouteOptions('auth.signin')).not.toHaveProperty('skipAuthCheck', true);
+    expect(getRouteOptions('auth.signup')).toEqual(expect.objectContaining({ path: '/signup', skipAuthCheck: true }));
+    expect(getRouteOptions('auth.forgotPassword')).toEqual(
+      expect.objectContaining({ path: '/forgot-password', skipAuthCheck: true }),
+    );
+    expect(getRouteOptions('auth.resetPassword')).toEqual(
+      expect.objectContaining({ path: '/reset-password', skipAuthCheck: true }),
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-auth/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/index.tsx
@@ -73,14 +73,17 @@ export class PluginAuthClient extends Plugin {
     });
     this.router.add('auth.signup', {
       path: '/signup',
+      skipAuthCheck: true,
       Component: 'SignUpPage',
     });
     this.router.add('auth.forgotPassword', {
       path: '/forgot-password',
+      skipAuthCheck: true,
       Component: 'ForgotPasswordPage',
     });
     this.router.add('auth.resetPassword', {
       path: '/reset-password',
+      skipAuthCheck: true,
       Component: 'ResetPasswordPage',
     });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
未登录用户从重置密码邮件打开链接时，页面会被跳转到登录页，导致用户不能直接进入修改密码页面。

### Description
本次调整让找回密码、注册和重置密码页面可以在未登录状态下正常访问。登录页保持原有认证检查逻辑，避免登录页上的认证错误提示被静默。

已补充认证插件路由测试，覆盖这些页面的公开访问配置，并确认登录页不会被错误地标记为跳过认证检查。

### Showcase
无界面样式变更。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where reset password links open the sign-in page |
| 🇨🇳 Chinese | 修复重置密码链接打开后进入登录页的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
