### PR TITLE
fix(markdown): unify vditor cdn asset path

### DIFF
--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -431,6 +431,10 @@ export abstract class BaseApplication<
     return getSubAppName(this.getPublicPath()) || null;
   }
 
+  getCdnUrl() {
+    return window['__webpack_public_path__'] || this.getPublicPath();
+  }
+
   getPublicPath() {
     let publicPath = this.options.publicPath || '/';
     if (!publicPath.endsWith('/')) {

--- a/packages/plugins/@nocobase/plugin-block-markdown/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-block-markdown/src/client-v2/plugin.tsx
@@ -20,9 +20,7 @@ export class PluginBlockMarkdownClient extends Plugin {
 
   getCDN() {
     if (process.env.NODE_ENV === 'production') {
-      // @ts-ignore 这里需要同时兼容有 CDN_BASE_URL 和没有 CDN_BASE_URL 的情况
-      const base = window['__webpack_public_path__'] || stripModernClientPrefix(this.app.getPublicPath());
-      return `${base}static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor`;
+      return this.app.getCdnUrl() + 'static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor';
     }
     return `https://cdn.jsdelivr.net/npm/vditor@3.11.2`;
   }

--- a/packages/plugins/@nocobase/plugin-block-markdown/src/client/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-block-markdown/src/client/plugin.tsx
@@ -19,7 +19,7 @@ export class PluginBlockMarkdownClient extends Plugin {
 
   getCDN() {
     if (process.env.NODE_ENV === 'production') {
-      return this.app.getPublicPath() + 'static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor';
+      return this.app.getCdnUrl() + 'static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor';
     }
     return `https://cdn.jsdelivr.net/npm/vditor@3.11.2`;
   }

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/build.config.ts
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/build.config.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 
 const vditor = path.dirname(require.resolve('vditor'));
-const vditorTargets = ['dist/client/vditor/dist', 'dist/client-v2/vditor/dist'];
+const vditorTargets = ['dist/client/vditor/dist'];
 
 export default defineConfig({
   afterBuild: async (log) => {

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/runtime.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/runtime.tsx
@@ -26,8 +26,7 @@ export class MarkdownVditorRuntime {
 
   getCDN() {
     if (process.env.NODE_ENV === 'production') {
-      const base = window['__webpack_public_path__'] || stripModernClientPrefix(this.getPublicPath());
-      return `${base}static/plugins/@nocobase/plugin-field-markdown-vditor/dist/client-v2/vditor`;
+      return this.app.getCdnUrl() + 'static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor';
     }
     return 'https://cdn.jsdelivr.net/npm/vditor@3.11.2';
   }

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/index.tsx
@@ -33,7 +33,7 @@ export class PluginFieldMarkdownVditorClient extends Plugin {
 
   getCDN() {
     if (process.env.NODE_ENV === 'production') {
-      return this.app.getPublicPath() + 'static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor';
+      return this.app.getCdnUrl() + 'static/plugins/@nocobase/plugin-block-markdown/dist/client/vditor';
     }
     return `https://cdn.jsdelivr.net/npm/vditor@3.11.2`;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Vditor asset loading in production by resolving plugin CDN paths from the effective webpack public path. |
| 🇨🇳 Chinese | 修复生产环境下 Vditor 静态资源加载路径，改为基于实际生效的 webpack public path 解析插件 CDN 路径。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
