### PR TITLE
fix(data-source-manager): hide deprecated v2 collection templates

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/plugin.tsx
@@ -184,6 +184,7 @@ export class PluginCalendarClient extends Plugin<any, Application> {
       title: tExpr('Calendar collection'),
       order: 20,
       color: 'orange',
+      creatable: false,
       collection: {
         options: {
           template: 'calendar',

--- a/packages/plugins/@nocobase/plugin-collection-fdw/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-collection-fdw/src/client-v2/plugin.tsx
@@ -37,6 +37,7 @@ export class PluginCollectionFDWClientV2 extends Plugin<any, Application> {
       title: tExpr('Connect to foreign data'),
       order: 70,
       color: 'yellow',
+      creatable: false,
       collection: {
         options: {
           template: 'foreign',

--- a/packages/plugins/@nocobase/plugin-comments/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-comments/src/client-v2/plugin.tsx
@@ -42,6 +42,7 @@ export class PluginCommentClientV2 extends Plugin<any, Application> {
       title: tExpr('Comment Collection'),
       order: 22,
       color: 'orange',
+      creatable: false,
       collection: {
         options: {
           template: 'comment',

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/__tests__/registries.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/__tests__/registries.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { CollectionTemplateRegistry } from '../plugin';
 import { DataSourcePermissionTabRegistry, type DataSourcePermissionTabProps } from '../registries';
 
 function PermissionTab() {
@@ -24,6 +25,25 @@ const tabProps: DataSourcePermissionTabProps = {
 };
 
 describe('data source manager registries', () => {
+  it('keeps non-creatable collection templates registered while hiding them from create options', () => {
+    const registry = new CollectionTemplateRegistry();
+
+    registry.register({
+      name: 'general',
+      title: 'General collection',
+      order: 10,
+    });
+    registry.register({
+      name: 'calendar',
+      title: 'Calendar collection',
+      order: 20,
+      creatable: false,
+    });
+
+    expect(registry.getAll().map((item) => item.name)).toEqual(['general', 'calendar']);
+    expect(registry.getCreatable().map((item) => item.name)).toEqual(['general']);
+  });
+
   it('returns sorted data source permission tabs and filters empty resolvers', () => {
     const registry = new DataSourcePermissionTabRegistry();
 

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
@@ -1387,7 +1387,7 @@ function CollectionsPage(props: CollectionsPageProps) {
   const allowCustomCollectionDeletion = Boolean(
     !isMainDataSource && !configureFieldsDisabled && dataSourceType?.allowCollectionDeletion && DeleteCollection,
   );
-  const collectionTemplates = useMemo(() => plugin.getCollectionTemplates(), [plugin]);
+  const collectionTemplates = useMemo(() => plugin.getCreatableCollectionTemplates(), [plugin]);
   const categoryRequest = useRequest(
     async () => {
       if (!isMainDataSource) {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/plugin.tsx
@@ -147,6 +147,7 @@ export interface CollectionTemplateOptions {
   order?: number;
   color?: string;
   divider?: boolean;
+  creatable?: boolean;
   collection?: {
     options?: Record<string, any> | (() => Record<string, any>);
     fields?: CollectionTemplateField[] | (() => CollectionTemplateField[]);
@@ -208,7 +209,7 @@ export interface CollectionTemplateOptions {
   beforeSubmit?: (values: Record<string, any>) => void;
 }
 
-class CollectionTemplateRegistry {
+export class CollectionTemplateRegistry {
   protected templates = new Map<string, CollectionTemplateOptions>();
 
   register(nameOrOptions: string | CollectionTemplateOptions, options?: CollectionTemplateOptions) {
@@ -229,6 +230,10 @@ class CollectionTemplateRegistry {
 
   getAll() {
     return [...this.templates.values()].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  }
+
+  getCreatable() {
+    return this.getAll().filter((template) => template.creatable !== false);
   }
 }
 
@@ -379,6 +384,10 @@ export class PluginDataSourceManagerClientV2 extends Plugin<any, Application> {
 
   getCollectionTemplates() {
     return this.collectionTemplateRegistry.getAll();
+  }
+
+  getCreatableCollectionTemplates() {
+    return this.collectionTemplateRegistry.getCreatable();
   }
 
   private registerBuiltInCollectionPresetFields() {

--- a/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client-v2/plugin.tsx
@@ -22,6 +22,7 @@ export default class PluginWorkflowDynamicCalculationClientV2 extends Plugin<any
       title: tExpr('Expression collection'),
       order: 60,
       color: 'orange',
+      creatable: false,
       collection: {
         options: {
           template: 'expression',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
In v2 data source management, some main data source collection templates are deprecated for new collection creation:

- Calendar collection
- Expression collection
- Comment collection
- Connect to foreign data

They should no longer appear in the create collection template menu, while historical collections that already use these templates must continue to display and work.

### Description
This PR adds a `creatable` flag to v2 collection templates and uses a filtered template list only for the main data source "Create collection" dropdown.

Key changes:

- Add `creatable?: boolean` to v2 collection template options.
- Add `getCreatableCollectionTemplates()` while keeping `getCollectionTemplates()` and `getCollectionTemplate()` unchanged.
- Hide `calendar`, `expression`, `comment`, and `foreign` templates from the create menu by setting `creatable: false`.
- Add a registry test to verify non-creatable templates remain registered but are excluded from create options.

Risk: Low. The change only filters v2 create-menu options. Existing registered templates remain available for labels, filters, edit/configuration flows, and historical collections.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/__tests__/registries.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/__tests__/registries.test.ts packages/plugins/@nocobase/plugin-calendar/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-workflow-dynamic-calculation/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-comments/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-collection-fdw/src/client-v2/plugin.tsx`

### Related issues

N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide deprecated v2 main data source collection templates from the create collection menu. |
| 🇨🇳 Chinese | 在 v2 主数据源中新建数据表菜单中隐藏已废弃的数据表模板。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
