### PR TITLE
fix(client-v2): refresh record scoped flow pages

### DIFF
--- a/packages/core/client-v2/src/flow/FlowPage.tsx
+++ b/packages/core/client-v2/src/flow/FlowPage.tsx
@@ -60,7 +60,9 @@ type FlowPageProps = {
 type FlowPageViewContext = FlowEngineContext & {
   view?: {
     inputArgs?: {
+      filterByTk?: unknown;
       isMobileLayout?: unknown;
+      sourceId?: unknown;
     };
   };
 };
@@ -102,6 +104,10 @@ export const FlowPage = React.memo((props: FlowPageProps & Record<string, unknow
         subType: 'object',
         use: pageModelClass,
       };
+      const isRuntimeRecordScopedPage =
+        !flowEngine.context.flowSettingsEnabled &&
+        (typeof ctx?.view?.inputArgs?.filterByTk !== 'undefined' ||
+          typeof ctx?.view?.inputArgs?.sourceId !== 'undefined');
       if (shouldInjectDefaultChildTab) {
         const tabTitle = defaultTabTitle || flowEngine.translate?.('Details');
         options['subModels'] = {
@@ -128,7 +134,9 @@ export const FlowPage = React.memo((props: FlowPageProps & Record<string, unknow
           },
         };
       }
-      const data = await flowEngine.loadOrCreateModel(options, { skipSave: !flowEngine.context.flowSettingsEnabled });
+      const data =
+        (isRuntimeRecordScopedPage && (await flowEngine.loadModel({ ...options, refresh: true }))) ||
+        (await flowEngine.loadOrCreateModel(options, { skipSave: !flowEngine.context.flowSettingsEnabled }));
       if (data?.uid && onModelLoaded) {
         data.context.addDelegate(ctx);
         bindViewLayoutState(data, ctx);

--- a/packages/core/client-v2/src/flow/__tests__/FlowPage.test.tsx
+++ b/packages/core/client-v2/src/flow/__tests__/FlowPage.test.tsx
@@ -9,7 +9,7 @@
 
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FlowPage } from '../FlowPage';
 
 type TestContextProperty = {
@@ -71,10 +71,15 @@ const createPageModel = (): TestPageModel => {
 };
 
 const mocks = vi.hoisted(() => ({
+  flowSettingsEnabled: false,
+  loadModel: vi.fn(),
+  loadOrCreateModel: vi.fn(),
   rendererMobileStates: [] as boolean[],
   rendererProps: undefined as RendererProps | undefined,
   model: undefined as TestPageModel | undefined,
+  viewFilterByTk: undefined as unknown,
   viewInputMobileLayout: true as boolean | undefined,
+  viewSourceId: undefined as unknown,
   contextMobileLayout: undefined as boolean | undefined,
 }));
 
@@ -94,15 +99,20 @@ vi.mock('@nocobase/flow-engine', async () => {
     }),
     useFlowEngine: vi.fn(() => ({
       getModelClassAsync: vi.fn(async () => TestPageModelClass),
-      loadOrCreateModel: vi.fn(async () => mocks.model),
-      context: {},
+      loadModel: mocks.loadModel,
+      loadOrCreateModel: mocks.loadOrCreateModel,
+      context: {
+        flowSettingsEnabled: mocks.flowSettingsEnabled,
+      },
       translate: vi.fn((value: string) => value),
     })),
     useFlowModelById: vi.fn(() => mocks.model),
     useFlowViewContext: vi.fn(() => ({
       view: {
         inputArgs: {
+          ...(typeof mocks.viewFilterByTk !== 'undefined' ? { filterByTk: mocks.viewFilterByTk } : {}),
           ...(typeof mocks.viewInputMobileLayout === 'boolean' ? { isMobileLayout: mocks.viewInputMobileLayout } : {}),
+          ...(typeof mocks.viewSourceId !== 'undefined' ? { sourceId: mocks.viewSourceId } : {}),
         },
       },
       ...(typeof mocks.contextMobileLayout === 'boolean' ? { isMobileLayout: mocks.contextMobileLayout } : {}),
@@ -154,11 +164,21 @@ vi.mock('ahooks', async () => {
 });
 
 describe('FlowPage', () => {
+  beforeEach(() => {
+    mocks.loadModel.mockImplementation(async () => null);
+    mocks.loadOrCreateModel.mockImplementation(async () => mocks.model);
+  });
+
   afterEach(() => {
+    mocks.flowSettingsEnabled = false;
+    mocks.loadModel.mockReset();
+    mocks.loadOrCreateModel.mockReset();
     mocks.rendererMobileStates = [];
     mocks.rendererProps = undefined;
     mocks.model = undefined;
+    mocks.viewFilterByTk = undefined;
     mocks.viewInputMobileLayout = true;
+    mocks.viewSourceId = undefined;
     mocks.contextMobileLayout = undefined;
   });
 
@@ -203,4 +223,31 @@ describe('FlowPage', () => {
       expect(mocks.rendererMobileStates[0]).toBe(expected);
     },
   );
+
+  it('reloads runtime page models for record scoped views', async () => {
+    mocks.model = createPageModel();
+    mocks.viewFilterByTk = 1;
+    mocks.loadModel.mockImplementation(async () => mocks.model);
+
+    render(<FlowPage onModelLoaded={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mocks.loadModel).toHaveBeenCalled();
+    });
+    expect(mocks.loadModel.mock.calls[0]?.[0]).toMatchObject({ refresh: true });
+    expect(mocks.loadOrCreateModel).not.toHaveBeenCalled();
+  });
+
+  it('keeps configured page model cache behavior in flow settings mode', async () => {
+    mocks.flowSettingsEnabled = true;
+    mocks.model = createPageModel();
+    mocks.viewFilterByTk = 1;
+
+    render(<FlowPage onModelLoaded={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(mocks.loadOrCreateModel).toHaveBeenCalled();
+    });
+    expect(mocks.loadModel).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Runtime record-scoped FlowPage instances can reuse stale page models when users open different records from an edit popup. Linkage rules mutate field model props such as disabled at runtime, so the next record may inherit the previous record's disabled state.

### Description 
- Reload record-scoped FlowPage models with refresh in runtime mode before falling back to the existing loadOrCreateModel path.
- Keep flow settings mode on the existing cache path to avoid disturbing UI configuration behavior.
- Add FlowPage tests for runtime record-scoped reload and settings-mode cache behavior.

Potential risks:
- Runtime record popup pages may perform one extra page model load.
- If a page model cannot be found by refresh, the existing fallback path is preserved.

Testing suggestions:
- Open an edit popup for record A, then record B, then record A/B again, and verify linkage-driven disabled states do not leak between records.
- Verify UI configuration mode still edits popup page settings normally.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed stale linkage field states when switching records in runtime edit popups. |
| 🇨🇳 Chinese | 修复运行态编辑弹窗切换记录时联动字段状态残留的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary