### PR TITLE
fix(plugin-file-manager): register v2 attachment field interface

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/attachment-interface.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/attachment-interface.test.ts
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Application } from '@nocobase/client-v2';
+import { describe, expect, it } from 'vitest';
+import { AttachmentFieldInterface } from '../interfaces/attachment';
+import PluginFileManagerClientV2 from '../plugin';
+
+describe('AttachmentFieldInterface', () => {
+  it('provides v2 data source manager metadata for attachment fields', async () => {
+    const app = new Application({
+      plugins: [PluginFileManagerClientV2],
+    });
+
+    await app.load();
+
+    const fieldInterface =
+      app.dataSourceManager.collectionFieldInterfaceManager.getFieldInterface<AttachmentFieldInterface>('attachment');
+
+    expect(fieldInterface).toBeInstanceOf(AttachmentFieldInterface);
+    expect(fieldInterface.group).toBe('media');
+    expect(fieldInterface.default).toMatchObject({
+      interface: 'attachment',
+      type: 'belongsToMany',
+      target: 'attachments',
+      uiSchema: {
+        type: 'array',
+        'x-component': 'Upload.Attachment',
+      },
+    });
+    expect(fieldInterface.configure?.items?.map((item) => item.name)).toEqual([
+      'target',
+      'targetKey',
+      'uiSchema.x-component-props.accept',
+      'uiSchema.x-component-props.multiple',
+    ]);
+  });
+
+  it('initializes required belongsToMany keys', () => {
+    const fieldInterface = new AttachmentFieldInterface({} as never);
+    const values: Record<string, unknown> = {};
+
+    fieldInterface.initialize(values);
+
+    expect(values).toMatchObject({
+      sourceKey: 'id',
+      targetKey: 'id',
+    });
+    expect(values.through).toMatch(/^t_/);
+    expect(values.foreignKey).toMatch(/^f_/);
+    expect(values.otherKey).toMatch(/^f_/);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/index.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/index.tsx
@@ -36,6 +36,7 @@ export {
 export type { DefaultFieldProps } from './components/DefaultField';
 export type { PathFieldProps } from './components/PathField';
 export { CardUpload, UploadFieldModel } from './models/UploadFieldModel';
+export { AttachmentFieldInterface } from './interfaces/attachment';
 
 // Preview registry consumed by file-previewer plugins (e.g. plugin-file-previewer-office)
 // to add custom preview handlers under v2 without going through the v1 `@nocobase/plugin-file-manager/client` entry.

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/interfaces/attachment.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/interfaces/attachment.ts
@@ -1,0 +1,86 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { uid } from '@formily/shared';
+import { CollectionFieldInterface } from '@nocobase/client-v2';
+import { tExpr } from '../locale';
+
+export class AttachmentFieldInterface extends CollectionFieldInterface {
+  name = 'attachment';
+  type = 'object';
+  group = 'media';
+  title = tExpr('Attachment');
+  isAssociation = true;
+  default = {
+    interface: 'attachment',
+    type: 'belongsToMany',
+    target: 'attachments',
+    uiSchema: {
+      type: 'array',
+      'x-component': 'Upload.Attachment',
+      'x-use-component-props': 'useAttachmentFieldProps',
+    },
+  };
+  availableTypes = ['belongsToMany'];
+  configure = {
+    items: [
+      {
+        name: 'target',
+        title: tExpr('File collection'),
+        component: 'Select' as const,
+        required: true,
+        defaultValue: 'attachments',
+        schema: {
+          enum: '{{fileCollections}}',
+        },
+      },
+      {
+        name: 'targetKey',
+        defaultValue: 'id',
+        hidden: true,
+      },
+      {
+        name: 'uiSchema.x-component-props.accept',
+        title: tExpr('MIME type'),
+        component: 'Input' as const,
+        componentProps: {
+          placeholder: 'image/*',
+        },
+      },
+      {
+        name: 'uiSchema.x-component-props.multiple',
+        title: tExpr('Allow uploading multiple files'),
+        component: 'Checkbox' as const,
+        defaultValue: true,
+      },
+    ],
+  };
+  filterable = {
+    nested: true,
+    children: [],
+  };
+
+  initialize(values: Record<string, unknown>) {
+    if (!values.through) {
+      values.through = `t_${uid()}`;
+    }
+    if (!values.foreignKey) {
+      values.foreignKey = `f_${uid()}`;
+    }
+    if (!values.otherKey) {
+      values.otherKey = `f_${uid()}`;
+    }
+    if (!values.sourceKey) {
+      values.sourceKey = 'id';
+    }
+    if (!values.targetKey) {
+      values.targetKey = 'id';
+    }
+  }
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
@@ -18,6 +18,7 @@ import {
   STORAGE_TYPE_TX_COS,
 } from '../constants';
 import { NAMESPACE } from '../common/constants';
+import { AttachmentFieldInterface } from './interfaces/attachment';
 import { tExpr } from './locale';
 
 type UploadFileResult = {
@@ -88,6 +89,8 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
   storageTypes = new Map<string, StorageType>();
 
   async load() {
+    this.app.addFieldInterfaces([AttachmentFieldInterface]);
+
     const title = this.app.i18n.t('File manager', { ns: NAMESPACE });
     const dataSourceManager = (this.app.pm.get('@nocobase/plugin-data-source-manager') ||
       this.app.pm.get('data-source-manager')) as

--- a/packages/plugins/@nocobase/plugin-public-forms/src/server/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/server/__tests__/plugin.test.ts
@@ -10,8 +10,21 @@
 import { describe, expect, it, vi } from 'vitest';
 import { PluginPublicFormsServer } from '../plugin';
 
+type PublicFormsServerApp = ConstructorParameters<typeof PluginPublicFormsServer>[0];
+
 function createPlugin() {
   return Object.create(PluginPublicFormsServer.prototype) as PluginPublicFormsServer & Record<string, any>;
+}
+
+function createAclPlugin() {
+  return new PluginPublicFormsServer(
+    {
+      db: {
+        getCollection: vi.fn(() => null),
+      },
+    } as unknown as PublicFormsServerApp,
+    { name: 'public-forms' },
+  );
 }
 
 function setupGetMetaPlugin(options: { password?: string; enabled?: boolean } = {}) {
@@ -76,6 +89,23 @@ function setupGetMetaPlugin(options: { password?: string; enabled?: boolean } = 
 
   return { plugin, sign };
 }
+
+type PublicFormAclContext = {
+  PublicForm: {
+    collectionName: string;
+    targetCollections: string[];
+  };
+  action: {
+    resourceName: string;
+    actionName: string;
+    params: {
+      fileCollectionName?: string;
+    };
+  };
+  permission?: {
+    skip: boolean;
+  };
+};
 
 describe('PluginPublicFormsServer', () => {
   it('keeps primary collection options in public form meta', async () => {
@@ -378,5 +408,28 @@ describe('PluginPublicFormsServer', () => {
     expect(plugin.validatePublicFormToken).toHaveBeenCalledWith('pf1', 'token');
     expect(plugin.isFlowModelDescendant).toHaveBeenCalledWith('pf1', 'popup-grid');
     expect(findModelById).toHaveBeenCalledWith('popup-grid', { includeAsyncNode: true });
+  });
+
+  it('allows public form storage checks', async () => {
+    const plugin = createAclPlugin();
+    const ctx: PublicFormAclContext = {
+      PublicForm: {
+        collectionName: 'orders',
+        targetCollections: [],
+      },
+      action: {
+        resourceName: 'storages',
+        actionName: 'check',
+        params: {
+          fileCollectionName: 'publicFiles',
+        },
+      },
+    };
+    const next = vi.fn(async () => undefined);
+
+    await plugin.parseACL(ctx, next);
+
+    expect(ctx.permission).toEqual({ skip: true });
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/server/plugin.ts
@@ -347,7 +347,7 @@ export class PluginPublicFormsServer extends Plugin {
     } else if (
       (['list', 'get'].includes(actionName) && ctx.PublicForm['targetCollections'].includes(resourceName)) ||
       (collection?.options.template === 'file' && actionName === 'create') ||
-      (resourceName === 'storages' && ['getBasicInfo', 'createPresignedUrl'].includes(actionName)) ||
+      (resourceName === 'storages' && ['getBasicInfo', 'createPresignedUrl', 'check'].includes(actionName)) ||
       (resourceName === 'vditor' && ['check'].includes(actionName)) ||
       (resourceName === 'map-configuration' && actionName === 'get')
     ) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 data table manager did not show the regular Attachment field interface under the Media group. The v1 file-manager client registers `attachment`, and the v2 Attachment (URL) plugin registers `attachmentURL`, but file-manager v2 was missing the `attachment` field interface registration.

After the v2 attachment field became available, public forms that contain relationship fields targeting file collections could hit a 403 during image upload. The v2 upload field calls `storages:check` before uploading, while public forms only allowed `storages:getBasicInfo` and `storages:createPresignedUrl`.

### Description
- Add a v2 `AttachmentFieldInterface` in file-manager.
- Register it during file-manager v2 plugin load so the data source manager can list Attachment in field interface options.
- Keep the same attachment data semantics as v1: `belongsToMany` targeting `attachments`, with generated `through`, `foreignKey`, `otherKey`, `sourceKey`, and `targetKey` defaults.
- Add a unit test covering v2 registration metadata and relation key initialization.
- Allow `storages:check` for public form requests so v2 file relationship fields can complete their upload preflight check.
- Add a public-forms server test covering the `storages:check` ACL path.

Potential risk is low. The attachment registration change is scoped to `plugin-file-manager` client-v2 field interface registration. The public-forms change only adds `storages:check` to the existing public form storage action allowlist and does not change database schema, migrations, or legacy v1 client behavior.

Tested with:

```bash
yarn eslint --fix packages/plugins/@nocobase/plugin-file-manager/src/client-v2/interfaces/attachment.ts packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-file-manager/src/client-v2/index.tsx packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/attachment-interface.test.ts
yarn test packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/attachment-interface.test.ts --run --reporter=verbose
yarn eslint --fix packages/plugins/@nocobase/plugin-public-forms/src/server/plugin.ts packages/plugins/@nocobase/plugin-public-forms/src/server/__tests__/plugin.test.ts
yarn test packages/plugins/@nocobase/plugin-public-forms/src/server/__tests__/plugin.test.ts --run --reporter=verbose
yarn test packages/core/client/src/schema-component/antd/association-field/__tests__/InternalCascadeSelect.test.tsx --run --reporter=verbose
git diff --check
```

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed missing Attachment field interface in v2 data table management, and fixed image upload preflight checks for public form file relationship fields. |
| 🇨🇳 Chinese | 修复 v2 数据表管理中缺失 Attachment 字段接口的问题，并修复公开表单文件关系字段上传图片时的预检查权限问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
