### PR TITLE
fix(public-forms): skip auth-gated requests

### DIFF
--- a/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
+++ b/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
@@ -1666,7 +1666,7 @@ describe('FlowRoute', () => {
     expect(engine.getModel('public-form-1')).toBeUndefined();
   });
 
-  it('should not skip accessible route loading just because layout authCheck is false', async () => {
+  it('should skip accessible route loading when layout authCheck is false', async () => {
     const engine = new FlowEngine();
     const ensureAccessibleLoaded = vi.fn().mockRejectedValue(new Error('cannot load accessible routes'));
     const getRouteBySchemaUid = vi.fn();
@@ -1735,7 +1735,7 @@ describe('FlowRoute', () => {
     await waitFor(() => {
       expect(layoutModel.registerRoutePage).toHaveBeenCalledWith('public-form-1', expect.any(Object));
     });
-    expect(ensureAccessibleLoaded).toHaveBeenCalledTimes(1);
+    expect(ensureAccessibleLoaded).not.toHaveBeenCalled();
     expect(getRouteBySchemaUid).not.toHaveBeenCalled();
   });
 

--- a/packages/core/client-v2/src/flow/components/FlowRoute.tsx
+++ b/packages/core/client-v2/src/flow/components/FlowRoute.tsx
@@ -274,11 +274,12 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
   useEffect(() => {
     let active = true;
     const requestId = ++requestIdRef.current;
+    const requiresAccessibleRoute = shouldRequireAccessibleRoute(routeLayout);
 
     const run = async () => {
       setGuardState({ pageUid, pending: true, allowBridge: false, notFound: false });
 
-      if (!skipRouteRepositoryCheck && !routeRepository?.isAccessibleLoaded?.()) {
+      if (requiresAccessibleRoute && !skipRouteRepositoryCheck && !routeRepository?.isAccessibleLoaded?.()) {
         try {
           await routeRepository?.ensureAccessibleLoaded?.();
         } catch (_error) {
@@ -293,8 +294,11 @@ const FlowRoute = (props: FlowRouteProps = {}) => {
         return;
       }
 
-      const route = skipRouteRepositoryCheck ? undefined : getAccessibleRouteByPageUid(routeRepository, pageUid);
-      if (!route && !skipRouteRepositoryCheck && shouldRequireAccessibleRoute(routeLayout)) {
+      const route =
+        skipRouteRepositoryCheck || !requiresAccessibleRoute
+          ? undefined
+          : getAccessibleRouteByPageUid(routeRepository, pageUid);
+      if (!route && !skipRouteRepositoryCheck && requiresAccessibleRoute) {
         setGuardState({ pageUid, pending: false, allowBridge: false, notFound: true });
         return;
       }

--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/AIEmployeesProvider.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/AIEmployeesProvider.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { CurrentUserContext } from '@nocobase/client';
+import { AIEmployeesProvider } from '../ai-employees/AIEmployeesProvider';
+
+const { appMock } = vi.hoisted(() => ({
+  appMock: {
+    router: {
+      isSkippedAuthCheckRoute: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@nocobase/client', async () => {
+  const actual = await vi.importActual<typeof import('@nocobase/client')>('@nocobase/client');
+  return {
+    ...actual,
+    useApp: () => appMock,
+  };
+});
+
+vi.mock('../ai-employees/1.x/selector/AISelectorProvider', () => ({
+  AISelectionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../ai-employees/AISettingsProvider', () => ({
+  AISettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../ai-employees/chatbox/ChatBoxLayout', () => ({
+  ChatBoxLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="chat-box-layout">{children}</div>,
+}));
+
+vi.mock('../ai-employees/AISelection', () => ({
+  AISelection: () => null,
+}));
+
+vi.mock('../ai-employees/AISelectionControl', () => ({
+  AISelectionControl: () => null,
+}));
+
+describe('AIEmployeesProvider', () => {
+  it('does not mount chat box on routes that skip auth check', () => {
+    appMock.router.isSkippedAuthCheckRoute.mockReturnValue(true);
+
+    render(
+      <MemoryRouter initialEntries={['/public-forms/form-1']}>
+        <CurrentUserContext.Provider value={{ data: { data: { id: 1 } } } as any}>
+          <AIEmployeesProvider>
+            <div data-testid="content" />
+          </AIEmployeesProvider>
+        </CurrentUserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-box-layout')).not.toBeInTheDocument();
+  });
+
+  it('mounts chat box on routes that require auth check', () => {
+    appMock.router.isSkippedAuthCheckRoute.mockReturnValue(false);
+
+    render(
+      <MemoryRouter initialEntries={['/admin/page-1']}>
+        <CurrentUserContext.Provider value={{ data: { data: { id: 1 } } } as any}>
+          <AIEmployeesProvider>
+            <div data-testid="content" />
+          </AIEmployeesProvider>
+        </CurrentUserContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('chat-box-layout')).toBeInTheDocument();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/AIEmployeesProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/AIEmployeesProvider.tsx
@@ -13,13 +13,16 @@ import { AISettingsProvider } from './AISettingsProvider';
 import { ChatBoxLayout } from './chatbox/ChatBoxLayout';
 import { AISelection } from './AISelection';
 import { AISelectionControl } from './AISelectionControl';
-import { CurrentUserContext } from '@nocobase/client';
+import { CurrentUserContext, useApp } from '@nocobase/client';
+import { useLocation } from 'react-router-dom';
 
 export const AIEmployeesProvider: React.FC<{
   children: React.ReactNode;
 }> = (props) => {
+  const app = useApp();
+  const location = useLocation();
   const currentUserCtx = useContext(CurrentUserContext);
-  if (!currentUserCtx?.data?.data) {
+  if (app.router.isSkippedAuthCheckRoute(location.pathname) || !currentUserCtx?.data?.data) {
     return <>{props.children}</>;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 公开表单页面不需要登录即可访问，但页面加载时仍会触发部分需要登录权限的接口请求，导致浏览器 Network 中出现 401 或 403 报错。

### Description
本次调整让公开表单这类免登录页面不再启动需要登录权限的请求：

- 在免登录路由下不挂载 AI 员工聊天入口，避免请求 AI 员工列表和会话未读数。
- 在 `authCheck: false` 的 V2 页面下跳过可访问菜单路由加载，避免请求当前用户可访问的桌面路由。
- 补充了对应单元测试，覆盖公开路由不触发这些登录态请求的场景。

潜在风险较低，主要影响免登录路由下的初始化行为；后台页面仍保持原来的登录态加载逻辑。

### Showcase
无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix unnecessary login-required requests on V2 public form pages |
| 🇨🇳 Chinese | 修复 V2 公开表单页面触发不必要登录态请求的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
