### PR TITLE
fix(plugin-workflow): respect readonly state in v2 field assignment

### DIFF
--- a/packages/core/client-v2/src/flow/components/FieldAssignExactDatePicker.tsx
+++ b/packages/core/client-v2/src/flow/components/FieldAssignExactDatePicker.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { DatePicker, Select, Space } from 'antd';
 import { inferPickerType } from '../../flow-compat';
 import { dayjs, getDateTimeFormat, getPickerFormat } from '@nocobase/utils/client';
@@ -29,6 +29,7 @@ export interface FieldAssignExactDatePickerProps {
   isRange?: boolean;
   onChange?: (value: ExactDatePickerValue) => void;
   style?: React.CSSProperties;
+  disabled?: boolean;
 }
 
 function getRawSingleValue(value: unknown, isRange: boolean): unknown {
@@ -114,7 +115,7 @@ function parseRangeValue(value: unknown, format: string): [dayjs.Dayjs, dayjs.Da
 }
 
 export const FieldAssignExactDatePicker: React.FC<FieldAssignExactDatePickerProps> = (props) => {
-  const { picker = 'date', format, showTime, timeFormat, value, isRange = false, onChange, style } = props;
+  const { picker = 'date', format, showTime, timeFormat, value, isRange = false, onChange, style, disabled } = props;
   const flowCtx = useFlowContext();
   const t = flowCtx.model.translate.bind(flowCtx.model);
 
@@ -124,16 +125,16 @@ export const FieldAssignExactDatePicker: React.FC<FieldAssignExactDatePickerProp
     return inferPickerFromRawValue(rawSingleValue, picker);
   });
 
-  const getResolvedFormat = (nextPicker: ExactDatePickerMode) => {
-    const baseFormat = nextPicker === picker && format ? format : getPickerFormat(nextPicker);
-    const dateFormat = nextPicker === 'date' ? stripTimeFromFormat(baseFormat) : baseFormat;
-    return getDateTimeFormat(nextPicker, dateFormat, showTime, timeFormat);
-  };
-
-  const resolvedFormat = useMemo(
-    () => getResolvedFormat(targetPicker),
-    [targetPicker, format, picker, showTime, timeFormat],
+  const getResolvedFormat = useCallback(
+    (nextPicker: ExactDatePickerMode) => {
+      const baseFormat = nextPicker === picker && format ? format : getPickerFormat(nextPicker);
+      const dateFormat = nextPicker === 'date' ? stripTimeFromFormat(baseFormat) : baseFormat;
+      return getDateTimeFormat(nextPicker, dateFormat, showTime, timeFormat);
+    },
+    [format, picker, showTime, timeFormat],
   );
+
+  const resolvedFormat = useMemo(() => getResolvedFormat(targetPicker), [getResolvedFormat, targetPicker]);
 
   const singleValue = useMemo(() => {
     if (isRange) return null;
@@ -156,6 +157,10 @@ export const FieldAssignExactDatePicker: React.FC<FieldAssignExactDatePickerProp
   );
 
   const handlePickerTypeChange = (nextPicker: ExactDatePickerMode) => {
+    if (disabled) {
+      return;
+    }
+
     setTargetPicker(nextPicker);
 
     if (!onChange) {
@@ -182,7 +187,11 @@ export const FieldAssignExactDatePicker: React.FC<FieldAssignExactDatePickerProp
     inputReadOnly: flowCtx.isMobileLayout,
     showTime: showTime ? { defaultValue: dayjs('00:00:00', 'HH:mm:ss') } : false,
     value: singleValue,
+    disabled,
     onChange: (nextDate: dayjs.Dayjs | null) => {
+      if (disabled) {
+        return;
+      }
       if (nextDate && dayjs.isDayjs(nextDate)) {
         onChange?.(nextDate);
         return;
@@ -200,7 +209,11 @@ export const FieldAssignExactDatePicker: React.FC<FieldAssignExactDatePickerProp
     inputReadOnly: flowCtx.isMobileLayout,
     showTime: showTime ? { defaultValue: [dayjs('00:00:00', 'HH:mm:ss'), dayjs('23:59:59', 'HH:mm:ss')] } : false,
     value: rangeValue,
+    disabled,
     onChange: (nextDates: [dayjs.Dayjs | null, dayjs.Dayjs | null] | null) => {
+      if (disabled) {
+        return;
+      }
       if (Array.isArray(nextDates) && nextDates[0] && nextDates[1]) {
         onChange?.([nextDates[0], nextDates[1]]);
         return;
@@ -218,6 +231,7 @@ export const FieldAssignExactDatePicker: React.FC<FieldAssignExactDatePickerProp
         value={targetPicker}
         options={pickerOptions}
         onChange={handlePickerTypeChange}
+        disabled={disabled}
       />
       {isRange ? <DatePicker.RangePicker {...rangePickerProps} /> : <DatePicker {...singlePickerProps} />}
     </Space.Compact>

--- a/packages/core/client-v2/src/flow/components/FieldAssignValueInput.tsx
+++ b/packages/core/client-v2/src/flow/components/FieldAssignValueInput.tsx
@@ -344,6 +344,7 @@ interface Props {
   /** 是否允许在变量选择器中使用 RunJS。默认 true，保持历史行为。 */
   allowRunJS?: boolean;
   maxAssociationFieldDepth?: number;
+  disabled?: boolean;
 }
 
 type ResolvedFieldContext = {
@@ -716,6 +717,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
   enableDateVariableAsConstant = false,
   allowRunJS = true,
   maxAssociationFieldDepth = 2,
+  disabled = false,
 }) => {
   const flowCtx = useFlowContext<FlowModelContext>();
   const normalizeEventValue = React.useCallback((eventOrValue: unknown) => {
@@ -1076,7 +1078,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
       fm.setStepParams('selectSettings', 'fieldNames', { label: overrideLabel });
     }
     fm?.setProps?.({
-      disabled: false,
+      disabled,
       readPretty: false,
       pattern: 'editable',
       updateAssociation: false,
@@ -1139,6 +1141,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
     preferFormItemFieldModel,
     associationFieldNamesOverride?.label,
     associationFieldNamesOverride?.value,
+    disabled,
   ]);
 
   // 当传入 operator / operatorMetaList 时，按 operator schema 适配临时字段的输入组件与 props。
@@ -1191,6 +1194,9 @@ export const FieldAssignValueInput: React.FC<Props> = ({
       React.useEffect(() => {
         const coercedValue = coerceEmptyValueForRenderer(inputProps?.value);
         const handleChange = (ev: any) => {
+          if (inputProps?.disabled) {
+            return;
+          }
           const nextRaw = normalizeEventValue(ev);
           const normalizedForStore = operator ? normalizeFilterValueByOperator(operator, nextRaw) : nextRaw;
           const nextValue = coerceEmptyValueForRenderer(normalizedForStore);
@@ -1222,6 +1228,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
             value={inputProps?.value}
             onChange={(e) => inputProps?.onChange?.(normalizeEventValue(e))}
             placeholder={placeholder}
+            disabled={inputProps?.disabled}
             style={withFullWidthStyle(wrapperStyle)}
           />
         );
@@ -1240,6 +1247,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
     const C: React.FC<any> = (inputProps) => {
       const wrapperStyle = pickStyle(inputProps?.style);
       const raw = inputProps?.value;
+      const isDisabled = Boolean(inputProps?.disabled);
       const parsed = isCtxDateExpression(raw) ? parseCtxDateExpression(raw) : raw;
       const parsedValue = typeof parsed === 'undefined' ? undefined : parsed;
       const { token } = theme.useToken();
@@ -1264,6 +1272,9 @@ export const FieldAssignValueInput: React.FC<Props> = ({
       });
 
       const handleSelect = (val: string) => {
+        if (isDisabled) {
+          return;
+        }
         setOpen(false);
         if (val === 'exact') {
           inputProps?.onChange?.('');
@@ -1278,10 +1289,16 @@ export const FieldAssignValueInput: React.FC<Props> = ({
       };
 
       const handleExactSingleChange = (nextValue: any) => {
+        if (isDisabled) {
+          return;
+        }
         inputProps?.onChange?.(nextValue || '');
       };
 
       const handleExactRangeChange = (nextValue: any) => {
+        if (isDisabled) {
+          return;
+        }
         inputProps?.onChange?.(nextValue || '');
       };
 
@@ -1326,7 +1343,11 @@ export const FieldAssignValueInput: React.FC<Props> = ({
           <Select
             options={options}
             open={open}
-            onDropdownVisibleChange={setOpen}
+            onDropdownVisibleChange={(nextOpen) => {
+              if (!isDisabled) {
+                setOpen(nextOpen);
+              }
+            }}
             allowClear={false}
             style={{
               width: '100%',
@@ -1336,13 +1357,18 @@ export const FieldAssignValueInput: React.FC<Props> = ({
             value={selectedType}
             onChange={handleSelect}
             dropdownRender={dropdownRender}
+            disabled={isDisabled}
           />
           {['past', 'next'].includes(selectedType) && [
             <InputNumber
               key="number"
               style={{ flex: 1 }}
               value={(parsedValue as any)?.number}
+              disabled={isDisabled}
               onChange={(nextNumber) => {
+                if (isDisabled) {
+                  return;
+                }
                 inputProps?.onChange?.({
                   ...(parsedValue as any),
                   type: selectedType,
@@ -1355,7 +1381,11 @@ export const FieldAssignValueInput: React.FC<Props> = ({
               key="unit"
               value={(parsedValue as any)?.unit}
               style={{ minWidth: 130, maxWidth: 140 }}
+              disabled={isDisabled}
               onChange={(nextUnit) => {
+                if (isDisabled) {
+                  return;
+                }
                 inputProps?.onChange?.({
                   ...(parsedValue as any),
                   type: selectedType,
@@ -1378,6 +1408,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
               isRange={isRange}
               value={isRange ? exactRangeValue : exactSingleValue}
               onChange={isRange ? handleExactRangeChange : handleExactSingleChange}
+              disabled={isDisabled}
               style={{ flex: 1 }}
             />
           )}
@@ -1397,7 +1428,12 @@ export const FieldAssignValueInput: React.FC<Props> = ({
 
   const RunJSComponent = React.useMemo(() => {
     const C: React.FC<any> = (inputProps) => (
-      <RunJSValueEditor t={flowCtx.t} value={inputProps?.value} onChange={inputProps?.onChange} />
+      <RunJSValueEditor
+        t={flowCtx.t}
+        value={inputProps?.value}
+        onChange={inputProps?.onChange}
+        disabled={inputProps?.disabled}
+      />
     );
     return C;
   }, [flowCtx]);
@@ -1443,6 +1479,10 @@ export const FieldAssignValueInput: React.FC<Props> = ({
 
   const handleVariableInputChange = React.useCallback(
     (nextValue: any) => {
+      if (disabled) {
+        return;
+      }
+
       if (!useDateVariableConstant) {
         onChange(nextValue);
         return;
@@ -1450,7 +1490,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
 
       onChange(normalizeDateVariableOutput(nextValue, dateVariableComponentProps));
     },
-    [dateVariableComponentProps, onChange, useDateVariableConstant],
+    [dateVariableComponentProps, disabled, onChange, useDateVariableConstant],
   );
 
   if (!fieldPath) {
@@ -1465,6 +1505,7 @@ export const FieldAssignValueInput: React.FC<Props> = ({
       metaTree={metaTree}
       style={{ width: '100%' }}
       clearValue={''}
+      disabled={disabled}
       converters={{
         renderInputComponent: (meta) => {
           const firstPath = meta?.paths?.[0];

--- a/packages/core/client-v2/src/flow/components/RunJSValueEditor.tsx
+++ b/packages/core/client-v2/src/flow/components/RunJSValueEditor.tsx
@@ -15,6 +15,7 @@ export interface RunJSValueEditorProps {
   t?: (key: string) => string;
   value?: unknown;
   onChange?: (value: RunJSValue) => void;
+  disabled?: boolean;
   height?: string;
   scene?: string;
   containerStyle?: React.CSSProperties;
@@ -25,6 +26,7 @@ export const RunJSValueEditor: React.FC<RunJSValueEditorProps> = (props) => {
     t,
     value,
     onChange,
+    disabled,
     height = '200px',
     scene = 'formValue',
     containerStyle = { flex: 1, minWidth: 0 },
@@ -38,9 +40,15 @@ export const RunJSValueEditor: React.FC<RunJSValueEditorProps> = (props) => {
     <div style={containerStyle}>
       <CodeEditor
         value={current.code}
-        onChange={(code) => onChange?.({ ...current, code })}
+        onChange={(code) => {
+          if (disabled) {
+            return;
+          }
+          onChange?.({ ...current, code });
+        }}
         version={current.version}
         height={height}
+        readonly={disabled}
         enableLinter
         placeholder={placeholderText}
         scene={scene}

--- a/packages/core/flow-engine/src/components/FlowContextSelector.tsx
+++ b/packages/core/flow-engine/src/components/FlowContextSelector.tsx
@@ -292,11 +292,11 @@ const FlowContextSelectorComponent: React.FC<FlowContextSelectorProps> = ({
   const defaultChildren = useMemo(() => {
     const hasSelected = active ?? Boolean(currentPath && currentPath.length > 0);
     return (
-      <Button type={hasSelected ? 'primary' : 'default'} style={defaultButtonStyle}>
+      <Button type={hasSelected ? 'primary' : 'default'} style={defaultButtonStyle} disabled={cascaderProps.disabled}>
         x
       </Button>
     );
-  }, [active, currentPath]);
+  }, [active, cascaderProps.disabled, currentPath]);
 
   // 处理选择变化事件
   const handleChange = useCallback(

--- a/packages/core/flow-engine/src/components/variables/VariableInput.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableInput.tsx
@@ -357,6 +357,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
         metaTree={resolvedMetaTree}
         value={innerValue}
         active={isVariableValue(innerValue)}
+        disabled={disabled}
         onChange={handleVariableSelect}
         parseValueToPath={resolvePathFromValue}
         formatPathToValue={resolveValueFromPath}

--- a/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
@@ -113,6 +113,18 @@ describe('VariableInput', () => {
     expect(selectorButton).toBeInTheDocument();
   });
 
+  it('disables the FlowContextSelector button when disabled', async () => {
+    const flowContext = createTestFlowContext();
+    render(
+      <TestFlowContextWrapper context={flowContext}>
+        <VariableInput value="test" metaTree={() => flowContext.getPropertyMetaTree()} disabled />
+      </TestFlowContextWrapper>,
+    );
+
+    const selectorButton = await screen.findByRole('button');
+    expect(selectorButton).toBeDisabled();
+  });
+
   it('should not highlight the selector button for synthetic constant/null paths', async () => {
     const flowContext = createTestFlowContext();
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
@@ -98,12 +98,14 @@ export function AssignedFieldsEditor({
   onChange,
   fieldFilter = defaultFieldFilter,
   pruneFilteredValues,
+  disabled = false,
 }: {
   collection?: string;
   value?: AssignedValues;
   onChange?: (value: AssignedValues) => void;
   fieldFilter?: AssignedFieldFilter;
   pruneFilteredValues?: boolean;
+  disabled?: boolean;
 }) {
   const flowEngine = useFlowEngine();
   const t = useT();
@@ -130,7 +132,7 @@ export function AssignedFieldsEditor({
   );
 
   useEffect(() => {
-    if (!pruneFilteredValues) {
+    if (!pruneFilteredValues || disabled) {
       return;
     }
 
@@ -142,13 +144,19 @@ export function AssignedFieldsEditor({
     }
 
     onChange?.(Object.fromEntries(nextEntries));
-  }, [fields, normalizedValue, onChange, pruneFilteredValues]);
+  }, [disabled, fields, normalizedValue, onChange, pruneFilteredValues]);
 
   const updateValue = (fieldName: string, nextValue: unknown) => {
+    if (disabled) {
+      return;
+    }
     onChange?.({ ...normalizedValue, [fieldName]: nextValue === undefined ? '' : nextValue });
   };
 
   const removeField = (fieldName: string) => {
+    if (disabled) {
+      return;
+    }
     const { [fieldName]: _, ...rest } = normalizedValue;
     onChange?.(rest);
   };
@@ -156,6 +164,9 @@ export function AssignedFieldsEditor({
   const menu = useMemo<MenuProps>(
     () => ({
       onClick: ({ key }) => {
+        if (disabled) {
+          return;
+        }
         onChange?.({ ...normalizedValue, [String(key)]: '' });
       },
       style: {
@@ -164,10 +175,11 @@ export function AssignedFieldsEditor({
       },
       items: unassignedFields.map((field) => ({
         key: field.name,
+        disabled,
         label: getFieldTitle(field, t),
       })),
     }),
-    [normalizedValue, onChange, t, unassignedFields],
+    [disabled, normalizedValue, onChange, t, unassignedFields],
   );
 
   if (!collection) {
@@ -196,12 +208,14 @@ export function AssignedFieldsEditor({
                 value={normalizedValue[field.name]}
                 onChange={(nextValue) => updateValue(field.name, nextValue)}
                 allowRunJS={false}
+                disabled={disabled}
               />
             </Form.Item>
             <Button
               aria-label={t('Remove field')}
               type="link"
               icon={<CloseCircleOutlined />}
+              disabled={disabled}
               onClick={() => removeField(field.name)}
               style={{
                 position: 'absolute',
@@ -213,8 +227,8 @@ export function AssignedFieldsEditor({
           </div>
         ))}
         {unassignedFields.length ? (
-          <Dropdown menu={menu} trigger={['click']}>
-            <Button aria-label={t('Add field')} icon={<PlusOutlined />}>
+          <Dropdown disabled={disabled} menu={menu} trigger={['click']}>
+            <Button aria-label={t('Add field')} icon={<PlusOutlined />} disabled={disabled}>
               {t('Add field')}
             </Button>
           </Dropdown>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
@@ -43,14 +43,17 @@ const { collection, createModel, mockFieldAssignValueInput, mockFlowEngine, work
         targetPath,
         value,
         onChange,
+        disabled,
       }: {
         targetPath: string;
         value?: unknown;
         onChange?: (value: unknown) => void;
+        disabled?: boolean;
       }) => (
         <input
           aria-label={`value-${targetPath}`}
           value={value == null ? '' : String(value)}
+          disabled={Boolean(disabled)}
           onChange={(event) => onChange?.(event.target.value)}
         />
       ),
@@ -151,5 +154,29 @@ describe('AssignedFieldsEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
     expect(await screen.findByText('Status')).toBeTruthy();
     expect(screen.queryByText('Comments')).toBeNull();
+  });
+
+  it('disables value changes, field removal, and field addition', async () => {
+    const onChange = vi.fn();
+
+    render(<AssignedFieldsEditor collection="posts" value={{ title: 'old' }} onChange={onChange} disabled />);
+
+    await waitFor(() => {
+      expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetPath: 'title',
+          disabled: true,
+        }),
+        expect.anything(),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText('value-title'), { target: { value: 'new' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Remove field' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+
+    expect(screen.getByRole('button', { name: 'Remove field' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add field' })).toBeDisabled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/updateFieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/updateFieldset.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Form } from 'antd';
-import { NodeContext } from '../../canvas/contexts';
+import { CurrentWorkflowContext, NodeContext } from '../../canvas/contexts';
 import { UpdateFieldset } from '../components/update';
 
 vi.mock('../../locale', () => ({
@@ -48,10 +48,12 @@ vi.mock('../../components/collection', () => ({
     collection,
     fieldFilter,
     pruneFilteredValues,
+    disabled,
   }: {
     collection?: string;
     fieldFilter?: (field: MockAssignedField) => boolean;
     pruneFilteredValues?: boolean;
+    disabled?: boolean;
   }) => {
     const fields: MockAssignedField[] = [
       { name: 'title', type: 'string' },
@@ -64,6 +66,7 @@ vi.mock('../../components/collection', () => ({
       <div
         data-testid="assigned-fields"
         data-collection={collection ?? ''}
+        data-disabled={String(Boolean(disabled))}
         data-fields={fields
           .filter((field) => fieldFilter?.(field) ?? true)
           .map((field) => field.name)
@@ -106,18 +109,20 @@ vi.mock('../../components/RadioWithTooltip', () => ({
   ),
 }));
 
-function renderWithForm(node: any, initialValues: any) {
+function renderWithForm(node: any, initialValues: any, workflow: any = {}) {
   let formRef: ReturnType<typeof Form.useForm>[0] | undefined;
 
   function Wrapper() {
     const [form] = Form.useForm();
     formRef = form;
     return (
-      <NodeContext.Provider value={node}>
-        <Form form={form} initialValues={initialValues}>
-          <UpdateFieldset />
-        </Form>
-      </NodeContext.Provider>
+      <CurrentWorkflowContext.Provider value={workflow}>
+        <NodeContext.Provider value={node}>
+          <Form form={form} initialValues={initialValues}>
+            <UpdateFieldset />
+          </Form>
+        </NodeContext.Provider>
+      </CurrentWorkflowContext.Provider>
     );
   }
 
@@ -204,6 +209,23 @@ describe('UpdateFieldset', () => {
     await waitFor(() => {
       expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-fields', 'title,author,comments,tags');
       expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-prune-filtered-values', 'false');
+    });
+  });
+
+  it('disables assigned fields after the workflow has been executed', async () => {
+    renderWithForm(
+      { id: 1, config: { collection: 'posts' } },
+      {
+        config: {
+          collection: 'posts',
+          params: { individualHooks: false, values: { title: 'new' } },
+        },
+      },
+      { versionStats: { executed: 1 } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assigned-fields')).toHaveAttribute('data-disabled', 'true');
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/create.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/create.tsx
@@ -9,7 +9,7 @@
 
 import React, { useEffect } from 'react';
 import { Form } from 'antd';
-import { useNodeContext } from '../../canvas/contexts';
+import { useCurrentWorkflowContext, useNodeContext } from '../../canvas/contexts';
 import { AppendsSelect, AssignedFieldsEditor } from '../../components/collection';
 import { useT } from '../../locale';
 import { NodeCollectionField } from './collection';
@@ -17,7 +17,9 @@ import { NodeCollectionField } from './collection';
 function CreateFields() {
   const t = useT();
   const form = Form.useFormInstance();
+  const workflow = useCurrentWorkflowContext();
   const collection = Form.useWatch(['config', 'collection']);
+  const disabled = Boolean(workflow?.versionStats?.executed);
 
   useEffect(() => {
     if (collection) {
@@ -35,7 +37,7 @@ function CreateFields() {
           'Unassigned fields will be set to default values, and those without default values will be set to null.',
         )}
       >
-        <AssignedFieldsEditor collection={collection} />
+        <AssignedFieldsEditor collection={collection} disabled={disabled} />
       </Form.Item>
       {collection ? (
         <Form.Item

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/update.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/components/update.tsx
@@ -9,7 +9,7 @@
 
 import React, { useEffect } from 'react';
 import { Form } from 'antd';
-import { useNodeContext } from '../../canvas/contexts';
+import { useCurrentWorkflowContext, useNodeContext } from '../../canvas/contexts';
 import { AssignedFieldsEditor, isAssociationField, type AssignedFieldFilter } from '../../components/collection';
 import { RadioWithTooltip, type RadioWithTooltipOption } from '../../components/RadioWithTooltip';
 import { useT } from '../../locale';
@@ -42,10 +42,12 @@ function useUpdateModeOptions(): RadioWithTooltipOption[] {
 function UpdateFields() {
   const t = useT();
   const form = Form.useFormInstance();
+  const workflow = useCurrentWorkflowContext();
   const collection = Form.useWatch(['config', 'collection']);
   const individualHooks = Form.useWatch(['config', 'params', 'individualHooks'], form);
   const updateModeOptions = useUpdateModeOptions();
   const isBatchUpdateMode = individualHooks !== true;
+  const disabled = Boolean(workflow?.versionStats?.executed);
 
   useEffect(() => {
     if (!collection) {
@@ -75,6 +77,7 @@ function UpdateFields() {
           collection={collection}
           fieldFilter={isBatchUpdateMode ? batchUpdateFieldFilter : undefined}
           pruneFilteredValues={isBatchUpdateMode}
+          disabled={disabled}
         />
       </Form.Item>
     </>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 workflow update-record node could still modify single-select assigned field values after the workflow version had been executed and the node configuration drawer was supposed to be read-only. The assigned-field editor used custom v2 value inputs that did not inherit the surrounding Ant Design Form disabled state, and the temporary field model explicitly forced `disabled: false`.

### Description
- Propagate readonly/disabled state through v2 workflow assigned-field editors for create/update nodes.
- Add disabled support to `FieldAssignValueInput`, date constant editors, RunJS value editor, and variable selector trigger.
- Prevent value changes, field removal, and field addition when assigned fields are disabled.
- Add tests for disabled assigned-field editing and variable selector disabled state.

Potential risks: shared field assignment components now accept a disabled state, but default behavior remains editable when disabled is not provided.

Testing suggestions: reopen an executed v2 workflow update-record node and verify single-select assigned fields, variable selector, add field, and remove field controls are disabled.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where v2 workflow assigned fields could still be edited in read-only executed workflow versions. |
| 🇨🇳 Chinese | 修复 v2 工作流已执行版本只读状态下仍可修改字段赋值的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
