### PR TITLE
fix: incorrect default value for filter form

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/FilterFormBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/FilterFormBlockModel.tsx
@@ -432,6 +432,7 @@ export class FilterFormBlockModel extends FilterBlockModel<{
 
   private canApplyFormDefaultValue(name: string, current: any, force?: boolean) {
     if (force) return true;
+    if (this.userEditedFieldNames.has(name)) return false;
     if (isEmptyValue(current)) return true;
     if (!this.lastDefaultValueByFieldName.has(name)) return false;
     return isEqual(current, this.lastDefaultValueByFieldName.get(name));

--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/defaultValues.wiring.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/defaultValues.wiring.test.ts
@@ -301,6 +301,40 @@ describe('filter-form defaultValues wiring', () => {
     expect(values.username_user).toBe('Manual');
   });
 
+  it('does not reapply a filter form default value after user clears the field', async () => {
+    const { model, values } = createFilterFormDefaultValuesModel([
+      {
+        key: 'username-default',
+        enable: true,
+        targetPath: 'username',
+        mode: 'default',
+        value: 'admin',
+      },
+    ]);
+
+    await FilterFormBlockModel.prototype.applyFormDefaultValues.call(model as any);
+    expect(values.username_user).toBe('admin');
+
+    values.username_user = undefined;
+    (model as any).handleFilterFormValuesChange({ username_user: undefined }, { username_user: undefined });
+
+    await waitFor(() => {
+      expect(model.dispatchEvent).toHaveBeenCalledWith(
+        'formValuesChange',
+        {
+          changedValues: {
+            username_user: undefined,
+          },
+          allValues: {
+            username_user: undefined,
+          },
+        },
+        { debounce: true },
+      );
+    });
+    expect(values.username_user).toBeUndefined();
+  });
+
   it('applies fixed values even when the target filter field already has a value', async () => {
     const { model, values } = createFilterFormDefaultValuesModel(
       [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where association field default values in filter forms could not be cleared. |
| 🇨🇳 Chinese | 修复筛选表单关系字段设置默认值后无法被清空的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
