### PR TITLE
refactor(plugin-file-manager): tighten file field configuration

### DIFF
--- a/packages/core/client-v2/src/collection-field-interface/CollectionFieldInterface.ts
+++ b/packages/core/client-v2/src/collection-field-interface/CollectionFieldInterface.ts
@@ -115,6 +115,7 @@ export abstract class CollectionFieldInterface {
   titleUsable?: boolean;
   usePathOptions?(field: any): any;
   hidden?: boolean;
+  deprecated?: boolean;
 
   addComponentOption(componentOption: CollectionFieldInterfaceComponentOption) {
     if (!this.componentOptions) {

--- a/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddFieldAction.tsx
@@ -172,7 +172,10 @@ export const AddFieldAction = (props) => {
   const { t } = useTranslation();
   const { isDialect } = useDialect();
   const options = useFieldInterfaceOptions();
-  const fields = getCollection(record.name)?.options?.fields || record.fields || [];
+  const fields = useMemo(
+    () => getCollection(record.name)?.options?.fields || record.fields || [],
+    [getCollection, record],
+  );
 
   const currentCollections = useMemo(() => {
     return collections.map((v) => {
@@ -181,7 +184,7 @@ export const AddFieldAction = (props) => {
         value: v.name,
       };
     });
-  }, []);
+  }, [collections, compile]);
   const getFieldOptions = useCallback(() => {
     const { availableFieldInterfaces } = getTemplate(record.template) || {};
     const { exclude, include } = (availableFieldInterfaces || {}) as any;
@@ -191,7 +194,7 @@ export const AddFieldAction = (props) => {
         optionArr.push({
           ...v,
           children: v.children.filter((v) => {
-            if (v.hidden) {
+            if (v.hidden || v.deprecated) {
               return false;
             } else if (v.value === 'tableoid') {
               if (include?.length) {
@@ -209,6 +212,7 @@ export const AddFieldAction = (props) => {
           include.forEach((k) => {
             const field = v?.children?.find((h) => [k, k.interface].includes(h.name));
             field &&
+              !field.deprecated &&
               children.push({
                 ...field,
                 targetScope: k?.targetScope,
@@ -216,10 +220,10 @@ export const AddFieldAction = (props) => {
           });
         } else if (exclude?.length) {
           children = v?.children?.filter((v) => {
-            return !exclude.includes(v.name);
+            return !v.deprecated && !exclude.includes(v.name);
           });
         } else {
-          children = v?.children;
+          children = v?.children?.filter((v) => !v.deprecated);
         }
         children?.length &&
           optionArr.push({
@@ -229,7 +233,7 @@ export const AddFieldAction = (props) => {
       }
     });
     return optionArr;
-  }, [getTemplate, record]);
+  }, [database?.dialect, getTemplate, options, record]);
   const items = useMemo<MenuProps['items']>(() => {
     return getFieldOptions()
       .map((option): ItemType & { title: string; children?: ItemType[] } => {
@@ -272,7 +276,7 @@ export const AddFieldAction = (props) => {
         };
       })
       .filter((v) => v?.children?.length);
-  }, [getFieldOptions]);
+  }, [compile, getFieldOptions, record.template]);
   const menu = useMemo<MenuProps>(() => {
     return {
       style: {
@@ -291,7 +295,7 @@ export const AddFieldAction = (props) => {
       },
       items,
     };
-  }, [getInterface, items, record]);
+  }, [compile, getInterface, items, record]);
   const scopeKeyOptions = useMemo(() => {
     return fields
       .filter((v) => {
@@ -303,7 +307,7 @@ export const AddFieldAction = (props) => {
           label: compile(k.uiSchema?.title),
         };
       });
-  }, [fields?.length]);
+  }, [compile, fields]);
   return (
     record.template !== 'sql' && (
       <RecordProvider record={record}>

--- a/packages/core/client/src/collection-manager/Configuration/AddSubFieldAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddSubFieldAction.tsx
@@ -112,17 +112,21 @@ export const AddSubFieldAction = () => {
   const options = useFieldInterfaceOptions();
   const { t } = useTranslation();
   const items = useMemo(() => {
-    return options.map((option) => {
-      const children = option.children.map((child) => {
-        return { label: compile(child.title), key: child.name };
-      });
-      return {
-        label: compile(option.label),
-        key: option.key,
-        children,
-      };
-    });
-  }, [options]);
+    return options
+      .map((option) => {
+        const children = option.children
+          .filter((child) => !child.deprecated)
+          .map((child) => {
+            return { label: compile(child.title), key: child.name };
+          });
+        return {
+          label: compile(option.label),
+          key: option.key,
+          children,
+        };
+      })
+      .filter((option) => option.children.length);
+  }, [compile, options]);
   const menu = useMemo<MenuProps>(() => {
     return {
       style: {
@@ -136,7 +140,7 @@ export const AddSubFieldAction = () => {
       },
       items,
     };
-  }, [items]);
+  }, [getInterface, items]);
   const recordData = useCollectionRecordData();
 
   return (

--- a/packages/core/client/src/data-source/collection-field-interface/CollectionFieldInterface.ts
+++ b/packages/core/client/src/data-source/collection-field-interface/CollectionFieldInterface.ts
@@ -69,6 +69,7 @@ export abstract class CollectionFieldInterface {
   usePathOptions?(field: CollectionFieldOptions): any;
   schemaInitialize?(schema: ISchema, data: any): void;
   hidden?: boolean;
+  deprecated?: boolean;
 
   addComponentOption(componentOption: CollectionFieldInterfaceComponentOption) {
     if (!this.componentOptions) {

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldForm.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldForm.tsx
@@ -103,8 +103,9 @@ function filterFieldInterfacesByTemplate(
   ctx: any,
   mode: 'create' | 'edit',
   databaseDialect?: string,
+  filterCreate = mode === 'create',
 ) {
-  if (mode !== 'create') {
+  if (!filterCreate) {
     return fieldInterfaces;
   }
   const plugin = ctx.app.pm.get(PluginDataSourceManagerClientV2);
@@ -1720,8 +1721,9 @@ export function FieldForm(props: FieldFormProps) {
         ctx,
         props.mode,
         databaseDialect,
+        props.mode === 'create' && !props.field && !props.override,
       ),
-    [databaseDialect, ctx, dataSource?.options?.type, props.collection, props.mode],
+    [databaseDialect, ctx, dataSource?.options?.type, props.collection, props.field, props.mode, props.override],
   );
   const [interfaceName, setInterfaceName] = useState(
     props.field?.interface || props.interfaceName || fieldInterfaces[0]?.name,

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -59,6 +59,7 @@ type FieldInterfaceOption = {
   group?: string;
   order?: number;
   hidden?: boolean;
+  deprecated?: boolean;
   isAssociation?: boolean;
   availableTypes?: string[];
   default?: Record<string, any>;
@@ -852,6 +853,7 @@ function ViewSyncFieldsDrawer(props: {
                 options: group.options.map((option) => ({
                   value: option.value,
                   label: compileLegacyTemplate(option.label, t),
+                  disabled: props.fieldInterfacesByName[option.value]?.deprecated && option.value !== value,
                 })),
               }))}
               onChange={(nextInterfaceName) => {
@@ -1504,6 +1506,7 @@ export default function FieldsPage(props: FieldsPageProps) {
               options: group.children.map((fieldInterface) => ({
                 value: fieldInterface.name,
                 label: compileLegacyTemplate(getFieldInterfaceLabel(fieldInterface), t),
+                disabled: fieldInterface.deprecated && fieldInterface.name !== value,
               })),
             }))
             .filter((group) => group.options.length);

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/ViewCollectionConfigure.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/ViewCollectionConfigure.tsx
@@ -32,6 +32,7 @@ type CollectionRecord = {
 
 type FieldInterfaceRecord = {
   availableTypes?: string[];
+  deprecated?: boolean;
   default?: {
     type?: string;
     uiSchema?: Record<string, unknown>;
@@ -191,7 +192,10 @@ function mergeViewFields(options: {
 function getFieldInterfaceOptions(manager: FieldInterfaceManager) {
   const groups = manager?.getFieldInterfaceGroups?.() || {};
   const interfaces = manager?.getFieldInterfaces?.() || [];
-  const grouped = new Map<string, Array<{ label: React.ReactNode; value: string; availableTypes?: string[] }>>();
+  const grouped = new Map<
+    string,
+    Array<{ label: React.ReactNode; value: string; availableTypes?: string[]; deprecated?: boolean }>
+  >();
 
   interfaces
     .filter(
@@ -204,6 +208,7 @@ function getFieldInterfaceOptions(manager: FieldInterfaceManager) {
         value: String(fieldInterface.name),
         label: fieldInterface.title || String(fieldInterface.name),
         availableTypes: fieldInterface.availableTypes,
+        deprecated: fieldInterface.deprecated,
       });
       grouped.set(group, items);
     });
@@ -524,10 +529,15 @@ export function ViewFieldsConfigureItem(props: CollectionTemplateConfigureItemPr
             options={fieldOptions.map((group) => ({
               label: compileLegacyTemplate(group.label, t),
               options: group.options
-                .filter((option) => !record.type || option.availableTypes?.includes(record.type))
+                .filter(
+                  (option) =>
+                    (!record.type || option.availableTypes?.includes(record.type)) &&
+                    (!option.deprecated || option.value === value),
+                )
                 .map((option) => ({
                   value: option.value,
                   label: compileLegacyTemplate(option.label, t),
+                  disabled: option.deprecated && option.value !== value,
                 })),
             }))}
             value={value || undefined}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/collectionTemplateFieldInterfaces.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/collectionTemplateFieldInterfaces.ts
@@ -23,6 +23,7 @@ type FieldInterfacePolicy = {
 type FieldInterfaceLike = {
   group?: string;
   name: string;
+  deprecated?: boolean;
 };
 
 function getFieldInterfacePolicy(template?: CollectionTemplateOptions): FieldInterfacePolicy | undefined {
@@ -74,6 +75,9 @@ export function filterCreateFieldInterfacesByCollectionTemplate<T extends FieldI
   const hasIncludes = Array.isArray(include) && include.length > 0;
 
   return fieldInterfaces.filter((fieldInterface) => {
+    if (fieldInterface.deprecated) {
+      return false;
+    }
     if (hasIncludes) {
       return isIncludedFieldInterface(include, fieldInterface.name);
     }

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/AddFieldAction.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/AddFieldAction.tsx
@@ -225,7 +225,7 @@ const AddFieldAction = (props) => {
         value: v.name,
       };
     });
-  }, []);
+  }, [collections, compile]);
   const fieldOptions = useFieldInterfaceOptions();
   const getFieldOptions = useCallback(() => {
     const { availableFieldInterfaces } = getTemplate(record.template) || {};
@@ -238,6 +238,7 @@ const AddFieldAction = (props) => {
           include.forEach((k) => {
             const field = v?.children?.find((h) => [k, k.interface].includes(h.value));
             field &&
+              !field.deprecated &&
               children.push({
                 ...field,
                 targetScope: k?.targetScope,
@@ -245,10 +246,10 @@ const AddFieldAction = (props) => {
           });
         } else if (exclude?.length) {
           children = v?.children?.filter((v) => {
-            return !exclude.includes(v.value);
+            return !v.deprecated && !exclude.includes(v.value);
           });
         } else {
-          children = v?.children;
+          children = v?.children?.filter((v) => !v.deprecated);
         }
         children?.length &&
           optionArr.push({
@@ -258,7 +259,7 @@ const AddFieldAction = (props) => {
       }
     });
     return optionArr;
-  }, [getTemplate, record]);
+  }, [fieldOptions, getTemplate, record]);
   const items = useMemo<MenuProps['items']>(() => {
     return getFieldOptions()
       .map((option) => {
@@ -301,7 +302,7 @@ const AddFieldAction = (props) => {
         };
       })
       .filter((v) => v?.children?.length);
-  }, [getFieldOptions]);
+  }, [compile, getFieldOptions, record.template]);
   const menu = useMemo<MenuProps>(() => {
     return {
       style: {
@@ -320,7 +321,7 @@ const AddFieldAction = (props) => {
       },
       items,
     };
-  }, [getInterface, items, record]);
+  }, [compile, getInterface, items, record]);
   return (
     record.template !== 'sql' && (
       <RecordProvider record={record}>

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/components/CollectionFieldInterfaceSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/CollectionsManager/components/CollectionFieldInterfaceSelect.tsx
@@ -130,7 +130,7 @@ export const CollectionFieldInterfaceSelect = observer(
         {options.map((group) => (
           <Select.OptGroup key={group.key} label={compile(group.label)}>
             {group.children.map((item) => (
-              <Select.Option key={item.name} value={item.name}>
+              <Select.Option key={item.name} value={item.name} disabled={item.deprecated && item.name !== value}>
                 {compile(item.label)}
               </Select.Option>
             ))}

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/CollectionFields.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client/component/MainDataSourceManager/Configuration/CollectionFields.tsx
@@ -355,7 +355,7 @@ const FieldInterfaceRenderer = ({ value, record, updateFieldHandler, isPresetFie
       {options.map((group) => (
         <Select.OptGroup key={group.key} label={compile(group.label)}>
           {group.children.map((item) => (
-            <Select.Option key={item.name} value={item.name}>
+            <Select.Option key={item.name} value={item.name} disabled={item.deprecated && item.name !== value}>
               {compile(item.label)}
             </Select.Option>
           ))}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/attachment-interface.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/attachment-interface.test.ts
@@ -24,6 +24,7 @@ describe('AttachmentFieldInterface', () => {
       app.dataSourceManager.collectionFieldInterfaceManager.getFieldInterface<AttachmentFieldInterface>('attachment');
 
     expect(fieldInterface).toBeInstanceOf(AttachmentFieldInterface);
+    expect(fieldInterface.deprecated).toBe(true);
     expect(fieldInterface.group).toBe('media');
     expect(fieldInterface.default).toMatchObject({
       interface: 'attachment',

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/interfaces/attachment.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/interfaces/attachment.ts
@@ -16,6 +16,7 @@ export class AttachmentFieldInterface extends CollectionFieldInterface {
   type = 'object';
   group = 'media';
   title = tExpr('Attachment');
+  deprecated = true;
   isAssociation = true;
   default = {
     interface: 'attachment',

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
@@ -8,8 +8,10 @@
  */
 
 import type { Application } from '@nocobase/client-v2';
-import { Plugin } from '@nocobase/client-v2';
-import type React from 'react';
+import { Plugin, RemoteSelect } from '@nocobase/client-v2';
+import { useFlowContext } from '@nocobase/flow-engine';
+import { Form } from 'antd';
+import React from 'react';
 import {
   FILE_SIZE_LIMIT_DEFAULT,
   STORAGE_TYPE_ALI_OSS,
@@ -19,7 +21,45 @@ import {
 } from '../constants';
 import { NAMESPACE } from '../common/constants';
 import { AttachmentFieldInterface } from './interfaces/attachment';
-import { tExpr } from './locale';
+import { tExpr, useT } from './locale';
+
+type StorageRecord = {
+  name?: string;
+  title?: string;
+};
+
+function selectStorageRecords(response: unknown): StorageRecord[] {
+  const body = (response as { data?: unknown })?.data;
+  const payload = (body as { data?: unknown })?.data;
+  if (Array.isArray(payload)) {
+    return payload as StorageRecord[];
+  }
+  const nestedPayload = (payload as { data?: unknown })?.data;
+  return Array.isArray(nestedPayload) ? (nestedPayload as StorageRecord[]) : [];
+}
+
+function FileCollectionStorageConfigureItem(props: { item: { name?: string; required?: boolean } }) {
+  const ctx = useFlowContext();
+  const t = useT();
+
+  return (
+    <Form.Item
+      name={props.item.name || 'storage'}
+      label={t('File storage')}
+      rules={props.item.required ? [{ required: true }] : undefined}
+    >
+      <RemoteSelect<StorageRecord, unknown>
+        request={() => ctx.api.resource('storages').list({ paginate: false })}
+        selectItems={selectStorageRecords}
+        fieldNames={{
+          label: 'title',
+          value: 'name',
+        }}
+        cacheKey="file-collection-storage-options"
+      />
+    </Form.Item>
+  );
+}
 
 type UploadFileResult = {
   errorMessage?: string;
@@ -224,6 +264,16 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
       },
       presetFields: {
         disabled: true,
+      },
+      configure: {
+        items: [
+          {
+            name: 'storage',
+            label: tExpr('File storage'),
+            required: true,
+            Component: FileCollectionStorageConfigureItem,
+          },
+        ],
       },
     });
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/interfaces/attachment.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/interfaces/attachment.ts
@@ -17,6 +17,7 @@ export class AttachmentFieldInterface extends CollectionFieldInterface {
   type = 'object';
   group = 'media';
   title = `{{t("Attachment", { ns: "${NAMESPACE}" })}}`;
+  deprecated = true;
   isAssociation = true;
   default = {
     type: 'belongsToMany',

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/templates/file.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/templates/file.ts
@@ -178,6 +178,7 @@ export class FileCollectionTemplate extends CollectionTemplate {
       type: 'string',
       name: 'storage',
       title: `{{t("File storage", { ns: "${NAMESPACE}" })}}`,
+      required: true,
       'x-decorator': 'FormItem',
       'x-component': 'RemoteSelect',
       'x-component-props': {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
The legacy attachment field interface should no longer be offered when creating new collection fields, while existing attachment fields must keep their current display and edit behavior. File collections should also explicitly choose a file storage instead of relying on the default storage fallback during collection configuration.

### Description
This PR marks the attachment field interface as deprecated in both client runtimes and filters deprecated field interfaces from create-field entry points. Existing attachment fields remain registered and visible in edit flows, and deprecated interface options are disabled when editing other fields so users cannot switch new fields to the legacy attachment type.

It also makes file collection storage required in both legacy and v2 collection create/edit forms. The runtime fallback for existing file collections without storage is kept unchanged to avoid breaking existing data.

Testing suggestions:
- Create a new collection field and confirm the attachment interface is not selectable.
- Edit an existing attachment field and confirm it remains displayed as attachment and is not automatically changed.
- Create or edit a file collection and confirm file storage is required.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Deprecated attachment fields can no longer be selected when creating new fields, and file collections now require an explicit file storage. |
| 🇨🇳 Chinese | 新建字段时不再允许选择已废弃的附件字段，文件表现在必须显式选择文件存储。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
