### PR TITLE
fix(client-v2): hide relation operator setting

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/FilterFormItemModel.tsx
@@ -62,9 +62,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+interface CollectionFieldWithAssociationMarker {
+  isAssociationField?: () => boolean;
+  target?: unknown;
+}
+
+function hasAssociationMarker(value: unknown): value is CollectionFieldWithAssociationMarker {
+  return isRecord(value) && (typeof value.isAssociationField === 'function' || 'target' in value);
+}
+
+const isAssociationCollectionField = (collectionField: unknown) => {
+  if (!hasAssociationMarker(collectionField)) {
+    return false;
+  }
+  return collectionField.isAssociationField ? collectionField.isAssociationField() : Boolean(collectionField.target);
+};
+
 const normalizeAssociationDefaultFilterValue = (value: any, fieldModel: any) => {
   const collectionField = fieldModel?.context?.collectionField;
-  if (!collectionField?.isAssociationField?.()) {
+  if (!isAssociationCollectionField(collectionField)) {
     return value;
   }
 
@@ -171,8 +187,7 @@ const buildFilterFormFieldItem = ({
   if (!binding) {
     return;
   }
-  const isAssociation =
-    typeof field?.isAssociationField === 'function' ? field.isAssociationField() : Boolean(field?.target);
+  const isAssociation = isAssociationCollectionField(field);
   const fieldModel =
     isAssociation && ctxWithFlags.engine?.getModelClass?.('FilterFormRecordSelectFieldModel')
       ? 'FilterFormRecordSelectFieldModel'
@@ -507,10 +522,7 @@ export class FilterFormItemModel extends FilterableItemModel<{
     const formValue = this.context.form?.getFieldValue(this.props.name);
     const modelValue = fieldModel.getFilterValue ? fieldModel.getFilterValue() : formValue;
     const collectionField = (fieldModel as any)?.context?.collectionField;
-    const isAssociationField =
-      typeof collectionField?.isAssociationField === 'function'
-        ? collectionField.isAssociationField()
-        : !!collectionField?.target;
+    const isAssociationField = isAssociationCollectionField(collectionField);
     const shouldUseFormValue =
       isAssociationField &&
       !this.mounted &&
@@ -547,11 +559,7 @@ export class FilterFormItemModel extends FilterableItemModel<{
       return value;
     }
     const collectionField = (fieldModel as any)?.context?.collectionField;
-    const isAssociation =
-      typeof collectionField?.isAssociationField === 'function'
-        ? collectionField.isAssociationField()
-        : !!collectionField?.target;
-    if (!isAssociation) {
+    if (!isAssociationCollectionField(collectionField)) {
       return value;
     }
     const normalizedFieldNames = normalizeAssociationFieldNames(
@@ -798,6 +806,13 @@ FilterFormItemModel.registerFlow({
     },
     defaultOperator: {
       use: 'defaultOperator',
+      hideInSettings(ctx) {
+        const collectionField =
+          ctx.collectionField ||
+          ctx.model?.context?.collectionField ||
+          ctx.model?.subModels?.field?.context?.collectionField;
+        return isAssociationCollectionField(collectionField);
+      },
     },
     operatorComponentProps: {
       use: 'operatorComponentProps',

--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/FilterFormItemModel.defineChildren.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/FilterFormItemModel.defineChildren.test.ts
@@ -33,6 +33,42 @@ class DummyCollectionBlockModel extends CollectionBlockModel {
 }
 
 describe('FilterFormItemModel defineChildren association fields', () => {
+  it('hides default operator setting for association filter fields', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({
+      FilterFormItemModel,
+    });
+
+    const filterItem = engine.createModel<FilterFormItemModel>({
+      uid: 'association-filter-item-settings',
+      use: 'FilterFormItemModel',
+    });
+
+    const defaultOperatorStep = filterItem.getFlow('filterFormItemSettings')?.steps?.defaultOperator as {
+      hideInSettings?: (ctx: {
+        collectionField?: unknown;
+        model?: {
+          subModels?: {
+            field?: {
+              context?: {
+                collectionField?: unknown;
+              };
+            };
+          };
+        };
+      }) => boolean;
+    };
+    expect(defaultOperatorStep?.hideInSettings?.({ collectionField: { isAssociationField: () => true } })).toBe(true);
+    expect(
+      defaultOperatorStep?.hideInSettings?.({
+        model: { subModels: { field: { context: { collectionField: { target: 'departments' } } } } },
+      }),
+    ).toBe(true);
+    expect(defaultOperatorStep?.hideInSettings?.({ collectionField: { interface: 'input', type: 'string' } })).toBe(
+      false,
+    );
+  });
+
   it('groups association target fields and supports recursive paths', async () => {
     const engine = new FlowEngine();
     engine.registerModels({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在筛选表单中配置关系字段时，字段设置菜单会显示“默认操作符”配置项。该配置对关系字段不适用，容易让用户误以为可以在这里配置关系字段的默认筛选方式。

### Description 
本次调整后，筛选表单里的关系字段不再显示“默认操作符”配置项，普通字段仍保持原有行为。

已验证：
- 关系字段的设置菜单不再出现“默认操作符”
- 普通字段的默认操作符相关逻辑不受影响
- 新增单元测试覆盖关系字段隐藏该配置项的场景

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix association fields showing the default operator setting in filter forms |
| 🇨🇳 Chinese | 修复筛选表单关系字段显示默认操作符配置的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
