### PR TITLE
fix(data-source-main): skip inherited fields during sync

### DIFF
--- a/packages/core/server/src/main-data-source.ts
+++ b/packages/core/server/src/main-data-source.ts
@@ -8,8 +8,13 @@
  */
 
 import { Context } from '@nocobase/actions';
-import { CollectionOptions, DataSourceOptions, SequelizeDataSource } from '@nocobase/data-source-manager';
-import { Collection, Model } from '@nocobase/database';
+import {
+  CollectionOptions,
+  DataSourceOptions,
+  FieldOptions,
+  SequelizeDataSource,
+} from '@nocobase/data-source-manager';
+import { Collection, InheritedCollection, Model } from '@nocobase/database';
 
 type MainDataSourceStatus = 'loaded' | 'loading';
 
@@ -138,6 +143,51 @@ export class MainDataSource extends SequelizeDataSource {
     return loadedData;
   }
 
+  private getFieldColumnName(field: Partial<FieldOptions>) {
+    return field.columnName || field.field || field.name;
+  }
+
+  private async getInheritedParentColumnNames(collection: InheritedCollection) {
+    const queryInterface = this.collectionManager.db.sequelize.getQueryInterface();
+    const columnNames = new Set<string>();
+
+    for (const parentCollection of collection.getFlatParents()) {
+      const parentColumns = await queryInterface.describeTable(parentCollection.getTableNameWithSchema());
+      for (const columnName of Object.keys(parentColumns)) {
+        columnNames.add(columnName);
+      }
+    }
+
+    return columnNames;
+  }
+
+  private async filterInheritedParentFields(values: CollectionOptions, loadedCollection: { fields?: FieldOptions[] }) {
+    const collection = this.collectionManager.db.getCollection(values.name);
+    if (!collection?.isInherited()) {
+      return values.fields;
+    }
+
+    const inheritedParentColumnNames = await this.getInheritedParentColumnNames(collection as InheritedCollection);
+    if (!inheritedParentColumnNames.size) {
+      return values.fields;
+    }
+
+    const loadedFields = loadedCollection.fields || [];
+    const loadedFieldNames = new Set(loadedFields.map((field) => field.name));
+    const loadedFieldColumnNames = new Set(
+      loadedFields.map((field) => this.getFieldColumnName(field)).filter(Boolean),
+    );
+
+    return values.fields.filter((field) => {
+      const columnName = this.getFieldColumnName(field);
+      if (!columnName || !inheritedParentColumnNames.has(columnName)) {
+        return true;
+      }
+
+      return loadedFieldNames.has(field.name) || loadedFieldColumnNames.has(columnName);
+    });
+  }
+
   async syncFieldsFromDatabase(ctx: any, collectionNames?: string[]) {
     let filter = {};
     if (collectionNames?.length) {
@@ -165,7 +215,9 @@ export class MainDataSource extends SequelizeDataSource {
         delete values.schema;
       }
 
-      const existsFields = loadedCollections[values.tableName].fields;
+      const loadedCollection = loadedCollections[values.tableName];
+      values.fields = await this.filterInheritedParentFields(values, loadedCollection);
+      const existsFields = loadedCollection.fields;
       const deletedFields = existsFields.filter((field: any) => !values.fields.find((f) => f.name === field.name));
 
       await db.sequelize.transaction(async (transaction) => {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/read-db-tables.test.ts
@@ -333,5 +333,91 @@ describe('db2cm test', () => {
       });
       expect(collectionRecord.get('schema')).toBeUndefined();
     });
+
+    it('should not materialize inherited parent fields when syncing CTI child fields', async () => {
+      const parentName = `${collectionName}_parent`;
+      const childName = `${collectionName}_child`;
+      const agent = app.agent();
+
+      await agent.resource('collections').create({
+        values: {
+          name: parentName,
+          fields: [
+            {
+              type: 'string',
+              name: 'name',
+              interface: 'input',
+              uiSchema: {
+                type: 'string',
+                title: 'Animal Name',
+                'x-component': 'Input',
+              },
+            },
+          ],
+        },
+      });
+
+      await agent.resource('collections').create({
+        values: {
+          name: childName,
+          inherits: [parentName],
+          fields: [
+            {
+              type: 'string',
+              name: 'breed',
+            },
+          ],
+        },
+      });
+
+      const childFieldRows = async () => {
+        const fields = await db.getRepository('fields').find({
+          filter: {
+            collectionName: childName,
+          },
+        });
+        return fields.map((field) => field.toJSON()).sort((a, b) => a.name.localeCompare(b.name));
+      };
+
+      expect((await childFieldRows()).map((field) => field.name)).toEqual(['breed']);
+
+      const syncResponse = await agent.resource('mainDataSource').syncFields({
+        values: {
+          collections: [childName],
+        },
+      });
+      expect(syncResponse.status).toBe(200);
+
+      expect((await childFieldRows()).map((field) => field.name)).toEqual(['breed']);
+      expect(db.getCollection(childName).getField('name').get('uiSchema').title).toBe('Animal Name');
+
+      const overrideResponse = await agent.resource('fields').create({
+        values: {
+          collectionName: childName,
+          type: 'string',
+          name: 'name',
+          interface: 'input',
+          uiSchema: {
+            type: 'string',
+            title: 'Dog Name',
+            'x-component': 'Input',
+          },
+        },
+      });
+      expect(overrideResponse.status).toBe(200);
+
+      const secondSyncResponse = await agent.resource('mainDataSource').syncFields({
+        values: {
+          collections: [childName],
+        },
+      });
+      expect(secondSyncResponse.status).toBe(200);
+
+      const fieldsAfterOverrideSync = await childFieldRows();
+      expect(fieldsAfterOverrideSync.map((field) => field.name)).toEqual(['breed', 'name']);
+      const overrideField = fieldsAfterOverrideSync.find((field) => field.name === 'name');
+      expect(overrideField?.overriding).toBeTruthy();
+      expect(overrideField?.uiSchema.title).toBe('Dog Name');
+    });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
On PostgreSQL CTI collections, `mainDataSource:syncFields` currently introspects inherited parent columns from child tables and writes them back as child fields. The `fields.beforeCreate` hook then marks those rows as `overriding`, which degrades inherited field metadata and stops later parent field updates from propagating to the child.

### Description 
- Filter inherited parent table columns out of `MainDataSource.syncFieldsFromDatabase` before collection field updates are applied.
- Preserve already existing child override fields by matching loaded fields by name or physical column, so intentional overrides are not removed by a later sync.
- Add a PostgreSQL-only regression test covering both the no-materialization path and the existing override preservation path.

Risk is limited to the main data source field sync path for inherited collections. Non-inherited collection sync keeps the existing behavior.

Validation:

```bash
git diff --check
```

I also attempted to start the target test file locally with SQLite as a runner-level check, but the sparse checkout plus `--ignore-scripts` dependency install does not generate workspace `lib/` outputs, so Vitest failed before collecting tests while resolving `@nocobase/database/lib/index.js`. The new regression is PostgreSQL-only and should run in the repository's backend CI Postgres job.

### Related issues
Closes #9862

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed PostgreSQL CTI field sync so inherited parent columns are not materialized as child override fields. |
| 🇨🇳 Chinese | 修复 PostgreSQL CTI 字段同步时将继承父表字段写成子表覆盖字段的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
