### PR TITLE
fix(cli): honor configured builtin db image defaults in init

### DIFF
--- a/packages/core/cli/src/__tests__/app-management-commands.test.ts
+++ b/packages/core/cli/src/__tests__/app-management-commands.test.ts
@@ -2828,6 +2828,9 @@ test('env info shows grouped app details with secrets masked by default', async 
 
   await EnvInfo.prototype.run.call(command);
 
+  expect(String(command.log.mock.calls[0]?.[0] ?? '')).toContain('Env');
+  expect(String(command.log.mock.calls[0]?.[0] ?? '')).toContain('name');
+  expect(String(command.log.mock.calls[0]?.[0] ?? '')).toContain('app1');
   expect(String(command.log.mock.calls[0]?.[0] ?? '')).toContain('App');
   expect(String(command.log.mock.calls[0]?.[0] ?? '')).toContain('sourcePath');
   expect(String(command.log.mock.calls[0]?.[0] ?? '')).toContain('/tmp/local-app');
@@ -2885,6 +2888,7 @@ test('env info supports the deprecated --env alias with grouped json output', as
 
   expect(JSON.parse(String(command.log.mock.calls[0]?.[0] ?? '{}'))).toEqual({
     ok: true,
+    name: 'remote',
     kind: 'http',
     env: 'remote',
     app: {
@@ -2961,6 +2965,7 @@ test('env info derives app url from api base urls with public paths and subapps'
 
   expect(JSON.parse(String(command.log.mock.calls[0]?.[0] ?? '{}'))).toMatchObject({
     ok: true,
+    name: 'remote',
     kind: 'http',
     env: 'remote',
     app: {
@@ -3118,6 +3123,7 @@ test('env info supports positional env name and shows grouped details', async ()
   expect(mocks.resolveManagedAppRuntime.mock.calls).toEqual([['remote']]);
   expect(JSON.parse(String(command.log.mock.calls[0]?.[0] ?? '{}'))).toMatchObject({
     ok: true,
+    name: 'remote',
     kind: 'http',
     env: 'remote',
     api: {

--- a/packages/core/cli/src/__tests__/config-command.test.ts
+++ b/packages/core/cli/src/__tests__/config-command.test.ts
@@ -694,6 +694,35 @@ test('nb config set/get/delete supports nb image settings', async () => {
   });
 });
 
+test('nb config get nb-image-registry falls back to aliyun when locale is zh-CN', async () => {
+  await withTempCliHome(async () => {
+    const { default: ConfigSet } = await import('../commands/config/set.js');
+    const { default: ConfigGet } = await import('../commands/config/get.js');
+
+    const setLocaleCommand = Object.assign(Object.create(ConfigSet.prototype), {
+      parse: vi.fn(async () => ({
+        args: {
+          key: 'locale',
+          value: 'zh-CN',
+        },
+      })),
+      log: vi.fn(),
+    });
+    await ConfigSet.prototype.run.call(setLocaleCommand);
+
+    const getRegistryCommand = Object.assign(Object.create(ConfigGet.prototype), {
+      parse: vi.fn(async () => ({
+        args: {
+          key: 'nb-image-registry',
+        },
+      })),
+      log: vi.fn(),
+    });
+    await ConfigGet.prototype.run.call(getRegistryCommand);
+    expect(getRegistryCommand.log).toHaveBeenCalledWith('aliyun');
+  });
+});
+
 test('nb config list prints only explicit settings', async () => {
   await withTempCliHome(async () => {
     const { default: ConfigSet } = await import('../commands/config/set.js');

--- a/packages/core/cli/src/__tests__/init.test.ts
+++ b/packages/core/cli/src/__tests__/init.test.ts
@@ -2178,6 +2178,74 @@ test('nb init resolves dynamic port defaults without showing fallback warnings',
   }
 });
 
+test('nb init does not seed a derived built-in database image into the web UI defaults', async () => {
+  const { default: Init } = await import('../commands/init.js');
+  const { default: Install } = await import('../commands/install.js');
+  const buildDbPromptInitialValues = vi.spyOn(Install, 'buildDbPromptInitialValues').mockResolvedValue({
+    builtinDbImage: 'postgres:16',
+    dbPort: '5432',
+  });
+
+  try {
+    const buildDynamicInitialValuesForInstall = (
+      Init as unknown as {
+        buildDynamicInitialValuesForInstall: (
+          flags: { yes?: boolean; 'app-port'?: string; 'db-port'?: string },
+          presetValues: Record<string, string | number | boolean>,
+        ) => Promise<Record<string, string | number | boolean>>;
+      }
+    ).buildDynamicInitialValuesForInstall;
+
+    const initialValues = await buildDynamicInitialValuesForInstall(
+      { yes: false },
+      {
+        appName: 'app1',
+        source: 'npm',
+        builtinDb: true,
+        dbDialect: 'postgres',
+      },
+    );
+
+    expect(initialValues.dbPort).toBe('5432');
+    expect(Object.prototype.hasOwnProperty.call(initialValues, 'builtinDbImage')).toBe(false);
+  } finally {
+    buildDbPromptInitialValues.mockRestore();
+  }
+});
+
+test('nb init seeds the configured docker registry into web UI defaults', async () => {
+  const { default: Init } = await import('../commands/init.js');
+
+  const buildDynamicInitialValuesForInstall = (
+    Init as unknown as {
+      buildDynamicInitialValuesForInstall: (
+        flags: { yes?: boolean; 'app-port'?: string; 'db-port'?: string },
+        presetValues: Record<string, string | number | boolean>,
+      ) => Promise<Record<string, string | number | boolean>>;
+    }
+  ).buildDynamicInitialValuesForInstall;
+
+  const { setCliConfigValue, deleteCliConfigValue } = await import('../lib/cli-config.js');
+
+  await setCliConfigValue('nb-image-registry', 'aliyun', { scope: 'global' });
+  try {
+    const initialValues = await buildDynamicInitialValuesForInstall(
+      { yes: false },
+      {
+        appName: 'app1',
+        source: 'docker',
+        builtinDb: true,
+        dbDialect: 'postgres',
+      },
+    );
+
+    expect(initialValues.dockerRegistry).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/nocobase');
+    expect(Object.prototype.hasOwnProperty.call(initialValues, 'builtinDbImage')).toBe(false);
+  } finally {
+    await deleteCliConfigValue('nb-image-registry', { scope: 'global' });
+  }
+});
+
 test('nb init preserves argument values that contain spaces when building install argv', async () => {
   const { default: Init } = await import('../commands/init.js');
   const originalArgv = process.argv;

--- a/packages/core/cli/src/__tests__/prompt-catalog-terminal.test.ts
+++ b/packages/core/cli/src/__tests__/prompt-catalog-terminal.test.ts
@@ -194,3 +194,33 @@ test('runPromptCatalog throws on missing non-interactive required text by defaul
 
   expect(mocks.input).not.toHaveBeenCalled();
 });
+
+test('runPromptCatalog includes non-catalog initial values when computing prompt defaults', async () => {
+  mocks.input.mockResolvedValue('registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16');
+
+  const { runPromptCatalog } = await import('../lib/prompt-catalog-terminal.ts');
+
+  const result = await runPromptCatalog(
+    {
+      builtinDbImage: {
+        type: 'text',
+        message: 'Built-in database Docker image',
+        initialValue: (values) => String(values.builtinDbImageRegistry ?? '').trim() || 'postgres:16',
+      },
+    },
+    {
+      initialValues: {
+        builtinDbImageRegistry: 'registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16',
+      },
+    },
+  );
+
+  expect(result).toEqual({
+    builtinDbImage: 'registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16',
+  });
+  expect(mocks.input).toHaveBeenCalledWith(
+    expect.objectContaining({
+      default: 'registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16',
+    }),
+  );
+});

--- a/packages/core/cli/src/__tests__/prompt-web-ui.test.ts
+++ b/packages/core/cli/src/__tests__/prompt-web-ui.test.ts
@@ -829,6 +829,25 @@ test('reflow uses CLI locale-aware docker registry defaults even when app langua
   expect(state.values.dockerRegistry).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/nocobase');
 });
 
+test('reflow recomputes the built-in database image from the configured registry seed', async () => {
+  const { reflowWebFormState } = await import('../lib/prompt-web-ui.js');
+  const { default: Init } = await import('../commands/init.js');
+
+  const state = reflowWebFormState(
+    Init.prompts,
+    {
+      hasNocobase: 'no',
+      dbDialect: 'mariadb',
+      builtinDb: true,
+    },
+    {
+      builtinDbImageRegistry: 'registry.cn-shanghai.aliyuncs.com/nocobase/nocobase',
+    },
+  );
+
+  expect(state.values.builtinDbImage).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/mariadb:11');
+});
+
 test('validate_field returns a field error for an occupied app port in web UI mode', async () => {
   const { runPromptCatalogWebUI } = await import('../lib/prompt-web-ui.js');
   const { default: Install } = await import('../commands/install.js');

--- a/packages/core/cli/src/__tests__/prompt-web-ui.test.ts
+++ b/packages/core/cli/src/__tests__/prompt-web-ui.test.ts
@@ -848,6 +848,25 @@ test('reflow recomputes the built-in database image from the configured registry
   expect(state.values.builtinDbImage).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/mariadb:11');
 });
 
+test('reflow recomputes the built-in database image from the zh-CN registry fallback seed', async () => {
+  const { reflowWebFormState } = await import('../lib/prompt-web-ui.js');
+  const { default: Init } = await import('../commands/init.js');
+
+  const state = reflowWebFormState(
+    Init.prompts,
+    {
+      hasNocobase: 'no',
+      dbDialect: 'postgres',
+      builtinDb: true,
+    },
+    {
+      builtinDbImageRegistry: 'registry.cn-shanghai.aliyuncs.com/nocobase/nocobase',
+    },
+  );
+
+  expect(state.values.builtinDbImage).toBe('registry.cn-shanghai.aliyuncs.com/nocobase/postgres:16');
+});
+
 test('validate_field returns a field error for an occupied app port in web UI mode', async () => {
   const { runPromptCatalogWebUI } = await import('../lib/prompt-web-ui.js');
   const { default: Install } = await import('../commands/install.js');

--- a/packages/core/cli/src/commands/env/info.ts
+++ b/packages/core/cli/src/commands/env/info.ts
@@ -205,9 +205,14 @@ export default class EnvInfo extends Command {
       'auth.accessToken': authGroup.accessToken,
       'auth.refreshToken': authGroup.refreshToken,
     };
+    const envGroup: EnvInfoGroup = {
+      name: runtime.envName,
+      kind: runtime.kind,
+    };
 
     const output = {
       ok: true,
+      name: runtime.envName,
       env: runtime.envName,
       kind: runtime.kind,
       app: serializeGroup(appGroup),
@@ -239,9 +244,12 @@ export default class EnvInfo extends Command {
     }
 
     this.log(
-      [createGroupTable('App', appGroup), createGroupTable('DB', dbGroup), createGroupTable('API', apiGroup)].join(
-        '\n\n',
-      ),
+      [
+        createGroupTable('Env', envGroup),
+        createGroupTable('App', appGroup),
+        createGroupTable('DB', dbGroup),
+        createGroupTable('API', apiGroup),
+      ].join('\n\n'),
     );
   }
 }

--- a/packages/core/cli/src/commands/init.ts
+++ b/packages/core/cli/src/commands/init.ts
@@ -27,7 +27,8 @@ import {
 } from '../lib/prompt-catalog.ts';
 import { applyCliLocale, localeText, translateCli } from '../lib/cli-locale.ts';
 import { resolveConfiguredEnvPath, resolveDefaultConfigScope, resolveEnvRelativePath } from '../lib/cli-home.js';
-import { resolveDefaultApiHost, resolveDefaultUiHost } from '../lib/cli-config.js';
+import { getCliConfigValue, resolveDefaultApiHost, resolveDefaultUiHost } from '../lib/cli-config.js';
+import { resolveOfficialDockerRegistry } from '../lib/docker-image.js';
 import {
   areConfiguredPathsEquivalent,
   deriveConfiguredSourcePath,
@@ -924,6 +925,15 @@ Prompt modes:
       downloadSeed.source = 'docker';
     }
 
+    const builtinDbImageRegistry =
+      String(presetValues.dockerRegistry ?? '').trim() ||
+      resolveOfficialDockerRegistry(await getCliConfigValue('nb-image-registry'));
+
+    if (!Object.prototype.hasOwnProperty.call(presetValues, 'dockerRegistry')) {
+      out.dockerRegistry = builtinDbImageRegistry;
+    }
+    out.builtinDbImageRegistry = builtinDbImageRegistry;
+
     const dbInitial = await Install.buildDbPromptInitialValues({
       flags,
       downloadResults: downloadSeed as Record<string, PromptValue>,
@@ -931,6 +941,9 @@ Prompt modes:
       warnOnPortFallback: false,
     });
     for (const [key, value] of Object.entries(dbInitial)) {
+      if (key === 'builtinDbImage') {
+        continue;
+      }
       if (!Object.prototype.hasOwnProperty.call(presetValues, key)) {
         out[key] = value;
       }

--- a/packages/core/cli/src/commands/install.ts
+++ b/packages/core/cli/src/commands/install.ts
@@ -774,7 +774,10 @@ export default class Install extends Command {
       type: 'text',
       message: installText('prompts.builtinDbImage.message'),
       placeholder: installText('prompts.builtinDbImage.placeholder'),
-      initialValue: (values) => defaultBuiltinDbImageForDialect(values.dbDialect),
+      initialValue: (values) =>
+        defaultBuiltinDbImageForDialect(values.dbDialect, {
+          registry: String(values.builtinDbImageRegistry ?? '').trim() || undefined,
+        }),
       hidden: (values) => !values.builtinDb || !supportsBuiltinDbDialect(values.dbDialect),
       required: true,
     },

--- a/packages/core/cli/src/lib/cli-config.ts
+++ b/packages/core/cli/src/lib/cli-config.ts
@@ -296,7 +296,9 @@ export function getEffectiveCliConfigValue(config: AuthConfig, key: SupportedCli
     case 'docker.container-prefix':
       return trimValue(config.name) || DEFAULT_DOCKER_CONTAINER_PREFIX;
     case 'nb-image-registry':
-      return explicit ?? DEFAULT_NB_IMAGE_REGISTRY;
+      return explicit ?? (resolveCliLocale(undefined, { configuredLocale: trimValue(config.settings?.locale) }) === 'zh-CN'
+        ? 'aliyun'
+        : DEFAULT_NB_IMAGE_REGISTRY);
     case 'nb-image-variant':
       return explicit ?? DEFAULT_NB_IMAGE_VARIANT;
     case 'bin.docker':

--- a/packages/core/cli/src/lib/prompt-catalog-terminal.ts
+++ b/packages/core/cli/src/lib/prompt-catalog-terminal.ts
@@ -35,6 +35,23 @@ import {
   type SelectOptionDef,
 } from './prompt-catalog-core.ts';
 
+function buildPromptComputationSeed(
+  catalog: PromptsCatalog,
+  initialValues: PromptInitialValues,
+): Record<string, PromptValue> {
+  const catalogKeys = new Set(Object.keys(catalog));
+  const seed: Record<string, PromptValue> = {};
+
+  for (const [key, value] of Object.entries(initialValues)) {
+    if (catalogKeys.has(key) || value === undefined || value === null) {
+      continue;
+    }
+    seed[key] = value as PromptValue;
+  }
+
+  return seed;
+}
+
 type PromptTerminalRenderer = {
   intro(message: string): void;
   outro(message: string): void;
@@ -168,11 +185,13 @@ export async function runPromptCatalog(
   const hooks = createTerminalHooks(locale, options.hooks);
   const interactive = Boolean(stdinStream.isTTY && stdoutStream.isTTY && !options.yes);
   const preset = options.values ?? {};
+  const computationSeed = buildPromptComputationSeed(catalog, resolveIv);
   const out: Record<string, PromptValue> = {};
   const renderer = createInquirerRenderer();
 
   for (const [key, def] of Object.entries(catalog)) {
-    if (isPromptBlockSkipped(def, out)) {
+    const valuesSoFar = { ...computationSeed, ...out } as PromptCatalogValues;
+    if (isPromptBlockSkipped(def, valuesSoFar)) {
       continue;
     }
 
@@ -180,7 +199,7 @@ export async function runPromptCatalog(
       const errV = await runPromptFieldValidate(
         def,
         out[key] as PromptValue,
-        out as unknown as PromptCatalogValues,
+        { ...computationSeed, ...out } as PromptCatalogValues,
       );
       if (errV) {
         hooks.onMissingNonInteractive(errV);
@@ -199,7 +218,7 @@ export async function runPromptCatalog(
     }
 
     if (def.type === 'run') {
-      await def.run(out, options.command);
+      await def.run({ ...computationSeed, ...out }, options.command);
       continue;
     }
 
@@ -209,19 +228,23 @@ export async function runPromptCatalog(
         ? resolvePromptText(def.placeholder, locale)
         : undefined;
       if (!interactive) {
-        const merged = mergedText(key, def, resolveIv, useYesInitial, out);
+        const merged = mergedText(key, def, resolveIv, useYesInitial, valuesSoFar);
         if (def.required && isBlankText(merged)) {
           hooks.onMissingNonInteractive(t('promptCatalog.nonInteractive.textRequired', { key }));
         }
         out[key] = merged;
-        const errT = await runPromptFieldValidate(def, merged, { ...out, [key]: merged } as PromptCatalogValues);
+        const errT = await runPromptFieldValidate(
+          def,
+          merged,
+          { ...computationSeed, ...out, [key]: merged } as PromptCatalogValues,
+        );
         if (errT) {
           hooks.onMissingNonInteractive(errT);
         }
         continue;
       }
 
-      const merged = mergedText(key, def, promptIv, false, out);
+      const merged = mergedText(key, def, promptIv, false, valuesSoFar);
       const raw = await callPrompt(
         () => renderer.text({
           message,
@@ -240,7 +263,7 @@ export async function runPromptCatalog(
             const result = runPromptFieldValidate(
               def,
               currentValue,
-              { ...out, [key]: currentValue } as PromptCatalogValues,
+              { ...computationSeed, ...out, [key]: currentValue } as PromptCatalogValues,
             );
 
             return result;
@@ -258,7 +281,11 @@ export async function runPromptCatalog(
       if (!interactive) {
         const b = mergedBoolean(key, def, resolveIv, useYesInitial);
         out[key] = b;
-        const errB = await runPromptFieldValidate(def, b, { ...out, [key]: b } as PromptCatalogValues);
+        const errB = await runPromptFieldValidate(
+          def,
+          b,
+          { ...computationSeed, ...out, [key]: b } as PromptCatalogValues,
+        );
         if (errB) {
           hooks.onMissingNonInteractive(errB);
         }
@@ -274,7 +301,11 @@ export async function runPromptCatalog(
             hooks,
           );
           const b = Boolean(raw);
-          const errB = await runPromptFieldValidate(def, b, { ...out, [key]: b } as PromptCatalogValues);
+          const errB = await runPromptFieldValidate(
+            def,
+            b,
+            { ...computationSeed, ...out, [key]: b } as PromptCatalogValues,
+          );
           if (errB) {
             renderer.error(errB);
             continue;
@@ -316,7 +347,11 @@ export async function runPromptCatalog(
           );
         }
         out[key] = merged as string;
-        const errS = await runPromptFieldValidate(def, merged as string, { ...out, [key]: merged } as PromptCatalogValues);
+        const errS = await runPromptFieldValidate(
+          def,
+          merged as string,
+          { ...computationSeed, ...out, [key]: merged } as PromptCatalogValues,
+        );
         if (errS) {
           hooks.onMissingNonInteractive(errS);
         }
@@ -347,7 +382,11 @@ export async function runPromptCatalog(
             hooks,
           );
           const picked = raw as string;
-          const errS = await runPromptFieldValidate(def, picked, { ...out, [key]: picked } as PromptCatalogValues);
+          const errS = await runPromptFieldValidate(
+            def,
+            picked,
+            { ...computationSeed, ...out, [key]: picked } as PromptCatalogValues,
+          );
           if (errS) {
             renderer.error(errS);
             continue;
@@ -374,13 +413,17 @@ export async function runPromptCatalog(
     if (def.type === 'password') {
       const message = resolvePromptText(def.message, locale, key);
       if (!interactive) {
-        const merged = mergedPassword(key, def, resolveIv, useYesInitial);
+        const merged = mergedPassword(key, def, resolveIv, useYesInitial, valuesSoFar);
         if (merged === undefined) {
           if (def.required) {
             hooks.onMissingNonInteractive(t('promptCatalog.nonInteractive.passwordRequired', { key }));
           }
           out[key] = '';
-          const errPE = await runPromptFieldValidate(def, '', { ...out, [key]: '' } as PromptCatalogValues);
+          const errPE = await runPromptFieldValidate(
+            def,
+            '',
+            { ...computationSeed, ...out, [key]: '' } as PromptCatalogValues,
+          );
           if (errPE) {
             hooks.onMissingNonInteractive(errPE);
           }
@@ -390,7 +433,11 @@ export async function runPromptCatalog(
           hooks.onMissingNonInteractive(t('promptCatalog.nonInteractive.passwordRequiredNonEmpty', { key }));
         }
         out[key] = merged;
-        const errP = await runPromptFieldValidate(def, merged, { ...out, [key]: merged } as PromptCatalogValues);
+        const errP = await runPromptFieldValidate(
+          def,
+          merged,
+          { ...computationSeed, ...out, [key]: merged } as PromptCatalogValues,
+        );
         if (errP) {
           hooks.onMissingNonInteractive(errP);
         }
@@ -414,7 +461,7 @@ export async function runPromptCatalog(
             const result = runPromptFieldValidate(
               def,
               currentValue,
-              { ...out, [key]: currentValue } as PromptCatalogValues,
+              { ...computationSeed, ...out, [key]: currentValue } as PromptCatalogValues,
             );
 
             return result;
@@ -440,14 +487,22 @@ export async function runPromptCatalog(
           }
           const z = def.initialValue ?? 0;
           out[key] = z;
-          const errI = await runPromptFieldValidate(def, z, { ...out, [key]: z } as PromptCatalogValues);
+          const errI = await runPromptFieldValidate(
+            def,
+            z,
+            { ...computationSeed, ...out, [key]: z } as PromptCatalogValues,
+          );
           if (errI) {
             hooks.onMissingNonInteractive(errI);
           }
           continue;
         }
         out[key] = merged;
-        const errI2 = await runPromptFieldValidate(def, merged, { ...out, [key]: merged } as PromptCatalogValues);
+        const errI2 = await runPromptFieldValidate(
+          def,
+          merged,
+          { ...computationSeed, ...out, [key]: merged } as PromptCatalogValues,
+        );
         if (errI2) {
           hooks.onMissingNonInteractive(errI2);
         }
@@ -470,7 +525,11 @@ export async function runPromptCatalog(
 
               if (def.validate) {
                 const z = def.initialValue ?? 0;
-                return runPromptFieldValidate(def, z, { ...out, [key]: z } as PromptCatalogValues);
+                return runPromptFieldValidate(
+                  def,
+                  z,
+                  { ...computationSeed, ...out, [key]: z } as PromptCatalogValues,
+                );
               }
 
               return undefined;
@@ -484,7 +543,11 @@ export async function runPromptCatalog(
             }
 
             const n = Number.parseInt(trimmed, 10);
-            return runPromptFieldValidate(def, n, { ...out, [key]: n } as PromptCatalogValues);
+            return runPromptFieldValidate(
+              def,
+              n,
+              { ...computationSeed, ...out, [key]: n } as PromptCatalogValues,
+            );
           },
         }),
         renderer,

--- a/packages/core/cli/src/lib/prompt-web-ui.ts
+++ b/packages/core/cli/src/lib/prompt-web-ui.ts
@@ -81,6 +81,23 @@ function isInputBlock(def: PromptBlock): boolean {
   );
 }
 
+function buildPromptComputationSeed(
+  catalog: PromptsCatalog,
+  userPreset: PromptInitialValues,
+): Record<string, PromptValue> {
+  const catalogKeys = new Set(Object.keys(catalog));
+  const seed: Record<string, PromptValue> = {};
+
+  for (const [key, value] of Object.entries(userPreset)) {
+    if (catalogKeys.has(key) || value === undefined || value === null) {
+      continue;
+    }
+    seed[key] = value as PromptValue;
+  }
+
+  return seed;
+}
+
 /**
  * Merges CLI/env **`userPreset`** with catalog block defaults, in the same key order and with the
  * same `hidden` / `run` semantics as {@link isPromptBlockSkipped}, so the web form can prefill
@@ -90,7 +107,7 @@ export function buildWebFormValuesFromCatalog(
   catalog: PromptsCatalog,
   userPreset: PromptInitialValues = {},
 ): PromptInitialValues {
-  const out: Record<string, PromptValue> = {};
+  const out: Record<string, PromptValue> = buildPromptComputationSeed(catalog, userPreset);
   for (const [key, def] of Object.entries(catalog)) {
     if (def.type === 'intro' || def.type === 'outro') {
       continue;
@@ -156,7 +173,7 @@ export function reflowWebFormState(
   raw: Record<string, unknown>,
   userSeed: PromptInitialValues = {},
 ): ReflowState {
-  const out: Record<string, PromptValue> = {};
+  const out: Record<string, PromptValue> = buildPromptComputationSeed(catalog, userSeed);
   const show: Record<string, boolean> = {};
   for (const [key, def] of Object.entries(catalog)) {
     if (def.type === 'intro' || def.type === 'outro') {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed NocoBase CLI default value issues for image registry fallback, built-in database images, env info display, and prompt initialization. |
| 🇨🇳 Chinese | 修复了 NocoBase CLI 在镜像仓库回退、内置数据库镜像、环境信息显示和提示默认值初始化方面的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary



