### PR TITLE
fix(plugin-user-data-sync): preserve incoming record order

### DIFF
--- a/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/data-sync.test.ts
+++ b/packages/plugins/@nocobase/plugin-departments/src/server/__tests__/data-sync.test.ts
@@ -120,6 +120,62 @@ describe('department data sync', async () => {
     expect(department3.parent).toBeNull();
   });
 
+  it('should reparent an existing child department when its parent is synced later', async () => {
+    await resourceManager.updateOrCreate({
+      sourceName: 'test',
+      dataType: 'department',
+      records: [
+        {
+          uid: '20',
+          title: 'child',
+          parentUid: '0',
+        },
+      ],
+    });
+
+    const child = await db.getRepository('departments').findOne({
+      filter: {
+        title: 'child',
+      },
+      appends: ['parent'],
+    });
+    expect(child).toBeTruthy();
+    expect(child.parent).toBeNull();
+
+    await resourceManager.updateOrCreate({
+      sourceName: 'test',
+      dataType: 'department',
+      records: [
+        {
+          uid: '10',
+          title: 'parent',
+          parentUid: '0',
+        },
+        {
+          uid: '20',
+          title: 'child',
+          parentUid: '10',
+        },
+      ],
+    });
+
+    const parent = await db.getRepository('departments').findOne({
+      filter: {
+        title: 'parent',
+      },
+      appends: ['children'],
+    });
+    const updatedChild = await db.getRepository('departments').findOne({
+      filterByTk: child.id,
+      appends: ['parent'],
+    });
+
+    expect(parent).toBeTruthy();
+    expect(updatedChild.parent?.id).toBe(parent.id);
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children[0].id).toBe(child.id);
+  });
+
   it('should sync department sort on create and update', async () => {
     await resourceManager.updateOrCreate({
       sourceName: 'test',

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/__tests__/resource-manager-order.test.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/__tests__/resource-manager-order.test.ts
@@ -1,0 +1,168 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type Database from '@nocobase/database';
+import type { SystemLogger } from '@nocobase/logger';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  OriginRecord,
+  PrimaryKey,
+  RecordResourceChanged,
+  SyncAccept,
+  SyncDataType,
+  UserDataRecord,
+  UserDataResource,
+  UserDataResourceManager,
+} from '../user-data-resource-manager';
+
+type StoredOriginRecord = OriginRecord & {
+  lastMetaData?: UserDataRecord;
+  save: () => Promise<void>;
+  createResource: (values: { resource: string; resourcePk: PrimaryKey }) => Promise<void>;
+};
+
+class OrderedDepartmentResource extends UserDataResource {
+  name = 'departments';
+  accepts: SyncAccept[] = ['department'];
+  calls: string[] = [];
+
+  constructor() {
+    super({} as Database, { debug: vi.fn(), warn: vi.fn() } as unknown as SystemLogger);
+  }
+
+  async update(record: OriginRecord): Promise<RecordResourceChanged[]> {
+    this.calls.push(`update:${record.sourceUk}`);
+    return [];
+  }
+
+  async create(record: OriginRecord): Promise<RecordResourceChanged[]> {
+    this.calls.push(`create:${record.sourceUk}`);
+    return [{ resourcesPk: record.sourceUk, isDeleted: false }];
+  }
+}
+
+function createStoredRecord(values: {
+  id: number;
+  sourceName: string;
+  sourceUk: string;
+  dataType: SyncDataType;
+  metaData: UserDataRecord;
+  resources?: OriginRecord['resources'];
+}): StoredOriginRecord {
+  const record: StoredOriginRecord = {
+    ...values,
+    resources: values.resources ?? [],
+    save: vi.fn(async () => undefined),
+    createResource: vi.fn(async ({ resource, resourcePk }) => {
+      record.resources.push({
+        resource,
+        resourcePk: String(resourcePk),
+      });
+    }),
+  };
+  return record;
+}
+
+describe('user-data-resource-manager record order', () => {
+  it('processes resources in the same order as incoming records', async () => {
+    const manager = new UserDataResourceManager();
+    const resource = new OrderedDepartmentResource();
+    const storedRecords = new Map<string, StoredOriginRecord>();
+    let nextId = 2;
+
+    storedRecords.set(
+      '20',
+      createStoredRecord({
+        id: 1,
+        sourceName: 'test',
+        sourceUk: '20',
+        dataType: 'department',
+        metaData: {
+          uid: '20',
+          title: 'child',
+          parentUid: '0',
+        },
+        resources: [{ resource: 'departments', resourcePk: 'child-department-id' }],
+      }),
+    );
+
+    manager.syncRecordRepo = {
+      findOne: vi.fn(
+        async ({
+          where,
+          filter,
+        }: {
+          where?: { sourceName: string; sourceUk: string; dataType: SyncDataType };
+          filter?: { id?: number };
+        }) => {
+          if (where) {
+            return storedRecords.get(where.sourceUk);
+          }
+          if (filter?.id != null) {
+            return Array.from(storedRecords.values()).find((record) => record.id === filter.id);
+          }
+          return undefined;
+        },
+      ),
+      create: vi.fn(
+        async ({
+          values,
+        }: {
+          values: { sourceName: string; sourceUk: string; dataType: SyncDataType; metaData: UserDataRecord };
+        }) => {
+          const record = createStoredRecord({
+            id: nextId,
+            sourceName: values.sourceName,
+            sourceUk: values.sourceUk,
+            dataType: values.dataType,
+            metaData: values.metaData,
+          });
+          nextId += 1;
+          storedRecords.set(values.sourceUk, record);
+          return record;
+        },
+      ),
+      find: vi.fn(
+        async ({ filter }: { filter: { sourceName: string; dataType: SyncDataType; sourceUk: { $in: string[] } } }) => {
+          return ['20', '10']
+            .map((sourceUk) => storedRecords.get(sourceUk))
+            .filter((record): record is StoredOriginRecord => {
+              return Boolean(
+                record &&
+                  record.sourceName === filter.sourceName &&
+                  record.dataType === filter.dataType &&
+                  filter.sourceUk.$in.includes(record.sourceUk),
+              );
+            });
+        },
+      ),
+    } as unknown as UserDataResourceManager['syncRecordRepo'];
+    manager.syncRecordResourceRepo = {} as UserDataResourceManager['syncRecordResourceRepo'];
+    manager.registerResource(resource);
+
+    await manager.updateOrCreate({
+      sourceName: 'test',
+      dataType: 'department',
+      records: [
+        {
+          uid: '10',
+          title: 'parent',
+          parentUid: '0',
+        },
+        {
+          uid: '20',
+          title: 'child',
+          parentUid: '10',
+        },
+      ],
+    });
+
+    expect(resource.calls).toEqual(['create:10', 'update:20']);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts
+++ b/packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts
@@ -156,10 +156,30 @@ export class UserDataResourceManager {
     }
   }
 
-  async findOriginRecords({ sourceName, dataType, sourceUks }): Promise<OriginRecord[]> {
-    return await this.syncRecordRepo.find({
+  async findOriginRecords({
+    sourceName,
+    dataType,
+    sourceUks,
+  }: {
+    sourceName: string;
+    dataType: SyncDataType;
+    sourceUks: string[];
+  }): Promise<OriginRecord[]> {
+    const originRecords = await this.syncRecordRepo.find({
       appends: ['resources'],
       filter: { sourceName, dataType, sourceUk: { $in: sourceUks } },
+    });
+    const sourceUkOrder = new Map<string, number>();
+    sourceUks.forEach((sourceUk, index) => {
+      if (!sourceUkOrder.has(sourceUk)) {
+        sourceUkOrder.set(sourceUk, index);
+      }
+    });
+    return originRecords.sort((a, b) => {
+      return (
+        (sourceUkOrder.get(a.sourceUk) ?? Number.MAX_SAFE_INTEGER) -
+        (sourceUkOrder.get(b.sourceUk) ?? Number.MAX_SAFE_INTEGER)
+      );
     });
   }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When syncing external department data, existing sync records were fetched by database order instead of the incoming record order. If a child department had already been synced first, and its parent department became available in a later sync batch, the child could be processed before the newly created parent and remain detached from the parent.

### Description 
This PR preserves the incoming record order when loading existing sync records in `UserDataResourceManager`.

Key changes:
- Sort existing origin records according to the order of incoming `sourceUks`.
- Add a unit test to cover mixed create/update ordering.
- Add a department sync regression test for reparenting an existing child department after its parent is synced later.

Potential risk:
- Low. The change only affects processing order for records already matched by `sourceUk`.

Testing:
- `yarn test packages/plugins/@nocobase/plugin-user-data-sync/src/server/__tests__/resource-manager-order.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-user-data-sync/src/server/user-data-resource-manager.ts packages/plugins/@nocobase/plugin-user-data-sync/src/server/__tests__/resource-manager-order.test.ts packages/plugins/@nocobase/plugin-departments/src/server/__tests__/data-sync.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed external department sync order so child departments can be reparented correctly when their parent is synced later. |
| 🇨🇳 Chinese | 修复外部部门同步顺序问题，确保父部门后续同步时，已存在的子部门可以正确挂载到父部门下。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary