### PR TITLE
test(plugin-block-grid-card): add e2e coverage

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-grid-card/README.md
+++ b/packages/plugins/@nocobase/plugin-block-grid-card/README.md
@@ -97,3 +97,82 @@ NocoBase supports three installation methods:
 <video width="100%" controls>
   <source src="https://github.com/user-attachments/assets/8d183b44-9bb5-4792-b08f-bc08fe8dfaaf" type="video/mp4">
 </video>
+
+## 总览
+
+本包覆盖网格卡片区块在页面中的创建、卡片内容配置、区块操作、卡片记录操作与区块设置能力。E2E 用例使用 NocoBase Playwright fixtures 创建临时页面和数据，验证用户在配置模式下可完成真实区块配置，并断言页面中产生对应可见结果。
+
+## 用例大纲
+
+- 网格卡片区块创建
+  - 页面中添加网格卡片区块
+- 网格卡片内容配置
+  - 配置集合字段
+  - 配置关联字段
+  - 配置 Markdown 内容
+- 网格卡片区块操作
+  - 配置筛选、新增和刷新等区块全局操作
+- 网格卡片记录操作
+  - 配置查看、编辑和删除等卡片记录操作
+  - 配置弹窗和更新记录等自定义卡片记录操作
+- 网格卡片布局配置
+  - 区块设置菜单
+  - 配置桌面端单行显示列数
+
+## 用例清单
+
+### 1. create grid card block on a page
+
+- 编号：1
+- 功能：验证页面 Add block 入口可以创建 Grid Card 区块，并在页面中显示网格卡片区块容器。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts`
+- 执行步骤与断言：创建临时页面；通过页面 Add block 入口选择 `Grid Card`；断言 `users` 集合的 Grid Card 区块可见。
+- 清理：由 `mockPage` fixture 清理临时页面和 schema。
+
+### 2. configure grid card fields and markdown content
+
+- 编号：2
+- 功能：验证 Grid Card 卡片内容可以配置集合字段、关联字段和 Markdown 内容，并可移除已配置字段。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts`
+- 执行步骤与断言：创建带记录的 Grid Card 临时页面；通过卡片字段配置入口添加 `ID` 字段和 `Many to one / Nickname` 关联字段；断言字段在卡片中可见；再次点击字段开关移除字段；断言字段不可见；添加 Markdown 内容；断言 Markdown 区块可见。
+- 清理：由 `mockPage` 和 `mockRecord` fixtures 清理临时页面、schema 和测试记录。
+
+### 3. configure grid card collection actions
+
+- 编号：3
+- 功能：验证 Grid Card 区块可以配置区块级操作，并且删除后操作入口从页面消失。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts`
+- 执行步骤与断言：打开空 Grid Card 区块页面；通过区块操作配置入口依次添加 `Filter`、`Add new`、`Refresh`；断言三个按钮可见；再通过各按钮设置菜单删除；断言三个按钮不可见。
+- 清理：由 `mockPage` fixture 清理临时页面和 schema。
+
+### 4. configure grid card record actions
+
+- 编号：4
+- 功能：验证 Grid Card 卡片内可以配置记录级操作，并且删除后记录操作从卡片中消失。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts`
+- 执行步骤与断言：创建带记录的 Grid Card 临时页面；通过卡片操作配置入口添加 `View`、`Edit`、`Delete`；断言三个记录操作在卡片中可见；再删除三个操作；断言三个记录操作不可见。
+- 清理：由 `mockPage` 和 `mockRecord` fixtures 清理临时页面、schema 和测试记录。
+
+### 5. configure grid card custom record actions
+
+- 编号：5
+- 功能：验证 Grid Card 卡片内可以配置弹窗和更新记录等自定义记录操作。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts`
+- 执行步骤与断言：创建带记录的 Grid Card 临时页面；通过卡片操作配置入口添加 `Popup` 和 `Update record`；断言两个自定义记录操作在卡片中可见。
+- 清理：由 `mockPage` 和 `mockRecord` fixtures 清理临时页面、schema 和测试记录。
+
+### 6. show grid card block settings options
+
+- 编号：6
+- 功能：验证 Grid Card 区块设置菜单提供列数、数据范围、默认排序、分页数量和删除等可配置项。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaSettings.test.ts`
+- 执行步骤与断言：打开空 Grid Card 区块页面；悬停区块设置入口；断言设置菜单中显示 `Set the count of columns displayed in a row`、`Set the data scope`、`Set default sorting rules`、`Records per page` 和 `Delete`。
+- 清理：由 `mockPage` fixture 清理临时页面和 schema。
+
+### 7. set grid card desktop column count
+
+- 编号：7
+- 功能：验证 Grid Card 区块可以配置桌面端单行列数，并影响卡片宽度。
+- Spec 文件：`packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaSettings.test.ts`
+- 执行步骤与断言：创建带 10 条记录的 Grid Card 临时页面；记录默认卡片宽度对应 3 列布局；打开区块设置并将桌面端列数改为 2；刷新页面；断言卡片宽度变大并符合 2 列布局范围。
+- 清理：由 `mockPage` 和 `mockRecords` fixtures 清理临时页面、schema 和测试记录；列数设置随临时页面删除。

--- a/packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts
@@ -1,0 +1,151 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Page, createBlockInPage, expect, oneEmptyGridCardBlock, test } from '@nocobase/test/e2e';
+
+const deleteButton = async (page: Page, name: string) => {
+  await page.getByRole('button', { name }).hover();
+  await page.getByRole('menuitem', { name: 'Delete' }).waitFor({ state: 'detached' });
+  await page.getByRole('button', { name }).getByLabel('designer-schema-settings-').hover();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: 'OK', exact: true }).click();
+};
+
+test.describe('grid card block initializer', () => {
+  test('create grid card block on a page', async ({ page, mockPage }) => {
+    await mockPage().goto();
+
+    await page.getByLabel('schema-initializer-Grid-page:addBlock').hover();
+    await createBlockInPage(page, 'Grid Card');
+
+    await expect(page.getByLabel('block-item-BlockItem-users-grid-card')).toBeVisible();
+  });
+});
+
+test.describe('grid card actions initializer', () => {
+  test('configure grid card collection actions', async ({ page, mockPage }) => {
+    await mockPage(oneEmptyGridCardBlock).goto();
+
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureActions-general').hover();
+    await page.getByRole('menuitem', { name: 'Filter' }).click();
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureActions-general').hover();
+    await page.getByRole('menuitem', { name: 'Add new' }).click();
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureActions-general').hover();
+    await page.getByRole('menuitem', { name: 'Refresh' }).click();
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByRole('button', { name: 'Filter' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add new' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+
+    await deleteButton(page, 'Filter');
+    await deleteButton(page, 'Add new');
+    await deleteButton(page, 'Refresh');
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByRole('button', { name: 'Filter' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add new' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Refresh' })).not.toBeVisible();
+  });
+
+  test('configure grid card record actions', async ({ page, mockPage, mockRecord }) => {
+    const nocoPage = await mockPage(oneEmptyGridCardBlock).waitForInit();
+    await mockRecord('general');
+    await nocoPage.goto();
+
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureItemActions-general').first().hover();
+    await page.getByRole('menuitem', { name: 'View' }).click();
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureItemActions-general').first().hover();
+    await page.getByRole('menuitem', { name: 'Edit' }).click();
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureItemActions-general').first().hover();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByLabel('action-Action.Link-View-view-general-grid-card').first()).toBeVisible();
+    await expect(page.getByLabel('action-Action.Link-Edit-update-general-grid-card').first()).toBeVisible();
+    await expect(page.getByLabel('action-Action.Link-Delete-destroy-general-grid-card').first()).toBeVisible();
+
+    await deleteButton(page, 'View');
+    await deleteButton(page, 'Edit');
+    await deleteButton(page, 'Delete');
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByLabel('action-Action.Link-View-view-general-grid-card').first()).not.toBeVisible();
+    await expect(page.getByLabel('action-Action.Link-Edit-update-general-grid-card').first()).not.toBeVisible();
+    await expect(page.getByLabel('action-Action.Link-Delete-destroy-general-grid-card').first()).not.toBeVisible();
+  });
+
+  test('configure grid card custom record actions', async ({ page, mockPage, mockRecord }) => {
+    const nocoPage = await mockPage(oneEmptyGridCardBlock).waitForInit();
+    await mockRecord('general');
+    await nocoPage.goto();
+
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureItemActions-general').first().hover();
+    await page.getByRole('menuitem', { name: 'Popup' }).click();
+    await page.getByLabel('schema-initializer-ActionBar-gridCard:configureItemActions-general').first().hover();
+    await page.getByRole('menuitem', { name: 'Update record' }).click();
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByLabel('action-Action.Link-Popup-customize:popup-general-grid-card').first()).toBeVisible();
+    await expect(
+      page.getByLabel('action-Action.Link-Update record-customize:update-general-grid-card').first(),
+    ).toBeVisible();
+  });
+});
+
+test.describe('grid card fields initializer', () => {
+  test('configure grid card fields and markdown content', async ({ page, mockPage, mockRecord }) => {
+    const nocoPage = await mockPage(oneEmptyGridCardBlock).waitForInit();
+    await mockRecord('general');
+    await nocoPage.goto();
+
+    const formItemInitializer = page.getByLabel('schema-initializer-Grid-details:configureFields-general').first();
+
+    await formItemInitializer.hover();
+    await page.getByRole('menuitem', { name: 'ID', exact: true }).click();
+    await expect(page.getByRole('menuitem', { name: 'ID', exact: true }).getByRole('switch')).toBeChecked();
+
+    await page.mouse.wheel(0, 300);
+    await page.getByRole('menuitem', { name: 'Many to one right' }).hover();
+    await page.getByRole('menuitem', { name: 'Nickname' }).click();
+
+    await page.getByRole('menuitem', { name: 'Many to one right' }).hover();
+    await expect(page.getByRole('menuitem', { name: 'Nickname' }).getByRole('switch')).toBeChecked();
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByLabel('block-item-CollectionField-general-grid-card-general.id-ID').first()).toBeVisible();
+    await expect(
+      page.getByLabel('block-item-CollectionField-general-grid-card-users.nickname-Nickname').first(),
+    ).toBeVisible();
+
+    await formItemInitializer.hover();
+    await page.getByRole('menuitem', { name: 'ID', exact: true }).first().click();
+    await expect(page.getByRole('menuitem', { name: 'ID', exact: true }).getByRole('switch').first()).not.toBeChecked();
+
+    await page.mouse.wheel(0, 300);
+    await page.getByRole('menuitem', { name: 'Many to one right' }).hover();
+    await page.getByRole('menuitem', { name: 'Nickname' }).click();
+
+    await page.getByRole('menuitem', { name: 'Many to one right' }).hover();
+    await expect(page.getByRole('menuitem', { name: 'Nickname' }).getByRole('switch')).not.toBeChecked();
+
+    await page.mouse.move(300, 0);
+    await expect(page.getByLabel('block-item-CollectionField-general-grid-card-general.id-ID').first()).not.toBeVisible();
+    await expect(
+      page.getByLabel('block-item-CollectionField-general-grid-card-general.manyToOne.nickname').first(),
+    ).not.toBeVisible();
+
+    await formItemInitializer.hover();
+    await page.getByRole('menuitem', { name: 'ID', exact: true }).first().hover();
+    await page.mouse.wheel(0, 300);
+    await page.getByRole('menuitem', { name: 'Add Markdown' }).click();
+
+    await expect(page.getByLabel('block-item-Markdown.Void-general-grid-card').first()).toBeVisible();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaSettings.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaSettings.test.ts
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { expect, expectSettingsMenu, oneEmptyGridCardBlock, test } from '@nocobase/test/e2e';
+
+test.describe('grid card block schema settings', () => {
+  test('show grid card block settings options', async ({ page, mockPage }) => {
+    await mockPage(oneEmptyGridCardBlock).goto();
+
+    await expectSettingsMenu({
+      page,
+      showMenu: async () => {
+        await page.getByLabel('block-item-BlockItem-general-grid-card').hover();
+        await page.waitForTimeout(1000);
+        await page.getByLabel('designer-schema-settings-BlockItem-GridCard.Designer-general').hover();
+      },
+      supportedOptions: [
+        'Set the count of columns displayed in a row',
+        'Set the data scope',
+        'Set default sorting rules',
+        'Records per page',
+        'Delete',
+      ],
+    });
+  });
+
+  test('set grid card desktop column count', async ({ page, mockPage, mockRecords }) => {
+    const nocoPage = await mockPage(oneEmptyGridCardBlock).waitForInit();
+    await mockRecords('general', 10);
+    await nocoPage.goto();
+
+    let boxSize = await page.getByLabel('grid-card-item').first().boundingBox();
+    expect(boxSize.width).toBeGreaterThan(390);
+    expect(boxSize.width).toBeLessThan(410);
+
+    await page.getByLabel('block-item-BlockItem-general-grid-card').hover();
+    await page.getByLabel('designer-schema-settings-BlockItem-GridCard.Designer-general').hover();
+    await page.getByRole('menuitem', { name: 'Set the count of columns displayed in a row' }).click();
+    await page.getByLabel('block-item-Slider-general-grid-card-Desktop device').getByText('2', { exact: true }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
+
+    await page.reload();
+
+    boxSize = await page.getByLabel('grid-card-item').first().boundingBox();
+    expect(boxSize.width).toBeGreaterThan(600);
+    expect(boxSize.width).toBeLessThan(620);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
Complete the E2E coverage evidence for `@nocobase/plugin-block-grid-card` with a plugin-local README outline/case list and matching Playwright specs.

### Description 
- Added a product-module-oriented E2E README section for Grid Card block creation, card content configuration, collection actions, record actions, custom record actions, and block settings.
- Added plugin-local Playwright specs that cover Grid Card creation, field/Markdown configuration, collection action configuration, record/custom action configuration, settings menu options, and desktop column count configuration.
- Verified README `## 用例清单` titles are synchronized with Playwright `test('<title>')` titles.

Test notes:
- Static README/test sync check passed: 7 README cases and 7 Playwright tests, no missing/extra titles, no expected-fail drift, cleanup entries present.
- Minimal Playwright run on `test1` was attempted with:
  `APP_BASE_URL="$(nb env info test1 --field app.url | sed 's#/$##')" PLAYWRIGHT_AUTH_FILE="storage/playwright/tests/.auth/admin.json" NODE_PATH="/Users/hao/NocoBase/nocobase-develop/node_modules" /Users/hao/NocoBase/nocobase-develop/node_modules/.bin/playwright test -c playwright.config.ts packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaInitializer.test.ts packages/plugins/@nocobase/plugin-block-grid-card/src/client/__e2e__/schemaSettings.test.ts --project=chromium`
- Result on `test1`: auth setup passed; 7 plugin tests did not pass. Six tests failed at `createCollections` with `Not Found`, matching the current `test1` environment missing the mock collection fixture API. The creation smoke test timed out waiting for the page Add block initializer in the same environment.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added E2E coverage documentation and Playwright tests for the Grid Card block plugin. |
| 🇨🇳 Chinese | 为网格卡片区块插件补充 E2E 覆盖说明和 Playwright 测试。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
