### PR TITLE
fix(data-visualization): reapply chart events when chart instance is ready

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -15,6 +15,7 @@ import {
   useFlowContext,
 } from '@nocobase/flow-engine';
 import React, { createRef } from 'react';
+import type { EChartsType } from 'echarts';
 import _ from 'lodash';
 import { Button, Space } from 'antd';
 import dayjs from 'dayjs';
@@ -91,8 +92,23 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
   // 统一管理 refresh 监听引用，便于 off 解绑
   private __onResourceRefresh = () => this.renderChart();
+  private __eventsBoundChart?: EChartsType;
+  private __eventsBoundRaw?: string;
   private lastRefreshSnapshot: ChartDirtyRefreshSnapshot | null = null;
   private dirtyRefreshing = false;
+
+  private __onChartRefReady = (chart: EChartsType) => {
+    try {
+      this.props.chart?.onRefReady?.(chart);
+    } catch (error) {
+      console.error('Chart onRefReady error:', error);
+    }
+
+    const raw = this.getConfiguredEventsRaw();
+    if (raw) {
+      void this.applyEvents(raw, chart);
+    }
+  };
 
   private getCurrentRefreshSnapshot(): ChartDirtyRefreshSnapshot | null {
     return getChartDirtyRefreshSnapshot({
@@ -175,6 +191,26 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
     return this.getStepParams('chartSettings', 'configure');
   }
 
+  private getConfiguredEventsRaw() {
+    return this.getResourceSettingsInitParams()?.chart?.events?.raw;
+  }
+
+  private shouldSkipApplyEvents(raw: string, chart: EChartsType) {
+    return this.__eventsBoundChart === chart && this.__eventsBoundRaw === raw;
+  }
+
+  private markEventsBound(raw: string, chart: EChartsType) {
+    this.__eventsBoundChart = chart;
+    this.__eventsBoundRaw = raw;
+  }
+
+  private clearEventsBound(raw: string, chart: EChartsType) {
+    if (this.__eventsBoundChart === chart && this.__eventsBoundRaw === raw) {
+      this.__eventsBoundChart = undefined;
+      this.__eventsBoundRaw = undefined;
+    }
+  }
+
   async buildQueryRequest(query: any) {
     if (!query || query?.mode === 'sql') {
       return query;
@@ -231,13 +267,13 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
   }
 
   renderComponent() {
-    // TODO onRefReady 的逻辑理清，内部的 onRefReady props是否已经没必要？
     return (
       <Chart
         {...this.props.chart}
         dataSource={this.resource.getData()}
         loading={this.resource.loading}
         heightMode={this.decoratorProps?.heightMode}
+        onRefReady={this.__onChartRefReady}
         ref={this.context.chartRef}
       />
     );
@@ -474,18 +510,46 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
   }
 
   // 应用事件配置（仅设置，不负责渲染）
-  async applyEvents(raw?: string) {
+  async applyEvents(raw?: string, chartInstance?: EChartsType) {
     if (!raw) return;
 
+    if (chartInstance) {
+      await this.runChartEvents(raw, chartInstance);
+      return;
+    }
+
+    const chart = (this.context.chartRef as any).current as EChartsType | null;
+    if (chart) {
+      await this.runChartEvents(raw, chart);
+      return;
+    }
+
     this.context.onRefReady(this.context.chartRef, async () => {
-      const { success, value, error, timeout } = await this.context.runjs(raw, {
-        chart: (this.context.chartRef as any).current,
-      });
-      if (!success && error) {
-        console.error('applyEvents runjs error:', error);
-        return;
+      const currentChart = (this.context.chartRef as any).current as EChartsType | null;
+      if (currentChart) {
+        await this.runChartEvents(raw, currentChart);
       }
     });
+  }
+
+  private async runChartEvents(raw: string, chart: EChartsType) {
+    if (this.shouldSkipApplyEvents(raw, chart)) {
+      return;
+    }
+
+    this.markEventsBound(raw, chart);
+
+    const { success, error, timeout } = await this.context.runjs(raw, {
+      chart,
+    });
+    if (success) {
+      return;
+    }
+
+    this.clearEventsBound(raw, chart);
+    if (error || timeout) {
+      console.error('applyEvents runjs error:', error || 'timeout');
+    }
   }
 
   // 显式渲染（必要时可直接调用）

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -106,7 +106,9 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
     const raw = this.getConfiguredEventsRaw();
     if (raw) {
-      void this.applyEvents(raw, chart);
+      this.applyEvents(raw, chart).catch((error) => {
+        console.error('Chart applyEvents error:', error);
+      });
     }
   };
 
@@ -539,16 +541,21 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
     this.markEventsBound(raw, chart);
 
-    const { success, error, timeout } = await this.context.runjs(raw, {
-      chart,
-    });
-    if (success) {
-      return;
-    }
+    try {
+      const { success, error, timeout } = await this.context.runjs(raw, {
+        chart,
+      });
+      if (success) {
+        return;
+      }
 
-    this.clearEventsBound(raw, chart);
-    if (error || timeout) {
-      console.error('applyEvents runjs error:', error || 'timeout');
+      this.clearEventsBound(raw, chart);
+      if (error || timeout) {
+        console.error('applyEvents runjs error:', error || 'timeout');
+      }
+    } catch (error) {
+      this.clearEventsBound(raw, chart);
+      throw error;
     }
   }
 

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { FlowEngine } from '@nocobase/flow-engine';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ChartBlockModel } from '../ChartBlockModel';
 
 type ChartQuery = {
@@ -225,5 +225,75 @@ describe('ChartBlockModel onActive dirty refresh', () => {
     await model.onActive();
 
     expect(resource.refreshCalls).toBe(2);
+  });
+});
+
+describe('ChartBlockModel chart events binding', () => {
+  it('runs chart events once for the same chart instance and raw events, then reruns for a new chart instance', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const raw = 'chart.on("click", () => {})';
+    const chartA = {} as any;
+    const chartB = {} as any;
+    const runjs = vi.spyOn(model.context, 'runjs').mockResolvedValue({ success: true, value: undefined });
+
+    await model.applyEvents(raw, chartA);
+    await model.applyEvents(raw, chartA);
+    await model.applyEvents(raw, chartB);
+
+    expect(runjs).toHaveBeenCalledTimes(2);
+    expect(runjs).toHaveBeenNthCalledWith(1, raw, { chart: chartA });
+    expect(runjs).toHaveBeenNthCalledWith(2, raw, { chart: chartB });
+  });
+
+  it('clears the bound marker when chart events throw so the same chart can retry', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const raw = 'chart.on("click", () => {})';
+    const chart = {} as any;
+    const runjs = vi
+      .spyOn(model.context, 'runjs')
+      .mockRejectedValueOnce(new Error('events failed'))
+      .mockResolvedValueOnce({ success: true, value: undefined });
+
+    await expect(model.applyEvents(raw, chart)).rejects.toThrow('events failed');
+    await model.applyEvents(raw, chart);
+
+    expect(runjs).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles asynchronous onRefReady chart event failures explicitly', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const raw = 'chart.on("click", () => {})';
+    const chart = {} as any;
+    const error = new Error('events failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const applyEvents = vi.spyOn(model, 'applyEvents').mockRejectedValue(error);
+    model.setProps({ chart: {} } as any);
+    model.setStepParams('chartSettings', 'configure', {
+      query: {
+        mode: 'builder',
+        collectionPath: ['main', 'orders'],
+      },
+      chart: {
+        events: {
+          raw,
+        },
+      },
+    });
+
+    (model as any).__onChartRefReady(chart);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(applyEvents).toHaveBeenCalledWith(raw, chart);
+    expect(consoleError).toHaveBeenCalledWith('Chart applyEvents error:', error);
+    consoleError.mockRestore();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Chart event scripts are currently applied when the chart configuration flow runs. If an ECharts instance is recreated later, for example after dashboard configuration mode or layout rerendering, the visible chart can keep rendering while losing its click event handlers until the chart configuration panel is opened again.

### Description 
Reapply configured chart event scripts when the ECharts instance becomes ready, so recreated chart instances receive the current `events.raw` handlers without requiring the chart configuration flow to run again.

The change also keeps the existing `onRefReady` callback behavior and skips reapplying the same event script to the same ECharts instance.

Potential risk is limited to chart blocks with custom event scripts. Suggested testing:
- Open a chart with click drilldown events
- Toggle configuration mode or otherwise trigger chart rerendering
- Confirm chart click interactions still work without reopening the chart configuration panel

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed chart click interactions that could stop working after chart rerendering |
| 🇨🇳 Chinese | 修复图表重新渲染后点击交互可能失效的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
