### PR TITLE
fix(plugin-workflow): keep v2 condition operands on one row by default

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/Calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/Calculation.tsx
@@ -46,6 +46,28 @@ const operatorWidthClassName = css`
   }
 `;
 
+// `TypedVariableInput` is full-width by default (`<div style={{ width: '100%' }}>` +
+// `Space.Compact style={{ display: 'flex', width: '100%' }}`), which works for
+// form rows but not for the v1-style calculation builder. Here we locally
+// restore the old intrinsic-width behavior so the row stays on one line by
+// default, yet can wrap when a selected variable path becomes too long.
+const operandClassName = css`
+  flex: 0 1 auto;
+  min-width: 12em;
+  max-width: 100%;
+
+  > div {
+    width: auto !important;
+    max-width: 100%;
+  }
+
+  > div > .ant-space-compact {
+    display: inline-flex !important;
+    width: auto !important;
+    max-width: 100%;
+  }
+`;
+
 interface Calculator {
   name: string;
   type: 'boolean' | 'number' | 'string' | 'date' | 'unknown' | 'null' | 'array';
@@ -110,22 +132,20 @@ function Calculation({ calculator, operands = [], onChange }: any) {
         display: flex;
         gap: 0.5em;
         align-items: center;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         margin: 0;
         padding: 0;
         border: none;
-        min-width: 0;
       `}
     >
-      {/* Operands flex to fill; the operator select stays narrow (auto-width) —
-          matches v1's single-row [operand · operator · operand] layout. */}
-      <TypedVariableInput
-        types={OPERAND_TYPES}
-        metaTree={leftMetaTree}
-        value={operands[0]}
-        onChange={leftOperandOnChange}
-        style={{ flex: 1, minWidth: 0 }}
-      />
+      <div className={operandClassName} data-testid="calculation-operand">
+        <TypedVariableInput
+          types={OPERAND_TYPES}
+          metaTree={leftMetaTree}
+          value={operands[0]}
+          onChange={leftOperandOnChange}
+        />
+      </div>
       <Select
         // antd's Select prop type doesn't surface DOM passthrough props (`role`), though it forwards them — same as the
         // core `CollectionSelectorFieldModel`.
@@ -150,13 +170,14 @@ function Calculation({ calculator, operands = [], onChange }: any) {
             </Select.OptGroup>
           ))}
       </Select>
-      <TypedVariableInput
-        types={OPERAND_TYPES}
-        metaTree={rightMetaTree}
-        value={operands[1]}
-        onChange={rightOperandOnChange}
-        style={{ flex: 1, minWidth: 0 }}
-      />
+      <div className={operandClassName} data-testid="calculation-operand">
+        <TypedVariableInput
+          types={OPERAND_TYPES}
+          metaTree={rightMetaTree}
+          value={operands[1]}
+          onChange={rightOperandOnChange}
+        />
+      </div>
     </fieldset>
   );
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/Calculation.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/Calculation.test.tsx
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CalculationConfig } from '../Calculation';
 
 const holder = vi.hoisted(() => ({
-  typedVariableInputProps: [] as Array<{ metaTree: unknown; value: unknown }>,
+  typedVariableInputProps: [] as Array<{ metaTree: unknown; value: unknown; style: unknown }>,
 }));
 
 vi.mock('../../locale', () => ({
@@ -27,6 +27,7 @@ vi.mock('@nocobase/client-v2', () => ({
     holder.typedVariableInputProps.push({
       metaTree: props.metaTree,
       value: props.value,
+      style: props.style,
     });
     return <div data-testid="typed-variable-input" />;
   },
@@ -62,5 +63,34 @@ describe('CalculationConfig', () => {
     expect(useVariableHook).toHaveBeenCalledTimes(2);
     expect(holder.typedVariableInputProps).toHaveLength(2);
     expect(holder.typedVariableInputProps[0].metaTree).not.toBe(holder.typedVariableInputProps[1].metaTree);
+  });
+
+  it('keeps the condition operands wrappable without forcing each operand onto its own row', () => {
+    holder.typedVariableInputProps = [];
+
+    const { container } = render(
+      <CalculationConfig
+        useVariableHook={() => [{ name: '$context', title: 'Trigger variables', paths: ['$context'], type: '' }]}
+        value={{
+          group: {
+            type: 'and',
+            calculations: [
+              { calculator: 'equal', operands: ['{{$context.data.id}}', '{{$jobsMapByNodeKey.a.result}}'] },
+            ],
+          },
+        }}
+        onChange={() => undefined}
+      />,
+    );
+
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset).not.toBeNull();
+    expect(fieldset).toHaveStyle({ display: 'flex', flexWrap: 'wrap' });
+    const operands = screen.getAllByTestId('calculation-operand');
+    expect(operands).toHaveLength(2);
+    expect(operands[0]).toHaveStyle({ flexGrow: '0', flexShrink: '1', flexBasis: 'auto' });
+    expect(holder.typedVariableInputProps).toHaveLength(2);
+    expect(holder.typedVariableInputProps[0].style).toBeUndefined();
+    expect(holder.typedVariableInputProps[1].style).toBeUndefined();
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow v2 condition builders no longer matched the v1 row layout. Long variable paths could overflow horizontally, and a naive wrap-only fix made each operand occupy its own row by default.

### Description 
- Restore wrapping for workflow v2 condition rows in `CalculationConfig`.
- Locally override `TypedVariableInput`'s default full-width layout inside condition operands so both operands and the operator stay on one row by default, but wrap when selected variable paths are too long.
- Add regression coverage for the wrappable single-row operand layout.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow v2 condition operands to stay on one row by default and wrap correctly when selected variable paths are too long. |
| 🇨🇳 Chinese | 修复工作流 v2 条件操作数默认保持单行显示，并在所选变量路径过长时正确换行。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
