### PR TITLE
feat(data-visualization): support chart event cleanup

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -97,6 +97,7 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
   private __eventsBoundChart?: EChartsType;
   private __eventsBoundRaw?: string;
   private chartEventsCleanup?: ChartEventCleanup;
+  private __eventsApplyToken = 0;
   private lastRefreshSnapshot: ChartDirtyRefreshSnapshot | null = null;
   private dirtyRefreshing = false;
 
@@ -541,31 +542,37 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
   // 应用事件配置（仅设置，不负责渲染）
   async applyEvents(raw?: string, chartInstance?: EChartsType) {
+    const applyToken = ++this.__eventsApplyToken;
+
     if (!raw) {
       await this.cleanupChartEvents();
       return;
     }
 
     if (chartInstance) {
-      await this.runChartEvents(raw, chartInstance);
+      await this.runChartEvents(raw, chartInstance, applyToken);
       return;
     }
 
     const chart = (this.context.chartRef as any).current as EChartsType | null;
     if (chart) {
-      await this.runChartEvents(raw, chart);
+      await this.runChartEvents(raw, chart, applyToken);
       return;
     }
 
     this.context.onRefReady(this.context.chartRef, async () => {
+      if (applyToken !== this.__eventsApplyToken) {
+        return;
+      }
+
       const currentChart = (this.context.chartRef as any).current as EChartsType | null;
-      if (currentChart) {
-        await this.runChartEvents(raw, currentChart);
+      if (currentChart && applyToken === this.__eventsApplyToken) {
+        await this.runChartEvents(raw, currentChart, applyToken);
       }
     });
   }
 
-  private async runChartEvents(raw: string, chart: EChartsType) {
+  private async runChartEvents(raw: string, chart: EChartsType, applyToken: number) {
     if (this.shouldSkipApplyEvents(raw, chart)) {
       return;
     }
@@ -581,6 +588,11 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
       if (success) {
         if (typeof value === 'function') {
           cleanups.push(value);
+        }
+        if (applyToken !== this.__eventsApplyToken) {
+          this.clearEventsBound(raw, chart);
+          await this.runChartEventCleanups(cleanups);
+          return;
         }
         this.chartEventsCleanup = cleanups.length ? () => this.runChartEventCleanups(cleanups) : undefined;
         return;

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -578,6 +578,10 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
     }
 
     await this.cleanupChartEvents();
+    if (applyToken !== this.__eventsApplyToken) {
+      return;
+    }
+
     this.markEventsBound(raw, chart);
     const cleanups: ChartEventCleanup[] = [];
 

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/ChartBlockModel.tsx
@@ -37,6 +37,8 @@ import {
 
 const NO_PREVIEW_SNAPSHOT = Symbol('NO_PREVIEW_SNAPSHOT');
 
+type ChartEventCleanup = () => void | Promise<void>;
+
 type ChartBlockModelStructure = {
   subModels: {
     page: ChildPageModel;
@@ -94,6 +96,7 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
   private __onResourceRefresh = () => this.renderChart();
   private __eventsBoundChart?: EChartsType;
   private __eventsBoundRaw?: string;
+  private chartEventsCleanup?: ChartEventCleanup;
   private lastRefreshSnapshot: ChartDirtyRefreshSnapshot | null = null;
   private dirtyRefreshing = false;
 
@@ -210,6 +213,31 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
     if (this.__eventsBoundChart === chart && this.__eventsBoundRaw === raw) {
       this.__eventsBoundChart = undefined;
       this.__eventsBoundRaw = undefined;
+    }
+  }
+
+  private resetEventsBound() {
+    this.__eventsBoundChart = undefined;
+    this.__eventsBoundRaw = undefined;
+  }
+
+  private async runChartEventCleanups(cleanups: ChartEventCleanup[]) {
+    for (const cleanup of cleanups.slice().reverse()) {
+      try {
+        await cleanup();
+      } catch (error) {
+        console.error('Chart events cleanup error:', error);
+      }
+    }
+  }
+
+  private async cleanupChartEvents() {
+    const cleanup = this.chartEventsCleanup;
+    this.chartEventsCleanup = undefined;
+    this.resetEventsBound();
+
+    if (cleanup) {
+      await this.runChartEventCleanups([cleanup]);
     }
   }
 
@@ -513,7 +541,10 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
 
   // 应用事件配置（仅设置，不负责渲染）
   async applyEvents(raw?: string, chartInstance?: EChartsType) {
-    if (!raw) return;
+    if (!raw) {
+      await this.cleanupChartEvents();
+      return;
+    }
 
     if (chartInstance) {
       await this.runChartEvents(raw, chartInstance);
@@ -539,22 +570,30 @@ export class ChartBlockModel extends DataBlockModel<ChartBlockModelStructure> {
       return;
     }
 
+    await this.cleanupChartEvents();
     this.markEventsBound(raw, chart);
+    const cleanups: ChartEventCleanup[] = [];
 
     try {
-      const { success, error, timeout } = await this.context.runjs(raw, {
+      const { success, value, error, timeout } = await this.context.runjs(raw, {
         chart,
       });
       if (success) {
+        if (typeof value === 'function') {
+          cleanups.push(value);
+        }
+        this.chartEventsCleanup = cleanups.length ? () => this.runChartEventCleanups(cleanups) : undefined;
         return;
       }
 
       this.clearEventsBound(raw, chart);
+      await this.runChartEventCleanups(cleanups);
       if (error || timeout) {
         console.error('applyEvents runjs error:', error || 'timeout');
       }
     } catch (error) {
       this.clearEventsBound(raw, chart);
+      await this.runChartEventCleanups(cleanups);
       throw error;
     }
   }
@@ -739,9 +778,7 @@ ChartBlockModel.registerFlow({
           });
 
           // 事件部分
-          if (chart.events?.raw) {
-            await ctx.model.applyEvents(chart.events?.raw);
-          }
+          await ctx.model.applyEvents(chart.events?.raw);
         } catch (error) {
           console.error('ChartBlockModel chartSettings configure flow handler() error:', error);
         }

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/EventsPanel.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/EventsPanel.tsx
@@ -14,14 +14,15 @@ import { useT } from '../../locale';
 import { FunctionOutlined } from '@ant-design/icons';
 import { observer, useFlowSettingsContext } from '@nocobase/flow-engine';
 
-const DEFAULT_EVENTS_RAW = `// chart.off('click');
-// chart.on('click', 'series', function() {
+const DEFAULT_EVENTS_RAW = `// const handler = function() {
 //   ctx.openView(ctx.model.uid + '-1', {
 //     mode: 'dialog',
 //     size: 'large',
 //     defineProperties: {}, // inject context into the new view
 //   });
-// });
+// };
+// chart.on('click', 'series', handler);
+// return () => chart.off('click', handler);
 `;
 
 const getFormValues = (ctx: any) => ctx.getStepFormValues('chartSettings', 'configure') || {};

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -244,8 +244,44 @@ describe('ChartBlockModel chart events binding', () => {
     await model.applyEvents(raw, chartB);
 
     expect(runjs).toHaveBeenCalledTimes(2);
-    expect(runjs).toHaveBeenNthCalledWith(1, raw, { chart: chartA });
-    expect(runjs).toHaveBeenNthCalledWith(2, raw, { chart: chartB });
+    expect(runjs).toHaveBeenNthCalledWith(1, raw, expect.objectContaining({ chart: chartA }));
+    expect(runjs).toHaveBeenNthCalledWith(2, raw, expect.objectContaining({ chart: chartB }));
+  });
+
+  it('runs the previous cleanup function before applying different raw events', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const firstCleanup = vi.fn();
+    const secondCleanup = vi.fn();
+    const chart = {} as any;
+
+    vi.spyOn(model.context, 'runjs').mockImplementation(async (raw: string) => {
+      return { success: true, value: raw === 'first' ? firstCleanup : secondCleanup };
+    });
+
+    await model.applyEvents('first', chart);
+    await model.applyEvents('second', chart);
+
+    expect(firstCleanup).toHaveBeenCalledTimes(1);
+    expect(secondCleanup).not.toHaveBeenCalled();
+  });
+
+  it('runs returned cleanup functions when events are cleared', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const cleanup = vi.fn();
+    const chart = {} as any;
+
+    vi.spyOn(model.context, 'runjs').mockResolvedValue({ success: true, value: cleanup });
+
+    await model.applyEvents('return cleanup;', chart);
+    await model.applyEvents(undefined, chart);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('clears the bound marker when chart events throw so the same chart can retry', async () => {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -284,6 +284,84 @@ describe('ChartBlockModel chart events binding', () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
+  it('ignores stale onRefReady callbacks after chart events are cleared', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const chartRef = { current: null as any };
+    const chart = {} as any;
+    let readyCallback: (() => Promise<void>) | undefined;
+    const runjs = vi.spyOn(model.context, 'runjs').mockResolvedValue({ success: true, value: undefined });
+
+    model.context.defineProperty('chartRef', { value: chartRef });
+    vi.spyOn(model.context, 'onRefReady').mockImplementation((_ref: any, callback: any) => {
+      readyCallback = callback;
+    });
+
+    await model.applyEvents('chart.on("click", () => {})');
+    await model.applyEvents(undefined);
+
+    chartRef.current = chart;
+    await readyCallback?.();
+
+    expect(runjs).not.toHaveBeenCalled();
+  });
+
+  it('ignores stale onRefReady callbacks after chart events are replaced', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const chartRef = { current: null as any };
+    const chart = {} as any;
+    const readyCallbacks: (() => Promise<void>)[] = [];
+    const runjs = vi.spyOn(model.context, 'runjs').mockResolvedValue({ success: true, value: undefined });
+
+    model.context.defineProperty('chartRef', { value: chartRef });
+    vi.spyOn(model.context, 'onRefReady').mockImplementation((_ref: any, callback: any) => {
+      readyCallbacks.push(callback);
+    });
+
+    await model.applyEvents('first');
+    await model.applyEvents('second');
+
+    chartRef.current = chart;
+    await readyCallbacks[0]?.();
+    await readyCallbacks[1]?.();
+
+    expect(runjs).toHaveBeenCalledTimes(1);
+    expect(runjs).toHaveBeenCalledWith('second', expect.objectContaining({ chart }));
+  });
+
+  it('cleans returned handlers from stale asynchronous chart event runs', async () => {
+    const { model } = setupModel({
+      mode: 'builder',
+      collectionPath: ['main', 'orders'],
+    });
+    const staleCleanup = vi.fn();
+    const activeCleanup = vi.fn();
+    const chart = {} as any;
+    let resolveFirst: ((value: any) => void) | undefined;
+    const firstResult = new Promise<any>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    vi.spyOn(model.context, 'runjs')
+      .mockReturnValueOnce(firstResult as any)
+      .mockResolvedValueOnce({ success: true, value: activeCleanup });
+
+    const firstApply = model.applyEvents('first', chart);
+    await model.applyEvents('second', chart);
+    resolveFirst?.({ success: true, value: staleCleanup });
+    await firstApply;
+
+    await model.applyEvents(undefined, chart);
+
+    expect(staleCleanup).toHaveBeenCalledTimes(1);
+    expect(activeCleanup).toHaveBeenCalledTimes(1);
+  });
+
   it('clears the bound marker when chart events throw so the same chart can retry', async () => {
     const { model } = setupModel({
       mode: 'builder',

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client-v2/flow/models/__tests__/ChartBlockModel.dirtyRefresh.test.ts
@@ -334,32 +334,34 @@ describe('ChartBlockModel chart events binding', () => {
     expect(runjs).toHaveBeenCalledWith('second', expect.objectContaining({ chart }));
   });
 
-  it('cleans returned handlers from stale asynchronous chart event runs', async () => {
+  it('does not run stale chart events after asynchronous cleanup finishes', async () => {
     const { model } = setupModel({
       mode: 'builder',
       collectionPath: ['main', 'orders'],
     });
-    const staleCleanup = vi.fn();
-    const activeCleanup = vi.fn();
     const chart = {} as any;
-    let resolveFirst: ((value: any) => void) | undefined;
-    const firstResult = new Promise<any>((resolve) => {
-      resolveFirst = resolve;
-    });
+    let resolveCleanup: (() => void) | undefined;
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    const runjs = vi
+      .spyOn(model.context, 'runjs')
+      .mockResolvedValueOnce({ success: true, value: cleanup })
+      .mockResolvedValueOnce({ success: true, value: undefined });
 
-    vi.spyOn(model.context, 'runjs')
-      .mockReturnValueOnce(firstResult as any)
-      .mockResolvedValueOnce({ success: true, value: activeCleanup });
+    await model.applyEvents('active', chart);
+    const staleApply = model.applyEvents('stale', chart);
+    await Promise.resolve();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    const clearApply = model.applyEvents(undefined, chart);
+    resolveCleanup?.();
+    await Promise.all([staleApply, clearApply]);
 
-    const firstApply = model.applyEvents('first', chart);
-    await model.applyEvents('second', chart);
-    resolveFirst?.({ success: true, value: staleCleanup });
-    await firstApply;
-
-    await model.applyEvents(undefined, chart);
-
-    expect(staleCleanup).toHaveBeenCalledTimes(1);
-    expect(activeCleanup).toHaveBeenCalledTimes(1);
+    expect(runjs).toHaveBeenCalledTimes(1);
+    expect(runjs).toHaveBeenCalledWith('active', expect.objectContaining({ chart }));
   });
 
   it('clears the bound marker when chart events throw so the same chart can retry', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Chart event scripts can register handlers with `chart.on(...)`, but there was no managed cleanup path when chart events were reapplied or removed. This made custom chart interactions rely on manual cleanup patterns inside every script.

### Description 
- Support cleanup functions returned from chart `events.raw` scripts.
- Run the previous cleanup before applying different chart event scripts and when events are cleared.
- Update the default chart events example to use `chart.on(...)` with a returned cleanup function.
- Add focused tests for chart event reapplication and cleanup.

Potential risk: existing event scripts continue to work, but scripts that return a function will now have that function executed as cleanup during event reapplication or clearing.

Testing suggestions:
- Configure a chart event script with `chart.on(...)` and `return () => chart.off(...)`, then reconfigure or clear events.
- Verify existing chart event scripts without returned cleanup still run normally.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved chart event scripts so custom event handlers can clean up safely |
| 🇨🇳 Chinese | 改进图表事件脚本，支持安全清理自定义事件处理器 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
