### PR TITLE
fix(plugin-collection-tree): avoid passing field models to path collection

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-tree/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-collection-tree/src/server/plugin.ts
@@ -43,11 +43,18 @@ class PluginCollectionTreeServer extends Plugin {
             options['schema'] = collection.options.schema;
           }
 
+          let nodePkType = 'bigInt';
           if (eventOptions.fieldModels) {
-            options['fieldModels'] = eventOptions.fieldModels;
+            const pk = eventOptions.fieldModels.find((x) => x.options.primaryKey === true);
+            if (pk) {
+              nodePkType = pk.type;
+            }
           }
 
-          this.defineTreePathCollection(name, options);
+          this.defineTreePathCollection(name, {
+            ...options,
+            nodePkType,
+          });
 
           //afterSync
           collectionManager.db.on(`${collection.name}.afterSync`, async ({ transaction }) => {
@@ -195,15 +202,8 @@ class PluginCollectionTreeServer extends Plugin {
     });
   }
 
-  private async defineTreePathCollection(name: string, options: { schema?: string; fieldModels?: Model[] }) {
-    let nodePkType = 'bigInt';
-    if (options.fieldModels) {
-      const pk = options.fieldModels.find((x) => x.options.primaryKey === true);
-      if (pk) {
-        nodePkType = pk.type;
-      }
-    }
-
+  private async defineTreePathCollection(name: string, options: { schema?: string; nodePkType: string }) {
+    const { nodePkType, ...collectionOptions } = options;
     this.db.collection({
       name,
       autoGenId: false,
@@ -218,7 +218,7 @@ class PluginCollectionTreeServer extends Plugin {
           fields: [{ name: 'path', length: 191 }],
         },
       ],
-      ...options,
+      ...collectionOptions,
     });
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Tree path collection creation only needs `fieldModels` to infer the node primary key type. Passing the whole `fieldModels` value into `db.collection()` leaks internal event metadata into collection options.

### Description 
This PR moves the node primary key type calculation before `defineTreePathCollection()` and passes only `nodePkType` into that helper. Before calling `db.collection()`, `nodePkType` is removed from the options object so neither `fieldModels` nor `nodePkType` is propagated as collection options.

Risk is low. The change is scoped to tree path collection definition and keeps the existing default `bigInt` behavior when field models are unavailable.

Testing note: local test and lint commands could not run in this worktree because dependencies are unavailable (`nocobase-v1`, `eslint`, and `lint-staged` commands are missing).

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed tree path collection creation to avoid passing internal field model metadata into collection options. |
| 🇨🇳 Chinese | 修复树路径集合创建时将内部字段模型元数据传入集合配置的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary