### PR TITLE
fix(plugin-public-forms): respect UI editor state

### DIFF
--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormsSettingsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormsSettingsPage.test.ts
@@ -385,7 +385,7 @@ describe('PublicFormsSettingsPage toolbar', () => {
 });
 
 describe('PublicFormsSettingsLayoutModel password settings', () => {
-  it('renders the configured page model inside an embed FlowView context', async () => {
+  it('renders the configured page model inside an embed FlowView context without forcing UI Editor mode', async () => {
     const pageModel = {
       uid: 'page-model-1',
       context: new FlowContext(),
@@ -424,12 +424,105 @@ describe('PublicFormsSettingsLayoutModel password settings', () => {
       type: 'embed',
       inputArgs: {},
     });
-    expect(testState.renderedFlowSettingsEnabled).toBe(true);
+    expect(testState.renderedFlowSettingsEnabled).toBe(false);
     expect(testState.renderedModelFlowView).toMatchObject({
       type: 'embed',
       inputArgs: {},
     });
+    expect(testState.renderedModelFlowSettingsEnabled).toBe(false);
+  });
+
+  it('inherits UI Editor mode from the outer flow context', async () => {
+    const pageModel = {
+      uid: 'page-model-1',
+      context: new FlowContext(),
+    };
+    const routeModel = {
+      uid: 'form-1',
+      subModels: {
+        page: pageModel,
+      },
+    };
+    testState.routeParams = {
+      name: 'form-1',
+    };
+    (testState.flowContext as FlowContext).defineProperty('flowSettingsEnabled', {
+      value: true,
+    });
+    testState.get.mockResolvedValue({
+      data: {
+        data: {
+          key: 'form-1',
+          title: 'Form 1',
+          version: 'v2',
+          enabled: true,
+        },
+      },
+    });
+    testState.ensurePublicFormFlowModel.mockResolvedValue(routeModel);
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(App, null, React.createElement(PublicFormsSettingsDetailPage)),
+      ),
+    );
+
+    expect((await screen.findByTestId('flow-model-renderer')).textContent).toBe('page-model-1');
+    expect(testState.renderedFlowSettingsEnabled).toBe(true);
     expect(testState.renderedModelFlowSettingsEnabled).toBe(true);
+  });
+
+  it('keeps UI Editor mode bound to the outer flow context after render', async () => {
+    let flowSettingsEnabled = false;
+    const pageModel = {
+      uid: 'page-model-1',
+      context: new FlowContext(),
+    };
+    const routeModel = {
+      uid: 'form-1',
+      subModels: {
+        page: pageModel,
+      },
+    };
+    const getFlowSettingsEnabled = (context: FlowContext) =>
+      (context as FlowContext & { flowSettingsEnabled?: boolean }).flowSettingsEnabled;
+
+    testState.routeParams = {
+      name: 'form-1',
+    };
+    (testState.flowContext as FlowContext).defineProperty('flowSettingsEnabled', {
+      get: () => flowSettingsEnabled,
+      cache: false,
+    });
+    testState.get.mockResolvedValue({
+      data: {
+        data: {
+          key: 'form-1',
+          title: 'Form 1',
+          version: 'v2',
+          enabled: true,
+        },
+      },
+    });
+    testState.ensurePublicFormFlowModel.mockResolvedValue(routeModel);
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(App, null, React.createElement(PublicFormsSettingsDetailPage)),
+      ),
+    );
+
+    expect((await screen.findByTestId('flow-model-renderer')).textContent).toBe('page-model-1');
+    expect(testState.renderedFlowSettingsEnabled).toBe(false);
+    expect(testState.renderedModelFlowSettingsEnabled).toBe(false);
+    expect(getFlowSettingsEnabled(pageModel.context)).toBe(false);
+
+    flowSettingsEnabled = true;
+    expect(getFlowSettingsEnabled(pageModel.context)).toBe(true);
   });
 
   it('does not render v1 records from the v2 configure route', async () => {

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsDetailPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsDetailPage.tsx
@@ -51,7 +51,8 @@ function PublicFormPageRenderer(props: { model: FlowModel }) {
       value: view,
     });
     nextContext.defineProperty('flowSettingsEnabled', {
-      value: true,
+      get: () => !!ctx?.flowSettingsEnabled,
+      cache: false,
     });
     return nextContext;
   }, [ctx]);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
公开表单的配置页应该和全局 UI Editor 状态保持一致。此前即使全局 UI Editor 没有开启，公开表单详情页仍可能进入可配置状态，导致关系字段等配置项在不同刷新方式下表现不一致。

### Description 
本次调整后，公开表单详情页不再单独强制开启配置状态，而是跟随外层的全局 UI Editor 状态：

- 全局 UI Editor 关闭时，公开表单详情页不会进入配置态。
- 全局 UI Editor 开启时，公开表单详情页仍可正常配置。
- 补充了单元测试覆盖默认关闭、继承开启状态，以及状态变化时不使用旧缓存的场景。

测试建议：在公开表单配置页分别关闭和开启全局 UI Editor 后刷新页面，确认字段组件配置入口只在 UI Editor 开启时可用。

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where public forms can still be configured when UI Editor is off |
| 🇨🇳 Chinese | 修复关闭 UI Editor 后公开表单仍可配置的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
