### PR TITLE
fix: isolate row action linkage refresh

### DIFF
--- a/packages/core/client-v2/src/flow/actions/__tests__/linkageRulesRefresh.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/linkageRulesRefresh.test.ts
@@ -135,44 +135,12 @@ describe('linkageRulesRefresh action', () => {
     expect(handler).toHaveBeenCalledWith(ctx, { value: ['master-mounted'] });
   });
 
-  it('runs linkage action on master model when forks exist in design mode', async () => {
+  it('skips master model when forks can handle flow in design mode', async () => {
     const handler = vi.fn(async () => {});
     const model: any = {
-      isFork: false,
-      forks: new Set([{}]),
-      getFlow: vi.fn(() => ({})),
-      getStepParams: vi.fn(() => ({ value: ['master'] })),
-      context: {
-        flowSettingsEnabled: true,
-      },
-    };
-    const ctx: any = {
-      model,
-      resolveJsonTemplate: vi.fn(async (p: any) => p),
-      getAction: vi.fn(() => ({ handler })),
-    };
-
-    await linkageRulesRefresh.handler(ctx, {
-      actionName: 'actionLinkageRules',
-      flowKey: 'buttonSettings',
-    });
-
-    expect(handler).toHaveBeenCalledWith(ctx, { value: ['master'] });
-  });
-
-  it('skips record action master in design mode when row forks can handle linkage rules', async () => {
-    const handler = vi.fn(async () => {});
-    class TestRecordAction {
-      static _getScene() {
-        return ['record'];
-      }
-    }
-    const model: any = {
-      constructor: TestRecordAction,
       isFork: false,
       forks: new Set([
         {
-          disposed: false,
           getFlow: vi.fn(() => ({})),
         },
       ]),

--- a/packages/core/client-v2/src/flow/actions/__tests__/linkageRulesRefresh.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/linkageRulesRefresh.test.ts
@@ -160,6 +160,42 @@ describe('linkageRulesRefresh action', () => {
     expect(handler).toHaveBeenCalledWith(ctx, { value: ['master'] });
   });
 
+  it('skips record action master in design mode when row forks can handle linkage rules', async () => {
+    const handler = vi.fn(async () => {});
+    class TestRecordAction {
+      static _getScene() {
+        return ['record'];
+      }
+    }
+    const model: any = {
+      constructor: TestRecordAction,
+      isFork: false,
+      forks: new Set([
+        {
+          disposed: false,
+          getFlow: vi.fn(() => ({})),
+        },
+      ]),
+      getFlow: vi.fn(() => ({})),
+      getStepParams: vi.fn(() => ({ value: ['master'] })),
+      context: {
+        flowSettingsEnabled: true,
+      },
+    };
+    const ctx: any = {
+      model,
+      resolveJsonTemplate: vi.fn(async (p: any) => p),
+      getAction: vi.fn(() => ({ handler })),
+    };
+
+    await linkageRulesRefresh.handler(ctx, {
+      actionName: 'actionLinkageRules',
+      flowKey: 'buttonSettings',
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('runs linkage action on fork model and resolves params', async () => {
     const handler = vi.fn(async () => {});
     const model: any = {

--- a/packages/core/client-v2/src/flow/actions/linkageRulesRefresh.tsx
+++ b/packages/core/client-v2/src/flow/actions/linkageRulesRefresh.tsx
@@ -21,32 +21,6 @@ type LinkageRulesRefreshParams = {
   stepKey?: string;
 };
 
-function isRecordActionLinkageRefresh(params: Partial<LinkageRulesRefreshParams>) {
-  return params?.actionName === 'actionLinkageRules' && params?.flowKey === 'buttonSettings';
-}
-
-type RecordActionClassLike = {
-  _getScene?: () => unknown;
-};
-
-type ModelWithActionClass = {
-  constructor?: RecordActionClassLike;
-};
-
-function isRecordActionModel(model: unknown) {
-  const modelClass = (model as ModelWithActionClass | null)?.constructor;
-  const getScene = modelClass?._getScene;
-  if (typeof getScene !== 'function') {
-    return false;
-  }
-  try {
-    const scene = getScene.call(modelClass);
-    return Array.isArray(scene) && scene.includes('record');
-  } catch {
-    return false;
-  }
-}
-
 export const linkageRulesRefresh = defineAction({
   name: 'linkageRulesRefresh',
   async handler(ctx, params) {
@@ -61,12 +35,8 @@ export const linkageRulesRefresh = defineAction({
     // Prefer running on the current model; fallback to blockModel when the current model doesn't own the flow.
     if (!hasFlow) return;
 
-    // In runtime, only skip master when there are mounted forks that can handle the same flow.
+    // Skip master when unmounted forks can handle the same flow.
     // Otherwise master is likely the rendered model and still needs refresh.
-    // In design mode, always refresh master so the currently edited model state stays in sync.
-    const flowSettingsEnabled = Boolean(
-      (ctx as any)?.flowSettingsEnabled || (model as any)?.context?.flowSettingsEnabled,
-    );
     const hasForkWithFlow =
       !model?.isFork &&
       !!model?.forks?.size &&
@@ -75,12 +45,7 @@ export const linkageRulesRefresh = defineAction({
         return !!fork?.getFlow?.(flowKey);
       });
     const isMasterMounted = Boolean((model as any)?.context?.ref?.current);
-    const shouldPreferRowForks =
-      hasForkWithFlow && isRecordActionLinkageRefresh({ actionName, flowKey, stepKey }) && isRecordActionModel(model);
-    if (shouldPreferRowForks) {
-      return;
-    }
-    if (hasForkWithFlow && !isMasterMounted && !flowSettingsEnabled) {
+    if (hasForkWithFlow && !isMasterMounted) {
       return;
     }
 

--- a/packages/core/client-v2/src/flow/actions/linkageRulesRefresh.tsx
+++ b/packages/core/client-v2/src/flow/actions/linkageRulesRefresh.tsx
@@ -21,6 +21,32 @@ type LinkageRulesRefreshParams = {
   stepKey?: string;
 };
 
+function isRecordActionLinkageRefresh(params: Partial<LinkageRulesRefreshParams>) {
+  return params?.actionName === 'actionLinkageRules' && params?.flowKey === 'buttonSettings';
+}
+
+type RecordActionClassLike = {
+  _getScene?: () => unknown;
+};
+
+type ModelWithActionClass = {
+  constructor?: RecordActionClassLike;
+};
+
+function isRecordActionModel(model: unknown) {
+  const modelClass = (model as ModelWithActionClass | null)?.constructor;
+  const getScene = modelClass?._getScene;
+  if (typeof getScene !== 'function') {
+    return false;
+  }
+  try {
+    const scene = getScene.call(modelClass);
+    return Array.isArray(scene) && scene.includes('record');
+  } catch {
+    return false;
+  }
+}
+
 export const linkageRulesRefresh = defineAction({
   name: 'linkageRulesRefresh',
   async handler(ctx, params) {
@@ -49,6 +75,11 @@ export const linkageRulesRefresh = defineAction({
         return !!fork?.getFlow?.(flowKey);
       });
     const isMasterMounted = Boolean((model as any)?.context?.ref?.current);
+    const shouldPreferRowForks =
+      hasForkWithFlow && isRecordActionLinkageRefresh({ actionName, flowKey, stepKey }) && isRecordActionModel(model);
+    if (shouldPreferRowForks) {
+      return;
+    }
     if (hasForkWithFlow && !isMasterMounted && !flowSettingsEnabled) {
       return;
     }

--- a/packages/core/client-v2/src/flow/models/blocks/table/TableActionsColumnModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableActionsColumnModel.tsx
@@ -121,10 +121,11 @@ const Columns = observer<any>(({ record, model, index }) => {
           fork.context.defineProperty('recordIndex', {
             get: () => index,
           });
+          const rendererKey = `${fork.uid}:${fork.forkId}`;
           const renderer = (
             <FlowModelRenderer
               showFlowSettings={{ showBorder: false, toolbarPosition: 'above' }}
-              key={fork.uid}
+              key={rendererKey}
               model={fork}
               inputArgs={record}
               fallback={<Skeleton.Button size="small" />}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where button linkage rule states in table blocks could become polluted after pagination. |
| 🇨🇳 Chinese | 修复表格区块按钮联动规则翻页后可能存在状态污染。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
