### PR TITLE
ci(frontend): shard client tests

### DIFF
--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -88,5 +88,7 @@ jobs:
           path: .
 
       - run: tar -xf node_modules.tar
-      - run: yarn test:client --shard=${{ matrix.shard }}/4
+      - run: yarn test:client --shard=${{ matrix.shard }}/4 --silent
+        env:
+          LOGGER_LEVEL: error
     timeout-minutes: 60

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -40,24 +40,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore dependency archive
-        id: restore-dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: node_modules.tar
-          key: frontend-node-modules-v2-${{ runner.os }}-node-${{ matrix.node_version }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**/package.json', '.env.example', '.env.test.example', 'patches/**') }}
-
       - name: Use Node.js ${{ matrix.node_version }}
-        if: steps.restore-dependencies.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
-        if: steps.restore-dependencies.outputs.cache-hit != 'true'
       - name: Pack dependencies
-        if: steps.restore-dependencies.outputs.cache-hit != 'true'
         run: |
           find . -name node_modules -type d -prune -print0 > node_modules.list
           for file in .env .env.test; do
@@ -66,12 +56,6 @@ jobs:
             fi
           done
           tar --null -cf node_modules.tar -T node_modules.list
-      - name: Save dependency archive
-        if: steps.restore-dependencies.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: node_modules.tar
-          key: ${{ steps.restore-dependencies.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-node-modules-node-${{ matrix.node_version }}

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - name: Pack dependencies
         run: |
           find . -name node_modules -type d -prune -print0 > node_modules.list

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
-          cache: 'yarn'
 
       - run: yarn install
       - name: Pack dependencies

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Pack dependencies
         run: |
           find . -name node_modules -type d -prune -print0 > node_modules.list
+          for file in .env .env.test; do
+            if [ -f "$file" ]; then
+              printf '%s\0' "$file" >> node_modules.list
+            fi
+          done
           tar --null -cf node_modules.tar -T node_modules.list
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: node_modules.tar
-          key: frontend-node-modules-v1-${{ runner.os }}-node-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
+          key: frontend-node-modules-v2-${{ runner.os }}-node-${{ matrix.node_version }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/**/package.json', '.env.example', '.env.test.example', 'patches/**') }}
 
       - name: Use Node.js ${{ matrix.node_version }}
         if: steps.restore-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -31,14 +31,14 @@ on:
       - '!packages/plugins/**/src/server/**'
 
 jobs:
-  frontend-test:
+  install-deps:
     strategy:
       matrix:
         node_version: ['22']
     runs-on: ubuntu-latest
     container: node:${{ matrix.node_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v4
@@ -47,5 +47,41 @@ jobs:
           cache: 'yarn'
 
       - run: yarn install
-      - run: yarn test:client
+      - name: Pack dependencies
+        run: |
+          find . -name node_modules -type d -prune -print0 > node_modules.list
+          tar --null -cf node_modules.tar -T node_modules.list
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-node-modules-node-${{ matrix.node_version }}
+          path: node_modules.tar
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+    timeout-minutes: 60
+
+  frontend-test:
+    needs: install-deps
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: ['22']
+        shard: [1, 2, 3, 4]
+    runs-on: ubuntu-latest
+    container: node:${{ matrix.node_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node_version }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-node-modules-node-${{ matrix.node_version }}
+          path: .
+
+      - run: tar -xf node_modules.tar
+      - run: yarn test:client --shard=${{ matrix.shard }}/4
     timeout-minutes: 60

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -40,14 +40,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore dependency archive
+        id: restore-dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules.tar
+          key: frontend-node-modules-v1-${{ runner.os }}-node-${{ matrix.node_version }}-${{ hashFiles('yarn.lock') }}
+
       - name: Use Node.js ${{ matrix.node_version }}
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
       - name: Pack dependencies
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
         run: |
           find . -name node_modules -type d -prune -print0 > node_modules.list
           for file in .env .env.test; do
@@ -56,6 +66,12 @@ jobs:
             fi
           done
           tar --null -cf node_modules.tar -T node_modules.list
+      - name: Save dependency archive
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: node_modules.tar
+          key: ${{ steps.restore-dependencies.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-node-modules-node-${{ matrix.node_version }}

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
+          cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
       - name: Pack dependencies


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
前端单测 CI 目前会在一个 job 中完成依赖安装和全部测试。依赖安装耗时较长，测试也只能在单个 GitHub Actions job 中完成，导致整体反馈时间偏长。

### Description
本 PR 将前端单测 CI 拆成依赖安装和测试两个阶段：先安装依赖并上传依赖产物，然后由 4 个测试分片 job 下载依赖产物并并行执行 Vitest 分片测试。

这样可以减少重复安装依赖的时间，并让前端单测更快完成。风险主要在于依赖产物打包和解包是否完整，建议重点观察首次 CI 运行中 artifact 上传、下载、解包和 4 个分片测试是否都能正常完成。

### Showcase
无界面变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Frontend unit test CI now runs in parallel shards |
| 🇨🇳 Chinese | 前端单测 CI 现在会并行分片运行 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
