### PR TITLE
fix(client): normalize webpack public path trailing slash

### DIFF
--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -80,6 +80,10 @@ const trimTrailingSlashes = (value: string) => {
   return match ? value.slice(0, -match[0].length) : value;
 };
 
+const ensureTrailingSlash = (value: string) => {
+  return `${trimTrailingSlashes(value)}/`;
+};
+
 const isRenderableComponentType = (value: unknown): value is AnyComponent => isValidElementType(value);
 
 export type DevDynamicImport = (packageName: string) => Promise<{ default: PluginClass }>;
@@ -432,15 +436,11 @@ export abstract class BaseApplication<
   }
 
   getCdnUrl() {
-    return window['__webpack_public_path__'] || this.getPublicPath();
+    return ensureTrailingSlash(window['__webpack_public_path__'] || this.getPublicPath());
   }
 
   getPublicPath() {
-    let publicPath = this.options.publicPath || '/';
-    if (!publicPath.endsWith('/')) {
-      publicPath += '/';
-    }
-    return publicPath;
+    return ensureTrailingSlash(this.options.publicPath || '/');
   }
 
   getApiUrl(pathname = '') {

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -34,6 +34,7 @@ describe('app', () => {
     afterEach(() => {
       document.querySelectorAll('link[rel="shortcut icon"]').forEach((node) => node.remove());
       document.documentElement.removeAttribute('lang');
+      delete window['__webpack_public_path__'];
       vi.restoreAllMocks();
     });
 
@@ -56,6 +57,31 @@ describe('app', () => {
       expect(app.jsonLogic.apply({ $eq: [1, '1'] })).toBe(true);
       app.jsonLogic.addOperation('$testAlwaysTrue', () => true);
       expect(app.jsonLogic.apply({ $testAlwaysTrue: [] })).toBe(true);
+    });
+
+    it('should normalize publicPath and webpack public path with a single trailing slash', () => {
+      const app = new Application({
+        router,
+        publicPath: '/admin//',
+      });
+
+      expect(app.getPublicPath()).toBe('/admin/');
+
+      window['__webpack_public_path__'] = '/cdn/assets///';
+      expect(app.getCdnUrl()).toBe('/cdn/assets/');
+
+      delete window['__webpack_public_path__'];
+      expect(app.getCdnUrl()).toBe('/admin/');
+    });
+
+    it('should normalize webpack public path without a trailing slash', () => {
+      const app = new Application({
+        router,
+        publicPath: '/admin/',
+      });
+
+      window['__webpack_public_path__'] = '/cdn/assets';
+      expect(app.getCdnUrl()).toBe('/cdn/assets/');
     });
 
     it('should apply the provided favicon immediately', () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The client-side application helpers normalized `publicPath`, but the `__webpack_public_path__` runtime override path also needs to be normalized when it is injected without a trailing slash. Without this coverage, CDN/runtime asset URLs can end up inconsistent and the test case for that edge case was missing.

### Description 
- Normalize both `publicPath` and runtime `__webpack_public_path__` through the same trailing-slash helper in `BaseApplication`.
- Add app-level tests covering both repeated trailing slashes and the missing trailing slash case for `__webpack_public_path__`.
- Risk is low because the change is limited to URL normalization for client asset base paths.
- Suggested verification: run the client-v2 app tests and confirm `getCdnUrl()` returns a single trailing slash for `/cdn/assets///` and `/cdn/assets`.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed client runtime asset base URL normalization when `__webpack_public_path__` is injected without a trailing slash, and added coverage for that edge case. |
| 🇨🇳 Chinese | 修复 `__webpack_public_path__` 以不带尾随 `/` 的形式注入时客户端运行时静态资源基础路径归一化不一致的问题，并补充了该边界场景的测试覆盖。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
