### PR TITLE
fix(plugin-workflow): handle trigger failures during execution creation

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -45,7 +45,12 @@ export type EventOptions = {
   force?: boolean;
   stack?: Array<number | string>;
   parentExecutionId?: number | string;
-  onTriggerFail?: Function;
+  onTriggerFail?: (
+    workflow: WorkflowModel,
+    context: object,
+    options: EventOptions,
+    error?: unknown,
+  ) => void | Promise<void>;
   [key: string]: any;
 } & Transactionable;
 
@@ -89,12 +94,12 @@ export default class Dispatcher {
     workflow: WorkflowModel,
     context: object,
     options: EventOptions = {},
-  ): void | Promise<Processor | null> {
+  ): void | Promise<Processor | null | void> {
     const logger = this.plugin.getLogger(workflow.id);
     if (!this.ready) {
       logger.warn(`app is not ready, event of workflow ${workflow.id} will be ignored`);
       logger.debug(`ignored event data:`, context);
-      return;
+      return this.handleTriggerFail(workflow, context, options, new Error('app is not ready'));
     }
     if (!options.force && !options.manually && !workflow.enabled) {
       logger.warn(`workflow ${workflow.id} is not enabled, event will be ignored`);
@@ -111,7 +116,7 @@ export default class Dispatcher {
     }
     if (context == null) {
       logger.warn(`workflow ${workflow.id} event data context is null, event will be ignored`);
-      return;
+      return this.handleTriggerFail(workflow, context, options, new Error('event context is null'));
     }
 
     if (options.manually || this.plugin.isWorkflowSync(workflow)) {
@@ -369,6 +374,14 @@ export default class Dispatcher {
     return valid;
   }
 
+  private async handleTriggerFail(workflow: WorkflowModel, context: object, options: EventOptions, error?: unknown) {
+    try {
+      await options.onTriggerFail?.(workflow, context, options, error);
+    } catch (triggerFailError) {
+      this.plugin.getLogger(workflow.id).error(`trigger failure callback failed`, { error: triggerFailError });
+    }
+  }
+
   private async createExecution(
     workflow: WorkflowModel,
     context: object,
@@ -382,22 +395,35 @@ export default class Dispatcher {
       });
       stack = parentExecution ? [...(parentExecution.stack ?? []), parentExecution.id] : [];
     }
-    const valid = await this.validateEvent(workflow, context, { ...options, stack });
+    let valid: boolean;
+    try {
+      valid = await this.validateEvent(workflow, context, { ...options, stack });
+    } catch (error) {
+      await this.handleTriggerFail(workflow, context, options, error);
+      throw error;
+    }
     if (!valid) {
-      options.onTriggerFail?.(workflow, context, options);
-      throw new Error('event is not valid');
+      const error = new Error('event is not valid');
+      await this.handleTriggerFail(workflow, context, options, error);
+      throw error;
     }
 
-    const execution: ExecutionModel = await workflow.createExecution({
-      context,
-      key: workflow.key,
-      eventKey: options.eventKey ?? randomUUID(),
-      stack,
-      parentExecutionId: options.parentExecutionId ?? null,
-      dispatched: deferred ?? false,
-      status: deferred ? EXECUTION_STATUS.STARTED : EXECUTION_STATUS.QUEUEING,
-      manually: options.manually,
-    });
+    let execution: ExecutionModel;
+    try {
+      execution = await workflow.createExecution({
+        context,
+        key: workflow.key,
+        eventKey: options.eventKey ?? randomUUID(),
+        stack,
+        parentExecutionId: options.parentExecutionId ?? null,
+        dispatched: deferred ?? false,
+        status: deferred ? EXECUTION_STATUS.STARTED : EXECUTION_STATUS.QUEUEING,
+        manually: options.manually,
+      });
+    } catch (error) {
+      await this.handleTriggerFail(workflow, context, options, error);
+      throw error;
+    }
 
     this.plugin.getLogger(workflow.id).info(`execution of workflow ${workflow.id} created as ${execution.id}`);
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -506,7 +506,7 @@ export default class PluginWorkflowServer extends Plugin {
     workflow: WorkflowModel,
     context: object,
     options: EventOptions = {},
-  ): void | Promise<Processor | null> {
+  ): void | Promise<Processor | null | void> {
     return this.dispatcher.trigger(workflow, context, options);
   }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -10,6 +10,7 @@
 import { MockServer } from '@nocobase/test';
 import Database, { Transaction } from '@nocobase/database';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
+import { vi } from 'vitest';
 
 import Plugin, { Processor } from '..';
 import { EXECUTION_STATUS } from '../constants';
@@ -350,6 +351,53 @@ describe('workflow > Plugin', () => {
       await e1.reload();
       expect(e1.dispatched).toBe(false);
       expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
+    });
+
+    it('should notify trigger failure callback when async execution creation fails', async () => {
+      type SavingDispatcher = {
+        saving: Promise<unknown> | null;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: SavingDispatcher }).dispatcher;
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      const error = new Error('duplicate execution id');
+      const createExecution = vi.spyOn(workflow, 'createExecution').mockRejectedValueOnce(error);
+      const onTriggerFail = vi.fn(async () => {
+        await sleep(10);
+      });
+
+      plugin.trigger(workflow, { data: true }, { eventKey: 'failed-event', onTriggerFail });
+
+      await dispatcher.saving?.catch(() => null);
+
+      expect(createExecution).toHaveBeenCalledTimes(1);
+      expect(onTriggerFail).toHaveBeenCalledTimes(1);
+      expect(onTriggerFail.mock.calls[0]).toEqual([
+        workflow,
+        { data: true },
+        { eventKey: 'failed-event', onTriggerFail },
+        error,
+      ]);
+    });
+
+    it('should notify trigger failure callback when async event context is null', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      const onTriggerFail = vi.fn(async () => {
+        await sleep(10);
+      });
+
+      await plugin.trigger(workflow, null as unknown as object, { eventKey: 'invalid-context-event', onTriggerFail });
+
+      expect(onTriggerFail).toHaveBeenCalledTimes(1);
+      expect(onTriggerFail.mock.calls[0][0]).toBe(workflow);
+      expect(onTriggerFail.mock.calls[0][1]).toBeNull();
+      expect(onTriggerFail.mock.calls[0][2]).toEqual({ eventKey: 'invalid-context-event', onTriggerFail });
+      expect(onTriggerFail.mock.calls[0][3]).toBeInstanceOf(Error);
     });
 
     it('should recover after unexpected dispatch error before cleanup', async () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Subflow nodes can remain pending when the target workflow fails before its execution record is created. One observed failure path is a database error during execution creation, such as a duplicate primary key on the `executions` table. In that case, the parent subflow job has already been saved as pending, but the child workflow history never gets an execution record, leaving the parent job without a normal resume path.

### Description
This PR makes workflow trigger failure handling awaitable and invokes it when execution creation fails.

- Types `onTriggerFail` as an async-capable callback.
- Awaits `onTriggerFail` when event validation rejects the trigger or when `workflow.createExecution()` throws.
- Keeps normal ignore semantics for disabled workflows and duplicate queued event keys.
- Notifies the failure callback for `app not ready` and null context early exits, where no execution will be created.
- Adds regression coverage for async execution creation failures and invalid event context.

Potential risk: callers that provide `onTriggerFail` may now have their callback awaited on the affected failure paths. The callback error is caught and logged so it does not replace the original trigger failure.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow-subflow/src/server/__tests__/instruction.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed subflow nodes remaining pending when the child workflow fails before creating an execution record |
| 🇨🇳 Chinese | 修复子流程在目标工作流执行记录创建前失败时父节点可能一直等待的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
