### PR TITLE
fix(database): prevent invalid belongsToMany through collection

### DIFF
--- a/packages/core/database/src/__tests__/fields/belongs-to-many-field.test.ts
+++ b/packages/core/database/src/__tests__/fields/belongs-to-many-field.test.ts
@@ -73,8 +73,8 @@ describe('belongs to many field', () => {
     console.log(error.message);
   });
 
-  it('should define belongs to many when change alias name', async () => {
-    const Through = db.collection({
+  it('should not define belongs to many when through and target are the same collection', async () => {
+    db.collection({
       name: 't1',
       fields: [
         {
@@ -87,10 +87,6 @@ describe('belongs to many field', () => {
 
     const A = db.collection({
       name: 'a',
-    });
-
-    const B = db.collection({
-      name: 'b',
     });
 
     await db.sync();
@@ -122,7 +118,8 @@ describe('belongs to many field', () => {
       error2 = e;
     }
 
-    expect(error2).not.toBeDefined();
+    expect(error2).toBeDefined();
+    expect(error2.message).toContain('cannot use target collection "t1" as through collection');
   });
 
   it('should define belongs to many relation through exists pivot collection', async () => {

--- a/packages/core/database/src/fields/belongs-to-many-field.ts
+++ b/packages/core/database/src/fields/belongs-to-many-field.ts
@@ -65,6 +65,12 @@ export class BelongsToManyField extends RelationField {
     let { foreignKey, sourceKey, otherKey, targetKey } = this.options;
 
     const through = this.through;
+    if (through === this.target) {
+      throw new Error(
+        `BelongsToMany relation "${this.name}" cannot use target collection "${this.target}" as through collection`,
+      );
+    }
+
     const throughCollection = database.getCollection(through);
 
     if (!throughCollection) {

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/fields/belongs-to-many.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/fields/belongs-to-many.test.ts
@@ -122,6 +122,25 @@ describe('belongsToMany', () => {
     expect(error).toBeDefined();
   });
 
+  it('should throw error when through and target are the same collection', async () => {
+    await expect(
+      Field.repository.create({
+        values: {
+          name: 'confirmors',
+          type: 'belongsToMany',
+          collectionName: 'posts',
+          target: 'tags',
+          through: 'tags',
+          sourceKey: 'id',
+          targetKey: 'id',
+          foreignKey: 'post_id',
+          otherKey: 'tag_id',
+        },
+        context: {},
+      }),
+    ).rejects.toThrow('cannot use target collection "tags" as through collection');
+  });
+
   it('should define belongs to many when change alias name', async () => {
     await Collection.repository.create({
       values: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Invalid belongsToMany field configurations can accidentally use the target collection as the through collection. This creates unsafe relation metadata and can lead to unexpected cascade behavior.

### Description
This PR rejects belongsToMany fields when `through` and `target` point to the same collection.

It also updates regression tests for both direct database field definition and the data source main field repository path.

Testing performed:
- `yarn test packages/core/database/src/__tests__/fields/belongs-to-many-field.test.ts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevented invalid many-to-many relationship field configurations from being saved |
| 🇨🇳 Chinese | 禁止保存无效的多对多关系字段配置 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
