### PR TITLE
feat(plugin-public-forms): support v2 in v1 settings

### DIFF
--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormPageModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormPageModel.test.tsx
@@ -64,4 +64,20 @@ describe('PublicFormPageModel', () => {
 
     expect(model.props.showFlowSettings).toBe(false);
   });
+
+  it('uses the injected public form data source manager outside the v2 layout route', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ PublicFormPageModel });
+    const model = engine.createModel<PublicFormPageModel>({
+      uid: 'public-form-page',
+      use: 'PublicFormPageModel',
+    });
+    const publicFormDataSourceManager = { key: 'public-form-data-source-manager' };
+
+    model.context.defineProperty('publicFormDataSourceManager', {
+      value: publicFormDataSourceManager,
+    });
+
+    expect(model.context.dataSourceManager).toBe(publicFormDataSourceManager);
+  });
 });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/modelLoaders.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/modelLoaders.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { FlowEngine } from '@nocobase/flow-engine';
+import {
+  PUBLIC_FORM_LAYOUT_MODEL,
+  PUBLIC_FORM_PAGE_MODEL,
+  PUBLIC_FORM_SUBMIT_ACTION_MODEL,
+  PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL,
+} from './constants';
+
+export function registerPublicFormV2ModelLoaders(flowEngine: Pick<FlowEngine, 'registerModelLoaders'>) {
+  flowEngine.registerModelLoaders({
+    [PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL]: {
+      loader: () => import('./models/PublicFormsSettingsLayoutModel'),
+    },
+    [PUBLIC_FORM_LAYOUT_MODEL]: {
+      loader: () => import('./models/PublicFormLayoutModel'),
+    },
+    [PUBLIC_FORM_PAGE_MODEL]: {
+      loader: () => import('./models/PublicFormPageModel'),
+    },
+    [PUBLIC_FORM_SUBMIT_ACTION_MODEL]: {
+      loader: () => import('./models/PublicFormSubmitActionModel'),
+    },
+  });
+}

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormPageModel.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormPageModel.tsx
@@ -22,6 +22,7 @@ type PublicFormLayoutRuntimeModel = FlowModel & {
   getPageUidFromLayoutRoute?: (match: unknown) => string;
   context: FlowModel['context'] & {
     dataSourceManager?: DataSourceManager;
+    publicFormDataSourceManager?: DataSourceManager;
   };
 };
 
@@ -91,6 +92,10 @@ export class PublicFormPageModel extends ChildPageModel {
   }
 
   private getPublicFormDataSourceManager() {
+    if (this.context.publicFormDataSourceManager) {
+      return this.context.publicFormDataSourceManager;
+    }
+
     const layoutModel = this.flowEngine.getModel<PublicFormLayoutRuntimeModel>(PUBLIC_FORM_LAYOUT_UID, true);
     const routePageUid = this.parent?.uid;
     const layoutPageUid = layoutModel?.getPageUidFromLayoutRoute?.(layoutModel.currentLayoutRoute);

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsDetailPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/pages/PublicFormsSettingsDetailPage.tsx
@@ -90,10 +90,8 @@ function PublicFormPageRenderer(props: { model: FlowModel }) {
   );
 }
 
-export default function PublicFormsSettingsDetailPage() {
-  const params = useParams<{ name?: string }>();
-  const pageUid = params.name;
-
+export function PublicFormsSettingsDetailContent(props: { pageUid?: string }) {
+  const { pageUid } = props;
   return (
     <PublicFormsSettingsDetailView pageUid={pageUid}>
       {(routeModel) => {
@@ -107,4 +105,10 @@ export default function PublicFormsSettingsDetailPage() {
       }}
     </PublicFormsSettingsDetailView>
   );
+}
+
+export default function PublicFormsSettingsDetailPage() {
+  const params = useParams<{ name?: string }>();
+
+  return <PublicFormsSettingsDetailContent pageUid={params.name} />;
 }

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/plugin.tsx
@@ -14,29 +14,15 @@ import {
   PUBLIC_FORM_LAYOUT_UID,
   PUBLIC_FORM_PAGE_MODEL,
   PUBLIC_FORM_ROUTE_NAME,
-  PUBLIC_FORM_SUBMIT_ACTION_MODEL,
   PUBLIC_FORMS_NAMESPACE,
-  PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL,
 } from './constants';
+import { registerPublicFormV2ModelLoaders } from './modelLoaders';
 
 export class PluginPublicFormsClientV2 extends Plugin<Record<string, never>, Application> {
   async load() {
     const title = this.app.i18n.t('Public forms', { ns: PUBLIC_FORMS_NAMESPACE });
 
-    this.flowEngine.registerModelLoaders({
-      [PUBLIC_FORMS_SETTINGS_LAYOUT_MODEL]: {
-        loader: () => import('./models/PublicFormsSettingsLayoutModel'),
-      },
-      [PUBLIC_FORM_LAYOUT_MODEL]: {
-        loader: () => import('./models/PublicFormLayoutModel'),
-      },
-      [PUBLIC_FORM_PAGE_MODEL]: {
-        loader: () => import('./models/PublicFormPageModel'),
-      },
-      [PUBLIC_FORM_SUBMIT_ACTION_MODEL]: {
-        loader: () => import('./models/PublicFormSubmitActionModel'),
-      },
-    });
+    registerPublicFormV2ModelLoaders(this.flowEngine);
 
     this.pluginSettingsManager.addMenuItem({
       key: PUBLIC_FORMS_NAMESPACE,

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/AdminPublicFormPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/AdminPublicFormPage.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@nocobase/test/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AdminPublicFormPage } from '../components/AdminPublicFormPage';
+
+const testState = vi.hoisted(() => ({
+  record: {
+    data: {
+      enabled: true,
+      key: 'legacy-form',
+      title: 'Legacy public form',
+      version: 'v1',
+    },
+  } as { data?: Record<string, unknown> },
+  refresh: vi.fn(),
+}));
+
+vi.mock('react-router', () => ({
+  useParams: () => ({
+    name: 'public-form-1',
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children }: React.PropsWithChildren) => <a>{children}</a>,
+}));
+
+vi.mock('@formily/antd-v5', () => ({
+  FormLayout: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock('@ant-design/pro-layout', () => ({
+  PageHeader: ({ style, title }: { style?: React.CSSProperties; title?: React.ReactNode }) => (
+    <header data-testid="v2-settings-header" style={style}>
+      {title}
+    </header>
+  ),
+}));
+
+vi.mock('../hooks', () => ({
+  usePublicSubmitActionProps: vi.fn(),
+}));
+
+vi.mock('@nocobase/client', () => ({
+  ApplicationContext: React.createContext({}),
+  Checkbox: () => null,
+  FormDialog: () => ({
+    open: vi.fn(),
+  }),
+  FormItem: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  PoweredBy: () => <div>Powered by NocoBase</div>,
+  RemoteSchemaComponent: ({ uid }: { uid: string }) => <div data-testid="legacy-admin-public-form">{uid}</div>,
+  SchemaComponent: () => null,
+  SchemaComponentOptions: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  TextAreaWithGlobalScope: () => null,
+  VariablesProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useAPIClient: () => ({
+    resource: () => ({
+      update: vi.fn(),
+    }),
+  }),
+  useApp: () => ({
+    getHref: (path: string) => `/${path}`,
+  }),
+  useCompile: () => (value: string) => value,
+  useGlobalTheme: () => ({
+    theme: {},
+  }),
+  useGlobalVariable: () => ({}),
+  useRequest: () => ({
+    data: testState.record,
+    loading: false,
+    refresh: testState.refresh,
+  }),
+}));
+
+vi.mock('../locale', () => ({
+  NAMESPACE: 'public-forms',
+  usePublicFormTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../client-v2/pages/PublicFormsSettingsDetailPage', () => ({
+  PublicFormsSettingsDetailContent: ({ pageUid }: { pageUid?: string }) => (
+    <div data-testid="v2-admin-public-form">{pageUid}</div>
+  ),
+}));
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+
+  return {
+    ...actual,
+    Breadcrumb: ({ items }: { items?: { title?: React.ReactNode }[] }) => (
+      <nav>{items?.map((item, index) => <span key={index}>{item.title}</span>)}</nav>
+    ),
+    Button: ({ children }: React.PropsWithChildren) => <button>{children}</button>,
+    Dropdown: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+    Popover: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+    QRCode: () => <div />,
+    Space: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+    Spin: () => <div>Loading</div>,
+    Switch: () => <input type="checkbox" />,
+    theme: {
+      useToken: () => ({
+        token: {
+          colorBgContainer: '#fff',
+          colorBgLayout: '#f5f5f5',
+          colorBorderSecondary: '#eee',
+          controlHeightLG: 40,
+          lineWidth: 1,
+          marginLG: 24,
+          padding: 16,
+          paddingLG: 24,
+          paddingSM: 12,
+        },
+      }),
+    },
+  };
+});
+
+describe('AdminPublicFormPage', () => {
+  beforeEach(() => {
+    testState.record = {
+      data: {
+        enabled: true,
+        key: 'legacy-form',
+        title: 'Legacy public form',
+        version: 'v1',
+      },
+    };
+    testState.refresh.mockReset();
+  });
+
+  it('keeps legacy v1 public forms on the RemoteSchemaComponent settings page', () => {
+    render(<AdminPublicFormPage />);
+
+    expect(screen.getByTestId('legacy-admin-public-form')).toHaveTextContent('public-form-1');
+    expect(screen.queryByTestId('v2-admin-public-form')).toBeNull();
+  });
+
+  it('routes v2 public forms to the v2 FlowModel settings page from the v1 settings URL', () => {
+    testState.record = {
+      data: {
+        enabled: true,
+        key: 'public-form-1',
+        title: 'V2 public form',
+        version: 'v2',
+      },
+    };
+
+    render(<AdminPublicFormPage />);
+
+    expect(screen.getByTestId('v2-admin-public-form')).toHaveTextContent('public-form-1');
+    expect(screen.getByTestId('v2-settings-header')).toHaveTextContent('Public forms');
+    expect(screen.getByTestId('v2-settings-header')).toHaveStyle({
+      paddingTop: '12px',
+      paddingBottom: '12px',
+    });
+    expect(screen.getByTestId('v2-settings-header').parentElement).toHaveStyle({
+      marginTop: '-54px',
+    });
+    expect(screen.queryByTestId('legacy-admin-public-form')).toBeNull();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/PublicFormPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/PublicFormPage.test.tsx
@@ -12,6 +12,10 @@ import { render, screen } from '@nocobase/test/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PublicFormPage } from '../components/PublicFormPage';
 
+type MockFlowContext = {
+  defineProperty: ReturnType<typeof vi.fn>;
+};
+
 const mocks = vi.hoisted(() => {
   const requestInterceptorUse = vi.fn(() => 1);
   const requestInterceptorEject = vi.fn();
@@ -23,6 +27,22 @@ const mocks = vi.hoisted(() => {
     },
     requestInterceptorEject,
     requestInterceptorUse,
+    flowEngine: {
+      createModelAsync: vi.fn(),
+      getModel: vi.fn(),
+      modelRepository: {},
+      resolveModelTree: vi.fn(),
+      setModelRepository: vi.fn(),
+      context: {
+        dataSourceManager: {
+          collectionFieldInterfaceManager: {},
+          requester: {},
+        },
+      },
+    },
+    flowModelRendererModel: null as { uid?: string } | null,
+    flowViewContext: null as MockFlowContext | null,
+    publicFormFlowModelRepository: vi.fn(),
     useRequest: vi.fn(() => ({
       data: {
         data: {
@@ -78,6 +98,53 @@ vi.mock('../components/components/MobilePicker', () => ({
 
 vi.mock('../hooks', () => ({
   usePublicSubmitActionProps: vi.fn(),
+}));
+
+vi.mock('../locale', () => ({
+  usePublicFormTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@nocobase/flow-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nocobase/flow-engine')>();
+
+  class FlowContext {
+    addDelegate = vi.fn();
+    defineMethod = vi.fn();
+    defineProperty = vi.fn();
+    removeDelegate = vi.fn();
+  }
+
+  class DataSourceManager {
+    setCollectionFieldInterfaceManager = vi.fn();
+    setFlowEngine = vi.fn();
+    setRequester = vi.fn();
+    upsertDataSource = vi.fn();
+    getDataSource = vi.fn(() => ({
+      setCollections: vi.fn(),
+    }));
+  }
+
+  return {
+    ...actual,
+    DataSourceManager,
+    FlowContext,
+    FlowModelRenderer: ({ model }: { model?: { uid?: string } }) => {
+      mocks.flowModelRendererModel = model || null;
+      return <div data-testid="public-form-flow-model">{model?.uid}</div>;
+    },
+    FlowViewContextProvider: ({ children, context }: React.PropsWithChildren<{ context?: MockFlowContext }>) => {
+      mocks.flowViewContext = context || null;
+      return <>{children}</>;
+    },
+    useFlowEngine: () => mocks.flowEngine,
+  };
+});
+
+vi.mock('../../client-v2/publicFormFlowModelRepository', () => ({
+  PublicFormFlowModelRepository: mocks.publicFormFlowModelRepository,
+  isPublicFormFlowModelRepository: () => false,
 }));
 
 vi.mock('@nocobase/client', () => {
@@ -167,6 +234,41 @@ describe('PublicFormPage', () => {
   beforeEach(() => {
     mocks.device.isDesktop = false;
     mocks.device.isMobile = true;
+    mocks.flowEngine.createModelAsync.mockReset();
+    mocks.flowEngine.createModelAsync.mockResolvedValue({
+      subModels: {
+        page: {
+          context: {
+            addDelegate: vi.fn(),
+            removeDelegate: vi.fn(),
+          },
+          setProps: vi.fn(),
+          uid: 'public-form-page-model',
+        },
+      },
+      uid: 'public-form-1',
+    });
+    mocks.flowEngine.getModel.mockReset();
+    mocks.flowEngine.getModel.mockReturnValue(null);
+    mocks.flowEngine.resolveModelTree.mockReset();
+    mocks.flowEngine.setModelRepository.mockReset();
+    mocks.flowModelRendererModel = null;
+    mocks.flowViewContext = null;
+    mocks.publicFormFlowModelRepository.mockClear();
+    mocks.useRequest.mockClear();
+    mocks.useRequest.mockReturnValue({
+      data: {
+        data: {
+          dataSource: { key: 'main' },
+          schema: {},
+          title: 'Public form',
+          token: 'form-token',
+        },
+      },
+      error: null,
+      loading: false,
+      run: vi.fn(),
+    });
     vi.stubGlobal('CSS', {
       supports: vi.fn(() => true),
     });
@@ -220,5 +322,78 @@ describe('PublicFormPage', () => {
     expect(publicFormContainer?.style.height).toBe('100%');
     expect(publicFormContainer?.style.overflow).toBe('auto');
     expect(publicFormContainer?.style.overflowX).toBe('');
+  });
+
+  it('renders the v2 FlowModel runtime when public form meta contains a flowModel', async () => {
+    mocks.useRequest.mockReturnValue({
+      data: {
+        data: {
+          dataSource: { key: 'main', collections: [] },
+          flowModel: {
+            uid: 'public-form-1',
+            subModels: {
+              page: {
+                uid: 'public-form-page-model',
+              },
+            },
+          },
+          title: 'V2 public form',
+          token: 'form-token',
+        },
+      },
+      error: null,
+      loading: false,
+      run: vi.fn(),
+    });
+
+    render(<PublicFormPage />);
+
+    expect(await screen.findByTestId('public-form-flow-model')).toHaveTextContent('public-form-page-model');
+    expect(screen.queryByTestId('public-form-schema')).toBeNull();
+    expect(mocks.flowEngine.resolveModelTree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uid: 'public-form-1',
+      }),
+    );
+    expect(mocks.flowEngine.createModelAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uid: 'public-form-1',
+      }),
+      {
+        delegate: mocks.flowViewContext,
+      },
+    );
+    expect(mocks.flowViewContext?.defineProperty).toHaveBeenCalledWith(
+      'view',
+      expect.objectContaining({
+        value: expect.objectContaining({
+          type: 'embed',
+        }),
+      }),
+    );
+    expect(mocks.flowViewContext?.defineProperty).toHaveBeenCalledWith(
+      'dataSourceManager',
+      expect.objectContaining({
+        get: expect.any(Function),
+        cache: false,
+      }),
+    );
+  });
+
+  it('renders the public form password error inline', async () => {
+    mocks.useRequest.mockReturnValue({
+      data: null,
+      error: {
+        response: {
+          status: 401,
+        },
+      },
+      loading: false,
+      run: vi.fn(),
+    });
+
+    render(<PublicFormPage />);
+
+    expect(await screen.findByText('Incorrect password')).toBeInTheDocument();
   });
 });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/PublicFormPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/PublicFormPage.test.tsx
@@ -96,6 +96,11 @@ vi.mock('../components/components/MobilePicker', () => ({
   MobilePicker: () => <div data-testid="mobile-picker" />,
 }));
 
+vi.mock('../components/UnEnabledFormPlaceholder', () => ({
+  UnEnabledFormPlaceholder: () => <div data-testid="public-form-disabled" />,
+  UnFoundFormPlaceholder: () => <div data-testid="public-form-not-found" />,
+}));
+
 vi.mock('../hooks', () => ({
   usePublicSubmitActionProps: vi.fn(),
 }));
@@ -378,6 +383,30 @@ describe('PublicFormPage', () => {
         cache: false,
       }),
     );
+  });
+
+  it('shows the not-found state when the v2 FlowModel runtime fails to load', async () => {
+    mocks.useRequest.mockReturnValue({
+      data: {
+        data: {
+          dataSource: { key: 'main', collections: [] },
+          flowModel: {
+            uid: 'public-form-1',
+          },
+          title: 'V2 public form',
+          token: 'form-token',
+        },
+      },
+      error: null,
+      loading: false,
+      run: vi.fn(),
+    });
+    mocks.flowEngine.resolveModelTree.mockRejectedValueOnce(new Error('Failed to resolve public form model'));
+
+    render(<PublicFormPage />);
+
+    expect(await screen.findByTestId('public-form-not-found')).toBeInTheDocument();
+    expect(screen.queryByText('Loading')).toBeNull();
   });
 
   it('renders the public form password error inline', async () => {

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/publicFormsSchema.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/publicFormsSchema.test.ts
@@ -11,9 +11,9 @@ import { describe, expect, it } from 'vitest';
 import { publicFormsSchema } from '../schemas/publicForms';
 
 describe('publicFormsSchema', () => {
-  it('lists v1 public forms and historical unversioned records', () => {
+  it('lists v1, v2, and historical unversioned public forms', () => {
     expect(publicFormsSchema['x-decorator-props']?.params?.filter).toEqual({
-      $or: [{ version: 'v1' }, { 'version.$empty': true }],
+      $or: [{ version: 'v1' }, { version: 'v2' }, { 'version.$empty': true }],
     });
   });
 });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/useSubmitActionProps.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/__tests__/useSubmitActionProps.test.ts
@@ -1,0 +1,190 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { act, renderHook } from '@nocobase/test/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSubmitActionProps } from '../hooks/useSubmitActionProps';
+
+const testState = vi.hoisted(() => ({
+  apiResource: vi.fn(),
+  ensurePublicFormFlowModel: vi.fn(),
+  flowEngine: { uid: 'flow-engine' },
+  form: {
+    submit: vi.fn(),
+    reset: vi.fn(),
+    values: {} as Record<string, unknown>,
+  },
+  messageSuccess: vi.fn(),
+  resource: {
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  serviceRefresh: vi.fn(),
+  setVisible: vi.fn(),
+  uiSchemasInsert: vi.fn(),
+}));
+
+vi.mock('..', () => ({
+  default: class PluginPublicFormsClient {},
+}));
+
+vi.mock('@formily/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@formily/react')>();
+
+  return {
+    ...actual,
+    useForm: () => testState.form,
+  };
+});
+
+vi.mock('@formily/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@formily/shared')>();
+
+  return {
+    ...actual,
+    uid: () => 'generated-public-form-key',
+  };
+});
+
+vi.mock('@nocobase/flow-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nocobase/flow-engine')>();
+
+  return {
+    ...actual,
+    useFlowEngine: () => testState.flowEngine,
+  };
+});
+
+vi.mock('@nocobase/client', () => ({
+  useActionContext: () => ({
+    setVisible: testState.setVisible,
+  }),
+  useAPIClient: () => ({
+    resource: testState.apiResource,
+  }),
+  useBlockRequestContext: () => ({
+    service: {
+      refresh: testState.serviceRefresh,
+    },
+  }),
+  useCollection: () => ({
+    filterTargetKey: 'key',
+  }),
+  useDataBlockResource: () => testState.resource,
+  usePlugin: () => ({
+    getFormSchemaByType: () => () => ({}),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+
+  return {
+    ...actual,
+    App: {
+      ...actual.App,
+      useApp: () => ({
+        message: {
+          success: testState.messageSuccess,
+        },
+      }),
+    },
+  };
+});
+
+vi.mock('../../client-v2/modelTree', () => ({
+  ensurePublicFormFlowModel: testState.ensurePublicFormFlowModel,
+}));
+
+describe('useSubmitActionProps', () => {
+  beforeEach(() => {
+    testState.apiResource.mockReset();
+    testState.ensurePublicFormFlowModel.mockReset();
+    testState.form.submit.mockReset();
+    testState.form.reset.mockReset();
+    testState.form.values = {};
+    testState.messageSuccess.mockReset();
+    testState.resource.create.mockReset();
+    testState.resource.update.mockReset();
+    testState.serviceRefresh.mockReset();
+    testState.setVisible.mockReset();
+    testState.uiSchemasInsert.mockReset();
+    testState.apiResource.mockReturnValue({
+      insert: testState.uiSchemasInsert,
+    });
+  });
+
+  it('creates v2 public forms from the v1 settings list without inserting a legacy uiSchema', async () => {
+    testState.form.values = {
+      collection: 'main:users',
+      enabled: true,
+      title: 'Public form',
+      type: 'form',
+    };
+
+    const { result } = renderHook(() => useSubmitActionProps());
+
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    expect(testState.resource.create).toHaveBeenCalledWith({
+      values: {
+        collection: 'main:users',
+        enabled: true,
+        key: 'generated-public-form-key',
+        title: 'Public form',
+        type: 'form',
+        version: 'v2',
+      },
+    });
+    expect(testState.ensurePublicFormFlowModel).toHaveBeenCalledWith(
+      testState.flowEngine,
+      expect.objectContaining({
+        key: 'generated-public-form-key',
+        version: 'v2',
+      }),
+      expect.any(Function),
+    );
+    expect(testState.uiSchemasInsert).not.toHaveBeenCalled();
+    expect(testState.form.reset).toHaveBeenCalled();
+    expect(testState.serviceRefresh).toHaveBeenCalled();
+    expect(testState.setVisible).toHaveBeenCalledWith(false);
+  });
+
+  it('preserves the v2 version when editing an existing v2 public form from the v1 settings list', async () => {
+    testState.form.values = {
+      collection: 'main:users',
+      key: 'existing-form',
+      title: 'Updated public form',
+      type: 'form',
+      version: 'v2',
+    };
+
+    const { result } = renderHook(() => useSubmitActionProps());
+
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    expect(testState.resource.update).toHaveBeenCalledWith({
+      filterByTk: 'existing-form',
+      values: {
+        collection: 'main:users',
+        key: 'existing-form',
+        title: 'Updated public form',
+        type: 'form',
+        version: 'v2',
+      },
+    });
+    expect(testState.ensurePublicFormFlowModel).not.toHaveBeenCalled();
+    expect(testState.uiSchemasInsert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/components/AdminPublicFormPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/components/AdminPublicFormPage.tsx
@@ -77,11 +77,7 @@ type PublicFormAdminRecord = {
   [key: string]: unknown;
 };
 
-function LegacyAdminPublicFormPage(props: {
-  name?: string;
-  data?: PublicFormAdminRecord;
-  refresh: () => Promise<void>;
-}) {
+function LegacyAdminPublicFormPage(props: { name?: string; data?: PublicFormAdminRecord; refresh: () => void }) {
   const { data, name, refresh } = props;
   const { t } = usePublicFormTranslation();
   const { theme } = useGlobalTheme();
@@ -96,7 +92,7 @@ function LegacyAdminPublicFormPage(props: {
       filterByTk: name,
       values: { ...values },
     });
-    await refresh();
+    refresh();
   };
   const handleSetPassword = async () => {
     const values = await FormDialog(
@@ -136,7 +132,7 @@ function LegacyAdminPublicFormPage(props: {
 
   const handleCopyLink = () => {
     const baseURL = window.location.origin;
-    const link = baseURL + app.getHref(`public-forms/${params.name}`);
+    const link = baseURL + app.getHref(`public-forms/${name}`);
     navigator.clipboard.writeText(link);
     message.success(t('Link copied successfully'));
   };

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/components/AdminPublicFormPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/components/AdminPublicFormPage.tsx
@@ -8,6 +8,7 @@
  */
 
 import { EyeOutlined, SettingOutlined } from '@ant-design/icons';
+import { PageHeader } from '@ant-design/pro-layout';
 import {
   PoweredBy,
   RemoteSchemaComponent,
@@ -45,6 +46,7 @@ import { Link } from 'react-router-dom';
 import { FormLayout } from '@formily/antd-v5';
 import { usePublicSubmitActionProps } from '../hooks';
 import { usePublicFormTranslation, NAMESPACE } from '../locale';
+import { PublicFormsSettingsDetailContent } from '../../client-v2/pages/PublicFormsSettingsDetailPage';
 
 const PublicFormQRCode = () => {
   const [open, setOpen] = useState(false);
@@ -67,8 +69,20 @@ const PublicFormQRCode = () => {
     </Popover>
   );
 };
-export function AdminPublicFormPage() {
-  const params = useParams();
+
+type PublicFormAdminRecord = {
+  enabled?: boolean;
+  title?: string;
+  version?: string;
+  [key: string]: unknown;
+};
+
+function LegacyAdminPublicFormPage(props: {
+  name?: string;
+  data?: PublicFormAdminRecord;
+  refresh: () => Promise<void>;
+}) {
+  const { data, name, refresh } = props;
   const { t } = usePublicFormTranslation();
   const { theme } = useGlobalTheme();
   const apiClient = useAPIClient();
@@ -76,16 +90,10 @@ export function AdminPublicFormPage() {
   const { token } = AntdTheme.useToken();
   const app = useApp();
   const environmentCtx = useGlobalVariable('$env');
-  const { data, loading, refresh } = useRequest<any>({
-    url: `publicForms:get/${params.name}`,
-  });
-  const { enabled, title, ...others } = data?.data || {};
-  if (loading) {
-    return <Spin />;
-  }
-  const handleEditPublicForm = async (values) => {
+  const { enabled, title, ...others } = data || {};
+  const handleEditPublicForm = async (values: Record<string, unknown>) => {
     await apiClient.resource('publicForms').update({
-      filterByTk: params.name,
+      filterByTk: name,
       values: { ...values },
     });
     await refresh();
@@ -158,7 +166,7 @@ export function AdminPublicFormPage() {
           ]}
         />
         <Space>
-          <Link target={'_blank'} to={`/public-forms/${params.name}`}>
+          <Link target={'_blank'} to={`/public-forms/${name}`}>
             <Button disabled={!enabled} icon={<EyeOutlined />}>
               {t('Open form', { ns: NAMESPACE })}
             </Button>
@@ -219,7 +227,7 @@ export function AdminPublicFormPage() {
           }}
         >
           <RemoteSchemaComponent
-            uid={params.name}
+            uid={name}
             scope={{ useCreateActionProps: usePublicSubmitActionProps }}
             components={{ PublicFormMessageProvider: (props) => props.children }}
           />
@@ -228,4 +236,60 @@ export function AdminPublicFormPage() {
       </div>
     </div>
   );
+}
+
+function V2AdminPublicFormPage(props: { pageUid?: string }) {
+  const { pageUid } = props;
+  const { t } = usePublicFormTranslation();
+  const { token } = AntdTheme.useToken();
+  const contentMargin = token.marginLG;
+  const detailHeaderOffset = 54;
+
+  return (
+    <div
+      style={{
+        margin: -contentMargin,
+        marginTop: -detailHeaderOffset,
+        minHeight: `calc(100vh - var(--nb-header-height) + ${detailHeaderOffset}px)`,
+        background: token.colorBgLayout,
+      }}
+    >
+      <PageHeader
+        ghost={false}
+        title={t('Public forms', { ns: NAMESPACE })}
+        style={{
+          background: token.colorBgContainer,
+          borderBlockEnd: `${token.lineWidth}px solid ${token.colorBorderSecondary}`,
+          paddingTop: token.paddingSM,
+          paddingBottom: token.paddingSM,
+          paddingInline: token.paddingLG,
+        }}
+      />
+      <div
+        style={{
+          padding: token.paddingLG,
+        }}
+      >
+        <PublicFormsSettingsDetailContent pageUid={pageUid} />
+      </div>
+    </div>
+  );
+}
+
+export function AdminPublicFormPage() {
+  const params = useParams();
+  const { data, loading, refresh } = useRequest<{ data?: PublicFormAdminRecord }>({
+    url: `publicForms:get/${params.name}`,
+  });
+  const record = data?.data;
+
+  if (loading) {
+    return <Spin />;
+  }
+
+  if (record?.version === 'v2') {
+    return <V2AdminPublicFormPage pageUid={params.name} />;
+  }
+
+  return <LegacyAdminPublicFormPage name={params.name} data={record} refresh={refresh} />;
 }

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/components/PublicFormPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/components/PublicFormPage.tsx
@@ -401,29 +401,35 @@ function PublicFormFlowRuntime(props: { formKey?: string; meta: PublicFormMeta }
       }
 
       setLoading(true);
-      await flowEngine.resolveModelTree(tree);
-      if (cancelled) {
-        return;
-      }
-      const nextRouteModel =
-        flowEngine.getModel(tree.uid) ||
-        (await flowEngine.createModelAsync(tree, {
-          delegate: runtimeContextRef.current,
-        }));
-      if (cancelled) {
-        return;
-      }
-      const pageModel = getPublicFormPageModel(nextRouteModel);
+      try {
+        await flowEngine.resolveModelTree(tree);
+        if (cancelled) {
+          return;
+        }
+        const nextRouteModel =
+          flowEngine.getModel(tree.uid) ||
+          (await flowEngine.createModelAsync(tree, {
+            delegate: runtimeContextRef.current,
+          }));
+        if (cancelled) {
+          return;
+        }
+        const pageModel = getPublicFormPageModel(nextRouteModel);
 
-      if (pageModel?.setProps) {
-        pageModel.setProps('publicRuntime', true);
-      }
-      detachRuntimeContext();
-      attachRuntimeContext(nextRouteModel);
+        if (pageModel?.setProps) {
+          pageModel.setProps('publicRuntime', true);
+        }
+        detachRuntimeContext();
+        attachRuntimeContext(nextRouteModel);
 
-      if (!cancelled) {
         setRouteModel(nextRouteModel);
         setLoading(false);
+      } catch (_error) {
+        if (!cancelled) {
+          detachRuntimeContext();
+          setRouteModel(null);
+          setLoading(false);
+        }
       }
     };
 

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/components/PublicFormPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/components/PublicFormPage.tsx
@@ -11,6 +11,14 @@ import { css } from '@emotion/css';
 import { useField } from '@formily/react';
 import { useMemoizedFn } from 'ahooks';
 import {
+  DataSourceManager as FlowDataSourceManager,
+  FlowContext,
+  FlowModelRenderer,
+  FlowViewContextProvider,
+  useFlowEngine,
+} from '@nocobase/flow-engine';
+import type { CollectionOptions, CreateModelOptions, DataSourceOptions, FlowModel } from '@nocobase/flow-engine';
+import {
   ACLCustomContext,
   Action,
   APIClientProvider,
@@ -29,12 +37,17 @@ import {
   useRequest,
   VariablesProvider,
 } from '@nocobase/client';
-import { Input, Modal, Spin } from 'antd';
+import { Form, Input, Modal, Spin } from 'antd';
 import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { isDesktop, isMobile } from 'react-device-detect';
 import { useParams } from 'react-router';
+import {
+  isPublicFormFlowModelRepository,
+  PublicFormFlowModelRepository,
+} from '../../client-v2/publicFormFlowModelRepository';
 import { usePublicSubmitActionProps } from '../hooks';
+import { usePublicFormTranslation } from '../locale';
 import { MobileDateTimePicker } from './components/MobileDatePicker';
 import { MobilePicker } from './components/MobilePicker';
 import { UnEnabledFormPlaceholder, UnFoundFormPlaceholder } from './UnEnabledFormPlaceholder';
@@ -171,23 +184,294 @@ const mobileComponents = {
   Modal: MobileDialog,
   AssociationField: AssociationFieldMobile,
 };
+
+type PublicFormDataSourceOptions = DataSourceOptions & {
+  collections?: CollectionOptions[];
+};
+
+type PublicFormMeta = {
+  dataSource?: PublicFormDataSourceOptions | null;
+  flowModel?: CreateModelOptions | null;
+  schema?: unknown;
+};
+
+type PublicFormRuntimeView = {
+  type: 'embed';
+  inputArgs: Record<string, unknown>;
+  Header: null;
+  Footer: null;
+  close: () => Promise<void>;
+  update: () => void;
+};
+
+const PUBLIC_FORM_RUNTIME_CACHE_KEYS = ['dataSourceManager', 'dataSource', 'collection', 'resource', 'association'];
+
+function getPublicFormPageModel(routeModel?: FlowModel | null) {
+  const page = routeModel?.subModels?.page;
+  return Array.isArray(page) ? page[0] : page;
+}
+
+function visitFlowModelTree(model: FlowModel | null | undefined, callback: (model: FlowModel) => void) {
+  const visited = new Set<FlowModel>();
+  const visit = (current?: FlowModel | FlowModel[] | null) => {
+    if (!current) {
+      return;
+    }
+
+    if (Array.isArray(current)) {
+      current.forEach(visit);
+      return;
+    }
+
+    if (visited.has(current)) {
+      return;
+    }
+
+    visited.add(current);
+    callback(current);
+    Object.values(current.subModels || {}).forEach(visit);
+  };
+
+  visit(model);
+}
+
+function PublicFormFlowRuntime(props: { formKey?: string; meta: PublicFormMeta }) {
+  const { formKey, meta } = props;
+  const app = useApp();
+  const flowEngine = useFlowEngine();
+  const [loading, setLoading] = useState(true);
+  const [routeModel, setRouteModel] = useState<FlowModel | null>(null);
+  const [publicFormSubmitted, setPublicFormSubmitted] = useState(false);
+  const publicFormSubmittedRef = useRef(false);
+  const runtimeContextRef = useRef<FlowContext>();
+  const publicDataSourceManagerRef = useRef<FlowDataSourceManager>();
+  const attachedRuntimeModelsRef = useRef<Set<FlowModel>>(new Set());
+  const originalModelRepositoryRef = useRef(flowEngine.modelRepository);
+
+  publicFormSubmittedRef.current = publicFormSubmitted;
+
+  const getPublicDataSourceManager = useCallback(() => {
+    if (!publicDataSourceManagerRef.current) {
+      const manager = new FlowDataSourceManager();
+      const rootManager = flowEngine.context.dataSourceManager;
+
+      manager.setFlowEngine(flowEngine);
+      manager.setRequester(rootManager?.requester);
+      manager.setCollectionFieldInterfaceManager(rootManager?.collectionFieldInterfaceManager);
+      publicDataSourceManagerRef.current = manager;
+    }
+
+    return publicDataSourceManagerRef.current;
+  }, [flowEngine]);
+
+  if (!runtimeContextRef.current) {
+    const runtimeContext = new FlowContext();
+    const view: PublicFormRuntimeView = {
+      type: 'embed',
+      inputArgs: {},
+      Header: null,
+      Footer: null,
+      close: async () => undefined,
+      update: () => undefined,
+    };
+
+    runtimeContext.addDelegate(flowEngine.context);
+    runtimeContext.defineProperty('view', {
+      value: view,
+    });
+    runtimeContext.defineProperty('publicFormRuntime', {
+      get: () => true,
+      cache: false,
+    });
+    runtimeContext.defineProperty('dataSourceManager', {
+      get: () => getPublicDataSourceManager(),
+      cache: false,
+    });
+    runtimeContext.defineProperty('publicFormDataSourceManager', {
+      get: () => getPublicDataSourceManager(),
+      cache: false,
+    });
+    runtimeContext.defineProperty('publicFormSubmitted', {
+      get: () => publicFormSubmittedRef.current,
+      observable: true,
+      cache: false,
+    });
+    runtimeContext.defineProperty('skipAclCheck', {
+      get: () => true,
+      cache: false,
+    });
+    runtimeContext.defineProperty('flowSettingsEnabled', {
+      get: () => false,
+      cache: false,
+    });
+    runtimeContext.defineMethod('setPublicFormSubmitted', (submitted: boolean) => {
+      setPublicFormSubmitted(!!submitted);
+    });
+    runtimeContextRef.current = runtimeContext;
+  }
+
+  useEffect(() => {
+    const currentRepository = flowEngine.modelRepository;
+
+    if (isPublicFormFlowModelRepository(currentRepository)) {
+      currentRepository.setFormKey(formKey);
+      return;
+    }
+
+    if (!app?.apiClient || !currentRepository) {
+      return;
+    }
+
+    const repository = new PublicFormFlowModelRepository({
+      app,
+      formKey,
+      delegate: currentRepository,
+    });
+
+    originalModelRepositoryRef.current = currentRepository;
+    flowEngine.setModelRepository(repository);
+
+    return () => {
+      if (flowEngine.modelRepository === repository && originalModelRepositoryRef.current) {
+        flowEngine.setModelRepository(originalModelRepositoryRef.current);
+      }
+    };
+  }, [app, flowEngine, formKey]);
+
+  useEffect(() => {
+    const dataSource = meta?.dataSource;
+    if (!dataSource?.key) {
+      return;
+    }
+
+    const { collections = [], ...options } = dataSource;
+    const manager = getPublicDataSourceManager();
+
+    manager.upsertDataSource(options);
+    manager.getDataSource(dataSource.key)?.setCollections(collections, { clearFields: true });
+  }, [getPublicDataSourceManager, meta?.dataSource]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const detachRuntimeContext = () => {
+      const runtimeContext = runtimeContextRef.current;
+      if (runtimeContext) {
+        attachedRuntimeModelsRef.current.forEach((model) => {
+          model.context?.removeDelegate?.(runtimeContext);
+        });
+      }
+      attachedRuntimeModelsRef.current.clear();
+    };
+
+    const attachRuntimeContext = (model: FlowModel) => {
+      const runtimeContext = runtimeContextRef.current;
+      if (!runtimeContext) {
+        return;
+      }
+
+      visitFlowModelTree(model, (currentModel) => {
+        currentModel.context?.addDelegate?.(runtimeContext);
+        PUBLIC_FORM_RUNTIME_CACHE_KEYS.forEach((key) => {
+          currentModel.context?.removeCache?.(key);
+        });
+        attachedRuntimeModelsRef.current.add(currentModel);
+      });
+    };
+
+    const loadFlowModel = async () => {
+      const tree = meta?.flowModel;
+
+      if (!tree?.uid) {
+        detachRuntimeContext();
+        setRouteModel(null);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      await flowEngine.resolveModelTree(tree);
+      if (cancelled) {
+        return;
+      }
+      const nextRouteModel =
+        flowEngine.getModel(tree.uid) ||
+        (await flowEngine.createModelAsync(tree, {
+          delegate: runtimeContextRef.current,
+        }));
+      if (cancelled) {
+        return;
+      }
+      const pageModel = getPublicFormPageModel(nextRouteModel);
+
+      if (pageModel?.setProps) {
+        pageModel.setProps('publicRuntime', true);
+      }
+      detachRuntimeContext();
+      attachRuntimeContext(nextRouteModel);
+
+      if (!cancelled) {
+        setRouteModel(nextRouteModel);
+        setLoading(false);
+      }
+    };
+
+    loadFlowModel();
+
+    return () => {
+      cancelled = true;
+      detachRuntimeContext();
+    };
+  }, [flowEngine, meta?.flowModel]);
+
+  const pageModel = getPublicFormPageModel(routeModel);
+
+  if (loading) {
+    return <Spin />;
+  }
+
+  if (!pageModel || !runtimeContextRef.current) {
+    return <UnFoundFormPlaceholder />;
+  }
+
+  return (
+    <FlowViewContextProvider context={runtimeContextRef.current}>
+      <FlowModelRenderer model={pageModel} showFlowSettings={false} />
+    </FlowViewContextProvider>
+  );
+}
+
 function InternalPublicForm() {
   const params = useParams();
+  const { t } = usePublicFormTranslation();
+  const [pwd, setPwd] = useState('');
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
   const { error, data, loading, run } = useRequest<any>(
     {
       url: `publicForms:getMeta/${params.name}`,
       skipAuth: true,
+      skipNotify: (nextError) => nextError?.response?.status === 401,
     },
     {
       onSuccess(data) {
+        setPasswordErrorMessage('');
         localStorage.setItem('NOCOBASE_FORM_TOKEN', data?.data?.token);
+      },
+      onError(nextError) {
+        if (nextError?.response?.status === 401) {
+          setPasswordErrorMessage(t('Incorrect password'));
+        }
       },
     },
   );
-  const [pwd, setPwd] = useState('');
   const ctx = useContext(SchemaComponentContext);
 
   useTitle(data);
+  useEffect(() => {
+    if (error?.['response']?.status === 401) {
+      setPasswordErrorMessage(t('Incorrect password'));
+    }
+  }, [error, t]);
   // 设置的移动端 meta
   useEffect(() => {
     if (!isDesktop) {
@@ -214,22 +498,36 @@ function InternalPublicForm() {
       <div>
         <Modal
           centered
-          title="Password"
+          title={t('Password')}
           open={true}
           cancelButtonProps={{
             hidden: true,
           }}
+          confirmLoading={loading}
           onOk={() => {
+            setPasswordErrorMessage('');
             run({
               password: pwd,
             });
           }}
         >
-          <Input.Password
-            onChange={(e) => {
-              setPwd(e.target.value);
-            }}
-          />
+          <Form layout="vertical">
+            <Form.Item
+              validateStatus={passwordErrorMessage ? 'error' : undefined}
+              help={passwordErrorMessage || undefined}
+              style={{ marginBottom: 0 }}
+            >
+              <Input.Password
+                value={pwd}
+                onChange={(e) => {
+                  setPwd(e.target.value);
+                  if (passwordErrorMessage) {
+                    setPasswordErrorMessage('');
+                  }
+                }}
+              />
+            </Form.Item>
+          </Form>
         </Modal>
       </div>
     );
@@ -245,6 +543,7 @@ function InternalPublicForm() {
   if (!data?.data) {
     return <UnEnabledFormPlaceholder />;
   }
+  const meta = data.data as PublicFormMeta;
   const components = isMobile ? mobileComponents : {};
   const containerHeight = getPublicFormContainerHeight();
   return (
@@ -278,17 +577,21 @@ function InternalPublicForm() {
               padding-top: 0px;
             `}
           >
-            <PublicPublicFormProvider dataSource={data?.data?.dataSource}>
-              <SchemaComponentContext.Provider value={{ ...ctx, designable: false }}>
-                <SchemaComponent
-                  schema={data?.data?.schema}
-                  scope={{
-                    useCreateActionProps: usePublicSubmitActionProps,
-                  }}
-                  components={{ PublicFormMessageProvider: PublicFormMessageProvider, ...components }}
-                />
-              </SchemaComponentContext.Provider>
-            </PublicPublicFormProvider>
+            {meta.flowModel ? (
+              <PublicFormFlowRuntime formKey={params.name} meta={meta} />
+            ) : (
+              <PublicPublicFormProvider dataSource={meta.dataSource}>
+                <SchemaComponentContext.Provider value={{ ...ctx, designable: false }}>
+                  <SchemaComponent
+                    schema={meta.schema}
+                    scope={{
+                      useCreateActionProps: usePublicSubmitActionProps,
+                    }}
+                    components={{ PublicFormMessageProvider: PublicFormMessageProvider, ...components }}
+                  />
+                </SchemaComponentContext.Provider>
+              </PublicPublicFormProvider>
+            )}
             <div style={{ marginBottom: '20px' }}>
               <PoweredBy />
             </div>

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/components/PublicFormPage.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/components/PublicFormPage.tsx
@@ -37,6 +37,7 @@ import {
   useRequest,
   VariablesProvider,
 } from '@nocobase/client';
+import type { ISchema } from '@nocobase/client';
 import { Form, Input, Modal, Spin } from 'antd';
 import { Button as MobileButton, Dialog as MobileDialog } from 'antd-mobile';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
@@ -192,8 +193,18 @@ type PublicFormDataSourceOptions = DataSourceOptions & {
 type PublicFormMeta = {
   dataSource?: PublicFormDataSourceOptions | null;
   flowModel?: CreateModelOptions | null;
-  schema?: unknown;
+  schema?: ISchema | null;
 };
+
+type ResponseErrorLike = {
+  response?: {
+    status?: number;
+  };
+};
+
+function getResponseStatus(error: unknown) {
+  return (error as ResponseErrorLike | null)?.response?.status;
+}
 
 type PublicFormRuntimeView = {
   type: 'embed';
@@ -450,7 +461,7 @@ function InternalPublicForm() {
     {
       url: `publicForms:getMeta/${params.name}`,
       skipAuth: true,
-      skipNotify: (nextError) => nextError?.response?.status === 401,
+      skipNotify: (nextError) => getResponseStatus(nextError) === 401,
     },
     {
       onSuccess(data) {
@@ -458,7 +469,7 @@ function InternalPublicForm() {
         localStorage.setItem('NOCOBASE_FORM_TOKEN', data?.data?.token);
       },
       onError(nextError) {
-        if (nextError?.response?.status === 401) {
+        if (getResponseStatus(nextError) === 401) {
           setPasswordErrorMessage(t('Incorrect password'));
         }
       },
@@ -468,7 +479,7 @@ function InternalPublicForm() {
 
   useTitle(data);
   useEffect(() => {
-    if (error?.['response']?.status === 401) {
+    if (getResponseStatus(error) === 401) {
       setPasswordErrorMessage(t('Incorrect password'));
     }
   }, [error, t]);
@@ -493,7 +504,7 @@ function InternalPublicForm() {
     }
   }, []);
 
-  if (error?.['response']?.status === 401 || data?.data?.passwordRequired) {
+  if (getResponseStatus(error) === 401 || data?.data?.passwordRequired) {
     return (
       <div>
         <Modal
@@ -533,7 +544,7 @@ function InternalPublicForm() {
     );
   }
 
-  if (error?.['response']?.status === 500) {
+  if (getResponseStatus(error) === 500) {
     return <UnFoundFormPlaceholder />;
   }
 
@@ -583,7 +594,7 @@ function InternalPublicForm() {
               <PublicPublicFormProvider dataSource={meta.dataSource}>
                 <SchemaComponentContext.Provider value={{ ...ctx, designable: false }}>
                   <SchemaComponent
-                    schema={meta.schema}
+                    schema={meta.schema || undefined}
                     scope={{
                       useCreateActionProps: usePublicSubmitActionProps,
                     }}

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/useSubmitActionProps.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/hooks/useSubmitActionProps.ts
@@ -9,9 +9,9 @@
 
 import { useForm } from '@formily/react';
 import { uid } from '@formily/shared';
+import { useFlowEngine } from '@nocobase/flow-engine';
 import {
   useActionContext,
-  useAPIClient,
   useBlockRequestContext,
   useCollection,
   useDataBlockResource,
@@ -19,42 +19,7 @@ import {
 } from '@nocobase/client';
 import { App as AntdApp } from 'antd';
 import PluginPublicFormsClient from '..';
-
-const initialSchema = (values, formSchema, t) => {
-  return {
-    type: 'void',
-    name: uid(),
-    'x-decorator': 'PublicFormMessageProvider',
-    properties: {
-      form: formSchema,
-      promptMessage: {
-        type: 'void',
-        'x-component': 'h3',
-        'x-component-props': {
-          style: { margin: '10px 0px 10px' },
-          children: '{{ t("Prompt after successful submission",{ns:"public-forms"})}}',
-        },
-      },
-      success: {
-        type: 'void',
-        'x-editable': false,
-        'x-toolbar-props': {
-          draggable: false,
-        },
-        'x-settings': 'blockSettings:publicMarkdown',
-        'x-component': 'Markdown.Void',
-        'x-decorator': 'CardItem',
-        'x-component-props': {
-          content: t('# Submitted successfully!\nThis is a demo text, **supports Markdown syntax**.'),
-        },
-        'x-decorator-props': {
-          name: 'markdown',
-          engine: 'handlebars',
-        },
-      },
-    },
-  };
-};
+import { ensurePublicFormFlowModel } from '../../client-v2/modelTree';
 
 export const useSubmitActionProps = () => {
   const { setVisible } = useActionContext();
@@ -62,8 +27,8 @@ export const useSubmitActionProps = () => {
   const form = useForm();
   const resource = useDataBlockResource();
   const collection = useCollection();
-  const api = useAPIClient();
   const plugin = usePlugin(PluginPublicFormsClient);
+  const flowEngine = useFlowEngine();
   const { service } = useBlockRequestContext();
 
   return {
@@ -75,33 +40,22 @@ export const useSubmitActionProps = () => {
         await resource.update({
           values: {
             ...values,
-            version: 'v1',
+            version: values.version || 'v1',
           },
           filterByTk: values[collection.filterTargetKey],
         });
       } else {
         const key = uid();
-        const uiSchemaCallback = plugin.getFormSchemaByType(values.type);
-        const keys = values.collection.split(':');
-        const collection = keys.pop();
-        const dataSource = keys.pop() || 'main';
-        const schema = initialSchema(
-          values,
-          uiSchemaCallback({
-            collection,
-            dataSource,
-          }),
-          plugin.t.bind(plugin),
-        );
-        schema['x-uid'] = key;
+        const nextRecord = {
+          ...values,
+          key,
+          type: values.type || 'form',
+          version: 'v2',
+        };
         await resource.create({
-          values: {
-            ...values,
-            key,
-            version: 'v1',
-          },
+          values: nextRecord,
         });
-        await api.resource('uiSchemas').insert({ values: schema });
+        await ensurePublicFormFlowModel(flowEngine, nextRecord, plugin.t.bind(plugin));
       }
       form.reset();
       await service.refresh();

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/index.tsx
@@ -16,6 +16,7 @@ const { PublicFormPage } = lazy(() => import('./components/PublicFormPage'), 'Pu
 import { formSchemaCallback } from './schemas/formSchemaCallback';
 import { publicFormBlockSettings, publicMarkdownBlockSettings } from './settings';
 import { NAMESPACE } from './locale';
+import { registerPublicFormV2ModelLoaders } from '../client-v2/modelLoaders';
 export class PluginPublicFormsClient extends Plugin {
   protected formTypes = new Map();
 
@@ -41,6 +42,8 @@ export class PluginPublicFormsClient extends Plugin {
   }
 
   async load() {
+    registerPublicFormV2ModelLoaders(this.app.flowEngine);
+
     this.app.schemaSettingsManager.add(publicFormBlockSettings);
     this.app.schemaSettingsManager.add(publicMarkdownBlockSettings);
 

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/publicForms.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client/schemas/publicForms.tsx
@@ -27,7 +27,7 @@ export const publicFormsSchema: ISchema = {
       sort: '-createdAt',
       appends: ['createdBy', 'updatedBy'],
       filter: {
-        $or: [{ version: 'v1' }, { 'version.$empty': true }],
+        $or: [{ version: 'v1' }, { version: 'v2' }, { 'version.$empty': true }],
       },
     },
     showIndex: true,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
公开表单的旧管理入口需要继续支持历史表单，但新增表单应统一使用新版表单能力。这样用户可以在旧入口中看到和配置已有的旧表单，也可以创建、配置和打开新版公开表单。

### Description
本次调整让旧管理入口可以混合展示旧版、历史未标记版本和新版公开表单。旧入口新增公开表单时会创建新版表单，并使用新版配置能力。

旧入口打开公开表单配置页时，会根据表单版本展示对应的配置界面。公开访问页也会根据接口返回内容展示旧版表单或新版表单，确保从旧入口创建的新版表单可以正常访问。

已补充相关单元测试，覆盖列表、创建、配置页分流、公开访问页分流，以及新版入口的回归场景。

### Showcase
无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | In the v1 public form, support creating v2 forms and prohibit creating v1 forms |
| 🇨🇳 Chinese | 在 v1 公开表单中支持创建 v2 的表单，禁止创建 v1 的表单 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
