### PR TITLE
fix(plugin-workflow): handle manual execution without trigger

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -97,7 +97,14 @@ function ExecutedStatusMessage({ data, option }) {
   );
 }
 
-function getExecutedStatusMessage({ id, status }) {
+function getExecutedStatusMessage(execution) {
+  if (!execution) {
+    return {
+      type: 'info' as NoticeType,
+      content: lang('Workflow was not triggered because the current request did not meet the trigger requirements.'),
+    };
+  }
+  const { id, status } = execution;
   const option = ExecutionStatusOptionsMap[status];
   if (!option) {
     return null;

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/de-DE.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/de-DE.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Wird im Hintergrund als Aufgabe in der Warteschlange ausgeführt.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow ausgeführt, der Ergebnisstatus ist <1>{{statusText}}</1><2>Ausführung anzeigen</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Der Workflow wurde nicht ausgelöst, weil die aktuelle Anfrage die Auslöseanforderungen nicht erfüllt.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow-Aufgaben",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/en-US.json
@@ -261,6 +261,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Workflow was not triggered because the current request did not meet the trigger requirements.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/es-ES.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/es-ES.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Flujo de trabajo",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "El flujo de trabajo no se activó porque la solicitud actual no cumplió los requisitos del desencadenador.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/fr-FR.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/fr-FR.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Le workflow n’a pas été déclenché, car la requête actuelle ne répond pas aux exigences du déclencheur.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/hu-HU.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/hu-HU.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "A háttérben sorba állított feladatként kerül végrehajtásra.",
   "Workflow": "Munkafolyamat",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Munkafolyamat végrehajtva, az eredmény állapota: <1>{{statusText}}</1><2>Végrehajtás megtekintése</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "A munkafolyamat nem indult el, mert az aktuális kérés nem felelt meg az indítási feltételeknek.",
   "Workflow is not exists": "Workflow is not exists",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Munkafolyamat teendők",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/id-ID.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/id-ID.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Akan dieksekusi di latar belakang sebagai tugas antrean.",
   "Workflow": "Alur kerja",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Alur kerja dieksekusi, status hasilnya adalah <1>{{statusText}}</1><2>Lihat eksekusi</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Alur kerja tidak dipicu karena permintaan saat ini tidak memenuhi persyaratan pemicu.",
   "Workflow is not exists": "Workflow is not exists",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Tugas alur kerja",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/it-IT.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/it-IT.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Verrà eseguito in background come attività in coda.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow eseguito, lo stato del risultato è <1>{{statusText}}</1><2>Visualizza l'esecuzione</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Il workflow non è stato attivato perché la richiesta corrente non soddisfa i requisiti del trigger.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Da fare",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/ja-JP.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/ja-JP.json
@@ -253,6 +253,7 @@
   "Will be executed in the background as a queued task.": "キュータスクとしてバックグラウンドで実行されます。",
   "Workflow": "ワークフロー",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "ワークフローが実行されました。結果ステータス: <1>{{statusText}}</1><2>実行詳細を表示</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "現在のリクエストがトリガー要件を満たしていないため、ワークフローはトリガーされませんでした。",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "ワークフロー対応事項",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/ko-KR.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/ko-KR.json
@@ -269,6 +269,7 @@
   "Will be executed in the background as a queued task.": "백그라운드에서 대기 작업으로 실행됩니다.",
   "Workflow": "워크플로우",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "워크플로우가 실행되었습니다. 결과 상태는 <1>{{statusText}}</1><2>실행 보기</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "현재 요청이 트리거 요구 사항을 충족하지 않아 워크플로우가 트리거되지 않았습니다.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "워크플로우 할 일",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/nl-NL.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/nl-NL.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "De workflow is niet geactiveerd omdat de huidige aanvraag niet aan de triggervereisten voldoet.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/pt-BR.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/pt-BR.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Fluxo de trabalho",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "O workflow não foi acionado porque a solicitação atual não atende aos requisitos do gatilho.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/ru-RU.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/ru-RU.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Будет выполнен в фоновом режиме как задача в очереди.",
   "Workflow": "Рабочий процесс",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Рабочий процесс выполнен, статус результата: <1>{{statusText}}</1><2>Посмотреть выполнение</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Рабочий процесс не был запущен, так как текущий запрос не соответствует требованиям триггера.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Задачи рабочего процесса",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/tr-TR.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/tr-TR.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "İş Akışı",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Geçerli istek tetikleme gereksinimlerini karşılamadığı için iş akışı tetiklenmedi.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/uk-UA.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/uk-UA.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Робочий процес не було запущено, оскільки поточний запит не відповідає вимогам тригера.",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/vi-VN.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/vi-VN.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "Quy trình làm việc không được kích hoạt vì yêu cầu hiện tại không đáp ứng các điều kiện kích hoạt.",
   "Workflow is not exists": "Workflow is not exists",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-CN.json
@@ -270,6 +270,7 @@
   "Will be executed in the background as a queued task.": "将作为队列任务在后台执行。",
   "Workflow": "工作流",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "工作流已执行，结果状态为 <1>{{statusText}}</1><2>查看执行详情</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "当前请求未满足触发要求，工作流未触发。",
   "Workflow of execution is not existed": "执行计划对应的工作流不存在",
   "Workflow tasks": "流程待办",
   "Workflow todos": "流程待办",

--- a/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-TW.json
+++ b/packages/plugins/@nocobase/plugin-workflow/src/locale/zh-TW.json
@@ -251,6 +251,7 @@
   "Will be executed in the background as a queued task.": "Will be executed in the background as a queued task.",
   "Workflow": "Workflow",
   "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>": "Workflow executed, the result status is <1>{{statusText}}</1><2>View the execution</2>",
+  "Workflow was not triggered because the current request did not meet the trigger requirements.": "目前請求未滿足觸發要求，工作流未觸發。",
   "Workflow of execution is not existed": "Workflow of execution is not existed",
   "Workflow tasks": "Workflow tasks",
   "Workflow todos": "Workflow todos",

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -902,6 +902,38 @@ describe('workflow > triggers > collection', () => {
       expect(e2s[0].toJSON()).toMatchObject(data.execution);
       expect(data.execution.status).toBe(EXECUTION_STATUS.RESOLVED);
     });
+
+    it('should not fail when manually executed data does not match condition', async () => {
+      const workflow = await WorkflowModel.create({
+        type: 'collection',
+        sync: true,
+        config: {
+          mode: 1,
+          collection: 'posts',
+          condition: {
+            id: -1,
+          },
+        },
+      });
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+
+      const {
+        status,
+        body: { data },
+      } = await agent.resource('workflows').execute({
+        filterByTk: workflow.id,
+        values: {
+          data: post.toJSON(),
+        },
+      });
+
+      expect(status).toBe(200);
+      expect(data.execution).toBeNull();
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(0);
+    });
   });
 
   describe('cycling trigger', () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
@@ -185,6 +185,12 @@ export async function execute(context: Context, next) {
   let processor;
   try {
     processor = (await plugin.execute(workflow, values, { manually: true })) as Processor;
+    if (processor === null) {
+      context.body = {
+        execution: null,
+      };
+      return next();
+    }
     if (!processor) {
       return context.throw(400, 'workflow not triggered');
     }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -302,6 +302,9 @@ export default class CollectionTrigger extends Trigger {
 
   async execute(workflow: WorkflowModel, values, options: EventOptions) {
     const ctx = await this.prepare(workflow, values?.data, options);
+    if (!ctx) {
+      return null;
+    }
     const [dataSourceName] = parseCollectionName(workflow.config.collection);
     const { transaction } = options;
     return this.workflow.trigger(workflow, ctx, {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/index.ts
@@ -51,7 +51,7 @@ export abstract class Trigger {
     workflow: WorkflowModel,
     values: any,
     options: Transactionable,
-  ): void | Processor | Promise<void | Processor>;
+  ): void | Processor | null | Promise<void | Processor | null>;
 }
 
 export default Trigger;

--- a/packages/plugins/@nocobase/plugin-workflow/src/swagger/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/swagger/index.ts
@@ -407,7 +407,8 @@ export default {
           '**autoRevision:** When set to `1`, if the workflow has never been executed',
           '(`executed === 0`), a new revision is created automatically after execution.',
           '',
-          '**Returns:** `{ execution: { id, status }, newVersionId? }`',
+          '**Returns:** `{ execution: { id, status } | null, newVersionId? }`.',
+          '`execution` is `null` when the request is valid but no execution is started.',
         ].join('\n'),
         parameters: [
           {
@@ -447,6 +448,7 @@ export default {
                   properties: {
                     execution: {
                       type: 'object',
+                      nullable: true,
                       properties: {
                         id: { type: 'integer', description: 'Execution ID' },
                         status: { type: 'integer', description: 'Execution status code' },
@@ -463,7 +465,7 @@ export default {
             },
           },
           400: {
-            description: 'Bad Request. Request body or `filterByTk` is missing/invalid, or workflow not triggered.',
+            description: 'Bad Request. Request body or `filterByTk` is missing/invalid.',
           },
           404: { description: 'Not Found. Workflow does not exist.' },
         },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Manual execution of a collection-event workflow could return a BadRequest error when the trigger validation completed successfully but the trigger did not actually start an execution, for example when the selected record did not match the configured trigger condition.

### Description
This PR updates manual workflow execution so a valid request that does not start an execution returns `execution: null` instead of failing with `workflow not triggered`.

It also:
- avoids dispatching collection-trigger workflows when prepared context is empty
- shows a generic "not triggered" message in the workflow canvas
- documents `execution: null` in the workflow execute API
- adds a server test for manually executing collection-trigger workflows with unmatched trigger conditions
- adds translations for the new generic message

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed manual workflow execution returning an error when a valid request does not start an execution. |
| 🇨🇳 Chinese | 修复手动执行工作流时，请求有效但未启动执行会返回错误的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
