### PR TITLE
fix(flow-engine): prevent typing after variable selection

### DIFF
--- a/packages/core/flow-engine/src/components/variables/VariableInput.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableInput.tsx
@@ -329,6 +329,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
         ...baseProps,
         onClear: handleClear,
         disabled,
+        allowCustomTagInput: false,
         metaTreeNode: resolvedMetaTreeNode,
         metaTree,
         style: stableProps.style,

--- a/packages/core/flow-engine/src/components/variables/VariableTag.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableTag.tsx
@@ -23,6 +23,7 @@ const VariableTagComponent: React.FC<VariableTagProps> = ({
   value,
   onClear,
   disabled = false,
+  allowCustomTagInput = true,
   className,
   style,
   metaTreeNode,
@@ -177,8 +178,10 @@ const VariableTagComponent: React.FC<VariableTagProps> = ({
         ...style,
       }}
       value={displayState?.text ? [displayState.text] : []}
-      mode="tags"
+      mode={allowCustomTagInput ? 'tags' : 'multiple'}
       open={false}
+      showSearch={allowCustomTagInput}
+      searchValue={allowCustomTagInput ? undefined : ''}
       allowClear={!disabled && !!onClear}
       onClear={disabled ? undefined : onClear}
       disabled={disabled || !onClear}

--- a/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
@@ -155,6 +155,27 @@ describe('VariableInput', () => {
     expect(selectorButton.className).toContain('ant-btn-primary');
   });
 
+  it('disables custom tag input when rendering a selected variable', async () => {
+    const flowContext = createTestFlowContext();
+    const { container } = render(
+      <TestFlowContextWrapper context={flowContext}>
+        <VariableInput value="{{ ctx.user.name }}" metaTree={() => flowContext.getPropertyMetaTree()} />
+      </TestFlowContextWrapper>,
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('User/Name')).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const selectElement = container.querySelector('.ant-select.variable');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).not.toHaveClass('ant-select-show-search');
+    expect(container.querySelector('.ant-select-selection-search-input')).toHaveAttribute('readonly');
+  });
+
   it('should render FlowContextSelector button', async () => {
     const flowContext = createTestFlowContext();
     render(

--- a/packages/core/flow-engine/src/components/variables/__tests__/VariableTag.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/VariableTag.test.tsx
@@ -54,6 +54,44 @@ describe('VariableTag', () => {
     expect(onClear).toBeInstanceOf(Function);
   });
 
+  it('keeps custom tag input enabled by default', async () => {
+    const onClear = vi.fn();
+    const { container } = renderWithCtx(<VariableTag value="{{ ctx.User.Email }}" onClear={onClear} />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('User/Email')).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const selectElement = container.querySelector('.ant-select.variable');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).toHaveClass('ant-select-show-search');
+    expect(container.querySelector('.ant-select-selection-search-input')).not.toHaveAttribute('readonly');
+  });
+
+  it('can disable custom tag input while keeping clear enabled', async () => {
+    const onClear = vi.fn();
+    const { container } = renderWithCtx(
+      <VariableTag value="{{ ctx.User.Email }}" onClear={onClear} allowCustomTagInput={false} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('User/Email')).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const selectElement = container.querySelector('.ant-select.variable');
+    expect(selectElement).toBeInTheDocument();
+    expect(selectElement).not.toHaveClass('ant-select-disabled');
+    expect(selectElement).not.toHaveClass('ant-select-show-search');
+    expect(container.querySelector('.ant-select-clear')).toBeInTheDocument();
+    expect(container.querySelector('.ant-select-selection-search-input')).toHaveAttribute('readonly');
+  });
+
   it('should not show close button when onClear is not provided', async () => {
     const { container } = renderWithCtx(<VariableTag value="{{ ctx.User.Name }}" />);
 

--- a/packages/core/flow-engine/src/components/variables/types.ts
+++ b/packages/core/flow-engine/src/components/variables/types.ts
@@ -96,6 +96,7 @@ export interface VariableTagProps {
   value?: string;
   onClear?: () => void;
   disabled?: boolean;
+  allowCustomTagInput?: boolean;
   className?: string;
   style?: React.CSSProperties;
   metaTreeNode?: MetaTreeNode | null;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When a variable is selected through `VariableInput`, the rendered variable tag still allowed users to type additional custom text because `VariableTag` uses Ant Design `Select` in `tags` mode. In v2 workflow field assignment, this made fields accept mixed manual text after selecting a variable, which should be a single variable/constant value instead.

### Description 
- Added `allowCustomTagInput` to `VariableTag`, defaulting to `true` to preserve existing direct `VariableTag` behavior.
- Updated `VariableInput` so selected variable tags disable custom tag input while still allowing clear/reselect.
- Added tests covering both the preserved default `VariableTag` behavior and the tightened `VariableInput` variable-tag behavior.

Potential risk: all `VariableInput` variable-state displays now prevent extra custom typing after a selected variable. This is intentional for single-value variable inputs. Direct `VariableTag` usage keeps the legacy behavior by default.

Testing suggestions: verify v2 workflow update/create field assignment values, flow filters/linkage filters, default values, and assign-form variable value inputs can select and clear variables but cannot append manual text after a selected variable.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where users could type extra text after selecting a variable in single-value variable inputs. |
| 🇨🇳 Chinese | 修复单值变量输入框选择变量后仍可继续输入额外文本的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary