### PR TITLE
fix(client): use app public path when CDN base is empty

### DIFF
--- a/packages/core/app/client-v2/src/__tests__/runtimePublicPath.test.ts
+++ b/packages/core/app/client-v2/src/__tests__/runtimePublicPath.test.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { resolveRuntimeAssetPublicPath } from '../runtimePublicPath';
+
+describe('resolveRuntimeAssetPublicPath', () => {
+  it('should append the fixed build asset directory to the CDN base URL', () => {
+    expect(resolveRuntimeAssetPublicPath('https://cdn.nocobase.com/dist/2.1.22/', '/v/', 'v')).toBe(
+      'https://cdn.nocobase.com/dist/2.1.22/v/',
+    );
+  });
+
+  it('should use the modern client public path when the CDN base URL is empty', () => {
+    expect(resolveRuntimeAssetPublicPath('', '/v/', 'v')).toBe('/v/');
+  });
+
+  it('should use APP_PUBLIC_PATH plus the runtime modern prefix when the CDN base URL is empty', () => {
+    expect(resolveRuntimeAssetPublicPath('', '/custom-base/modern/', 'v')).toBe('/custom-base/modern/');
+  });
+});

--- a/packages/core/app/client-v2/src/main.tsx
+++ b/packages/core/app/client-v2/src/main.tsx
@@ -10,6 +10,7 @@
 import { Application, getModernClientPrefix } from '@nocobase/client-v2';
 import devDynamicImport from './.plugins';
 import { NocoBaseClientPresetPluginV2 } from '@nocobase/preset-nocobase/client-v2';
+import { resolveRuntimeAssetPublicPath } from './runtimePublicPath';
 
 declare global {
   interface Window {
@@ -113,9 +114,7 @@ function getBuildAssetDir() {
 declare let __webpack_public_path__: string;
 const cdnBase = window.__webpack_public_path__;
 // eslint-disable-next-line prefer-const
-__webpack_public_path__ = cdnBase
-  ? ensureSlash(`${cdnBase.replace(/\/$/, '')}/${getBuildAssetDir()}/`, '/')
-  : v2PublicPath;
+__webpack_public_path__ = resolveRuntimeAssetPublicPath(cdnBase, v2PublicPath, getBuildAssetDir());
 
 const app = new Application({
   publicPath: v2PublicPath,

--- a/packages/core/app/client-v2/src/runtimePublicPath.ts
+++ b/packages/core/app/client-v2/src/runtimePublicPath.ts
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+function normalizePublicPath(value: string, fallback: string) {
+  let normalized = value.trim() || fallback;
+  if (!normalized.endsWith('/')) {
+    normalized = `${normalized}/`;
+  }
+  return normalized;
+}
+
+export function resolveRuntimeAssetPublicPath(
+  cdnPublicPath: string | undefined,
+  appPublicPath: string,
+  buildAssetDir: string,
+) {
+  const normalizedAppPublicPath = normalizePublicPath(appPublicPath, '/');
+  const normalizedCdnPublicPath = cdnPublicPath?.trim();
+  if (!normalizedCdnPublicPath) {
+    return normalizedAppPublicPath;
+  }
+
+  const normalizedBuildAssetDir = buildAssetDir.replace(/^\/+|\/+$/g, '');
+  return normalizePublicPath(
+    `${normalizedCdnPublicPath.replace(/\/+$/, '')}/${normalizedBuildAssetDir}/`,
+    normalizedAppPublicPath,
+  );
+}

--- a/packages/core/app/client/src/__tests__/runtimePublicPath.test.ts
+++ b/packages/core/app/client/src/__tests__/runtimePublicPath.test.ts
@@ -11,13 +11,23 @@ import { resolveRuntimeAssetPublicPath } from '../runtimePublicPath';
 
 describe('resolveRuntimeAssetPublicPath', () => {
   it('should prefer the injected window public path over an auto-detected runtime path', () => {
-    expect(resolveRuntimeAssetPublicPath('/dist/2.1.8/', 'https://static.cloudflareinsights.com/assets/../')).toBe(
+    expect(resolveRuntimeAssetPublicPath('/dist/2.1.8/', '/', 'https://static.cloudflareinsights.com/assets/../')).toBe(
       '/dist/2.1.8/',
     );
   });
 
-  it('should fall back to the runtime public path when the injected value is missing', () => {
-    expect(resolveRuntimeAssetPublicPath(undefined, 'https://cdn.nocobase.com/dist/2.1.8/')).toBe(
+  it('should use the app public path when the CDN base URL is empty', () => {
+    expect(resolveRuntimeAssetPublicPath('', '/', 'https://static.cloudflareinsights.com/assets/../')).toBe('/');
+  });
+
+  it('should use the configured APP_PUBLIC_PATH when the CDN base URL is empty', () => {
+    expect(resolveRuntimeAssetPublicPath('', '/custom-base/', 'https://static.cloudflareinsights.com/assets/../')).toBe(
+      '/custom-base/',
+    );
+  });
+
+  it('should fall back to the runtime public path when the injected paths are missing', () => {
+    expect(resolveRuntimeAssetPublicPath(undefined, undefined, 'https://cdn.nocobase.com/dist/2.1.8/')).toBe(
       'https://cdn.nocobase.com/dist/2.1.8/',
     );
   });

--- a/packages/core/app/client/src/runtimePublicPath.ts
+++ b/packages/core/app/client/src/runtimePublicPath.ts
@@ -9,6 +9,7 @@
 
 declare global {
   interface Window {
+    __nocobase_public_path__?: string;
     __webpack_public_path__?: string;
   }
 }
@@ -22,10 +23,14 @@ function normalizePublicPath(value: string | undefined, fallback = '/') {
 }
 
 export function resolveRuntimeAssetPublicPath(
-  windowPublicPath: string | undefined,
+  cdnPublicPath: string | undefined,
+  appPublicPath: string | undefined,
   runtimePublicPath: string | undefined,
 ) {
-  return normalizePublicPath(windowPublicPath, normalizePublicPath(runtimePublicPath, '/'));
+  return normalizePublicPath(
+    cdnPublicPath,
+    normalizePublicPath(appPublicPath, normalizePublicPath(runtimePublicPath, '/')),
+  );
 }
 
 // `__webpack_public_path__` is a webpack magic global that must be assigned
@@ -36,5 +41,9 @@ const runtimePublicPath = typeof __webpack_public_path__ === 'string' ? __webpac
 
 if (typeof window !== 'undefined' && typeof __webpack_public_path__ !== 'undefined') {
   // eslint-disable-next-line prefer-const
-  __webpack_public_path__ = resolveRuntimeAssetPublicPath(window.__webpack_public_path__, runtimePublicPath);
+  __webpack_public_path__ = resolveRuntimeAssetPublicPath(
+    window.__webpack_public_path__,
+    window.__nocobase_public_path__,
+    runtimePublicPath,
+  );
 }

--- a/packages/core/client-v2/src/BaseApplication.tsx
+++ b/packages/core/client-v2/src/BaseApplication.tsx
@@ -34,6 +34,7 @@ import { SystemSettingsSource } from './flow/system-settings';
 import { LayoutManager } from './layout-manager/LayoutManager';
 import type { PluginClass, PluginManager, PluginType } from './PluginManager';
 import { RouteRepository } from './RouteRepository';
+import { stripModernClientPrefix } from './authRedirect';
 import type {
   ComponentTypeAndString,
   RenderableComponentType,
@@ -436,7 +437,7 @@ export abstract class BaseApplication<
   }
 
   getCdnUrl() {
-    return ensureTrailingSlash(window['__webpack_public_path__'] || this.getPublicPath());
+    return ensureTrailingSlash(window['__webpack_public_path__'] || stripModernClientPrefix(this.getPublicPath()));
   }
 
   getPublicPath() {

--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -35,6 +35,7 @@ describe('app', () => {
       document.querySelectorAll('link[rel="shortcut icon"]').forEach((node) => node.remove());
       document.documentElement.removeAttribute('lang');
       delete window['__webpack_public_path__'];
+      delete window['__nocobase_modern_client_prefix__'];
       vi.restoreAllMocks();
     });
 
@@ -82,6 +83,34 @@ describe('app', () => {
 
       window['__webpack_public_path__'] = '/cdn/assets';
       expect(app.getCdnUrl()).toBe('/cdn/assets/');
+    });
+
+    it('should remove the modern client prefix from the CDN fallback path', () => {
+      const app = new Application({
+        router,
+        publicPath: '/v/',
+      });
+
+      expect(app.getCdnUrl()).toBe('/');
+    });
+
+    it('should preserve APP_PUBLIC_PATH when removing the modern client prefix', () => {
+      const app = new Application({
+        router,
+        publicPath: '/nocobase/v/',
+      });
+
+      expect(app.getCdnUrl()).toBe('/nocobase/');
+    });
+
+    it('should support a custom modern client prefix', () => {
+      window['__nocobase_modern_client_prefix__'] = 'modern';
+      const app = new Application({
+        router,
+        publicPath: '/nocobase/modern/',
+      });
+
+      expect(app.getCdnUrl()).toBe('/nocobase/');
     });
 
     it('should apply the provided favicon immediately', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When `CDN_BASE_URL` is empty, automatic public-path detection can be affected by externally injected scripts, causing lazy-loaded assets to be requested from an incorrect domain.

### Description

- Make the legacy client fall back to `APP_PUBLIC_PATH` when the CDN base URL is empty.
- Make the modern client use its independent runtime public path while preserving the fixed CDN build directory `v/`.
- Add regression tests for root paths, custom application paths, CDN paths, and polluted runtime paths.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix lazy-loaded assets using an external script URL when `CDN_BASE_URL` is empty. |
| 🇨🇳 Chinese | 修复 `CDN_BASE_URL` 为空时异步资源错误使用外部脚本地址的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
