### PR TITLE
fix(plugin-workflow): render unsupported nodes as normal cards

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/Node.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/Node.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { Suspense, lazy, useCallback, useMemo, useState } from 'react';
-import { Button, Dropdown, Input, Skeleton, Tag, Tooltip } from 'antd';
+import { Button, Dropdown, Input, Skeleton, Tag } from 'antd';
 import { CloseOutlined, CopyOutlined, DeleteOutlined, EllipsisOutlined } from '@ant-design/icons';
 import { useFlowEngine } from '@nocobase/flow-engine';
 import { NodeContext, useFlowContext, useWorkflowCanvasExecuted } from './contexts';
@@ -136,8 +136,8 @@ function isInteractiveClickTarget(target: EventTarget | null): boolean {
  * `ComponentLoader` can reuse the exact card and append its own subtree after it
  * (e.g. the condition node's Yes/No branches). `cardExtra` is an internal slot
  * for node-specific notices inside the card, directly after the title — the v2
- * mirror of v1's `NodeDefaultView` (doc §9.5, ADR-0003). Assumes the type is
- * registered; the unregistered placeholder is handled by `NodeCard`.
+ * mirror of v1's `NodeDefaultView` (doc §9.5, ADR-0003). Unregistered types
+ * still render with the same card chrome, but do not open the config drawer.
  */
 export function NodeDefaultView({
   cardExtra,
@@ -161,6 +161,9 @@ export function NodeDefaultView({
   const isDraggingSelf = Boolean(dragContext?.dragging && dragContext?.dragNode?.id === data.id);
 
   const openConfig = useCallback(() => {
+    if (!instruction) {
+      return;
+    }
     openNodeConfigDrawer({ ctx: flowEngine.context, data, instruction, t, workflow, refresh });
   }, [flowEngine, data, instruction, t, workflow, refresh]);
 
@@ -176,7 +179,7 @@ export function NodeDefaultView({
     [data, dragContext],
   );
 
-  const typeTitle = t(instruction?.title as string);
+  const typeTitle = instruction ? t(instruction.title as string) : t('Unsupported node');
 
   return (
     <div className={cx(styles.nodeClass, nodeTypeClassName(data.type))}>
@@ -185,6 +188,7 @@ export function NodeDefaultView({
         role="button"
         aria-label={`${typeTitle}-${data.title ?? data.id}`}
         onMouseDown={onCardMouseDown}
+        aria-disabled={!instruction}
         onClick={(ev) => {
           // A drag just ended → swallow the click so it doesn't open the drawer.
           if (dragContext?.consumeClick?.()) {
@@ -198,7 +202,9 @@ export function NodeDefaultView({
       >
         <div className={styles.nodeHeaderClass}>
           <div className={cx(styles.nodeMetaClass, 'workflow-node-meta')}>
-            <Tag icon={instruction?.icon}>{typeTitle}</Tag>
+            <Tag icon={instruction?.icon} color={instruction ? undefined : 'error'}>
+              {typeTitle}
+            </Tag>
             <span className="workflow-node-id">{data.id}</span>
           </div>
           <div className="workflow-node-actions">
@@ -215,8 +221,6 @@ export function NodeDefaultView({
 }
 
 function NodeCard({ data }: { data: any }) {
-  const { styles, cx } = useStyles();
-  const t = useT();
   const instruction = useInstruction(data.type);
 
   const Rendered = useMemo(() => {
@@ -226,23 +230,9 @@ function NodeCard({ data }: { data: any }) {
     return null;
   }, [instruction]);
 
-  // Unregistered in v2 (only implemented in v1) → placeholder card, topology intact.
+  // Unregistered in v2 (only implemented in v1) → keep the normal card actions and title editing, but disable config.
   if (!instruction) {
-    return (
-      <div className={cx(styles.nodeClass, nodeTypeClassName(data.type))}>
-        <Tooltip title={t('This node type is not available in the new canvas yet.')}>
-          <div className={cx(styles.nodeCardClass, 'invalid')}>
-            <div className={styles.nodeHeaderClass}>
-              <div className={cx(styles.nodeMetaClass, 'workflow-node-meta')}>
-                <Tag color="warning">{t('Unsupported node')}</Tag>
-                <span className="workflow-node-id">{data.id}</span>
-              </div>
-            </div>
-            <Input.TextArea value={data.title ?? `#${data.id}`} disabled autoSize />
-          </div>
-        </Tooltip>
-      </div>
-    );
+    return <NodeDefaultView data={data} />;
   }
 
   // Branch nodes self-render via ComponentLoader (it draws its own card by wrapping `NodeDefaultView` and appending

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/Node.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/Node.test.tsx
@@ -7,10 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NodeDefaultView } from '../Node';
+
+const openNodeConfigDrawerMock = vi.hoisted(() => vi.fn());
+const useInstructionMock = vi.hoisted(() => vi.fn());
+const requestRemoveMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@nocobase/flow-engine', () => ({
   useFlowEngine: () => ({
@@ -55,9 +59,7 @@ vi.mock('../style', () => ({
 }));
 
 vi.mock('../useWorkflowInstruction', () => ({
-  useInstruction: () => ({
-    title: 'Approval',
-  }),
+  useInstruction: useInstructionMock,
 }));
 
 vi.mock('../NodeClipboardContext', () => ({
@@ -69,11 +71,13 @@ vi.mock('../NodeDragContext', () => ({
 }));
 
 vi.mock('../RemoveNodeContext', () => ({
-  useRemoveNodeContext: () => null,
+  useRemoveNodeContext: () => ({
+    requestRemove: requestRemoveMock,
+  }),
 }));
 
 vi.mock('../NodeConfigDrawer', () => ({
-  openNodeConfigDrawer: vi.fn(),
+  openNodeConfigDrawer: openNodeConfigDrawerMock,
 }));
 
 vi.mock('../JobButton', () => ({
@@ -81,6 +85,14 @@ vi.mock('../JobButton', () => ({
 }));
 
 describe('NodeDefaultView', () => {
+  beforeEach(() => {
+    openNodeConfigDrawerMock.mockClear();
+    requestRemoveMock.mockClear();
+    useInstructionMock.mockReturnValue({
+      title: 'Approval',
+    });
+  });
+
   it('renders card extra content inside the node card after the title while keeping children outside', () => {
     const { container } = render(
       <NodeDefaultView
@@ -98,5 +110,20 @@ describe('NodeDefaultView', () => {
     expect(nodeCard).toContainElement(cardExtra);
     expect(nodeCard).not.toContainElement(children);
     expect(nodeCard.lastElementChild).toBe(cardExtra);
+  });
+
+  it('renders unsupported node types as a normal card without opening the config drawer', () => {
+    useInstructionMock.mockReturnValue(undefined);
+
+    const { container } = render(<NodeDefaultView data={{ id: 13, title: 'Legacy node', type: 'legacy' }} />);
+
+    const nodeCard = container.querySelector('.node-card') as HTMLElement;
+
+    expect(screen.getByText('Unsupported node')).toBeInTheDocument();
+    expect(container.querySelector('.workflow-node-action-button')).toBeInTheDocument();
+
+    fireEvent.click(nodeCard);
+
+    expect(openNodeConfigDrawerMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow v2 canvas nodes with unsupported types were rendered as simplified placeholder cards. The placeholder did not keep the normal node action menu, so users could not handle unsupported nodes consistently from the canvas.

### Description
This PR updates unsupported workflow v2 canvas nodes to reuse the normal node card rendering. The node type tag is shown as `Unsupported node`, while normal card actions such as copy, delete, title editing, and job result entry remain available.

The node configuration drawer remains disabled for unsupported node types because there is no registered instruction or migrated configuration UI for them.

Tested with:
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/Node.test.tsx --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/Node.tsx packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/Node.test.tsx`

### Related issues
Task: 5115

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Unsupported workflow v2 canvas nodes now keep the normal node card actions while showing the node type as unsupported. |
| 🇨🇳 Chinese | 工作流 v2 画布中暂不支持的节点现在会保留普通节点卡片操作，并将节点类型显示为暂不支持。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
