### PR TITLE
fix(server): add fallback app manifest storage

### DIFF
--- a/packages/core/server/src/__tests__/app-supervisor/app-manifest.test.ts
+++ b/packages/core/server/src/__tests__/app-supervisor/app-manifest.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppSupervisor } from '../../app-supervisor';
+import type { AppDiscoveryAdapter } from '../../app-supervisor';
+
+describe('AppSupervisor app manifests', () => {
+  let supervisor: AppSupervisor | undefined;
+
+  afterEach(async () => {
+    await supervisor?.destroy();
+    supervisor = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('stores manifests in the supervisor when the discovery adapter has no custom implementation', async () => {
+    supervisor = AppSupervisor.getInstance();
+    const customerPortal = {
+      uid: 'customer',
+      routePath: '/customer',
+    };
+    const partnerPortal = {
+      uid: 'partner',
+      routePath: '/partner',
+    };
+
+    await supervisor.setAppManifestItem('main', 'multi-portal', 'customer', customerPortal);
+    await supervisor.setAppManifestItem('alpha', 'multi-portal', 'partner', partnerPortal);
+
+    await expect(supervisor.getAppManifestItems('main', 'multi-portal')).resolves.toEqual([customerPortal]);
+    await expect(supervisor.getAppManifests('multi-portal', ['main', 'alpha', 'beta'])).resolves.toEqual({
+      main: [customerPortal],
+      alpha: [partnerPortal],
+    });
+
+    await supervisor.removeAppManifestItem('main', 'multi-portal', 'customer');
+    await expect(supervisor.getAppManifestItems('main', 'multi-portal')).resolves.toEqual([]);
+
+    await supervisor.removeAppManifest('alpha', 'multi-portal');
+    await expect(supervisor.getAppManifestItems('alpha', 'multi-portal')).resolves.toEqual([]);
+  });
+
+  it('prefers manifest methods implemented by the discovery adapter', async () => {
+    supervisor = AppSupervisor.getInstance();
+    const customItem = {
+      uid: 'shared',
+      routePath: '/shared',
+    };
+    const adapter: AppDiscoveryAdapter = {
+      name: 'custom',
+      setAppLastSeenAt: vi.fn(),
+      getAppLastSeenAt: vi.fn(() => null),
+      getAppStatus: vi.fn(() => null),
+      setAppStatus: vi.fn(),
+      setAppManifestItem: vi.fn(async () => undefined),
+      removeAppManifestItem: vi.fn(async () => undefined),
+      removeAppManifest: vi.fn(async () => undefined),
+      getAppManifestItems: vi.fn(async () => [customItem]),
+      getAppManifests: vi.fn(async () => ({ main: [customItem] })),
+    };
+    Reflect.set(supervisor, 'discoveryAdapter', adapter);
+
+    await supervisor.setAppManifestItem('main', 'multi-portal', 'shared', customItem);
+    await supervisor.removeAppManifestItem('main', 'multi-portal', 'shared');
+    await supervisor.removeAppManifest('main', 'multi-portal');
+
+    await expect(supervisor.getAppManifestItems('main', 'multi-portal')).resolves.toEqual([customItem]);
+    await expect(supervisor.getAppManifests('multi-portal', ['main'])).resolves.toEqual({ main: [customItem] });
+
+    expect(adapter.setAppManifestItem).toHaveBeenCalledWith('main', 'multi-portal', 'shared', customItem);
+    expect(adapter.removeAppManifestItem).toHaveBeenCalledWith('main', 'multi-portal', 'shared');
+    expect(adapter.removeAppManifest).toHaveBeenCalledWith('main', 'multi-portal');
+    expect(adapter.getAppManifestItems).toHaveBeenCalledWith('main', 'multi-portal');
+    expect(adapter.getAppManifests).toHaveBeenCalledWith('multi-portal', ['main']);
+  });
+
+  it('clears default manifests when the supervisor is destroyed', async () => {
+    supervisor = AppSupervisor.getInstance();
+    await supervisor.setAppManifestItem('main', 'multi-portal', 'customer', {
+      uid: 'customer',
+      routePath: '/customer',
+    });
+
+    await supervisor.destroy();
+    supervisor = AppSupervisor.getInstance();
+
+    await expect(supervisor.getAppManifestItems('main', 'multi-portal')).resolves.toEqual([]);
+  });
+});

--- a/packages/core/server/src/app-supervisor/index.ts
+++ b/packages/core/server/src/app-supervisor/index.ts
@@ -75,6 +75,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   private commandAdapterName: string;
   private appDbCreator = new ConditionalRegistry<AppDbCreatorOptions, void>();
   private appConditions = new Map<string, AppCondition>();
+  private appManifests = new Map<string, Map<string, unknown>>();
   private appSsoIssuer?: string;
   public appOptionsFactory: AppOptionsFactory = appOptionsFactory;
 
@@ -364,6 +365,7 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
     await this.processAdapter.removeAllApps();
     await this.discoveryAdapter.dispose?.();
     await this.commandAdapter?.dispose?.();
+    this.appManifests.clear();
     if (this.environmentHeartbeatTimer) {
       this.environmentHeartbeatTimer = null;
     }
@@ -539,31 +541,32 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
   }
 
   async setAppManifestItem(appName: string, namespace: string, itemKey: string, item: unknown) {
-    if (typeof this.discoveryAdapter.setAppManifestItem !== 'function') {
-      return;
+    if (typeof this.discoveryAdapter.setAppManifestItem === 'function') {
+      return this.discoveryAdapter.setAppManifestItem(appName, namespace, itemKey, item);
     }
-    return this.discoveryAdapter.setAppManifestItem(appName, namespace, itemKey, item);
+    const manifest = this.getOrCreateAppManifest(appName, namespace);
+    manifest.set(itemKey, item);
   }
 
   async removeAppManifestItem(appName: string, namespace: string, itemKey: string) {
-    if (typeof this.discoveryAdapter.removeAppManifestItem !== 'function') {
-      return;
+    if (typeof this.discoveryAdapter.removeAppManifestItem === 'function') {
+      return this.discoveryAdapter.removeAppManifestItem(appName, namespace, itemKey);
     }
-    return this.discoveryAdapter.removeAppManifestItem(appName, namespace, itemKey);
+    this.appManifests.get(this.getAppManifestKey(appName, namespace))?.delete(itemKey);
   }
 
   async removeAppManifest(appName: string, namespace: string) {
-    if (typeof this.discoveryAdapter.removeAppManifest !== 'function') {
-      return;
+    if (typeof this.discoveryAdapter.removeAppManifest === 'function') {
+      return this.discoveryAdapter.removeAppManifest(appName, namespace);
     }
-    return this.discoveryAdapter.removeAppManifest(appName, namespace);
+    this.appManifests.delete(this.getAppManifestKey(appName, namespace));
   }
 
   async getAppManifestItems<T = unknown>(appName: string, namespace: string) {
-    if (typeof this.discoveryAdapter.getAppManifestItems !== 'function') {
-      return [] as T[];
+    if (typeof this.discoveryAdapter.getAppManifestItems === 'function') {
+      return this.discoveryAdapter.getAppManifestItems<T>(appName, namespace);
     }
-    return this.discoveryAdapter.getAppManifestItems<T>(appName, namespace);
+    return Array.from(this.appManifests.get(this.getAppManifestKey(appName, namespace))?.values() || []) as T[];
   }
 
   async getAppManifests<T = unknown>(namespace: string, appNames: string[]) {
@@ -581,6 +584,21 @@ export class AppSupervisor extends EventEmitter implements AsyncEmitter {
       }),
     );
     return result;
+  }
+
+  private getAppManifestKey(appName: string, namespace: string) {
+    return `${namespace}:${appName}`;
+  }
+
+  private getOrCreateAppManifest(appName: string, namespace: string) {
+    const key = this.getAppManifestKey(appName, namespace);
+    const manifest = this.appManifests.get(key);
+    if (manifest) {
+      return manifest;
+    }
+    const nextManifest = new Map<string, unknown>();
+    this.appManifests.set(key, nextManifest);
+    return nextManifest;
   }
 
   registerAppCondition(name: string, condition: AppCondition) {

--- a/packages/core/server/src/app-supervisor/main-only-adapter.ts
+++ b/packages/core/server/src/app-supervisor/main-only-adapter.ts
@@ -17,7 +17,6 @@ export class MainOnlyAdapter implements AppDiscoveryAdapter, AppProcessAdapter {
   apps: Record<string, Application> = {};
   status: AppStatus;
   appErrors: Record<string, Error> = {};
-  private readonly appManifests = new Map<string, Map<string, unknown>>();
 
   constructor(protected readonly supervisor: AppSupervisor) {
     this.name = 'main-only';
@@ -68,34 +67,6 @@ export class MainOnlyAdapter implements AppDiscoveryAdapter, AppProcessAdapter {
 
   async listAppModels() {
     return [];
-  }
-
-  async setAppManifestItem(appName: string, namespace: string, itemKey: string, item: unknown) {
-    const manifest = this.getOrCreateAppManifest(appName, namespace);
-    manifest.set(itemKey, item);
-  }
-
-  async removeAppManifestItem(appName: string, namespace: string, itemKey: string) {
-    this.appManifests.get(this.getAppManifestKey(appName, namespace))?.delete(itemKey);
-  }
-
-  async removeAppManifest(appName: string, namespace: string) {
-    this.appManifests.delete(this.getAppManifestKey(appName, namespace));
-  }
-
-  async getAppManifestItems<T = unknown>(appName: string, namespace: string) {
-    return Array.from(this.appManifests.get(this.getAppManifestKey(appName, namespace))?.values() || []) as T[];
-  }
-
-  async getAppManifests<T = unknown>(namespace: string, appNames: string[]) {
-    const result: Record<string, T[]> = {};
-    for (const appName of appNames) {
-      const data = await this.getAppManifestItems<T>(appName, namespace);
-      if (data.length > 0) {
-        result[appName] = data;
-      }
-    }
-    return result;
   }
 
   hasApp(appName: string) {
@@ -189,20 +160,5 @@ export class MainOnlyAdapter implements AppDiscoveryAdapter, AppProcessAdapter {
 
   getAppLastSeenAt(appName: string) {
     return null;
-  }
-
-  private getAppManifestKey(appName: string, namespace: string) {
-    return `${namespace}:${appName}`;
-  }
-
-  private getOrCreateAppManifest(appName: string, namespace: string) {
-    const key = this.getAppManifestKey(appName, namespace);
-    const manifest = this.appManifests.get(key);
-    if (manifest) {
-      return manifest;
-    }
-    const nextManifest = new Map<string, unknown>();
-    this.appManifests.set(key, nextManifest);
-    return nextManifest;
   }
 }

--- a/packages/plugins/@nocobase/plugin-multi-app-manager/src/server/__tests__/legacy-adapter-worker-mode.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-app-manager/src/server/__tests__/legacy-adapter-worker-mode.test.ts
@@ -83,4 +83,18 @@ describe('LegacyAdapter _bootStrapApp should skip setAppStatus only for transien
     expect(setAppStatusSpy).toHaveBeenCalledWith('test-app', 'initializing');
     expect(setAppStatusSpy).toHaveBeenCalledWith('test-app', 'not_found');
   });
+
+  it('should use the supervisor manifest fallback', async () => {
+    const item = {
+      uid: 'customer',
+      routePath: '/customer',
+    };
+
+    await appSupervisor.setAppManifestItem('main', 'multi-portal', 'customer', item);
+
+    await expect(appSupervisor.getAppManifestItems('main', 'multi-portal')).resolves.toEqual([item]);
+    await expect(appSupervisor.getAppManifests('multi-portal', ['main'])).resolves.toEqual({
+      main: [item],
+    });
+  });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Discovery adapters that do not implement app manifest storage currently cause manifest writes to be ignored and reads to return empty results. This prevents custom portals from appearing when the legacy adapter is selected without enabling a multi-application plugin.

### Description

- Add default in-memory app manifest storage to `AppSupervisor`
- Prefer discovery adapter manifest methods when an adapter provides its own implementation
- Remove duplicate manifest storage from `MainOnlyAdapter`
- Clear default manifest state when the supervisor resets
- Add coverage for default, custom, and legacy adapter behavior

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed custom portals missing when multi-application plugins are disabled |
| 🇨🇳 Chinese | 修复未启用多应用插件时自定义工作区不显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
