### PR TITLE
fix(plugin-workflow-delay): validate delay duration

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
@@ -21,6 +21,7 @@ type ValueOf<T> = T[keyof T];
 interface DelayConfig {
   endStatus: ValueOf<typeof JOB_STATUS>;
   duration: number;
+  unit: number;
 }
 
 const UNITS = [1_000, 60_000, 3_600_000, 86_400_000, 604_800_000];
@@ -29,6 +30,7 @@ export default class extends Instruction {
   timers: Map<string, NodeJS.Timeout> = new Map();
 
   configSchema = Joi.object({
+    duration: Joi.number().min(1),
     endStatus: Joi.number().valid(JOB_STATUS.RESOLVED, JOB_STATUS.FAILED),
     unit: Joi.number().valid(...UNITS),
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Delay node durations are constrained to values greater than or equal to 1 in the client, but the server did not enforce the same rule. API requests could therefore save a duration of 0, which was later silently treated as 1 during workflow execution.

### Description 
Add server-side Joi validation requiring numeric delay durations to be greater than or equal to 1. Also complete the delay configuration type with the existing unit field.

Potential risk and testing suggestion: verify both literal numeric durations and variable-based duration configurations when reviewing this change.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevented delay nodes from accepting numeric durations less than 1 through the API |
| 🇨🇳 Chinese | 阻止通过 API 为延时节点设置小于 1 的数值时长 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
