### PR TITLE
Fix form draft loss

### DIFF
--- a/packages/plugins/@nocobase/plugin-form-drafts/src/client/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-form-drafts/src/client/plugin.tsx
@@ -75,7 +75,10 @@ FormBlockModel.registerFlow({
           await ctx.draftRepository.create();
           return;
         }
-        await ctx.setFormValues(draft.values);
+        await ctx.setFormValues(draft.values, {
+          source: 'system',
+          triggerEvent: false,
+        });
         ctx.showDraftAlert(
           'This is an unsubmitted draft. You can continue editing and submit it, or click “Delete draft” to start over.',
         );
@@ -93,7 +96,7 @@ FormBlockModel.registerFlow({
         if (ctx.draftRepository.disabled) {
           return;
         }
-        await ctx.draftRepository.save(ctx.form.getFieldsValue());
+        await ctx.draftRepository.save(ctx.form.getFieldsValue(true));
         ctx.showDraftAlert(
           'Your draft has been saved. You can continue editing and submit it, or click “Delete Draft” to start over.',
         );


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Form drafts could be overwritten with empty values during restoration and disappear after another page refresh.

### Description

Prevent draft restoration from triggering automatic saving, and persist all form values even before fields are mounted.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed form drafts disappearing after consecutive page refreshes |
| 🇨🇳 Chinese | 修复表单草稿在连续刷新页面后丢失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |      |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
