### PR TITLE
fix(plugin-workflow): handle trigger failures during execution creation

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -34,7 +34,12 @@ export type EventOptions = {
   manually?: boolean;
   force?: boolean;
   stack?: Array<number | string>;
-  onTriggerFail?: Function;
+  onTriggerFail?: (
+    workflow: WorkflowModel,
+    context: object,
+    options: EventOptions,
+    error?: unknown,
+  ) => void | Promise<void>;
   [key: string]: any;
 } & Transactionable;
 
@@ -82,12 +87,12 @@ export default class Dispatcher {
     workflow: WorkflowModel,
     context: object,
     options: EventOptions = {},
-  ): void | Promise<Processor | null> {
+  ): void | Promise<Processor | null | void> {
     const logger = this.plugin.getLogger(workflow.id);
     if (!this.ready) {
       logger.warn(`app is not ready, event of workflow ${workflow.id} will be ignored`);
       logger.debug(`ignored event data:`, context);
-      return;
+      return this.handleTriggerFail(workflow, context, options, new Error('app is not ready'));
     }
     if (!options.force && !options.manually && !workflow.enabled) {
       logger.warn(`workflow ${workflow.id} is not enabled, event will be ignored`);
@@ -104,7 +109,7 @@ export default class Dispatcher {
     }
     if (context == null) {
       logger.warn(`workflow ${workflow.id} event data context is null, event will be ignored`);
-      return;
+      return this.handleTriggerFail(workflow, context, options, new Error('event context is null'));
     }
 
     if (options.manually || this.plugin.isWorkflowSync(workflow)) {
@@ -266,6 +271,14 @@ export default class Dispatcher {
     return valid;
   }
 
+  private async handleTriggerFail(workflow: WorkflowModel, context: object, options: EventOptions, error?: unknown) {
+    try {
+      await options.onTriggerFail?.(workflow, context, options, error);
+    } catch (triggerFailError) {
+      this.plugin.getLogger(workflow.id).error(`trigger failure callback failed`, { error: triggerFailError });
+    }
+  }
+
   private async createExecution(
     workflow: WorkflowModel,
     context,
@@ -274,13 +287,23 @@ export default class Dispatcher {
     const { deferred } = options;
     const transaction = await this.plugin.useDataSourceTransaction('main', options.transaction, true);
     const sameTransaction = options.transaction === transaction;
-    const valid = await this.validateEvent(workflow, context, { ...options, transaction });
+    let valid: boolean;
+    try {
+      valid = await this.validateEvent(workflow, context, { ...options, transaction });
+    } catch (error) {
+      if (!sameTransaction) {
+        await transaction.rollback();
+      }
+      await this.handleTriggerFail(workflow, context, options, error);
+      throw error;
+    }
     if (!valid) {
+      const error = new Error('event is not valid');
       if (!sameTransaction) {
         await transaction.commit();
       }
-      options.onTriggerFail?.(workflow, context, options);
-      return Promise.reject(new Error('event is not valid'));
+      await this.handleTriggerFail(workflow, context, options, error);
+      throw error;
     }
 
     let execution: ExecutionModel;
@@ -301,6 +324,7 @@ export default class Dispatcher {
       if (!sameTransaction) {
         await transaction.rollback();
       }
+      await this.handleTriggerFail(workflow, context, options, err);
       throw err;
     }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -446,7 +446,7 @@ export default class PluginWorkflowServer extends Plugin {
     workflow: WorkflowModel,
     context: object,
     options: EventOptions = {},
-  ): void | Promise<Processor | null> {
+  ): void | Promise<Processor | null | void> {
     return this.dispatcher.trigger(workflow, context, options);
   }
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -10,6 +10,7 @@
 import { MockServer } from '@nocobase/test';
 import Database from '@nocobase/database';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
+import { vi } from 'vitest';
 
 import Plugin, { Processor } from '..';
 import { EXECUTION_STATUS } from '../constants';
@@ -318,6 +319,54 @@ describe('workflow > Plugin', () => {
       await e1.reload();
       expect(e1.dispatched).toBe(false);
       expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
+    });
+
+    it('should notify trigger failure callback when async execution creation fails', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      const error = new Error('duplicate execution id');
+      const createExecution = vi.spyOn(workflow, 'createExecution').mockRejectedValueOnce(error);
+      const onTriggerFail = vi.fn(async () => {
+        await sleep(10);
+      });
+
+      plugin.trigger(workflow, { data: true }, { eventKey: 'failed-event', onTriggerFail });
+
+      for (let i = 0; i < 20; i++) {
+        if (onTriggerFail.mock.calls.length) {
+          break;
+        }
+        await sleep(50);
+      }
+
+      expect(createExecution).toHaveBeenCalledTimes(1);
+      expect(onTriggerFail).toHaveBeenCalledTimes(1);
+      expect(onTriggerFail.mock.calls[0]).toEqual([
+        workflow,
+        { data: true },
+        { eventKey: 'failed-event', onTriggerFail },
+        error,
+      ]);
+    });
+
+    it('should notify trigger failure callback when async event context is null', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      const onTriggerFail = vi.fn(async () => {
+        await sleep(10);
+      });
+
+      await plugin.trigger(workflow, null as unknown as object, { eventKey: 'invalid-context-event', onTriggerFail });
+
+      expect(onTriggerFail).toHaveBeenCalledTimes(1);
+      expect(onTriggerFail.mock.calls[0][0]).toBe(workflow);
+      expect(onTriggerFail.mock.calls[0][1]).toBeNull();
+      expect(onTriggerFail.mock.calls[0][2]).toEqual({ eventKey: 'invalid-context-event', onTriggerFail });
+      expect(onTriggerFail.mock.calls[0][3]).toBeInstanceOf(Error);
     });
 
     it('should treat postgres deadlock as concurrent acquire error', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Backport #10043 to v1. When a workflow trigger fails before creating an execution record, subflow nodes can remain pending because the trigger failure callback is not awaited or invoked on the execution creation failure path.

### Description 
- Await and guard the trigger failure callback when trigger preparation fails before an execution is created.
- Notify the callback for app-not-ready, null context, validation failure, and execution creation failure paths.
- Preserve v1 transaction handling while rolling back execution creation failures before running the failure callback.
- Add server tests for async execution creation failure and null context failure callback behavior.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts`
- Attempted `Plugin.test.ts`; the local workspace could not complete it because current untracked 2.x workspace plugins caused dependency resolution to load `@opentelemetry/resources@2.2.0` for v1 telemetry code.

### Related issues

Backport of #10043.

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed subflow nodes remaining pending when the child workflow fails before creating an execution record |
| 🇨🇳 Chinese | 修复子流程在目标工作流执行记录创建前失败时父节点可能一直等待的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
