### PR TITLE
fix(app): isolate cache Redis configuration

### DIFF
--- a/packages/core/app/src/config/cache.ts
+++ b/packages/core/app/src/config/cache.ts
@@ -9,7 +9,7 @@
 
 import { CacheManagerOptions } from '@nocobase/cache';
 
-const redisURL = process.env.REDIS_URL || process.env.CACHE_REDIS_URL;
+const redisURL = process.env.CACHE_REDIS_URL;
 export const cacheManager: CacheManagerOptions = {
   defaultStore: process.env.CACHE_DEFAULT_STORE || 'memory',
   stores: {

--- a/packages/core/app/src/config/cache.ts
+++ b/packages/core/app/src/config/cache.ts
@@ -9,7 +9,7 @@
 
 import { CacheManagerOptions } from '@nocobase/cache';
 
-const redisURL = process.env.CACHE_REDIS_URL;
+const redisURL = process.env.CACHE_REDIS_URL || process.env.REDIS_URL;
 export const cacheManager: CacheManagerOptions = {
   defaultStore: process.env.CACHE_DEFAULT_STORE || 'memory',
   stores: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Redis-backed cache configuration preferred the general Redis connection when both URLs were configured. Cache resets could therefore clear data belonging to other Redis-backed services.

### Description 
Configure the Redis cache store exclusively from `CACHE_REDIS_URL` so that `REDIS_URL` is not used as a cache fallback.

Potential risk: deployments that relied on `REDIS_URL` for Redis cache storage must configure `CACHE_REDIS_URL` explicitly.

Testing:
- ESLint on the changed file

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Redis cache configuration ignoring the dedicated cache URL |
| 🇨🇳 Chinese | 修复 Redis 缓存配置忽略专用缓存地址的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
