### PR TITLE
feat: add MiniMax LLM provider

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/index.tsx
@@ -59,6 +59,7 @@ import { setupAICoding } from './ai-employees/ai-coding/setup';
 import { setupDataModeling } from './ai-employees/data-modeling/setup';
 import { AIEmployeeInstruction } from './workflow/nodes/employee';
 import { mimoProviderOptions } from './llm-providers/mimo';
+import { minimaxProviderOptions } from './llm-providers/minimax';
 import { mistralProviderOptions } from './llm-providers/mistral';
 import { orcarouterProviderOptions } from './llm-providers/orcarouter';
 const { AIEmployeesProvider } = lazy(() => import('./ai-employees/AIEmployeesProvider'), 'AIEmployeesProvider');
@@ -170,6 +171,7 @@ export class PluginAIClient extends Plugin {
     this.aiManager.registerLLMProvider('kimi', kimiProviderOptions);
     this.aiManager.registerLLMProvider('xai', xaiProviderOptions);
     this.aiManager.registerLLMProvider('mimo', mimoProviderOptions);
+    this.aiManager.registerLLMProvider('minimax', minimaxProviderOptions);
     this.aiManager.registerLLMProvider('mistral', mistralProviderOptions);
     this.aiManager.registerLLMProvider('orcarouter', orcarouterProviderOptions);
     this.aiManager.chatSettings.set('messages', {

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-providers/minimax/ModelSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-providers/minimax/ModelSettings.tsx
@@ -1,0 +1,177 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { SchemaComponent } from '@nocobase/client';
+import { tval } from '@nocobase/utils/client';
+import { namespace, useT } from '../../locale';
+import { Collapse } from 'antd';
+import { ModelSelect } from '../components/ModelSelect';
+
+const Options: React.FC = () => {
+  const t = useT();
+  return (
+    <div
+      style={{
+        marginBottom: 24,
+      }}
+    >
+      <Collapse
+        bordered={false}
+        size="small"
+        items={[
+          {
+            key: 'options',
+            label: t('Options'),
+            forceRender: true,
+            children: (
+              <SchemaComponent
+                schema={{
+                  type: 'void',
+                  name: 'minimax',
+                  properties: {
+                    maxCompletionTokens: {
+                      title: tval('Max completion tokens', { ns: namespace }),
+                      description: tval('Max completion tokens description', { ns: namespace }),
+                      type: 'number',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'InputNumber',
+                      default: -1,
+                    },
+                    temperature: {
+                      title: tval('Temperature', { ns: namespace }),
+                      description: tval('Temperature description', { ns: namespace }),
+                      type: 'number',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'InputNumber',
+                      default: 1.0,
+                      'x-component-props': {
+                        step: 0.1,
+                        min: 0.0,
+                        max: 2.0,
+                      },
+                    },
+                    topP: {
+                      title: tval('Top P', { ns: namespace }),
+                      description: tval('Top P description', { ns: namespace }),
+                      type: 'number',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'InputNumber',
+                      'x-component-props': {
+                        step: 0.1,
+                        min: 0.0,
+                        max: 1.0,
+                      },
+                    },
+                    thinking: {
+                      title: tval('Thinking mode', { ns: namespace }),
+                      description: tval('Thinking mode description', { ns: namespace }),
+                      type: 'string',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'Select',
+                      enum: [
+                        {
+                          label: t('Adaptive'),
+                          value: 'adaptive',
+                        },
+                        {
+                          label: t('Disabled'),
+                          value: 'disabled',
+                        },
+                      ],
+                      'x-component-props': {
+                        allowClear: true,
+                        placeholder: t('Use model default'),
+                      },
+                      'x-reactions': {
+                        dependencies: ['.model'],
+                        fulfill: {
+                          state: {
+                            visible: '{{$deps[0] === "MiniMax-M3"}}',
+                          },
+                        },
+                      },
+                    },
+                    serviceTier: {
+                      title: tval('Service tier', { ns: namespace }),
+                      description: tval('Service tier description', { ns: namespace }),
+                      type: 'string',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'Select',
+                      enum: [
+                        {
+                          label: t('Standard'),
+                          value: 'standard',
+                        },
+                        {
+                          label: t('Priority'),
+                          value: 'priority',
+                        },
+                      ],
+                      'x-component-props': {
+                        allowClear: true,
+                        placeholder: t('Use model default'),
+                      },
+                      'x-reactions': {
+                        dependencies: ['.model'],
+                        fulfill: {
+                          state: {
+                            visible: '{{$deps[0] === "MiniMax-M3"}}',
+                          },
+                        },
+                      },
+                    },
+                    timeout: {
+                      title: tval('Timeout (ms)', { ns: namespace }),
+                      type: 'number',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'InputNumber',
+                      default: 60000,
+                    },
+                    maxRetries: {
+                      title: tval('Max retries', { ns: namespace }),
+                      type: 'number',
+                      'x-decorator': 'FormItem',
+                      'x-component': 'InputNumber',
+                      default: 1,
+                    },
+                  },
+                }}
+              />
+            ),
+          },
+        ]}
+      />
+    </div>
+  );
+};
+
+export const ModelSettingsForm: React.FC = () => {
+  return (
+    <SchemaComponent
+      components={{ Options, ModelSelect }}
+      schema={{
+        type: 'void',
+        properties: {
+          model: {
+            title: tval('Model', { ns: namespace }),
+            type: 'string',
+            required: true,
+            'x-decorator': 'FormItem',
+            'x-component': 'ModelSelect',
+          },
+          options: {
+            type: 'void',
+            'x-component': 'Options',
+          },
+        },
+      }}
+    />
+  );
+};

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-providers/minimax/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-providers/minimax/index.ts
@@ -1,0 +1,21 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { LLMProviderOptions } from '../../manager/ai-manager';
+import { formatModelLabel } from '../../llm-services/component/EnabledModelsSelect';
+import { ProviderSettingsForm } from '../openai/components/ProviderSettings';
+import { ModelSettingsForm } from './ModelSettings';
+
+export const minimaxProviderOptions: LLMProviderOptions = {
+  components: {
+    ProviderSettingsForm,
+    ModelSettingsForm,
+  },
+  formatModelLabel,
+};

--- a/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/LLMServices.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/llm-services/LLMServices.tsx
@@ -149,6 +149,7 @@ const providerDescriptions: Record<string, string> = {
   xai: 'Grok models by xAI',
   ollama: 'Local models',
   mimo: 'Xiaomi MIMO',
+  minimax: 'MiniMax',
   mistral: 'Mistral models',
   orcarouter: 'OrcaRouter (model routing gateway)',
 };

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -461,5 +461,14 @@
   "When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.": "When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.",
   "Connection test failed": "Connection test failed",
   "The MCP server uses current user variables and the connection test failed. Do you want to save it anyway?": "The MCP server uses current user variables and the connection test failed. Do you want to save it anyway?",
-  "Save anyway": "Save anyway"
+  "Save anyway": "Save anyway",
+  "Thinking mode": "Thinking mode",
+  "Thinking mode description": "Controls whether MiniMax-M3 emits thinking content. Leave empty to use the model default.",
+  "Service tier": "Service tier",
+  "Service tier description": "Select the request admission tier. Leave empty to use the standard tier.",
+  "Adaptive": "Adaptive",
+  "Disabled": "Disabled",
+  "Standard": "Standard",
+  "Priority": "Priority",
+  "Use model default": "Use model default"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -467,5 +467,14 @@
   "When enabled, URL and headers can use current user variables and NocoBase request variables. Stdio transport is not supported.": "启用后，可在 URL 和请求头中使用当前用户变量和 NocoBase 请求变量。Stdio 传输方式不支持。",
   "Connection test failed": "连接测试失败",
   "The MCP server uses current user variables and the connection test failed. Do you want to save it anyway?": "该 MCP 服务使用当前用户变量，且连接测试失败。是否仍然保存？",
-  "Save anyway": "仍然保存"
+  "Save anyway": "仍然保存",
+  "Thinking mode": "思考模式",
+  "Thinking mode description": "控制 MiniMax-M3 是否输出思考内容。留空时使用模型默认设置。",
+  "Service tier": "服务等级",
+  "Service tier description": "选择请求准入等级。留空时使用标准等级。",
+  "Adaptive": "自适应",
+  "Disabled": "关闭",
+  "Standard": "标准",
+  "Priority": "优先",
+  "Use model default": "使用模型默认设置"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/minimax.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/minimax.test.ts
@@ -1,0 +1,243 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Context } from '@nocobase/actions';
+import type { AttachmentModel } from '@nocobase/plugin-file-manager';
+import type { Application } from '@nocobase/server';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { convertMessagesToCompletionsMessageParams } from '@langchain/openai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { encodeFile } from '../../utils';
+import type { ReasoningChatOpenAI } from '../common/reasoning';
+import { MiniMaxProvider, minimaxProviderOptions } from '../minimax';
+import type { ParsedAttachmentResult } from '../provider';
+import { SupportedModel } from '../../manager/ai-manager';
+
+vi.mock('../../utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils')>();
+  return {
+    ...actual,
+    encodeFile: vi.fn().mockResolvedValue('encoded-video'),
+  };
+});
+
+function createApp(
+  renderedValue?: Record<string, unknown>,
+  fileURL = 'https://files.example.com/sample.mp4',
+): Application {
+  return {
+    environment: {
+      renderJsonTemplate: () => renderedValue ?? {},
+    },
+    pm: {
+      get: () => ({
+        getFileURL: async () => fileURL,
+      }),
+    },
+  } as unknown as Application;
+}
+
+class TestMiniMaxProvider extends MiniMaxProvider {
+  resolvedBaseURL() {
+    return this.getResolvedBaseURL();
+  }
+
+  supportsAttachment(mimetype: string) {
+    return this.isApiSupportedAttachment({ mimetype } as AttachmentModel);
+  }
+
+  convertAttachment(ctx: Context, attachment: AttachmentModel): Promise<ParsedAttachmentResult> {
+    return this.convertToContent(ctx, attachment);
+  }
+
+  requestModelKwargs() {
+    return (this.chatModel as ReasoningChatOpenAI & { modelKwargs?: Record<string, unknown> }).modelKwargs;
+  }
+}
+
+const originalWhitelist = process.env.SERVER_REQUEST_WHITELIST;
+
+describe('MiniMax provider', () => {
+  afterEach(() => {
+    process.env.SERVER_REQUEST_WHITELIST = originalWhitelist;
+    vi.clearAllMocks();
+  });
+
+  it('creates a chat model using the default MiniMax baseURL', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'MiniMax-M3' },
+    });
+
+    expect(provider.chatModel).toBeDefined();
+    expect(provider.resolvedBaseURL()).toBe('https://api.minimax.io/v1');
+  });
+
+  it('normalizes a regional baseURL override', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimaxi.com';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp({ apiKey: 'test-key', baseURL: 'https://api.minimaxi.com/v1/' }),
+      modelOptions: { model: 'MiniMax-M3' },
+    });
+
+    expect(provider.serviceOptions.baseURL).toBe('https://api.minimaxi.com/v1');
+    expect(provider.resolvedBaseURL()).toBe('https://api.minimaxi.com/v1');
+  });
+
+  it('maps MiniMax-M3 request options to supported API fields', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: {
+        model: 'MiniMax-M3',
+        thinking: 'disabled',
+        serviceTier: 'priority',
+        maxCompletionTokens: -1,
+      },
+    });
+
+    expect(provider.requestModelKwargs()).toEqual({
+      reasoning_split: true,
+      thinking: { type: 'disabled' },
+      service_tier: 'priority',
+    });
+  });
+
+  it('keeps MiniMax-M2.7 thinking enabled and omits M3-only options', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: {
+        model: 'MiniMax-M2.7',
+        thinking: 'disabled',
+        serviceTier: 'priority',
+      },
+    });
+
+    expect(provider.requestModelKwargs()).toEqual({ reasoning_split: true });
+  });
+
+  it('accepts multimodal attachments only for MiniMax-M3', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const m3Provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'MiniMax-M3' },
+    });
+    const m27Provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'MiniMax-M2.7' },
+    });
+
+    expect(m3Provider.supportsAttachment('image/png')).toBe(true);
+    expect(m3Provider.supportsAttachment('video/mp4')).toBe(true);
+    expect(m3Provider.supportsAttachment('audio/mpeg')).toBe(false);
+    expect(m27Provider.supportsAttachment('image/png')).toBe(false);
+    expect(m27Provider.supportsAttachment('video/mp4')).toBe(false);
+  });
+
+  it('converts video attachments to compatible content blocks', async () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'MiniMax-M3' },
+    });
+    const ctx = {} as Context;
+    const attachment = { mimetype: 'video/mp4' } as AttachmentModel;
+
+    await expect(provider.convertAttachment(ctx, attachment)).resolves.toEqual({
+      placement: 'contentBlocks',
+      content: {
+        type: 'video_url',
+        video_url: {
+          url: 'data:video/mp4;base64,encoded-video',
+        },
+      },
+    });
+    expect(encodeFile).toHaveBeenCalledWith(ctx, 'https://files.example.com/sample.mp4');
+  });
+
+  it('preserves video content blocks when building completion messages', () => {
+    const [message] = convertMessagesToCompletionsMessageParams({
+      model: 'MiniMax-M3',
+      messages: [
+        new HumanMessage({
+          content: [
+            {
+              type: 'video_url',
+              video_url: {
+                url: 'data:video/mp4;base64,encoded-video',
+              },
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(message).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'video_url',
+          video_url: {
+            url: 'data:video/mp4;base64,encoded-video',
+          },
+        },
+      ],
+    });
+  });
+
+  it('parses reasoning content from streamed chunks', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'MiniMax-M3' },
+    });
+    const chunk = new AIMessageChunk({
+      content: 'final answer',
+      additional_kwargs: { reasoning_content: 'reasoning step' },
+    });
+
+    expect(provider.parseReasoningContent(chunk)).toEqual({
+      status: 'streaming',
+      content: 'reasoning step',
+    });
+  });
+
+  it('returns null reasoning content when the chunk carries none', () => {
+    process.env.SERVER_REQUEST_WHITELIST = 'api.minimax.io';
+
+    const provider = new TestMiniMaxProvider({
+      app: createApp(),
+      serviceOptions: { apiKey: 'test-key' },
+      modelOptions: { model: 'MiniMax-M3' },
+    });
+
+    expect(provider.parseReasoningContent(new AIMessageChunk({ content: 'answer' }))).toBeNull();
+  });
+
+  it('exposes the target models in priority order', () => {
+    expect(minimaxProviderOptions.title).toBe('MiniMax');
+    expect(minimaxProviderOptions.models?.[SupportedModel.LLM]).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/minimax.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/minimax.ts
@@ -1,0 +1,128 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Context } from '@nocobase/actions';
+import { Model } from '@nocobase/database';
+import { AttachmentModel, PluginFileManagerServer } from '@nocobase/plugin-file-manager';
+import _ from 'lodash';
+import { encodeFile } from '../utils';
+import { LLMProviderMeta, SupportedModel } from '../manager/ai-manager';
+import { AIMessageChunk } from '@langchain/core/messages';
+import { ReasoningChatOpenAI } from './common/reasoning';
+import { LLMProvider, ParsedAttachmentResult } from './provider';
+
+const MINIMAX_M3 = 'MiniMax-M3';
+const MINIMAX_M27 = 'MiniMax-M2.7';
+
+function isThinkingMode(value: unknown): value is 'adaptive' | 'disabled' {
+  return value === 'adaptive' || value === 'disabled';
+}
+
+function isServiceTier(value: unknown): value is 'standard' | 'priority' {
+  return value === 'standard' || value === 'priority';
+}
+
+export class MiniMaxProvider extends LLMProvider {
+  declare chatModel: ReasoningChatOpenAI;
+
+  get baseURL() {
+    return 'https://api.minimax.io/v1';
+  }
+
+  createModel() {
+    const { apiKey } = this.serviceOptions || {};
+    const { thinking, serviceTier, ...modelOptions } = this.modelOptions || {};
+    if (modelOptions.maxCompletionTokens === -1) {
+      delete modelOptions.maxCompletionTokens;
+    }
+
+    const modelKwargs: Record<string, unknown> = {
+      reasoning_split: true,
+    };
+    if (modelOptions.model === MINIMAX_M3 && isThinkingMode(thinking)) {
+      modelKwargs.thinking = { type: thinking };
+    }
+    if (modelOptions.model === MINIMAX_M3 && isServiceTier(serviceTier)) {
+      modelKwargs.service_tier = serviceTier;
+    }
+
+    return new ReasoningChatOpenAI({
+      apiKey,
+      ...modelOptions,
+      modelKwargs,
+      configuration: {
+        baseURL: this.getResolvedBaseURL(),
+      },
+      verbose: true,
+    });
+  }
+
+  protected isApiSupportedAttachment(attachment: AttachmentModel): boolean {
+    if (this.modelOptions?.model !== MINIMAX_M3) {
+      return false;
+    }
+    return ['image/', 'video/'].some((prefix) => attachment?.mimetype?.startsWith(prefix));
+  }
+
+  protected async convertToContent(ctx: Context, attachment: AttachmentModel): Promise<ParsedAttachmentResult> {
+    if (!attachment.mimetype?.startsWith('video/')) {
+      return super.convertToContent(ctx, attachment);
+    }
+
+    const fileManager = this.app.pm.get('file-manager') as PluginFileManagerServer;
+    const url = await fileManager.getFileURL(attachment);
+    const data = await encodeFile(ctx, decodeURIComponent(url));
+    return {
+      placement: 'contentBlocks',
+      content: {
+        type: 'video_url',
+        video_url: {
+          url: `data:${attachment.mimetype};base64,${data}`,
+        },
+      },
+    };
+  }
+
+  parseResponseMessage(message: Model) {
+    const result = super.parseResponseMessage(message);
+    if (['user', 'tool'].includes(result?.role)) {
+      return result;
+    }
+    const { metadata } = message?.toJSON() ?? {};
+    if (!_.isEmpty(metadata?.additional_kwargs?.reasoning_content)) {
+      result.content = {
+        ...(result.content ?? {}),
+        reasoning: {
+          status: 'stop',
+          content: metadata?.additional_kwargs.reasoning_content,
+        },
+      };
+    }
+    return result;
+  }
+
+  parseReasoningContent(chunk: AIMessageChunk): { status: string; content: string } | null {
+    if (!_.isEmpty(chunk?.additional_kwargs?.reasoning_content)) {
+      return {
+        status: 'streaming',
+        content: chunk.additional_kwargs.reasoning_content as string,
+      };
+    }
+    return null;
+  }
+}
+
+export const minimaxProviderOptions: LLMProviderMeta = {
+  title: 'MiniMax',
+  supportedModel: [SupportedModel.LLM],
+  models: {
+    [SupportedModel.LLM]: [MINIMAX_M3, MINIMAX_M27],
+  },
+  provider: MiniMaxProvider,
+};

--- a/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
@@ -44,6 +44,7 @@ import { DocumentLoaders } from './document-loader';
 import type PluginFileManagerServer from '@nocobase/plugin-file-manager';
 import { CheckpointCleaner, SequelizeCollectionSaver } from './ai-employees/checkpoints';
 import { mimoProviderOptions } from './llm-providers/mimo';
+import { minimaxProviderOptions } from './llm-providers/minimax';
 import { mistralProviderOptions } from './llm-providers/mistral';
 import { orcarouterProviderOptions } from './llm-providers/orcarouter';
 import { SubAgentsDispatcher } from './ai-employees/sub-agents';
@@ -176,6 +177,7 @@ export class PluginAIServer extends Plugin {
     this.aiManager.registerLLMProvider('dashscope', dashscopeProviderOptions);
     this.aiManager.registerLLMProvider('kimi', kimiProviderOptions);
     this.aiManager.registerLLMProvider('mimo', mimoProviderOptions);
+    this.aiManager.registerLLMProvider('minimax', minimaxProviderOptions);
     this.aiManager.registerLLMProvider('mistral', mistralProviderOptions);
     this.aiManager.registerLLMProvider('ollama', ollamaProviderOptions);
     this.aiManager.registerLLMProvider('openai-completions', openaiCompletionsProviderOptions);


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Add MiniMax as a built-in LLM provider for the AI plugin.

### Description
- Register the provider in the server and client registries.
- Expose MiniMax-M3 and MiniMax-M2.7 in the recommended model list.
- Support regional OpenAI-compatible Base URL overrides through the existing service setting.
- Map model-specific thinking and service-tier options while preserving reasoning content.
- Accept image and video attachments for MiniMax-M3 and keep MiniMax-M2.7 text-only.
- Add localized settings and focused unit coverage.

### Related issues

### Showcase

### Changelog

| Language | Changelog |
| --- | --- |
| English | Add a built-in MiniMax LLM provider. |
| Chinese | 新增内置 MiniMax LLM Provider。 |

### Docs

| Language | Link |
| --- | --- |
| English | Not needed |
| Chinese | 不需要 |

### Testing
- `corepack yarn test packages/plugins/@nocobase/plugin-ai/src/server/llm-providers/__tests__/minimax.test.ts --run --reporter=verbose` (10 tests passed)
- ESLint passed for all touched TypeScript files.
- The repository-wide TypeScript check reports existing diagnostics outside the touched paths; no touched path reported a TypeScript diagnostic.

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
