### PR TITLE
fix(plugin-ui-layout): keep mobile links in sub-app

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts
@@ -40,6 +40,9 @@ describe('PluginUiLayoutClientV2', () => {
         }),
       },
       getRouteUrl: vi.fn((pathname: string) => `/v/${pathname.replace(/^\/+/, '')}`),
+      router: {
+        getBasename: vi.fn(() => '/v/'),
+      },
       layoutManager: {
         hasLayout: vi.fn(() => false),
         registerLayout: vi.fn(),
@@ -181,6 +184,49 @@ describe('PluginUiLayoutClientV2', () => {
       layoutModelClass: 'AdminLayoutModel',
       authCheck: true,
     });
+  });
+
+  it('should include the sub-app router basename in the mobile settings link', async () => {
+    const { default: PluginUiLayoutClientV2 } = await import('../plugin');
+    const app = {
+      i18n: {
+        t: vi.fn((key: string) => key),
+      },
+      pluginSettingsManager: {
+        addMenuItem: vi.fn(),
+        addPageTabItem: vi.fn(),
+        setPluginSettingsLink: vi.fn(),
+      },
+      apiClient: {
+        request: vi.fn().mockResolvedValue({ data: { data: [] } }),
+      },
+      getRouteUrl: vi.fn((pathname: string) => `/v/${pathname.replace(/^\/+/, '')}`),
+      router: {
+        getBasename: vi.fn(() => '/v/apps/sub-app/'),
+      },
+      layoutManager: {
+        hasLayout: vi.fn(() => false),
+        registerLayout: vi.fn(),
+      },
+      flowEngine: {
+        registerModelLoaders: vi.fn(),
+        registerActions: vi.fn(),
+        flowSettings: {
+          registerComponents: vi.fn(),
+        },
+      },
+    };
+    const plugin = new PluginUiLayoutClientV2({} as Record<string, never>, app as unknown as Application);
+
+    await plugin.load();
+
+    expect(app.pluginSettingsManager.addMenuItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'mobile',
+        link: '/v/apps/sub-app/mobile',
+      }),
+    );
+    expect(app.getRouteUrl).not.toHaveBeenCalledWith('/mobile');
   });
 
   it('should register custom layout routes during plugin load', async () => {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx
@@ -22,6 +22,11 @@ function MobileSettingsRedirect() {
 }
 
 function getMobileSettingsLink(app: Application) {
+  const basename = app.router.getBasename?.();
+  if (basename) {
+    return `${basename.replace(/\/+$/, '')}/mobile`;
+  }
+
   return app.getRouteUrl?.('/mobile') || '/mobile';
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The Mobile settings entry in a sub-application opened the main application because its URL was built from `app.getRouteUrl('/mobile')`, which does not include the sub-application router basename.

### Description 
- Build the Mobile settings link from the current router basename when available.
- Preserve `app.getRouteUrl('/mobile')` as a fallback when no basename is configured.
- Add regression coverage for both the main application (`/v/mobile`) and a sub-application (`/v/apps/<app-name>/mobile`).
- Risk is limited to Mobile settings-link URL generation.
- Verified with:
  - `yarn test packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts --run --reporter=verbose`
  - `yarn eslint --fix packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts`

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the Mobile settings link opening the main application from a sub-application. |
| 🇨🇳 Chinese | 修复子应用中的 Mobile 设置入口错误跳转到主应用的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary