### PR TITLE
fix(client-v2): prevent quick edit fixed column bleed-through

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -300,7 +300,7 @@ export class TableBlockModel extends CollectionBlockModel<TableBlockModelStructu
                 transform: translateY(-50%);
               }
               &:hover {
-                background: rgba(24, 144, 255, 0.1) !important;
+                box-shadow: inset 0 0 0 9999px rgba(24, 144, 255, 0.1);
               }
               &:hover .edit-icon {
                 display: inline-flex;

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
@@ -102,7 +102,7 @@ const RenderCell = observer<any>((props) => {
               transform: translateY(-50%);
             }
             &:hover {
-              background: rgba(24, 144, 255, 0.1) !important;
+              box-shadow: inset 0 0 0 9999px rgba(24, 144, 255, 0.1);
             }
             &:hover .edit-icon {
               display: inline-flex;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When quick edit is enabled on a fixed v2 table column, hovering the cell replaces Ant Design's opaque fixed-cell background with a translucent background. Horizontally scrolled column content underneath the sticky cell can then show through, making the fixed column appear to contain data from another column.

### Description
- Preserve the opaque table-cell background required by Ant Design fixed columns.
- Render the quick-edit hover highlight with an inset box shadow instead of a translucent background.
- Apply the same fix to regular v2 tables and popup subtables.

The change is low risk because it only changes the hover paint layer. It does not alter the table structure, fixed positioning, quick-edit events, or record updates. Ant Design renders fixed-column boundary shadows on pseudo-elements, so they do not conflict with the inset shadow.

Testing suggestions:
- Enable quick edit on a left- or right-fixed column.
- Scroll the table horizontally and hover the fixed editable cells.
- Confirm that content from columns underneath is no longer visible.
- Confirm that the quick-edit hover highlight, edit icon, and edit action still work.
- Check regular v2 tables and popup subtables.

Automated checks:
- `yarn eslint --fix packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx`
- `yarn test packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.quickEditRefresh.test.ts --run --reporter=verbose`
- `git diff --check`

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed other column content showing through fixed v2 table columns when quick edit is enabled. |
| 🇨🇳 Chinese | 修复 v2 表格固定列开启快速编辑后透出其他列内容的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
