### PR TITLE
fix(plugin-ai): authorize tool-call approvals by message session

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/resource/aiConversations.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/resource/aiConversations.ts
@@ -695,6 +695,15 @@ export default {
         ctx.throw(400);
       }
 
+      const messageConversation = await plugin.aiConversationsManager.getConversation({
+        sessionId: message.sessionId,
+        userId,
+      });
+
+      if (!messageConversation) {
+        ctx.throw(400);
+      }
+
       const toolCalls = message.toolCalls;
       if (!toolCalls?.length) {
         ctx.throw(400);
@@ -733,7 +742,7 @@ export default {
           },
         },
       });
-      const toolMessageMap = new Map<string, any>(
+      const toolMessageMap = new Map<string, Model>(
         toolMessages.map((toolMessage: Model) => [toolMessage.toolCallId, toolMessage]),
       );
 
@@ -804,6 +813,15 @@ export default {
           return next();
         }
 
+        const messageConversation = await plugin.aiConversationsManager.getConversation({
+          sessionId: message.sessionId,
+          userId,
+        });
+        if (!messageConversation) {
+          sendErrorResponse(ctx, 'conversation not found');
+          return next();
+        }
+
         const tools = message.toolCalls;
         if (!tools?.length) {
           sendErrorResponse(ctx, 'No tool calls found');
@@ -822,7 +840,7 @@ export default {
           model: resolvedModel,
         });
 
-        const userDecisions = await plugin.aiConversationsManager.getUserDecisions(messageId);
+        const userDecisions = await plugin.aiConversationsManager.getUserDecisions(message.messageId);
         await aiEmployee.stream({
           userDecisions,
         });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI tool-call approval actions receive a `messageId`, but the request `sessionId` can point to the main conversation while the tool-call message belongs to a sub-agent conversation. The backend must authorize the message's owning conversation before reading decisions or updating tool-message state.

### Description 
This PR keeps the existing API shape and main-agent resume flow. After loading the target message, `updateUserDecision` and `resumeToolCall` verify that `message.sessionId` belongs to the current user. Tool-message updates continue to use `message.sessionId`, and `resumeToolCall` continues to create `AIEmployee` with the request `sessionId`.

Key changes:
- Add message owner conversation authorization after `updateUserDecision` loads the target message.
- Add message owner conversation authorization after `resumeToolCall` resolves the target message.
- Preserve the no-`messageId` `resumeToolCall` branch that resumes the latest message from the request `sessionId`.

Testing:
- `git diff --check`
- Not run in this worktree: `yarn eslint --fix packages/plugins/@nocobase/plugin-ai/src/server/resource/aiConversations.ts` fails because `eslint` is not available from the local Yarn command.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI tool-call approvals to authorize against the message's owning conversation before updating decisions. |
| 🇨🇳 Chinese | 修复 AI 工具调用审批会先校验消息所属会话权限后再更新决策的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
