### PR TITLE
fix(plugin-ui-layout): preserve mobile app path

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/plugin.test.ts
@@ -39,10 +39,7 @@ describe('PluginUiLayoutClientV2', () => {
           },
         }),
       },
-      getRouteUrl: vi.fn((pathname: string) => `/v/${pathname.replace(/^\/+/, '')}`),
-      router: {
-        getBasename: vi.fn(() => '/v/'),
-      },
+      getHref: vi.fn((pathname: string) => `/v/${pathname.replace(/^\/+/, '')}`),
       layoutManager: {
         hasLayout: vi.fn(() => false),
         registerLayout: vi.fn(),
@@ -71,6 +68,7 @@ describe('PluginUiLayoutClientV2', () => {
       aclSnippet: 'pm.mobile',
       link: '/v/mobile',
     });
+    expect(app.getHref).toHaveBeenCalledWith('/mobile');
     expect(app.pluginSettingsManager.addPageTabItem).toHaveBeenCalledWith({
       menuKey: 'mobile',
       key: 'index',
@@ -186,47 +184,20 @@ describe('PluginUiLayoutClientV2', () => {
     });
   });
 
-  it('should include the sub-app router basename in the mobile settings link', async () => {
+  it('should preserve the current sub-app path in the mobile settings link', async () => {
     const { default: PluginUiLayoutClientV2 } = await import('../plugin');
-    const app = {
-      i18n: {
-        t: vi.fn((key: string) => key),
-      },
-      pluginSettingsManager: {
-        addMenuItem: vi.fn(),
-        addPageTabItem: vi.fn(),
-        setPluginSettingsLink: vi.fn(),
-      },
-      apiClient: {
-        request: vi.fn().mockResolvedValue({ data: { data: [] } }),
-      },
-      getRouteUrl: vi.fn((pathname: string) => `/v/${pathname.replace(/^\/+/, '')}`),
-      router: {
-        getBasename: vi.fn(() => '/v/apps/sub-app/'),
-      },
-      layoutManager: {
-        hasLayout: vi.fn(() => false),
-        registerLayout: vi.fn(),
-      },
-      flowEngine: {
-        registerModelLoaders: vi.fn(),
-        registerActions: vi.fn(),
-        flowSettings: {
-          registerComponents: vi.fn(),
-        },
-      },
-    };
-    const plugin = new PluginUiLayoutClientV2({} as Record<string, never>, app as unknown as Application);
+    const app = createMockClient({
+      name: 'portal',
+      publicPath: '/nocobase/v/',
+      plugins: [PluginUiLayoutClientV2],
+    });
+    app.apiMock.onGet('uiLayouts:listEnabled').reply(200, { data: [] });
 
-    await plugin.load();
+    await app.load();
 
-    expect(app.pluginSettingsManager.addMenuItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        key: 'mobile',
-        link: '/v/apps/sub-app/mobile',
-      }),
-    );
-    expect(app.getRouteUrl).not.toHaveBeenCalledWith('/mobile');
+    expect(app.pluginSettingsManager.get('mobile', false)).toMatchObject({
+      link: '/nocobase/v/apps/portal/mobile',
+    });
   });
 
   it('should register custom layout routes during plugin load', async () => {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/plugin.tsx
@@ -22,12 +22,7 @@ function MobileSettingsRedirect() {
 }
 
 function getMobileSettingsLink(app: Application) {
-  const basename = app.router.getBasename?.();
-  if (basename) {
-    return `${basename.replace(/\/+$/, '')}/mobile`;
-  }
-
-  return app.getRouteUrl?.('/mobile') || '/mobile';
+  return app.getHref('/mobile');
 }
 
 export class PluginUiLayoutClientV2 extends Plugin<Record<string, never>, Application> {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

在子应用中点击 Mobile 设置入口时，页面仍可能跳转到主应用的 `/mobile`，丢失当前子应用路径。

### Description

- 使用应用自身提供的链接生成能力，确保 Mobile 设置入口保留当前子应用路径。
- 使用真实子应用配置补充回归测试，同时确认主应用的 Mobile 链接保持不变。
- 变更仅影响 Mobile 设置入口的链接生成。

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the Mobile settings link losing the current sub-application path |
| 🇨🇳 Chinese | 修复 Mobile 设置入口丢失当前子应用路径的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
