### PR TITLE
fix(plugin-workflow): inherit form disabled state

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowTypedVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowTypedVariableInput.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import { ConfigProvider } from 'antd';
 import { TypedVariableInput, type TypedConstantSpec, type TypedVariableInputProps } from '@nocobase/client-v2';
 import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from './useWorkflowVariableOptions';
 import { useHideVariable } from '../components/HideVariableContext';
@@ -21,8 +22,16 @@ export type WorkflowTypedVariableInputProps = Omit<
   variableOptions?: UseWorkflowVariableOptions;
 };
 
-export function WorkflowTypedVariableInput({ variableOptions, ...rest }: WorkflowTypedVariableInputProps) {
+export function WorkflowTypedVariableInput({ variableOptions, disabled, ...rest }: WorkflowTypedVariableInputProps) {
+  const { componentDisabled } = ConfigProvider.useConfig();
   const metaTree = useWorkflowVariableOptions(variableOptions);
   const hideVariable = useHideVariable();
-  return <TypedVariableInput {...rest} hideVariable={hideVariable} metaTree={metaTree} />;
+  return (
+    <TypedVariableInput
+      {...rest}
+      disabled={Boolean(componentDisabled || disabled)}
+      hideVariable={hideVariable}
+      metaTree={metaTree}
+    />
+  );
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
@@ -23,6 +23,7 @@
  */
 
 import React, { useMemo } from 'react';
+import { ConfigProvider } from 'antd';
 import { VariableHybridInput } from '@nocobase/flow-engine';
 import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from './useWorkflowVariableOptions';
 import { workflowVariableConverters } from './workflowVariableConverters';
@@ -44,8 +45,16 @@ export type WorkflowVariableInputProps = {
 };
 
 export function WorkflowVariableInput(props: WorkflowVariableInputProps) {
-  const { variableOptions, ...rest } = props;
+  const { variableOptions, disabled, ...rest } = props;
+  const { componentDisabled } = ConfigProvider.useConfig();
   const metaTree = useWorkflowVariableOptions(variableOptions);
   const tree = useMemo(() => metaTree, [metaTree]);
-  return <VariableHybridInput {...rest} metaTree={tree} converters={workflowVariableConverters} />;
+  return (
+    <VariableHybridInput
+      {...rest}
+      disabled={Boolean(componentDisabled || disabled)}
+      metaTree={tree}
+      converters={workflowVariableConverters}
+    />
+  );
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowTypedVariableInput.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/WorkflowTypedVariableInput.test.tsx
@@ -9,6 +9,7 @@
 
 import { FlowContext, FlowContextProvider } from '@nocobase/flow-engine';
 import { render, screen } from '@testing-library/react';
+import { Form } from 'antd';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { HideVariableContext } from '../../components/HideVariableContext';
@@ -46,5 +47,16 @@ describe('WorkflowTypedVariableInput', () => {
 
     expect(screen.getByRole('button', { name: 'variable-tag' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'variable-switcher' })).toBeNull();
+  });
+
+  it('inherits disabled state from the parent form', () => {
+    renderWithCtx(
+      <Form disabled>
+        <WorkflowTypedVariableInput value="{{$context.id}}" types={[]} onChange={() => undefined} />
+      </Form>,
+    );
+
+    expect(screen.getByRole('button', { name: 'variable-switcher' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'icon-close' })).toBeNull();
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/Calculation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/Calculation.tsx
@@ -26,7 +26,7 @@ import { css, cx } from '@emotion/css';
 import { TypedVariableInput, type TypedConstantSpec } from '@nocobase/client-v2';
 import type { MetaTreeNode } from '@nocobase/flow-engine';
 import { Registry } from '@nocobase/utils/client';
-import { Button, Select } from 'antd';
+import { Button, ConfigProvider, Select } from 'antd';
 import React, { createContext, useCallback, useContext } from 'react';
 import { Trans } from 'react-i18next';
 import { useT, useWorkflowTranslation, NAMESPACE } from '../locale';
@@ -110,6 +110,8 @@ function useOperandMetaTree(): MetaTreeNode[] {
 
 function Calculation({ calculator, operands = [], onChange }: any) {
   const compile = useT();
+  const { componentDisabled } = ConfigProvider.useConfig();
+  const disabled = Boolean(componentDisabled);
   // Keep the left/right operands on separate meta-tree instances. `TypedVariableInput`
   // lazily resolves relation children by mutating its `metaTree` in place; sharing one
   // tree between both sides can leave the other cascader stuck on a stale loading column
@@ -144,6 +146,7 @@ function Calculation({ calculator, operands = [], onChange }: any) {
           metaTree={leftMetaTree}
           value={operands[0]}
           onChange={leftOperandOnChange}
+          disabled={disabled}
         />
       </div>
       <Select
@@ -176,6 +179,7 @@ function Calculation({ calculator, operands = [], onChange }: any) {
           metaTree={rightMetaTree}
           value={operands[1]}
           onChange={rightOperandOnChange}
+          disabled={disabled}
         />
       </div>
     </fieldset>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/FilterDynamicComponent.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/FilterDynamicComponent.tsx
@@ -19,6 +19,7 @@ import {
   type MetaTreeNode,
 } from '@nocobase/flow-engine';
 import { useMemoizedFn } from 'ahooks';
+import { ConfigProvider } from 'antd';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { removeInvalidFilterItems, type FilterGroupType } from '@nocobase/utils/client';
 import { useWorkflowVariableOptions } from '../canvas/useWorkflowVariableOptions';
@@ -277,7 +278,7 @@ export function FilterDynamicComponent({
   collection,
   value,
   onChange,
-  disabled = false,
+  disabled,
   rightAsVariable = true,
   maxAssociationFieldDepth = 2,
 }: {
@@ -299,6 +300,8 @@ export function FilterDynamicComponent({
 }) {
   const flowEngine = useFlowEngine();
   const t = useT();
+  const { componentDisabled } = ConfigProvider.useConfig();
+  const mergedDisabled = Boolean(componentDisabled || disabled);
   const stableT = useMemoizedFn((key: string, options?: Record<string, unknown>) => t(key, options));
   const workflowMetaTree = useWorkflowVariableOptions();
   const rightMetaTree = useMemo(
@@ -383,7 +386,7 @@ export function FilterDynamicComponent({
         <VariableFilterItem
           value={value}
           model={filterModel}
-          disabled={disabled}
+          disabled={mergedDisabled}
           rightAsVariable={rightAsVariable}
           rightMetaTree={rightMetaTree}
           maxAssociationFieldDepth={maxAssociationFieldDepth}
@@ -392,9 +395,11 @@ export function FilterDynamicComponent({
     );
     Component.displayName = 'WorkflowVariableFilterItem';
     return Component;
-  }, [disabled, filterModel, maxAssociationFieldDepth, rightAsVariable, rightMetaTree]);
+  }, [filterModel, maxAssociationFieldDepth, mergedDisabled, rightAsVariable, rightMetaTree]);
 
-  return <FilterGroup value={filterRef.current} FilterItem={FilterItemComponent ?? undefined} disabled={disabled} />;
+  return (
+    <FilterGroup value={filterRef.current} FilterItem={FilterItemComponent ?? undefined} disabled={mergedDisabled} />
+  );
 }
 
 export const ConditionField = FilterDynamicComponent;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/Calculation.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/Calculation.test.tsx
@@ -9,11 +9,12 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { Form } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { CalculationConfig } from '../Calculation';
 
 const holder = vi.hoisted(() => ({
-  typedVariableInputProps: [] as Array<{ metaTree: unknown; value: unknown; style: unknown }>,
+  typedVariableInputProps: [] as Array<{ disabled: boolean; metaTree: unknown; value: unknown; style: unknown }>,
 }));
 
 vi.mock('../../locale', () => ({
@@ -23,8 +24,9 @@ vi.mock('../../locale', () => ({
 }));
 
 vi.mock('@nocobase/client-v2', () => ({
-  TypedVariableInput: (props: any) => {
+  TypedVariableInput: (props: { disabled?: boolean; metaTree?: unknown; style?: unknown; value?: unknown }) => {
     holder.typedVariableInputProps.push({
+      disabled: Boolean(props.disabled),
       metaTree: props.metaTree,
       value: props.value,
       style: props.style,
@@ -92,5 +94,27 @@ describe('CalculationConfig', () => {
     expect(holder.typedVariableInputProps).toHaveLength(2);
     expect(holder.typedVariableInputProps[0].style).toBeUndefined();
     expect(holder.typedVariableInputProps[1].style).toBeUndefined();
+  });
+
+  it('inherits disabled state from the parent form for both operands', () => {
+    holder.typedVariableInputProps = [];
+
+    render(
+      <Form disabled>
+        <CalculationConfig
+          useVariableHook={() => [{ name: '$context', title: 'Trigger variables', paths: ['$context'], type: '' }]}
+          value={{
+            group: {
+              type: 'and',
+              calculations: [{ calculator: 'equal', operands: ['{{$context.data.id}}', 0] }],
+            },
+          }}
+          onChange={() => undefined}
+        />
+      </Form>,
+    );
+
+    expect(holder.typedVariableInputProps).toHaveLength(2);
+    expect(holder.typedVariableInputProps.every((props) => props.disabled)).toBe(true);
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/FilterDynamicComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/FilterDynamicComponent.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FlowEngine, FlowEngineProvider } from '@nocobase/flow-engine';
+import { Form } from 'antd';
 import { FilterDynamicComponent } from '../FilterDynamicComponent';
 
 const testState = vi.hoisted(() => ({
@@ -313,6 +314,27 @@ describe('FilterDynamicComponent', () => {
           onChange={() => undefined}
           disabled
         />
+      </FlowEngineProvider>,
+    );
+
+    expect(testState.variableFilterItems.length).toBeGreaterThan(0);
+    expect(testState.variableFilterItems.at(-1)?.disabled).toBe(true);
+    expect(screen.getByText('Add condition').closest('button')).toBeDisabled();
+    expect(screen.getByText('Add condition group').closest('button')).toBeDisabled();
+  });
+
+  it('inherits disabled state from the parent form', () => {
+    const { engine } = setupEngine();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <Form disabled>
+          <FilterDynamicComponent
+            collection="posts"
+            value={{ $and: [{ title: { $eq: 'foo' } }] }}
+            onChange={() => undefined}
+          />
+        </Form>
       </FlowEngineProvider>,
     );
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
@@ -12,7 +12,7 @@ import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
 import { FieldAssignValueInput } from '@nocobase/client-v2';
 import { FlowModelProvider, useFlowEngine, type FlowModel } from '@nocobase/flow-engine';
-import { Button, Dropdown, Empty, Form } from 'antd';
+import { Button, ConfigProvider, Dropdown, Empty, Form } from 'antd';
 import type { MenuProps } from 'antd';
 import { useWorkflowVariableOptions } from '../../canvas/useWorkflowVariableOptions';
 import { formatWorkflowPathToValue, parseWorkflowValueToPath } from '../../canvas/workflowVariableConverters';
@@ -99,7 +99,7 @@ export function AssignedFieldsEditor({
   onChange,
   fieldFilter = defaultFieldFilter,
   pruneFilteredValues,
-  disabled = false,
+  disabled,
 }: {
   collection?: string;
   value?: AssignedValues;
@@ -110,6 +110,8 @@ export function AssignedFieldsEditor({
 }) {
   const flowEngine = useFlowEngine();
   const t = useT();
+  const { componentDisabled } = ConfigProvider.useConfig();
+  const mergedDisabled = Boolean(componentDisabled || disabled);
   const workflowVariableTree = useWorkflowVariableOptions();
   const contextModel = useCollectionContextModel(collection, workflowVariableTree);
   const allFields = useMemo(
@@ -133,7 +135,7 @@ export function AssignedFieldsEditor({
   );
 
   useEffect(() => {
-    if (!pruneFilteredValues || disabled) {
+    if (!pruneFilteredValues || mergedDisabled) {
       return;
     }
 
@@ -145,17 +147,17 @@ export function AssignedFieldsEditor({
     }
 
     onChange?.(Object.fromEntries(nextEntries));
-  }, [disabled, fields, normalizedValue, onChange, pruneFilteredValues]);
+  }, [fields, mergedDisabled, normalizedValue, onChange, pruneFilteredValues]);
 
   const updateValue = (fieldName: string, nextValue: unknown) => {
-    if (disabled) {
+    if (mergedDisabled) {
       return;
     }
     onChange?.({ ...normalizedValue, [fieldName]: nextValue === undefined ? '' : nextValue });
   };
 
   const removeField = (fieldName: string) => {
-    if (disabled) {
+    if (mergedDisabled) {
       return;
     }
     const { [fieldName]: _, ...rest } = normalizedValue;
@@ -165,7 +167,7 @@ export function AssignedFieldsEditor({
   const menu = useMemo<MenuProps>(
     () => ({
       onClick: ({ key }) => {
-        if (disabled) {
+        if (mergedDisabled) {
           return;
         }
         onChange?.({ ...normalizedValue, [String(key)]: '' });
@@ -176,11 +178,11 @@ export function AssignedFieldsEditor({
       },
       items: unassignedFields.map((field) => ({
         key: field.name,
-        disabled,
+        disabled: mergedDisabled,
         label: getFieldTitle(field, t),
       })),
     }),
-    [disabled, normalizedValue, onChange, t, unassignedFields],
+    [mergedDisabled, normalizedValue, onChange, t, unassignedFields],
   );
 
   if (!collection) {
@@ -209,7 +211,7 @@ export function AssignedFieldsEditor({
                 value={normalizedValue[field.name]}
                 onChange={(nextValue) => updateValue(field.name, nextValue)}
                 allowRunJS={false}
-                disabled={disabled}
+                disabled={mergedDisabled}
                 variableConverters={{
                   resolvePathFromValue: (currentValue) =>
                     typeof currentValue === 'string' ? parseWorkflowValueToPath(currentValue) : undefined,
@@ -221,7 +223,7 @@ export function AssignedFieldsEditor({
               aria-label={t('Remove field')}
               type="link"
               icon={<CloseCircleOutlined />}
-              disabled={disabled}
+              disabled={mergedDisabled}
               onClick={() => removeField(field.name)}
               style={{
                 position: 'absolute',
@@ -233,8 +235,8 @@ export function AssignedFieldsEditor({
           </div>
         ))}
         {unassignedFields.length ? (
-          <Dropdown disabled={disabled} menu={menu} trigger={['click']}>
-            <Button aria-label={t('Add field')} icon={<PlusOutlined />} disabled={disabled}>
+          <Dropdown disabled={mergedDisabled} menu={menu} trigger={['click']}>
+            <Button aria-label={t('Add field')} icon={<PlusOutlined />} disabled={mergedDisabled}>
               {t('Add field')}
             </Button>
           </Dropdown>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Executed workflows should remain read-only, but some client-v2 condition, variable, and assigned-field controls did not inherit the disabled state from their parent form.

### Description

- Inherit the Ant Design form disabled state in shared workflow form controls.
- Merge explicitly configured and inherited disabled states.
- Add regression coverage for condition filters, calculation operands, variable inputs, and assigned fields.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Workflow form controls now correctly inherit the disabled state when viewing executed workflows. |
| 🇨🇳 Chinese | 查看已执行工作流时，工作流表单控件现在会正确继承禁用状态。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
