### PR TITLE
fix(plugin-field-markdown-vditor): upgrade vditor

### DIFF
--- a/packages/core/client-v2/src/collection-manager/field-validation.ts
+++ b/packages/core/client-v2/src/collection-manager/field-validation.ts
@@ -132,7 +132,7 @@ fieldValidationConfigureRegistry.registerMany([
   { key: 'uri', label: 'URI', hasValue: false, params: [], paramsType: 'object' },
   {
     key: 'multiple',
-    label: 'Multiple',
+    label: 'Multiple of',
     hasValue: true,
     params: [{ key: 'base', label: 'Base', componentType: 'inputNumber', required: true }],
   },

--- a/packages/core/client-v2/src/flow-compat/fieldValidationConstants.ts
+++ b/packages/core/client-v2/src/flow-compat/fieldValidationConstants.ts
@@ -231,7 +231,7 @@ export const FIELDS_VALIDATION_OPTIONS = {
     },
     {
       key: 'multiple',
-      label: 'Multiple',
+      label: 'Multiple of',
       hasValue: true,
       params: [{ key: 'base', label: 'Base', componentType: 'inputNumber', required: true }],
     },

--- a/packages/core/client/src/collection-manager/constants.ts
+++ b/packages/core/client/src/collection-manager/constants.ts
@@ -230,7 +230,7 @@ export const FIELDS_VALIDATION_OPTIONS = {
     },
     {
       key: 'multiple',
-      label: 'Multiple',
+      label: 'Multiple of',
       hasValue: true,
       params: [{ key: 'base', label: 'Base', componentType: 'inputNumber', required: true }],
     },

--- a/packages/core/client/src/locale/en-US.json
+++ b/packages/core/client/src/locale/en-US.json
@@ -874,6 +874,7 @@
   "Move up": "Move up",
   "Move {{title}} to": "Move {{title}} to",
   "Multiple": "Multiple",
+  "Multiple of": "Multiple of",
   "Multiple select": "Multiple select",
   "Multiply by": "Multiply by",
   "Must be 1-50 characters in length (excluding @.<>\"'/)": "Must be 1-50 characters in length (excluding @.<>\"'/)",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -1633,6 +1633,7 @@
   "Enable select action": "启用选择操作",
   "Enable remove action": "启用移除操作",
   "Multiple": "多选",
+  "Multiple of": "多倍数",
   "Custom column width": "自定义列宽度",
   "The block is hidden and only visible when the UI Editor is active": "当前区块已被隐藏,仅配置状态下显示",
   "The field is hidden and only visible when the UI Editor is active": "当前字段已被隐藏,仅配置状态下显示",

--- a/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client-v2/component/BulkEditFieldV2.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-edit/src/client-v2/component/BulkEditFieldV2.tsx
@@ -11,7 +11,7 @@ import { Select, Space } from 'antd';
 import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/css';
 import { BulkEditFormItemValueType } from '../types';
-import { lang } from '../locale';
+import { useBulkEditTranslation } from '../locale';
 
 function toFormFieldValue(value: any) {
   if (BulkEditFormItemValueType.Clear in value) {
@@ -24,6 +24,7 @@ function toFormFieldValue(value: any) {
 }
 
 export const BulkEditFieldV2 = (props) => {
+  const { t } = useBulkEditTranslation();
   const { formItemModel, onChange, field, ...rest } = props;
   const [type, setType] = useState<number>(BulkEditFormItemValueType.RemainsTheSame);
   const [value, setValue] = useState(null);
@@ -65,7 +66,7 @@ export const BulkEditFieldV2 = (props) => {
       // 移除所有规则
       formItemModel?.setProps({ required: false, rules: [] });
     }
-  }, [type]);
+  }, [formItemModel, originalRules, type]);
 
   const valueChangeHandler = (val) => {
     const v = val?.target?.value ?? val?.target?.checked ?? val;
@@ -89,9 +90,9 @@ export const BulkEditFieldV2 = (props) => {
       direction="vertical"
     >
       <Select defaultValue={type} value={type} onChange={typeChangeHandler} disabled={props.aclDisabled}>
-        <Select.Option value={BulkEditFormItemValueType.RemainsTheSame}>{lang('Remains the same')}</Select.Option>
-        <Select.Option value={BulkEditFormItemValueType.ChangedTo}>{lang('Changed to')}</Select.Option>
-        <Select.Option value={BulkEditFormItemValueType.Clear}>{lang('Clear')}</Select.Option>
+        <Select.Option value={BulkEditFormItemValueType.RemainsTheSame}>{t('Remains the same')}</Select.Option>
+        <Select.Option value={BulkEditFormItemValueType.ChangedTo}>{t('Changed to')}</Select.Option>
+        <Select.Option value={BulkEditFormItemValueType.Clear}>{t('Clear')}</Select.Option>
       </Select>
       {[BulkEditFormItemValueType.ChangedTo, BulkEditFormItemValueType.AddAttach].includes(type) && child}
     </Space>

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/package.json
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/package.json
@@ -26,7 +26,7 @@
     "@formily/shared": "2.x",
     "antd": "5.x",
     "koa-send": "^5.0.1",
-    "vditor": "^3.10.3"
+    "vditor": "^3.11.2"
   },
   "keywords": [
     "Collection fields"

--- a/yarn.lock
+++ b/yarn.lock
@@ -34940,10 +34940,10 @@ vasync@^2.2.1:
   dependencies:
     verror "1.10.0"
 
-vditor@^3.10.3:
-  version "3.10.4"
-  resolved "https://registry.npmmirror.com/vditor/-/vditor-3.10.4.tgz#df7e5cdf8c737b588152b2119942ff0e0904c9cd"
-  integrity sha512-NWaMom0buUvRjOCaK/jKeJEVfZNmfTgblK4+pxBoeTdiCYn5yWokcGYMh9GzHIvt5gy6FiQFc1VQvytIwyeIwA==
+vditor@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.npmmirror.com/vditor/-/vditor-3.11.2.tgz#612a405c74b71278a4eea188db3c7d93c0884c11"
+  integrity sha512-8QguQQUPWbBFocnfQmWjz4jiykQnvsmCuhOomGIVVK7vc+dQq2h8w9qQQuEjUTZpnZT5fEdYbj4aLr1NGdAZaA==
   dependencies:
     diff-match-patch "^1.0.5"
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Production uses the packaged Vditor assets, which currently resolve to Vditor 3.10.4. When a V2 form contains a field named `process`, Ant Design can generate `id="process"`, exposing `window.process` as an HTML input. Vditor/Lute 3.10.4 can fail during initialization in that case, leaving the Markdown field without the editor.

### Description 
Upgrade `vditor` for `@nocobase/plugin-field-markdown-vditor` from `^3.10.3` to `^3.11.2` and update the lockfile resolution to 3.11.2.

Potential risk: production Markdown assets must be rebuilt and deployed so the served `plugin-block-markdown` Vditor static files use the upgraded dependency.

Testing suggestions:
- Verify a V2 form containing both a Markdown field and a `process` field renders the Markdown editor in production mode.
- Rebuild Markdown plugin assets before deployment.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Markdown editor initialization failure when a V2 form includes a `process` field. |
| 🇨🇳 Chinese | 修复 V2 表单包含 `process` 字段时 Markdown 编辑器初始化失败的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Verification performed:
- `yarn install --ignore-scripts --frozen-lockfile`
- Playwright smoke check that loads `node_modules/vditor/dist/js/lute/lute.min.js` after an existing `<input id="process">`; `window.Lute` loads and no page errors are emitted.
