### PR TITLE
fix(client-v2): stabilize scan input camera preview

### DIFF
--- a/packages/core/client-v2/src/components/form/ScanInput/CodeScanner.tsx
+++ b/packages/core/client-v2/src/components/form/ScanInput/CodeScanner.tsx
@@ -49,6 +49,21 @@ function CodeScannerContent({ visible, formatsToSupport, onClose, onScanSuccess 
     message.error(t('Code recognition failed, please scan again'));
   }, [t]);
 
+  const showCameraStartFailure = useCallback(
+    (error: unknown) => {
+      const errorName = error instanceof Error ? error.name : '';
+      const errorMessage = error instanceof Error ? error.message : '';
+      const errorMap: Record<string, string> = {
+        NotFoundError: t('No camera device detected'),
+        NotAllowedError: t('You have not granted permission to use the camera'),
+      };
+
+      message.error(errorMap[errorName] || errorMessage || t('You have not granted permission to use the camera'));
+      onClose();
+    },
+    [onClose, t],
+  );
+
   const handleScanSuccess = useCallback(
     (text: string) => {
       onScanSuccess(text);
@@ -64,6 +79,7 @@ function CodeScannerContent({ visible, formatsToSupport, onClose, onScanSuccess 
     scanBoxSize,
     onScanSuccess: handleScanSuccess,
     onScanFailure: showScanFailure,
+    onCameraStartFailure: showCameraStartFailure,
   });
 
   useEffect(() => {
@@ -129,7 +145,7 @@ function CodeScannerContent({ visible, formatsToSupport, onClose, onScanSuccess 
     inset: 0;
     z-index: ${token.zIndexPopupBase + 1000};
     overflow: hidden;
-    background: ${token.colorBgMask};
+    background: #000;
   `;
   const scannerWrapperClass = css`
     position: absolute;
@@ -137,16 +153,17 @@ function CodeScannerContent({ visible, formatsToSupport, onClose, onScanSuccess 
     overflow: hidden;
   `;
   const scannerClass = css`
+    position: relative;
     width: 100%;
     height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    overflow: hidden;
 
     video {
-      width: auto !important;
+      position: absolute !important;
+      inset: 0 !important;
+      width: 100% !important;
       height: 100% !important;
-      max-width: none !important;
+      object-fit: cover !important;
     }
 
     #qr-shaded-region {

--- a/packages/core/client-v2/src/components/form/ScanInput/__tests__/useCodeScanner.test.tsx
+++ b/packages/core/client-v2/src/components/form/ScanInput/__tests__/useCodeScanner.test.tsx
@@ -74,13 +74,23 @@ vi.mock('html5-qrcode', () => ({
 
 vi.mock('jsqr', () => jsQrMocks);
 
-function ScannerHost({ scanBoxSize }: { scanBoxSize?: { width: number; height: number } } = {}) {
+function ScannerHost({
+  onCameraStartFailure,
+  onScanFailure,
+  scanBoxSize,
+}: {
+  onCameraStartFailure?: (error: unknown) => void;
+  onScanFailure?: () => void;
+  scanBoxSize?: { width: number; height: number };
+} = {}) {
   const handleScanSuccess = useCallback(() => undefined, []);
 
   useCodeScanner({
     elementId: 'scanner',
     enabled: true,
     scanBoxSize,
+    onCameraStartFailure,
+    onScanFailure,
     onScanSuccess: handleScanSuccess,
   });
 
@@ -192,6 +202,30 @@ describe('useCodeScanner', () => {
       | undefined;
 
     expect(config?.qrbox?.(1200, 844)).toEqual({ width: 319, height: 240 });
+  });
+
+  it('clamps the scan box to the camera viewfinder size', async () => {
+    render(<ScannerHost scanBoxSize={{ width: 319, height: 240 }} />);
+
+    await waitFor(() => expect(mocks.start).toHaveBeenCalled());
+
+    const config = mocks.start.mock.calls[0]?.[1] as
+      | { qrbox?: (width: number, height: number) => { width: number; height: number } }
+      | undefined;
+
+    expect(config?.qrbox?.(200, 160)).toEqual({ width: 200, height: 160 });
+  });
+
+  it('reports camera start failures through the dedicated handler', async () => {
+    const cameraStartError = Object.assign(new Error('Camera failed'), { name: 'NotAllowedError' });
+    const handleCameraStartFailure = vi.fn();
+    const handleScanFailure = vi.fn();
+    mocks.start.mockRejectedValueOnce(cameraStartError);
+
+    render(<ScannerHost onCameraStartFailure={handleCameraStartFailure} onScanFailure={handleScanFailure} />);
+
+    await waitFor(() => expect(handleCameraStartFailure).toHaveBeenCalledWith(cameraStartError));
+    expect(handleScanFailure).not.toHaveBeenCalled();
   });
 
   it('uses jsQR first for Safari uploaded QR images', async () => {

--- a/packages/core/client-v2/src/components/form/ScanInput/useCodeScanner.ts
+++ b/packages/core/client-v2/src/components/form/ScanInput/useCodeScanner.ts
@@ -25,6 +25,7 @@ type UseCodeScannerOptions = {
   onScannerSizeChanged?: (size: ScannerSize) => void;
   onScanSuccess: (text: string) => void;
   onScanFailure?: () => void;
+  onCameraStartFailure?: (error: unknown) => void;
 };
 
 type ImageDataVariant = {
@@ -67,6 +68,13 @@ export function getCodeScanBoxSize(width: number, height: number) {
   return {
     width: Math.floor(Math.min(width * 0.82, 520)),
     height: Math.floor(Math.min(height * 0.32, 240)),
+  };
+}
+
+function clampCodeScanBoxSize(scanBoxSize: ScannerSize, width: number, height: number) {
+  return {
+    width: Math.min(scanBoxSize.width, width),
+    height: Math.min(scanBoxSize.height, height),
   };
 }
 
@@ -212,6 +220,7 @@ export function useCodeScanner({
   onScannerSizeChanged,
   onScanSuccess,
   onScanFailure,
+  onCameraStartFailure,
 }: UseCodeScannerOptions) {
   const [scanner, setScanner] = useState<Html5Qrcode>();
 
@@ -223,7 +232,7 @@ export function useCodeScanner({
           fps: 10,
           qrbox(width, height) {
             onScannerSizeChanged?.({ width, height });
-            return scanBoxSize ?? getCodeScanBoxSize(width, height);
+            return clampCodeScanBoxSize(scanBoxSize ?? getCodeScanBoxSize(width, height), width, height);
           },
         },
         (decodedText) => {
@@ -273,14 +282,18 @@ export function useCodeScanner({
       verbose: false,
     });
     setScanner(scannerInstance);
-    startScanCamera(scannerInstance).catch(() => {
+    startScanCamera(scannerInstance).catch((error: unknown) => {
+      if (onCameraStartFailure) {
+        onCameraStartFailure(error);
+        return;
+      }
       onScanFailure?.();
     });
 
     return () => {
       stopScanner(scannerInstance, { clear: true }).catch(() => undefined);
     };
-  }, [elementId, enabled, formatsToSupport, onScanFailure, startScanCamera]);
+  }, [elementId, enabled, formatsToSupport, onCameraStartFailure, onScanFailure, startScanCamera]);
 
   return {
     startScanFile,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Fix the v2 ScanInput camera preview layout on iOS Chrome. After camera playback starts, the `html5-qrcode` video element can be laid out incorrectly and expose the underlying form through the scanner mask.

### Description 
This PR only changes the v2 ScanInput implementation:

- Makes the scanner overlay background opaque black to prevent underlying form bleed-through.
- Positions the camera `video` element absolutely in the scanner viewport and centers it with `min-width` / `min-height` coverage.
- Clamps the `qrbox` size to the actual camera viewfinder dimensions.
- Routes camera start failures through a dedicated handler so the scanner closes instead of staying half-initialized.
- Adds unit tests for `qrbox` clamping and camera start failure handling.

Potential risk: the visual preview sizing changes for v2 ScanInput camera scanning. Please verify on real iOS Chrome/Safari and Android Chrome devices.

### Related issues
N/A

### Showcase
N/A. This is a camera preview layout fix and should be verified on a real mobile device.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed v2 scan input camera preview layout issues on iOS Chrome. |
| 🇨🇳 Chinese | 修复 v2 扫描输入在 iOS Chrome 中的摄像头预览布局异常。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
