### PR TITLE
fix(plugin-ai): load documents from temp files in worker

### DIFF
--- a/packages/core/ai/src/__tests__/document-loader.test.ts
+++ b/packages/core/ai/src/__tests__/document-loader.test.ts
@@ -1,0 +1,63 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { loadByWorker } from '../document-loader';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import * as XLSX from 'xlsx';
+
+describe('Document loader worker', () => {
+  const tempDirs: string[] = [];
+
+  const createTempFile = async (filename: string, content: string | Buffer) => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'nocobase-document-loader-test-'));
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, filename);
+    await writeFile(filePath, content);
+    return filePath;
+  };
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((tempDir) => rm(tempDir, { recursive: true, force: true })));
+  });
+
+  it('loads text files by path', async () => {
+    const filePath = await createTempFile('source.txt', 'hello knowledge base\nsecond line\n');
+
+    const documents = await loadByWorker('.txt', {
+      filePath,
+      mimeType: 'text/plain',
+    });
+
+    expect(documents).toHaveLength(1);
+    expect(documents[0].pageContent).toBe('hello knowledge base\nsecond line\n');
+    expect(documents[0].metadata.source).toBe(filePath);
+  });
+
+  it('loads xlsx files by path', async () => {
+    const worksheet = XLSX.utils.aoa_to_sheet([
+      ['name', 'value'],
+      ['alpha', 1],
+    ]);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');
+    const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+    const filePath = await createTempFile('source.xlsx', buffer);
+
+    const documents = await loadByWorker('.xlsx', {
+      filePath,
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+
+    expect(documents).toHaveLength(1);
+    expect(documents[0].pageContent).toBe('Sheet: Sheet1\nname\tvalue\nalpha\t1');
+    expect(documents[0].metadata.source).toBe(filePath);
+  });
+});

--- a/packages/core/ai/src/document-loader/index.ts
+++ b/packages/core/ai/src/document-loader/index.ts
@@ -11,8 +11,12 @@ import { Document } from '@langchain/core/documents';
 import { Worker } from 'node:worker_threads';
 import path from 'node:path';
 
-export const loadByWorker = async (extname: string, blob: Blob): Promise<Document[]> => {
-  const buffer = Buffer.from(await blob.arrayBuffer());
+export type DocumentLoaderWorkerOptions = {
+  filePath: string;
+  mimeType?: string;
+};
+
+export const loadByWorker = async (extname: string, options: DocumentLoaderWorkerOptions): Promise<Document[]> => {
   const isTsRuntime = __filename.endsWith('.ts');
   const workerPath = path.join(__dirname, `loader.worker.${isTsRuntime ? 'ts' : 'js'}`);
   const worker = new Worker(workerPath, {
@@ -48,8 +52,8 @@ export const loadByWorker = async (extname: string, blob: Blob): Promise<Documen
 
     worker.postMessage({
       extname,
-      mimeType: blob.type,
-      buffer: Uint8Array.from(buffer),
+      filePath: options.filePath,
+      mimeType: options.mimeType,
     });
   }).finally(() => {
     worker.terminate().catch(() => undefined);

--- a/packages/core/ai/src/document-loader/loader.worker.ts
+++ b/packages/core/ai/src/document-loader/loader.worker.ts
@@ -19,7 +19,7 @@ import { loadXlsx } from './xlsx';
 type ParsePayload = {
   extname: string;
   mimeType?: string;
-  buffer: Uint8Array;
+  filePath: string;
 };
 
 type WorkerResponse = {
@@ -27,54 +27,51 @@ type WorkerResponse = {
   error?: string;
 };
 
-const loadPdf = async (blob: Blob): Promise<Document[]> => {
-  const loader = new PDFLoader(blob);
+const loadPdf = async (filePath: string): Promise<Document[]> => {
+  const loader = new PDFLoader(filePath);
   return loader.load();
 };
 
-const loadDoc = async (blob: Blob, type: 'docx' | 'doc'): Promise<Document[]> => {
-  const loader = new DocxLoader(blob, { type });
+const loadDoc = async (filePath: string, type: 'docx' | 'doc'): Promise<Document[]> => {
+  const loader = new DocxLoader(filePath, { type });
   return loader.load();
 };
 
-const loadPpt = async (blob: Blob): Promise<Document[]> => {
-  const loader = new PPTXLoader(blob);
+const loadPpt = async (filePath: string): Promise<Document[]> => {
+  const loader = new PPTXLoader(filePath);
   return loader.load();
 };
 
-const loadTxt = async (blob: Blob): Promise<Document[]> => {
-  const loader = new TextLoader(blob);
+const loadTxt = async (filePath: string): Promise<Document[]> => {
+  const loader = new TextLoader(filePath);
   return loader.load();
 };
 
-const loadCsv = async (blob: Blob): Promise<Document[]> => {
-  const loader = new CSVLoader(blob);
+const loadCsv = async (filePath: string): Promise<Document[]> => {
+  const loader = new CSVLoader(filePath);
   return loader.load();
 };
 
 const loadByExtname = async (payload: ParsePayload): Promise<Document[]> => {
-  // @ts-ignore
-  const blob = new Blob([Buffer.from(payload.buffer)], { type: payload.mimeType ?? 'application/octet-stream' });
-
   switch (payload.extname) {
     case '.pdf':
-      return loadPdf(blob);
+      return loadPdf(payload.filePath);
     case '.ppt':
     case '.pptx':
-      return loadPpt(blob);
+      return loadPpt(payload.filePath);
     case '.doc':
-      return loadDoc(blob, 'doc');
+      return loadDoc(payload.filePath, 'doc');
     case '.docx':
-      return loadDoc(blob, 'docx');
+      return loadDoc(payload.filePath, 'docx');
     case '.csv':
-      return loadCsv(blob);
+      return loadCsv(payload.filePath);
     case '.xls':
     case '.xlsx':
-      return loadXlsx(blob);
+      return loadXlsx(payload.filePath, payload.mimeType);
     case '.json':
     case '.md':
     case '.txt':
-      return loadTxt(blob);
+      return loadTxt(payload.filePath);
     default:
       return [];
   }

--- a/packages/core/ai/src/document-loader/xlsx.ts
+++ b/packages/core/ai/src/document-loader/xlsx.ts
@@ -8,6 +8,7 @@
  */
 
 import { Document } from '@langchain/core/documents';
+import { readFile } from 'node:fs/promises';
 import * as XLSX from 'xlsx';
 
 const normalizeCellValue = (value: unknown): string => {
@@ -43,10 +44,10 @@ const sheetToLines = (sheet: XLSX.WorkSheet): string[] => {
     .filter((line) => line.trim().length > 0);
 };
 
-export const loadXlsx = async (blob: Blob): Promise<Document[]> => {
-  const buffer = await blob.arrayBuffer();
+export const loadXlsx = async (filePath: string, mimeType?: string): Promise<Document[]> => {
+  const buffer = await readFile(filePath);
   const workbook = XLSX.read(buffer, {
-    type: 'array',
+    type: 'buffer',
     cellText: true,
   });
 
@@ -69,8 +70,8 @@ export const loadXlsx = async (blob: Blob): Promise<Document[]> => {
       new Document({
         pageContent: [`Sheet: ${sheetName}`, ...lines].join('\n'),
         metadata: {
-          source: 'blob',
-          blobType: blob.type,
+          source: filePath,
+          blobType: mimeType,
           sheetName,
           sheetIndex: index,
         },

--- a/packages/plugins/@nocobase/plugin-ai/src/server/document-loader/loader.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/document-loader/loader.ts
@@ -9,11 +9,15 @@
 
 import PluginFileManagerServer from '@nocobase/plugin-file-manager';
 import { Document } from '@langchain/core/documents';
-import { Readable } from 'node:stream';
 import { SUPPORTED_DOCUMENT_EXTNAMES } from './constants';
 import { ParseableFile } from './types';
 import { resolveExtname } from './utils';
 import { loadByWorker } from '@nocobase/ai';
+import { createWriteStream } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
 export class DocumentLoader {
   constructor(private readonly fileManager: PluginFileManagerServer) {}
@@ -25,18 +29,17 @@ export class DocumentLoader {
     }
 
     const { stream, contentType } = await this.fileManager.getFileStream(file as any, options);
-    const blob = await this.streamToBlob(stream, contentType ?? file.mimetype);
-    return await loadByWorker(extname, blob);
-  }
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'nocobase-document-loader-'));
+    const tempFilePath = path.join(tempDir, `source${extname}`);
 
-  private async streamToBlob(stream: Readable, mimeType = 'application/octet-stream') {
-    const chunks: Uint8Array[] = [];
-
-    for await (const chunk of stream) {
-      chunks.push(chunk);
+    try {
+      await pipeline(stream, createWriteStream(tempFilePath));
+      return await loadByWorker(extname, {
+        filePath: tempFilePath,
+        mimeType: contentType ?? file.mimetype,
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
     }
-
-    // @ts-ignore
-    return new Blob(chunks, { type: mimeType });
   }
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Large document uploads were loaded into memory as Blob/Buffer payloads before being sent to the document loader worker. This caused unnecessary memory amplification in the main process during knowledge base document parsing.

### Description 
- Stream document files from file manager storage into a temporary file before invoking the loader worker.
- Change the document loader worker API to receive a file path instead of a Blob/Buffer payload.
- Load PDF, Office, CSV, text, and spreadsheet documents from file paths inside the worker.
- Add coverage for path-based text and xlsx document loading.

Potential risk: document metadata source now records the temporary file path during parsing. The temp file is removed after loading completes.

Testing suggestions:
- Upload a large text document to a knowledge base and confirm segmentation still completes.
- Upload an xlsx document and confirm parsed content is still indexed correctly.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reduced main-process memory usage when parsing uploaded knowledge base documents. |
| 🇨🇳 Chinese | 降低上传知识库文档解析时主进程的内存占用。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
