### PR TITLE
fix(plugin-workflow): omit hidden fields in workflow toJSON

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
@@ -180,18 +180,35 @@ export async function abortExecution(
   }
 }
 
-export function toJSON(data: any): any {
+function getHiddenFieldNames(model: Model) {
+  const { collection } = model.constructor as typeof Model;
+  if (!collection?.fields) {
+    return [];
+  }
+
+  return Array.from(collection.fields.values())
+    .filter((field) => field?.options?.hidden)
+    .map((field) => field.options.name)
+    .filter((name): name is string => typeof name === 'string');
+}
+
+export function toJSON<T>(data: T): T {
   if (Array.isArray(data)) {
-    return data.map(toJSON);
+    return data.map(toJSON) as T;
   }
   if (!(data instanceof Model) || !data) {
     return data;
   }
-  const result = data.get();
+
+  const result = { ...(data.get() as Record<string, unknown>) };
+  for (const fieldName of getHiddenFieldNames(data)) {
+    delete result[fieldName];
+  }
+
   Object.keys((<typeof Model>data.constructor).associations).forEach((key) => {
     if (result[key] != null && typeof result[key] === 'object') {
       result[key] = toJSON(result[key]);
     }
   });
-  return result;
+  return result as T;
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Workflow's lightweight `toJSON()` helper serializes models with `data.get()` to avoid transaction-related recursion issues in some approval workflows. Because that bypasses `Model.toJSON()`, hidden fields from appended associations, such as user passwords, can leak into workflow payloads and API responses.

### Description
This PR updates the workflow `toJSON()` helper to remove fields marked as `hidden` on each model's collection before recursively serializing loaded associations.

The change keeps the existing lightweight `data.get()` based serialization path, so it does not switch back to `Model.toJSON()`.

Potential risk: workflow payloads that previously depended on hidden fields being present will no longer receive those fields.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts`
- `TZ=Asia/Singapore yarn test packages/plugins/@nocobase/plugin-workflow-approval/src/server/__tests__/acl.test.ts -t "omits hidden fields from deep file appends"`
- `TZ=Asia/Singapore yarn test packages/plugins/@nocobase/plugin-workflow-approval/src/server/__tests__/acl.test.ts`

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed hidden fields being included when workflow serializes appended association data |
| 🇨🇳 Chinese | 修复工作流序列化追加关联数据时会包含隐藏字段的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
