### PR TITLE
fix(plugin-workflow): handle unresolved filter variables

### DIFF
--- a/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
@@ -131,6 +131,10 @@ export interface VariableFilterItemProps {
    * 默认使用整棵 ctx 的 metaTree：model.context.getPropertyMetaTree()
    */
   rightMetaTree?: MetaTreeNode[] | (() => MetaTreeNode[] | Promise<MetaTreeNode[]>);
+  /**
+   * 右侧变量的领域转换器。常量和空值仍由 VariableFilterItem 处理，未匹配的值回退到 FlowEngine 默认转换器。
+   */
+  rightVariableConverters?: Pick<Converters, 'resolvePathFromValue' | 'resolveValueFromPath'>;
   ignoreFieldNames?: string[];
   maxAssociationFieldDepth?: number;
 }
@@ -352,7 +356,16 @@ function findMetaTreeNodeByPath(metaTree: MetaTreeNode[], targetPath: string[]):
  * 上下文筛选项组件
  */
 export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
-  ({ value, model, disabled = false, rightAsVariable, rightMetaTree, ignoreFieldNames, maxAssociationFieldDepth }) => {
+  ({
+    value,
+    model,
+    disabled = false,
+    rightAsVariable,
+    rightMetaTree,
+    rightVariableConverters,
+    ignoreFieldNames,
+    maxAssociationFieldDepth,
+  }) => {
     // 使用 View 上下文，确保可访问 ctx.view 的异步子树
     const ctx = useFlowViewContext();
     const t = model.translate;
@@ -684,17 +697,19 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
           const first = meta?.paths?.[0];
           if (first === 'constant') return '';
           if (first === 'null') return null;
-          return undefined; // 交给默认逻辑格式化变量表达式
+          return rightVariableConverters?.resolveValueFromPath?.(meta);
         },
         resolvePathFromValue: (val) => {
           if (val === null) return ['null'];
-          // 变量表达式：使用内置解析；其他静态值走 constant
-          const parsed = typeof val === 'string' ? parseValueToPath(val) : undefined;
+          // 变量表达式：优先使用领域转换器，再回退内置解析；其他静态值走 constant
+          const parsed =
+            rightVariableConverters?.resolvePathFromValue?.(val) ??
+            (typeof val === 'string' ? parseValueToPath(val) : undefined);
           if (parsed) return parsed;
           return ['constant'];
         },
       };
-    }, [NullComponent, staticInputRenderer]);
+    }, [NullComponent, rightVariableConverters, staticInputRenderer]);
 
     // 为 2.0 左侧字段选择器追加“接口 filterable.children”定义（如 chinaRegion 的“省市区名称”子项），
     // 以恢复 1.0 左侧子菜单的能力。

--- a/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { VariableFilterItem, VariableFilterItemValue } from '../VariableFilterItem';
-import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
+import { FlowEngine, FlowModel, type Converters, type MetaTreeNode } from '@nocobase/flow-engine';
 import { observable } from '@formily/reactive';
 import { createMockFlowApp, TestCollectionFieldInterface } from '../../../__tests__/helpers/mockFlowApp';
 
@@ -177,6 +177,54 @@ describe('VariableFilterItem', () => {
     const operatorSelect = document.body.querySelector('.ant-select') as HTMLDivElement | null;
     expect(operatorSelect).not.toBeNull();
     expect(operatorSelect).toHaveClass('ant-select-disabled');
+  });
+
+  it('composes custom right variable converters with constant, null, and core fallbacks', () => {
+    const value: VariableFilterItemValue = {
+      path: 'name',
+      operator: '$eq',
+      value: '{{$context.data.id}}',
+    };
+    const model = CreateModel();
+    const rightVariableConverters: Pick<Converters, 'resolvePathFromValue' | 'resolveValueFromPath'> = {
+      resolvePathFromValue: (input) => (input === '{{$context.data.id}}' ? ['$context', 'data', 'id'] : undefined),
+      resolveValueFromPath: (metaTreeNode) =>
+        metaTreeNode.paths?.[0] === '$context' ? `{{${metaTreeNode.paths.join('.')}}}` : undefined,
+    };
+
+    render(
+      <VariableFilterItem
+        value={value}
+        model={model}
+        rightAsVariable
+        rightVariableConverters={rightVariableConverters}
+      />,
+    );
+
+    const variableInputProps = (
+      globalThis as {
+        __LAST_VARIABLE_INPUT_PROPS__?: {
+          converters?: Converters;
+          value?: unknown;
+        };
+      }
+    ).__LAST_VARIABLE_INPUT_PROPS__;
+    const converters = variableInputProps?.converters;
+    const constantNode: MetaTreeNode = { name: 'constant', title: 'Constant', type: 'string', paths: ['constant'] };
+    const nullNode: MetaTreeNode = { name: 'null', title: 'Null', type: 'object', paths: ['null'] };
+    const workflowNode: MetaTreeNode = {
+      name: 'id',
+      title: 'ID',
+      type: 'number',
+      paths: ['$context', 'data', 'id'],
+    };
+
+    expect(variableInputProps?.value).toBe('{{$context.data.id}}');
+    expect(converters?.resolvePathFromValue?.('{{$context.data.id}}')).toEqual(['$context', 'data', 'id']);
+    expect(converters?.resolvePathFromValue?.('{{ ctx.$context.data.id }}')).toEqual(['$context', 'data', 'id']);
+    expect(converters?.resolveValueFromPath?.(constantNode)).toBe('');
+    expect(converters?.resolveValueFromPath?.(nullNode)).toBeNull();
+    expect(converters?.resolveValueFromPath?.(workflowNode)).toBe('{{$context.data.id}}');
   });
 
   it('uses scoped context dataSourceManager when app dataSourceManager has no field interface manager', async () => {

--- a/packages/core/flow-engine/src/components/variables/VariableInput.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableInput.tsx
@@ -201,16 +201,11 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
     const Component = renderInputComponent?.(resolvedMetaTreeNode);
     const CustomComponent = resolvedMetaTreeNode?.render;
     // Some domains (workflow) persist variables as `{{$context...}}` rather than the core `{{ ctx... }}` form.
-    // Those values are not recognized by `isVariableValue`, but if the active converters can resolve them back to a
-    // real meta-tree path and that path maps to a plain variable node (not Constant / Null / RunJS), they should still
-    // render as the labelled pill instead of falling back to the raw input text.
+    // When a custom converter recognizes such a value as a variable path, render VariableTag even if the path no longer
+    // exists in the current meta tree. VariableTag will then show either the resolved label or the parsing-failed state.
     const shouldRenderVariableTag =
       isVariableValue(innerValue) ||
-      (Boolean(resolvedMetaTreeNode) &&
-        Array.isArray(resolvedPath) &&
-        resolvedPath.length > 0 &&
-        !Component &&
-        !CustomComponent);
+      (Array.isArray(resolvedPath) && resolvedPath.length > 0 && !Component && !CustomComponent);
     const finalComponent = shouldRenderVariableTag ? VariableTag : Component || CustomComponent || Input;
     return finalComponent;
   }, [renderInputComponent, resolvedMetaTreeNode, innerValue, resolvedPath]);
@@ -218,8 +213,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
   const isVariableActive = useMemo(() => {
     return (
       isVariableValue(innerValue) ||
-      (Boolean(resolvedMetaTreeNode) &&
-        Array.isArray(resolvedPath) &&
+      (Array.isArray(resolvedPath) &&
         resolvedPath.length > 0 &&
         !renderInputComponent?.(resolvedMetaTreeNode) &&
         !resolvedMetaTreeNode?.render)
@@ -332,6 +326,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
         allowCustomTagInput: false,
         metaTreeNode: resolvedMetaTreeNode,
         metaTree,
+        resolvedPath,
         style: stableProps.style,
       };
     }
@@ -354,6 +349,7 @@ const VariableInputComponent: React.FC<VariableInputProps> = ({
     disabled,
     handleClear,
     resolvedMetaTreeNode,
+    resolvedPath,
     metaTree,
     ValueComponent,
     stableProps,

--- a/packages/core/flow-engine/src/components/variables/VariableTag.tsx
+++ b/packages/core/flow-engine/src/components/variables/VariableTag.tsx
@@ -28,6 +28,7 @@ const VariableTagComponent: React.FC<VariableTagProps> = ({
   style,
   metaTreeNode,
   metaTree,
+  resolvedPath,
 }) => {
   const { resolvedMetaTree } = useResolvedMetaTree(metaTree);
   const ctx = useFlowContext();
@@ -87,7 +88,7 @@ const VariableTagComponent: React.FC<VariableTagProps> = ({
 
       // 2) metaTreeNode 存在但缺少 parentTitles：尝试根据 value/metaTreeNode.paths 从 metaTree 还原完整路径
       if (metaTreeNode) {
-        const rawPath = parseValueToPath(value) || metaTreeNode.paths;
+        const rawPath = resolvedPath || parseValueToPath(value) || metaTreeNode.paths;
         const result = await resolveLabelFromPath(rawPath as any);
         if (result.resolved && result.label != null) {
           return { text: result.label, invalid: false };
@@ -100,7 +101,7 @@ const VariableTagComponent: React.FC<VariableTagProps> = ({
 
       // 3) 无 metaTreeNode：从 value 还原路径并拼接标题链；若找不到任何前缀则回退原始路径字符串
       if (!value) return { text: String(value), invalid: false };
-      const rawPath = parseValueToPath(value);
+      const rawPath = resolvedPath || parseValueToPath(value);
       const result = await resolveLabelFromPath(rawPath as any);
       if (result.resolved && result.label != null) {
         return { text: result.label, invalid: false };
@@ -110,7 +111,7 @@ const VariableTagComponent: React.FC<VariableTagProps> = ({
       }
       return { text: Array.isArray(rawPath) ? rawPath.join('/') : String(value), invalid: false };
     },
-    { refreshDeps: [resolvedMetaTree, value, metaTreeNode] },
+    { refreshDeps: [resolvedMetaTree, resolvedPath, value, metaTreeNode] },
   );
 
   const { token } = theme.useToken();

--- a/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
+++ b/packages/core/flow-engine/src/components/variables/__tests__/VariableInput.test.tsx
@@ -155,6 +155,52 @@ describe('VariableInput', () => {
     expect(selectorButton.className).toContain('ant-btn-primary');
   });
 
+  it('renders a parsing failure tag when a custom variable path is missing from the meta tree', async () => {
+    const flowContext = createTestFlowContext();
+    const workflowMetaTree = [
+      {
+        name: '$context',
+        title: 'Trigger variables',
+        type: 'object',
+        paths: ['$context'],
+        children: [
+          {
+            name: 'data',
+            title: 'Trigger data',
+            type: 'object',
+            paths: ['$context', 'data'],
+          },
+        ],
+      },
+    ];
+
+    render(
+      <TestFlowContextWrapper context={flowContext}>
+        <VariableInput
+          value="{{$context.data.id}}"
+          metaTree={workflowMetaTree}
+          converters={{
+            resolvePathFromValue: (currentValue) =>
+              currentValue === '{{$context.data.id}}' ? ['$context', 'data', 'id'] : undefined,
+            resolveValueFromPath: () => undefined,
+          }}
+        />
+      </TestFlowContextWrapper>,
+    );
+
+    await waitFor(
+      () => {
+        const variableTag = screen.getByText('Variable parsing failed');
+        expect(variableTag).toBeInTheDocument();
+        expect(variableTag.closest('.ant-tag')).toHaveClass('ant-tag-error');
+      },
+      { timeout: 3000 },
+    );
+
+    expect(screen.queryByDisplayValue('{{$context.data.id}}')).not.toBeInTheDocument();
+    expect(screen.getByRole('button').className).toContain('ant-btn-primary');
+  });
+
   it('disables custom tag input when rendering a selected variable', async () => {
     const flowContext = createTestFlowContext();
     const { container } = render(

--- a/packages/core/flow-engine/src/components/variables/types.ts
+++ b/packages/core/flow-engine/src/components/variables/types.ts
@@ -94,6 +94,7 @@ export interface VariableInputProps {
 
 export interface VariableTagProps {
   value?: string;
+  resolvedPath?: Array<string | number>;
   onClear?: () => void;
   disabled?: boolean;
   allowCustomTagInput?: boolean;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/workflowVariableConverters.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/__tests__/workflowVariableConverters.test.ts
@@ -16,34 +16,27 @@
 
 import { describe, expect, it } from 'vitest';
 import { adaptVariableOptionToMetaTree } from '../adaptVariableOptionToMetaTree';
-
-// Re-declare the converters here as a pure-logic mirror (the component wires the same functions into
-// VariableHybridInput). Keeping them inline avoids importing the .tsx component (and React) into a pure logic test.
-const formatPathToValue = (item: { paths?: string[] }) => {
-  const path = item?.paths ?? [];
-  return path.length ? `{{${path.join('.')}}}` : '';
-};
-const parseValueToPath = (value?: string) => {
-  if (typeof value !== 'string') return undefined;
-  const match = value.trim().match(/^\{\{\s*(.+?)\s*\}\}$/);
-  return match ? match[1].split('.') : undefined;
-};
+import { formatWorkflowPathToValue, parseWorkflowValueToPath } from '../workflowVariableConverters';
 
 describe('workflow variable converters', () => {
   it('formats an adapter-built leaf path to the $jobsMapByNodeKey template', () => {
     const node = adaptVariableOptionToMetaTree({ value: 'title', children: null }, ['$jobsMapByNodeKey', 'node1']);
     expect(node.paths).toEqual(['$jobsMapByNodeKey', 'node1', 'title']);
-    expect(formatPathToValue(node)).toBe('{{$jobsMapByNodeKey.node1.title}}');
+    expect(formatWorkflowPathToValue(node)).toBe('{{$jobsMapByNodeKey.node1.title}}');
   });
 
   it('round-trips: format → parse === the leaf paths', () => {
     const node = adaptVariableOptionToMetaTree({ value: 'field' }, ['$jobsMapByNodeKey', 'nodeX']);
-    const value = formatPathToValue(node);
-    expect(parseValueToPath(value)).toEqual(node.paths);
+    const value = formatWorkflowPathToValue(node);
+    expect(parseWorkflowValueToPath(value)).toEqual(node.paths);
   });
 
   it('parse tolerates inner whitespace and returns undefined for non-variable strings', () => {
-    expect(parseValueToPath('{{ $jobsMapByNodeKey.n.f }}')).toEqual(['$jobsMapByNodeKey', 'n', 'f']);
-    expect(parseValueToPath('plain text')).toBeUndefined();
+    expect(parseWorkflowValueToPath('{{ $jobsMapByNodeKey.n.f }}')).toEqual(['$jobsMapByNodeKey', 'n', 'f']);
+    expect(parseWorkflowValueToPath('plain text')).toBeUndefined();
+  });
+
+  it('parses the FlowEngine ctx form without adding ctx to the workflow path', () => {
+    expect(parseWorkflowValueToPath('{{ ctx.$context.data.id }}')).toEqual(['$context', 'data', 'id']);
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/workflowVariableConverters.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/workflowVariableConverters.ts
@@ -24,7 +24,8 @@ export function parseWorkflowValueToPath(value?: string) {
   if (!match) {
     return undefined;
   }
-  return match[1].split('.');
+  const path = match[1].split('.');
+  return path[0] === 'ctx' && path[1]?.startsWith('$') ? path.slice(1) : path;
 }
 
 export const workflowVariableConverters: VariableHybridInputConverters = {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/FilterDynamicComponent.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/FilterDynamicComponent.tsx
@@ -16,6 +16,7 @@ import {
   reaction,
   toJS,
   useFlowEngine,
+  type Converters,
   type MetaTreeNode,
 } from '@nocobase/flow-engine';
 import { useMemoizedFn } from 'ahooks';
@@ -23,6 +24,7 @@ import { ConfigProvider } from 'antd';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { removeInvalidFilterItems, type FilterGroupType } from '@nocobase/utils/client';
 import { useWorkflowVariableOptions } from '../canvas/useWorkflowVariableOptions';
+import { formatWorkflowPathToValue, parseWorkflowValueToPath } from '../canvas/workflowVariableConverters';
 import { useT } from '../locale';
 import { getCollection } from './collection/utils';
 
@@ -36,9 +38,6 @@ type FilterGroupValue = {
 function createEmptyGroup(): FilterGroupType {
   return { logic: '$and', items: [] };
 }
-
-const WORKFLOW_VARIABLE_REGEXP = /^\{\{\s*([^{}]+?)\s*\}\}$/;
-const CTX_WORKFLOW_VARIABLE_REGEXP = /^\{\{\s*ctx\.(\$[^{}]+?)\s*\}\}$/;
 
 const dateRangeVariableKeys = [
   'yesterday',
@@ -88,27 +87,10 @@ const dateRangeVariableTitles: Record<(typeof dateRangeVariableKeys)[number], st
   next90Days: 'Next 90 days',
 };
 
-function toVariableFilterValue(value: unknown): unknown {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  const match = value.trim().match(WORKFLOW_VARIABLE_REGEXP);
-  if (!match || match[1].startsWith('ctx.')) {
-    return value;
-  }
-  return `{{ ctx.${match[1]} }}`;
-}
-
-function toWorkflowFilterValue(value: unknown): unknown {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  const match = value.trim().match(CTX_WORKFLOW_VARIABLE_REGEXP);
-  if (!match) {
-    return value;
-  }
-  return `{{${match[1]}}}`;
-}
+const workflowFilterVariableConverters: Pick<Converters, 'resolvePathFromValue' | 'resolveValueFromPath'> = {
+  resolvePathFromValue: (value) => (typeof value === 'string' ? parseWorkflowValueToPath(value) : undefined),
+  resolveValueFromPath: (metaTreeNode) => formatWorkflowPathToValue(metaTreeNode),
+};
 
 function createDateRangeNode(t: (key: string) => string): MetaTreeNode {
   return {
@@ -188,7 +170,7 @@ function compileFilterGroup(group: FilterGroupType | undefined): Record<string, 
       if (!item.path || !item.operator) {
         return undefined;
       }
-      return nestPath(item.path, { [item.operator]: toWorkflowFilterValue(item.value) });
+      return nestPath(item.path, { [item.operator]: item.value });
     })
     .filter((item): item is Record<string, unknown> => Boolean(item));
   if (!compiled.length) {
@@ -204,7 +186,7 @@ function decompileConditions(value: unknown, path: string[] = []): FilterConditi
           {
             path: path.join('.'),
             operator: '$eq',
-            value: toVariableFilterValue(value) as VariableFilterItemValue['value'],
+            value: value as VariableFilterItemValue['value'],
           },
         ]
       : [];
@@ -219,7 +201,7 @@ function decompileConditions(value: unknown, path: string[] = []): FilterConditi
     return operatorEntries.map(([operator, operatorValue]) => ({
       path: path.join('.'),
       operator,
-      value: toVariableFilterValue(operatorValue) as VariableFilterItemValue['value'],
+      value: operatorValue as VariableFilterItemValue['value'],
     }));
   }
 
@@ -389,6 +371,7 @@ export function FilterDynamicComponent({
           disabled={mergedDisabled}
           rightAsVariable={rightAsVariable}
           rightMetaTree={rightMetaTree}
+          rightVariableConverters={workflowFilterVariableConverters}
           maxAssociationFieldDepth={maxAssociationFieldDepth}
         />
       </FlowModelProvider>

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/FilterDynamicComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/__tests__/FilterDynamicComponent.test.tsx
@@ -277,10 +277,20 @@ describe('FilterDynamicComponent', () => {
       </FlowEngineProvider>,
     );
 
-    expect(screen.getByDisplayValue('{{ ctx.$jobsMapByNodeKey.n1.title }}')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('{{$jobsMapByNodeKey.n1.title}}')).toBeInTheDocument();
+    const rightVariableConverters = testState.variableFilterItems.at(-1)?.rightVariableConverters;
+    expect(rightVariableConverters?.resolvePathFromValue?.('{{$context.data.id}}')).toEqual(['$context', 'data', 'id']);
+    expect(rightVariableConverters?.resolvePathFromValue?.('{{ ctx.$context.data.id }}')).toEqual([
+      '$context',
+      'data',
+      'id',
+    ]);
+    expect(rightVariableConverters?.resolveValueFromPath?.({ paths: ['$context', 'data', 'id'] })).toBe(
+      '{{$context.data.id}}',
+    );
 
     fireEvent.change(screen.getByTestId('variable-filter-item'), {
-      target: { value: '{{ ctx.$jobsMapByNodeKey.n1.body }}' },
+      target: { value: '{{$jobsMapByNodeKey.n1.body}}' },
     });
 
     await waitFor(() => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Workflow collection filters previously converted workflow variable expressions into the FlowEngine `ctx` format. When a valid expression referenced a path missing from the returned metadata tree, it fell back to a raw input instead of displaying the parsing failure state.

### Description

- Allow `VariableFilterItem` to accept domain-specific right-side variable converters while preserving constant, null, and core fallbacks.
- Keep workflow filter expressions in the native `{{$...}}` format and support parsing both workflow and FlowEngine formats.
- Pass converter-resolved paths to `VariableTag` so unresolved metadata displays the red parsing failure pill.
- Add regression coverage for valid variables, unresolved paths, converter composition, and workflow filter round trips.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Workflow filters now preserve workflow variable expressions and show a clear parsing error when variable metadata cannot be resolved. |
| 🇨🇳 Chinese | 工作流筛选条件现在会保留工作流变量表达式，并在变量元数据无法解析时显示明确的错误提示。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
