### PR TITLE
fix(notification): keep receiver IDs numeric

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/MessageConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/MessageConfigForm.tsx
@@ -22,7 +22,7 @@ function withPrefix(namePrefix: Array<string | number> | undefined, ...segments:
   return [...(namePrefix ?? []), ...segments];
 }
 
-type ReceiverValue = string | { filter?: Record<string, unknown> };
+type ReceiverValue = number | string | { filter?: Record<string, unknown> };
 type SortableReceiverRowContextValue = {
   attributes?: DraggableAttributes;
   listeners?: DraggableSyntheticListeners;

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/InAppNotificationChannel.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/InAppNotificationChannel.ts
@@ -158,7 +158,7 @@ export default class InAppNotificationChannel extends BaseNotificationChannel {
     if (receivers?.type === 'userId') {
       userIds = receivers.value;
     } else {
-      userIds = (await parseUserSelectionConf(message.receivers, userRepo, { transaction })).map((i) => parseInt(i));
+      userIds = (await parseUserSelectionConf(message.receivers, userRepo, { transaction })).map((id) => Number(id));
     }
     const resolveReceiversMs = Date.now() - resolveReceiversStartedAt;
 

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/parseUserSelectionConf.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/server/parseUserSelectionConf.ts
@@ -11,12 +11,12 @@ import { Transactionable } from '@nocobase/database';
 import { Repository } from '@nocobase/database';
 import { isValidFilter } from '@nocobase/utils';
 export async function parseUserSelectionConf(
-  userSelectionConfig: Array<Record<any, any> | string>,
+  userSelectionConfig: Array<Record<any, any> | number | string>,
   UserRepo: Repository,
   options: Transactionable = {},
 ) {
   const SelectionConfigs = userSelectionConfig.flat().filter(Boolean);
-  const users = new Set<string>();
+  const users = new Set<number | string>();
   for (const item of SelectionConfigs) {
     if (typeof item === 'object') {
       if (!isValidFilter(item.filter)) {

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/types/index.ts
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/types/index.ts
@@ -33,7 +33,7 @@ export type SSEData = {
   data: Message;
 };
 export interface InAppMessageFormValues {
-  receivers: string[];
+  receivers: Array<number | string | { filter?: Record<string, unknown> }>;
   content: string;
   senderName: string;
   senderId: string;

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/UserAddition.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/UserAddition.tsx
@@ -13,8 +13,8 @@ import React, { useCallback, useState } from 'react';
 import { useNotificationTranslation } from '../../locale';
 
 export type UserAdditionProps = {
-  value?: Array<string | { filter?: Record<string, unknown> }>;
-  onChange?: (next: Array<string | { filter?: Record<string, unknown> }>) => void;
+  value?: Array<number | string | { filter?: Record<string, unknown> }>;
+  onChange?: (next: Array<number | string | { filter?: Record<string, unknown> }>) => void;
   disabled?: boolean;
 };
 

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/UserSelect.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/UserSelect.tsx
@@ -27,9 +27,10 @@ import {
 } from '@nocobase/plugin-workflow/client-v2';
 import { useNotificationTranslation } from '../../locale';
 
-type UserOption = { id: number | string; nickname?: string };
+type UserOption = { id: number; nickname?: string };
+type ReceiverScalarValue = number | string;
 type ReceiverQueryValue = { filter?: Record<string, unknown> };
-type ReceiverValue = string | ReceiverQueryValue;
+type ReceiverValue = ReceiverScalarValue | ReceiverQueryValue;
 type UsersListResponse = { data?: { data?: UserOption[] } };
 type MetaNodeTooltipOptions = { tooltip?: React.ReactNode };
 
@@ -67,7 +68,7 @@ function formatWorkflowPathToValue(item?: MetaTreeNode) {
   return path.length ? `{{${path.join('.')}}}` : '';
 }
 
-function parseWorkflowValueToPath(value?: string) {
+function parseWorkflowValueToPath(value?: ReceiverScalarValue | null) {
   if (typeof value !== 'string') {
     return undefined;
   }
@@ -111,20 +112,21 @@ function normalizeWorkflowVariableOptions(options: MetaTreeNode[], t: (key: stri
   ].filter(Boolean) as MetaTreeNode[];
 }
 
-function UserPickerInput(props: { value?: string; onChange?: (next: string) => void }) {
+function UserPickerInput(props: { value?: ReceiverScalarValue; onChange?: (next: ReceiverScalarValue) => void }) {
   const { value, onChange } = props;
   const ctx = useFlowContext();
+  const normalizedValue = typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value;
 
   return (
-    <RemoteSelect<UserOption>
-      value={value}
-      onChange={(next) => onChange?.(next == null ? '' : String(next))}
+    <RemoteSelect<UserOption, UserOption[], ReceiverScalarValue>
+      value={normalizedValue}
+      onChange={(next) => onChange?.(next == null ? '' : next)}
       request={async () => {
         const response = await ctx.api.resource('users').list();
         const payload = (response as UsersListResponse)?.data?.data;
         return Array.isArray(payload) ? payload : [];
       }}
-      mapOptions={(item) => ({ label: item.nickname || String(item.id), value: String(item.id) })}
+      mapOptions={(item) => ({ label: item.nickname || String(item.id), value: item.id })}
       style={{ width: '100%' }}
     />
   );
@@ -132,15 +134,16 @@ function UserPickerInput(props: { value?: string; onChange?: (next: string) => v
 
 function WorkflowUserVariableInput(props: {
   metaTree: MetaTreeNode[];
-  onChange?: (next: string) => void;
+  onChange?: (next: ReceiverScalarValue) => void;
   translate: (key: string) => string;
-  value?: string | null;
+  value?: ReceiverScalarValue | null;
 }) {
   const { metaTree, onChange, translate, value } = props;
   const { token } = theme.useToken();
   const { resolvedMetaTree } = useResolvedMetaTree(metaTree);
   const [updateFlag, setUpdateFlag] = useState(0);
-  const selectedPath = useMemo(() => parseWorkflowValueToPath(value ?? '') ?? ['constant'], [value]);
+  const variableValue = typeof value === 'string' ? value : '';
+  const selectedPath = useMemo(() => parseWorkflowValueToPath(value) ?? ['constant'], [value]);
   const isVariableValue = selectedPath[0] !== 'constant';
 
   const renderTooltipIcon = useMemoizedFn((title: React.ReactNode, label: React.ReactNode) => {
@@ -227,7 +230,7 @@ function WorkflowUserVariableInput(props: {
 
   const valueNode = isVariableValue ? (
     <WorkflowVariableTag
-      value={value ?? ''}
+      value={variableValue}
       onClear={() => onChange?.('')}
       metaTree={resolvedMetaTree ?? metaTree}
       style={{ width: '100%', minWidth: 0 }}
@@ -251,7 +254,10 @@ function WorkflowUserVariableInput(props: {
   );
 }
 
-function WorkflowUserSelectInput(props: { value?: string | null; onChange?: (next: string) => void }) {
+function WorkflowUserSelectInput(props: {
+  value?: ReceiverScalarValue | null;
+  onChange?: (next: ReceiverScalarValue) => void;
+}) {
   const { value, onChange } = props;
   const { t } = useNotificationTranslation();
   const ctx = useFlowContext();
@@ -312,7 +318,10 @@ export function UserSelect(props: UserSelectProps) {
   }
 
   return (
-    <WorkflowUserSelectInput value={typeof props.value === 'string' ? props.value : ''} onChange={props.onChange} />
+    <WorkflowUserSelectInput
+      value={typeof props.value === 'string' || typeof props.value === 'number' ? props.value : ''}
+      onChange={props.onChange}
+    />
   );
 }
 

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/__tests__/UserSelect.test.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/client-v2/components/User/__tests__/UserSelect.test.tsx
@@ -107,6 +107,64 @@ describe('UserSelect', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
+  it('returns the numeric user id when selecting a constant receiver', async () => {
+    const onChange = vi.fn();
+    holder.ctx = {
+      api: {
+        resource: () => ({
+          list: vi.fn().mockResolvedValue({
+            data: {
+              data: [{ id: 1, nickname: 'Demo user' }],
+            },
+          }),
+        }),
+      },
+    };
+
+    render(<UserSelect value="" onChange={onChange} />);
+
+    fireEvent.mouseDown(await screen.findByRole('combobox'));
+    fireEvent.click(await screen.findByText('Demo user'));
+
+    expect(onChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it('renders a saved numeric user id as the selected receiver', async () => {
+    holder.ctx = {
+      api: {
+        resource: () => ({
+          list: vi.fn().mockResolvedValue({
+            data: {
+              data: [{ id: 1, nickname: 'Demo user' }],
+            },
+          }),
+        }),
+      },
+    };
+
+    render(<UserSelect value={1} onChange={() => undefined} />);
+
+    expect(await screen.findByText('Demo user')).toBeInTheDocument();
+  });
+
+  it('renders a saved string user id as the selected receiver', async () => {
+    holder.ctx = {
+      api: {
+        resource: () => ({
+          list: vi.fn().mockResolvedValue({
+            data: {
+              data: [{ id: 1, nickname: 'Demo user' }],
+            },
+          }),
+        }),
+      },
+    };
+
+    render(<UserSelect value="1" onChange={() => undefined} />);
+
+    expect(await screen.findByText('Demo user')).toBeInTheDocument();
+  });
+
   it('restricts workflow receiver variables to user id fields', async () => {
     holder.ctx = {
       api: {

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/__tests__/parseUserSelectionConfig.test.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/__tests__/parseUserSelectionConfig.test.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Repository } from '@nocobase/database';
+import { describe, expect, it, vi } from 'vitest';
+import { parseUserSelectionConfig } from '../parseUserSelectionConfig';
+
+describe('parseUserSelectionConfig', () => {
+  it('accepts numeric receiver IDs while preserving the string output contract', async () => {
+    const userRepo = {
+      find: vi.fn().mockResolvedValue([{ id: 3 }]),
+    } as unknown as Repository;
+
+    await expect(parseUserSelectionConfig([1, '2', { filter: { id: 3 } }], userRepo)).resolves.toEqual(['1', '2', '3']);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/parseUserSelectionConfig.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/parseUserSelectionConfig.ts
@@ -11,18 +11,18 @@ import { Repository } from '@nocobase/database';
 export async function parseUserSelectionConfig(
   userSelectionConfig: Array<Record<any, any> | number | string>,
   UserRepo: Repository,
-) {
+): Promise<string[]> {
   const SelectionConfigs = userSelectionConfig.flat().filter(Boolean);
-  const users = new Set<number | string>();
+  const users = new Set<string>();
   for (const item of SelectionConfigs) {
     if (typeof item === 'object') {
       const result = await UserRepo.find({
         ...item,
         fields: ['id'],
       });
-      result.forEach((item) => users.add(item.id));
+      result.forEach((item) => users.add(String(item.id)));
     } else {
-      users.add(item);
+      users.add(String(item));
     }
   }
 

--- a/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/parseUserSelectionConfig.ts
+++ b/packages/plugins/@nocobase/plugin-notification-manager/src/server/utils/parseUserSelectionConfig.ts
@@ -9,11 +9,11 @@
 
 import { Repository } from '@nocobase/database';
 export async function parseUserSelectionConfig(
-  userSelectionConfig: Array<Record<any, any> | string>,
+  userSelectionConfig: Array<Record<any, any> | number | string>,
   UserRepo: Repository,
 ) {
   const SelectionConfigs = userSelectionConfig.flat().filter(Boolean);
-  const users = new Set<string>();
+  const users = new Set<number | string>();
   for (const item of SelectionConfigs) {
     if (typeof item === 'object') {
       const result = await UserRepo.find({

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client-v2/nodes/__tests__/RecipientsInput.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client-v2/nodes/__tests__/RecipientsInput.test.tsx
@@ -33,16 +33,16 @@ afterEach(() => {
 });
 
 describe('RecipientsInput', () => {
-  it('normalizes numeric user ids for the v2 user selector and preserves them when echoed back', () => {
+  it('passes numeric user ids through the shared user selector', () => {
     const onChange = vi.fn();
     const value = [1, { filter: { $and: [] } }];
 
     render(<RecipientsInput value={value} onChange={onChange} />);
 
-    expect(holder.userSelect).toHaveBeenNthCalledWith(1, expect.objectContaining({ value: '1' }));
+    expect(holder.userSelect).toHaveBeenNthCalledWith(1, expect.objectContaining({ value: 1 }));
     expect(holder.userSelect).toHaveBeenNthCalledWith(2, expect.objectContaining({ value: value[1] }));
 
-    holder.userSelect.mock.calls[0][0].onChange('1');
+    holder.userSelect.mock.calls[0][0].onChange(1);
     expect(onChange).toHaveBeenLastCalledWith([1, value[1]]);
   });
 

--- a/packages/plugins/@nocobase/plugin-workflow-cc/src/client-v2/nodes/components/RecipientsInput.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow-cc/src/client-v2/nodes/components/RecipientsInput.tsx
@@ -23,25 +23,14 @@ export interface RecipientsInputProps {
   value?: RecipientValue[];
 }
 
-function normalizeValue(item: RecipientValue): string | { filter?: Record<string, unknown> } {
-  return typeof item === 'number' ? String(item) : item;
-}
-
-function preserveValue(next: string | { filter?: Record<string, unknown> }, previous?: RecipientValue): RecipientValue {
-  if (typeof previous === 'number' && next === String(previous)) {
-    return previous;
-  }
-  return next;
-}
-
 function RecipientsAddition({
   disabled,
   onChange,
   value = [],
 }: {
   disabled?: boolean;
-  onChange?: (value: Array<string | { filter?: Record<string, unknown> }>) => void;
-  value?: Array<string | { filter?: Record<string, unknown> }>;
+  onChange?: (value: RecipientValue[]) => void;
+  value?: RecipientValue[];
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -121,7 +110,7 @@ function RecipientRow({
         type="text"
       />
       <div style={{ flex: 1, minWidth: 0 }}>
-        <UserSelect value={normalizeValue(item)} onChange={(next) => onUpdate(preserveValue(next, item))} />
+        <UserSelect value={item} onChange={onUpdate} />
       </div>
       {disabled ? null : (
         <>
@@ -177,8 +166,8 @@ export function RecipientsInput({ disabled, onChange, value = [] }: RecipientsIn
   const update = useMemoizedFn((index: number, next: RecipientValue) => {
     onChange?.(value.map((item, currentIndex) => (currentIndex === index ? next : item)));
   });
-  const updateAll = useMemoizedFn((nextValue: Array<string | { filter?: Record<string, unknown> }>) => {
-    onChange?.(nextValue.map((item, index) => preserveValue(item, value[index])));
+  const updateAll = useMemoizedFn((nextValue: RecipientValue[]) => {
+    onChange?.(nextValue);
   });
   const remove = useMemoizedFn((index: number) => {
     onChange?.(value.filter((_item, currentIndex) => currentIndex !== index));
@@ -209,7 +198,7 @@ export function RecipientsInput({ disabled, onChange, value = [] }: RecipientsIn
           ))}
         </Flex>
       ) : null}
-      <RecipientsAddition value={value.map(normalizeValue)} onChange={updateAll} disabled={disabled} />
+      <RecipientsAddition value={value} onChange={updateAll} disabled={disabled} />
     </Flex>
   );
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

工作流通知中选择接收人后，用户 ID 会被保存为字符串，与之前版本保存数字的行为不一致。已有字符串格式的配置在重新打开时，也可能无法正确显示对应的用户名称。

### Description

- 直接选择用户时保存数字格式的用户 ID，与之前版本的行为保持一致。
- 兼容已有的字符串格式用户 ID，重新打开配置时仍能正确显示用户名称。
- 工作流变量和按条件查询用户的配置方式保持不变。
- 同步调整站内通知和工作流抄送场景，并补充数字保存、数字回显和字符串回显测试。

建议重点验证：直接选择用户后保存并重新打开、打开已有字符串格式配置，以及使用工作流变量或查询条件选择接收人。

### Showcase

无界面样式变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix receiver selection saving user IDs as text |
| 🇨🇳 Chinese | 修复通知接收人选择后用户 ID 保存为文本的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
