### PR TITLE
fix(plugin-auth): resolve authenticator page declaration errors

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/client-v2/pages/AuthenticatorsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client-v2/pages/AuthenticatorsPage.tsx
@@ -34,10 +34,6 @@ type AuthTypeOption = { name: string; title?: string };
 
 const AUTHENTICATOR_LIST_FIELDS = ['id', 'name', 'authType', 'title', 'description', 'enabled'];
 
-type AuthenticatorDetailResource = {
-  get: (options: { filterByTk: AuthenticatorRecord['id'] }) => Promise<{ data?: unknown }>;
-};
-
 function recursiveTrim(value: any): any {
   if (typeof value === 'string') return value.trim();
   if (Array.isArray(value)) return value.map(recursiveTrim);
@@ -67,7 +63,7 @@ function useAuthTypesFromServer() {
 }
 
 export async function loadAuthenticatorForEdit(
-  resource: AuthenticatorDetailResource,
+  resource: ReturnType<typeof useAuthenticatorsResource>,
   record: AuthenticatorRecord,
 ): Promise<AuthenticatorRecord> {
   const response = await resource.get({ filterByTk: record.id });
@@ -267,7 +263,7 @@ export default function AuthenticatorsPage() {
   const { token } = theme.useToken();
   const { modal, message } = App.useApp();
   const resource = useAuthenticatorsResource();
-  const plugin = ctx.app.pm.get(PluginAuthClientV2);
+  const plugin = ctx.app.pm.get('@nocobase/plugin-auth') as PluginAuthClientV2;
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The `plugin-auth` declaration build failed because the authenticator detail loader required an explicit `get` property that was incompatible with the dynamic `IResource` type, and the plugin class was used as a runtime value despite being imported with `import type`.

### Description

- Use the actual authenticators resource return type for the edit-detail loader.
- Resolve the auth plugin instance through its registered package-name alias while keeping the plugin class as a type-only import.
- No runtime behavior or UI changes are intended.

Testing:

- `yarn eslint --fix packages/plugins/@nocobase/plugin-auth/src/client-v2/pages/AuthenticatorsPage.tsx`
- `yarn test packages/plugins/@nocobase/plugin-auth/src/client-v2/__tests__/AuthenticatorsPage.test.tsx --run --reporter=verbose`
- Generated declarations for `packages/plugins/@nocobase/plugin-auth` with `buildDeclaration`

### Related issues

N/A

### Showcase

N/A — declaration-only fix with no UI changes.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed declaration generation errors in the v2 authenticator management page |
| 🇨🇳 Chinese | 修复 v2 认证器管理页面的声明生成错误 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
