### PR TITLE
fix(markdown): sanitize iframe rendering in v1

### DIFF
--- a/packages/core/client/src/schema-component/antd/markdown/__tests__/markdown.test.tsx
+++ b/packages/core/client/src/schema-component/antd/markdown/__tests__/markdown.test.tsx
@@ -9,9 +9,17 @@
 
 import { act, fireEvent, render } from '@nocobase/test/client';
 import React from 'react';
+import { vi } from 'vitest';
 import App1 from '../demos/demo1';
 import App2 from '../demos/demo2';
+import { parseMarkdown } from '../util';
 import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../md', () => ({
+  default: {
+    render: (text: string) => `<p>${text}</p>`,
+  },
+}));
 
 describe('Markdown', () => {
   it('should display the value of user input', function () {
@@ -39,5 +47,19 @@ describe('Markdown.Void', function () {
     // TODO: fix this test
     // await userEvent.click(button);
     // expect(document.querySelector('.ant-input')).not.toBeNull();
+  });
+});
+
+describe('Markdown sanitization', function () {
+  it('should remove iframes from rendered markdown while preserving normal content', async () => {
+    const html = await parseMarkdown(
+      '<iframe srcdoc="<img src=x onerror=alert(1)>"></iframe>before <strong>safe</strong> after',
+    );
+
+    expect(html).not.toContain('<iframe');
+    expect(html).not.toContain('srcdoc');
+    expect(html).toContain('before');
+    expect(html).toContain('after');
+    expect(html).toContain('<strong>safe</strong>');
   });
 });

--- a/packages/core/client/src/schema-component/antd/markdown/util.ts
+++ b/packages/core/client/src/schema-component/antd/markdown/util.ts
@@ -9,13 +9,14 @@
 
 import _ from 'lodash';
 import { useEffect, useState } from 'react';
+import { stripMarkdownIframes } from '@nocobase/client-v2';
 
 export const parseMarkdown = _.memoize(async (text: string) => {
   if (!text) {
     return text;
   }
   const m = await import('./md');
-  return m.default.render(text);
+  return stripMarkdownIframes(m.default.render(text));
 });
 
 export function useParseMarkdown(text: string) {

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Display.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Display.tsx
@@ -10,6 +10,7 @@
 import { Field } from '@formily/core';
 import { useField } from '@formily/react';
 import { withDynamicSchemaProps } from '@nocobase/client';
+import { removeMarkdownIframes, stripMarkdownIframes } from '@nocobase/client-v2';
 import { Popover } from 'antd';
 import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import Vditor from 'vditor';
@@ -43,8 +44,15 @@ function DisplayInner(props: { value: string; style?: CSSProperties }) {
     Vditor.preview(containerRef.current, props.value ?? '', {
       mode: 'light',
       cdn,
-    });
+      markdown: {
+        sanitize: true,
+      },
+      transform: stripMarkdownIframes,
+    })
+      .then(() => removeMarkdownIframes(containerRef.current))
+      .catch(() => removeMarkdownIframes(containerRef.current));
     setTimeout(() => {
+      removeMarkdownIframes(containerRef.current);
       containerRef.current?.querySelectorAll('img').forEach((img: HTMLImageElement) => {
         img.style.cursor = 'zoom-in';
         img.addEventListener('click', () => {
@@ -52,7 +60,7 @@ function DisplayInner(props: { value: string; style?: CSSProperties }) {
         });
       });
     }, 0);
-  }, [props.value]);
+  }, [props.value, cdn]);
 
   return wrapSSR(
     <span className={`${hashId} ${componentCls}`}>
@@ -116,18 +124,27 @@ export const Display = withDynamicSchemaProps((props) => {
       Vditor.md2html(props.value, {
         mode: 'light',
         cdn,
+        markdown: {
+          sanitize: true,
+        },
       })
         .then((html) => {
-          setText(convertToText(html));
+          setText(convertToText(stripMarkdownIframes(html)));
         })
         .catch(() => setText(''));
     } else {
       Vditor.preview(containerRef.current, props.value ?? field?.value, {
         mode: 'light',
         cdn,
-      });
+        markdown: {
+          sanitize: true,
+        },
+        transform: stripMarkdownIframes,
+      })
+        .then(() => removeMarkdownIframes(containerRef.current))
+        .catch(() => removeMarkdownIframes(containerRef.current));
     }
-  }, [props.value, props.ellipsis, field?.value]);
+  }, [props.value, props.ellipsis, field, field?.value, cdn]);
 
   const isOverflowTooltip = useCallback(() => {
     if (!elRef.current) return false;

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Edit.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client/components/Edit.tsx
@@ -18,6 +18,7 @@ import {
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Vditor from 'vditor';
+import { stripMarkdownIframeTags, stripMarkdownIframes } from '@nocobase/client-v2';
 import { defaultToolbar } from '../interfaces/markdown-vditor';
 import { NAMESPACE } from '../locale';
 import { useCDN } from './const';
@@ -58,13 +59,20 @@ export const Edit = withDynamicSchemaProps((props) => {
     if (!containerRef.current) return;
 
     const toolbarConfig = toolbar ?? defaultToolbar;
+    const safeValue = stripMarkdownIframeTags(value ?? '');
 
     const vditor = new Vditor(containerRef.current, {
-      value: value ?? '',
+      value: safeValue,
       lang,
       cache: { enable: false },
       undoDelay: 0,
-      preview: { math: { engine: 'KaTeX' } },
+      preview: {
+        markdown: {
+          sanitize: true,
+        },
+        math: { engine: 'KaTeX' },
+        transform: stripMarkdownIframes,
+      },
       toolbar: toolbarConfig,
       fullscreen: {
         index: 1200,
@@ -81,8 +89,6 @@ export const Edit = withDynamicSchemaProps((props) => {
         const savedScrollX = window.scrollX || window.pageXOffset;
         const savedScrollY = window.scrollY || window.pageYOffset;
 
-        vditor.setValue(value ?? '');
-
         // Restore scroll position to prevent autoscroll during initialization
         // This fixes the issue where fields without '\n' at the end cause unwanted scrolling
         requestAnimationFrame(() => {
@@ -95,8 +101,12 @@ export const Edit = withDynamicSchemaProps((props) => {
           vditor.enable();
         }
       },
-      input(value) {
-        onChange(value);
+      input(nextValue) {
+        const safeNextValue = stripMarkdownIframeTags(nextValue);
+        if (safeNextValue !== nextValue) {
+          vditor.setValue(safeNextValue);
+        }
+        onChange(safeNextValue);
       },
       upload: {
         multiple: false,
@@ -194,13 +204,14 @@ export const Edit = withDynamicSchemaProps((props) => {
   useEffect(() => {
     if (editorReady && vdRef.current) {
       const editor = vdRef.current;
-      if (value !== editor.getValue()) {
+      const safeValue = stripMarkdownIframeTags(value ?? '');
+      if (safeValue !== editor.getValue()) {
         // Save scroll positions before setting value to prevent unwanted autoscroll
         // This fixes the issue where fields without '\n' at the end cause unwanted scrolling
         const savedScrollX = window.scrollX || window.pageXOffset;
         const savedScrollY = window.scrollY || window.pageYOffset;
 
-        editor.setValue(value ?? '');
+        editor.setValue(safeValue);
         // editor.focus();
 
         // Query for preArea after setValue as DOM may have been updated by vditor
@@ -276,7 +287,8 @@ export const Edit = withDynamicSchemaProps((props) => {
   }, [zIndex]);
 
   useLayoutEffect(() => {
-    if (!containerRef.current) return;
+    const container = containerRef.current;
+    if (!container) return;
 
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -291,10 +303,10 @@ export const Edit = withDynamicSchemaProps((props) => {
       }
     });
 
-    observer.observe(containerRef.current);
+    observer.observe(container);
 
     return () => {
-      observer.unobserve(containerRef.current);
+      observer.unobserve(container);
     };
   }, []);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

PR #9986 fixed iframe sanitization for v2 Markdown rendering and editing. The v1 Markdown and Markdown Vditor paths still allowed iframe HTML to reach the rendered DOM.

### Description

- Reuse the shared Markdown iframe sanitizer from client-v2 in v1.
- Sanitize v1 Markdown Vditor edit initialization, input, controlled updates, preview, and ellipsis rendering.
- Sanitize core v1 Markdown parser output before it is assigned through dangerouslySetInnerHTML.
- Add a regression test covering iframe srcdoc removal while preserving normal content.

Potential risk: iframe HTML in v1 Markdown content will no longer render. This is intentional for the security fix. This change targets iframe rendering and is not a general sanitizer for every possible raw HTML payload.

Testing suggestions:

- Open a v1 Markdown Vditor field containing an iframe with srcdoc and confirm it is removed in edit and display modes.
- Verify normal Markdown content continues to render.
- Run the related Markdown unit test and ESLint.

### Related issues

Related PR: #9986

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed iframe sanitization for v1 Markdown rendering and editing. |
| 🇨🇳 Chinese | 修复 v1 Markdown 渲染和编辑中的 iframe 清理问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
