### PR TITLE
fix(client-v2): stabilize current user provider identity

### DIFF
--- a/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
+++ b/packages/core/client-v2/src/nocobase-buildin-plugin/index.tsx
@@ -298,6 +298,8 @@ const CurrentUserProvider: FC = ({ children }) => {
   return <CurrentUserContext.Provider value={contextValue}>{children}</CurrentUserContext.Provider>;
 };
 
+CurrentUserProvider.displayName = 'CurrentUserProvider';
+
 const RootRedirect: FC = () => {
   const app = useApp<Application>();
   const hasToken = !!app?.apiClient?.auth?.token;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Authentication plugins insert automatic-login providers before `CurrentUserProvider`. Production minification can rename the component function and make name-based provider lookup fail.

### Description

Assign a stable `displayName` to `CurrentUserProvider` so authentication plugins can reliably preserve provider ordering in development and production builds.

The change only adds component metadata and does not alter the current-user authentication flow.

### Related issues

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed automatic SSO redirect providers failing to preserve authentication order in production builds |
| 🇨🇳 Chinese | 修复自动 SSO 跳转 Provider 在生产构建中无法保持正确鉴权顺序的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
