### PR TITLE
fix(plugin-file-manager): prevent active XML content XSS

### DIFF
--- a/packages/core/cli-v1/nocobase.conf.tpl
+++ b/packages/core/cli-v1/nocobase.conf.tpl
@@ -36,10 +36,11 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-    location ~* ^{{publicPath}}storage/uploads/(.*\.(?:htm|html|svg|svgz|xhtml))$ {
+    location ~* ^{{publicPath}}storage/uploads/(.*\.(?:htm|html|pdf|svg|svgz|xht|xhtml|xml|xsl|xslt))$ {
         alias {{cwd}}/storage/uploads/$1;
         add_header Cache-Control "public";
         add_header Content-Disposition "attachment" always;
+        add_header Content-Security-Policy "sandbox" always;
         add_header X-Content-Type-Options "nosniff" always;
         access_log off;
         autoindex off;
@@ -48,6 +49,7 @@ server {
     location {{publicPath}}storage/uploads/ {
         alias {{cwd}}/storage/uploads/;
         add_header Cache-Control "public";
+        add_header Content-Security-Policy "sandbox" always;
         add_header X-Content-Type-Options "nosniff" always;
         access_log off;
         autoindex off;
@@ -55,6 +57,8 @@ server {
         location ~* \.md$ {
             default_type text/markdown;
             add_header Content-Disposition "inline";
+            add_header Content-Security-Policy "sandbox" always;
+            add_header X-Content-Type-Options "nosniff" always;
         }
     }
 

--- a/packages/core/cli/assets/env-proxy/nginx/snippets/uploads-location.conf
+++ b/packages/core/cli/assets/env-proxy/nginx/snippets/uploads-location.conf
@@ -1,12 +1,14 @@
 add_header Cache-Control "public" always;
+add_header Content-Security-Policy "sandbox" always;
 add_header X-Content-Type-Options "nosniff" always;
 
 access_log off;
 autoindex off;
 
 # Force potentially renderable uploaded files to download.
-location ~* \.(?:htm|html|svg|svgz|xhtml)$ {
+location ~* \.(?:htm|html|pdf|svg|svgz|xht|xhtml|xml|xsl|xslt)$ {
     add_header Cache-Control "public" always;
+    add_header Content-Security-Policy "sandbox" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Content-Disposition "attachment" always;
 }
@@ -16,6 +18,7 @@ location ~* \.md$ {
     default_type text/markdown;
 
     add_header Cache-Control "public" always;
+    add_header Content-Security-Policy "sandbox" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Content-Disposition "inline" always;
 }

--- a/packages/core/cli/src/__tests__/env-proxy.test.ts
+++ b/packages/core/cli/src/__tests__/env-proxy.test.ts
@@ -445,6 +445,12 @@ test('syncEnvProxyNginxSnippets copies nginx snippets into the provider snippets
       'uploads-location.conf',
     ]),
   );
+  expect(await readFile(path.join(outputDir, 'uploads-location.conf'), 'utf8')).toContain(
+    'location ~* \\.(?:htm|html|pdf|svg|svgz|xht|xhtml|xml|xsl|xslt)$',
+  );
+  expect(await readFile(path.join(outputDir, 'uploads-location.conf'), 'utf8')).toContain(
+    'add_header Content-Security-Policy "sandbox" always;',
+  );
 });
 
 test('replaceManagedNginxConfigBlock preserves user-edited content outside the managed block', async () => {
@@ -476,6 +482,11 @@ test('buildEnvProxyConfig renders a full Caddy app config when provider is caddy
   expect(result.content).toContain(':80 {');
   expect(result.content).toContain('encode zstd gzip');
   expect(result.content).toContain('handle_path /dist/*');
+  expect(result.content).toContain(
+    '@activeUploadedContent path_regexp activeUploadedContent (?i)\\.(?:htm|html|pdf|svg|svgz|xht|xhtml|xml|xsl|xslt)$',
+  );
+  expect(result.content).toContain('header @activeUploadedContent Content-Disposition attachment');
+  expect(result.content).toContain('header Content-Security-Policy sandbox');
   expect(result.content).toContain('try_files {path} /index-v1.html');
   expect(result.content).toContain('file_server');
   expect(result.content).toContain('reverse_proxy 127.0.0.1:13000');

--- a/packages/core/cli/src/lib/env-proxy.ts
+++ b/packages/core/cli/src/lib/env-proxy.ts
@@ -1441,15 +1441,17 @@ function renderNginxLocationTemplate(context: EnvProxyTemplateContext): string {
         default_type text/markdown;
         add_header Cache-Control "public";
         add_header Content-Disposition "inline";
+        add_header Content-Security-Policy "sandbox" always;
         add_header X-Content-Type-Options "nosniff" always;
         access_log off;
         autoindex off;
     }
 
-    location ~* ^${context.appPublicPath}storage/uploads/(.*\\.(?:htm|html|svg|svgz|xhtml|pdf))$ {
+    location ~* ^${context.appPublicPath}storage/uploads/(.*\\.(?:htm|html|pdf|svg|svgz|xht|xhtml|xml|xsl|xslt))$ {
         alias ${context.uploadsPath}/$1;
         add_header Cache-Control "public";
         add_header Content-Disposition "attachment" always;
+        add_header Content-Security-Policy "sandbox" always;
         add_header X-Content-Type-Options "nosniff" always;
         access_log off;
         autoindex off;
@@ -1458,6 +1460,7 @@ function renderNginxLocationTemplate(context: EnvProxyTemplateContext): string {
     location ${context.appPublicPath}storage/uploads/ {
         alias ${context.uploadsPath}/;
         add_header Cache-Control "public";
+        add_header Content-Security-Policy "sandbox" always;
         add_header X-Content-Type-Options "nosniff" always;
         access_log off;
         autoindex off;
@@ -1589,10 +1592,14 @@ function renderCaddyAppTemplate(siteAddress: string, context: EnvProxyTemplateCo
     `${siteAddress} {`,
     `    encode zstd gzip${rootRedirectBlock}${appPublicPathRedirectBlock}${modernClientRedirectBlock}${shorthandModernClientRedirectBlock}`,
     '',
+    '    @activeUploadedContent path_regexp activeUploadedContent (?i)\\.(?:htm|html|pdf|svg|svgz|xht|xhtml|xml|xsl|xslt)$',
+    '',
     `    handle_path ${uploadsPathMatcher} {`,
     `        root * ${context.uploadsPath}`,
     '        header Cache-Control public',
+    '        header Content-Security-Policy sandbox',
     '        header X-Content-Type-Options nosniff',
+    '        header @activeUploadedContent Content-Disposition attachment',
     '        file_server',
     '    }',
     '',

--- a/packages/core/server/src/__tests__/gateway-upload-security.test.ts
+++ b/packages/core/server/src/__tests__/gateway-upload-security.test.ts
@@ -1,0 +1,78 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { supertest } from '@nocobase/test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AppSupervisor } from '../app-supervisor';
+import { Gateway } from '../gateway';
+
+const originalAppPublicPath = process.env.APP_PUBLIC_PATH;
+const originalStoragePath = process.env.STORAGE_PATH;
+
+describe('gateway upload security', () => {
+  let storagePath: string;
+
+  beforeEach(async () => {
+    storagePath = await mkdtemp(path.join(os.tmpdir(), 'nocobase-gateway-upload-security-'));
+    await mkdir(path.join(storagePath, 'uploads'), { recursive: true });
+    process.env.APP_PUBLIC_PATH = '/console/';
+    process.env.STORAGE_PATH = storagePath;
+  });
+
+  afterEach(async () => {
+    if (originalAppPublicPath === undefined) {
+      delete process.env.APP_PUBLIC_PATH;
+    } else {
+      process.env.APP_PUBLIC_PATH = originalAppPublicPath;
+    }
+
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_PATH;
+    } else {
+      process.env.STORAGE_PATH = originalStoragePath;
+    }
+
+    await Gateway.getInstance().destroy();
+    await AppSupervisor.getInstance().destroy();
+    await rm(storagePath, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['report.pdf', '%PDF-1.4'],
+    ['payload.xml', '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'],
+  ])('forces active uploaded file %s to download', async (filename, content) => {
+    await writeFile(path.join(storagePath, 'uploads', filename), content);
+
+    const response = await supertest
+      .agent(Gateway.getInstance().getCallback())
+      .get(`/console/storage/uploads/${filename}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-disposition']).toContain('attachment');
+    expect(response.headers['content-security-policy']).toBe('sandbox');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('keeps non-active uploaded files inline while sandboxing the response', async () => {
+    await writeFile(path.join(storagePath, 'uploads', 'notes.txt'), 'safe text');
+
+    const response = await supertest
+      .agent(Gateway.getInstance().getCallback())
+      .get('/console/storage/uploads/notes.txt');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-disposition']).toContain('inline');
+    expect(response.headers['content-security-policy']).toBe('sandbox');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.text).toBe('safe text');
+  });
+});

--- a/packages/core/server/src/__tests__/gateway/static-file-security.test.ts
+++ b/packages/core/server/src/__tests__/gateway/static-file-security.test.ts
@@ -16,21 +16,32 @@ describe('static file security', () => {
     expect(hasActiveContentExtension('/storage/uploads/a.pdf')).toBe(true);
     expect(hasActiveContentExtension('/storage/uploads/a.SVG')).toBe(true);
     expect(hasActiveContentExtension('/storage/uploads/a.svgz?download=1')).toBe(true);
+    expect(hasActiveContentExtension('/storage/uploads/a.xml')).toBe(true);
+    expect(hasActiveContentExtension('/storage/uploads/a.xsl')).toBe(true);
     expect(hasActiveContentExtension('/storage/uploads/a.txt')).toBe(false);
   });
 
-  it('should force attachment for active content while preserving nosniff for all uploads', () => {
+  it('should sandbox uploads and force attachment for active content', () => {
     expect(getStorageUploadSecurityHeaders('/storage/uploads/a.xhtml')).toEqual({
       'Content-Disposition': 'attachment',
+      'Content-Security-Policy': 'sandbox',
       'X-Content-Type-Options': 'nosniff',
     });
 
     expect(getStorageUploadSecurityHeaders('/storage/uploads/a.pdf')).toEqual({
       'Content-Disposition': 'attachment',
+      'Content-Security-Policy': 'sandbox',
+      'X-Content-Type-Options': 'nosniff',
+    });
+
+    expect(getStorageUploadSecurityHeaders('/storage/uploads/a.xml')).toEqual({
+      'Content-Disposition': 'attachment',
+      'Content-Security-Policy': 'sandbox',
       'X-Content-Type-Options': 'nosniff',
     });
 
     expect(getStorageUploadSecurityHeaders('/storage/uploads/a.txt')).toEqual({
+      'Content-Security-Policy': 'sandbox',
       'X-Content-Type-Options': 'nosniff',
     });
   });

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -439,14 +439,17 @@ export class Gateway extends EventEmitter {
         }
       }
       const headers = getStorageUploadSecurityHeaders(pathname);
-      for (const [key, value] of Object.entries(headers)) {
-        res.setHeader(key, value);
-      }
       req.url = req.url.substring(APP_PUBLIC_PATH.length + 'storage'.length);
       await compress(req, res);
       return handler(req, res, {
         public: resolveStorageRoot(),
         directoryListing: false,
+        headers: [
+          {
+            source: '**/*',
+            headers: Object.entries(headers).map(([key, value]) => ({ key, value })),
+          },
+        ],
       });
     }
 

--- a/packages/core/server/src/gateway/static-file-security.ts
+++ b/packages/core/server/src/gateway/static-file-security.ts
@@ -9,7 +9,18 @@
 
 import path from 'node:path';
 
-const ACTIVE_CONTENT_EXTENSIONS = new Set(['.htm', '.html', '.pdf', '.svg', '.svgz', '.xhtml']);
+const ACTIVE_CONTENT_EXTENSIONS = new Set([
+  '.htm',
+  '.html',
+  '.pdf',
+  '.svg',
+  '.svgz',
+  '.xht',
+  '.xhtml',
+  '.xml',
+  '.xsl',
+  '.xslt',
+]);
 
 function stripQueryAndHash(pathname = '') {
   return pathname.split('?')[0].split('#')[0];
@@ -22,6 +33,7 @@ export function hasActiveContentExtension(pathname = '') {
 
 export function getStorageUploadSecurityHeaders(pathname = '') {
   const headers: Record<string, string> = {
+    'Content-Security-Policy': 'sandbox',
     'X-Content-Type-Options': 'nosniff',
   };
 

--- a/packages/core/server/src/index.ts
+++ b/packages/core/server/src/index.ts
@@ -14,6 +14,7 @@ export * from './gateway/ws-server';
 export { Application as default } from './application';
 export * from './audit-manager';
 export * from './gateway';
+export * from './gateway/static-file-security';
 export * as middlewares from './middlewares';
 export * from './migration';
 export * from './plugin';

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
@@ -127,8 +127,16 @@ const FALLBACK_ICON_MAP: Record<string, string> = {
   default: '/file-placeholder/unknown-200-200.png',
 };
 
-const ACTIVE_CONTENT_MIMETYPES = new Set(['application/pdf', 'application/xhtml+xml', 'image/svg+xml', 'text/html']);
-const ACTIVE_CONTENT_EXTENSIONS = new Set(['htm', 'html', 'pdf', 'svg', 'svgz', 'xhtml']);
+const ACTIVE_CONTENT_MIMETYPES = new Set([
+  'application/pdf',
+  'application/xhtml+xml',
+  'application/xml',
+  'application/xslt+xml',
+  'image/svg+xml',
+  'text/html',
+  'text/xml',
+]);
+const ACTIVE_CONTENT_EXTENSIONS = new Set(['htm', 'html', 'pdf', 'svg', 'svgz', 'xht', 'xhtml', 'xml', 'xsl', 'xslt']);
 
 const stripQueryAndHash = (url: string) => url.split('?')[0].split('#')[0];
 

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts
@@ -67,6 +67,10 @@ describe('getDownloadFileName', () => {
     expect(isActiveContentFile({ mimetype: 'application/pdf', url: 'https://example.com/files/report.pdf' })).toBe(
       true,
     );
+    expect(isActiveContentFile({ mimetype: 'application/xml', url: 'https://example.com/files/payload.xml' })).toBe(
+      true,
+    );
+    expect(isActiveContentFile({ filename: 'payload.xsl', url: 'https://example.com/files/payload.xsl' })).toBe(true);
     expect(isActiveContentFile({ filename: 'index.html', url: 'https://example.com/files/index.html' })).toBe(true);
     expect(isActiveContentFile({ mimetype: 'image/png', url: 'https://example.com/files/avatar.png' })).toBe(false);
   });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
@@ -205,6 +205,20 @@ describe('action', () => {
         expect(res.text).toContain('Hello world!');
       });
 
+      it('should force uploaded XML files to download when served locally', async () => {
+        const { body, status } = await agent.resource('attachments').create({
+          [FILE_FIELD_NAME]: path.resolve(__dirname, './files/svg-as-xml.xml'),
+        });
+
+        expect(status).toBe(200);
+        expect(body.data.extname).toBe('.xml');
+
+        const res = await agent.get(body.data.url);
+        expect(res.headers['content-disposition']).toBe('attachment');
+        expect(res.headers['content-security-policy']).toBe('sandbox');
+        expect(res.headers['x-content-type-options']).toBe('nosniff');
+      });
+
       it('filename with special character (URL)', async () => {
         const rawText = '[]中文报告! 1%~50.4% (123) {$#}';
         const rawFilename = `${rawText}.txt`;
@@ -383,14 +397,16 @@ describe('action', () => {
           Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
           Buffer.from('ddddddddddddddddddd<img src=axxxx onerror="onerror=alert(1)" s>'),
         ]);
-        const response = await agent
-          .post(`/attachments:create?${querystring.stringify({ attachmentField: 'customers.avatar' })}`)
-          .attach(FILE_FIELD_NAME, forgedHtml, {
-            filename: 'custom_name.html',
-            contentType: 'image/jpeg',
-          });
+        for (const filename of ['custom_name.html', 'custom_name.xml']) {
+          const response = await agent
+            .post(`/attachments:create?${querystring.stringify({ attachmentField: 'customers.avatar' })}`)
+            .attach(FILE_FIELD_NAME, forgedHtml, {
+              filename,
+              contentType: 'image/jpeg',
+            });
 
-        expect(response.status).toBe(400);
+          expect(response.status).toBe(400);
+        }
       });
 
       it('allows a forged image upload when its active content filename is explicitly allowed', async () => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/files/svg-as-xml.xml
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/files/svg-as-xml.xml
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"><script>window.__nocobaseUploadXssTest = true;</script></svg>

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/index.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { MockServer, createMockServer } from '@nocobase/test';
+import { getStorageUploadSecurityHeaders } from '@nocobase/server';
 import send from 'koa-send';
 import path from 'path';
 import supertest from 'supertest';
@@ -25,6 +26,7 @@ export async function getApp(options = {}): Promise<MockServer> {
 
   app.use(async (ctx, next) => {
     if (ctx.path.startsWith('/storage/uploads')) {
+      ctx.set(getStorageUploadSecurityHeaders(ctx.path));
       const storages = await app.db.getRepository('storages').find({
         filter: {
           type: STORAGE_TYPE_LOCAL,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -25,7 +25,15 @@ import {
 import { StorageClassType, StorageType } from '../storages';
 import { getDocumentRoot, normalizeLocalStoragePath, resolveSafePath } from '../storages/local';
 
-const ACTIVE_CONTENT_MIMETYPES = new Set(['application/pdf', 'application/xhtml+xml', 'image/svg+xml', 'text/html']);
+const ACTIVE_CONTENT_MIMETYPES = new Set([
+  'application/pdf',
+  'application/xhtml+xml',
+  'application/xml',
+  'application/xslt+xml',
+  'image/svg+xml',
+  'text/html',
+  'text/xml',
+]);
 
 function matchesMimePattern(mimetype: string, pattern: string | string[] = '*') {
   const normalizedPattern = pattern.toString().trim();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Uploaded XML files can contain SVG active content. When these files are served inline from the application origin, browsers may execute embedded scripts and expose the current user's session token. The existing static file protection covered HTML and SVG extensions but did not cover XML-based variants.

### Description

- Treat XML, XSL, XSLT, and related extensions and MIME types as active content.
- Force known active uploaded content to download in the Koa gateway, legacy nginx template, managed nginx configuration, and Caddy configuration.
- Pass gateway security headers through `serve-handler` configuration so its default inline disposition cannot overwrite them.
- Add `Content-Security-Policy: sandbox` to uploaded file responses as defense in depth against unrecognized active content extensions.
- Prevent XML active content from being used as a raw frontend preview or bypassing restricted storage MIME rules.
- Add regression coverage using an SVG document uploaded with an `.xml` extension.
- Add real gateway response coverage for PDF, XML, and non-active text files.

Potential risk: the sandbox policy applies to all locally served uploaded files. It does not affect normal image or file downloads, but custom deployments that intentionally render executable uploaded documents inline should verify their behavior.

Testing suggestions:

- Upload an SVG document using an `.xml` filename and verify the response includes `Content-Disposition: attachment`, `Content-Security-Policy: sandbox`, and `X-Content-Type-Options: nosniff`.
- Verify normal text and image uploads remain accessible.
- Generate nginx and Caddy proxy configurations and verify the upload security headers are present.

### Related issues

- https://github.com/nocobase/nocobase/security/advisories/GHSA-722v-mxqw-prh7

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevented uploaded XML and other active content files from executing scripts in the application origin |
| 🇨🇳 Chinese | 防止上传的 XML 等主动内容文件在应用同源环境中执行脚本 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not applicable |
| 🇨🇳 Chinese | 不适用 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
