### PR TITLE
fix(plugin-ai): preserve pasted file attachment source

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/uploadAttachment.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/uploadAttachment.test.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeAIFileUploadAttachment } from '../../ai-employees/chatbox/utils';
+
+describe('normalizeAIFileUploadAttachment', () => {
+  it('promotes upload response meta source to attachment source', () => {
+    const source = {
+      dataSourceKey: 'main',
+      collectionName: 'aiFiles',
+    };
+    const attachment = {
+      id: 1,
+      filename: 'paste.png',
+      meta: {
+        source,
+      },
+    };
+
+    expect(normalizeAIFileUploadAttachment(attachment, 'done')).toEqual({
+      ...attachment,
+      source,
+      status: 'done',
+    });
+  });
+
+  it('keeps response data when source is missing', () => {
+    const attachment = {
+      id: 2,
+      filename: 'paste.txt',
+      meta: {},
+    };
+
+    expect(normalizeAIFileUploadAttachment(attachment, 'done')).toEqual({
+      ...attachment,
+      status: 'done',
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/Sender.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/Sender.tsx
@@ -20,6 +20,7 @@ import { useChatMessageActions } from './hooks/useChatMessageActions';
 import { useChatBoxStore } from './stores/chat-box';
 import { useChatBoxActions } from './hooks/useChatBoxActions';
 import { useUploadFiles } from './hooks/useUploadFiles';
+import { normalizeAIFileUploadAttachment } from './utils';
 import _ from 'lodash';
 
 const useSendMessage = () => {
@@ -168,10 +169,7 @@ export const Sender: React.FC = () => {
                     response,
                   };
                 }
-                return {
-                  ...fileData,
-                  status: 'done',
-                };
+                return normalizeAIFileUploadAttachment(fileData, 'done');
               }
               return item;
             }),

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useUploadFiles.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useUploadFiles.ts
@@ -12,6 +12,7 @@ import PluginFileManagerClient from '@nocobase/plugin-file-manager/client';
 import { useAISettingsContext } from '../../AISettingsProvider';
 import { useChat } from '../hooks/useChat';
 import { useChatConversationsStore } from '../stores/chat-conversations';
+import { normalizeAIFileUploadAttachment } from '../utils';
 
 export function useStorage(storage: string) {
   const name = storage ?? '';
@@ -94,11 +95,7 @@ export const useUploadFiles = () => {
             if (!file?.response?.data) {
               return file;
             }
-            return {
-              ...file.response.data,
-              ...(file.response.data.meta?.source ? { source: file.response.data.meta.source } : {}),
-              status: file.status,
-            };
+            return normalizeAIFileUploadAttachment(file.response.data, file.status);
           }
           return file;
         }),

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/utils.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/utils.ts
@@ -15,6 +15,23 @@ import PluginAIClient from '../..';
 
 dayjs.extend(duration);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+export function normalizeAIFileUploadAttachment(fileData: unknown, status: string) {
+  if (!isRecord(fileData)) {
+    return fileData;
+  }
+  const meta = isRecord(fileData.meta) ? fileData.meta : undefined;
+  const source = isRecord(meta?.source) ? meta.source : undefined;
+  return {
+    ...fileData,
+    ...(source ? { source } : {}),
+    status,
+  };
+}
+
 async function replaceVariables(template, variables, localVariables = {}) {
   const regex = /\{\{\s*(.*?)\s*\}\}/g;
   let result = template;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Pasted files in the AI employee chat input are uploaded through a separate paste flow. After attachment verification was added, this flow did not preserve the uploaded AI file source on the message attachment, so sending a pasted file could fail with an invalid attachment error.

### Description 
This PR normalizes AI file upload responses in chatbox utilities so the `meta.source` returned by `aiFiles:create` is promoted to the attachment `source` field.

The same normalization is now used by both regular file uploads and pasted file uploads. Unit tests cover source promotion and the fallback behavior when the response has no source.

Potential risk is limited to AI employee chat attachment payload formatting.

Testing suggestions:
- Paste a file into the AI employee chat input and send it.
- Upload a file through the attachment button and send it.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an error when sending files pasted into the AI employee chat input |
| 🇨🇳 Chinese | 修复在 AI 员工聊天输入框粘贴文件后发送报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
