### PR TITLE
fix(client-v2): reset markdown heading styles

### DIFF
--- a/packages/core/client-v2/src/flow/common/Markdown/style.ts
+++ b/packages/core/client-v2/src/flow/common/Markdown/style.ts
@@ -26,6 +26,10 @@ export default function useStyle() {
     () => ({
       [`.${COMPONENT_CLS}`]: {
         '.vditor-reset': { fontSize: `${token.fontSize}px !important`, color: 'unset' },
+        '.vditor-reset h2': {
+          borderBottom: 'none !important',
+          boxShadow: 'none !important',
+        },
         '.vditor': {
           borderRadius: 8,
         },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Markdown h2 elements in the v2 client inherited unwanted border and box-shadow styles, causing inconsistent rendering.

### Description
Reset the Markdown h2 `border-bottom` and `box-shadow` styles to remove the unwanted visual decoration. This is a scoped client-side style change with low risk.

Testing suggestions:
- Verify Markdown content containing h2 headings in the v2 client.
- Confirm h2 headings do not show a bottom border or shadow.

### Related issues
None.

### Showcase
Not applicable; this is a style-only fix.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reset unwanted border and shadow styles on Markdown h2 headings. |
| 🇨🇳 Chinese | 重置 Markdown 二级标题多余的边框和阴影样式。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not applicable. |
| 🇨🇳 Chinese | 不适用。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary