### PR TITLE
fix(database): prevent SQL injection in view metadata queries

### DIFF
--- a/packages/core/database/src/__tests__/query-interface/view-definition.test.ts
+++ b/packages/core/database/src/__tests__/query-interface/view-definition.test.ts
@@ -1,0 +1,118 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Database } from '../../database';
+import MysqlQueryInterface from '../../query-interface/mysql-query-interface';
+import PostgresQueryInterface from '../../query-interface/postgres-query-interface';
+import SqliteQueryInterface from '../../query-interface/sqlite-query-interface';
+
+const viewName = "x.v1' UNION SELECT 1,2,3,4,5,6,7--";
+
+describe('view definition query interface', () => {
+  it('should parameterize PostgreSQL view metadata queries', async () => {
+    const query = vi.fn().mockImplementation(async (sql: string) => {
+      if (sql.includes('view_column_usage')) {
+        return [];
+      }
+
+      return [{ definition: 'SELECT 1 AS safe_field' }];
+    });
+    const db = {
+      options: {},
+      sequelize: {
+        getQueryInterface: () => ({}),
+        query,
+      },
+    } as unknown as Database;
+    const queryInterface = new PostgresQueryInterface(db);
+    vi.spyOn(queryInterface, 'parseSQL').mockReturnValue({
+      ast: [{ columns: [] }],
+    });
+
+    await queryInterface.viewColumnUsage({
+      schema: 'public',
+      viewName,
+    });
+
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.not.stringContaining(viewName),
+      expect.objectContaining({
+        replacements: {
+          schema: 'public',
+          viewName,
+        },
+      }),
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.not.stringContaining(viewName),
+      expect.objectContaining({
+        replacements: {
+          schema: 'public',
+          viewName,
+        },
+      }),
+    );
+  });
+
+  it('should quote MySQL view identifiers', async () => {
+    const query = vi.fn().mockResolvedValue([
+      {
+        'Create View': 'CREATE VIEW `safe-view` AS SELECT 1 AS safe_field',
+      },
+    ]);
+    const quoteTable = vi.fn().mockReturnValue('`safe-view`');
+    const db = {
+      sequelize: {
+        getQueryInterface: () => ({}),
+        query,
+      },
+      utils: {
+        quoteTable,
+      },
+    } as unknown as Database;
+    const queryInterface = new MysqlQueryInterface(db);
+
+    await queryInterface.viewDef({
+      schema: 'tenant',
+      viewName,
+    });
+
+    expect(quoteTable).toHaveBeenCalledWith({
+      schema: 'tenant',
+      tableName: viewName,
+    });
+    expect(query).toHaveBeenCalledWith('SHOW CREATE VIEW `safe-view`', { type: 'SELECT' });
+  });
+
+  it('should parameterize SQLite view definition queries', async () => {
+    const query = vi.fn().mockResolvedValue([
+      {
+        sql: 'CREATE VIEW "safe-view" AS SELECT 1 AS safe_field',
+      },
+    ]);
+    const db = {
+      sequelize: {
+        getQueryInterface: () => ({}),
+        query,
+      },
+    } as unknown as Database;
+    const queryInterface = new SqliteQueryInterface(db);
+
+    await queryInterface.viewDef({ viewName });
+
+    expect(query).toHaveBeenCalledWith(expect.not.stringContaining(viewName), {
+      replacements: {
+        viewName,
+      },
+      type: 'SELECT',
+    });
+  });
+});

--- a/packages/core/database/src/__tests__/query-interface/view-definition.test.ts
+++ b/packages/core/database/src/__tests__/query-interface/view-definition.test.ts
@@ -14,8 +14,31 @@ import SqliteQueryInterface from '../../query-interface/sqlite-query-interface';
 
 const viewName = "x.v1' UNION SELECT 1,2,3,4,5,6,7--";
 
-describe('view definition query interface', () => {
-  it('should parameterize PostgreSQL view metadata queries', async () => {
+describe('view query interfaces', () => {
+  it('should parameterize the PostgreSQL view list schema', async () => {
+    const schema = "public' UNION SELECT current_database(),current_user,version()--";
+    const query = vi.fn().mockResolvedValue([]);
+    const db = {
+      options: {},
+      sequelize: {
+        getQueryInterface: () => ({}),
+        query,
+      },
+    } as unknown as Database;
+    const queryInterface = new PostgresQueryInterface(db);
+
+    await queryInterface.listViews({ schema });
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('WHERE schemaname = :targetSchema'), {
+      replacements: {
+        targetSchema: schema,
+      },
+      type: 'SELECT',
+    });
+    expect(query.mock.calls[0][0]).not.toContain(schema);
+  });
+
+  it('should parameterize PostgreSQL view metadata queries with the configured schema', async () => {
     const query = vi.fn().mockImplementation(async (sql: string) => {
       if (sql.includes('view_column_usage')) {
         return [];
@@ -24,7 +47,9 @@ describe('view definition query interface', () => {
       return [{ definition: 'SELECT 1 AS safe_field' }];
     });
     const db = {
-      options: {},
+      options: {
+        schema: 'tenant',
+      },
       sequelize: {
         getQueryInterface: () => ({}),
         query,
@@ -36,30 +61,25 @@ describe('view definition query interface', () => {
     });
 
     await queryInterface.viewColumnUsage({
-      schema: 'public',
       viewName,
     });
 
-    expect(query).toHaveBeenNthCalledWith(
-      1,
-      expect.not.stringContaining(viewName),
-      expect.objectContaining({
-        replacements: {
-          schema: 'public',
-          viewName,
-        },
-      }),
-    );
-    expect(query).toHaveBeenNthCalledWith(
-      2,
-      expect.not.stringContaining(viewName),
-      expect.objectContaining({
-        replacements: {
-          schema: 'public',
-          viewName,
-        },
-      }),
-    );
+    expect(query).toHaveBeenNthCalledWith(1, expect.stringContaining('WHERE view_schema = :schema'), {
+      replacements: {
+        schema: 'tenant',
+        viewName,
+      },
+      type: 'SELECT',
+    });
+    expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining("format('%I.%I', :schema, :viewName)"), {
+      replacements: {
+        schema: 'tenant',
+        viewName,
+      },
+      type: 'SELECT',
+    });
+    expect(query.mock.calls[0][0]).not.toContain(viewName);
+    expect(query.mock.calls[1][0]).not.toContain(viewName);
   });
 
   it('should quote MySQL view identifiers', async () => {
@@ -108,11 +128,12 @@ describe('view definition query interface', () => {
 
     await queryInterface.viewDef({ viewName });
 
-    expect(query).toHaveBeenCalledWith(expect.not.stringContaining(viewName), {
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('WHERE name = :viewName'), {
       replacements: {
         viewName,
       },
       type: 'SELECT',
     });
+    expect(query.mock.calls[0][0]).not.toContain(viewName);
   });
 });

--- a/packages/core/database/src/__tests__/view/view-inference.test.ts
+++ b/packages/core/database/src/__tests__/view/view-inference.test.ts
@@ -155,4 +155,40 @@ describe('view inference', function () {
 
     await db.sequelize.query(dropViewSQL);
   });
+
+  it('should safely infer fields from a view name with SQL metacharacters', async () => {
+    const UserCollection = db.collection({
+      name: 'users',
+      fields: [
+        {
+          name: 'name',
+          type: 'string',
+          interface: 'test',
+        },
+      ],
+    });
+
+    await db.sync();
+
+    const viewName = "x.v1' UNION SELECT 1,2,3,4,5,6,7--";
+    const viewSchema = db.inDialect('postgres') ? 'public' : undefined;
+    const tableName = viewSchema ? db.utils.addSchema(viewName, viewSchema) : viewName;
+    const quotedViewName = db.utils.quoteTable(tableName);
+    const dropViewSQL = `DROP VIEW IF EXISTS ${quotedViewName}`;
+
+    await db.sequelize.query(dropViewSQL);
+    await db.sequelize.query(
+      `CREATE VIEW ${quotedViewName} AS SELECT users.name AS safe_name FROM ${UserCollection.quotedTableName()} AS users`,
+    );
+
+    const inferredFields = await ViewFieldInference.inferFields({
+      db,
+      viewName,
+      viewSchema,
+    });
+
+    expect(inferredFields.safe_name).toBeDefined();
+
+    await db.sequelize.query(dropViewSQL);
+  });
 });

--- a/packages/core/database/src/__tests__/view/view-inference.test.ts
+++ b/packages/core/database/src/__tests__/view/view-inference.test.ts
@@ -155,40 +155,4 @@ describe('view inference', function () {
 
     await db.sequelize.query(dropViewSQL);
   });
-
-  it('should safely infer fields from a view name with SQL metacharacters', async () => {
-    const UserCollection = db.collection({
-      name: 'users',
-      fields: [
-        {
-          name: 'name',
-          type: 'string',
-          interface: 'test',
-        },
-      ],
-    });
-
-    await db.sync();
-
-    const viewName = "x.v1' UNION SELECT 1,2,3,4,5,6,7--";
-    const viewSchema = db.inDialect('postgres') ? 'public' : undefined;
-    const tableName = viewSchema ? db.utils.addSchema(viewName, viewSchema) : viewName;
-    const quotedViewName = db.utils.quoteTable(tableName);
-    const dropViewSQL = `DROP VIEW IF EXISTS ${quotedViewName}`;
-
-    await db.sequelize.query(dropViewSQL);
-    await db.sequelize.query(
-      `CREATE VIEW ${quotedViewName} AS SELECT users.name AS safe_name FROM ${UserCollection.quotedTableName()} AS users`,
-    );
-
-    const inferredFields = await ViewFieldInference.inferFields({
-      db,
-      viewName,
-      viewSchema,
-    });
-
-    expect(inferredFields.safe_name).toBeDefined();
-
-    await db.sequelize.query(dropViewSQL);
-  });
 });

--- a/packages/core/database/src/database.ts
+++ b/packages/core/database/src/database.ts
@@ -1046,7 +1046,10 @@ export class Database extends EventEmitter implements AsyncEmitter {
 
       async onDump(dumper, collection: Collection) {
         try {
-          const viewDef = await collection.db.queryInterface.viewDef(collection.getTableNameWithSchemaAsString());
+          const viewDef = await collection.db.queryInterface.viewDef({
+            viewName: collection.model.tableName,
+            schema: collection.db.inDialect('postgres') ? collection.collectionSchema() : undefined,
+          });
 
           dumper.writeSQLContent(`view-${collection.name}`, {
             sql: [

--- a/packages/core/database/src/query-interface/mysql-query-interface.ts
+++ b/packages/core/database/src/query-interface/mysql-query-interface.ts
@@ -50,7 +50,7 @@ export default class MysqlQueryInterface extends QueryInterface {
     };
   }> {
     try {
-      const { ast } = this.parseSQL(await this.viewDef(options.viewName));
+      const { ast } = this.parseSQL(await this.viewDef(options));
 
       const columns = ast.columns;
 
@@ -79,8 +79,15 @@ export default class MysqlQueryInterface extends QueryInterface {
     return sqlParser.parse(sql);
   }
 
-  async viewDef(viewName: string): Promise<string> {
-    const viewDefinition = await this.db.sequelize.query(`SHOW CREATE VIEW ${viewName}`, { type: 'SELECT' });
+  async viewDef(options: { viewName: string; schema?: string }): Promise<string> {
+    const tableName = options.schema
+      ? {
+          schema: options.schema,
+          tableName: options.viewName,
+        }
+      : options.viewName;
+    const quotedViewName = this.db.utils.quoteTable(tableName);
+    const viewDefinition = await this.db.sequelize.query(`SHOW CREATE VIEW ${quotedViewName}`, { type: 'SELECT' });
     const createView = viewDefinition[0]['Create View'];
     const regex = /(?<=AS\s)([\s\S]*)/i;
     const match = createView.match(regex);

--- a/packages/core/database/src/query-interface/postgres-query-interface.ts
+++ b/packages/core/database/src/query-interface/postgres-query-interface.ts
@@ -110,25 +110,24 @@ export default class PostgresQueryInterface extends QueryInterface {
   async listViews(options?: { schema?: string }) {
     const targetSchema = options?.schema || this.db.options?.schema || 'public';
 
-    const sql = targetSchema
-      ? `
+    const sql = `
       SELECT viewname as name, definition, schemaname as schema
       FROM pg_views
-      WHERE schemaname = '${targetSchema}'
-      ORDER BY viewname;
-    `
-      : `
-      SELECT viewname as name, definition, schemaname as schema
-      FROM pg_views
-      WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+      WHERE schemaname = :targetSchema
       ORDER BY viewname;
     `;
 
-    return await this.db.sequelize.query(sql, { type: 'SELECT' });
+    return await this.db.sequelize.query(sql, {
+      replacements: {
+        targetSchema,
+      },
+      type: 'SELECT',
+    });
   }
 
   async viewDef(options: { viewName: string; schema?: string }) {
-    const { viewName, schema = this.db.options.schema || 'public' } = options;
+    const { viewName } = options;
+    const schema = options.schema || this.db.options.schema || 'public';
 
     const viewDefQuery = await this.db.sequelize.query(
       `
@@ -159,7 +158,8 @@ export default class PostgresQueryInterface extends QueryInterface {
       table_schema?: string;
     };
   }> {
-    const { viewName, schema = 'public' } = options;
+    const { viewName } = options;
+    const schema = options.schema || this.db.options.schema || 'public';
     const sql = `
       SELECT *
       FROM information_schema.view_column_usage

--- a/packages/core/database/src/query-interface/postgres-query-interface.ts
+++ b/packages/core/database/src/query-interface/postgres-query-interface.ts
@@ -127,14 +127,20 @@ export default class PostgresQueryInterface extends QueryInterface {
     return await this.db.sequelize.query(sql, { type: 'SELECT' });
   }
 
-  async viewDef(viewName: string) {
-    const [schema, name] = viewName.split('.');
+  async viewDef(options: { viewName: string; schema?: string }) {
+    const { viewName, schema = this.db.options.schema || 'public' } = options;
 
     const viewDefQuery = await this.db.sequelize.query(
       `
-    select pg_get_viewdef(format('%I.%I', '${schema}', '${name}')::regclass, true) as definition
+    select pg_get_viewdef(format('%I.%I', :schema, :viewName)::regclass, true) as definition
     `,
-      { type: 'SELECT' },
+      {
+        replacements: {
+          schema,
+          viewName,
+        },
+        type: 'SELECT',
+      },
     );
 
     return lodash.trim(viewDefQuery[0]['definition']);
@@ -146,7 +152,7 @@ export default class PostgresQueryInterface extends QueryInterface {
     });
   }
 
-  async viewColumnUsage(options): Promise<{
+  async viewColumnUsage(options: { viewName: string; schema?: string }): Promise<{
     [view_column_name: string]: {
       column_name: string;
       table_name: string;
@@ -157,17 +163,23 @@ export default class PostgresQueryInterface extends QueryInterface {
     const sql = `
       SELECT *
       FROM information_schema.view_column_usage
-      WHERE view_schema = '${schema}'
-        AND view_name = '${viewName}';
+      WHERE view_schema = :schema
+        AND view_name = :viewName;
     `;
 
-    const columnUsages = (await this.db.sequelize.query(sql, { type: 'SELECT' })) as Array<{
+    const columnUsages = (await this.db.sequelize.query(sql, {
+      replacements: {
+        schema,
+        viewName,
+      },
+      type: 'SELECT',
+    })) as Array<{
       column_name: string;
       table_name: string;
       table_schema: string;
     }>;
 
-    const def = await this.viewDef(`${schema}.${viewName}`);
+    const def = await this.viewDef({ schema, viewName });
 
     try {
       const { ast } = this.parseSQL(def);

--- a/packages/core/database/src/query-interface/query-interface.ts
+++ b/packages/core/database/src/query-interface/query-interface.ts
@@ -27,7 +27,7 @@ export default abstract class QueryInterface {
 
   abstract listViews(options?: { schema?: string });
 
-  abstract viewDef(viewName: string): Promise<string>;
+  abstract viewDef(options: { viewName: string; schema?: string }): Promise<string>;
 
   abstract viewColumnUsage(options: { viewName: string; schema?: string }): Promise<{
     [view_column_name: string]: {

--- a/packages/core/database/src/query-interface/sqlite-query-interface.ts
+++ b/packages/core/database/src/query-interface/sqlite-query-interface.ts
@@ -53,7 +53,7 @@ export default class SqliteQueryInterface extends QueryInterface {
     };
   }> {
     try {
-      const { ast } = this.parseSQL(await this.viewDef(options.viewName));
+      const { ast } = this.parseSQL(await this.viewDef(options));
 
       const columns = ast.columns;
 
@@ -81,12 +81,15 @@ export default class SqliteQueryInterface extends QueryInterface {
     return sqlParser.parse(sql);
   }
 
-  async viewDef(viewName: string): Promise<string> {
+  async viewDef(options: { viewName: string; schema?: string }): Promise<string> {
     const viewDefinition = await this.db.sequelize.query(
       `SELECT sql
        FROM sqlite_master
-       WHERE name = '${viewName}' AND type = 'view'`,
+       WHERE name = :viewName AND type = 'view'`,
       {
+        replacements: {
+          viewName: options.viewName,
+        },
         type: 'SELECT',
       },
     );

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/view-collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/view-collection.test.ts
@@ -190,6 +190,29 @@ SELECT * FROM numbers;
     }
   });
 
+  it('should safely get fields from a view name with SQL metacharacters', async () => {
+    const viewName = "x.v1' UNION SELECT 1,2,3,4,5,6,7--";
+    const viewSchema = db.inDialect('postgres') ? schema || 'public' : undefined;
+    const tableName = viewSchema ? db.utils.addSchema(viewName, viewSchema) : viewName;
+    const quotedViewName = db.utils.quoteTable(tableName);
+    const dropViewSQL = `DROP VIEW IF EXISTS ${quotedViewName}`;
+
+    await db.sequelize.query(dropViewSQL);
+    await db.sequelize.query(`CREATE VIEW ${quotedViewName} AS SELECT 1 AS safe_field`);
+
+    try {
+      const response = await agent.resource('dbViews').get({
+        filterByTk: viewName,
+        schema: viewSchema,
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.fields.map((field) => field.name)).toEqual(['safe_field']);
+    } finally {
+      await db.sequelize.query(dropViewSQL);
+    }
+  });
+
   it.skipIf(process.env['DB_DIALECT'] === 'sqlite')('should return possible types for json fields', async () => {
     if (app.db.inDialect('mariadb')) {
       // can not get json type from mariadb

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/view-collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/view-collection.test.ts
@@ -207,7 +207,9 @@ SELECT * FROM numbers;
       });
 
       expect(response.status).toBe(200);
-      expect(response.body.data.fields.map((field) => field.name)).toEqual(['safe_field']);
+      expect(
+        [...response.body.data.fields, ...response.body.data.unsupportedFields].map((field) => field.name),
+      ).toEqual(['safe_field']);
     } finally {
       await db.sequelize.query(dropViewSQL);
     }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Database view metadata queries interpolated view and schema names directly into SQL. Specially crafted view names could alter the PostgreSQL query structure, while MySQL and SQLite had similar unsafe query construction.

### Description 

- Parameterize PostgreSQL view listing, definition, and column usage queries
- Use the configured database schema consistently when callers omit a schema
- Pass schema and view names separately so quoted identifiers containing dots are handled correctly
- Quote MySQL view identifiers and parameterize SQLite view definition lookups
- Add an HTTP API regression test using a view name containing SQL metacharacters
- Add query construction tests for PostgreSQL, MySQL, and SQLite

The internal `viewDef` method signature changes from a combined string to separate schema and view name options. All repository call sites and dialect implementations have been updated. This change does not modify schema access authorization behavior.

Tested with:

- `yarn test packages/core/database/src/__tests__/query-interface/view-definition.test.ts --run --reporter=verbose`
- `yarn test packages/core/database/src/__tests__/view/list-view.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/http-api/view-collection.test.ts --run --reporter=verbose`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an SQL injection risk when reading database view metadata |
| 🇨🇳 Chinese | 修复读取数据库视图元数据时的 SQL 注入风险 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
