### PR TITLE
fix(client-v2): guard missing collection

### DIFF
--- a/packages/core/client-v2/src/flow/models/base/CollectionBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/CollectionBlockModel.tsx
@@ -569,9 +569,13 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
     }
     if (fieldPath.includes('.')) {
       // 关系数据
+      const collection = this.collection;
+      if (!collection) {
+        return;
+      }
       const [field1, field2] = fieldPath.split('.');
       const associationField = this.context.dataSourceManager.getCollectionField(
-        `${this.collection.dataSourceKey}.${this.collection.name}.${field1}`,
+        `${collection.dataSourceKey}.${collection.name}.${field1}`,
       ) as CollectionField;
       if (!associationField) {
         return;
@@ -583,7 +587,7 @@ export class CollectionBlockModel<T = DefaultStructure> extends DataBlockModel<T
       }
 
       const collectionField = this.context.dataSourceManager.getCollectionField(
-        `${this.collection.dataSourceKey}.${targetCollectionName}.${field2}`,
+        `${collection.dataSourceKey}.${targetCollectionName}.${field2}`,
       ) as CollectionField;
 
       if (collectionField && collectionField.isAssociationField()) {

--- a/packages/core/client-v2/src/flow/models/base/__tests__/CollectionBlockModel.addAppends.test.ts
+++ b/packages/core/client-v2/src/flow/models/base/__tests__/CollectionBlockModel.addAppends.test.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine, FlowModelContext, MultiRecordResource } from '@nocobase/flow-engine';
+import { describe, expect, it } from 'vitest';
+import { CollectionBlockModel } from '../CollectionBlockModel';
+
+class AddAppendsCollectionBlockModel extends CollectionBlockModel {
+  createResource(ctx: FlowModelContext) {
+    return ctx.createResource(MultiRecordResource);
+  }
+}
+
+describe('CollectionBlockModel addAppends', () => {
+  it('does not throw for a nested field path when the collection is unavailable', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ AddAppendsCollectionBlockModel });
+
+    const model = engine.createModel<AddAppendsCollectionBlockModel>({
+      uid: 'missing-collection-add-appends-block',
+      use: 'AddAppendsCollectionBlockModel',
+      stepParams: {
+        resourceSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'missing_collection',
+          },
+        },
+      },
+    });
+
+    expect(model.collection).toBeUndefined();
+    expect(() => model.addAppends('createdBy.departments')).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

审批页面加载引用区块时，如果嵌套关联字段对应的数据表信息不可用，页面会出现报错并中断加载。

### Description

在处理嵌套关联字段前检查数据表信息。数据表信息不存在时安全返回，避免页面因读取空数据而崩溃。

新增回归测试，覆盖数据表信息不存在时加载嵌套字段不再抛出异常。相关区块测试和字段模型测试均已通过。

本次只修复已经确认的页面报错，不调整数据表缓存、加载顺序或重试机制。待获得可稳定复现的环境后，再单独分析其他可能的触发条件。

### Showcase

不适用。本次为异常保护修复，没有界面样式变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix an error that could prevent approval pages from loading |
| 🇨🇳 Chinese | 修复可能导致审批页面无法加载的报错问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
