### PR TITLE
fix(client-v2): avoid stale tab route updates

### DIFF
--- a/packages/core/client-v2/src/flow/models/base/PageModel/PageTabModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/PageModel/PageTabModel.tsx
@@ -9,6 +9,7 @@
 
 import { FlowModel, FlowModelRenderer, observable, tExpr } from '@nocobase/flow-engine';
 import { Icon, type NocoBaseDesktopRoute } from '../../../../flow-compat';
+import type { RouteRepository } from '../../../../RouteRepository';
 import { useRequest } from 'ahooks';
 import React from 'react';
 import { SkeletonFallback } from '../../../components/SkeletonFallback';
@@ -50,6 +51,25 @@ function normalizePersistedRoute(payload: unknown): Partial<NocoBaseDesktopRoute
     return payload as Partial<NocoBaseDesktopRoute>;
   }
   return undefined;
+}
+
+type RefreshableRouteRepository = Pick<RouteRepository, 'refreshAccessible'>;
+
+const routeRefreshQueues = new WeakMap<RefreshableRouteRepository, Promise<unknown>>();
+
+async function refreshRouteRepository(repository: RefreshableRouteRepository) {
+  const previous = routeRefreshQueues.get(repository) || Promise.resolve();
+  const current = previous.catch(() => undefined).then(() => repository.refreshAccessible());
+
+  routeRefreshQueues.set(repository, current);
+
+  try {
+    await current;
+  } finally {
+    if (routeRefreshQueues.get(repository) === current) {
+      routeRefreshQueues.delete(repository);
+    }
+  }
 }
 
 export class BasePageTabModel extends FlowModel<{
@@ -168,22 +188,36 @@ export class RootPageTabModel extends BasePageTabModel {
   async save() {
     const json = this.serialize();
     const documentTitle = this.stepParams?.pageTabSettings?.tab?.documentTitle;
-    const response = await this.context.api.request({
-      method: 'post',
-      url: 'desktopRoutes:updateOrCreate',
-      params: {
-        filterKeys: ['schemaUid'],
+    const route = this.props.route || {};
+    const persisted = route.id != null;
+    const currentRoute =
+      persisted && route.schemaUid ? this.context.routeRepository?.getRouteBySchemaUid?.(route.schemaUid) : undefined;
+    const data = {
+      ...(persisted ? { schemaUid: route.schemaUid } : route),
+      title: this.getTabTitle(''),
+      icon: this.getTabIcon(),
+      options: {
+        ...(currentRoute ? currentRoute.options : route.options),
+        flowRegistry: json.flowRegistry,
+        documentTitle,
       },
-      data: {
-        ...this.props.route,
-        title: this.getTabTitle(''),
-        icon: this.getTabIcon(),
-        options: {
-          flowRegistry: json.flowRegistry,
-          documentTitle,
-        },
-      },
-    });
+    };
+    const response = await this.context.api.request(
+      persisted
+        ? {
+            method: 'post',
+            url: `desktopRoutes:update?filter[id]=${route.id}`,
+            data,
+          }
+        : {
+            method: 'post',
+            url: 'desktopRoutes:updateOrCreate',
+            params: {
+              filterKeys: ['schemaUid'],
+            },
+            data,
+          },
+    );
     const persistedRoute = normalizePersistedRoute(response?.data?.data);
 
     // 新建 tab 首次保存后需要立即拿到持久化 route id，拖拽排序会直接依赖它。
@@ -196,6 +230,20 @@ export class RootPageTabModel extends BasePageTabModel {
           ...persistedRoute.options,
         },
       });
+    }
+
+    // 后续保存会从 RouteRepository 读取扩展 options，当前写入完成后必须先同步最新路由快照。
+    try {
+      if (this.context.routeRepository?.refreshAccessible) {
+        await refreshRouteRepository(this.context.routeRepository);
+      } else {
+        await this.context.refreshDesktopRoutes?.();
+      }
+    } catch (error) {
+      this.context.logger?.warn?.(
+        { err: error },
+        '[client-v2] Failed to refresh desktop routes after saving a page tab',
+      );
     }
   }
 

--- a/packages/core/client-v2/src/flow/models/base/PageModel/__tests__/PageTabModel.test.ts
+++ b/packages/core/client-v2/src/flow/models/base/PageModel/__tests__/PageTabModel.test.ts
@@ -59,6 +59,51 @@ vi.mock('ahooks', async (importOriginal) => {
   };
 });
 
+type RootPageTabModelClass = typeof import('../PageTabModel').RootPageTabModel;
+
+type TestRoute = {
+  schemaUid?: string;
+  options?: Record<string, unknown>;
+} & Record<string, unknown>;
+
+type RootPageTabModelTestOptions = {
+  props?: {
+    route?: TestRoute;
+  };
+  stepParams?: {
+    pageTabSettings?: {
+      tab?: {
+        title?: string;
+        icon?: string;
+        documentTitle?: string;
+      };
+    };
+  };
+  context: {
+    api: {
+      request: ReturnType<typeof vi.fn>;
+    };
+    routeRepository?: {
+      getRouteBySchemaUid?: (schemaUid: string) => TestRoute | undefined;
+      refreshAccessible?: () => Promise<unknown>;
+    };
+    refreshDesktopRoutes?: () => Promise<unknown>;
+    logger?: {
+      warn?: (context: { err: unknown }, message: string) => void;
+    };
+    t: (value: string) => string;
+  };
+};
+
+type RootPageTabModelTestConstructor = new (
+  options: RootPageTabModelTestOptions,
+) => InstanceType<RootPageTabModelClass>;
+
+function createRootPageTabModel(Model: RootPageTabModelClass, options: RootPageTabModelTestOptions) {
+  const TestModel = Model as unknown as RootPageTabModelTestConstructor;
+  return new TestModel(options);
+}
+
 describe('PageTabModel', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -113,7 +158,7 @@ describe('PageTabModel', () => {
   it('should persist tab documentTitle to route options on save', async () => {
     const { RootPageTabModel } = await import('../PageTabModel');
     const request = vi.fn().mockResolvedValue({});
-    const model = new RootPageTabModel({
+    const model = createRootPageTabModel(RootPageTabModel, {
       props: {
         route: {
           schemaUid: 'tab-1',
@@ -132,13 +177,420 @@ describe('PageTabModel', () => {
         api: { request },
         t: (value: string) => value,
       },
-    } as any);
+    });
 
     await model.save();
 
     const call = request.mock.calls[0][0];
     expect(call.url).toBe('desktopRoutes:updateOrCreate');
     expect(call.data.options.documentTitle).toBe('Tab doc title');
+  });
+
+  it('should update a persisted tab route by id with only editable fields and latest options', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const request = vi.fn().mockResolvedValue({});
+    const model = createRootPageTabModel(RootPageTabModel, {
+      props: {
+        route: {
+          id: 123,
+          parentId: 456,
+          schemaUid: 'tab-1',
+          type: 'tabs',
+          sort: 1,
+          hidden: true,
+          tabSchemaName: 'tab-name-1',
+          hideInMenu: false,
+          enableTabs: false,
+          roles: [{ name: 'admin', title: 'Admin' }],
+          createdAt: '2026-07-16T00:00:00.000Z',
+          updatedAt: '2026-07-16T01:00:00.000Z',
+          options: {
+            badge: {
+              showZero: false,
+            },
+            pluginState: 'stale',
+            removedPluginState: 'stale-only',
+            flowRegistry: { stale: true },
+            documentTitle: 'Stale document title',
+          },
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Renamed tab',
+            icon: 'TableOutlined',
+            documentTitle: 'Current document title',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        routeRepository: {
+          getRouteBySchemaUid: vi.fn(() => ({
+            schemaUid: 'tab-1',
+            options: {
+              badge: {
+                showZero: true,
+              },
+              pluginState: 'fresh',
+              flowRegistry: { fresh: true },
+              documentTitle: 'Fresh document title',
+            },
+          })),
+        },
+        t: (value: string) => value,
+      },
+    });
+
+    await model.save();
+
+    const call = request.mock.calls[0][0];
+    expect(call).toEqual({
+      method: 'post',
+      url: 'desktopRoutes:update?filter[id]=123',
+      data: {
+        schemaUid: 'tab-1',
+        title: 'Renamed tab',
+        icon: 'TableOutlined',
+        options: {
+          badge: {
+            showZero: true,
+          },
+          pluginState: 'fresh',
+          flowRegistry: {},
+          documentTitle: 'Current document title',
+        },
+      },
+    });
+    expect(Object.keys(call.data).sort()).toEqual(['icon', 'options', 'schemaUid', 'title']);
+  });
+
+  it('should fall back to model route options when the current route is unavailable', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const request = vi.fn().mockResolvedValue({});
+    const model = createRootPageTabModel(RootPageTabModel, {
+      props: {
+        route: {
+          id: 123,
+          parentId: 456,
+          schemaUid: 'tab-1',
+          type: 'tabs',
+          sort: 1,
+          hidden: true,
+          options: {
+            badge: {
+              showZero: true,
+            },
+          },
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Renamed tab',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        routeRepository: {
+          getRouteBySchemaUid: vi.fn(() => undefined),
+        },
+        t: (value: string) => value,
+      },
+    });
+
+    await model.save();
+
+    const call = request.mock.calls[0][0];
+    expect(call).toEqual({
+      method: 'post',
+      url: 'desktopRoutes:update?filter[id]=123',
+      data: {
+        schemaUid: 'tab-1',
+        title: 'Renamed tab',
+        icon: undefined,
+        options: {
+          badge: {
+            showZero: true,
+          },
+          flowRegistry: {},
+          documentTitle: undefined,
+        },
+      },
+    });
+  });
+
+  it('should await a route refresh after the request before a subsequent persisted tab save', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const events: string[] = [];
+    let resolveFirstRefresh: () => void = () => {};
+    const firstRefreshDone = new Promise<void>((resolve) => {
+      resolveFirstRefresh = resolve;
+    });
+    let currentRoute = {
+      schemaUid: 'tab-1',
+      options: {
+        pluginState: 'before-save',
+      },
+    };
+    let requestCall = 0;
+    const request = vi.fn(async () => {
+      requestCall += 1;
+      events.push(`request:${requestCall}`);
+      if (requestCall === 1) {
+        return {
+          data: {
+            data: [
+              {
+                id: 123,
+                schemaUid: 'tab-1',
+                options: {
+                  pluginState: 'after-save',
+                  serverHookState: true,
+                },
+              },
+            ],
+          },
+        };
+      }
+      return {};
+    });
+    let refreshCall = 0;
+    const refreshAccessible = vi.fn(async () => {
+      refreshCall += 1;
+      events.push(`refresh:${refreshCall}:start`);
+      if (refreshCall === 1) {
+        await firstRefreshDone;
+        currentRoute = {
+          schemaUid: 'tab-1',
+          options: {
+            pluginState: 'after-save',
+            serverHookState: true,
+          },
+        };
+      }
+      events.push(`refresh:${refreshCall}:end`);
+    });
+    const model = createRootPageTabModel(RootPageTabModel, {
+      props: {
+        route: {
+          id: 123,
+          schemaUid: 'tab-1',
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Renamed tab',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        routeRepository: {
+          getRouteBySchemaUid: vi.fn(() => currentRoute),
+          refreshAccessible,
+        },
+        t: (value: string) => value,
+      },
+    });
+
+    let firstSaveResolved = false;
+    const firstSave = model.save().then(() => {
+      firstSaveResolved = true;
+      events.push('save:1:end');
+    });
+
+    await vi.waitFor(() => expect(refreshAccessible).toHaveBeenCalledTimes(1));
+    expect(events.slice(0, 2)).toEqual(['request:1', 'refresh:1:start']);
+    await Promise.resolve();
+    expect(firstSaveResolved).toBe(false);
+
+    resolveFirstRefresh();
+    await firstSave;
+    expect(events.indexOf('request:1')).toBeLessThan(events.indexOf('refresh:1:start'));
+    expect(events.indexOf('refresh:1:end')).toBeLessThan(events.indexOf('save:1:end'));
+
+    await model.save();
+
+    expect(refreshAccessible).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[1][0].data.options).toMatchObject({
+      pluginState: 'after-save',
+      serverHookState: true,
+    });
+  });
+
+  it('should serialize route refreshes when new tabs are saved concurrently', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    let releaseFirstRefresh: () => void = () => {};
+    const firstRefreshDone = new Promise<void>((resolve) => {
+      releaseFirstRefresh = resolve;
+    });
+    let refreshCall = 0;
+    let activeRefreshes = 0;
+    let maxActiveRefreshes = 0;
+    const refreshAccessible = vi.fn(async () => {
+      refreshCall += 1;
+      activeRefreshes += 1;
+      maxActiveRefreshes = Math.max(maxActiveRefreshes, activeRefreshes);
+      if (refreshCall === 1) {
+        await firstRefreshDone;
+      }
+      activeRefreshes -= 1;
+    });
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            id: 101,
+            schemaUid: 'tab-1',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            id: 102,
+            schemaUid: 'tab-2',
+          },
+        },
+      });
+    const routeRepository = {
+      refreshAccessible,
+    };
+    const createModel = (schemaUid: string, title: string) =>
+      createRootPageTabModel(RootPageTabModel, {
+        props: {
+          route: {
+            parentId: 999,
+            schemaUid,
+            tabSchemaName: `${schemaUid}-name`,
+            type: 'tabs',
+          },
+        },
+        stepParams: {
+          pageTabSettings: {
+            tab: {
+              title,
+            },
+          },
+        },
+        context: {
+          api: { request },
+          routeRepository,
+          t: (value: string) => value,
+        },
+      });
+
+    const saves = Promise.all([createModel('tab-1', 'Tab 1').save(), createModel('tab-2', 'Tab 2').save()]);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(refreshAccessible).toHaveBeenCalled());
+    await Promise.resolve();
+    await Promise.resolve();
+    const refreshCallsBeforeRelease = refreshAccessible.mock.calls.length;
+
+    releaseFirstRefresh();
+    await saves;
+
+    expect(refreshCallsBeforeRelease).toBe(1);
+    expect(refreshAccessible).toHaveBeenCalledTimes(2);
+    expect(maxActiveRefreshes).toBe(1);
+  });
+
+  it('should keep a successful route save when refreshing the route cache fails', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const refreshError = new Error('refresh failed');
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            id: 123,
+            schemaUid: 'tab-1',
+          },
+        },
+      })
+      .mockResolvedValueOnce({});
+    const refreshAccessible = vi.fn().mockRejectedValueOnce(refreshError).mockResolvedValueOnce([]);
+    const warn = vi.fn();
+    const model = createRootPageTabModel(RootPageTabModel, {
+      props: {
+        route: {
+          parentId: 999,
+          schemaUid: 'tab-1',
+          tabSchemaName: 'tab-name-1',
+          type: 'tabs',
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Tab title',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        routeRepository: {
+          refreshAccessible,
+        },
+        logger: { warn },
+        t: (value: string) => value,
+      },
+    });
+
+    await expect(model.save()).resolves.toBeUndefined();
+
+    expect(model.props.route.id).toBe(123);
+    expect(warn).toHaveBeenCalledWith(
+      { err: refreshError },
+      '[client-v2] Failed to refresh desktop routes after saving a page tab',
+    );
+
+    await expect(model.save()).resolves.toBeUndefined();
+    expect(refreshAccessible).toHaveBeenCalledTimes(2);
+  });
+
+  it('should still reject when writing the tab route fails', async () => {
+    const { RootPageTabModel } = await import('../PageTabModel');
+    const writeError = new Error('write failed');
+    const request = vi.fn().mockRejectedValue(writeError);
+    const refreshAccessible = vi.fn().mockResolvedValue([]);
+    const warn = vi.fn();
+    const model = createRootPageTabModel(RootPageTabModel, {
+      props: {
+        route: {
+          parentId: 999,
+          schemaUid: 'tab-1',
+          tabSchemaName: 'tab-name-1',
+          type: 'tabs',
+        },
+      },
+      stepParams: {
+        pageTabSettings: {
+          tab: {
+            title: 'Tab title',
+          },
+        },
+      },
+      context: {
+        api: { request },
+        routeRepository: {
+          refreshAccessible,
+        },
+        logger: { warn },
+        t: (value: string) => value,
+      },
+    });
+
+    await expect(model.save()).rejects.toBe(writeError);
+    expect(refreshAccessible).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(model.props.route.id).toBeUndefined();
   });
 
   it('should sync persisted route id after save', async () => {
@@ -152,16 +604,24 @@ describe('PageTabModel', () => {
         },
       },
     });
-    const model = new RootPageTabModel({
+    const model = createRootPageTabModel(RootPageTabModel, {
       props: {
         route: {
+          parentId: 999,
           schemaUid: 'tab-1',
+          tabSchemaName: 'tab-name-1',
+          type: 'tabs',
+          params: [],
+          hideInMenu: false,
+          enableTabs: false,
         },
       },
       stepParams: {
         pageTabSettings: {
           tab: {
             title: 'Tab title',
+            icon: 'TableOutlined',
+            documentTitle: 'Tab document title',
           },
         },
       },
@@ -169,10 +629,33 @@ describe('PageTabModel', () => {
         api: { request },
         t: (value: string) => value,
       },
-    } as any);
+    });
 
     await model.save();
 
+    const call = request.mock.calls[0][0];
+    expect(call).toEqual({
+      method: 'post',
+      url: 'desktopRoutes:updateOrCreate',
+      params: {
+        filterKeys: ['schemaUid'],
+      },
+      data: {
+        parentId: 999,
+        schemaUid: 'tab-1',
+        tabSchemaName: 'tab-name-1',
+        type: 'tabs',
+        params: [],
+        hideInMenu: false,
+        enableTabs: false,
+        title: 'Tab title',
+        icon: 'TableOutlined',
+        options: {
+          flowRegistry: {},
+          documentTitle: 'Tab document title',
+        },
+      },
+    });
     expect(model.props.route.id).toBe(123);
     expect(model.props.route.sort).toBe(9);
   });
@@ -192,7 +675,7 @@ describe('PageTabModel', () => {
         ],
       },
     });
-    const model = new RootPageTabModel({
+    const model = createRootPageTabModel(RootPageTabModel, {
       props: {
         route: {
           schemaUid: 'tab-1',
@@ -212,7 +695,7 @@ describe('PageTabModel', () => {
         api: { request },
         t: (value: string) => value,
       },
-    } as any);
+    });
 
     await model.save();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

新建页面并开启页面标签页后，如果不刷新页面就直接修改默认标签页名称，前端仍可能持有开启标签页之前的旧路由数据。保存名称时，这些已经过期、且应由后端维护的路由字段会被一并提交，导致最新路由状态被旧值覆盖。

### Description

- 已存在的标签页改为按路由 ID 更新，只提交名称、图标、页面配置和路由标识，不再回写 `hidden`、父级、排序等非本次编辑字段。
- 保存时从当前路由数据中合并扩展配置，避免仅修改名称时丢失其他插件写入的标签页配置。
- 新建标签页仍保留完整创建数据，并兼容接口返回单条记录或数组的情况，确保创建后可以立即获得路由 ID。
- 同一路由数据源的保存后刷新按顺序执行；刷新失败只记录警告，不会把已经成功的保存误判为失败。
- 补充单元测试，覆盖已有标签页更新、新标签页创建、连续保存、并发刷新、刷新失败和真实保存失败等场景。

测试建议：新建页面并开启标签页，不刷新页面直接修改默认标签页名称；确认保存请求不包含 `hidden` 等非编辑字段，刷新页面后标签页状态和名称仍保持正确。

### Showcase

已使用浏览器按原复现步骤完成回归验证。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix inconsistent route state after renaming a newly enabled page tab |
| 🇨🇳 Chinese | 修复页面开启标签页后立即改名可能导致路由状态不一致的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
