### PR TITLE
fix(workflow): ensure pre-action events run before approval

### DIFF
--- a/packages/core/resourcer/src/__tests__/resourcer.test.ts
+++ b/packages/core/resourcer/src/__tests__/resourcer.test.ts
@@ -373,6 +373,49 @@ describe('resourcer', () => {
     );
     expect(context.arr).toStrictEqual([7, 1, 2, 3, 4, 5, 6, 8]);
   });
+  it('sorts middleware after parseVariables and before default', async () => {
+    const resourcer = new Resourcer();
+    resourcer.use(
+      async (ctx, next) => {
+        ctx.arr.push('parseVariables');
+        await next();
+      },
+      { group: 'parseVariables' },
+    );
+    resourcer.use(async (ctx, next) => {
+      ctx.arr.push('default');
+      await next();
+    });
+    resourcer.use(
+      async (ctx, next) => {
+        ctx.arr.push('requestInterceptor');
+        await next();
+      },
+      {
+        after: 'parseVariables',
+        before: 'default',
+      },
+    );
+    resourcer.define({
+      name: 'test',
+      actions: {
+        async list(ctx) {
+          ctx.arr.push('action');
+        },
+      },
+    });
+    const context = {
+      arr: [],
+    };
+    await resourcer.execute(
+      {
+        resource: 'test',
+        action: 'list',
+      },
+      context,
+    );
+    expect(context.arr).toStrictEqual(['parseVariables', 'requestInterceptor', 'default', 'action']);
+  });
   it('middlewares#only', async () => {
     const resourcer = new Resourcer();
     resourcer.define({

--- a/packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/RequestInterceptionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/RequestInterceptionTrigger.ts
@@ -221,7 +221,10 @@ export default class RequestInterceptionTrigger extends Trigger {
   constructor(workflow) {
     super(workflow);
 
-    workflow.app.dataSourceManager.use(this.middleware);
+    workflow.app.dataSourceManager.use(this.middleware, {
+      after: 'parseVariables',
+      before: 'default',
+    });
 
     workflow.app.pm.get(PluginErrorHandler).errorHandler.register(
       (err) => err instanceof RequestInterceptionError || err.name === 'RequestInterceptionError',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When a pre-action workflow and a before-save approval workflow are configured for the same collection action, the approval middleware can run first and return a 202 response without calling the downstream middleware. This prevents the pre-action workflow from being triggered.

### Description
- Register the request interceptor middleware after `parseVariables` and before the `default` middleware group.
- Keep the approval middleware in the `default` group so pre-action workflows always run before before-save approval handling.
- Add a ResourceManager regression test that registers the default middleware first and verifies the final order is `parseVariables -> requestInterceptor -> default -> action`.

Potential risk: the request interceptor now consistently runs before every middleware in the `default` group. This is intentional for pre-action interception and is covered by the middleware ordering test and existing request interceptor tests.

Testing:
- `yarn test packages/core/resourcer/src/__tests__/resourcer.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/__tests__/trigger.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/__tests__/validation.test.ts --run --reporter=verbose`

### Related issues

None.

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed pre-action workflows not triggering when used together with before-save approval workflows. |
| 🇨🇳 Chinese | 修复操作前事件与审批保存前模式同时使用时，操作前事件可能未触发的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
