### PR TITLE
fix(client-v2): register device type early

### DIFF
--- a/packages/core/client-v2/package.json
+++ b/packages/core/client-v2/package.json
@@ -44,6 +44,7 @@
     "json5": "^2.2.3",
     "jsqr": "^1.4.0",
     "lodash": "4.17.21",
+    "react-device-detect": "2.2.3",
     "react-i18next": "^11.15.1",
     "react-router-dom": "^6.30.1"
   }

--- a/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
+++ b/packages/core/client-v2/src/flow/__tests__/FlowRoute.test.tsx
@@ -112,6 +112,7 @@ describe('FlowRoute', () => {
         }),
       );
     });
+    expect(engine.context.deviceType).toBe('computer');
 
     rerender(
       <FlowEngineProvider engine={engine}>

--- a/packages/core/client-v2/src/flow/__tests__/PluginFlowEngine.test.ts
+++ b/packages/core/client-v2/src/flow/__tests__/PluginFlowEngine.test.ts
@@ -1,0 +1,58 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createMockClient, PluginFlowEngine } from '@nocobase/client-v2';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { detectedDeviceType } = vi.hoisted(() => ({
+  detectedDeviceType: { value: 'mobile' },
+}));
+
+vi.mock('react-device-detect', () => ({
+  get deviceType() {
+    return detectedDeviceType.value;
+  },
+}));
+
+describe('PluginFlowEngine', () => {
+  beforeEach(() => {
+    detectedDeviceType.value = 'mobile';
+  });
+
+  it('should register the current device type before shared flow components', async () => {
+    const app = createMockClient({
+      router: {
+        type: 'memory',
+        initialEntries: ['/'],
+      },
+    });
+    const plugin = new PluginFlowEngine({}, app);
+    const addComponents = app.addComponents.bind(app);
+    const deviceTypesBeforeComponentRegistration: string[] = [];
+    vi.spyOn(app, 'addComponents').mockImplementation((components) => {
+      deviceTypesBeforeComponentRegistration.push(app.flowEngine.context.deviceType);
+      return addComponents(components);
+    });
+
+    await plugin.load();
+
+    expect(app.flowEngine.context.deviceType).toBe('mobile');
+    expect(deviceTypesBeforeComponentRegistration).toEqual(['mobile']);
+  });
+
+  it('should normalize the browser device type to computer', async () => {
+    detectedDeviceType.value = 'browser';
+    const app = createMockClient();
+    const plugin = new PluginFlowEngine({}, app);
+
+    await plugin.load();
+
+    expect(app.flowEngine.context.deviceType).toBe('computer');
+  });
+});

--- a/packages/core/client-v2/src/flow/components/FlowRoute.tsx
+++ b/packages/core/client-v2/src/flow/components/FlowRoute.tsx
@@ -9,7 +9,6 @@
 
 import { type FlowEngine, useFlowContext, useFlowEngine } from '@nocobase/flow-engine';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { deviceType } from 'react-device-detect';
 import { useParams } from 'react-router-dom';
 import { useApp } from '../../hooks/useApp';
 import { NocoBaseDesktopRouteType } from '../../flow-compat';
@@ -19,6 +18,7 @@ import { getLayoutModel, type BaseLayoutModel } from '../admin-shell/BaseLayoutM
 import { useLayoutRoutePage } from '../admin-shell/useLayoutRoutePage';
 import { AppNotFound } from '../../components';
 import { useKeepAlive } from '../../components/KeepAlive';
+import { registerDeviceTypeContext } from '../internal/registerDeviceTypeContext';
 
 type FlowRouteGuardState = {
   pending: boolean;
@@ -94,31 +94,9 @@ const BridgeFlowRoute = ({
   const layoutContentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    flowEngine.context.defineProperty('deviceType', {
-      get: () => (deviceType === 'browser' ? 'computer' : deviceType),
-      cache: false,
-      meta: {
-        type: 'string',
-        title: flowEngine.translate('Current device type'),
-        interface: 'select',
-        uiSchema: {
-          enum: [
-            { label: flowEngine.translate('Computer'), value: 'computer' },
-            { label: flowEngine.translate('Mobile'), value: 'mobile' },
-            { label: flowEngine.translate('Tablet'), value: 'tablet' },
-            { label: flowEngine.translate('SmartTv'), value: 'smarttv' },
-            { label: flowEngine.translate('Console'), value: 'console' },
-            { label: flowEngine.translate('Wearable'), value: 'wearable' },
-            { label: flowEngine.translate('Embedded'), value: 'embedded' },
-          ],
-          'x-component': 'Select',
-        },
-      },
-      info: {
-        description: 'Current device type (computer/mobile/tablet/...).',
-        detail: 'string',
-      },
-    });
+    if (!flowEngine.context.getPropertyOptions('deviceType')) {
+      registerDeviceTypeContext(flowEngine);
+    }
   }, [flowEngine]);
 
   useLayoutRoutePage({
@@ -136,8 +114,8 @@ const BridgeFlowRoute = ({
 /**
  * 管理后台动态页面路由组件。
  *
- * 负责读取当前路由页面 UID，补充运行时设备变量，
- * 并把页面生命周期桥接到 AdminLayout host model。
+ * 负责读取当前路由页面 UID，并把页面生命周期桥接到 AdminLayout host model。
+ * 设备变量通常由 PluginFlowEngine 共享初始化提供；独立渲染时会在挂载后补充注册。
  *
  * @example
  * ```tsx

--- a/packages/core/client-v2/src/flow/index.ts
+++ b/packages/core/client-v2/src/flow/index.ts
@@ -22,12 +22,14 @@ import { Markdown } from './common/Markdown/Markdown';
 import { LiquidEngine } from './common/Liquid';
 import type { PreviewRunJSResult } from './components/code-editor/runjsDiagnostics';
 import { TextAreaWithContextSelector } from './components/TextAreaWithContextSelector';
+import { registerDeviceTypeContext } from './internal/registerDeviceTypeContext';
 
 export class PluginFlowEngine<TApp extends BaseApplication<any> = BaseApplication<any>> extends Plugin<
   PluginOptions<any>,
   TApp
 > {
   async load() {
+    registerDeviceTypeContext(this.flowEngine);
     this.app.addComponents({ FlowRoute });
     this.app.flowEngine.setModelRepository(new FlowModelRepository(this.app));
     const filteredModels = Object.fromEntries(

--- a/packages/core/client-v2/src/flow/internal/registerDeviceTypeContext.ts
+++ b/packages/core/client-v2/src/flow/internal/registerDeviceTypeContext.ts
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { FlowEngine } from '@nocobase/flow-engine';
+import { deviceType } from 'react-device-detect';
+
+export const registerDeviceTypeContext = (flowEngine: FlowEngine) => {
+  flowEngine.context.defineProperty('deviceType', {
+    get: () => (deviceType === 'browser' ? 'computer' : deviceType),
+    cache: false,
+    meta: {
+      type: 'string',
+      title: flowEngine.translate('Current device type'),
+      interface: 'select',
+      uiSchema: {
+        enum: [
+          { label: flowEngine.translate('Computer'), value: 'computer' },
+          { label: flowEngine.translate('Mobile'), value: 'mobile' },
+          { label: flowEngine.translate('Tablet'), value: 'tablet' },
+          { label: flowEngine.translate('SmartTv'), value: 'smarttv' },
+          { label: flowEngine.translate('Console'), value: 'console' },
+          { label: flowEngine.translate('Wearable'), value: 'wearable' },
+          { label: flowEngine.translate('Embedded'), value: 'embedded' },
+        ],
+        'x-component': 'Select',
+      },
+    },
+    info: {
+      description: 'Current device type (computer/mobile/tablet/...).',
+      detail: 'string',
+    },
+  });
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

菜单联动规则使用“当前设备类型”判断菜单是否隐藏时，手机端首次打开页面可能拿不到设备类型，导致本应显示的菜单被错误隐藏。刷新规则或再次计算后才会恢复正确状态。

### Description

- 在 V1 和 V2 共用的客户端初始化阶段提前提供当前设备类型，确保菜单规则首次执行时即可读取。
- 保留动态页面路由独立使用时的兼容处理，避免影响已有使用方式。
- 增加设备类型注册顺序、手机端取值、浏览器归一化和独立路由兼容测试。

本次修改不改变公开 API。建议重点验证手机端和桌面端首次打开页面时，使用设备类型条件的菜单显示结果是否正确。

### Showcase

已通过手机端与桌面端浏览器回归验证，无需额外截图。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix mobile menus hidden incorrectly by device type rules |
| 🇨🇳 Chinese | 修复设备类型规则导致手机端菜单错误隐藏的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
