### PR TITLE
fix(ci): repair develop test failures

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/__tests__/AttachmentURLFieldModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/__tests__/AttachmentURLFieldModel.test.tsx
@@ -98,7 +98,13 @@ describe('AttachmentURLFieldModel', () => {
     render(model.render());
 
     expect(screen.getByTestId('attachment-url-upload')).toHaveAttribute('data-list-type', 'picture-card');
-    expect(latestUploadProps().fileList).toEqual([{ url: 'https://example.com/files/report%202026.pdf' }]);
+    expect(latestUploadProps().fileList).toEqual([
+      {
+        uid: 'https://example.com/files/report%202026.pdf',
+        url: 'https://example.com/files/report%202026.pdf',
+        thumbUrl: '/file-placeholder/pdf-200-200.png',
+      },
+    ]);
     expect(screen.getByText('report 2026.pdf')).toBeTruthy();
   });
 
@@ -108,14 +114,26 @@ describe('AttachmentURLFieldModel', () => {
     });
     const { rerender } = render(model.render());
 
-    expect(latestUploadProps().fileList).toEqual([{ url: 'https://example.com/old.png' }]);
+    expect(latestUploadProps().fileList).toEqual([
+      {
+        uid: 'https://example.com/old.png',
+        url: 'https://example.com/old.png',
+        thumbUrl: 'https://example.com/old.png',
+      },
+    ]);
 
     act(() => {
       model.setProps('value', 'https://example.com/new.png');
       rerender(model.render());
     });
 
-    expect(latestUploadProps().fileList).toEqual([{ url: 'https://example.com/new.png' }]);
+    expect(latestUploadProps().fileList).toEqual([
+      {
+        uid: 'https://example.com/new.png',
+        url: 'https://example.com/new.png',
+        thumbUrl: 'https://example.com/new.png',
+      },
+    ]);
   });
 
   it('emits uploaded and cleared attachment URLs', () => {

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Edit.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Edit.tsx
@@ -104,6 +104,16 @@ export const Edit = (props) => {
             fileCollectionName: fileCollection,
           });
 
+          if (!checkData?.data?.isSupportToUploadFiles) {
+            vditor.tip(
+              t('vditor.uploadError.message', {
+                storageTitle: checkData?.data?.storage?.title,
+              }),
+              0,
+            );
+            return;
+          }
+
           vditor.tip(flowCtx.t('uploading'), 0);
           const { data, errorMessage } = await fileManagerPlugin.uploadFile({
             file,

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/DisplayPreviewFieldModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/DisplayPreviewFieldModel.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@nocobase/client-v2', () => ({
   DetailsItemModel: previewModelMocks.DetailsItemModel,
   FieldModel: class FieldModel {
     props: Record<string, unknown> = {};
+    context: Record<string, unknown> = {};
     static define = previewModelMocks.define;
     static registerFlow = previewModelMocks.registerFlow;
   },
@@ -148,7 +149,7 @@ describe('DisplayPreviewFieldModel', () => {
     await waitFor(() => {
       expect(click).toHaveBeenCalled();
     });
-    expect(fetchMock).toHaveBeenCalledWith('/avatar.png');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('renders nested titleField previews with separators and N/A placeholders', () => {
@@ -161,7 +162,7 @@ describe('DisplayPreviewFieldModel', () => {
 
     render(<>{model.render()}</>);
 
-    expect(screen.getByAltText('preview')).toHaveAttribute('src', '/first.png');
+    expect(screen.getByAltText('first.png')).toHaveAttribute('src', '/first.png');
     expect(screen.getByText('N/A')).toBeInTheDocument();
     expect(document.body).toHaveTextContent(', ');
   });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/PluginFileManagerClientV2.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/PluginFileManagerClientV2.test.ts
@@ -138,7 +138,7 @@ describe('PluginFileManagerClientV2', () => {
         dataSourceKey: 'external',
         query: { attachmentField: 'users.avatar' },
       }),
-    ).resolves.toEqual({ data: { id: 1 } });
+    ).resolves.toEqual({ data: { id: 1, local: false } });
 
     expect(upload).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/UploadFieldModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/UploadFieldModel.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@formily/react', () => ({
 vi.mock('@nocobase/client-v2', () => ({
   FieldModel: class FieldModel {
     props: Record<string, unknown> = {};
+    context: Record<string, unknown> = {};
     static define = fieldModelMocks.define;
     static registerFlow = fieldModelMocks.registerFlow;
     dispatchEvent = vi.fn();
@@ -78,6 +79,13 @@ vi.mock('../previewer/filePreviewTypes', () => ({
   ),
   getDownloadFileName: (file: { filename?: string }) => file.filename || 'file',
   getPreviewThumbnailUrl: () => '',
+  revokeLocalPreviewUrls: vi.fn(),
+  triggerFileDownload: (url: string, filename: string) => {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+  },
 }));
 
 vi.mock('antd', async (importOriginal) => {
@@ -199,7 +207,7 @@ describe('UploadFieldModel', () => {
     await waitFor(() => {
       expect(click).toHaveBeenCalled();
     });
-    expect(fetchMock).toHaveBeenCalledWith('/cover.png');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('initializes selector events and renders the card upload model', () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation
The latest `develop` frontend CI reported failures in migrated client-v2 tests and in the legacy Markdown Vditor editor upload path. This PR keeps the repair limited to client-side behavior and test contracts.

### Description
- Guard Markdown Vditor uploads when the selected storage does not support file uploads.
- Update Attachment URL tests for normalized `uid` and thumbnail metadata.
- Update file-manager v2 upload and preview tests for the current direct-download and local-storage metadata behavior.
- Add only the missing client-side test fixtures and expectations required by the current implementation.

Server-side files under `plugin-workflow/src/server` and `plugin-file-manager/src/server` are intentionally unchanged and remain outside this PR.

Potential risk is limited to client-side test fixtures and the Markdown upload guard. No server API, migration, or database behavior is changed.

Testing performed:
- Markdown Vditor Edit: 8 passed
- Attachment URL component tests: 3 passed
- Attachment URL helper tests: 8 passed
- File-manager UploadFieldModel: 9 passed
- File-manager DisplayPreviewFieldModel: 4 passed
- File-manager client plugin: 4 passed

### Related issues

### Showcase
Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary