### PR TITLE
feat(system-settings): add Myanmar language option

### DIFF
--- a/packages/core/client-v2/src/locale/languageCodes.ts
+++ b/packages/core/client-v2/src/locale/languageCodes.ts
@@ -54,6 +54,7 @@ export const languageCodes: Record<string, LocaleOptions> = {
   'ml-IN': { label: 'മലയാളം' },
   'mn-MN': { label: 'Монгол хэл' },
   'ms-MY': { label: 'بهاس ملايو' },
+  'my-MM': { label: 'မြန်မာဘာသာ' },
   'nb-NO': { label: 'Norsk bokmål' },
   'ne-NP': { label: 'नेपाली' },
   'nl-BE': { label: 'Vlaams' },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Allow administrators to select Burmese/Myanmar as an enabled language in System Settings.

### Description
- Add the BCP 47 locale `my-MM` with the native label `မြန်မာဘာသာ` to the language options used by System Settings.
- This change only exposes the language in System Settings; it does not add a Burmese translation bundle.

Validation: `git diff --check` passed. ESLint could not be run because this checkout does not contain the ESLint executable.

### Related issues

### Showcase
Not applicable; this is a single additional option in the existing language selector.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added Myanmar (`my-MM`) to the languages selectable in System Settings. |
| 🇨🇳 Chinese | 在系统设置的可选语言中增加缅甸语（`my-MM`）。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
