### PR TITLE
fix(plugin-calendar): add scrollbar to v2 calendar overflow

### DIFF
--- a/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/global.style.ts
+++ b/packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/global.style.ts
@@ -13,6 +13,8 @@ const GlobalStyle = createGlobalStyle`
   .rbc-overlay {
     position: absolute;
     z-index: 50;
+    max-height: ${({ theme }) => `min(360px, calc(100vh - ${theme.marginXL * 2}px))`};
+    overflow-y: auto;
     margin-top: ${({ theme }) => `${theme.marginXXS}px`};
     border-radius: ${({ theme }) => `${theme.borderRadius}px`};
     background-color: ${({ theme }) => theme.colorBgElevated};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When the v2 calendar contains many events, the “more items” overlay can grow beyond the viewport and become difficult to use.

### Description
The v2 calendar event overlay now has a bounded maximum height and enables vertical scrolling for overflowing content. The behavior matches the existing calendar overlay handling.

Potential risk is limited to the v2 calendar overlay layout.

Testing:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/global.style.ts`
- `yarn test packages/plugins/@nocobase/plugin-calendar/src/client-v2/models/components/__tests__/CalendarBlock.test.ts --run --reporter=verbose`

### Related issues

### Showcase
Not applicable; this is a layout-only fix.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add scrolling to the v2 calendar event overlay when many events are shown. |
| 🇨🇳 Chinese | 修复 v2 日历事项过多时浮层超出页面的问题，增加滚动条。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary