### PR TITLE
feat(server): support standalone SPA portals

### DIFF
--- a/packages/core/app/client/rsbuild.config.ts
+++ b/packages/core/app/client/rsbuild.config.ts
@@ -15,7 +15,7 @@ import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
-import { generatePlugins, getRsbuildBrowserAlias } from '@nocobase/devtools/rsbuildConfig';
+import { createPortalProxyBypass, generatePlugins, getRsbuildBrowserAlias } from '@nocobase/devtools/rsbuildConfig';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -252,6 +252,12 @@ export default defineConfig(({ command }) => {
             [`^${v2BasePath}`]: v2BasePath,
           },
           xfwd: true,
+        },
+        [resolvedAppPublicPath]: {
+          target: proxyTargetUrl,
+          changeOrigin: true,
+          xfwd: true,
+          bypass: createPortalProxyBypass(resolvedAppPublicPath),
         },
       },
       historyApiFallback: {

--- a/packages/core/devtools/rsbuildConfig.d.ts
+++ b/packages/core/devtools/rsbuildConfig.d.ts
@@ -1,4 +1,7 @@
+import type { IncomingMessage } from 'node:http';
+
 export declare function getRsbuildAlias(): Record<string, string>;
 export declare function getRsbuildBrowserAlias(): Record<string, string>;
+export declare function createPortalProxyBypass(appPublicPath: string): (req: IncomingMessage) => true | undefined;
 export declare function generatePlugins(): void;
 export declare function generateV2Plugins(): void;

--- a/packages/core/devtools/rsbuildConfig.js
+++ b/packages/core/devtools/rsbuildConfig.js
@@ -1,7 +1,9 @@
 import common from './common.js';
 import path from 'node:path';
+import portalUtils from '@nocobase/utils/portal.js';
 
 const { getPackagePaths, generateV2Plugins, generatePlugins } = common;
+const { PortalRequestResolver } = portalUtils;
 
 export function getRsbuildAlias() {
   return getPackagePaths().reduce((memo, item) => {
@@ -23,6 +25,11 @@ export function getRsbuildBrowserAlias() {
   addPackageModuleAlias(alias, '@nocobase/client-v2', '@nocobase/client-v2', 'es/index.mjs');
   addPackageModuleAlias(alias, '@nocobase/client-v2', '@nocobase/client-v2/flow-compat', 'es/flow-compat/index.mjs');
   return alias;
+}
+
+export function createPortalProxyBypass(appPublicPath) {
+  const resolver = new PortalRequestResolver();
+  return (req) => (resolver.resolve(req.url || '/', appPublicPath) ? undefined : true);
 }
 
 export { generateV2Plugins, generatePlugins };

--- a/packages/core/server/src/__tests__/gateway-portals.test.ts
+++ b/packages/core/server/src/__tests__/gateway-portals.test.ts
@@ -1,0 +1,146 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { supertest } from '@nocobase/test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AppSupervisor } from '../app-supervisor';
+import { Gateway } from '../gateway';
+
+const originalAppPublicPath = process.env.APP_PUBLIC_PATH;
+const originalApiBasePath = process.env.API_BASE_PATH;
+const originalStoragePath = process.env.STORAGE_PATH;
+
+describe('gateway portals', () => {
+  let storageRoot: string;
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(path.join(os.tmpdir(), 'nocobase-gateway-portal-'));
+    const distPath = path.join(storageRoot, 'portals', 'test-dist', 'dist');
+    await mkdir(path.join(distPath, 'assets'), { recursive: true });
+    await writeFile(path.join(distPath, 'index.html'), '<!doctype html><main>Portal application</main>');
+    await writeFile(path.join(distPath, 'assets', 'app.js'), 'console.log("portal");');
+    await writeFile(path.join(distPath, 'assets', 'logo mark.svg'), '<svg></svg>');
+    await writeFile(path.join(distPath, 'extensionless'), 'extensionless asset');
+    await writeFile(path.join(distPath, '.env'), 'SECRET=value');
+
+    process.env.APP_PUBLIC_PATH = '/console/';
+    process.env.API_BASE_PATH = '/api/';
+    process.env.STORAGE_PATH = storageRoot;
+  });
+
+  afterEach(async () => {
+    if (originalAppPublicPath === undefined) {
+      delete process.env.APP_PUBLIC_PATH;
+    } else {
+      process.env.APP_PUBLIC_PATH = originalAppPublicPath;
+    }
+    if (originalApiBasePath === undefined) {
+      delete process.env.API_BASE_PATH;
+    } else {
+      process.env.API_BASE_PATH = originalApiBasePath;
+    }
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_PATH;
+    } else {
+      process.env.STORAGE_PATH = originalStoragePath;
+    }
+
+    await Gateway.getInstance().destroy();
+    await AppSupervisor.getInstance().destroy();
+    await rm(storageRoot, { recursive: true, force: true });
+  });
+
+  it('redirects the portal root to a trailing slash and preserves the query string', async () => {
+    const response = await supertest.agent(Gateway.getInstance().getCallback()).get('/console/test-dist?theme=dark');
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('/console/test-dist/?theme=dark');
+  });
+
+  it('serves a portal directly under the site root when APP_PUBLIC_PATH is root', async () => {
+    process.env.APP_PUBLIC_PATH = '/';
+    const response = await supertest.agent(Gateway.getInstance().getCallback()).get('/test-dist/');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Portal application');
+  });
+
+  it('serves the portal index and static assets with conservative headers', async () => {
+    const agent = supertest.agent(Gateway.getInstance().getCallback());
+    const indexResponse = await agent.get('/console/test-dist/');
+    const assetResponse = await agent.get('/console/test-dist/assets/app.js');
+    const encodedAssetResponse = await agent.get('/console/test-dist/assets/logo%20mark.svg');
+
+    expect(indexResponse.status).toBe(200);
+    expect(indexResponse.text).toContain('Portal application');
+    expect(indexResponse.headers['cache-control']).toBe('no-cache');
+    expect(indexResponse.headers['x-content-type-options']).toBe('nosniff');
+    expect(assetResponse.status).toBe(200);
+    expect(assetResponse.text).toBe('console.log("portal");');
+    expect(assetResponse.headers['content-type']).toContain('application/javascript');
+    expect(assetResponse.headers['last-modified']).toBeTruthy();
+    expect(encodedAssetResponse.status).toBe(200);
+    expect(encodedAssetResponse.headers['content-type']).toContain('image/svg+xml');
+  });
+
+  it('uses index.html only for extensionless HTML navigations', async () => {
+    const agent = supertest.agent(Gateway.getInstance().getCallback());
+    const navigationResponse = await agent.get('/console/test-dist/users/123').set('Accept', 'text/html');
+    const dataResponse = await agent.get('/console/test-dist/users/123').set('Accept', 'application/json');
+    const missingAssetResponse = await agent.get('/console/test-dist/assets/missing.js').set('Accept', 'text/html');
+
+    expect(navigationResponse.status).toBe(200);
+    expect(navigationResponse.text).toContain('Portal application');
+    expect(dataResponse.status).toBe(404);
+    expect(dataResponse.text).toBe('Not Found');
+    expect(missingAssetResponse.status).toBe(404);
+    expect(missingAssetResponse.text).toBe('Not Found');
+  });
+
+  it('serves an existing extensionless file before applying SPA fallback', async () => {
+    const response = await supertest
+      .agent(Gateway.getInstance().getCallback())
+      .get('/console/test-dist/extensionless')
+      .set('Accept', 'text/html');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe('extensionless asset');
+  });
+
+  it('rejects hidden files and malformed encoded paths', async () => {
+    const agent = supertest.agent(Gateway.getInstance().getCallback());
+    const hiddenFileResponse = await agent.get('/console/test-dist/%2Eenv');
+    const malformedPathResponse = await agent.get('/console/test-dist/%E0%A4%A');
+
+    expect(hiddenFileResponse.status).toBe(404);
+    expect(hiddenFileResponse.text).toBe('Not Found');
+    expect(malformedPathResponse.status).toBe(400);
+    expect(malformedPathResponse.text).toBe('Bad Request');
+  });
+
+  it('rejects non-static HTTP methods inside a portal', async () => {
+    const response = await supertest.agent(Gateway.getInstance().getCallback()).post('/console/test-dist/action');
+
+    expect(response.status).toBe(405);
+    expect(response.headers.allow).toBe('GET, HEAD');
+    expect(response.text).toBe('Method Not Allowed');
+  });
+});

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -30,6 +30,7 @@ import { getPackageDirByExposeUrl, getPackageNameByExposeUrl } from '../plugin-m
 import { applyErrorWithArgs, getErrorWithCode } from './errors';
 import { IPCSocketClient } from './ipc-socket-client';
 import { IPCSocketServer } from './ipc-socket-server';
+import { PortalStaticServer } from './portal-static';
 import { getStorageUploadSecurityHeaders } from './static-file-security';
 import {
   injectRuntimeScript,
@@ -122,6 +123,7 @@ export class Gateway extends EventEmitter {
   private host = '0.0.0.0';
   private socketPath = getSocketPath();
   private v2IndexTemplateCache: { file: string; mtimeMs: number; html: string } | null = null;
+  private portalStaticServer = new PortalStaticServer();
   private terminating = false;
 
   private getOriginalRequestUrl(req: IncomingMessage) {
@@ -212,6 +214,7 @@ export class Gateway extends EventEmitter {
   public reset() {
     this.middlewares = new Toposort<GatewayMiddleware>();
     this.selectorMiddlewares = new Toposort<AppSelectorMiddleware>();
+    this.portalStaticServer.clearCache();
 
     this.addAppSelectorMiddleware(
       async (ctx: AppSelectorMiddlewareContext, next) => {
@@ -530,6 +533,10 @@ export class Gateway extends EventEmitter {
     const isFilesRequest = Boolean(getFileAccessRestPath(pathname, APP_PUBLIC_PATH));
 
     if (!pathname.startsWith(process.env.API_BASE_PATH) && !isFilesRequest) {
+      if (await this.portalStaticServer.handle(req, res, APP_PUBLIC_PATH)) {
+        return;
+      }
+
       if (this.isV2Request(pathname)) {
         if (handleApp !== 'main') {
           const isProxy = await this.proxyRequestToSubApp(supervisor, handleApp, req, res);

--- a/packages/core/server/src/gateway/portal-static.ts
+++ b/packages/core/server/src/gateway/portal-static.ts
@@ -1,0 +1,182 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */
+
+import { lstat } from 'node:fs/promises';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type { PortalRequestMatch } from '@nocobase/utils/portal';
+import { PortalRequestResolver } from '@nocobase/utils/portal';
+import compression from 'compression';
+import handler from 'serve-handler';
+
+const compress = promisify(compression());
+
+function endResponse(req: IncomingMessage, res: ServerResponse, statusCode: number, message: string) {
+  res.statusCode = statusCode;
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.end(req.method === 'HEAD' ? undefined : message);
+}
+
+function decodePortalPath(relativePath: string) {
+  try {
+    return decodeURIComponent(relativePath || '/');
+  } catch {
+    return null;
+  }
+}
+
+function isUnsafePortalPath(decodedPath: string) {
+  if (!decodedPath.startsWith('/') || decodedPath.includes('\0') || decodedPath.includes('\\')) {
+    return true;
+  }
+  return decodedPath.split('/').some((segment) => segment.startsWith('.'));
+}
+
+function isPathInside(root: string, candidate: string) {
+  const relativePath = path.relative(root, candidate);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${path.sep}`) && relativePath !== '..' && !path.isAbsolute(relativePath))
+  );
+}
+
+async function isRegularFile(filePath: string) {
+  try {
+    return (await lstat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function encodePathname(filePath: string) {
+  return filePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+async function resolveExistingFile(match: PortalRequestMatch, decodedPath: string) {
+  const relativePath = decodedPath.replace(/^\/+/, '');
+  const candidate = path.resolve(match.distPath, relativePath);
+  if (!isPathInside(match.distPath, candidate)) {
+    return null;
+  }
+
+  if (await isRegularFile(candidate)) {
+    return `/${path.relative(match.distPath, candidate).split(path.sep).join('/')}`;
+  }
+
+  try {
+    if ((await lstat(candidate)).isDirectory()) {
+      const indexPath = path.join(candidate, 'index.html');
+      if (await isRegularFile(indexPath)) {
+        return `/${path.relative(match.distPath, indexPath).split(path.sep).join('/')}`;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function acceptsHtml(req: IncomingMessage) {
+  return typeof req.headers.accept === 'string' && req.headers.accept.includes('text/html');
+}
+
+function canUseSpaFallback(req: IncomingMessage, decodedPath: string) {
+  const pathname = decodedPath.replace(/\/+$/, '');
+  return (req.method === 'GET' || req.method === 'HEAD') && acceptsHtml(req) && path.posix.extname(pathname) === '';
+}
+
+export class PortalStaticServer {
+  private readonly resolver: PortalRequestResolver;
+
+  constructor(resolver = new PortalRequestResolver()) {
+    this.resolver = resolver;
+  }
+
+  clearCache() {
+    this.resolver.clearCache();
+  }
+
+  async handle(req: IncomingMessage, res: ServerResponse, appPublicPath: string) {
+    const match = this.resolver.resolve(req.url || '/', appPublicPath);
+    if (!match) {
+      return false;
+    }
+
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.setHeader('Allow', 'GET, HEAD');
+      endResponse(req, res, 405, 'Method Not Allowed');
+      return true;
+    }
+
+    if (match.relativePath === '') {
+      res.statusCode = 302;
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Location', `${match.pathname}/${match.search}`);
+      res.end();
+      return true;
+    }
+
+    const decodedPath = decodePortalPath(match.relativePath);
+    if (decodedPath === null) {
+      endResponse(req, res, 400, 'Bad Request');
+      return true;
+    }
+    if (isUnsafePortalPath(decodedPath)) {
+      endResponse(req, res, 404, 'Not Found');
+      return true;
+    }
+
+    const existingFile = await resolveExistingFile(match, decodedPath);
+    const filePath = existingFile || (canUseSpaFallback(req, decodedPath) ? '/index.html' : null);
+    if (!filePath) {
+      endResponse(req, res, 404, 'Not Found');
+      return true;
+    }
+
+    const originalUrl = req.url;
+    req.url = `${encodePathname(filePath)}${match.search}`;
+    try {
+      await compress(req, res);
+      await handler(req, res, {
+        public: match.distPath,
+        cleanUrls: false,
+        directoryListing: false,
+        symlinks: false,
+        headers: [
+          {
+            source: '**/*',
+            headers: [
+              { key: 'Cache-Control', value: 'no-cache' },
+              { key: 'X-Content-Type-Options', value: 'nosniff' },
+            ],
+          },
+        ],
+      });
+    } finally {
+      req.url = originalUrl;
+    }
+    return true;
+  }
+}

--- a/packages/core/utils/portal.d.ts
+++ b/packages/core/utils/portal.d.ts
@@ -1,0 +1,43 @@
+export declare const DEFAULT_PORTAL_CACHE_TTL_MS = 1000;
+export declare const DEFAULT_RESERVED_PORTAL_NAMES: readonly string[];
+export declare const PORTAL_NAME_PATTERN: RegExp;
+
+export interface PortalRequestMatch {
+  portalName: string;
+  portalRoot: string;
+  distPath: string;
+  indexPath: string;
+  pathname: string;
+  search: string;
+  publicPath: string;
+  relativePath: string;
+}
+
+export interface PortalRequestResolverOptions {
+  cacheTtlMs?: number;
+  getStorageRoot?: () => string;
+  now?: () => number;
+  reservedNames?: Iterable<string>;
+}
+
+export interface ResolvePortalRequestOptions {
+  reservedNames?: Iterable<string>;
+}
+
+export declare function resolvePortalStorageRoot(): string;
+export declare function normalizePortalPublicPath(value?: string): string;
+export declare function getPortalReservedNames(env?: Readonly<Record<string, string | undefined>>): Set<string>;
+
+export declare class PortalRequestResolver {
+  constructor(options?: PortalRequestResolverOptions);
+  clearCache(): void;
+  resolve(requestUrl: string, appPublicPath?: string, options?: ResolvePortalRequestOptions): PortalRequestMatch | null;
+}
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */

--- a/packages/core/utils/portal.js
+++ b/packages/core/utils/portal.js
@@ -1,0 +1,166 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { parse } = require('node:url');
+
+const DEFAULT_PORTAL_CACHE_TTL_MS = 1000;
+const PORTAL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const DEFAULT_RESERVED_PORTAL_NAMES = Object.freeze([
+  'admin',
+  'api',
+  'apps',
+  'dist',
+  'files',
+  'forgot-password',
+  'mobile',
+  'reset-password',
+  'signin',
+  'signup',
+  'static',
+  'storage',
+  'ws',
+]);
+
+function resolvePortalStorageRoot() {
+  const storagePath = process.env.STORAGE_PATH;
+  if (!storagePath) {
+    return path.resolve(process.cwd(), 'storage');
+  }
+  return path.isAbsolute(storagePath) ? storagePath : path.resolve(process.cwd(), storagePath);
+}
+
+function normalizePortalPublicPath(value = '/') {
+  let normalized = value || '/';
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+  normalized = normalized.replace(/\/+/g, '/');
+  if (!normalized.endsWith('/')) {
+    normalized = `${normalized}/`;
+  }
+  return normalized;
+}
+
+function getFirstPathSegment(value) {
+  return String(value || '')
+    .replace(/^\/+/, '')
+    .split('/')[0];
+}
+
+function getPortalReservedNames(env = process.env) {
+  const names = new Set(DEFAULT_RESERVED_PORTAL_NAMES);
+  const configuredNames = [env.API_BASE_PATH, env.WS_PATH, env.APP_MODERN_CLIENT_PREFIX || 'v'];
+
+  for (const value of configuredNames) {
+    const name = getFirstPathSegment(value);
+    if (PORTAL_NAME_PATTERN.test(name)) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+class PortalRequestResolver {
+  constructor(options = {}) {
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PORTAL_CACHE_TTL_MS;
+    this.getStorageRoot = options.getStorageRoot || resolvePortalStorageRoot;
+    this.now = options.now || Date.now;
+    this.reservedNames = new Set(options.reservedNames || []);
+    this.cache = new Map();
+  }
+
+  clearCache() {
+    this.cache.clear();
+  }
+
+  resolve(requestUrl, appPublicPath = '/', options = {}) {
+    const parsedUrl = parse(requestUrl || '/');
+    const pathname = parsedUrl.pathname || '/';
+    const search = parsedUrl.search || '';
+    const publicPath = normalizePortalPublicPath(appPublicPath);
+    if (!pathname.startsWith(publicPath)) {
+      return null;
+    }
+
+    const restPath = pathname.slice(publicPath.length);
+    if (!restPath) {
+      return null;
+    }
+
+    const separatorIndex = restPath.indexOf('/');
+    const portalName = separatorIndex === -1 ? restPath : restPath.slice(0, separatorIndex);
+    if (!PORTAL_NAME_PATTERN.test(portalName)) {
+      return null;
+    }
+
+    const reservedNames = getPortalReservedNames();
+    for (const name of this.reservedNames) {
+      reservedNames.add(name);
+    }
+    for (const name of options.reservedNames || []) {
+      reservedNames.add(name);
+    }
+    if (reservedNames.has(portalName)) {
+      return null;
+    }
+
+    const storageRoot = this.getStorageRoot();
+    const portalRoot = path.join(storageRoot, 'portals', portalName);
+    const distPath = path.join(portalRoot, 'dist');
+    const indexPath = path.join(distPath, 'index.html');
+    if (!this.hasPortal(indexPath)) {
+      return null;
+    }
+
+    return {
+      portalName,
+      portalRoot,
+      distPath,
+      indexPath,
+      pathname,
+      search,
+      publicPath,
+      relativePath: separatorIndex === -1 ? '' : restPath.slice(separatorIndex),
+    };
+  }
+
+  hasPortal(indexPath) {
+    const now = this.now();
+    const cached = this.cache.get(indexPath);
+    if (cached && cached.expiresAt > now) {
+      return cached.exists;
+    }
+
+    let exists = false;
+    try {
+      exists = fs.lstatSync(indexPath).isFile();
+    } catch {
+      exists = false;
+    }
+
+    this.cache.set(indexPath, {
+      exists,
+      expiresAt: now + this.cacheTtlMs,
+    });
+    return exists;
+  }
+}
+
+module.exports = {
+  DEFAULT_PORTAL_CACHE_TTL_MS,
+  DEFAULT_RESERVED_PORTAL_NAMES,
+  PORTAL_NAME_PATTERN,
+  PortalRequestResolver,
+  getPortalReservedNames,
+  normalizePortalPublicPath,
+  resolvePortalStorageRoot,
+};

--- a/packages/core/utils/src/__tests__/portal.test.ts
+++ b/packages/core/utils/src/__tests__/portal.test.ts
@@ -1,0 +1,124 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import type { IncomingMessage } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { PortalRequestResolver, getPortalReservedNames } from '@nocobase/utils/portal';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createPortalProxyBypass } from '../../../devtools/rsbuildConfig.js';
+
+describe('PortalRequestResolver', () => {
+  const originalStoragePath = process.env.STORAGE_PATH;
+  let storageRoot: string;
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(path.join(os.tmpdir(), 'nocobase-portal-resolver-'));
+  });
+
+  afterEach(async () => {
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_PATH;
+    } else {
+      process.env.STORAGE_PATH = originalStoragePath;
+    }
+    await rm(storageRoot, { recursive: true, force: true });
+  });
+
+  async function createPortal(name: string) {
+    const distPath = path.join(storageRoot, 'portals', name, 'dist');
+    await mkdir(distPath, { recursive: true });
+    await writeFile(path.join(distPath, 'index.html'), '<!doctype html>');
+  }
+
+  it('resolves portal requests inside APP_PUBLIC_PATH', async () => {
+    await createPortal('test-dist');
+    const resolver = new PortalRequestResolver({ getStorageRoot: () => storageRoot });
+
+    expect(resolver.resolve('/console/test-dist', '/console/')).toMatchObject({
+      portalName: 'test-dist',
+      relativePath: '',
+      publicPath: '/console/',
+    });
+    expect(resolver.resolve('/console/test-dist/assets/app.js?version=1', '/console/')).toMatchObject({
+      portalName: 'test-dist',
+      relativePath: '/assets/app.js',
+      search: '?version=1',
+    });
+    expect(resolver.resolve('/test-dist/', '/console/')).toBeNull();
+  });
+
+  it('ignores invalid and reserved portal names', async () => {
+    await Promise.all(['admin', 'api', 'v', 'Bad-Portal', 'under_score'].map(createPortal));
+    const resolver = new PortalRequestResolver({ getStorageRoot: () => storageRoot });
+
+    expect(resolver.resolve('/admin/', '/')).toBeNull();
+    expect(resolver.resolve('/api/', '/')).toBeNull();
+    expect(resolver.resolve('/v/', '/')).toBeNull();
+    expect(resolver.resolve('/Bad-Portal/', '/')).toBeNull();
+    expect(resolver.resolve('/under_score/', '/')).toBeNull();
+  });
+
+  it('reserves configured API, websocket, and modern client prefixes', () => {
+    const reservedNames = getPortalReservedNames({
+      API_BASE_PATH: '/rest-api/',
+      WS_PATH: '/socket/',
+      APP_MODERN_CLIENT_PREFIX: 'modern',
+    });
+
+    expect(reservedNames.has('rest-api')).toBe(true);
+    expect(reservedNames.has('socket')).toBe(true);
+    expect(reservedNames.has('modern')).toBe(true);
+  });
+
+  it('discovers newly added portals after the short cache expires', async () => {
+    let now = 0;
+    const resolver = new PortalRequestResolver({
+      cacheTtlMs: 1000,
+      getStorageRoot: () => storageRoot,
+      now: () => now,
+    });
+
+    expect(resolver.resolve('/dynamic/', '/')).toBeNull();
+    await createPortal('dynamic');
+
+    now = 999;
+    expect(resolver.resolve('/dynamic/', '/')).toBeNull();
+
+    now = 1001;
+    expect(resolver.resolve('/dynamic/', '/')).toMatchObject({ portalName: 'dynamic' });
+  });
+
+  it('requires a regular dist/index.html file', async () => {
+    await mkdir(path.join(storageRoot, 'portals', 'incomplete', 'dist'), { recursive: true });
+    const resolver = new PortalRequestResolver({ getStorageRoot: () => storageRoot });
+
+    expect(resolver.resolve('/incomplete/', '/')).toBeNull();
+  });
+
+  it('creates an Rsbuild bypass that proxies only discovered portals', async () => {
+    await createPortal('test-dist');
+    process.env.STORAGE_PATH = storageRoot;
+    const bypass = createPortalProxyBypass('/console/');
+
+    expect(bypass({ url: '/console/test-dist/assets/app.js' } as IncomingMessage)).toBeUndefined();
+    expect(bypass({ url: '/console/not-a-portal/' } as IncomingMessage)).toBe(true);
+    expect(bypass({ url: '/console/admin/' } as IncomingMessage)).toBe(true);
+  });
+});

--- a/packages/core/utils/src/portal.d.ts
+++ b/packages/core/utils/src/portal.d.ts
@@ -1,0 +1,19 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */
+
+export * from '../portal';

--- a/packages/core/utils/src/portal.js
+++ b/packages/core/utils/src/portal.js
@@ -1,0 +1,19 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to https://www.nocobase.com/agreement.
+ */
+
+module.exports = require('../portal.js');


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Standalone SPA build artifacts placed under `storage/portals/` are currently swallowed by the NocoBase client SPA fallback, so they cannot be hosted under the NocoBase public path.

### Description

- Dynamically discover `storage/portals/<name>/dist/index.html` with a short cache and reserved-route protection.
- Serve portal assets through the Gateway using the existing static handler, including trailing-slash redirects, HTML-only history fallback, conservative caching, and common path security checks.
- Respect `APP_PUBLIC_PATH` while keeping existing NocoBase routes higher priority.
- Proxy discovered portal routes to the Gateway when running the legacy client with Rsbuild.
- Add resolver and Gateway regression tests for static assets, history fallback, invalid paths, reserved names, and dynamic discovery.
- Keep `/v/<name>/`, Umi, Nginx-native serving, and symlink support outside the initial scope.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added support for serving standalone SPA portals from `storage/portals` under the NocoBase public path. |
| 🇨🇳 Chinese | 支持将 `storage/portals` 中的独立 SPA 项目托管到 NocoBase 公共路径下。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
