### PR TITLE
fix(client-v2): preserve action titles across linkage refresh

### DIFF
--- a/packages/core/client-v2/src/flow/actions/__tests__/actionLinkageRules.forkProps.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/actionLinkageRules.forkProps.test.ts
@@ -1,0 +1,115 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionModel as ConfiguredActionModel } from '../../models/base/ActionModel';
+import { ActionModel } from '../../models/base/ActionModelCore';
+import { actionLinkageRules, linkageSetActionProps } from '../linkageRules';
+
+class TestActionModel extends ActionModel {}
+
+describe('action linkage rules on action forks', () => {
+  it('does not snapshot unrelated master props when disabling an action', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ TestActionModel });
+    const master = engine.createModel<TestActionModel>({
+      use: 'TestActionModel',
+      props: { title: 'Edit' },
+    });
+    const fork = master.createFork({ className: 'row-action' });
+
+    const ctx = {
+      flowKey: 'buttonSettings',
+      model: fork,
+      app: {
+        jsonLogic: {
+          apply: vi.fn(() => true),
+        },
+      },
+      t: (value: string) => value,
+      resolveJsonTemplate: vi.fn(async (value: unknown) => value),
+      getAction: (name: string) => {
+        if (name !== 'linkageSetActionProps') return undefined;
+        return {
+          handler: async (_ctx: unknown, params: { setProps: Function }) => {
+            params.setProps(fork, { disabled: true });
+          },
+        };
+      },
+    } as never;
+
+    await actionLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'disable-edit',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [{ name: 'linkageSetActionProps', params: { value: 'disabled' } }],
+        },
+      ],
+    });
+
+    expect(fork.localProps.title).toBeUndefined();
+    expect(fork.__originalProps.title).toBeUndefined();
+    expect(fork.localProps.disabled).toBe(true);
+
+    master.setProps('title', 'Updated');
+    await actionLinkageRules.handler(ctx, {
+      value: [
+        {
+          key: 'disable-edit',
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [{ name: 'linkageSetActionProps', params: { value: 'disabled' } }],
+        },
+      ],
+    });
+
+    expect(fork.getProps().title).toBe('Updated');
+    expect(fork.serialize().props.title).toBe('Updated');
+
+    const refreshedFork = master.createFork({ className: 'row-action' });
+    expect(refreshedFork.getProps().title).toBe('Updated');
+  });
+
+  it('updates a disabled row action title through the real beforeRender flow', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ ConfiguredActionModel });
+    engine.registerActions({ actionLinkageRules, linkageSetActionProps });
+    const master = engine.createModel<ConfiguredActionModel>({
+      use: 'ConfiguredActionModel',
+      props: { title: 'Edit' },
+      stepParams: {
+        buttonSettings: {
+          general: { title: 'Edit' },
+          linkageRules: {
+            value: [
+              {
+                key: 'disable-edit',
+                enable: true,
+                condition: { logic: '$and', items: [] },
+                actions: [{ name: 'linkageSetActionProps', params: { value: 'disabled' } }],
+              },
+            ],
+          },
+        },
+      },
+    });
+    const fork = master.createFork({ className: 'row-action' });
+
+    await fork.dispatchEvent('beforeRender', undefined, { useCache: false });
+    expect(fork.getProps()).toMatchObject({ title: 'Edit', disabled: true });
+
+    master.setStepParams('buttonSettings', 'general', { title: 'Updated' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fork.getProps()).toMatchObject({ title: 'Updated', disabled: true });
+  });
+});

--- a/packages/core/client-v2/src/flow/actions/linkageRules.tsx
+++ b/packages/core/client-v2/src/flow/actions/linkageRules.tsx
@@ -2174,17 +2174,30 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
               }
             : props;
 
-        // 存储原始值，用于恢复
-        if (!model.__originalProps) {
-          model.__originalProps = {
-            hiddenModel: model.hidden,
-            hiddenText: undefined,
-            disabled: undefined,
-            required: undefined,
-            hidden: undefined,
-            ...model.props,
-          };
-        }
+        // 只记录联动实际控制的属性，避免恢复状态时覆盖标题等无关的最新配置。
+        const originalProps = model.__originalProps || (model.__originalProps = {});
+        const rememberOriginalProp = (key: string, value: unknown) => {
+          if (!Object.prototype.hasOwnProperty.call(originalProps, key)) {
+            originalProps[key] = value;
+          }
+        };
+        Object.keys(normalizedProps || {}).forEach((key) => {
+          if (key === 'hiddenModel') {
+            rememberOriginalProp(
+              key,
+              Object.prototype.hasOwnProperty.call(model.props || {}, key) ? model.props?.[key] : model.hidden,
+            );
+            return;
+          }
+
+          rememberOriginalProp(key, model.props?.[key]);
+          if (key === 'hiddenText' && normalizedProps[key]) {
+            rememberOriginalProp('title', model.props?.title);
+          }
+          if (key === 'required') {
+            rememberOriginalProp('rules', model.props?.rules);
+          }
+        });
 
         // 临时存起来，遍历完所有规则后，再统一处理
         patchPropsByModel.set(model, {
@@ -2242,7 +2255,6 @@ const commonLinkageRulesHandler = async (ctx: FlowContext, params: any) => {
     const newProps = { ...model.__originalProps, ...patchProps };
     const prevHidden = !!model.hidden;
     const nextHidden = !!newProps.hiddenModel;
-
     model.setProps(_.omit(newProps, ['hiddenModel', 'value', 'hiddenText', LINKAGE_ASSIGN_MODE_PROP]));
     syncFieldOptionsToForks(model, patchProps);
     if (typeof model.setHidden === 'function') {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
When a v2 table row action is disabled by a linkage rule, editing the action title can be reverted to the old title during a linkage refresh or after the row fork is rebuilt.

### Description
The linkage handler previously captured the entire model props object in the __originalProps snapshot. For action forks, that snapshot included the current title and later reapplied it as a stale local prop. The handler now records only properties actually controlled by the linkage action. Titles are captured only when hiddenText is truly enabled, while hiddenText: false does not overwrite a newly configured title.

Potential risk is limited to the shared linkage property snapshot logic used by action, field, menu, and sub-form linkage flows. No FlowModel, table rendering, persistence protocol, database, or migration code was changed.

Testing suggestions: verify disabled row actions keep a newly edited title immediately, after linkage refresh, and after browser reload or fork rebuild.

### Related issues

### Showcase
Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix v2 table action titles being reverted after linkage refresh. |
| 🇨🇳 Chinese | 修复 v2 表格操作被联动禁用后，编辑操作标题在联动刷新或刷新页面后被旧标题覆盖。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not applicable. |
| 🇨🇳 Chinese | 不适用。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary