### PR TITLE
fix(client-v2): refresh select blocks after nested views

### DIFF
--- a/packages/core/client-v2/src/flow/models/base/BlockGridModel.tsx
+++ b/packages/core/client-v2/src/flow/models/base/BlockGridModel.tsx
@@ -14,8 +14,10 @@ import {
   FlowSettingsButton,
   buildSubModelGroups,
   buildSubModelItems,
+  type FlowModel,
   type SubModelItem,
   type SubModelItemsType,
+  VIEW_ACTIVATED_EVENT,
 } from '@nocobase/flow-engine';
 import React from 'react';
 import { FilterManager } from '../blocks/filter-manager/FilterManager';
@@ -24,6 +26,8 @@ import { GridModel } from './GridModel';
 const SELECT_SCENE_ALLOWED_OTHER_BLOCK_MODELS = ['JSBlockModel', 'IframeBlockModel', 'MarkdownBlockModel'] as const;
 
 export class BlockGridModel extends GridModel {
+  private viewActivatedListener?: () => void;
+
   dragOverlayConfig: DragOverlayConfig = {
     // 列内插入
     columnInsert: {
@@ -48,6 +52,28 @@ export class BlockGridModel extends GridModel {
         return new FilterManager(this, options['filterManager']);
       },
     });
+  }
+
+  protected onMount() {
+    super.onMount();
+    if (this.context.view?.inputArgs?.scene !== 'select' || this.viewActivatedListener) {
+      return;
+    }
+
+    this.viewActivatedListener = () => {
+      this.mapSubModels('items', (item) => {
+        (item as FlowModel & { onActive?: () => void }).onActive?.();
+      });
+    };
+    this.flowEngine.emitter.on(VIEW_ACTIVATED_EVENT, this.viewActivatedListener);
+  }
+
+  protected onUnmount() {
+    if (this.viewActivatedListener) {
+      this.flowEngine.emitter.off(VIEW_ACTIVATED_EVENT, this.viewActivatedListener);
+      this.viewActivatedListener = undefined;
+    }
+    super.onUnmount();
   }
 
   get subModelBaseClasses() {

--- a/packages/core/client-v2/src/flow/models/base/__tests__/BlockGridModel.selectSceneActivation.test.ts
+++ b/packages/core/client-v2/src/flow/models/base/__tests__/BlockGridModel.selectSceneActivation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine, type FlowModelContext, MultiRecordResource, VIEW_ACTIVATED_EVENT } from '@nocobase/flow-engine';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BlockGridModel } from '../BlockGridModel';
+import { CollectionBlockModel } from '../CollectionBlockModel';
+
+class TestBlockGridModel extends BlockGridModel {
+  mountForTest() {
+    super.onMount();
+  }
+
+  unmountForTest() {
+    super.onUnmount();
+  }
+}
+
+class TestMultiRecordResource extends MultiRecordResource<Record<string, unknown>> {
+  refreshCalls = 0;
+
+  override async refresh(): Promise<void> {
+    this.refreshCalls += 1;
+    this.emit('refresh');
+  }
+}
+
+class TestCollectionBlockModel extends CollectionBlockModel {
+  createResource(ctx: FlowModelContext) {
+    return ctx.createResource(TestMultiRecordResource);
+  }
+
+  mountForTest() {
+    super.onMount();
+  }
+}
+
+describe('BlockGridModel - select scene activation', () => {
+  let engine: FlowEngine;
+
+  beforeEach(() => {
+    engine = new FlowEngine();
+    engine.context.defineProperty('location', { value: { search: '' } });
+    engine.registerModels({ TestBlockGridModel, TestCollectionBlockModel });
+
+    engine.dataSourceManager.getDataSource('main').addCollection({
+      name: 'roles',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'name', type: 'string', interface: 'input' },
+      ],
+    });
+  });
+
+  function createModels(scene = 'select') {
+    engine.context.defineProperty('view', { value: { inputArgs: { scene } } });
+    const grid = engine.createModel<TestBlockGridModel>({ use: 'TestBlockGridModel' });
+    const block = grid.addSubModel<TestCollectionBlockModel>('items', {
+      use: 'TestCollectionBlockModel',
+      stepParams: {
+        resourceSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'roles',
+          },
+        },
+      },
+    });
+    const resource = block.context.resource as TestMultiRecordResource;
+
+    block.mountForTest();
+    grid.mountForTest();
+    return { grid, resource };
+  }
+
+  it('refreshes dirty collection blocks once when a nested view closes', async () => {
+    const { grid, resource } = createModels();
+
+    engine.markDataSourceDirty('main', 'roles');
+    engine.emitter.emit(VIEW_ACTIVATED_EVENT);
+    await Promise.resolve();
+
+    expect(resource.refreshCalls).toBe(1);
+
+    engine.emitter.emit(VIEW_ACTIVATED_EVENT);
+    await Promise.resolve();
+
+    expect(resource.refreshCalls).toBe(1);
+    grid.unmountForTest();
+  });
+
+  it('does not refresh without dirty data or after the grid unmounts', async () => {
+    const { grid, resource } = createModels();
+
+    engine.emitter.emit(VIEW_ACTIVATED_EVENT);
+    await Promise.resolve();
+    expect(resource.refreshCalls).toBe(0);
+
+    grid.unmountForTest();
+    engine.markDataSourceDirty('main', 'roles');
+    engine.emitter.emit(VIEW_ACTIVATED_EVENT);
+    await Promise.resolve();
+
+    expect(resource.refreshCalls).toBe(0);
+  });
+
+  it('does not handle activation outside the select scene', async () => {
+    const { grid, resource } = createModels('list');
+
+    engine.markDataSourceDirty('main', 'roles');
+    engine.emitter.emit(VIEW_ACTIVATED_EVENT);
+    await Promise.resolve();
+
+    expect(resource.refreshCalls).toBe(0);
+    grid.unmountForTest();
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In client v2 record picker popups, creating a record from the selection list marks the target collection as dirty, but the list does not send a new request after the nested create popup closes. The select popup renders a standalone `BlockGridModel` without the `PageModel` activation lifecycle that normally refreshes dirty data blocks.

### Description 
- Listen for `VIEW_ACTIVATED_EVENT` in `BlockGridModel` only when the current view scene is `select`.
- Invoke `onActive()` on the select grid's block items so existing dirty-version tracking decides whether a resource refresh is required.
- Remove the activation listener when the grid unmounts.
- Add tests covering dirty refresh, refresh deduplication, listener cleanup, and non-select scene isolation.

Potential risk: the activation lifecycle now applies to all select-scene grids, including association and file selectors. Existing dirty-version checks prevent unnecessary collection requests when no data changed.

Testing suggestions:
- Open a client v2 record picker, create a record from its selection popup, and confirm the list requests data and displays the new record after returning.
- Close a nested popup without modifying data and confirm the list does not request data again.
- Smoke-test association and file selection popups.

### Related issues

Task 2403

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix record picker lists not refreshing after creating a record in client v2. |
| 🇨🇳 Chinese | 修复客户端 v2 数据选择弹窗新增记录后列表不刷新的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
