### PR TITLE
fix(client-v2): avoid clearing popup relation values

### DIFF
--- a/packages/core/client-v2/src/flow/actions/__tests__/dataScopeFormValueClear.test.ts
+++ b/packages/core/client-v2/src/flow/actions/__tests__/dataScopeFormValueClear.test.ts
@@ -225,6 +225,108 @@ describe('ensureFormValueDrivenDataScopeClear', () => {
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
+  it('does not clear a popup form field when data scope depends on the external parent item', () => {
+    const emitter = new EventEmitter();
+    const formBlock = {
+      uid: 'form-1',
+      disposed: false,
+      emitter,
+      context: {
+        form: {},
+        formValues: { staff_m2o: null },
+      },
+    };
+
+    const onChange = vi.fn();
+    const model: any = {
+      disposed: false,
+      props: {
+        value: { id: 10 },
+        onChange,
+      },
+      context: {
+        blockModel: formBlock,
+      },
+    };
+
+    const ctx: any = {
+      model,
+      flowKey: 'selectSettings',
+    };
+
+    const filter = {
+      logic: '$and',
+      items: [{ path: 'orgId', operator: '$eq', value: '{{ ctx.item.parentItem.value.org_m2o.id }}' }],
+    };
+
+    ensureFormValueDrivenDataScopeClear(ctx, filter);
+
+    emitter.emit('formValuesChange', {
+      changedPaths: [['staff_m2o']],
+      allValues: { staff_m2o: { id: 10 } },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('maps popup current item dependencies to the popup form root', () => {
+    const emitter = new EventEmitter();
+    const formBlock = {
+      uid: 'form-1',
+      disposed: false,
+      emitter,
+      context: {
+        form: {},
+        formValues: {
+          org_m2o: { id: 1 },
+          staff_m2o: { id: 10 },
+        },
+      },
+    };
+
+    const onChange = vi.fn();
+    const model: any = {
+      disposed: false,
+      props: {
+        value: { id: 10 },
+        onChange,
+      },
+      context: {
+        blockModel: formBlock,
+      },
+    };
+
+    const ctx: any = {
+      model,
+      flowKey: 'selectSettings',
+    };
+
+    const filter = {
+      logic: '$and',
+      items: [{ path: 'orgId', operator: '$eq', value: '{{ ctx.item.value.org_m2o.id }}' }],
+    };
+
+    ensureFormValueDrivenDataScopeClear(ctx, filter);
+
+    emitter.emit('formValuesChange', {
+      changedPaths: [['staff_m2o']],
+      allValues: {
+        org_m2o: { id: 1 },
+        staff_m2o: { id: 10 },
+      },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    emitter.emit('formValuesChange', {
+      changedPaths: [['org_m2o']],
+      allValues: {
+        org_m2o: { id: 2 },
+        staff_m2o: { id: 10 },
+      },
+    });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
   it('does not clear a row field when a sibling field changes but the item dependency value is unchanged', () => {
     const emitter = new EventEmitter();
     const formBlock = {

--- a/packages/core/client-v2/src/flow/utils/dataScopeFormValueClear.ts
+++ b/packages/core/client-v2/src/flow/utils/dataScopeFormValueClear.ts
@@ -105,9 +105,6 @@ function resolveItemDependencyPath(ctx: FlowContext, depPath: NamePath): DataSco
     ctx,
     parseFieldIndexEntries((ctx.model as any)?.context?.fieldIndex ?? (ctx as any)?.fieldIndex),
   );
-  if (!entries.length) {
-    return wildcardDeps();
-  }
 
   let parentDepth = 0;
   let cursor = [...depPath];
@@ -119,6 +116,10 @@ function resolveItemDependencyPath(ctx: FlowContext, depPath: NamePath): DataSco
   const head = cursor[0];
   if (!head) {
     return wildcardDeps();
+  }
+
+  if (!entries.length) {
+    return parentDepth === 0 ? resolveRootItemDependencyPath(cursor) : emptyDeps();
   }
 
   if (parentDepth === entries.length) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In a popup form used to add a sub-table record, selecting a required association field could immediately trigger the required validation error when its data scope referenced `ctx.item.parentItem`.

The popup field has no sub-table `fieldIndex`, so the data-scope dependency tracker incorrectly treated the external parent-item dependency as a wildcard dependency. The field's own value change was therefore interpreted as a dependency change, and the newly selected value was cleared.

### Description 
- Distinguish popup-root current-item dependencies from external `parentItem` dependencies when no `fieldIndex` is available.
- Avoid registering the popup's local form watcher for an external parent-item-only dependency.
- Preserve precise dependency tracking for `ctx.item.value` in popup forms.
- Add regression tests covering both external parent-item and popup-root current-item dependencies.

Potential risk is low because the change is limited to dependency-path resolution for form models without a `fieldIndex`. Existing wildcard behavior for unresolved dependencies and existing sub-table row behavior remain unchanged.

Testing suggestions:
- Configure a required association field in a popup sub-table add form.
- Set its data scope using a field from `Current item / Parent item / Attributes`.
- Select and reselect records, confirming that the selected value remains and no required error appears.
- Change a popup-local field referenced through `ctx.item.value` and confirm that a dependent stale selection is still cleared.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed required association values being cleared after selection in popup sub-table forms with parent-item data scopes. |
| 🇨🇳 Chinese | 修复弹窗子表格表单中，关系字段使用父级数据范围时选中值被清空并误触发必填校验的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A — no documentation changes required |
| 🇨🇳 Chinese | N/A — 无需更新文档 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
