### PR TITLE
fix(flow-engine): translate secondary confirmation defaults

### DIFF
--- a/packages/core/flow-engine/src/locale/__tests__/index.test.ts
+++ b/packages/core/flow-engine/src/locale/__tests__/index.test.ts
@@ -1,0 +1,21 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getFlowEngineTranslation } from '../index';
+
+describe('flow engine locale', () => {
+  it('translates the default secondary confirmation text into Chinese', () => {
+    expect(getFlowEngineTranslation('Please Confirm', 'zh-CN')).toBe('请确认');
+    expect(getFlowEngineTranslation('Are you sure you want to perform the action?', 'zh-CN')).toBe(
+      '确定要执行此操作吗？',
+    );
+  });
+});

--- a/packages/core/flow-engine/src/locale/en-US.json
+++ b/packages/core/flow-engine/src/locale/en-US.json
@@ -1,5 +1,6 @@
 {
   "Add": "Add",
+  "Are you sure you want to perform the action?": "Are you sure you want to perform the action?",
   "Are you sure you want to delete this item? This action cannot be undone.": "Are you sure you want to delete this item? This action cannot be undone.",
   "Are you sure to convert this template block to copy mode?": "Are you sure you want to convert this template block to copy mode?",
   "Array index out of bounds": "Array index {{index}} out of bounds for '{{subKey}}'",
@@ -53,6 +54,7 @@
   "Other blocks": "Other blocks",
   "Parent not found, cannot replace block": "Parent not found, cannot replace block",
   "Previous step": "Previous step",
+  "Please Confirm": "Please Confirm",
   "Replace current block with template?": "Replace current block with template?",
   "Replaced with template block": "Replaced with template block",
   "Render failed": "Render failed",

--- a/packages/core/flow-engine/src/locale/zh-CN.json
+++ b/packages/core/flow-engine/src/locale/zh-CN.json
@@ -1,5 +1,6 @@
 {
   "Add": "添加",
+  "Are you sure you want to perform the action?": "确定要执行此操作吗？",
   "Are you sure you want to delete this item? This action cannot be undone.": "确定要删除此项吗？此操作不可撤销。",
   "Are you sure to convert this template block to copy mode?": "确定将该模板区块转换为复制模式吗？",
   "Array index out of bounds": "数组索引 {{index}} 超出 '{{subKey}}' 的边界",
@@ -59,6 +60,7 @@
   "OK": "确定",
   "Other blocks": "其他区块",
   "Previous step": "上一步",
+  "Please Confirm": "请确认",
   "Render failed": "渲染失败",
   "Response record": "响应结果记录",
   "Step configuration": "步骤配置",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The default title and content in the secondary confirmation settings remained in English when the interface language was Chinese. This was visible on actions that reuse the common Flow Engine confirmation action, including custom action workflow triggers.

### Description

- Add the missing English and Simplified Chinese locale entries for the default secondary confirmation title and content.
- Add a regression test covering the Simplified Chinese translations.
- The change only affects the default localized text; existing customized confirmation text is unchanged.

Testing:

- `yarn test packages/core/flow-engine/src/locale/__tests__/index.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/core/flow-engine/src/locale/en-US.json packages/core/flow-engine/src/locale/zh-CN.json packages/core/flow-engine/src/locale/__tests__/index.test.ts`

### Related issues

### Showcase

The default title is now displayed as “请确认” and the default content as “确定要执行此操作吗？” in Simplified Chinese.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed untranslated default text in secondary confirmation settings when using Simplified Chinese |
| 🇨🇳 Chinese | 修复简体中文环境下二次确认设置的默认文案仍显示英文的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  |
| 🇨🇳 Chinese |  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
