### PR TITLE
fix(auth): wait for token cleanup before shutdown

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/token-controller.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/token-controller.test.ts
@@ -12,6 +12,7 @@ import { Database, Model } from '@nocobase/database';
 import { MockServer, createMockServer } from '@nocobase/test';
 import { AuthErrorType } from '@nocobase/auth';
 import { RENEWED_JTI_CACHE_MS } from '../../constants';
+import { TokenController } from '../token-controller';
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -184,6 +185,47 @@ describe('auth', () => {
     });
 
     expect(record.get('authenticator')).toBe('app-sso');
+  });
+
+  it('waits for pending expired session token cleanup before stopping', async () => {
+    const tokenController = auth.tokenController as TokenController;
+    let resolveCleanup: (value: number) => void = () => undefined;
+    const cleanupPromise = new Promise<number>((resolve) => {
+      resolveCleanup = resolve;
+    });
+    const cleanupSpy = vi.spyOn(tokenController, 'removeSessionExpiredTokens').mockReturnValue(cleanupPromise);
+    let addSettled = false;
+    const originalDialect = process.env.DB_DIALECT;
+    process.env.DB_DIALECT = 'postgres';
+
+    try {
+      const addPromise = tokenController.add({ userId: user.id }).then(() => {
+        addSettled = true;
+      });
+
+      await vi.waitFor(() => expect(cleanupSpy).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(addSettled).toBe(true));
+      await addPromise;
+
+      let beforeStopSettled = false;
+      const beforeStopPromise = app.emitAsync('beforeStop').then(() => {
+        beforeStopSettled = true;
+      });
+
+      await Promise.resolve();
+      expect(beforeStopSettled).toBe(false);
+
+      resolveCleanup(0);
+      await beforeStopPromise;
+      expect(beforeStopSettled).toBe(true);
+    } finally {
+      resolveCleanup(0);
+      if (originalDialect === undefined) {
+        delete process.env.DB_DIALECT;
+      } else {
+        process.env.DB_DIALECT = originalDialect;
+      }
+    }
   });
 
   it('after JTI is renewed for 10s, any further renewal should fail.', async () => {

--- a/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/token-controller.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/__tests__/token-controller.test.ts
@@ -12,7 +12,6 @@ import { Database, Model } from '@nocobase/database';
 import { MockServer, createMockServer } from '@nocobase/test';
 import { AuthErrorType } from '@nocobase/auth';
 import { RENEWED_JTI_CACHE_MS } from '../../constants';
-import { TokenController } from '../token-controller';
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -185,47 +184,6 @@ describe('auth', () => {
     });
 
     expect(record.get('authenticator')).toBe('app-sso');
-  });
-
-  it('waits for pending expired session token cleanup before stopping', async () => {
-    const tokenController = auth.tokenController as TokenController;
-    let resolveCleanup: (value: number) => void = () => undefined;
-    const cleanupPromise = new Promise<number>((resolve) => {
-      resolveCleanup = resolve;
-    });
-    const cleanupSpy = vi.spyOn(tokenController, 'removeSessionExpiredTokens').mockReturnValue(cleanupPromise);
-    let addSettled = false;
-    const originalDialect = process.env.DB_DIALECT;
-    process.env.DB_DIALECT = 'postgres';
-
-    try {
-      const addPromise = tokenController.add({ userId: user.id }).then(() => {
-        addSettled = true;
-      });
-
-      await vi.waitFor(() => expect(cleanupSpy).toHaveBeenCalledOnce());
-      await vi.waitFor(() => expect(addSettled).toBe(true));
-      await addPromise;
-
-      let beforeStopSettled = false;
-      const beforeStopPromise = app.emitAsync('beforeStop').then(() => {
-        beforeStopSettled = true;
-      });
-
-      await Promise.resolve();
-      expect(beforeStopSettled).toBe(false);
-
-      resolveCleanup(0);
-      await beforeStopPromise;
-      expect(beforeStopSettled).toBe(true);
-    } finally {
-      resolveCleanup(0);
-      if (originalDialect === undefined) {
-        delete process.env.DB_DIALECT;
-      } else {
-        process.env.DB_DIALECT = originalDialect;
-      }
-    }
   });
 
   it('after JTI is renewed for 10s, any further renewal should fail.', async () => {

--- a/packages/plugins/@nocobase/plugin-auth/src/server/token-controller.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/token-controller.ts
@@ -36,17 +36,11 @@ export class TokenController implements TokenControlService {
   app: Application;
   db: Database;
   logger: SystemLogger;
-  private pendingSessionExpiredTokenCleanupTasks = new Set<Promise<void>>();
 
   constructor({ cache, app, logger }: { cache: Cache; app: Application; logger: SystemLogger }) {
     this.cache = cache;
     this.app = app;
     this.logger = logger;
-    this.app.on('beforeStop', async () => {
-      while (this.pendingSessionExpiredTokenCleanupTasks.size) {
-        await Promise.all(this.pendingSessionExpiredTokenCleanupTasks);
-      }
-    });
   }
 
   async setTokenInfo(id: string, value: TokenInfo): Promise<void> {
@@ -98,13 +92,6 @@ export class TokenController implements TokenControlService {
     }
   }
 
-  private cleanupSessionExpiredTokensInBackground(userId: number) {
-    const cleanupTask = this.cleanupSessionExpiredTokens(userId).finally(() => {
-      this.pendingSessionExpiredTokenCleanupTasks.delete(cleanupTask);
-    });
-    this.pendingSessionExpiredTokenCleanupTasks.add(cleanupTask);
-  }
-
   async add({ userId, authenticator }: { userId: number; authenticator?: string }) {
     const jti = randomUUID();
     const currTS = Date.now();
@@ -122,7 +109,7 @@ export class TokenController implements TokenControlService {
       // SQLITE does not support concurrent operations
       await this.cleanupSessionExpiredTokens(userId);
     } else {
-      this.cleanupSessionExpiredTokensInBackground(userId);
+      this.cleanupSessionExpiredTokens(userId);
     }
 
     return data;

--- a/packages/plugins/@nocobase/plugin-auth/src/server/token-controller.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/token-controller.ts
@@ -36,11 +36,17 @@ export class TokenController implements TokenControlService {
   app: Application;
   db: Database;
   logger: SystemLogger;
+  private pendingSessionExpiredTokenCleanupTasks = new Set<Promise<void>>();
 
   constructor({ cache, app, logger }: { cache: Cache; app: Application; logger: SystemLogger }) {
     this.cache = cache;
     this.app = app;
     this.logger = logger;
+    this.app.on('beforeStop', async () => {
+      while (this.pendingSessionExpiredTokenCleanupTasks.size) {
+        await Promise.all(this.pendingSessionExpiredTokenCleanupTasks);
+      }
+    });
   }
 
   async setTokenInfo(id: string, value: TokenInfo): Promise<void> {
@@ -84,6 +90,21 @@ export class TokenController implements TokenControlService {
     });
   }
 
+  private async cleanupSessionExpiredTokens(userId: number) {
+    try {
+      await this.removeSessionExpiredTokens(userId);
+    } catch (err) {
+      this.logger.error(err, { module: 'auth', submodule: 'token-controller', method: 'removeSessionExpiredTokens' });
+    }
+  }
+
+  private cleanupSessionExpiredTokensInBackground(userId: number) {
+    const cleanupTask = this.cleanupSessionExpiredTokens(userId).finally(() => {
+      this.pendingSessionExpiredTokenCleanupTasks.delete(cleanupTask);
+    });
+    this.pendingSessionExpiredTokenCleanupTasks.add(cleanupTask);
+  }
+
   async add({ userId, authenticator }: { userId: number; authenticator?: string }) {
     const jti = randomUUID();
     const currTS = Date.now();
@@ -97,15 +118,11 @@ export class TokenController implements TokenControlService {
     };
     await this.setTokenInfo(jti, data);
 
-    try {
-      if (process.env.DB_DIALECT === 'sqlite') {
-        // SQLITE does not support concurrent operations
-        await this.removeSessionExpiredTokens(userId);
-      } else {
-        this.removeSessionExpiredTokens(userId);
-      }
-    } catch (err) {
-      this.logger.error(err, { module: 'auth', submodule: 'token-controller', method: 'removeSessionExpiredTokens' });
+    if (process.env.DB_DIALECT === 'sqlite') {
+      // SQLITE does not support concurrent operations
+      await this.cleanupSessionExpiredTokens(userId);
+    } else {
+      this.cleanupSessionExpiredTokensInBackground(userId);
     }
 
     return data;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Expired session token cleanup runs asynchronously on non-SQLite databases. When an application stops while cleanup is still pending, Sequelize can close its connection manager before the cleanup query obtains a connection. This causes an intermittent unhandled rejection, especially in tests using Redis cache.

### Description

- Track asynchronous expired session token cleanup tasks.
- Wait for pending cleanup tasks during `beforeStop`, before the database connection is closed.
- Keep cleanup non-blocking for PostgreSQL and MySQL so token issuance latency is unchanged.
- Preserve synchronous cleanup for SQLite and log cleanup failures without interrupting token issuance.
- Add a regression test covering both non-blocking token issuance and shutdown draining.

Potential risk: application shutdown may wait briefly for an already-running expired token cleanup query to finish.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-auth/src/server/__tests__/token-controller.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-auth/src/server/token-controller.ts packages/plugins/@nocobase/plugin-auth/src/server/__tests__/token-controller.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an intermittent database connection error during application shutdown when Redis cache is enabled |
| 🇨🇳 Chinese | 修复启用 Redis 缓存时应用关闭过程中偶发的数据库连接错误 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
