### PR TITLE
fix(plugin-field-sequence): bind v2 rule option controls

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-sequence/src/client-v2/SequenceRulesConfigureField.tsx
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/client-v2/SequenceRulesConfigureField.tsx
@@ -73,6 +73,7 @@ function CronCycleEditor(props: {
   value?: string | null;
   onChange?: (value?: string | null) => void;
   disabled?: boolean;
+  id?: string;
 }) {
   const t = useT();
   const value = props.value ?? null;
@@ -84,6 +85,7 @@ function CronCycleEditor(props: {
     <Space direction="vertical" style={{ width: '100%' }}>
       <Select
         disabled={props.disabled}
+        id={props.id}
         value={selectedValue}
         options={cronCycleOptions.map((option) => ({
           value: option.value,
@@ -110,8 +112,11 @@ function SequenceRuleOptionControl(props: {
   form: FormInstance;
   ruleType?: Record<string, any>;
   disabled?: boolean;
+  id?: string;
+  value?: string | number | string[] | null;
+  onChange?: (value: string | number | string[] | null) => void;
 }) {
-  const { field, form, ruleType, disabled } = props;
+  const { field, form, ruleType, disabled, id, onChange, value } = props;
   const t = useT();
   const digits = Form.useWatch('digits', form);
   const componentProps = { ...(field.componentProps || {}) };
@@ -121,18 +126,50 @@ function SequenceRuleOptionControl(props: {
   }
 
   if (field.component === 'InputNumber') {
-    return <InputNumber style={{ width: '100%' }} disabled={disabled} {...componentProps} />;
+    return (
+      <InputNumber
+        style={{ width: '100%' }}
+        disabled={disabled}
+        {...componentProps}
+        id={id}
+        value={typeof value === 'number' ? value : null}
+        onChange={(nextValue) => onChange?.(nextValue)}
+      />
+    );
   }
 
   if (field.component === 'Select') {
-    return <Select disabled={disabled} options={normalizeSchemaEnum(field.enum, t)} {...componentProps} />;
+    return (
+      <Select
+        disabled={disabled}
+        options={normalizeSchemaEnum(field.enum, t)}
+        {...componentProps}
+        id={id}
+        value={value}
+        onChange={(nextValue) => onChange?.(nextValue)}
+      />
+    );
   }
 
   if (field.component === 'CronCycle') {
-    return <CronCycleEditor disabled={disabled} />;
+    return (
+      <CronCycleEditor
+        disabled={disabled}
+        id={id}
+        value={typeof value === 'string' ? value : null}
+        onChange={(nextValue) => onChange?.(nextValue ?? null)}
+      />
+    );
   }
 
-  return <Input disabled={disabled} />;
+  return (
+    <Input
+      disabled={disabled}
+      id={id}
+      value={typeof value === 'string' ? value : ''}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  );
 }
 
 function SequenceRuleOptionsForm(props: { form: FormInstance; ruleType?: Record<string, any>; disabled?: boolean }) {

--- a/packages/plugins/@nocobase/plugin-field-sequence/src/client-v2/__tests__/SequenceRulesConfigureField.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/client-v2/__tests__/SequenceRulesConfigureField.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
+import type { FormInstance } from 'antd/es/form';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { SequenceRulesConfigureField } from '../SequenceRulesConfigureField';
+
+vi.mock('../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+interface TestRuleType {
+  value: string;
+  label: string;
+  defaults: Record<string, unknown>;
+  fields: Array<{
+    name: string;
+    label: string;
+    component: string;
+    componentProps?: Record<string, unknown>;
+    enum?: Array<{ label: string; value: string }>;
+    required?: boolean;
+  }>;
+}
+
+function SequenceRulesHarness(props: {
+  formRef: React.MutableRefObject<FormInstance | undefined>;
+  options: Record<string, unknown>;
+  ruleType: TestRuleType;
+}) {
+  const [form] = Form.useForm();
+  props.formRef.current = form;
+
+  return (
+    <Form
+      form={form}
+      initialValues={{
+        patterns: [{ type: props.ruleType.value, options: props.options }],
+      }}
+    >
+      <SequenceRulesConfigureField
+        name="patterns"
+        namePath={['patterns']}
+        schema={{ required: true, 'x-component-props': { ruleTypes: [props.ruleType] } }}
+        form={form}
+        context={{}}
+        fieldInterface={{}}
+        mode="create"
+        title="Sequence rules"
+      />
+    </Form>
+  );
+}
+
+describe('SequenceRulesConfigureField', () => {
+  it('stores fixed text entered in the rule configuration form', async () => {
+    const formRef = { current: undefined } as React.MutableRefObject<FormInstance | undefined>;
+    const ruleType: TestRuleType = {
+      value: 'string',
+      label: 'Fixed text',
+      defaults: { value: '' },
+      fields: [{ name: 'value', label: 'Text content', component: 'Input', required: true }],
+    };
+
+    render(<SequenceRulesHarness formRef={formRef} options={{ value: '' }} ruleType={ruleType} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure' }));
+    const input = await screen.findByRole('textbox');
+    fireEvent.change(input, { target: { value: '11' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(formRef.current?.getFieldValue(['patterns', 0, 'options', 'value'])).toBe('11');
+    });
+  });
+
+  it('loads and stores numeric rule options', async () => {
+    const formRef = { current: undefined } as React.MutableRefObject<FormInstance | undefined>;
+    const ruleType: TestRuleType = {
+      value: 'integer',
+      label: 'Autoincrement',
+      defaults: { digits: 4 },
+      fields: [{ name: 'digits', label: 'Digits', component: 'InputNumber', required: true }],
+    };
+
+    render(<SequenceRulesHarness formRef={formRef} options={{ digits: 4 }} ruleType={ruleType} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure' }));
+    const input = await screen.findByRole('spinbutton');
+    expect(input).toHaveValue('4');
+
+    fireEvent.change(input, { target: { value: '6' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(formRef.current?.getFieldValue(['patterns', 0, 'options', 'digits'])).toBe(6);
+    });
+  });
+
+  it('stores selected character sets', async () => {
+    const formRef = { current: undefined } as React.MutableRefObject<FormInstance | undefined>;
+    const ruleType: TestRuleType = {
+      value: 'randomChar',
+      label: 'Random character',
+      defaults: { charsets: ['number'] },
+      fields: [
+        {
+          name: 'charsets',
+          label: 'Character sets',
+          component: 'Select',
+          componentProps: { mode: 'multiple' },
+          enum: [
+            { label: 'Number', value: 'number' },
+            { label: 'Uppercase letters', value: 'uppercase' },
+          ],
+          required: true,
+        },
+      ],
+    };
+
+    render(<SequenceRulesHarness formRef={formRef} options={{ charsets: ['number'] }} ruleType={ruleType} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure' }));
+    const select = await screen.findByLabelText('Character sets');
+    fireEvent.mouseDown(select);
+    fireEvent.click(await screen.findByText('Uppercase letters'));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(formRef.current?.getFieldValue(['patterns', 0, 'options', 'charsets'])).toEqual(['number', 'uppercase']);
+    });
+  });
+
+  it('stores the selected reset cycle', async () => {
+    const formRef = { current: undefined } as React.MutableRefObject<FormInstance | undefined>;
+    const ruleType: TestRuleType = {
+      value: 'integer',
+      label: 'Autoincrement',
+      defaults: { cycle: null },
+      fields: [{ name: 'cycle', label: 'Reset cycle', component: 'CronCycle' }],
+    };
+
+    render(<SequenceRulesHarness formRef={formRef} options={{ cycle: null }} ruleType={ruleType} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure' }));
+    const select = await screen.findByLabelText('Reset cycle');
+    fireEvent.mouseDown(select);
+    fireEvent.click(await screen.findByText('Daily'));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(formRef.current?.getFieldValue(['patterns', 0, 'options', 'cycle'])).toBe('0 0 * * *');
+    });
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In the v2 data source manager, entering a value for the fixed-text part of a sequence field still triggered the required-field validation error on submit.

The rule option renderer wrapped Ant Design controls in a custom component but did not forward the `value` and `onChange` properties injected by `Form.Item`. The visible input therefore kept only its local DOM state while the form store retained the original empty value. The same binding issue also affected number, character-set selection, and reset-cycle rule options.

### Description

- Make the v2 sequence rule option controls controlled by forwarding form values and changes for text, number, select, and cron-cycle editors.
- Forward the generated field `id` so labels remain associated with their controls.
- Preserve existing validation, dynamic numeric limits, sequence keys, server behavior, and database structure.
- Add regression tests covering fixed text, numeric options, character-set selection, and reset-cycle selection.

Risk is low because the change is limited to the client-v2 sequence rule configuration adapter and restores the standard Ant Design Form control contract. No API, server, database, migration, or i18n behavior is changed.

Tested with:

`yarn test packages/plugins/@nocobase/plugin-field-sequence/src/client-v2/__tests__/SequenceRulesConfigureField.test.tsx --run --reporter=verbose`

Result: 4 tests passed.

Also verified with ESLint, lint-staged, and `git diff --check`.

### Related issues

Task 5333

### Showcase

N/A. This is a form-state binding fix covered by component regression tests.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed v2 sequence rule options not saving entered values and fixed-text rules incorrectly reporting a required-field error. |
| 🇨🇳 Chinese | 修复 v2 自动编码规则选项无法保存输入值，以及固定文本填写后仍错误提示必填的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A — no documentation change required |
| 🇨🇳 Chinese | N/A — 无需修改文档 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
