### PR TITLE
fix(client-v2): execute RunJS in date range limits

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/__tests__/DateTimeNoTzFieldModel.dateLimit.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/__tests__/DateTimeNoTzFieldModel.dateLimit.test.tsx
@@ -17,6 +17,8 @@ import { DateTimeNoTzPicker } from '../DateTimeNoTzFieldModel';
 let capturedDatePickerProps: any;
 let currentForm: any;
 const mockResolveJsonTemplate = vi.fn();
+const mockRunjs = vi.fn();
+const mockLoggerWarn = vi.fn();
 
 vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@nocobase/flow-engine')>();
@@ -32,6 +34,10 @@ vi.mock('@nocobase/flow-engine', async (importOriginal) => {
     }),
     useFlowContext: () => ({
       resolveJsonTemplate: mockResolveJsonTemplate,
+      runjs: mockRunjs,
+      logger: {
+        warn: mockLoggerWarn,
+      },
     }),
   };
 });
@@ -64,6 +70,9 @@ describe('DateTimeNoTzPicker date range limit', () => {
     currentForm = undefined;
     capturedDatePickerProps = undefined;
     mockResolveJsonTemplate.mockReset();
+    mockRunjs.mockReset();
+    mockLoggerWarn.mockReset();
+    mockRunjs.mockResolvedValue({ success: true, value: undefined });
     mockResolveJsonTemplate.mockImplementation(async (params) => ({
       ...params,
       _maxDate: currentForm?.getFieldValue?.('b'),
@@ -238,5 +247,145 @@ describe('DateTimeNoTzPicker date range limit', () => {
     expect(timeConfig?.disabledHours?.()).toEqual([]);
     expect(timeConfig?.disabledMinutes?.(12)).toEqual([]);
     expect(timeConfig?.disabledSeconds?.(12, 34)).toEqual([]);
+  });
+
+  it('evaluates RunJS before applying minDate', async () => {
+    const code = 'return new Date("2026-05-10T08:09:10.000Z").toISOString();';
+    mockRunjs.mockResolvedValue({ success: true, value: '2026-05-10T08:09:10.000Z' });
+    mockResolveJsonTemplate.mockImplementation(async (params) => params);
+
+    render(<TestWrapper picker="date" showTime _minDate={{ code, version: 'v2' }} onChange={vi.fn()} value={null} />);
+
+    await waitFor(() => {
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-09 00:00:00'))).toBe(true);
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-10 00:00:00'))).toBe(false);
+    });
+
+    expect(mockRunjs.mock.calls[0]?.[0]).toBe(code);
+    expect(mockRunjs.mock.calls[0]?.[2]).toEqual({ version: 'v2' });
+    expect(mockResolveJsonTemplate).toHaveBeenCalledWith({
+      _minDate: '2026-05-10T08:09:10.000Z',
+      _maxDate: undefined,
+    });
+  });
+
+  it('supports a RunJS minDate together with a variable maxDate', async () => {
+    mockRunjs.mockResolvedValue({ success: true, value: '2026-05-10 08:00:00' });
+    mockResolveJsonTemplate.mockImplementation(async (params) => ({
+      ...params,
+      _maxDate: '2026-05-12 18:30:40',
+    }));
+
+    render(
+      <TestWrapper
+        picker="date"
+        showTime
+        _minDate={{ code: 'return "2026-05-10 08:00:00";', version: 'v2' }}
+        _maxDate={'{{ $nForm.max }}'}
+        onChange={vi.fn()}
+        value={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-09 00:00:00'))).toBe(true);
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-13 00:00:00'))).toBe(true);
+    });
+
+    expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-11 00:00:00'))).toBe(false);
+  });
+
+  it('clears stale restrictions when RunJS execution fails', async () => {
+    mockResolveJsonTemplate.mockImplementation(async (params) => params);
+    mockRunjs.mockImplementation(async (code) => {
+      if (code === 'throw new Error("failed");') {
+        return { success: false, error: new Error('failed') };
+      }
+      return { success: true, value: '2026-05-10 08:00:00' };
+    });
+
+    const view = render(
+      <TestWrapper
+        picker="date"
+        showTime
+        _minDate={{ code: 'return "2026-05-10 08:00:00";', version: 'v2' }}
+        onChange={vi.fn()}
+        value={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-09 00:00:00'))).toBe(true);
+    });
+
+    view.rerender(
+      <TestWrapper
+        picker="date"
+        showTime
+        _minDate={{ code: 'throw new Error("failed");', version: 'v2' }}
+        onChange={vi.fn()}
+        value={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockLoggerWarn).toHaveBeenCalled();
+      expect(capturedDatePickerProps?.minDate).toBeNull();
+      expect(capturedDatePickerProps?.disabledDate).toBeNull();
+      expect(capturedDatePickerProps?.disabledTime).toBeNull();
+    });
+  });
+
+  it('keeps the latest RunJS result when an earlier execution finishes later', async () => {
+    const slowResolvers: Array<(result: { success: boolean; value: string }) => void> = [];
+    mockResolveJsonTemplate.mockImplementation(async (params) => params);
+    mockRunjs.mockImplementation((code) => {
+      if (code === 'return "slow";') {
+        return new Promise((resolve) => {
+          slowResolvers.push(resolve);
+        });
+      }
+      return Promise.resolve({ success: true, value: '2026-06-01 00:00:00' });
+    });
+
+    const view = render(
+      <TestWrapper
+        picker="date"
+        showTime
+        _minDate={{ code: 'return "slow";', version: 'v2' }}
+        onChange={vi.fn()}
+        value={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(slowResolvers.length).toBeGreaterThan(0);
+    });
+
+    view.rerender(
+      <TestWrapper
+        picker="date"
+        showTime
+        _minDate={{ code: 'return "fast";', version: 'v2' }}
+        onChange={vi.fn()}
+        value={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-05-31 00:00:00'))).toBe(true);
+      expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-07-01 00:00:00'))).toBe(false);
+    });
+
+    slowResolvers.forEach((resolve) => resolve({ success: true, value: '2026-12-01 00:00:00' }));
+
+    await waitFor(() => {
+      expect(mockResolveJsonTemplate).toHaveBeenCalledWith({
+        _minDate: '2026-12-01 00:00:00',
+        _maxDate: undefined,
+      });
+    });
+
+    expect(capturedDatePickerProps?.disabledDate?.(dayjs('2026-07-01 00:00:00'))).toBe(false);
   });
 });

--- a/packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/dateLimit.ts
+++ b/packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/dateLimit.ts
@@ -8,140 +8,176 @@
  */
 
 import { autorun } from '@formily/reactive';
-import { Form } from 'antd';
-import { useFlowContext } from '@nocobase/flow-engine';
+import { Form, type FormInstance } from 'antd';
+import { resolveRunJSObjectValues, useFlowContext } from '@nocobase/flow-engine';
 import { dayjs } from '@nocobase/utils/client';
+import type { ConfigType, Dayjs } from 'dayjs';
 import { first, last } from 'lodash';
-import React, { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type DateLimitProps = {
-  _minDate?: any;
-  _maxDate?: any;
-  currentForm?: any;
+  _minDate?: unknown;
+  _maxDate?: unknown;
+  currentForm?: unknown;
 };
+
+type DisabledTimeConfig = {
+  disabledHours: () => number[];
+  disabledMinutes: (selectedHour: number) => number[];
+  disabledSeconds: (selectedHour: number, selectedMinute: number) => number[];
+};
+
+type DisabledDate = (current: Dayjs) => boolean;
+type DisabledTime = (current: Dayjs | null) => DisabledTimeConfig;
+
+function isAntdFormInstance(value: unknown): value is FormInstance {
+  if (!value || typeof value !== 'object') return false;
+  return typeof (value as Partial<FormInstance>).getFieldsValue === 'function';
+}
+
+function parseDateLimitValue(value: unknown): Dayjs | null {
+  if (!value) return null;
+  const parsed = dayjs(value as ConfigType);
+  return parsed.isValid() ? parsed : null;
+}
 
 export function useDateLimit(props: DateLimitProps) {
   const ctx = useFlowContext();
-  const isAntdFormInstance = typeof props.currentForm?.getFieldsValue === 'function';
-  const currentFormValues = Form.useWatch([], isAntdFormInstance ? props.currentForm : undefined);
-  const [minDate, setMinDate] = useState<dayjs.Dayjs | null>(null);
-  const [maxDate, setMaxDate] = useState<dayjs.Dayjs | null>(null);
-  const [disabledDate, setDisabledDate] = useState<any>(null);
-  const [disabledTime, setDisabledTime] = useState<any>(null);
-  const disposeRef = useRef<any>(null);
+  const currentForm = isAntdFormInstance(props.currentForm) ? props.currentForm : undefined;
+  const currentFormValues = Form.useWatch([], currentForm);
+  const [minDate, setMinDate] = useState<Dayjs | null>(null);
+  const [maxDate, setMaxDate] = useState<Dayjs | null>(null);
+  const [disabledDate, setDisabledDate] = useState<DisabledDate | null>(null);
+  const [disabledTime, setDisabledTime] = useState<DisabledTime | null>(null);
+  const evaluationIdRef = useRef(0);
+
+  const limitDate = useCallback(async () => {
+    const evaluationId = ++evaluationIdRef.current;
+
+    try {
+      const runJSResolvedParams = await resolveRunJSObjectValues(ctx, {
+        _minDate: props._minDate,
+        _maxDate: props._maxDate,
+      });
+      const resolvedParams = (await ctx.resolveJsonTemplate({
+        _minDate: runJSResolvedParams._minDate,
+        _maxDate: runJSResolvedParams._maxDate,
+      })) as { _minDate?: unknown; _maxDate?: unknown };
+
+      if (evaluationId !== evaluationIdRef.current) return;
+
+      const nextMinRaw = Array.isArray(resolvedParams?._minDate)
+        ? first(resolvedParams._minDate)
+        : resolvedParams?._minDate;
+      const nextMaxRaw = Array.isArray(resolvedParams?._maxDate)
+        ? last(resolvedParams._maxDate)
+        : resolvedParams?._maxDate;
+      const nextMinDate = parseDateLimitValue(nextMinRaw);
+      const nextMaxDate = parseDateLimitValue(nextMaxRaw);
+
+      setMinDate(nextMinDate);
+      setMaxDate(nextMaxDate);
+
+      const fullTimeArr = Array.from({ length: 60 }, (_, i) => i);
+
+      const nextDisabledDate: DisabledDate = (current) => {
+        if (!dayjs.isDayjs(current)) return false;
+
+        const min = nextMinDate?.startOf('day') || null;
+        const max = nextMaxDate?.endOf('day') || null;
+
+        if (min && current.startOf('day').isBefore(min)) {
+          return true;
+        }
+        if (max && current.startOf('day').isAfter(max)) {
+          return true;
+        }
+        return false;
+      };
+
+      const nextDisabledTime: DisabledTime = (current) => {
+        if (!current || (!nextMinDate && !nextMaxDate)) {
+          return { disabledHours: () => [], disabledMinutes: () => [], disabledSeconds: () => [] };
+        }
+
+        const isCurrentMinDay = !!nextMinDate && current.isSame(nextMinDate, 'day');
+        const isCurrentMaxDay = !!nextMaxDate && current.isSame(nextMaxDate, 'day');
+
+        const disabledHours = () => {
+          const hours = [];
+          if (isCurrentMinDay && nextMinDate) {
+            for (let hour = 0; hour < nextMinDate.hour(); hour++) {
+              hours.push(hour);
+            }
+          }
+          if (isCurrentMaxDay && nextMaxDate) {
+            for (let hour = nextMaxDate.hour() + 1; hour < 24; hour++) {
+              hours.push(hour);
+            }
+          }
+          return hours;
+        };
+
+        const disabledMinutes = (selectedHour: number) => {
+          if (isCurrentMinDay && nextMinDate && selectedHour === nextMinDate.hour()) {
+            return fullTimeArr.filter((minute) => minute < nextMinDate.minute());
+          }
+          if (isCurrentMaxDay && nextMaxDate && selectedHour === nextMaxDate.hour()) {
+            return fullTimeArr.filter((minute) => minute > nextMaxDate.minute());
+          }
+          return [];
+        };
+
+        const disabledSeconds = (selectedHour: number, selectedMinute: number) => {
+          if (
+            isCurrentMinDay &&
+            nextMinDate &&
+            selectedHour === nextMinDate.hour() &&
+            selectedMinute === nextMinDate.minute()
+          ) {
+            return fullTimeArr.filter((second) => second < nextMinDate.second());
+          }
+          if (
+            isCurrentMaxDay &&
+            nextMaxDate &&
+            selectedHour === nextMaxDate.hour() &&
+            selectedMinute === nextMaxDate.minute()
+          ) {
+            return fullTimeArr.filter((second) => second > nextMaxDate.second());
+          }
+          return [];
+        };
+
+        return {
+          disabledHours,
+          disabledMinutes,
+          disabledSeconds,
+        };
+      };
+
+      setDisabledDate(() => nextDisabledDate);
+      setDisabledTime(() => nextDisabledTime);
+    } catch (error) {
+      if (evaluationId !== evaluationIdRef.current) return;
+
+      ctx.logger?.warn?.({ err: error }, 'Failed to resolve date range limit');
+      setMinDate(null);
+      setMaxDate(null);
+      setDisabledDate(null);
+      setDisabledTime(null);
+    }
+  }, [ctx, props._maxDate, props._minDate]);
 
   useEffect(() => {
-    if (disposeRef.current) {
-      disposeRef.current();
-    }
-
-    disposeRef.current = autorun(() => {
-      void limitDate();
+    const dispose = autorun(() => {
+      limitDate();
     });
 
     return () => {
-      disposeRef.current?.();
+      evaluationIdRef.current += 1;
+      dispose();
     };
-  }, [ctx, currentFormValues, props._maxDate, props._minDate]);
-
-  const limitDate = async () => {
-    const resolvedParams = await ctx.resolveJsonTemplate({
-      _minDate: props._minDate,
-      _maxDate: props._maxDate,
-    });
-
-    const nextMinRaw = Array.isArray(resolvedParams?._minDate)
-      ? first(resolvedParams._minDate)
-      : resolvedParams?._minDate;
-    const nextMaxRaw = Array.isArray(resolvedParams?._maxDate)
-      ? last(resolvedParams._maxDate)
-      : resolvedParams?._maxDate;
-    const nextMinDate = nextMinRaw ? dayjs(nextMinRaw) : null;
-    const nextMaxDate = nextMaxRaw ? dayjs(nextMaxRaw) : null;
-
-    setMinDate(nextMinDate?.isValid?.() ? nextMinDate : null);
-    setMaxDate(nextMaxDate?.isValid?.() ? nextMaxDate : null);
-
-    const fullTimeArr = Array.from({ length: 60 }, (_, i) => i);
-
-    const nextDisabledDate = (current: dayjs.Dayjs) => {
-      if (!dayjs.isDayjs(current)) return false;
-
-      const min = nextMinDate?.isValid?.() ? nextMinDate.startOf('day') : null;
-      const max = nextMaxDate?.isValid?.() ? nextMaxDate.endOf('day') : null;
-
-      if (min && current.startOf('day').isBefore(min)) {
-        return true;
-      }
-      if (max && current.startOf('day').isAfter(max)) {
-        return true;
-      }
-      return false;
-    };
-
-    const nextDisabledTime = (current: dayjs.Dayjs) => {
-      if (!current || (!nextMinDate?.isValid?.() && !nextMaxDate?.isValid?.())) {
-        return { disabledHours: () => [], disabledMinutes: () => [], disabledSeconds: () => [] };
-      }
-
-      const isCurrentMinDay = !!nextMinDate?.isValid?.() && current.isSame(nextMinDate, 'day');
-      const isCurrentMaxDay = !!nextMaxDate?.isValid?.() && current.isSame(nextMaxDate, 'day');
-
-      const disabledHours = () => {
-        const hours = [];
-        if (isCurrentMinDay && nextMinDate) {
-          for (let hour = 0; hour < nextMinDate.hour(); hour++) {
-            hours.push(hour);
-          }
-        }
-        if (isCurrentMaxDay && nextMaxDate) {
-          for (let hour = nextMaxDate.hour() + 1; hour < 24; hour++) {
-            hours.push(hour);
-          }
-        }
-        return hours;
-      };
-
-      const disabledMinutes = (selectedHour: number) => {
-        if (isCurrentMinDay && nextMinDate && selectedHour === nextMinDate.hour()) {
-          return fullTimeArr.filter((minute) => minute < nextMinDate.minute());
-        }
-        if (isCurrentMaxDay && nextMaxDate && selectedHour === nextMaxDate.hour()) {
-          return fullTimeArr.filter((minute) => minute > nextMaxDate.minute());
-        }
-        return [];
-      };
-
-      const disabledSeconds = (selectedHour: number, selectedMinute: number) => {
-        if (
-          isCurrentMinDay &&
-          nextMinDate &&
-          selectedHour === nextMinDate.hour() &&
-          selectedMinute === nextMinDate.minute()
-        ) {
-          return fullTimeArr.filter((second) => second < nextMinDate.second());
-        }
-        if (
-          isCurrentMaxDay &&
-          nextMaxDate &&
-          selectedHour === nextMaxDate.hour() &&
-          selectedMinute === nextMaxDate.minute()
-        ) {
-          return fullTimeArr.filter((second) => second > nextMaxDate.second());
-        }
-        return [];
-      };
-
-      return {
-        disabledHours,
-        disabledMinutes,
-        disabledSeconds,
-      };
-    };
-
-    setDisabledDate(() => nextDisabledDate);
-    setDisabledTime(() => nextDisabledTime);
-  };
+  }, [currentFormValues, limitDate]);
 
   return {
     minDate,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In client v2 date fields, the Date range limit setting allows RunJS values for the minimum and maximum dates, but the field runtime only resolved JSON template expressions. The stored RunJS object was therefore passed to `dayjs()` without being executed, producing an invalid date and silently disabling the configured limit.

### Description 
- Execute RunJS date range values before resolving regular JSON template variables.
- Preserve support for constant dates, date arrays, and form/context variables.
- Clear stale date restrictions and log a warning when RunJS evaluation fails.
- Ignore late results from older asynchronous evaluations so they cannot overwrite the latest configuration.
- Add regression tests for RunJS evaluation, mixed RunJS and variable limits, execution failures, and asynchronous race conditions.

The change is implemented in the shared client v2 date limit hook, so it covers date, timezone-aware datetime, and timezone-free datetime fields without changing the persisted configuration format. No database migration or API change is required.

Testing:
- `yarn test packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/__tests__/DateTimeNoTzFieldModel.dateLimit.test.tsx --run --reporter=verbose`
- `yarn eslint --fix packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/dateLimit.ts packages/core/client-v2/src/flow/models/fields/DateTimeFieldModel/__tests__/DateTimeNoTzFieldModel.dateLimit.test.tsx`

### Related issues
N/A

### Showcase
N/A. This is a runtime behavior fix with no UI layout changes.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix RunJS values not taking effect in client v2 date range limits. |
| 🇨🇳 Chinese | 修复 v2 日期字段限定范围中 RunJS 值不生效的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A (no documentation changes required) |
| 🇨🇳 Chinese | N/A（无需文档变更） |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
