### PR TITLE
fix(plugin-backups): show v2 restore errors

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/RestoreErrors.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/RestoreErrors.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createMockClient, Plugin } from '@nocobase/client-v2';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { RestoreFromBackup } from '../components/RestoreFromBackup';
+import { RestoreFromLocal } from '../components/RestoreFromLocal';
+import type { BackupFile } from '../components/BackupsTable';
+
+const backup: BackupFile = {
+  name: 'backup.nbdata',
+  fileSize: '1 KB',
+  createdAt: '2026-07-22T00:00:00.000Z',
+  inProgress: false,
+};
+
+const RestoreTestPage = () => (
+  <>
+    <RestoreFromLocal />
+    <RestoreFromBackup backup={backup} />
+  </>
+);
+
+class RestoreTestPlugin extends Plugin {
+  async load() {
+    this.router.add('root', {
+      path: '/',
+      Component: RestoreTestPage,
+    });
+  }
+}
+
+function renderRestorePage() {
+  const app = createMockClient({ plugins: [RestoreTestPlugin] });
+  app.apiMock.onGet('backups:appInfo').reply(200, {
+    data: {
+      database: {
+        dialect: 'postgres',
+        schema: 'current_schema',
+      },
+    },
+  });
+
+  const Root = app.getRootComponent();
+  render(<Root />);
+  return app;
+}
+
+async function submitLocalRestore(errorMessage: string) {
+  const app = renderRestorePage();
+  app.apiMock.onPost('backups:upload').reply(500, {
+    errors: [{ message: errorMessage }],
+  });
+
+  fireEvent.click(await screen.findByText('Restore backup from local'));
+
+  const file = new File(['backup'], 'backup.nbdata', { type: 'application/octet-stream' });
+  const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const schemaInput = document.querySelector('input[type="text"][autocomplete="new-password"]') as HTMLInputElement;
+  const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+
+  fireEvent.change(fileInput, { target: { files: [file] } });
+  fireEvent.change(schemaInput, { target: { value: 'current_schema' } });
+  fireEvent.change(passwordInput, { target: { value: 'wrong-password' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+  expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(screen.getByText('backup.nbdata')).toBeInTheDocument();
+  expect(schemaInput).toHaveValue('current_schema');
+  expect(passwordInput).toHaveValue('wrong-password');
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled();
+  });
+}
+
+describe('backup restore errors', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    'Unable to restore: database underscored mismatch',
+    'Unable to restore: database schema mismatch',
+    'Not a valid backup file',
+    'Error decrypting backup, please check your password',
+  ])('shows the local restore error and preserves the form: %s', async (errorMessage) => {
+    await submitLocalRestore(errorMessage);
+  });
+
+  it('shows errors from restoring an existing backup and preserves the form', async () => {
+    const app = renderRestorePage();
+    app.apiMock.onPost('backups:restore').reply(500, {
+      errors: [{ message: 'Unable to restore: database schema mismatch' }],
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Restore', exact: true }));
+
+    const schemaInput = document.querySelector('input[type="text"][autocomplete="new-password"]') as HTMLInputElement;
+    const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    fireEvent.change(schemaInput, { target: { value: 'current_schema' } });
+    fireEvent.change(passwordInput, { target: { value: 'wrong-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Unable to restore: database schema mismatch')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(schemaInput).toHaveValue('current_schema');
+    expect(passwordInput).toHaveValue('wrong-password');
+  });
+
+  it('closes the local restore dialog after the restore task starts successfully', async () => {
+    const app = renderRestorePage();
+    app.apiMock.onPost('backups:upload').reply(200, {
+      data: {
+        task: 'restore-task',
+      },
+    });
+
+    fireEvent.click(await screen.findByText('Restore backup from local'));
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File(['backup'], 'backup.nbdata', { type: 'application/octet-stream' })],
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(app.apiMock.history.post).toHaveLength(1);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useFlowContext } from '@nocobase/flow-engine';
-import { Button, Form, Input, Modal } from 'antd';
+import { App, Button, Form, Input, Modal } from 'antd';
 import React from 'react';
 import { useBackupAppInfo } from '../hooks/useBackupAppInfo';
 import { useCheckBackupMessage } from '../hooks/useCheckBackupMessage';
@@ -24,9 +24,12 @@ type ResourceResponse<T> = {
   data?: T;
 };
 
+type ErrorMessage = string | { message?: string };
+
 export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
   const t = useT();
   const ctx = useFlowContext();
+  const { notification } = App.useApp();
   const [isModalVisible, setIsModalVisible] = React.useState(false);
   const [password, setPassword] = React.useState('');
   const [progressing, setProgressing] = React.useState(false);
@@ -53,6 +56,7 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
       const response = await ctx.api.request<ResourceResponse<RestoreTaskBody>>({
         url: 'backups:restore',
         method: 'post',
+        skipNotify: true,
         data: {
           name: backup.name,
           password,
@@ -61,12 +65,20 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
       });
       restoreTaskId.current = response.data?.data?.task ?? null;
       showCheckBackupMessage();
-    } catch (error) {
-      console.error(error);
+      setIsModalVisible(false);
+      resetFields();
+    } catch (error: unknown) {
+      const errors = ctx.api.toErrMessages(error) as ErrorMessage[];
+      notification.error({
+        message: errors.map((item, index) => {
+          const message = typeof item === 'string' ? item : item.message;
+          return <div key={`${index}_${message}`}>{message || t('Restore failed')}</div>;
+        }),
+        role: 'alert',
+      });
+    } finally {
+      setProgressing(false);
     }
-    setProgressing(false);
-    setIsModalVisible(false);
-    resetFields();
   };
 
   const handleCancel = () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
@@ -25,6 +25,8 @@ type ResourceResponse<T> = {
   data?: T;
 };
 
+type ErrorMessage = string | { message?: string };
+
 export const RestoreFromLocal = () => {
   const t = useT();
   const ctx = useFlowContext();
@@ -75,15 +77,24 @@ export const RestoreFromLocal = () => {
         url: 'backups:upload',
         method: 'post',
         data: formData,
+        skipNotify: true,
       });
       restoreTaskId.current = response.data?.data?.task ?? null;
       showCheckBackupMessage();
-    } catch (error) {
-      console.error(error);
+      setIsModalVisible(false);
+      resetFields();
+    } catch (error: unknown) {
+      const errors = ctx.api.toErrMessages(error) as ErrorMessage[];
+      notification.error({
+        message: errors.map((item, index) => {
+          const message = typeof item === 'string' ? item : item.message;
+          return <div key={`${index}_${message}`}>{message || t('Restore failed')}</div>;
+        }),
+        role: 'alert',
+      });
+    } finally {
+      setProgressing(false);
     }
-    setProgressing(false);
-    setIsModalVisible(false);
-    resetFields();
   };
 
   const handleCancel = () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
@@ -41,6 +41,7 @@
   "Required if application database schema is different with the backup": "Required if application database schema{{currentDbSchemaTips}} is different with the backup",
   "Restore": "Restore",
   "Restore backup from local": "Restore from local backup file",
+  "Restore failed": "Restore failed",
   "Restore password": "Restore password",
   "Run automatic backup on the cron schedule": "Run automatic backup on the cron schedule",
   "Settings": "Settings",

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
@@ -41,6 +41,7 @@
   "Required if application database schema is different with the backup": "仅应用数据库 Schema{{currentDbSchemaTips}} 与备份不一致时需要填写",
   "Restore": "还原",
   "Restore backup from local": "从本地备份还原",
+  "Restore failed": "还原失败",
   "Restore password": "还原密码",
   "Run automatic backup on the cron schedule": "根据 Cron 运行自动备份",
   "Settings": "设置",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Backup Manager in the v2 client did not display visible feedback when restore prechecks failed. Errors such as database underscored/schema mismatches, invalid backup files, and incorrect restore passwords were only logged to the browser console, while the restore dialog was closed and its values were cleared.

### Description

- Display restore request failures with the v2 application-scoped `notification.error` UI.
- Reuse the standard API error normalization through `ctx.api.toErrMessages()`.
- Keep the restore dialog, selected file, password, and database schema available after a failed request so users can correct and retry.
- Close and reset the dialog only after the restore task starts successfully.
- Mark restore requests with `skipNotify` to avoid duplicate notifications if global v2 request notifications are introduced later.
- Add v2 tests for underscored mismatch, schema mismatch, invalid backup files, incorrect passwords, restoring an existing backup, and the successful task-start path.

Potential risk is limited to the v2 Backup Manager restore dialogs. Server restore execution, database operations, and asynchronous restore-status handling are unchanged.

Testing performed:

- `yarn test packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/RestoreErrors.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-backups/src/client/__tests__/RestoreFromLocal.test.tsx --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/RestoreErrors.test.tsx`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing visible error notifications when Backup Manager restore requests fail in the v2 client. |
| 🇨🇳 Chinese | 修复 v2 备份管理器还原请求失败时没有可见错误提示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
