### PR TITLE
fix(plugin-flow-engine): directed field-menu lookup for flowSurfaces addField

### DIFF
--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service.ts
@@ -24807,6 +24807,104 @@ export class FlowSurfacesService {
     ]);
   }
 
+  private findFieldMenuAssociationLeafCandidateDirected(input: {
+    mode: 'table' | 'details' | 'form';
+    ownerUse: string;
+    resourceInit: Record<string, any>;
+    fieldPath: string;
+    enabledPackages?: ReadonlySet<string>;
+  }): FlowSurfaceFieldMenuCandidate | null {
+    const segments = String(input.fieldPath || '')
+      .split('.')
+      .filter(Boolean);
+    if (segments.length < 2) {
+      return null;
+    }
+
+    const leafFieldName = segments[segments.length - 1];
+    const associationSegments = segments.slice(0, -1);
+    let collection = this.getCollection(input.resourceInit.dataSourceKey, input.resourceInit.collectionName);
+    if (!collection) {
+      return null;
+    }
+
+    const titlePrefix: string[] = [];
+    let associationPathName = '';
+    const visitedCollectionKeys: string[] = [];
+    const rootCycleKey = buildCatalogCollectionCycleKey(collection, input.resourceInit.dataSourceKey);
+    if (rootCycleKey) {
+      visitedCollectionKeys.push(rootCycleKey);
+    }
+
+    for (const associationFieldName of associationSegments) {
+      const associationField = getCollectionFields(collection).find(
+        (field) => getFieldName(field) === associationFieldName,
+      );
+      if (!associationField || !getFieldInterface(associationField) || !isAssociationField(associationField)) {
+        return null;
+      }
+
+      const fieldInterface = String(getFieldInterface(associationField) || '').trim();
+      if (MULTI_VALUE_ASSOCIATION_INTERFACES.has(fieldInterface)) {
+        return null;
+      }
+
+      const targetCollection = resolveFieldTargetCollection(
+        associationField,
+        input.resourceInit.dataSourceKey,
+        (dataSourceKey, collectionName) => this.getCollection(dataSourceKey, collectionName),
+      );
+      if (!targetCollection) {
+        return null;
+      }
+
+      associationPathName = associationPathName
+        ? \.\
+        : associationFieldName;
+      titlePrefix.push(getFieldTitle(associationField));
+
+      const cycleKey = buildCatalogCollectionCycleKey(targetCollection, input.resourceInit.dataSourceKey);
+      if (cycleKey && visitedCollectionKeys.includes(cycleKey)) {
+        return null;
+      }
+      if (cycleKey) {
+        visitedCollectionKeys.push(cycleKey);
+      }
+      collection = targetCollection;
+    }
+
+    const targetField = getCollectionFields(collection).find((field) => getFieldName(field) === leafFieldName);
+    if (!targetField || !getFieldInterface(targetField)) {
+      return null;
+    }
+
+    const displaySemantics = this.resolveAssociationLeafDisplaySemantics(
+      targetField,
+      input.resourceInit.dataSourceKey,
+      input.enabledPackages,
+    );
+    if (!displaySemantics) {
+      return null;
+    }
+    if (
+      isRelationBackingForeignKeyField(collection, targetField) &&
+      !this.isCollectionTitleField(collection, leafFieldName)
+    ) {
+      return null;
+    }
+
+    return {
+      field: targetField,
+      fieldPath: \.\,
+      associationPathName,
+      label: [...titlePrefix, getFieldTitle(targetField)].join(' / '),
+      supportsJs: input.mode !== 'form',
+      explicitWrapperUse: input.mode === 'form' ? 'FormAssociationItemModel' : undefined,
+      explicitFieldUse: displaySemantics.fieldUse,
+      defaultTitleField: displaySemantics.defaultTitleField,
+    };
+  }
+
   private findFieldMenuCandidate(input: {
     ownerUse: string;
     resourceInit: Record<string, any>;
@@ -24814,17 +24912,39 @@ export class FlowSurfacesService {
     associationPathName?: string;
     enabledPackages?: ReadonlySet<string>;
   }) {
-    const candidates = this.buildFieldMenuCandidates({
+    const mode = this.getFieldMenuCatalogMode(input.ownerUse);
+    if (!mode) {
+      return null;
+    }
+
+    const normalizedFieldPath = normalizeFieldPath(input.fieldPath, input.associationPathName);
+    if (!normalizedFieldPath) {
+      return null;
+    }
+
+    // addField only needs the requested path. Build the full association menu only for
+    // catalog/menu listing paths; single-field lookup stays O(path) on large graphs.
+    const directCandidates = this.buildFieldMenuDirectCandidates({
+      mode,
       ownerUse: input.ownerUse,
       resourceInit: input.resourceInit,
       enabledPackages: input.enabledPackages,
     });
-    const normalizedFieldPath = normalizeFieldPath(input.fieldPath, input.associationPathName);
-    return (
-      candidates.find(
+    const directMatched =
+      directCandidates.find(
         (candidate) => normalizeFieldPath(candidate.fieldPath, candidate.associationPathName) === normalizedFieldPath,
-      ) || null
-    );
+      ) || null;
+    if (directMatched) {
+      return directMatched;
+    }
+
+    return this.findFieldMenuAssociationLeafCandidateDirected({
+      mode,
+      ownerUse: input.ownerUse,
+      resourceInit: input.resourceInit,
+      fieldPath: normalizedFieldPath,
+      enabledPackages: input.enabledPackages,
+    });
   }
 
   private buildCatalogItemOptionalFields(


### PR DESCRIPTION
## Summary

`flowSurfaces:addField` currently resolves the target field by building the **entire** association field menu (`buildFieldMenuCandidates` → recursive association leaf expansion) and then `.find()`-ing the requested path.

On large business schemas this causes combinatorial explosion during a single-field write:

| Metric (full-clone repro, wrong `titleField` probe on `orders.items`) | Before | After directed lookup |
| --- | ---: | ---: |
| Menu lookup time | ~27.6s | ~6–13ms |
| Candidate count | 86,222 | 38 (path-local) |
| Recursive association expansions | 2,155 | path walk only |
| Target field scans | 312,337 | path-local |

Hardware only amplifies the same algorithm issue (same clone was ~70s on a slower NAS host).

## Change

In `@nocobase/plugin-flow-engine` `flow-surfaces/service.ts`:

1. **`findFieldMenuCandidate`**
   - Resolve **direct** candidates first via existing `buildFieldMenuDirectCandidates`
   - If not found, resolve the requested path with a new **path-directed** helper
   - Do **not** build the full association menu for single-field `addField` lookup

2. **`findFieldMenuAssociationLeafCandidateDirected`** (new)
   - Walk only the association segments in the requested field path
   - Preserve the same leaf eligibility rules used by the full menu builder:
     - single-value associations only
     - cycle detection via `buildCatalogCollectionCycleKey`
     - `resolveAssociationLeafDisplaySemantics`
     - relation backing FK filtering via `isRelationBackingForeignKeyField` / title field rules

Catalog / menu listing paths that still call `buildFieldMenuCandidates` are unchanged.

## Why this is safe

- Reuses existing helpers already used by the full menu builder
- Keeps semantic filters identical; only changes *search strategy* from “enumerate all then find” to “walk requested path”
- Wrong `titleField` still fails validation quickly (observed ~3.3s client / 400) instead of hanging the request for tens of seconds

## Test plan

- [ ] Unit / existing flow-surfaces tests for `addField` on form/table/details owners
- [ ] `addField` of a direct field still succeeds
- [ ] `addField` of a 1-level association leaf / subTable title field still succeeds
- [ ] Invalid `titleField` returns 400 without multi-second menu enumeration on a schema with deep association graphs
- [ ] Field catalog / picker listing still returns full association candidates (no regression on menu build paths)

## Context

Found while migrating a large multi-collection ERP schema onto NocoBase 2.2.x. `addField` was effectively unusable for native sub-tables until this lookup stopped building the full association menu for a single path.

Happy to adjust naming / structure to match maintainer preferences.