### PR TITLE
refactor(plugin-workflow): use event queue for pending workflow tasks

### DIFF
--- a/packages/core/server/src/__tests__/event-queue.test.ts
+++ b/packages/core/server/src/__tests__/event-queue.test.ts
@@ -221,6 +221,37 @@ describe('memory queue adapter', () => {
     expect(mockPlugin.idle).toBe(true);
   });
 
+  test('consume next message immediately after processing completes', async () => {
+    let resolveFirst!: () => void;
+    const firstProcessing = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processedMessages: string[] = [];
+
+    await app.eventQueue.subscribe('test1', {
+      interval: 1000,
+      idle: () => true,
+      process: async (message) => {
+        if (message === 'message1') {
+          await firstProcessing;
+        }
+        processedMessages.push(message);
+      },
+    });
+    await app.eventQueue.connect();
+
+    await app.eventQueue.publish('test1', 'message1');
+    await app.eventQueue.publish('test1', 'message2');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(processedMessages).toHaveLength(0);
+    resolveFirst();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(processedMessages).toEqual(['message1', 'message2']);
+  });
+
   describe('error handling and retry', () => {
     test('message processing failure with retry', async () => {
       const mockListener = vi.fn().mockImplementation(() => {
@@ -323,6 +354,41 @@ describe('memory queue adapter', () => {
   });
 
   describe('storage', () => {
+    test('graceful shutdown waits for in-flight processing', async () => {
+      let resolveProcessing!: () => void;
+      const processing = new Promise<void>((resolve) => {
+        resolveProcessing = resolve;
+      });
+      let processingStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        processingStarted = resolve;
+      });
+      let closed = false;
+
+      await app.eventQueue.subscribe('test1', {
+        idle: () => true,
+        process: async () => {
+          processingStarted();
+          await processing;
+        },
+      });
+      await app.eventQueue.connect();
+      await app.eventQueue.publish('test1', 'message1');
+      await started;
+
+      const closing = app.eventQueue.close().then(() => {
+        closed = true;
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(closed).toBe(false);
+
+      resolveProcessing();
+      await closing;
+
+      expect(closed).toBe(true);
+    });
+
     test('graceful shutdown, will create storage', async () => {
       const mockListener = vi.fn();
       const queueFile = storagePathJoin('apps', app.name, 'event-queue.json');

--- a/packages/core/server/src/event-queue.ts
+++ b/packages/core/server/src/event-queue.ts
@@ -8,7 +8,6 @@
  */
 
 import { randomUUID } from 'crypto';
-import { EventEmitter } from 'events';
 import path from 'path';
 import fs from 'fs/promises';
 
@@ -68,16 +67,16 @@ export interface EventQueueOptions {
 export class MemoryEventQueueAdapter implements IEventQueueAdapter {
   private connected = false;
 
-  private emitter: EventEmitter = new EventEmitter();
-
   private reading: Map<string, Promise<void>[]> = new Map();
+
+  private scheduledChannels = new Set<string>();
 
   protected events: Map<string, QueueEventOptions> = new Map();
 
   protected queues: Map<string, { id: string; content: any; options?: QueueMessageOptions }[]> = new Map();
 
   get processing() {
-    const processing = Array.from(this.reading.values());
+    const processing = Array.from(this.reading.values()).flat();
 
     if (processing.length > 0) {
       return Promise.all(processing);
@@ -97,7 +96,6 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
     const { logger } = this.options;
     const event = this.events.get(channel);
     if (!event) {
-      logger.warn(`memory queue (${channel}) not found, skipping...`);
       return;
     }
     if (!event.idle()) {
@@ -121,14 +119,28 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
         if (index > -1) {
           reading.splice(index, 1);
         }
+        this.scheduleListen(channel);
       });
     });
     this.reading.set(channel, reading);
   };
 
-  constructor(private options: { appName: string; logger: SystemLogger }) {
-    this.emitter.setMaxListeners(0);
+  private scheduleListen(channel: string) {
+    if (this.scheduledChannels.has(channel)) {
+      return;
+    }
+
+    this.scheduledChannels.add(channel);
+    setImmediate(() => {
+      this.scheduledChannels.delete(channel);
+      if (!this.events.has(channel)) {
+        return;
+      }
+      this.listen(channel);
+    });
   }
+
+  constructor(private options: { appName: string; logger: SystemLogger }) {}
 
   isConnected(): boolean {
     return this.connected;
@@ -192,13 +204,6 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
       for (const channel of this.events.keys()) {
         this.consume(channel);
       }
-      // for (const channel of this.queues.keys()) {
-      //   const queue = this.queues.get(channel);
-      //   if (!queue?.length) {
-      //     continue;
-      //   }
-      //   this.emitter.emit(channel, channel);
-      // }
     });
   }
 
@@ -227,8 +232,6 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
       this.queues.set(channel, []);
     }
 
-    this.emitter.on(channel, this.listen);
-
     if (this.connected) {
       this.consume(channel);
     }
@@ -239,13 +242,13 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
       return;
     }
     this.events.delete(channel);
-    this.emitter.off(channel, this.listen);
   }
 
   publish(channel: string, content: any, options: QueueMessageOptions = { timestamp: Date.now() }) {
+    const { logger } = this.options;
     const event = this.events.get(channel);
     if (!event) {
-      console.debug(`memory queue (${channel}) not subscribed, skip`);
+      logger.debug(`memory queue (${channel}) not subscribed, skip`);
       return;
     }
     if (!this.queues.get(channel)) {
@@ -254,12 +257,9 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
     const queue = this.queues.get(channel);
     const message = { id: randomUUID(), content, options };
     queue.push(message);
-    const { logger } = this.options;
     logger.debug(`memory queue (${channel}) published message`, content);
 
-    setImmediate(() => {
-      this.emitter.emit(channel, channel);
-    });
+    this.scheduleListen(channel);
   }
 
   async consume(channel: string, once = false) {
@@ -275,6 +275,7 @@ export class MemoryEventQueueAdapter implements IEventQueueAdapter {
       if (once) {
         break;
       }
+      // Polling is the fallback that observes an external non-idle -> idle transition.
       await sleep(interval);
     }
   }

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/tools.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/tools.ts
@@ -10,7 +10,7 @@
 import type { Context } from '@nocobase/actions';
 import type { DynamicToolsProvider } from '@nocobase/ai';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
-import PluginWorkflowServer, { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
+import PluginWorkflowServer, { EXECUTION_STATUS, JOB_STATUS, type JobModel } from '@nocobase/plugin-workflow';
 import type { Plugin } from '@nocobase/server';
 import { AI_WORKFLOW_TASK_STATUS, REQUIRES_APPROVAL } from './constants';
 
@@ -112,7 +112,7 @@ export const getWorkflowTasks: WorkflowTaskToolProvider = (plugin) => async (reg
         };
       }
 
-      const job = await plugin.db.getModel('jobs').findByPk(task.jobId);
+      const job = await plugin.db.getModel<JobModel>('jobs').findByPk(task.jobId);
       if (!job) {
         return {
           status: 'fail',

--- a/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-delay/src/server/DelayInstruction.ts
@@ -102,7 +102,7 @@ export default class extends Instruction {
       job.execution = await job.getExecution();
     }
     if (job.execution.status === EXECUTION_STATUS.STARTED) {
-      this.workflow.resume(job);
+      await this.workflow.resume(job).catch(() => {});
     }
     const idStr = job.id.toString();
     if (this.timers.get(idStr)) {

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts
@@ -214,8 +214,7 @@ export default class ScriptInstruction extends Instruction {
             return;
           }
           job.set(jobResult);
-          job.execution = execution;
-          this.workflow.resume(job);
+          await this.workflow.resume(job).catch(() => {});
         });
       });
   }

--- a/packages/plugins/@nocobase/plugin-workflow-mailer/src/server/MailerInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-mailer/src/server/MailerInstruction.ts
@@ -412,8 +412,7 @@ export default class MailerInstruction extends Instruction {
       }
       if (!aborted && execution.status === EXECUTION_STATUS.STARTED && job.status === JOB_STATUS.PENDING) {
         job.set(jobDone);
-        job.execution = execution;
-        this.workflow.resume(job);
+        await this.workflow.resume(job);
       } else {
         processor.logger.warn(
           `smtp-mailer (#${node.id}) result discarded because execution (${execution.id}) is ended`,

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/ManualInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/ManualInstruction.ts
@@ -9,7 +9,8 @@
 
 import Joi from 'joi';
 import { Registry } from '@nocobase/utils';
-import WorkflowPlugin, { Processor, JOB_STATUS, Instruction } from '@nocobase/plugin-workflow';
+import WorkflowPlugin, { Instruction, JOB_STATUS, Processor } from '@nocobase/plugin-workflow';
+import type { FlowNodeModel, JobModel } from '@nocobase/plugin-workflow';
 
 import initFormTypes, { FormHandler } from './forms';
 
@@ -27,70 +28,6 @@ export interface ManualConfig {
   assignees?: (number | string)[];
   mode?: number;
   title?: string;
-}
-
-const MULTIPLE_ASSIGNED_MODE = {
-  SINGLE: Symbol('single'),
-  ALL: Symbol('all'),
-  ANY: Symbol('any'),
-  ALL_PERCENTAGE: Symbol('all percentage'),
-  ANY_PERCENTAGE: Symbol('any percentage'),
-};
-
-const Modes = {
-  [MULTIPLE_ASSIGNED_MODE.SINGLE]: {
-    getStatus(distribution, assignees) {
-      const done = distribution.find((item) => item.status !== JOB_STATUS.PENDING && item.count > 0);
-      return done ? done.status : null;
-    },
-  },
-  [MULTIPLE_ASSIGNED_MODE.ALL]: {
-    getStatus(distribution, assignees) {
-      const resolved = distribution.find((item) => item.status === JOB_STATUS.RESOLVED);
-      if (resolved && resolved.count === assignees.length) {
-        return JOB_STATUS.RESOLVED;
-      }
-      const rejected = distribution.find((item) => item.status < JOB_STATUS.PENDING);
-      if (rejected && rejected.count) {
-        return rejected.status;
-      }
-
-      return null;
-    },
-  },
-  [MULTIPLE_ASSIGNED_MODE.ANY]: {
-    getStatus(distribution, assignees) {
-      const resolved = distribution.find((item) => item.status === JOB_STATUS.RESOLVED);
-      if (resolved && resolved.count) {
-        return JOB_STATUS.RESOLVED;
-      }
-      const rejectedCount = distribution.reduce(
-        (count, item) => (item.status < JOB_STATUS.PENDING ? count + item.count : count),
-        0,
-      );
-      // NOTE: all failures are considered as rejected for now
-      if (rejectedCount === assignees.length) {
-        return JOB_STATUS.REJECTED;
-      }
-
-      return null;
-    },
-  },
-};
-
-function getMode(mode) {
-  switch (true) {
-    case mode === 1:
-      return Modes[MULTIPLE_ASSIGNED_MODE.ALL];
-    case mode === -1:
-      return Modes[MULTIPLE_ASSIGNED_MODE.ANY];
-    case mode > 0:
-      return Modes[MULTIPLE_ASSIGNED_MODE.ALL_PERCENTAGE];
-    case mode < 0:
-      return Modes[MULTIPLE_ASSIGNED_MODE.ANY_PERCENTAGE];
-    default:
-      return Modes[MULTIPLE_ASSIGNED_MODE.SINGLE];
-  }
 }
 
 export default class extends Instruction {
@@ -135,39 +72,8 @@ export default class extends Instruction {
     return job;
   }
 
-  async resume(node, job, processor: Processor) {
-    // NOTE: check all users jobs related if all done then continue as parallel
-    const { mode } = node.config as ManualConfig;
-
-    const TaskRepo = this.workflow.app.db.getRepository('workflowManualTasks');
-    const tasks = await TaskRepo.find({
-      where: {
-        jobId: job.id,
-      },
-    });
-    const assignees = [];
-    const distributionMap = tasks.reduce((result, item) => {
-      if (result[item.status] == null) {
-        result[item.status] = 0;
-      }
-      result[item.status] += 1;
-      assignees.push(item.userId);
-      return result;
-    }, {});
-    const distribution = Object.keys(distributionMap).map((status) => ({
-      status: Number.parseInt(status, 10),
-      count: distributionMap[status],
-    }));
-
-    const submitted = tasks.reduce((count, item) => (item.status !== JOB_STATUS.PENDING ? count + 1 : count), 0);
-    const status = job.status || (getMode(mode).getStatus(distribution, assignees) ?? JOB_STATUS.PENDING);
-    const result = mode ? (submitted || 0) / assignees.length : job.latestTask?.result ?? job.result;
-    processor.logger.debug(`manual resume job and next status: ${status}`);
-    job.set({
-      status,
-      result,
-    });
-
+  async resume(node: FlowNodeModel, job: JobModel, processor: Processor) {
+    processor.logger.debug(`manual resume job and next status: ${job.status}`);
     return job;
   }
 }

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/form.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/form.test.ts
@@ -612,7 +612,7 @@ describe('workflow > instructions > manual', () => {
                 type: 'update',
                 actions: [{ status: JOB_STATUS.RESOLVED, key: 'resolve' }],
                 collection: 'posts',
-                filter: { title: 't1' },
+                filter: { id: '{{$context.data.id}}' },
               },
             },
           },

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/mode.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/mode.test.ts
@@ -8,9 +8,15 @@
  */
 
 import Database from '@nocobase/database';
-import { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
+import PluginWorkflowServer, {
+  EXECUTION_STATUS,
+  getExecutionLockKey,
+  getJobLockKey,
+  JOB_STATUS,
+} from '@nocobase/plugin-workflow';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { MockServer } from '@nocobase/test';
+import { vi } from 'vitest';
 
 // NOTE: skipped because time is not stable on github ci, but should work in local
 describe('workflow > instructions > manual', () => {
@@ -283,6 +289,120 @@ describe('workflow > instructions > manual', () => {
       const [j2] = await e2.getJobs();
       expect(j2.status).toBe(JOB_STATUS.RESOLVED);
       expect(j2.result).toBe(1);
+    });
+
+    it('rolls back the task when updating the aggregated job fails', async () => {
+      await workflow.createNode({
+        type: 'manual',
+        config: {
+          assignees: [users[0].id, users[1].id],
+          mode: 1,
+          forms: {
+            f1: {
+              actions: [{ status: JOB_STATUS.RESOLVED, key: 'resolve' }],
+            },
+          },
+        },
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      const [job] = await execution.getJobs();
+      const [task] = await UserJobModel.findAll({ order: [['userId', 'ASC']] });
+      const failJobSave = (model) => {
+        if (model.id === job.id) {
+          throw new Error('simulated aggregate save failure');
+        }
+      };
+      db.on('jobs.beforeSave', failJobSave);
+
+      const failed = await userAgents[0].resource('workflowManualTasks').submit({
+        filterByTk: task.id,
+        values: {
+          result: { f1: { failed: true }, _: 'resolve' },
+        },
+      });
+      expect(failed.status).toBe(500);
+
+      await Promise.all([task.reload(), job.reload()]);
+      expect(task.status).toBe(JOB_STATUS.PENDING);
+      expect(job.status).toBe(JOB_STATUS.PENDING);
+
+      db.off('jobs.beforeSave', failJobSave);
+      const retried = await userAgents[0].resource('workflowManualTasks').submit({
+        filterByTk: task.id,
+        values: {
+          result: { f1: { retried: true }, _: 'resolve' },
+        },
+      });
+      expect(retried.status).toBe(202);
+    });
+
+    it('locks submissions by job and resumes only after the terminal transition', async () => {
+      await workflow.createNode({
+        type: 'manual',
+        config: {
+          assignees: [users[0].id, users[1].id],
+          mode: 1,
+          forms: {
+            f1: {
+              actions: [{ status: JOB_STATUS.RESOLVED, key: 'resolve' }],
+            },
+          },
+        },
+      });
+
+      await PostRepo.create({ values: { title: 't1' } });
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      const [job] = await execution.getJobs();
+      const tasks = await UserJobModel.findAll({ order: [['userId', 'ASC']] });
+      const workflowPlugin = app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
+      const resume = vi.spyOn(workflowPlugin, 'resume');
+      const executionLock = await app.lockManager.tryAcquire(getExecutionLockKey(execution.id));
+      try {
+        const firstResponse = await userAgents[0].resource('workflowManualTasks').submit({
+          filterByTk: tasks[0].id,
+          values: {
+            result: { f1: { index: 0 }, _: 'resolve' },
+          },
+        });
+        expect(firstResponse.status).toBe(202);
+      } finally {
+        await executionLock.release();
+      }
+      expect(resume).not.toHaveBeenCalled();
+
+      const jobLock = await app.lockManager.tryAcquire(getJobLockKey(job.id));
+      try {
+        const locked = await userAgents[1].resource('workflowManualTasks').submit({
+          filterByTk: tasks[1].id,
+          values: {
+            result: { f1: { locked: true }, _: 'resolve' },
+          },
+        });
+        expect(locked.status).toBe(409);
+      } finally {
+        await jobLock.release();
+      }
+
+      const secondResponse = await userAgents[1].resource('workflowManualTasks').submit({
+        filterByTk: tasks[1].id,
+        values: {
+          result: { f1: { index: 1 }, _: 'resolve' },
+        },
+      });
+      expect(secondResponse.status).toBe(202);
+      expect(resume).toHaveBeenCalledTimes(1);
+
+      await sleep(1000);
+      await execution.reload();
+      await job.reload();
+      expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(job.status).toBe(JOB_STATUS.RESOLVED);
     });
 
     it('first rejected', async () => {

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/parallel.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/__tests__/parallel.test.ts
@@ -1,0 +1,113 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import Database from '@nocobase/database';
+import { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
+import { getApp, sleep } from '@nocobase/plugin-workflow-test';
+import { MockServer } from '@nocobase/test';
+
+describe('workflow > instructions > manual > parallel', () => {
+  let app: MockServer;
+  let db: Database;
+  let PostRepo;
+  let UserRepo;
+  let UserJobModel;
+  let userAgents;
+  let users;
+  let workflow;
+
+  beforeEach(async () => {
+    app = await getApp({
+      plugins: ['workflow-manual', 'workflow-parallel'],
+    });
+    db = app.db;
+    PostRepo = db.getCollection('posts').repository;
+    UserRepo = db.getRepository('users');
+    UserJobModel = db.getModel('workflowManualTasks');
+
+    users = await UserRepo.create({
+      values: [
+        { id: 2, nickname: 'a' },
+        { id: 3, nickname: 'b' },
+      ],
+    });
+    userAgents = await Promise.all(users.map((user) => app.agent().login(user)));
+
+    workflow = await db.getCollection('workflows').model.create({
+      enabled: true,
+      type: 'collection',
+      config: {
+        mode: 1,
+        collection: 'posts',
+      },
+    });
+  });
+
+  afterEach(() => app.destroy());
+
+  it('allows manual jobs in different branches to be submitted concurrently', async () => {
+    const parallelNode = await workflow.createNode({
+      type: 'parallel',
+    });
+    await workflow.createNode({
+      type: 'manual',
+      upstreamId: parallelNode.id,
+      branchIndex: 0,
+      config: {
+        assignees: [users[0].id],
+        forms: {
+          f1: {
+            actions: [{ status: JOB_STATUS.RESOLVED, key: 'resolve' }],
+          },
+        },
+      },
+    });
+    await workflow.createNode({
+      type: 'manual',
+      upstreamId: parallelNode.id,
+      branchIndex: 1,
+      config: {
+        assignees: [users[1].id],
+        forms: {
+          f1: {
+            actions: [{ status: JOB_STATUS.RESOLVED, key: 'resolve' }],
+          },
+        },
+      },
+    });
+
+    await PostRepo.create({ values: { title: 't1' } });
+    await sleep(500);
+
+    const [execution] = await workflow.getExecutions();
+    expect(execution.status).toBe(EXECUTION_STATUS.STARTED);
+    const tasks = await UserJobModel.findAll({ order: [['userId', 'ASC']] });
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0].jobId).not.toBe(tasks[1].jobId);
+
+    const responses = await Promise.all(
+      tasks.map((task, index) =>
+        userAgents[index].resource('workflowManualTasks').submit({
+          filterByTk: task.id,
+          values: {
+            result: { f1: { index }, _: 'resolve' },
+          },
+        }),
+      ),
+    );
+    expect(responses.map((response) => response.status)).toEqual([202, 202]);
+
+    await sleep(1000);
+    await execution.reload();
+    expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
+    const manualJobs = (await execution.getJobs()).filter((job) => job.nodeId !== parallelNode.id);
+    expect(manualJobs).toHaveLength(2);
+    expect(manualJobs.every((job) => job.status === JOB_STATUS.RESOLVED)).toBe(true);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/actions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/actions.ts
@@ -8,9 +8,101 @@
  */
 
 import actions, { Context, utils } from '@nocobase/actions';
-import PluginWorkflowServer, { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
+import { Transaction, type Database, type Model } from '@nocobase/database';
+import PluginWorkflowServer, {
+  EXECUTION_STATUS,
+  type FlowNodeModel,
+  getJobLockKey,
+  isLockAcquireError,
+  JOB_STATUS,
+  type JobModel,
+  type Processor,
+} from '@nocobase/plugin-workflow';
 
-import ManualInstruction from './ManualInstruction';
+import ManualInstruction, { type ManualConfig } from './ManualInstruction';
+
+type ManualTaskModel = Model & {
+  userId: number | string;
+  status: number;
+  result?: unknown;
+};
+
+type StatusDistribution = {
+  status: number;
+  count: number;
+};
+
+function getSubmittedRatio(tasks: ManualTaskModel[]) {
+  if (!tasks.length) {
+    return 0;
+  }
+  const submitted = tasks.reduce((count, item) => (item.status !== JOB_STATUS.PENDING ? count + 1 : count), 0);
+  return submitted / tasks.length;
+}
+
+function getSingleModeStatus(distribution: StatusDistribution[]) {
+  return distribution.find((item) => item.status !== JOB_STATUS.PENDING && item.count > 0)?.status ?? null;
+}
+
+function getAllModeStatus(distribution: StatusDistribution[], assignees: Array<number | string>) {
+  const resolved = distribution.find((item) => item.status === JOB_STATUS.RESOLVED);
+  if (resolved?.count === assignees.length) {
+    return JOB_STATUS.RESOLVED;
+  }
+  const rejected = distribution.find((item) => item.status < JOB_STATUS.PENDING);
+  return rejected?.count ? rejected.status : null;
+}
+
+function getAnyModeStatus(distribution: StatusDistribution[], assignees: Array<number | string>) {
+  const resolved = distribution.find((item) => item.status === JOB_STATUS.RESOLVED);
+  if (resolved?.count) {
+    return JOB_STATUS.RESOLVED;
+  }
+  const rejectedCount = distribution.reduce(
+    (count, item) => (item.status < JOB_STATUS.PENDING ? count + item.count : count),
+    0,
+  );
+  return rejectedCount === assignees.length ? JOB_STATUS.REJECTED : null;
+}
+
+async function updateJobByManualTasks(
+  job: JobModel,
+  node: FlowNodeModel,
+  database: Database,
+  latestTask: ManualTaskModel,
+  transaction: Transaction,
+) {
+  const mode = (node.config as ManualConfig).mode ?? 0;
+  const tasks = await database.getModel<ManualTaskModel>('workflowManualTasks').findAll({
+    where: {
+      jobId: job.id,
+    },
+    transaction,
+  });
+  const assignees: Array<number | string> = [];
+  const distributionMap = new Map<number, number>();
+
+  for (const task of tasks) {
+    distributionMap.set(task.status, (distributionMap.get(task.status) ?? 0) + 1);
+    assignees.push(task.userId);
+  }
+
+  const distribution = Array.from(distributionMap.entries()).map(([status, count]) => ({ status, count }));
+  const status =
+    mode === 1
+      ? getAllModeStatus(distribution, assignees)
+      : mode === -1
+        ? getAnyModeStatus(distribution, assignees)
+        : getSingleModeStatus(distribution);
+
+  await job.update(
+    {
+      status: status ?? JOB_STATUS.PENDING,
+      result: mode ? getSubmittedRatio(tasks) : latestTask.result ?? job.result,
+    },
+    { transaction },
+  );
+}
 
 export async function submit(context: Context, next) {
   const repository = utils.getRepositoryFromParams(context);
@@ -66,66 +158,123 @@ export async function submit(context: Context, next) {
   }
 
   task.execution.workflow = task.workflow;
-  const processor = plugin.createProcessor(task.execution);
-  await processor.prepare();
+  const formConfig = forms[formKey];
+  const handler = instruction.formTypes.get(formConfig.type);
+  const usesMainDataSource = (formConfig.dataSource ?? 'main') === 'main';
+  const transactionOptions =
+    context.db.sequelize.getDialect() === 'sqlite' ? { type: Transaction.TYPES.IMMEDIATE } : {};
+  const validateTask = () => {
+    if (
+      task.status !== JOB_STATUS.PENDING ||
+      task.job.status !== JOB_STATUS.PENDING ||
+      task.execution.status !== EXECUTION_STATUS.STARTED
+    ) {
+      return context.throw(400);
+    }
+  };
+  const getPresetValues = (processor: Processor): Record<string, unknown> => {
+    const assignees = processor
+      .getParsedValue(task.node.config.assignees ?? [], task.nodeId)
+      .flat()
+      .filter(Boolean);
+    if (!assignees.includes(currentUser.id) || task.userId !== currentUser.id) {
+      return context.throw(403);
+    }
 
-  // NOTE: validate assignee
-  const assignees = processor
-    .getParsedValue(task.node.config.assignees ?? [], task.nodeId)
-    .flat()
-    .filter(Boolean);
-  if (!assignees.includes(currentUser.id) || task.userId !== currentUser.id) {
-    return context.throw(403);
-  }
-  const presetValues = processor.getParsedValue(actionItem.values ?? {}, task.nodeId, {
-    additionalScope: {
-      // @deprecated
-      currentUser: currentUser,
-      // @deprecated
-      currentRecord: values.result[formKey],
-      // @deprecated
-      currentTime: new Date(),
-      $user: currentUser,
-      $nForm: values.result[formKey],
-      $nDate: {
-        now: new Date(),
+    return processor.getParsedValue(actionItem.values ?? {}, task.nodeId, {
+      additionalScope: {
+        // @deprecated
+        currentUser: currentUser,
+        // @deprecated
+        currentRecord: values.result[formKey],
+        // @deprecated
+        currentTime: new Date(),
+        $user: currentUser,
+        $nForm: values.result[formKey],
+        $nDate: {
+          now: new Date(),
+        },
       },
-    },
-  });
+    });
+  };
+  const setTaskResult = (presetValues: Record<string, unknown>) => {
+    task.set({
+      status: actionItem.status,
+      result: actionItem.status
+        ? { [formKey]: { ...values.result[formKey], ...presetValues }, _: actionKey }
+        : { ...(task.result ?? {}), ...values.result },
+    });
+    task.changed('result', true);
+  };
+  const handleFormSubmission = async (transaction?: Transaction) => {
+    const processor = plugin.createProcessor(task.execution, { transaction });
+    await processor.prepare();
+    const presetValues = getPresetValues(processor);
+    setTaskResult(presetValues);
+    if (handler && task.status) {
+      const { actions, ...formOptions } = formConfig;
+      const parsedFormConfig = {
+        ...processor.getParsedValue(formOptions, task.nodeId),
+        actions,
+      };
+      await handler.call(instruction, task, parsedFormConfig, transaction);
+    }
+    return presetValues;
+  };
+  let shouldResume = false;
 
-  task.set({
-    status: actionItem.status,
-    result: actionItem.status
-      ? { [formKey]: { ...values.result[formKey], ...presetValues }, _: actionKey }
-      : { ...(task.result ?? {}), ...values.result },
-  });
-  task.changed('result', true);
+  try {
+    const lock = await context.app.lockManager.tryAcquire(getJobLockKey(task.job.id));
+    await lock.runExclusive(async () => {
+      let presetValues: Record<string, unknown> = {};
 
-  const handler = instruction.formTypes.get(forms[formKey].type);
-  if (handler && task.status) {
-    await handler.call(instruction, task, forms[formKey], processor);
+      if (!usesMainDataSource) {
+        await Promise.all([task.reload(), task.job.reload(), task.execution.reload()]);
+        validateTask();
+        presetValues = await handleFormSubmission();
+      }
+
+      await context.db.sequelize.transaction(transactionOptions, async (transaction) => {
+        await Promise.all([
+          task.reload({ transaction }),
+          task.job.reload({ transaction }),
+          task.execution.reload({ transaction }),
+        ]);
+        validateTask();
+
+        if (usesMainDataSource) {
+          await handleFormSubmission(transaction);
+        } else {
+          setTaskResult(presetValues);
+        }
+
+        await task.save({ transaction });
+        await updateJobByManualTasks(task.job, task.node, context.db, task, transaction);
+        shouldResume = task.job.status !== JOB_STATUS.PENDING;
+      });
+    }, 60_000);
+  } catch (error) {
+    if (isLockAcquireError(error)) {
+      return context.throw(409);
+    }
+    throw error;
   }
-
-  await task.save();
-
-  await processor.exit();
 
   context.body = task;
   context.status = 202;
 
   await next();
 
-  if (task.execution.status !== EXECUTION_STATUS.STARTED) {
+  if (!shouldResume) {
     return;
   }
 
-  task.job.execution = task.execution;
-  task.job.latestTask = task;
-
   // NOTE: resume the process and no `await` for quick returning
-  processor.logger.info(`manual node (${task.nodeId}) action trigger execution (${task.execution.id}) to resume`);
+  plugin
+    .getLogger(task.execution.workflowId)
+    .info(`manual node (${task.nodeId}) action trigger execution (${task.execution.id}) to resume`);
 
-  plugin.resume(task.job);
+  plugin.resume(task.job).catch(() => undefined);
 }
 
 export async function listMine(context: Context, next) {

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/forms/create.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/forms/create.ts
@@ -7,14 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Processor } from '@nocobase/plugin-workflow';
+import type { Transaction } from '@nocobase/database';
 import ManualInstruction from '../ManualInstruction';
 
 export default async function (
   this: ManualInstruction,
   instance,
   { dataSource = 'main', collection },
-  processor: Processor,
+  transaction?: Transaction,
 ) {
   const repo = this.workflow.app.dataSourceManager.dataSources
     .get(dataSource)
@@ -32,8 +32,8 @@ export default async function (
       updatedBy: instance.userId,
     },
     context: {
-      executionId: processor.execution.id,
+      executionId: instance.executionId,
     },
-    transaction: processor.transaction,
+    transaction,
   });
 }

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/forms/index.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/forms/index.ts
@@ -7,14 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Processor } from '@nocobase/plugin-workflow';
+import type { Transaction } from '@nocobase/database';
 
 import ManualInstruction from '../ManualInstruction';
 
 import create from './create';
 import update from './update';
 
-export type FormHandler = (this: ManualInstruction, instance, formConfig, processor: Processor) => Promise<void>;
+export type FormHandler = (this: ManualInstruction, instance, formConfig, transaction?: Transaction) => Promise<void>;
 
 export default function ({ formTypes }) {
   formTypes.register('create', create);

--- a/packages/plugins/@nocobase/plugin-workflow-manual/src/server/forms/update.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-manual/src/server/forms/update.ts
@@ -7,14 +7,14 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Processor } from '@nocobase/plugin-workflow';
+import type { Transaction } from '@nocobase/database';
 import ManualInstruction from '../ManualInstruction';
 
 export default async function (
   this: ManualInstruction,
   instance,
   { dataSource = 'main', collection, filter = {} },
-  processor: Processor,
+  transaction?: Transaction,
 ) {
   const repo = this.workflow.app.dataSourceManager.dataSources
     .get(dataSource)
@@ -26,14 +26,14 @@ export default async function (
   const { _, ...form } = instance.result;
   const [values] = Object.values(form);
   await repo.update({
-    filter: processor.getParsedValue(filter, instance.nodeId),
+    filter,
     values: {
       ...((values as { [key: string]: any }) ?? {}),
       updatedBy: instance.userId,
     },
     context: {
-      executionId: processor.execution.id,
+      executionId: instance.executionId,
     },
-    transaction: processor.transaction,
+    transaction,
   });
 }

--- a/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-parallel/src/server/__tests__/instruction.test.ts
@@ -621,8 +621,9 @@ describe('workflow > instructions > parallel', () => {
 
       await sleep(500);
 
-      expect(execution.status).toEqual(EXECUTION_STATUS.RESOLVED);
-      const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
+      const [e2] = await workflow.getExecutions();
+      expect(e2.status).toEqual(EXECUTION_STATUS.RESOLVED);
+      const jobs = await e2.getJobs({ order: [['id', 'ASC']] });
       expect(jobs.length).toEqual(5);
     });
 

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/RequestInstruction.ts
@@ -339,8 +339,7 @@ export default class extends Instruction {
         }
         if (!aborted && execution.status === EXECUTION_STATUS.STARTED && job.status === JOB_STATUS.PENDING) {
           job.set(jobDone);
-          job.execution = execution;
-          this.workflow.resume(job);
+          await this.workflow.resume(job);
         } else {
           processor.logger.warn(`request (#${node.id}) result discarded because execution (${execution.id}) is ended`);
         }

--- a/packages/plugins/@nocobase/plugin-workflow-request/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request/src/server/__tests__/instruction.test.ts
@@ -170,6 +170,19 @@ describe('workflow > instructions > request', () => {
     await app.destroy();
   });
 
+  async function waitForExecutionStatus(status: number | null, timeout = 1000) {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const [execution] = await workflow.getExecutions();
+      if (execution?.status === status) {
+        return execution;
+      }
+      await sleep(20);
+    }
+    const [execution] = await workflow.getExecutions();
+    return execution;
+  }
+
   describe('params processing', () => {
     it('trim should not crash', async () => {
       await workflow.createNode({
@@ -270,7 +283,7 @@ describe('workflow > instructions > request', () => {
         enabled: true,
         type: 'collection',
         options: {
-          timeout: 300,
+          timeout: 1000,
         },
         config: {
           mode: 1,
@@ -289,10 +302,7 @@ describe('workflow > instructions > request', () => {
 
       await PostRepo.create({ values: { title: 't1' } });
 
-      await sleep(100);
-
-      const plugin = app.pm.get(PluginWorkflow) as PluginWorkflow;
-      let [execution] = await workflow.getExecutions();
+      let execution = await waitForExecutionStatus(EXECUTION_STATUS.STARTED);
       expect(execution.status).toBe(EXECUTION_STATUS.STARTED);
       expect(execution.startedAt).toBeTruthy();
       expect(execution.expiresAt).toBeTruthy();
@@ -300,7 +310,7 @@ describe('workflow > instructions > request', () => {
       let [job] = await execution.getJobs();
       expect(job.status).toBe(JOB_STATUS.PENDING);
 
-      await sleep(350);
+      await sleep(1050);
 
       [execution] = await workflow.getExecutions();
       expect(execution.status).toBe(EXECUTION_STATUS.ABORTED);

--- a/packages/plugins/@nocobase/plugin-workflow-test/src/server/instructions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-test/src/server/instructions.ts
@@ -114,7 +114,7 @@ export default {
           status: 1,
         });
 
-        plugin.resume(job);
+        plugin.resume(job).catch(() => {});
       }, node.config.duration ?? 100);
 
       return null;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -21,19 +21,32 @@ import { WORKER_JOB_WORKFLOW_PROCESS } from './Plugin';
 import { getExecutionLockKey, isLockAcquireError } from './utils';
 
 const EXECUTION_ACQUIRE_MAX_ATTEMPTS = 5;
-const PENDING_DISPATCH_MAX_ATTEMPTS = 3;
+const QUEUE_TASK_MAX_ATTEMPTS = 3;
+const RECOVERY_BATCH_SIZE = 100;
+const RECOVERY_LOCK_TTL = 300_000;
 
 type AcquireRetryLogger = Pick<ReturnType<PluginWorkflowServer['getLogger']>, 'warn'>;
 
 type ExecutionPlan = [ExecutionModel, JobModel?, ProcessorRerunOptions?];
 
-type Pending = {
-  execution: ExecutionModel;
-  job?: JobModel;
-  immediate?: boolean;
-  rerun?: ProcessorRerunOptions;
-  dispatchAttempts?: number;
-};
+type ID = number | string;
+
+type WorkflowQueueTask =
+  | {
+      executionId: ID;
+      jobId?: never;
+      rerun?: never;
+    }
+  | {
+      executionId: ID;
+      jobId: ID;
+      rerun?: never;
+    }
+  | {
+      executionId: ID;
+      jobId?: never;
+      rerun: ProcessorRerunOptions;
+    };
 
 type CachedEvent = [WorkflowModel, any, EventOptions];
 
@@ -56,30 +69,55 @@ export type EventOptions = {
 
 export default class Dispatcher {
   private ready = false;
-  private executing: Promise<any> | null = null;
+  private executing: Promise<void> | null = null;
+  private recovering: Promise<void> | null = null;
   private saving: Promise<any> | null = null;
-  private pending: Pending[] = [];
   private events: CachedEvent[] = [];
   private eventsCount = 0;
 
   get idle() {
-    return this.ready && !this.executing && !this.saving && !this.pending.length && !this.events.length;
+    return this.ready && !this.executing && !this.saving && !this.events.length;
   }
 
   constructor(private readonly plugin: PluginWorkflowServer) {}
 
-  public readonly onQueueExecution: QueueEventOptions['process'] = async (event) => {
-    const ExecutionRepo = this.plugin.db.getRepository('executions');
-    const execution: ExecutionModel = await ExecutionRepo.findOne({
-      filterByTk: event.executionId,
-    });
-    if (!execution || execution.dispatched || execution.status !== EXECUTION_STATUS.QUEUEING) {
-      return;
+  public readonly onQueueTask: QueueEventOptions['process'] = async (event) => {
+    const task = event as WorkflowQueueTask;
+    let next: ExecutionPlan | null = null;
+    const previous = this.executing;
+
+    const executing = (async () => {
+      await previous?.catch(() => undefined);
+
+      this.plugin
+        .getLogger('dispatcher')
+        .info(`workflow queue task for execution (${task.executionId}) received from queue`);
+
+      next = await this.resolveTask(task);
+      if (!next) {
+        return;
+      }
+
+      this.plugin.getLogger(next[0].workflowId).info(`queued execution (${next[0].id}) ready to process`);
+      await this.process(next[0], next[1], { rerun: next[2] });
+    })();
+    this.executing = executing;
+
+    try {
+      await executing;
+    } catch (error) {
+      const workflowId = next?.[0]?.workflowId ?? task.executionId;
+      this.plugin.getLogger(workflowId).error(`workflow queue task failed`, { error });
+      throw error;
+    } finally {
+      if (this.executing === executing) {
+        this.executing = null;
+      }
+
+      if (this.events.length) {
+        this.saveEvent();
+      }
     }
-    this.plugin
-      .getLogger(execution.workflowId)
-      .info(`execution (${execution.id}) received from queue, adding to pending list`);
-    await this.run({ execution });
   };
 
   public setReady(ready: boolean) {
@@ -156,20 +194,12 @@ export default class Dispatcher {
             const execution = await this.createExecution(...event);
             // NOTE: cache first execution for most cases
             if (!execution.dispatched) {
-              if (this.plugin.serving() && !this.executing && !this.pending.length) {
-                logger.info(`local pending list is empty, adding execution (${execution.id}) to pending list`);
-                this.pending.push({ execution });
-              } else {
-                logger.info(
-                  `instance is not serving as worker or local pending list is not empty, sending execution (${execution.id}) to queue`,
-                );
-                try {
-                  await this.plugin.app.eventQueue.publish(this.plugin.channelPendingExecution, {
-                    executionId: execution.id,
-                  });
-                } catch (qErr) {
-                  logger.error(`publishing execution (${execution.id}) to queue failed:`, { error: qErr });
-                }
+              try {
+                await this.enqueue({
+                  executionId: execution.id,
+                });
+              } catch (qErr) {
+                logger.error(`publishing execution (${execution.id}) to queue failed:`, { error: qErr });
               }
             }
           } catch (error) {
@@ -180,39 +210,20 @@ export default class Dispatcher {
         this.saving = null;
         if (this.events.length) {
           this.saveEvent();
-        } else {
-          this.dispatch();
         }
       }
     })();
-  }
-
-  public async resume(job: JobModel) {
-    let { execution } = job;
-    if (!execution) {
-      execution = await job.getExecution();
-    }
-    this.plugin
-      .getLogger(execution.workflowId)
-      .info(`execution (${execution.id}) resuming from job (${job.id}) added to pending list`);
-
-    await this.run({ execution, job });
-  }
-
-  public async start(execution: ExecutionModel) {
-    if (execution.status) {
-      return;
-    }
-    this.plugin.getLogger(execution.workflowId).info(`starting deferred execution (${execution.id})`);
-
-    await this.run({ execution });
   }
 
   public async beforeStop() {
     this.ready = false;
     this.plugin.getLogger('dispatcher').info('app is stopping, draining local queues...');
 
-    while (this.saving || this.executing || this.events.length || this.pending.length) {
+    if (this.recovering) {
+      await this.recovering;
+    }
+
+    while (this.saving || this.executing || this.events.length) {
       if (this.saving) {
         await this.saving;
       }
@@ -222,97 +233,157 @@ export default class Dispatcher {
       if (this.events.length && !this.saving) {
         this.saveEvent();
       }
-      if (this.pending.length && !this.executing) {
-        this.dispatch();
-      }
       await new Promise((resolve) => setImmediate(resolve));
     }
 
     this.plugin.getLogger('dispatcher').info('local queues drained');
   }
 
-  public dispatch() {
-    if (!this.ready && !this.pending.length && !this.events.length) {
+  public async recover(options: { gracePeriod?: number } = {}) {
+    if (!this.ready) {
       return;
     }
 
-    if (this.executing) {
-      this.plugin.getLogger('dispatcher').warn(`workflow executing is not finished, new dispatching will be ignored`);
+    if (this.recovering) {
+      await this.recovering;
       return;
     }
 
-    if (this.events.length) {
-      this.saveEvent();
-      return;
-    }
-
-    this.executing = (async () => {
-      let next: ExecutionPlan | null = null;
-      let pending: Pending | null = null;
-      try {
-        pending = this.pending.shift() ?? null;
-        if (pending || (this.ready && this.plugin.serving())) {
-          const execution: ExecutionModel | null = await this.prepare(pending?.execution ?? null, {
-            immediate: pending?.immediate,
-          });
-          if (execution) {
-            next = [execution, pending?.job, pending?.rerun];
-          }
-          if (pending && next) {
-            this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
-          }
-        } else {
-          this.plugin
-            .getLogger('dispatcher')
-            .warn(
-              `${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance or app not ready, new dispatching will be ignored`,
-            );
-        }
-        if (next) {
-          try {
-            await this.process(next[0], next[1], { rerun: next[2] });
-          } catch (error) {
-            this.plugin.getLogger(next[0].workflowId).error(`execution (${next[0].id}) process failed`, { error });
-            if (pending && isLockAcquireError(error)) {
-              this.pending.unshift({ ...pending, execution: next[0], immediate: true });
-            }
-          }
-        }
-      } catch (error) {
-        this.plugin.getLogger('dispatcher').error(`workflow dispatch failed`, { error });
-        if (pending) {
-          const dispatchAttempts = (pending.dispatchAttempts ?? 0) + 1;
-          if (dispatchAttempts < PENDING_DISPATCH_MAX_ATTEMPTS) {
-            this.pending.push({ ...pending, dispatchAttempts });
-          } else {
-            this.plugin
-              .getLogger(pending.execution.workflowId)
-              .error(`pending execution (${pending.execution.id}) dispatch failed, local retry limit reached`, {
-                error,
-                dispatchAttempts,
-              });
-          }
-        }
-      } finally {
-        setImmediate(() => {
-          this.executing = null;
-
-          if (next || this.pending.length) {
-            this.plugin.getLogger('dispatcher').debug(`last process finished, will do another dispatch`);
-            this.dispatch();
-          }
-        });
+    const recovering = this.recoverQueueTasks(options.gracePeriod ?? 0);
+    this.recovering = recovering;
+    try {
+      await recovering;
+    } finally {
+      if (this.recovering === recovering) {
+        this.recovering = null;
       }
-    })();
+    }
   }
 
-  public async run(pending: Pending): Promise<void> {
-    this.pending.push({
-      ...pending,
-      immediate: !this.executing && !this.pending.length && !this.saving && !this.events.length,
-    });
+  private async recoverQueueTasks(gracePeriod: number) {
+    const logger = this.plugin.getLogger('dispatcher');
 
-    this.dispatch();
+    try {
+      if (!this.plugin.serving()) {
+        logger.warn(
+          `${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance, workflow queue recovery will be ignored`,
+        );
+        return;
+      }
+
+      let lock;
+      try {
+        lock = await this.plugin.app.lockManager.tryAcquire(`workflow:recover:${this.plugin.app.name}`);
+      } catch (error) {
+        if (isLockAcquireError(error)) {
+          logger.debug(`workflow queue recovery is already running on another instance`);
+          return;
+        }
+        throw error;
+      }
+
+      await lock.runExclusive(async () => {
+        let executionCursor: ID | null = null;
+        while (this.ready) {
+          const executions = await this.findQueueingExecutions(executionCursor, gracePeriod);
+          if (!executions.length) {
+            break;
+          }
+          for (const execution of executions) {
+            if (!this.ready) {
+              return;
+            }
+            await this.enqueue({ executionId: execution.id });
+          }
+          executionCursor = executions[executions.length - 1].id;
+        }
+      }, RECOVERY_LOCK_TTL);
+    } catch (error) {
+      logger.error(`workflow queue recovery failed`, { error });
+    }
+  }
+
+  public async enqueue(task: WorkflowQueueTask): Promise<void> {
+    await this.plugin.app.eventQueue.publish(this.plugin.channelPendingExecution, task, {
+      maxRetries: QUEUE_TASK_MAX_ATTEMPTS - 1,
+    });
+  }
+
+  private async loadJob(jobId: ID | undefined): Promise<JobModel | null> {
+    if (jobId == null) {
+      return null;
+    }
+    return this.plugin.db.getRepository('jobs').findOne({
+      filterByTk: jobId,
+    }) as Promise<JobModel | null>;
+  }
+
+  private async findQueueingExecutions(afterId: ID | null, gracePeriod: number): Promise<ExecutionModel[]> {
+    const executions = (await this.plugin.db.getRepository('executions').find({
+      filter: {
+        ...(afterId == null ? {} : { id: { $gt: afterId } }),
+        ...(gracePeriod > 0 ? { createdAt: { $lt: new Date(Date.now() - gracePeriod) } } : {}),
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+        startedAt: null,
+        'workflow.enabled': true,
+      },
+      sort: 'id',
+      limit: RECOVERY_BATCH_SIZE,
+    })) as ExecutionModel[];
+    for (const execution of executions) {
+      this.plugin.getLogger(execution.workflowId).info(`queueing execution (${execution.id}) found, publishing task`);
+    }
+    return executions;
+  }
+
+  private async resolveTask(task: WorkflowQueueTask): Promise<ExecutionPlan | null> {
+    const executionInput = (await this.plugin.db.getRepository('executions').findOne({
+      filterByTk: task.executionId,
+    })) as ExecutionModel;
+    if (!executionInput) {
+      this.plugin.getLogger('dispatcher').warn(`execution (${task.executionId}) not found, queue task ignored`);
+      return null;
+    }
+
+    if (
+      task.jobId == null &&
+      task.rerun == null &&
+      executionInput.status === EXECUTION_STATUS.STARTED &&
+      executionInput.startedAt
+    ) {
+      this.plugin
+        .getLogger(executionInput.workflowId)
+        .warn(`execution (${executionInput.id}) has already started, start task ignored`);
+      return null;
+    }
+
+    let job: JobModel | null = null;
+    if (task.jobId != null) {
+      job = await this.loadJob(task.jobId);
+      if (!job) {
+        this.plugin.getLogger(executionInput.workflowId).warn(`job (${task.jobId}) not found, resume ignored`);
+        return null;
+      }
+      if (String(job.executionId) !== String(executionInput.id)) {
+        this.plugin
+          .getLogger(executionInput.workflowId)
+          .warn(`job (${job.id}) does not belong to execution (${executionInput.id}), resume ignored`);
+        return null;
+      }
+    }
+
+    const execution = await this.prepare(executionInput);
+    if (!execution) {
+      return null;
+    }
+
+    if (job) {
+      job.execution = execution;
+      return [execution, job];
+    }
+
+    return [execution, undefined, task.rerun];
   }
 
   private async triggerSync(
@@ -449,10 +520,10 @@ export default class Dispatcher {
   }
 
   private async prepare(
-    input: ExecutionModel | null,
+    input: ExecutionModel,
     options: { transaction?: Transaction | null; immediate?: boolean } = {},
   ): Promise<ExecutionModel | null> {
-    const logger = input ? this.plugin.getLogger(input.workflowId) : this.plugin.getLogger('dispatcher');
+    const logger = this.plugin.getLogger(input.workflowId);
 
     // NOTE: when a transaction is provided by the caller (e.g. sync trigger),
     // the transaction boundary is managed externally, so run once without retry.
@@ -473,7 +544,7 @@ export default class Dispatcher {
     let result: ExecutionModel | null = null;
     // NOTE: acquireWithRetry rethrows non-concurrent errors (e.g. failing to open the
     // transaction itself). Catch them here and return null so a failed acquire neither
-    // throws to the dispatch loop (which would leave `executing` stuck) nor mutates the
+    // throws to the queue worker (which would leave `executing` stuck) nor mutates the
     // execution state.
     try {
       await this.acquireWithRetry(
@@ -499,12 +570,8 @@ export default class Dispatcher {
         },
         {
           logger,
-          conflictMessage: input
-            ? `acquiring pending execution (${input.id}) conflicted with another worker, retrying`
-            : `acquiring execution conflicted with another worker, retrying`,
-          maxAttemptsMessage: input
-            ? `acquiring pending execution (${input.id}) reached max retry attempts`
-            : `acquiring execution reached max retry attempts, will retry on next dispatch`,
+          conflictMessage: `acquiring queue task execution (${input.id}) conflicted with another worker, retrying`,
+          maxAttemptsMessage: `acquiring queue task execution (${input.id}) reached max retry attempts`,
         },
       );
     } catch (error) {
@@ -517,46 +584,15 @@ export default class Dispatcher {
   }
 
   private async acquireExecution(
-    input: ExecutionModel | null,
+    input: ExecutionModel,
     options: { immediate?: boolean },
     transaction: Transaction,
   ): Promise<ExecutionModel | null> {
-    let execution: ExecutionModel | null = input;
-    if (execution) {
-      if (!options.immediate || execution.status !== EXECUTION_STATUS.QUEUEING) {
-        await execution.reload({ transaction });
-      }
-    } else {
-      const workflowIds = [...this.plugin.enabledCache.keys()];
-      if (!workflowIds.length) {
-        this.plugin.getLogger('dispatcher').debug(`no enabled workflow to process`);
-        return null;
-      }
-
-      execution = (await this.plugin.db.getRepository('executions').findOne({
-        filter: {
-          dispatched: false,
-          status: EXECUTION_STATUS.QUEUEING,
-          startedAt: null,
-          workflowId: workflowIds,
-        },
-        sort: 'id',
-        transaction,
-        lock: transaction.LOCK.UPDATE,
-        skipLocked: true,
-      })) as ExecutionModel;
-      if (execution) {
-        this.plugin.getLogger(execution.workflowId).info(`execution (${execution.id}) fetched from db`);
-      } else {
-        this.plugin.getLogger('dispatcher').debug(`no execution in db queued to process`);
-      }
+    if (!options.immediate || input.status !== EXECUTION_STATUS.QUEUEING) {
+      await input.reload({ transaction });
     }
 
-    if (!execution) {
-      return null;
-    }
-
-    return this.enter(execution, transaction);
+    return this.enter(input, transaction);
   }
 
   private async acquireWithRetry(
@@ -665,7 +701,7 @@ export default class Dispatcher {
     const run = async () => {
       if (!execution.dispatched) {
         await execution.update({ dispatched: true, status: EXECUTION_STATUS.STARTED });
-        logger.info(`execution (${execution.id}) from pending list updated to started`);
+        logger.info(`execution (${execution.id}) from workflow queue updated to started`);
       }
       this.plugin.timeoutManager.scheduleExecutionTimeout(execution);
       const processor = this.plugin.createProcessor(execution, processorOptions);

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Plugin.ts
@@ -21,12 +21,13 @@ import { SequelizeCollectionManager } from '@nocobase/data-source-manager';
 import { Logger, LoggerOptions } from '@nocobase/logger';
 
 import Dispatcher, { EventOptions } from './Dispatcher';
-import Processor from './Processor';
+import Processor, { ProcessorRerunOptions } from './Processor';
 import ExecutionTimeoutManager from './ExecutionTimeoutManager';
 import RunningExecutionRegistry from './RunningExecutionRegistry';
 import initActions from './actions';
 import { NodeValidationError } from './actions/nodes';
 import { WorkflowValidationError } from './actions/workflows';
+import { EXECUTION_STATUS } from './constants';
 import initFunctions, { CustomFunction } from './functions';
 import Trigger from './triggers';
 import CollectionTrigger from './triggers/CollectionTrigger';
@@ -42,7 +43,7 @@ import QueryInstruction from './instructions/QueryInstruction';
 import UpdateInstruction from './instructions/UpdateInstruction';
 import MultiConditionsInstruction from './instructions/MultiConditionsInstruction';
 
-import type { ExecutionModel, WorkflowModel } from './types';
+import type { ExecutionModel, JobModel, WorkflowModel } from './types';
 import WorkflowRepository from './repositories/WorkflowRepository';
 import type { Transaction } from '@nocobase/database';
 
@@ -174,21 +175,21 @@ export default class PluginWorkflowServer extends Plugin {
     }
 
     this.checker = setInterval(() => {
-      this.dispatcher.dispatch();
+      this.dispatcher.recover({ gracePeriod: 60_000 });
     }, 300_000);
 
     await this.timeoutManager.load();
 
-    this.app.on('workflow:dispatch', () => {
-      this.app.logger.info('workflow:dispatch');
-      this.dispatcher.dispatch();
+    this.app.on('workflow:recover', () => {
+      this.app.logger.info('workflow:recover');
+      this.dispatcher.recover();
     });
 
     this.dispatcher.setReady(true);
 
     // check for queueing executions
     this.getLogger('dispatcher').info('(starting) check for queueing executions');
-    this.dispatcher.dispatch();
+    this.dispatcher.recover();
   };
 
   private onBeforeStop = async () => {
@@ -203,8 +204,6 @@ export default class PluginWorkflowServer extends Plugin {
     for (const workflow of this.enabledCache.values()) {
       this.toggle(workflow, false, { silent: true });
     }
-
-    this.app.eventQueue.unsubscribe(this.channelPendingExecution);
 
     this.loggerCache.clear();
   };
@@ -449,7 +448,7 @@ export default class PluginWorkflowServer extends Plugin {
 
     this.app.eventQueue.subscribe(this.channelPendingExecution, {
       idle: () => this.serving() && this.dispatcher.idle,
-      process: this.dispatcher.onQueueExecution,
+      process: this.dispatcher.onQueueTask,
     });
   }
 
@@ -510,28 +509,79 @@ export default class PluginWorkflowServer extends Plugin {
     return this.dispatcher.trigger(workflow, context, options);
   }
 
-  public async run(pending: Parameters<Dispatcher['run']>[0]): Promise<void> {
-    return this.dispatcher.run(pending);
+  public async rerun(execution: ExecutionModel | ID, rerun?: ProcessorRerunOptions): Promise<void> {
+    return this.dispatcher.enqueue({ executionId: this.getModelId(execution), rerun: rerun ?? {} });
   }
 
-  public dispatch() {
-    return this.dispatcher.dispatch();
+  public recover() {
+    return this.dispatcher.recover();
   }
 
-  public async resume(job) {
-    return this.dispatcher.resume(job);
+  /**
+   * Persist the current job state and publish a poke that evaluates that state.
+   *
+   * PENDING resume calls are valid for instructions such as delay and sequential approval.
+   * Callers that aggregate multiple user actions must only call this method when their
+   * atomic update changes the job from PENDING to a terminal status.
+   * Persistence and queue publication failures are logged and rethrown to awaiting callers.
+   */
+  public async resume(job: JobModel): Promise<void> {
+    const executionId = job.executionId ?? job.execution?.id;
+    if (executionId == null) {
+      this.getLogger('dispatcher').warn(`execution id of job (${job.id}) not found, resume ignored`);
+      return;
+    }
+
+    try {
+      if (job.changed()) {
+        await job.save();
+      }
+    } catch (error) {
+      this.getLogger('dispatcher').error(
+        `persisting job (${job.id}) before resuming execution (${executionId}) failed`,
+        { error, executionId, jobId: job.id },
+      );
+      throw error;
+    }
+
+    try {
+      await this.dispatcher.enqueue({ executionId, jobId: job.id });
+      this.getLogger('dispatcher').info(`execution (${executionId}) resuming from job (${job.id}) published to queue`);
+    } catch (error) {
+      this.getLogger('dispatcher').error(
+        `publishing resume task for execution (${executionId}) from job (${job.id}) failed`,
+        { error, executionId, jobId: job.id },
+      );
+      throw error;
+    }
   }
 
   /**
    * Start a deferred execution
    * @experimental
    */
-  public async start(execution: ExecutionModel) {
-    return this.dispatcher.start(execution);
+  public async start(execution: ExecutionModel | ID): Promise<void> {
+    if (typeof execution !== 'string' && typeof execution !== 'number') {
+      if (
+        execution.status !== EXECUTION_STATUS.QUEUEING &&
+        execution.status !== EXECUTION_STATUS.STARTED &&
+        execution.status != null
+      ) {
+        return;
+      }
+      if (execution.status === EXECUTION_STATUS.STARTED && execution.startedAt) {
+        return;
+      }
+    }
+    return this.dispatcher.enqueue({ executionId: this.getModelId(execution) });
   }
 
   public createProcessor(execution: ExecutionModel, options = {}): Processor {
     return new Processor(execution, { ...options, plugin: this });
+  }
+
+  private getModelId(input: ExecutionModel | ID): ID {
+    return typeof input === 'string' || typeof input === 'number' ? input : input.id;
   }
 
   async execute(workflow: WorkflowModel, values, options: EventOptions = {}) {

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -311,7 +311,7 @@ export default class Processor {
     }
   }
 
-  public resolveRerun(options: ProcessorRerunOptions = {}) {
+  private resolveRerun(options: ProcessorRerunOptions = {}) {
     const node = this.getRerunNode(options.nodeId);
     const targetJob = this.jobsMapByNodeKey[node.key];
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -7,14 +7,17 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import fs from 'node:fs/promises';
+
 import { MockServer } from '@nocobase/test';
 import Database, { Transaction } from '@nocobase/database';
+import { storagePathJoin } from '@nocobase/utils';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { vi } from 'vitest';
 
 import Plugin, { Processor } from '..';
-import { EXECUTION_STATUS } from '../constants';
-import type { ExecutionModel } from '../types';
+import { EXECUTION_STATUS, JOB_STATUS } from '../constants';
+import type { ExecutionModel, JobModel } from '../types';
 
 describe('workflow > Plugin', () => {
   let app: MockServer;
@@ -23,7 +26,12 @@ describe('workflow > Plugin', () => {
   let WorkflowModel;
   let plugin: Plugin;
 
+  const removeEventQueueStorage = async (appName = 'main') => {
+    await fs.rm(storagePathJoin('apps', appName, 'event-queue.json'), { force: true });
+  };
+
   beforeEach(async () => {
+    await removeEventQueueStorage();
     app = await getApp();
     db = app.db;
     WorkflowModel = db.getCollection('workflows').model;
@@ -31,7 +39,16 @@ describe('workflow > Plugin', () => {
     plugin = app.pm.get(Plugin) as Plugin;
   });
 
-  afterEach(() => app.destroy());
+  afterEach(async () => {
+    if (!app) {
+      await removeEventQueueStorage();
+      return;
+    }
+
+    const appName = app.name;
+    await app.destroy();
+    await removeEventQueueStorage(appName);
+  });
 
   describe('useDataSourceTransaction', () => {
     it('create should reuse the incoming same-datasource transaction', async () => {
@@ -282,8 +299,122 @@ describe('workflow > Plugin', () => {
   });
 
   describe('dispatcher', () => {
+    type DispatcherState = {
+      saving: Promise<unknown> | null;
+      executing: Promise<unknown> | null;
+    };
+
+    type PersistedWorkflowQueueTask = {
+      executionId: number | string;
+      jobId?: number | string;
+      rerun?: {
+        nodeId?: number | string;
+        overwrite?: boolean;
+      };
+    };
+
+    type PersistedQueueMessage = {
+      id: string;
+      content: PersistedWorkflowQueueTask;
+      options?: unknown;
+    };
+
+    const getDispatcher = () => (plugin as unknown as { dispatcher: DispatcherState }).dispatcher;
+
+    const waitFor = async <T>(load: () => Promise<T>, matched: (value: T) => boolean): Promise<T> => {
+      let value = await load();
+      for (let i = 0; i < 40; i++) {
+        if (matched(value)) {
+          return value;
+        }
+        await sleep(100);
+        value = await load();
+      }
+      return value;
+    };
+
+    const drainDispatcher = async () => {
+      const dispatcher = getDispatcher();
+      await dispatcher.saving?.catch(() => null);
+      await dispatcher.executing?.catch(() => null);
+    };
+
+    const closeQueueAndReadPersistedTasks = async (): Promise<PersistedQueueMessage[]> => {
+      await app.eventQueue.close();
+      const raw = await fs.readFile(storagePathJoin('apps', app.name, 'event-queue.json'), 'utf8');
+      const queues = JSON.parse(raw) as Record<string, PersistedQueueMessage[]>;
+      return queues[app.eventQueue.getFullChannel(plugin.channelPendingExecution)] ?? [];
+    };
+
+    it('should preserve resume save errors for awaiting callers', async () => {
+      const error = new Error('simulated save failure');
+      const job = {
+        id: 'job-1',
+        executionId: 'execution-1',
+        changed: () => true,
+        save: vi.fn().mockRejectedValue(error),
+      } as unknown as JobModel;
+
+      await expect(plugin.resume(job)).rejects.toBe(error);
+    });
+
+    it('should preserve resume publish errors for awaiting callers', async () => {
+      type EnqueueDispatcher = DispatcherState & {
+        enqueue(task: { executionId: number | string; jobId: number | string }): Promise<void>;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: EnqueueDispatcher }).dispatcher;
+      const error = new Error('simulated publish failure');
+      const enqueue = vi.spyOn(dispatcher, 'enqueue').mockRejectedValueOnce(error);
+      const job = {
+        id: 'job-1',
+        executionId: 'execution-1',
+        changed: () => false,
+      } as unknown as JobModel;
+
+      await expect(plugin.resume(job)).rejects.toBe(error);
+      expect(enqueue).toHaveBeenCalledWith({ executionId: job.executionId, jobId: job.id });
+    });
+
+    it('should serialize queue callbacks delivered concurrently by an adapter', async () => {
+      type SerialDispatcher = DispatcherState & {
+        onQueueTask(event: { executionId: string }, options?: unknown): Promise<void>;
+        resolveTask(task: { executionId: string }): Promise<null>;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: SerialDispatcher }).dispatcher;
+      const calls: string[] = [];
+      let notifyFirstEntered!: () => void;
+      let releaseFirst!: () => void;
+      const firstEntered = new Promise<void>((resolve) => {
+        notifyFirstEntered = resolve;
+      });
+      const firstBlocked = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const resolveTask = vi.spyOn(dispatcher, 'resolveTask').mockImplementation(async (task) => {
+        calls.push(`start:${task.executionId}`);
+        if (task.executionId === 'first') {
+          notifyFirstEntered();
+          await firstBlocked;
+        }
+        calls.push(`end:${task.executionId}`);
+        return null;
+      });
+
+      const first = dispatcher.onQueueTask({ executionId: 'first' });
+      await firstEntered;
+      const second = dispatcher.onQueueTask({ executionId: 'second' });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(calls).toEqual(['start:first']);
+
+      releaseFirst();
+      await Promise.all([first, second]);
+      expect(calls).toEqual(['start:first', 'end:first', 'start:second', 'end:second']);
+      expect(dispatcher.executing).toBeNull();
+      resolveTask.mockRestore();
+    });
+
     it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
-      'should acquire pending execution only once under concurrent dispatch',
+      'should acquire queueing execution only once under concurrent prepare',
       async () => {
         const w1 = await WorkflowModel.create({
           enabled: true,
@@ -300,10 +431,10 @@ describe('workflow > Plugin', () => {
           filterByTk: e1.id,
         })) as ExecutionModel;
 
-        type PendingDispatcher = {
-          prepare(input: ExecutionModel | null, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
+        type QueueingDispatcher = {
+          prepare(input: ExecutionModel, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
         };
-        const dispatcher = (plugin as unknown as { dispatcher: PendingDispatcher }).dispatcher;
+        const dispatcher = (plugin as unknown as { dispatcher: QueueingDispatcher }).dispatcher;
 
         const acquired = await Promise.all([
           dispatcher.prepare(e1, { immediate: true }),
@@ -319,7 +450,7 @@ describe('workflow > Plugin', () => {
       },
     );
 
-    it('should not acquire pending execution when acquire transaction fails', async () => {
+    it('should not acquire queueing execution when acquire transaction fails', async () => {
       const w1 = await WorkflowModel.create({
         enabled: true,
         type: 'asyncTrigger',
@@ -332,10 +463,10 @@ describe('workflow > Plugin', () => {
         status: EXECUTION_STATUS.QUEUEING,
       });
 
-      type PendingDispatcher = {
-        prepare(input: ExecutionModel | null, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
+      type QueueingDispatcher = {
+        prepare(input: ExecutionModel, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
       };
-      const dispatcher = (plugin as unknown as { dispatcher: PendingDispatcher }).dispatcher;
+      const dispatcher = (plugin as unknown as { dispatcher: QueueingDispatcher }).dispatcher;
       const transaction = db.sequelize.transaction;
       db.sequelize.transaction = (async () => {
         throw new Error('simulated transaction failure');
@@ -400,11 +531,11 @@ describe('workflow > Plugin', () => {
       expect(onTriggerFail.mock.calls[0][3]).toBeInstanceOf(Error);
     });
 
-    it('should recover after unexpected dispatch error before cleanup', async () => {
+    it('should recover after unexpected recovery error before cleanup', async () => {
       type RecoveringDispatcher = {
-        dispatch(): void;
+        recover(): Promise<void>;
         executing: Promise<unknown> | null;
-        pending: unknown[];
+        saving: Promise<unknown> | null;
         idle: boolean;
       };
       const dispatcher = (plugin as unknown as { dispatcher: RecoveringDispatcher }).dispatcher;
@@ -433,17 +564,20 @@ describe('workflow > Plugin', () => {
       }) as typeof plugin.serving;
 
       try {
-        dispatcher.dispatch();
+        await dispatcher.recover();
+        await dispatcher.saving?.catch(() => null);
         await dispatcher.executing?.catch(() => null);
 
         for (let i = 0; i < 20; i++) {
-          if (!dispatcher.executing) {
+          if (!dispatcher.executing && !dispatcher.saving) {
             break;
           }
           await sleep(50);
         }
+        await dispatcher.saving?.catch(() => null);
 
         expect(dispatcher.executing).toBeNull();
+        expect(dispatcher.saving).toBeNull();
         expect(dispatcher.idle).toBe(true);
 
         plugin.serving = serving;
@@ -471,18 +605,19 @@ describe('workflow > Plugin', () => {
         expect(e2?.dispatched).toBe(true);
       } finally {
         plugin.serving = serving;
+        await dispatcher.saving?.catch(() => null);
         await dispatcher.executing?.catch(() => null);
+        dispatcher.saving = null;
         dispatcher.executing = null;
-        dispatcher.pending = [];
       }
     });
 
-    it('should stop retrying local pending after repeated unexpected dispatch errors', async () => {
+    it('should stop retrying queued task after repeated unexpected queue errors', async () => {
       type RecoveringDispatcher = {
-        run(pending: { execution: ExecutionModel }): Promise<void>;
-        prepare(input: ExecutionModel | null, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
+        enqueue(task: { executionId: number | string; jobId?: number | string; rerun?: unknown }): Promise<void>;
+        prepare(input: ExecutionModel, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
         executing: Promise<unknown> | null;
-        pending: unknown[];
+        saving: Promise<unknown> | null;
       };
       const dispatcher = (plugin as unknown as { dispatcher: RecoveringDispatcher }).dispatcher;
       const prepare = dispatcher.prepare;
@@ -508,13 +643,13 @@ describe('workflow > Plugin', () => {
       }) as typeof dispatcher.prepare;
 
       try {
-        await dispatcher.run({ execution: e1 });
+        await dispatcher.enqueue({ executionId: e1.id });
 
-        for (let i = 0; i < 20; i++) {
-          if (!dispatcher.executing && !dispatcher.pending.length) {
+        for (let i = 0; i < 40; i++) {
+          if (prepareCalls >= 3 && !dispatcher.executing) {
             break;
           }
-          await sleep(50);
+          await sleep(100);
         }
 
         const callsAfterDrain = prepareCalls;
@@ -523,7 +658,6 @@ describe('workflow > Plugin', () => {
         expect(callsAfterDrain).toBe(3);
         expect(prepareCalls).toBe(callsAfterDrain);
         expect(dispatcher.executing).toBeNull();
-        expect(dispatcher.pending).toHaveLength(0);
 
         dispatcher.prepare = prepare;
 
@@ -549,9 +683,249 @@ describe('workflow > Plugin', () => {
         expect(e2?.status).toBe(EXECUTION_STATUS.RESOLVED);
       } finally {
         dispatcher.prepare = prepare;
+        await dispatcher.saving?.catch(() => null);
         await dispatcher.executing?.catch(() => null);
+        dispatcher.saving = null;
         dispatcher.executing = null;
-        dispatcher.pending = [];
+      }
+    });
+
+    it('should ignore duplicate start task for already started execution', async () => {
+      type QueueingDispatcher = {
+        enqueue(task: { executionId: number | string }): Promise<void>;
+        executing: Promise<unknown> | null;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: QueueingDispatcher }).dispatcher;
+
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await w1.createNode({
+        type: 'echo',
+      });
+      const e1 = await w1.createExecution({
+        key: w1.key,
+        context: {},
+        dispatched: true,
+        status: EXECUTION_STATUS.STARTED,
+        startedAt: new Date(),
+      });
+
+      await dispatcher.enqueue({ executionId: e1.id });
+      await sleep(500);
+
+      for (let i = 0; i < 20; i++) {
+        if (!dispatcher.executing) {
+          break;
+        }
+        await sleep(50);
+      }
+      await dispatcher.executing?.catch(() => null);
+
+      const jobs = await e1.getJobs();
+      await e1.reload();
+      expect(jobs).toHaveLength(0);
+      expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+    });
+
+    it('should persist queued start task outside dispatcher memory and process after queue reconnects', async () => {
+      const serving = plugin.serving;
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await w1.createNode({
+        type: 'echo',
+      });
+
+      plugin.serving = (() => false) as typeof plugin.serving;
+
+      try {
+        plugin.trigger(w1, { queued: true });
+        await drainDispatcher();
+
+        const [e1] = await waitFor(
+          () => w1.getExecutions({ order: [['id', 'ASC']] }) as Promise<ExecutionModel[]>,
+          (executions) => executions.length === 1,
+        );
+
+        await sleep(500);
+        await e1.reload();
+        expect(e1.dispatched).toBe(false);
+        expect(e1.status).toBe(EXECUTION_STATUS.QUEUEING);
+        expect(await e1.getJobs()).toHaveLength(0);
+
+        const queuedTasks = await closeQueueAndReadPersistedTasks();
+        expect(queuedTasks).toEqual([
+          expect.objectContaining({
+            content: {
+              executionId: e1.id,
+            },
+          }),
+        ]);
+
+        plugin.serving = serving;
+        await app.eventQueue.connect();
+
+        const [processed] = await waitFor(
+          async () => {
+            await e1.reload();
+            return [e1] as ExecutionModel[];
+          },
+          ([execution]) => execution.status === EXECUTION_STATUS.RESOLVED,
+        );
+        expect(processed.dispatched).toBe(true);
+        expect(processed.status).toBe(EXECUTION_STATUS.RESOLVED);
+      } finally {
+        plugin.serving = serving;
+        if (!app.eventQueue.isConnected()) {
+          await app.eventQueue.connect();
+        }
+        await drainDispatcher();
+      }
+    });
+
+    it('should persist queued resume task outside dispatcher memory and process after queue reconnects', async () => {
+      const serving = plugin.serving;
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      const n1 = await w1.createNode({
+        type: 'pending',
+      });
+      const n2 = await w1.createNode({
+        type: 'echo',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      plugin.trigger(w1, {});
+
+      const [e1] = await waitFor(
+        () => w1.getExecutions({ order: [['id', 'ASC']] }) as Promise<ExecutionModel[]>,
+        ([execution]) => execution?.status === EXECUTION_STATUS.STARTED,
+      );
+      const [pendingJob] = await waitFor(
+        () => e1.getJobs({ where: { nodeId: n1.id } }),
+        (jobs) => jobs.length === 1 && jobs[0].status === JOB_STATUS.PENDING,
+      );
+
+      plugin.serving = (() => false) as typeof plugin.serving;
+
+      try {
+        await pendingJob.update({
+          status: JOB_STATUS.RESOLVED,
+          result: {
+            resumed: true,
+          },
+        });
+        await plugin.resume(pendingJob);
+
+        await sleep(500);
+        await e1.reload();
+        expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
+        expect(await e1.getJobs({ where: { nodeId: n2.id } })).toHaveLength(0);
+
+        const queuedTasks = await closeQueueAndReadPersistedTasks();
+        expect(queuedTasks).toEqual([
+          expect.objectContaining({
+            content: {
+              executionId: e1.id,
+              jobId: pendingJob.id,
+            },
+          }),
+        ]);
+
+        plugin.serving = serving;
+        await app.eventQueue.connect();
+
+        const [processed] = await waitFor(
+          async () => {
+            await e1.reload();
+            return [e1] as ExecutionModel[];
+          },
+          ([execution]) => execution.status === EXECUTION_STATUS.RESOLVED,
+        );
+        expect(processed.status).toBe(EXECUTION_STATUS.RESOLVED);
+        expect(await e1.getJobs({ where: { nodeId: n2.id } })).toHaveLength(1);
+      } finally {
+        plugin.serving = serving;
+        if (!app.eventQueue.isConnected()) {
+          await app.eventQueue.connect();
+        }
+        await drainDispatcher();
+      }
+    });
+
+    it('should persist queued rerun task outside dispatcher memory and process after queue reconnects', async () => {
+      const serving = plugin.serving;
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      const n1 = await w1.createNode({
+        type: 'echo',
+      });
+      const n2 = await w1.createNode({
+        type: 'pending',
+        upstreamId: n1.id,
+      });
+      await n1.setDownstream(n2);
+
+      plugin.trigger(w1, {});
+
+      const [e1] = await waitFor(
+        () => w1.getExecutions({ order: [['id', 'ASC']] }) as Promise<ExecutionModel[]>,
+        ([execution]) => execution?.status === EXECUTION_STATUS.STARTED,
+      );
+      await waitFor(
+        () => e1.getJobs({ order: [['id', 'ASC']] }),
+        (jobs) =>
+          jobs.filter((job) => job.nodeId === n1.id).length === 1 &&
+          jobs.filter((job) => job.nodeId === n2.id).length === 1,
+      );
+
+      plugin.serving = (() => false) as typeof plugin.serving;
+
+      try {
+        await plugin.rerun(e1, { nodeId: n1.id });
+
+        await sleep(500);
+        const jobsBeforeReconnect = await e1.getJobs({ order: [['id', 'ASC']] });
+        expect(jobsBeforeReconnect.filter((job) => job.nodeId === n1.id)).toHaveLength(1);
+        expect(jobsBeforeReconnect.filter((job) => job.nodeId === n2.id)).toHaveLength(1);
+
+        const queuedTasks = await closeQueueAndReadPersistedTasks();
+        expect(queuedTasks).toEqual([
+          expect.objectContaining({
+            content: {
+              executionId: e1.id,
+              rerun: {
+                nodeId: n1.id,
+              },
+            },
+          }),
+        ]);
+
+        plugin.serving = serving;
+        await app.eventQueue.connect();
+
+        const jobsAfterReconnect = await waitFor(
+          () => e1.getJobs({ order: [['id', 'ASC']] }),
+          (jobs) =>
+            jobs.filter((job) => job.nodeId === n1.id).length === 2 &&
+            jobs.filter((job) => job.nodeId === n2.id).length === 2,
+        );
+        expect(jobsAfterReconnect.filter((job) => job.nodeId === n1.id)).toHaveLength(2);
+        expect(jobsAfterReconnect.filter((job) => job.nodeId === n2.id)).toHaveLength(2);
+      } finally {
+        plugin.serving = serving;
+        if (!app.eventQueue.isConnected()) {
+          await app.eventQueue.connect();
+        }
+        await drainDispatcher();
       }
     });
 
@@ -565,40 +939,9 @@ describe('workflow > Plugin', () => {
       expect(dispatcher.isConcurrentAcquireError(error)).toBe(true);
     });
 
-    it.skipIf(process.env['DB_DIALECT'] === 'sqlite')(
-      'should acquire queueing execution only once under concurrent dispatch',
-      async () => {
-        const w1 = await WorkflowModel.create({
-          enabled: true,
-          type: 'asyncTrigger',
-        });
-
-        const e1 = await w1.createExecution({
-          key: w1.key,
-          context: {},
-          dispatched: false,
-          status: EXECUTION_STATUS.QUEUEING,
-        });
-
-        type QueueingDispatcher = {
-          prepare(input: ExecutionModel | null, options?: { immediate?: boolean }): Promise<ExecutionModel | null>;
-        };
-        const dispatcher = (plugin as unknown as { dispatcher: QueueingDispatcher }).dispatcher;
-
-        const acquired = await Promise.all([dispatcher.prepare(null), dispatcher.prepare(null)]);
-
-        const acquiredExecutions = acquired.filter((execution): execution is ExecutionModel => Boolean(execution));
-        expect(acquiredExecutions.map((execution) => execution.id)).toEqual([e1.id]);
-
-        await e1.reload();
-        expect(e1.dispatched).toBe(true);
-        expect(e1.status).toBe(EXECUTION_STATUS.STARTED);
-      },
-    );
-
     it('should skip non-queueing undispatched executions when fetching from db', async () => {
       type DbFetchDispatcher = {
-        dispatch(): void;
+        recover(): Promise<void>;
         executing: Promise<unknown> | null;
       };
       const dispatcher = (plugin as unknown as { dispatcher: DbFetchDispatcher }).dispatcher;
@@ -631,7 +974,7 @@ describe('workflow > Plugin', () => {
         status: EXECUTION_STATUS.QUEUEING,
       });
 
-      dispatcher.dispatch();
+      await dispatcher.recover();
 
       for (let i = 0; i < 20; i++) {
         await queueing.reload();
@@ -648,6 +991,113 @@ describe('workflow > Plugin', () => {
       expect(queueing.dispatched).toBe(true);
 
       await dispatcher.executing?.catch(() => null);
+    });
+
+    it('should publish all queueing executions during one recovery', async () => {
+      const dispatcher = (plugin as unknown as { dispatcher: { recover(): Promise<void> } }).dispatcher;
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await workflow.createNode({ type: 'echo' });
+      const executions = await Promise.all(
+        Array.from({ length: 3 }, (_, index) =>
+          workflow.createExecution({
+            key: workflow.key,
+            context: { index },
+            dispatched: false,
+            status: EXECUTION_STATUS.QUEUEING,
+          }),
+        ),
+      );
+
+      await Promise.all([dispatcher.recover(), dispatcher.recover()]);
+
+      const processed = await waitFor(
+        async () => {
+          await Promise.all(executions.map((execution) => execution.reload()));
+          return executions;
+        },
+        (items) => items.every((execution) => execution.status === EXECUTION_STATUS.RESOLVED),
+      );
+      expect(processed.map((execution) => execution.status)).toEqual(Array(3).fill(EXECUTION_STATUS.RESOLVED));
+      for (const execution of executions) {
+        expect(await execution.getJobs()).toHaveLength(1);
+      }
+    });
+
+    it('should skip recently created queueing executions during periodic recovery', async () => {
+      type RecoveringDispatcher = {
+        recover(options?: { gracePeriod?: number }): Promise<void>;
+      };
+      const dispatcher = (plugin as unknown as { dispatcher: RecoveringDispatcher }).dispatcher;
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await workflow.createNode({ type: 'echo' });
+      const oldExecution = await workflow.createExecution({
+        key: workflow.key,
+        context: { old: true },
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+      await sleep(1200);
+      const recentExecution = await workflow.createExecution({
+        key: workflow.key,
+        context: { recent: true },
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+
+      await dispatcher.recover({ gracePeriod: 1000 });
+
+      await waitFor(
+        async () => {
+          await oldExecution.reload();
+          return [oldExecution] as ExecutionModel[];
+        },
+        ([execution]) => execution.status === EXECUTION_STATUS.RESOLVED,
+      );
+      await recentExecution.reload();
+      expect(oldExecution.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(recentExecution.status).toBe(EXECUTION_STATUS.QUEUEING);
+      expect(recentExecution.dispatched).toBe(false);
+    });
+
+    it('should skip recovery when another instance holds the recovery lock', async () => {
+      const dispatcher = (plugin as unknown as { dispatcher: { recover(): Promise<void> } }).dispatcher;
+      const workflow = await WorkflowModel.create({
+        enabled: true,
+        type: 'asyncTrigger',
+      });
+      await workflow.createNode({ type: 'echo' });
+      const execution = await workflow.createExecution({
+        key: workflow.key,
+        context: {},
+        dispatched: false,
+        status: EXECUTION_STATUS.QUEUEING,
+      });
+      const lock = await app.lockManager.tryAcquire(`workflow:recover:${app.name}`);
+
+      try {
+        await dispatcher.recover();
+        await execution.reload();
+        expect(execution.status).toBe(EXECUTION_STATUS.QUEUEING);
+        expect(execution.dispatched).toBe(false);
+      } finally {
+        await lock.release();
+      }
+
+      await dispatcher.recover();
+      await waitFor(
+        async () => {
+          await execution.reload();
+          return [execution] as ExecutionModel[];
+        },
+        ([item]) => item.status === EXECUTION_STATUS.RESOLVED,
+      );
+      expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
     });
 
     it('multiple triggers in same event', async () => {
@@ -678,18 +1128,18 @@ describe('workflow > Plugin', () => {
         },
       });
 
-      const p1 = await PostRepo.create({ values: { title: 't1' } });
+      await PostRepo.create({ values: { title: 't1' } });
 
-      await sleep(500);
-
-      const [e1] = await w1.getExecutions();
-      expect(e1.status).toBe(EXECUTION_STATUS.RESOLVED);
-
-      const [e2] = await w2.getExecutions();
-      expect(e2.status).toBe(EXECUTION_STATUS.RESOLVED);
-
-      const [e3] = await w3.getExecutions();
-      expect(e3.status).toBe(EXECUTION_STATUS.RESOLVED);
+      const executions = await waitFor(
+        async () => {
+          const [e1] = await w1.getExecutions();
+          const [e2] = await w2.getExecutions();
+          const [e3] = await w3.getExecutions();
+          return [e1, e2, e3] as ExecutionModel[];
+        },
+        (executions) => executions.every((execution) => execution?.status === EXECUTION_STATUS.RESOLVED),
+      );
+      expect(executions.map((execution) => execution?.status)).toEqual(Array(3).fill(EXECUTION_STATUS.RESOLVED));
     });
 
     it('multiple events on same workflow', async () => {
@@ -961,7 +1411,7 @@ describe('workflow > Plugin', () => {
       expect(e1s[0].dispatched).toBe(true);
       expect(e1s[0].status).toBe(EXECUTION_STATUS.STARTED);
 
-      plugin.start(e1s[0]);
+      await plugin.start(e1s[0]);
 
       await sleep(500);
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
@@ -228,6 +228,7 @@ describe('workflow > Processor', () => {
 
       await sleep(500);
 
+      await execution.reload();
       expect(execution.status).toEqual(EXECUTION_STATUS.RESOLVED);
 
       const jobs = await execution.getJobs({ order: [['id', 'ASC']] });
@@ -264,6 +265,7 @@ describe('workflow > Processor', () => {
 
       await sleep(500);
 
+      await execution.reload();
       expect(execution.status).toEqual(EXECUTION_STATUS.ERROR);
 
       const jobs = await execution.getJobs();
@@ -454,6 +456,7 @@ describe('workflow > Processor', () => {
 
       await sleep(500);
 
+      await execution.reload();
       expect(execution.status).toEqual(EXECUTION_STATUS.ERROR);
 
       const jobs = await execution.getJobs();

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/service-splitting.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/service-splitting.test.ts
@@ -60,7 +60,7 @@ describe('workflow > service splitting > as dispatcher', () => {
   });
 
   describe('manually execute', () => {
-    it('pending node should resume', async () => {
+    it('pending node should wait for worker to resume', async () => {
       await workflow.createNode({
         type: 'asyncResume',
       });
@@ -77,7 +77,7 @@ describe('workflow > service splitting > as dispatcher', () => {
       await sleep(500);
 
       const [e2] = await workflow.getExecutions();
-      expect(e2.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(e2.status).toBe(EXECUTION_STATUS.STARTED);
 
       const j2s = await e2.getJobs();
       expect(j2s.length).toBe(1);

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/executions.ts
@@ -71,12 +71,9 @@ export async function rerun(context: Context, next: Next) {
     return context.throw(400, 'Only started executions can be rerun');
   }
 
-  await workflowPlugin.run({
-    execution,
-    rerun: {
-      nodeId,
-      overwrite: overwrite === true,
-    },
+  await workflowPlugin.rerun(execution, {
+    nodeId,
+    overwrite: overwrite === true,
   });
 
   context.body = execution;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/jobs.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/jobs.ts
@@ -53,6 +53,5 @@ export async function resume(context: Context, next: Next) {
   context.status = 202;
   await next();
 
-  job.execution = execution;
-  workflowPlugin.resume(job);
+  await workflowPlugin.resume(job);
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/types/Execution.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/types/Execution.ts
@@ -15,11 +15,13 @@ export default class ExecutionModel extends Model {
   declare static readonly database: Database;
 
   declare id: number;
+  declare workflowId: number;
   declare title: string;
   declare context: any;
   declare status: number;
   declare reason?: string | null;
   declare dispatched: boolean;
+  declare manually?: boolean | null;
   declare parentExecutionId?: number | null;
   declare stack?: Array<number | string>;
   declare startedAt?: Date | null;

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/types/Job.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/types/Job.ts
@@ -9,9 +9,12 @@
 
 import { BelongsToGetAssociationMixin, Model } from '@nocobase/database';
 import FlowNodeModel from './FlowNode';
+import ExecutionModel from './Execution';
 
 export default class JobModel extends Model {
   declare id: number;
+  declare executionId: number;
+  declare workflowId?: number;
   declare status: number;
   declare result?: any;
   declare meta?: any;
@@ -25,4 +28,7 @@ export default class JobModel extends Model {
   declare nodeId: number;
   declare node?: FlowNodeModel;
   declare getNode: BelongsToGetAssociationMixin<FlowNodeModel>;
+
+  declare execution?: ExecutionModel;
+  declare getExecution: BelongsToGetAssociationMixin<ExecutionModel>;
 }

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/utils.ts
@@ -23,6 +23,10 @@ export function getExecutionLockKey(executionId: number | string) {
   return `workflow:execution:${executionId}`;
 }
 
+export function getJobLockKey(jobId: number | string) {
+  return `workflow:job:${jobId}`;
+}
+
 export function isLockAcquireError(error: unknown) {
   return error instanceof Error && error.constructor.name === 'LockAcquireError';
 }


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Backport the workflow pending queue changes from #9846 to `main` without including unrelated commits from `next`.

### Description

- Use the event queue to schedule pending workflow tasks.
- Update manual, request, parallel, delay, script, and mailer workflow processing for the queued execution strategy.
- Update workflow dispatcher, processor, actions, types, and related test coverage.

Risk is limited to workflow scheduling and pending task execution. The backport contains a single commit on top of `main`.

### Related issues

- Backport of #9846

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved pending workflow task scheduling by processing tasks through the event queue. |
| 🇨🇳 Chinese | 改进工作流待处理任务的调度方式，通过事件队列处理任务。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
