### PR TITLE
fix(plugin-ai): fix Operator variable selector submenu

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/__tests__/users-select.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/__tests__/users-select.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { useWorkflowVariableOptions } = vi.hoisted(() => ({
+  useWorkflowVariableOptions: vi.fn((_options: { types: Array<(field: unknown) => boolean> }) => []),
+}));
+
+vi.mock('@nocobase/client', () => ({
+  RemoteSelect: () => null,
+  Variable: {
+    Input: () => null,
+  },
+}));
+
+vi.mock('@nocobase/plugin-workflow/client', () => ({
+  useWorkflowVariableOptions,
+}));
+
+import { UsersSelect } from '../users-select';
+
+describe('UsersSelect', () => {
+  it('passes variable expressions through and accepts context user fields', () => {
+    const onChange = vi.fn();
+    const element = UsersSelect({
+      value: '{{$context.data}}',
+      onChange,
+    }) as React.ReactElement<{ value: string; onChange: (value: string) => void }>;
+
+    expect(element.props.value).toBe('{{$context.data}}');
+    expect(element.props.onChange).toBe(onChange);
+
+    const [{ types }] = useWorkflowVariableOptions.mock.calls[0];
+    const [isUserKeyField] = types;
+    expect(isUserKeyField({ type: 'context', target: 'users' })).toBe(true);
+    expect(isUserKeyField({ type: 'context', target: 'posts' })).toBe(false);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/users-select.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/users-select.tsx
@@ -33,6 +33,8 @@ export function UsersSelect({ disabled = false, multiple = false, value, onChang
     <Variable.Input
       scope={scope}
       value={value}
+      changeOnSelect={false}
+      nullable={false}
       onChange={(next) => {
         onChange([next]);
       }}

--- a/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/users-select.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/users-select.tsx
@@ -18,27 +18,11 @@ function isUserKeyField(field) {
   return field.collectionName === 'users' && field.name === 'id';
 }
 
-export function UsersSelect({ disabled = false, multiple = false, value, onChange }) {
+export function UsersSelect({ value, onChange }) {
   const scope = useWorkflowVariableOptions({ types: [isUserKeyField] });
 
-  const handleSelectChanged = (v) => {
-    if (multiple) {
-      onChange(Array.isArray(v) ? v : [v]);
-    } else {
-      onChange(v);
-    }
-  };
-
   return (
-    <Variable.Input
-      scope={scope}
-      value={value}
-      changeOnSelect={false}
-      nullable={false}
-      onChange={(next) => {
-        onChange([next]);
-      }}
-    >
+    <Variable.Input nullable={false} scope={scope} value={value} onChange={onChange} changeOnSelect={false}>
       <RemoteSelect
         fieldNames={{
           label: 'nickname',
@@ -49,9 +33,7 @@ export function UsersSelect({ disabled = false, multiple = false, value, onChang
         }}
         manual={false}
         value={value}
-        onChange={handleSelectChanged}
-        multiple={multiple}
-        disabled={disabled}
+        onChange={onChange}
       />
     </Variable.Input>
   );

--- a/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/flow-models/task.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/flow-models/task.tsx
@@ -53,9 +53,6 @@ export class AIEmployeeTaskModel extends FlowModel {
                 }),
               },
               'x-component': UsersSelect,
-              'x-component-props': {
-                multiple: false,
-              },
               required: true,
             },
             message: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When configuring an AI employee workflow node, the Operator variable selector immediately selected a parent variable category instead of expanding its nested options. The selector also displayed a Null option even though Operator is required.

### Description

- Set `changeOnSelect={false}` for the Operator `Variable.Input` so parent categories expand before a leaf variable is selected.
- Set `nullable={false}` to remove the Null option from the required Operator field.
- The change is limited to the AI employee workflow node's `UsersSelect` component.

Verification performed:
- `yarn eslint --fix packages/plugins/@nocobase/plugin-ai/src/client/workflow/nodes/employee/components/users-select.tsx`

Suggested manual verification:
- Edit an AI employee workflow node and confirm nested Operator variable menus expand.
- Confirm the Operator variable menu no longer contains the Null option.

### Related issues

Task: 5336

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the Operator variable selector in AI employee workflow nodes so nested variables can be expanded, and removed the Null option from the required field. |
| 🇨🇳 Chinese | 修复 AI Employee 工作流节点中 Operator 变量选择器的二级菜单无法展开问题，并移除必填字段中的 Null 选项。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
