### PR TITLE
fix(plugin-ai): include form item custom label in AI form context

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-employees/flow-models.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-employees/flow-models.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FormBlockModel, FormItemModel } from '@nocobase/client';
+import type { FlowModel } from '@nocobase/flow-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { FlowModelsContext } from '../../ai-employees/context/flow-models';
+
+type GetContent = NonNullable<typeof FlowModelsContext.getContent>;
+type WorkContextApplication = Parameters<GetContent>[0];
+
+const createApplication = (model: FlowModel) =>
+  ({
+    flowEngine: {
+      getModel: vi.fn().mockReturnValue(model),
+    },
+  }) as unknown as WorkContextApplication;
+
+const parseContextContent = async (model: FlowModel) => {
+  const content = await FlowModelsContext.getContent?.(createApplication(model), {
+    type: 'flow-model',
+    uid: model.uid,
+  });
+  expect(content).toBeDefined();
+  return content as Record<string, unknown>;
+};
+
+const createFormItemModel = (collectionField: Record<string, unknown>, label?: string): FormItemModel => {
+  const item = Object.create(FormItemModel.prototype) as FormItemModel;
+  const define = (key: string, value: unknown) => Object.defineProperty(item, key, { value, configurable: true });
+  define('collectionField', collectionField);
+  define('props', label === undefined ? {} : { label });
+  define('subModels', {});
+  define('uid', 'form-item');
+  define('title', collectionField.title);
+  define('use', 'FormItemModel');
+  return item;
+};
+
+const createFormModel = (items: FormItemModel[], value: Record<string, unknown> = {}): FormBlockModel => {
+  const form = Object.create(FormBlockModel.prototype) as FormBlockModel;
+  const define = (key: string, propertyValue: unknown) =>
+    Object.defineProperty(form, key, { value: propertyValue, configurable: true });
+  define('uid', 'form-block');
+  define('title', 'Form block');
+  define('use', 'FormBlockModel');
+  define('form', { getFieldsValue: vi.fn().mockReturnValue(value) });
+  define('subModels', { items });
+  return form;
+};
+
+describe('FlowModelsContext form field titles', () => {
+  it('prefers the custom form item label over the collection field title', async () => {
+    const address = createFormItemModel({ name: 'address', type: 'text', title: '地址' }, '改善措施');
+    const content = await parseContextContent(createFormModel([address]));
+
+    expect(content.fields).toEqual([expect.objectContaining({ name: 'address', title: '改善措施' })]);
+  });
+
+  it('falls back to the collection field title when no custom label is set', async () => {
+    const address = createFormItemModel({ name: 'address', type: 'text', title: '地址' });
+    const content = await parseContextContent(createFormModel([address]));
+
+    expect(content.fields).toEqual([expect.objectContaining({ name: 'address', title: '地址' })]);
+  });
+
+  it('keeps the internal field name as the data key regardless of the custom label', async () => {
+    const address = createFormItemModel({ name: 'address', type: 'text', title: '地址' }, '改善措施');
+    const content = await parseContextContent(createFormModel([address], { address: '测试测试' }));
+
+    const field = (content.fields as Array<Record<string, unknown>>)[0];
+    expect(field.name).toBe('address');
+    expect(field.name).not.toBe('改善措施');
+    expect(content.value).toEqual({ address: '测试测试' });
+  });
+
+  it('outputs the custom label for form items in the generic component tree', async () => {
+    const address = createFormItemModel({ name: 'address', type: 'text', title: '地址' }, '改善措施');
+    const root = {
+      uid: 'root',
+      title: 'Root',
+      use: 'SomeContainerModel',
+      subModels: { items: [address] },
+    } as unknown as FlowModel;
+    const content = await parseContextContent(root);
+
+    const children = content.children as { items: Array<{ props: Record<string, unknown> }> };
+    expect(children.items[0].props).toMatchObject({ name: 'address', title: '改善措施' });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/context/flow-models.tsx
@@ -66,6 +66,11 @@ const getRelationFieldPrompt = (collectionField: FormItemModel['collectionField'
   }[1]", and never return only a primitive id.`;
 };
 
+const getFormItemDisplayTitle = (model: FormItemModel) => {
+  const label = (model.props as { label?: unknown })?.label;
+  return typeof label === 'string' ? label : model.collectionField.title;
+};
+
 const toSimplifyForm = (model: FormBlockModel) => {
   const result: {
     uid: string;
@@ -83,8 +88,8 @@ const toSimplifyForm = (model: FormBlockModel) => {
       const collectionField = model.collectionField;
       result.fields.push({
         name: collectionField.name,
+        title: getFormItemDisplayTitle(model),
         type: collectionField.type,
-        // title: collectionField.title,
         enum: collectionField.enum,
         readonly: collectionField.readonly,
         defaultValue: collectionField.defaultValue,
@@ -146,7 +151,7 @@ const toSimplifyComponentTree = async (model: FlowModel) => {
       name: collectionField.name,
       type: collectionField.type,
       dataType: collectionField.dataType,
-      title: collectionField.title,
+      title: getFormItemDisplayTitle(model),
       enum: collectionField.enum,
       defaultValue: collectionField.defaultValue,
     };


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When a form field has a customized label, the AI employee context should describe the field using that label. Previously, the form context either omitted the field title or used the original collection field title, which could cause the AI employee to misunderstand the field's meaning.

### Description

- Prefer the form item's customized label when building AI form context.
- Fall back to the collection field title when no customized label is configured.
- Keep the internal field name unchanged as the form value key.
- Apply the same display-title behavior to form items in the generic component tree.
- Add regression tests covering customized labels, fallback behavior, value keys, and component-tree output.

Risk is low and limited to the field title exposed in AI work context.

Testing:

```bash
yarn test packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-employees/flow-models.test.ts --run --reporter=verbose
```

### Related issues

https://test_management.v2.test.nocobase.com/nocobase/admin/s3krd1gsrf7/view/k0pob0994gu/filterbytk/5281

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI form context not using customized form item labels |
| 🇨🇳 Chinese | 修复 AI 表单上下文未使用表单项自定义标签的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
