### PR TITLE
fix(plugin-ai): sync shortcut context to active conversation

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-employees/AIEmployeeShortcutModel.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-employees/AIEmployeeShortcutModel.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AIEmployee } from '../../ai-employees/types';
+import { AIEmployeeShortcutModel } from '../../ai-employees/flow/models/AIEmployeeShortcutModel';
+import { useChatConversationsStore } from '../../ai-employees/chatbox/stores/chat-conversations';
+import { useChatMessagesStore } from '../../ai-employees/chatbox/stores/chat-messages';
+
+const mocks = vi.hoisted(() => ({
+  triggerTask: vi.fn(),
+  syncContextAttachments: vi.fn(),
+  employee: {
+    username: 'atlas',
+    nickname: 'Atlas',
+    avatar: 'baseBlue',
+  },
+}));
+
+vi.mock('antd', () => {
+  const Component = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  return {
+    Alert: Component,
+    Avatar: ({ onClick }: { onClick?: () => void }) => (
+      <button type="button" onClick={onClick}>
+        AI employee
+      </button>
+    ),
+    Card: Object.assign(Component, { Meta: Component }),
+    Input: Component,
+    Popover: Component,
+    Select: Component,
+    Spin: Component,
+    Switch: Component,
+    Tag: Component,
+    Typography: Component,
+  };
+});
+
+vi.mock('@nocobase/flow-engine', () => ({
+  FlowModel: class FlowModel {
+    static registerFlow() {}
+  },
+  observer: (component: React.ComponentType) => component,
+  tExpr: (text: string) => text,
+  useFlowContext: () => ({
+    engine: {
+      getModel: () => true,
+    },
+    model: {
+      parent: undefined,
+    },
+  }),
+  useFlowSettingsContext: vi.fn(),
+}));
+
+vi.mock('@nocobase/client', () => ({
+  AddContextButton: vi.fn(),
+  RemoteSelect: vi.fn(),
+  TextAreaWithContextSelector: vi.fn(),
+  useCompile: () => (value: string) => value,
+  useRequest: () => ({ loading: false }),
+  useToken: () => ({ token: {} }),
+}));
+
+vi.mock('../../ai-employees/avatars', () => ({
+  avatars: () => 'avatar.svg',
+}));
+
+vi.mock('../../ai-employees/ProfileCard', () => ({
+  ProfileCard: () => null,
+}));
+
+vi.mock('../../ai-employees/AddContextButton', () => ({
+  AddContextButton: () => null,
+}));
+
+vi.mock('../../ai-employees/chatbox/ContextItem', () => ({
+  ContextItem: () => null,
+}));
+
+vi.mock('../../ai-employees/chatbox/hooks/useChatBoxActions', () => ({
+  useChatBoxActions: () => ({
+    triggerTask: mocks.triggerTask,
+  }),
+}));
+
+vi.mock('../../ai-employees/chatbox/hooks/useChatMessageActions', () => ({
+  useChatMessageActions: () => ({
+    syncContextAttachments: mocks.syncContextAttachments,
+  }),
+}));
+
+vi.mock('../../repositories/hooks/useAIConfigRepository', () => ({
+  useAIConfigRepository: () => ({
+    getAIEmployees: vi.fn().mockResolvedValue([mocks.employee]),
+    getAIEmployeesMap: () => ({
+      [mocks.employee.username]: mocks.employee,
+    }),
+  }),
+}));
+
+vi.mock('../../llm-services/hooks/useLLMServiceCatalog', () => ({
+  useLLMServiceCatalog: () => ({ services: [], loading: false }),
+}));
+
+vi.mock('../../locale', () => ({
+  namespace: 'ai',
+  tExpr: (text: string) => text,
+  useT: () => (text: string) => text,
+}));
+
+describe('AIEmployeeShortcutModel', () => {
+  const employee: AIEmployee = mocks.employee;
+  const workContext = [{ type: 'flow-model' as const, uid: 'block-1' }];
+
+  beforeEach(() => {
+    mocks.triggerTask.mockReset();
+    mocks.syncContextAttachments.mockReset();
+    useChatConversationsStore.getState().setCurrentConversation(undefined);
+    useChatMessagesStore.getState().resetSessionState(undefined);
+    useChatMessagesStore.getState().resetSessionState('session-1');
+  });
+
+  it('syncs shortcut context to the new draft when replacing an existing conversation', () => {
+    useChatConversationsStore.getState().setCurrentConversation('session-1');
+    mocks.triggerTask.mockImplementation(() => {
+      useChatConversationsStore.getState().setCurrentConversation(undefined);
+      return Promise.resolve();
+    });
+
+    const model = Object.create(AIEmployeeShortcutModel.prototype) as AIEmployeeShortcutModel;
+    model.props = {
+      aiEmployee: employee,
+      context: { workContext },
+      style: {},
+    };
+
+    render(model.render());
+    fireEvent.click(screen.getByRole('button', { name: 'AI employee' }));
+
+    expect(useChatMessagesStore.getState().getSessionState(undefined).contextItems).toEqual(workContext);
+    expect(useChatMessagesStore.getState().getSessionState('session-1').contextItems).toEqual([]);
+    expect(mocks.syncContextAttachments).toHaveBeenCalledWith(workContext);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/flow/models/AIEmployeeShortcutModel.tsx
@@ -72,7 +72,6 @@ const Shortcut: React.FC<ShortcutProps> = ({
   const chat = useChat(currentConversation);
 
   const { triggerTask } = useChatBoxActions();
-  const addContextItems = chat.addContextItems;
   const { syncContextAttachments } = useChatMessageActions();
 
   const currentAvatar = useMemo(() => {
@@ -120,9 +119,10 @@ const Shortcut: React.FC<ShortcutProps> = ({
     if (!shortcutContext.length) {
       return;
     }
-    addContextItems(shortcutContext);
+    const activeConversation = useChatConversationsStore.getState().currentConversation;
+    chat.for(activeConversation).addContextItems(shortcutContext);
     syncContextAttachments(shortcutContext);
-  }, [addContextItems, getShortcutContext, syncContextAttachments]);
+  }, [chat, getShortcutContext, syncContextAttachments]);
 
   if (!aiEmployee) {
     return null;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When an AI employee shortcut was triggered while an existing conversation was active, the chat was reset to a new draft but the shortcut context was still written through a facade bound to the previous conversation. As a result, the selected block context could remain on the old conversation and be missing from the new draft.

### Description

- Resolve the active conversation when synchronizing AI employee shortcut context, so the context is written to the current draft after the conversation changes.
- Add a regression test covering replacement of an existing conversation and verifying that the old conversation remains unchanged.

The change is limited to shortcut context synchronization. Testing should focus on triggering an AI employee shortcut with block context both from a new draft and while another conversation is open.

### Related issues

- [Task 5280](https://test_management.v2.test.nocobase.com/nocobase/admin/s3krd1gsrf7/view/k0pob0994gu/filterbytk/5280)

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI employee shortcuts losing block context when starting a new conversation from an existing conversation |
| 🇨🇳 Chinese | 修复在已有会话中启动新会话时 AI 员工快捷方式丢失区块上下文的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
