### PR TITLE
fix(plugin-auth): resolve custom domain sub-app paths

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/index.ts
@@ -15,6 +15,7 @@ export {
   default,
   getModernClientPrefix,
   presetAuthType,
+  resolveSubAppSegment,
   resolveSigninPrefix,
 } from './server';
 export type { BuildRedirectPathOptions, ResolveSigninPrefixOptions } from './server';

--- a/packages/plugins/@nocobase/plugin-auth/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/index.ts
@@ -13,6 +13,7 @@ export { presetAuthType } from '../preset';
 export { defaultTokenPolicyConfig } from '../constants';
 export { buildRedirectPath, getModernClientPrefix, resolveSigninPrefix } from './utils/buildRedirectPath';
 export type { BuildRedirectPathOptions, ResolveSigninPrefixOptions } from './utils/buildRedirectPath';
+export { resolveSubAppSegment } from './utils/resolveSubAppSegment';
 
 export { default } from './plugin';
 export * from '../constants';

--- a/packages/plugins/@nocobase/plugin-auth/src/server/utils/__tests__/resolveSubAppSegment.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/utils/__tests__/resolveSubAppSegment.test.ts
@@ -54,6 +54,42 @@ describe('resolveSubAppSegment', () => {
     expect(getAppNameByCName).toHaveBeenCalledWith('sub.example.com');
   });
 
+  it('normalizes ports and comma-separated values from x-hostname', async () => {
+    const getAppNameByCName = vi.fn().mockResolvedValue('sub');
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
+      runningMode: 'multiple',
+      getAppNameByCName,
+    } as unknown as AppSupervisor);
+
+    const req = createRequest({ 'x-hostname': 'sub.example.com:443, internal.example.com' });
+    expect(await resolveSubAppSegment(req, 'sub')).toBe('');
+    expect(getAppNameByCName).toHaveBeenCalledWith('sub.example.com');
+  });
+
+  it('uses the first valid x-hostname array value', async () => {
+    const getAppNameByCName = vi.fn().mockResolvedValue('sub');
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
+      runningMode: 'multiple',
+      getAppNameByCName,
+    } as unknown as AppSupervisor);
+
+    const req = createRequest({ 'x-hostname': ['', 'sub.example.com:443'] });
+    expect(await resolveSubAppSegment(req, 'sub')).toBe('');
+    expect(getAppNameByCName).toHaveBeenCalledWith('sub.example.com');
+  });
+
+  it('falls back to the request host when x-hostname has no valid values', async () => {
+    const getAppNameByCName = vi.fn().mockResolvedValue('sub');
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
+      runningMode: 'multiple',
+      getAppNameByCName,
+    } as unknown as AppSupervisor);
+
+    const req = createRequest({ host: 'sub.example.com:13000', 'x-hostname': ['', ' '] });
+    expect(await resolveSubAppSegment(req, 'sub')).toBe('');
+    expect(getAppNameByCName).toHaveBeenCalledWith('sub.example.com');
+  });
+
   it('returns the path segment when the request host is not the sub-app custom domain', async () => {
     vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
       runningMode: 'multiple',

--- a/packages/plugins/@nocobase/plugin-auth/src/server/utils/__tests__/resolveSubAppSegment.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/utils/__tests__/resolveSubAppSegment.test.ts
@@ -1,0 +1,65 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { AppSupervisor } from '@nocobase/server';
+import type { IncomingMessage } from 'http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveSubAppSegment } from '../resolveSubAppSegment';
+
+function createRequest(headers: IncomingMessage['headers'] = {}): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+describe('resolveSubAppSegment', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty segment for the main app', async () => {
+    expect(await resolveSubAppSegment(createRequest(), 'main')).toBe('');
+  });
+
+  it('returns an empty segment in single-app mode', async () => {
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({ runningMode: 'single' } as AppSupervisor);
+
+    expect(await resolveSubAppSegment(createRequest({ host: 'example.com' }), 'sub')).toBe('');
+  });
+
+  it('returns an empty segment when the request host is the sub-app custom domain', async () => {
+    const getAppNameByCName = vi.fn().mockResolvedValue('sub');
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
+      runningMode: 'multiple',
+      getAppNameByCName,
+    } as unknown as AppSupervisor);
+
+    expect(await resolveSubAppSegment(createRequest({ host: 'sub.example.com' }), 'sub')).toBe('');
+    expect(getAppNameByCName).toHaveBeenCalledWith('sub.example.com');
+  });
+
+  it('uses x-hostname when the gateway forwards the original hostname', async () => {
+    const getAppNameByCName = vi.fn().mockResolvedValue('sub');
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
+      runningMode: 'multiple',
+      getAppNameByCName,
+    } as unknown as AppSupervisor);
+
+    const req = createRequest({ host: 'internal.example.com', 'x-hostname': 'sub.example.com' });
+    expect(await resolveSubAppSegment(req, 'sub')).toBe('');
+    expect(getAppNameByCName).toHaveBeenCalledWith('sub.example.com');
+  });
+
+  it('returns the path segment when the request host is not the sub-app custom domain', async () => {
+    vi.spyOn(AppSupervisor, 'getInstance').mockReturnValue({
+      runningMode: 'multiple',
+      getAppNameByCName: vi.fn().mockResolvedValue(null),
+    } as unknown as AppSupervisor);
+
+    expect(await resolveSubAppSegment(createRequest({ host: 'main.example.com' }), 'sub')).toBe('/apps/sub');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-auth/src/server/utils/resolveSubAppSegment.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/utils/resolveSubAppSegment.ts
@@ -10,12 +10,36 @@
 import { AppSupervisor, getHostname } from '@nocobase/server';
 import type { IncomingMessage } from 'http';
 
+function normalizeHostname(value?: string): string {
+  const host = value?.split(',', 1)[0].trim();
+  if (!host) {
+    return '';
+  }
+
+  try {
+    return new URL(`http://${host}`).hostname;
+  } catch {
+    return '';
+  }
+}
+
 function getRequestHostname(req: IncomingMessage): string {
   const hostnameHeader = req.headers['x-hostname'];
   if (Array.isArray(hostnameHeader)) {
-    return hostnameHeader[0] || '';
+    for (const value of hostnameHeader) {
+      const hostname = normalizeHostname(value);
+      if (hostname) {
+        return hostname;
+      }
+    }
+  } else {
+    const hostname = normalizeHostname(hostnameHeader);
+    if (hostname) {
+      return hostname;
+    }
   }
-  return hostnameHeader || getHostname(req);
+
+  return getHostname(req);
 }
 
 /**

--- a/packages/plugins/@nocobase/plugin-auth/src/server/utils/resolveSubAppSegment.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/utils/resolveSubAppSegment.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { AppSupervisor, getHostname } from '@nocobase/server';
+import type { IncomingMessage } from 'http';
+
+function getRequestHostname(req: IncomingMessage): string {
+  const hostnameHeader = req.headers['x-hostname'];
+  if (Array.isArray(hostnameHeader)) {
+    return hostnameHeader[0] || '';
+  }
+  return hostnameHeader || getHostname(req);
+}
+
+/**
+ * Resolve the legacy sub-application URL segment for an authentication
+ * redirect. A sub-application reached through its custom domain is mounted at
+ * the root, while one reached through the supervisor domain uses
+ * `/apps/<name>`.
+ */
+export async function resolveSubAppSegment(req: IncomingMessage, appName?: string | null): Promise<string> {
+  if (!appName || appName === 'main') {
+    return '';
+  }
+
+  const appSupervisor = AppSupervisor.getInstance();
+  if (!appSupervisor || appSupervisor.runningMode === 'single') {
+    return '';
+  }
+
+  const hostname = getRequestHostname(req);
+  if (hostname) {
+    const cnameAppName = await appSupervisor.getAppNameByCName?.(hostname);
+    if (cnameAppName === appName) {
+      return '';
+    }
+  }
+
+  return `/apps/${appName}`;
+}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

SSO callbacks for a sub-application need to distinguish between access through the supervisor domain and access through the sub-application's custom domain.

### Description 

Add a shared server utility that resolves whether an authentication redirect should include the legacy sub-application path. It uses the original request hostname and App Supervisor custom-domain mapping, while preserving the existing behavior for the main application, single-application mode, and supervisor-domain access.

Tests cover main applications, single-application mode, custom domains, forwarded original hostnames, and supervisor-domain access.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect SSO redirects for sub-applications using custom domains |
| 🇨🇳 Chinese | 修复使用自定义域名的子应用 SSO 登录后跳转错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
