### PR TITLE
fix(ai): improve document loader timeout and PDF errors

### DIFF
--- a/packages/core/ai/src/document-loader/index.ts
+++ b/packages/core/ai/src/document-loader/index.ts
@@ -14,7 +14,11 @@ import path from 'node:path';
 export type DocumentLoaderWorkerOptions = {
   filePath: string;
   mimeType?: string;
+  /** Timeout in milliseconds for the worker to complete. Defaults to 5 minutes. */
+  timeout?: number;
 };
+
+const DEFAULT_WORKER_TIMEOUT = 5 * 60 * 1000;
 
 export const loadByWorker = async (extname: string, options: DocumentLoaderWorkerOptions): Promise<Document[]> => {
   const isTsRuntime = __filename.endsWith('.ts');
@@ -22,6 +26,7 @@ export const loadByWorker = async (extname: string, options: DocumentLoaderWorke
   const worker = new Worker(workerPath, {
     execArgv: isTsRuntime ? ['--require', 'tsx/cjs'] : undefined,
   });
+  const timeout = options.timeout ?? DEFAULT_WORKER_TIMEOUT;
   return new Promise<Document[]>((resolve, reject) => {
     let settled = false;
     const close = (error?: Error, result?: Document[]) => {
@@ -29,12 +34,17 @@ export const loadByWorker = async (extname: string, options: DocumentLoaderWorke
         return;
       }
       settled = true;
+      clearTimeout(timer);
       if (error) {
         reject(error);
         return;
       }
       resolve(result || []);
     };
+
+    const timer = setTimeout(() => {
+      close(new Error(`Document loading timed out after ${Math.round(timeout / 1000)}s`));
+    }, timeout);
 
     worker.once('message', (payload: { documents?: Document[]; error?: string }) => {
       if (payload?.error) {

--- a/packages/core/ai/src/document-loader/loader.worker.ts
+++ b/packages/core/ai/src/document-loader/loader.worker.ts
@@ -29,7 +29,15 @@ type WorkerResponse = {
 
 const loadPdf = async (filePath: string): Promise<Document[]> => {
   const loader = new PDFLoader(filePath);
-  return loader.load();
+  try {
+    return await loader.load();
+  } catch (error) {
+    const err = error as Error;
+    if (err?.name === 'PasswordException' || /password/i.test(err?.message)) {
+      throw new Error('The PDF file is password-protected and cannot be parsed. Please upload an unlocked version.');
+    }
+    throw error;
+  }
 };
 
 const loadDoc = async (filePath: string, type: 'docx' | 'doc'): Promise<Document[]> => {
@@ -89,8 +97,9 @@ parentPort?.on('message', async (payload: ParsePayload) => {
     };
     parentPort?.postMessage(response);
   } catch (error) {
+    const err = error as Error;
     const response: WorkerResponse = {
-      error: String(error?.stack || error),
+      error: err?.message || String(error),
     };
     parentPort?.postMessage(response);
   }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Document loading could expose raw stack traces for password-protected PDFs and wait indefinitely when a document-loader worker did not respond.

### Description

- Return a clear error for password-protected PDF files.
- Pass only the error message from the document-loader worker instead of serializing the full stack trace.
- Add a configurable document-loader worker timeout with a five-minute default.
- Terminate the worker after completion, failure, or timeout.

Potential risk: unusually large documents that require more than five minutes to parse will now fail with a timeout error. Suggested testing: upload a normal PDF, a password-protected PDF, and a document whose loader exceeds the configured timeout.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved document loading reliability with clearer password-protected PDF errors and timeout handling. |
| 🇨🇳 Chinese | 改进文档加载可靠性，为加密 PDF 提供清晰错误提示并增加超时处理。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary

### Verification

- Related touched files passed ESLint.
- Full automated tests were not run.
