### PR TITLE
fix(ai): reject invalid editor patches

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-coding/context-tools.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/ai-coding/context-tools.test.ts
@@ -186,6 +186,52 @@ const echarts = await ctx.requireAsync('https://cdn.jsdelivr.net/npm/echarts@5/d
     }
   });
 
+  it('rejects a patch with a bare hunk header without mutating the editor', async () => {
+    let code = 'const label = "old";\nctx.render(label);\n';
+    const previousState = useChatMessagesStore.getState();
+    useChatMessagesStore.setState({
+      ...previousState,
+      currentEditorRefUid: 'editor-bare-hunk-patch',
+      editorRef: {
+        'editor-bare-hunk-patch': {
+          read: () => code,
+          write: (nextCode: string) => {
+            code = nextCode;
+          },
+          snippetEntries: [],
+          logs: [],
+        } as any,
+      },
+    });
+
+    try {
+      const result = await patchJSCodeTool[1].invoke.call({}, {} as any, {
+        patch: `@@
+-const label = "old";
++const label = "new";
+`,
+      });
+      const readResult = await readJSCodeTool[1].invoke.call({}, {} as any, {});
+
+      expect(result.status).toBe('error');
+      expect(result.content.message).toContain('bare `@@` headers are not supported');
+      expect(code).toBe('const label = "old";\nctx.render(label);\n');
+      expect(readResult.content.version).toBe(0);
+    } finally {
+      useChatMessagesStore.setState(previousState, true);
+    }
+  });
+
+  it('rejects a valid patch that produces no changes', () => {
+    const source = 'const label = "old";\n';
+    const patch = `@@ -1,1 +1,1 @@
+-const label = "old";
++const label = "old";
+`;
+
+    expect(() => applyUnifiedDiff(source, patch)).toThrow('Patch produced no changes');
+  });
+
   it('returns a structured error when writeJSCode receives invalid params', async () => {
     let code = 'const value = 1;';
     const previousState = useChatMessagesStore.getState();

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/ai-coding/tools/context-tools.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/ai-coding/tools/context-tools.ts
@@ -12,7 +12,7 @@ import { useChat } from '../../chatbox/hooks/useChat';
 import { useChatConversationsStore } from '../../chatbox/stores/chat-conversations';
 import { useChatMessagesStore } from '../../chatbox/stores/chat-messages';
 import { FlowContext } from '@nocobase/flow-engine';
-import { applyPatch } from 'diff';
+import { applyPatch, parsePatch } from 'diff';
 
 const { CodeToolCard } = lazy(() => import('../ui/CodeToolCard'), 'CodeToolCard');
 
@@ -108,9 +108,25 @@ function normalizeUnifiedDiffHunkHeaders(patch: string) {
 }
 
 export function applyUnifiedDiff(source: string, patch: string) {
-  const result = applyPatch(source, normalizeUnifiedDiffHunkHeaders(patch), { fuzzFactor: 2 });
+  const normalizedPatch = normalizeUnifiedDiffHunkHeaders(patch);
+  const parsedPatches = parsePatch(normalizedPatch);
+  const hunks = parsedPatches.flatMap((parsedPatch) => parsedPatch.hunks);
+  if (!hunks.length) {
+    throw new Error(
+      'Invalid unified diff: no valid hunks found. Use headers such as `@@ -1,1 +1,1 @@`; bare `@@` headers are not supported.',
+    );
+  }
+  const hasChanges = hunks.some((hunk) => hunk.lines.some((line) => line.startsWith('+') || line.startsWith('-')));
+  if (!hasChanges) {
+    throw new Error('Invalid unified diff: no changed lines found.');
+  }
+
+  const result = applyPatch(source, normalizedPatch, { fuzzFactor: 2 });
   if (result === false) {
     throw new Error('Patch could not be applied to the current editor code.');
+  }
+  if (result === source) {
+    throw new Error('Patch produced no changes to the current editor code.');
   }
   return result;
 }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/ai/ai-employees/nathan/prompt.md
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/ai/ai-employees/nathan/prompt.md
@@ -98,6 +98,7 @@ Follow this exact order. Do NOT skip ahead to coding.
    - If you need to inspect the current editor code, call `readJSCode`. Never use `searchDocs` for current editor code, and never say the current code cannot be read.
    - Call `readJSCode` before complex edits, after any failed patch, or whenever the current editor structure is uncertain.
    - If the current work context already contains code and the user asks to add, modify, remove, fix, or extend behavior, call `patchJSCode` with a minimal patch instead of rewriting the whole editor.
+   - Every `patchJSCode` hunk must use a valid unified diff header such as `@@ -10,3 +10,4 @@`. Never use a bare `@@` header.
    - Call `writeJSCode` only when the editor is empty, the user asks for a complete replacement, or the change is truly a broad rewrite.
    - For multiple independent localized edits, prefer sequential focused `patchJSCode` calls over one large patch.
    - If a patch would change more than roughly 30 lines, replace a large function/component, or include large unchanged blocks, do not send a huge patch. Either split it into focused patches or use `writeJSCode` as a deliberate broad rewrite when the replacement is clearer than the diff.
@@ -118,6 +119,7 @@ Follow this exact order. Do NOT skip ahead to coding.
    - When calling `searchDocs` after validation failure, use a compact Bash script that searches the exact error text and nearby concepts, then reads focused snippets from likely matches.
    - If the tools and docs still do not confirm the fix, stop and ask the user instead of trying another unverified implementation.
    - When calling `patchJSCode`, provide only the unified diff patch. The tool reads the current editor code directly.
+   - Every hunk header must include old and new line ranges, for example `@@ -10,3 +10,4 @@`; a bare `@@` header is invalid.
    - Keep `patchJSCode` patches surgical: include only the changed lines plus the smallest necessary surrounding context.
    - Do NOT rewrite the entire file, replace a whole component/function, or include unchanged large blocks in a patch unless the whole block genuinely changed.
    - If more than roughly 30 lines would need to change, prefer `writeJSCode` only when this is a deliberate broad rewrite. For incremental requests, split into focused `patchJSCode` patches.

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/ai/ai-employees/nathan/skills/frontend-developer/SKILLS.md
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/ai/ai-employees/nathan/skills/frontend-developer/SKILLS.md
@@ -25,6 +25,7 @@ When helping users with JavaScript code, follow this process:
    - Write clean, correct JavaScript/JSX code based on the user's requirements
    - Use `readJSCode` before complex edits, after any patch failure, or whenever the current editor structure is uncertain. Never use documentation search to read current editor code.
    - If the current work context already contains code and the user asks to add, modify, remove, fix, or extend behavior, use `patchJSCode` with a minimal patch instead of rewriting the whole editor
+   - Every `patchJSCode` hunk must use a valid unified diff header such as `@@ -10,3 +10,4 @@`. Never use a bare `@@` header.
    - Use `writeJSCode` only when the editor is empty, the user asks for a complete replacement, or the change is truly a broad rewrite
    - If an edit would require a large patch, split it into focused patches. If the change replaces a large function/component or the patch would be larger than the full replacement, use `writeJSCode` as a deliberate broad rewrite.
    - Ensure the code follows best practices for NocoBase workflows

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/ai/ai-employees/nathan/skills/frontend-developer/tools/patchJSCode.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/ai/ai-employees/nathan/skills/frontend-developer/tools/patchJSCode.ts
@@ -21,12 +21,12 @@ export default defineTools({
   definition: {
     name: 'patchJSCode',
     description:
-      'Apply a minimal unified diff patch to the code currently in the editor, then write the patched code back to the editor. Use this for adding, modifying, removing, fixing, or extending existing code. The tool reads the current editor code directly; only provide the patch. Keep patches surgical: include only changed lines plus the smallest necessary context, and do not include unchanged large blocks.',
+      'Apply a minimal unified diff patch to the code currently in the editor, then write the patched code back to the editor. Use this for adding, modifying, removing, fixing, or extending existing code. The tool reads the current editor code directly; only provide the patch. Every hunk must use a valid header such as `@@ -10,3 +10,4 @@`; bare `@@` headers are invalid. Keep patches surgical: include only changed lines plus the smallest necessary context, and do not include unchanged large blocks.',
     schema: z.object({
       patch: z
         .string()
         .describe(
-          'Minimal unified diff patch to apply to the current editor code. Include only changed lines plus the smallest necessary context.',
+          'Minimal unified diff patch to apply to the current editor code. Every hunk header must include old and new line ranges, for example `@@ -10,3 +10,4 @@`; do not use a bare `@@` header. Include only changed lines plus the smallest necessary context.',
         ),
     }),
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Nathan's frontend patch tool could report success for malformed unified diffs with no valid hunks, even though the editor code remained unchanged.

### Description 

- Validate that editor patches contain valid unified diff hunks and changed lines
- Reject patches that cannot be applied or produce no editor changes before writing code or incrementing the editor version
- Clarify Nathan's prompt and tool description so generated patches use complete hunk headers
- Add regression coverage for bare hunk headers and no-op patches

Potential risk: non-standard patches that previously appeared successful will now return an error and require Nathan to read the current editor code and retry with a valid unified diff.

Testing suggestions:
- Apply a standard unified diff and verify the editor is updated
- Submit a patch with a bare `@@` header and verify it fails without changing the editor
- Submit a no-op patch and verify it is rejected

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevented Nathan from reporting malformed or unchanged code patches as successfully applied |
| 🇨🇳 Chinese | 修复 Nathan 将格式错误或未产生变更的代码补丁误报为应用成功的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
