### PR TITLE
feat(client): support filtered application language resources

### DIFF
--- a/packages/core/server/src/swagger/app.ts
+++ b/packages/core/server/src/swagger/app.ts
@@ -13,7 +13,22 @@ export default {
       tags: ['app'],
       summary: 'Get the current application language',
       description: 'Return the current locale used by the server.',
-      parameters: [],
+      parameters: [
+        {
+          name: 'locale',
+          in: 'query',
+          required: false,
+          schema: { type: 'string' },
+          description: 'Requested application locale. The server validates it against enabled languages.',
+        },
+        {
+          name: 'ns',
+          in: 'query',
+          required: false,
+          schema: { type: 'string' },
+          description: 'Comma-separated resource namespaces to return. Omit it to preserve the full legacy payload.',
+        },
+      ],
       responses: {
         200: {
           description: 'OK',

--- a/packages/plugins/@nocobase/plugin-client/src/server/__tests__/localeResources.test.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/__tests__/localeResources.test.ts
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { filterLocaleResources, parseLocaleResourceNamespaces } from '../localeResources';
+
+describe('locale resource filtering', () => {
+  it('accepts comma-separated and repeated namespace query values', () => {
+    expect(parseLocaleResourceNamespaces(['lm-collections,plugin-a', ' plugin-a , plugin-b '])).toEqual([
+      'lm-collections',
+      'plugin-a',
+      'plugin-b',
+    ]);
+  });
+
+  it('preserves the legacy full payload when ns is omitted', () => {
+    const payload = {
+      resources: {
+        client: { Save: 'Save' },
+        'lm-collections': { Users: 'Users' },
+      },
+      antd: { locale: 'en' },
+    };
+
+    expect(filterLocaleResources(payload, undefined)).toBe(payload);
+  });
+
+  it('filters only the resources map and preserves other locale payloads', () => {
+    const payload = {
+      resources: {
+        client: { Save: 'Save' },
+        'lm-collections': { Users: 'Users' },
+        'plugin-a': { Title: 'Title' },
+      },
+      antd: { locale: 'en' },
+      cron: { every: 'every' },
+    };
+
+    expect(filterLocaleResources(payload, 'lm-collections,plugin-a,missing')).toEqual({
+      resources: {
+        'lm-collections': { Users: 'Users' },
+        'plugin-a': { Title: 'Title' },
+      },
+      antd: { locale: 'en' },
+      cron: { every: 'every' },
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-client/src/server/localeResources.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/localeResources.ts
@@ -1,0 +1,38 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export function parseLocaleResourceNamespaces(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return [
+    ...new Set(
+      values
+        .flatMap((item) => (typeof item === 'string' ? item.split(',') : []))
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function filterLocaleResources<T extends { resources?: Record<string, unknown> }>(
+  payload: T,
+  namespaceQuery: unknown,
+): T {
+  const namespaces = parseLocaleResourceNamespaces(namespaceQuery);
+  if (!namespaces.length) return payload;
+
+  const resources = payload.resources || {};
+  return {
+    ...payload,
+    resources: Object.fromEntries(
+      namespaces
+        .filter((namespace) => Object.prototype.hasOwnProperty.call(resources, namespace))
+        .map((namespace) => [namespace, resources[namespace]]),
+    ),
+  };
+}

--- a/packages/plugins/@nocobase/plugin-client/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-client/src/server/server.ts
@@ -17,6 +17,7 @@ import { listAppPortals } from './appPortals';
 import { getAntdLocale } from './antd';
 import { getCronLocale } from './cron';
 import { getCronstrueLocale } from './cronstrue';
+import { filterLocaleResources } from './localeResources';
 
 async function getLang(ctx) {
   const SystemSetting = ctx.db.getRepository('systemSettings');
@@ -115,7 +116,7 @@ export class PluginClientServer extends Plugin {
         },
         async getLang(ctx, next) {
           const lang = await getLang(ctx);
-          const resources = await ctx.app.localeManager.get(lang);
+          const resources = filterLocaleResources(await ctx.app.localeManager.get(lang), ctx.request.query.ns);
           ctx.body = {
             lang,
             ...resources,


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

`app:getLang` currently returns every application translation namespace, even when a client only needs a small subset. This increases language payload size for lightweight or external clients.

### Description

- Add an optional `ns` query parameter to `app:getLang`.
- Accept comma-separated and repeated namespace values, with trimming and deduplication.
- Filter only the `resources` map while preserving `lang`, Ant Design locale data, cron locale data, and other response fields.
- Preserve the complete legacy response when `ns` is omitted.
- Document the `locale` and `ns` query parameters in Swagger.
- Add focused tests for namespace parsing, backward compatibility, and filtered responses.

Potential compatibility risk is limited to callers that explicitly send `ns`; callers without it receive the existing full payload unchanged.

Testing:

- `yarn vitest packages/plugins/@nocobase/plugin-client/src/server/__tests__/localeResources.test.ts --run`
- `yarn build @nocobase/plugin-client --no-dts`

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reduced application language responses to requested resource namespaces |
| 🇨🇳 Chinese | 按需返回应用语言资源命名空间，减少不必要的语言数据 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
