### PR TITLE
docs: fix PLUGIN_PACKAGE_PREFIX examples

### DIFF
--- a/docs/docs/cn/api/app/env.md
+++ b/docs/docs/cn/api/app/env.md
@@ -113,7 +113,7 @@ SERVER_REQUEST_WHITELIST=api.example.com,*.trusted.com,10.0.0.0/8,127.0.0.1
 PLUGIN_PACKAGE_PREFIX 可以配置为：
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 则插件名称和包名对应关系如下：

--- a/docs/docs/cn/get-started/installation/env.md
+++ b/docs/docs/cn/get-started/installation/env.md
@@ -152,7 +152,7 @@ CORS_ORIGIN_WHITELIST=https://www.example.com,https://admin.example.com
 PLUGIN_PACKAGE_PREFIX 可以配置为：
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 则插件名称和包名对应关系如下：

--- a/docs/docs/de/api/app/env.md
+++ b/docs/docs/de/api/app/env.md
@@ -113,7 +113,7 @@ Wenn Sie beispielsweise das Plugin `hello` zum Projekt `my-nocobase-app` hinzuf√
 PLUGIN_PACKAGE_PREFIX kann konfiguriert werden als:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Die Zuordnung von Plugin-Namen zu Paketnamen lautet dann:

--- a/docs/docs/de/get-started/installation/env.md
+++ b/docs/docs/de/get-started/installation/env.md
@@ -146,7 +146,7 @@ Wenn Sie beispielsweise das `hello` **Plugin** zu Ihrem `my-nocobase-app`-Projek
 `PLUGIN_PACKAGE_PREFIX` kann wie folgt konfiguriert werden:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Die Zuordnung zwischen **Plugin**-Namen und Paketnamen ist dann wie folgt:

--- a/docs/docs/en/api/app/env.md
+++ b/docs/docs/en/api/app/env.md
@@ -107,7 +107,7 @@ For example, to add the `hello` plugin to the `my-nocobase-app` project, the ful
 PLUGIN_PACKAGE_PREFIX can be configured as:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Then the mapping between plugin names and package names is as follows:

--- a/docs/docs/en/get-started/installation/env.md
+++ b/docs/docs/en/get-started/installation/env.md
@@ -146,7 +146,7 @@ For example, to add the `hello` plugin to the `my-nocobase-app` project, the plu
 PLUGIN_PACKAGE_PREFIX can be configured as:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 The correspondence between plugin name and package name is as follows:

--- a/docs/docs/es/api/app/env.md
+++ b/docs/docs/es/api/app/env.md
@@ -113,7 +113,7 @@ Por ejemplo, al añadir el Plugin `hello` al proyecto `my-nocobase-app`, el nomb
 PLUGIN_PACKAGE_PREFIX puede configurarse como:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Entonces, la correspondencia entre el nombre del Plugin y el nombre del paquete sería la siguiente:

--- a/docs/docs/es/get-started/installation/env.md
+++ b/docs/docs/es/get-started/installation/env.md
@@ -146,7 +146,7 @@ Por ejemplo, si desea añadir el **plugin** `hello` al proyecto `my-nocobase-app
 `PLUGIN_PACKAGE_PREFIX` se puede configurar de la siguiente manera:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 La correspondencia entre el nombre del **plugin** y el nombre del paquete es la siguiente:

--- a/docs/docs/fr/api/app/env.md
+++ b/docs/docs/fr/api/app/env.md
@@ -113,7 +113,7 @@ Par exemple, si vous ajoutez le plugin `hello` au projet `my-nocobase-app`, le n
 PLUGIN_PACKAGE_PREFIX peut être configuré comme suit :
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Les correspondances entre les noms des plugins et les noms des packages seront alors :

--- a/docs/docs/fr/get-started/installation/env.md
+++ b/docs/docs/fr/get-started/installation/env.md
@@ -146,7 +146,7 @@ Par exemple, pour ajouter le `plugin` `hello` au projet `my-nocobase-app`, le no
 `PLUGIN_PACKAGE_PREFIX` peut être configuré comme suit :
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 La correspondance entre le nom du `plugin` et le nom du package est la suivante :

--- a/docs/docs/id/api/app/env.md
+++ b/docs/docs/id/api/app/env.md
@@ -113,7 +113,7 @@ Sebagai contoh, menambahkan plugin `hello` ke proyek `my-nocobase-app`, nama pak
 PLUGIN_PACKAGE_PREFIX dapat dikonfigurasi sebagai:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Maka korespondensi antara nama plugin dan nama paket adalah sebagai berikut:

--- a/docs/docs/id/get-started/installation/env.md
+++ b/docs/docs/id/get-started/installation/env.md
@@ -152,7 +152,7 @@ Contohnya, menambahkan plugin `hello` ke proyek `my-nocobase-app`, maka nama pak
 PLUGIN_PACKAGE_PREFIX dapat dikonfigurasi sebagai:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Maka korespondensi antara nama plugin dan nama paket adalah sebagai berikut:

--- a/docs/docs/ja/api/app/env.md
+++ b/docs/docs/ja/api/app/env.md
@@ -113,7 +113,7 @@ SERVER_REQUEST_WHITELIST=api.example.com,*.trusted.com,10.0.0.0/8,127.0.0.1
 PLUGIN_PACKAGE_PREFIX は以下のように設定できます：
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 これにより、プラグイン名とパッケージ名の対応関係は以下のようになります：

--- a/docs/docs/ja/get-started/installation/env.md
+++ b/docs/docs/ja/get-started/installation/env.md
@@ -146,7 +146,7 @@ CORS_ORIGIN_WHITELIST=https://www.example.com,https://admin.example.com
 PLUGIN_PACKAGE_PREFIXは以下のように設定できます：
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 この場合、プラグイン名とパッケージ名の対応関係は以下のようになります：

--- a/docs/docs/pt/api/app/env.md
+++ b/docs/docs/pt/api/app/env.md
@@ -113,7 +113,7 @@ Por exemplo, ao adicionar o Plugin `hello` ao projeto `my-nocobase-app`, o nome 
 PLUGIN_PACKAGE_PREFIX pode ser configurado como:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 A correspondência entre o nome do Plugin e o nome do pacote ficará assim:

--- a/docs/docs/pt/get-started/installation/env.md
+++ b/docs/docs/pt/get-started/installation/env.md
@@ -146,7 +146,7 @@ Por exemplo, para adicionar o **plugin** `hello` ao projeto `my-nocobase-app`, o
 `PLUGIN_PACKAGE_PREFIX` pode ser configurado como:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 A correspondência entre o nome do **plugin** e o nome do pacote é a seguinte:

--- a/docs/docs/ru/api/app/env.md
+++ b/docs/docs/ru/api/app/env.md
@@ -113,7 +113,7 @@ SERVER_REQUEST_WHITELIST=api.example.com,*.trusted.com,10.0.0.0/8,127.0.0.1
 `PLUGIN_PACKAGE_PREFIX` можно настроить так:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Соответствие между именем плагина и именем пакета следующее:

--- a/docs/docs/ru/get-started/installation/env.md
+++ b/docs/docs/ru/get-started/installation/env.md
@@ -146,7 +146,7 @@ CORS_ORIGIN_WHITELIST=https://www.example.com,https://admin.example.com
 PLUGIN_PACKAGE_PREFIX можно настроить так:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Соответствие между именем плагина и именем пакета следующее:

--- a/docs/docs/vi/api/app/env.md
+++ b/docs/docs/vi/api/app/env.md
@@ -113,7 +113,7 @@ Ví dụ, thêm Plugin `hello` vào dự án `my-nocobase-app`, tên gói đầy
 PLUGIN_PACKAGE_PREFIX có thể được cấu hình thành:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Khi đó tương ứng giữa tên Plugin và tên gói như sau:

--- a/docs/docs/vi/get-started/installation/env.md
+++ b/docs/docs/vi/get-started/installation/env.md
@@ -152,7 +152,7 @@ Ví dụ, thêm Plugin `hello` vào dự án `my-nocobase-app`, tên package đ�
 PLUGIN_PACKAGE_PREFIX có thể cấu hình thành:
 
 ```bash
-PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase-preset-,@my-nocobase-app/plugin-
+PLUGIN_PACKAGE_PREFIX=@nocobase/plugin-,@nocobase/preset-,@my-nocobase-app/plugin-
 ```
 
 Tương ứng tên Plugin và tên package như sau:


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The PLUGIN_PACKAGE_PREFIX examples used @nocobase-preset-, which is not the preset package prefix used by NocoBase.

### Description
- Corrected the preset package prefix to @nocobase/preset- in the environment-variable and installation pages.
- Updated the corresponding pages in all 10 maintained documentation languages.
- Verified documentation tree alignment and file health.

### Related issues
https://forum.nocobase.com/t/13568

### Showcase
Not applicable — documentation-only change.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Corrected PLUGIN_PACKAGE_PREFIX examples so preset plugins use the @nocobase/preset- prefix. |
| 🇨🇳 Chinese | 修正文档中的 PLUGIN_PACKAGE_PREFIX 示例，确保预设插件使用 @nocobase/preset- 前缀。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Updated environment-variable and installation references |
| 🇨🇳 Chinese | 已更新环境变量与安装文档 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary