### PR TITLE
fix(notification-in-app-message): respect caller-provided variables in content template form

### DIFF
--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/ContentConfigForm.test.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/__tests__/ContentConfigForm.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { MetaTreeNode } from '@nocobase/flow-engine';
+import { render } from '@testing-library/react';
+import { Form } from 'antd';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({
+  inputs: [] as Array<{ metaTree?: MetaTreeNode[] }>,
+  textAreas: [] as Array<{ metaTree?: MetaTreeNode[] }>,
+}));
+
+vi.mock('@nocobase/plugin-workflow/client-v2', () => ({
+  WorkflowVariableInput: (props: { metaTree?: MetaTreeNode[] }) => {
+    holder.inputs.push(props);
+    return <input data-testid="workflow-variable-input" />;
+  },
+  WorkflowVariableTextArea: (props: { metaTree?: MetaTreeNode[] }) => {
+    holder.textAreas.push(props);
+    return <textarea data-testid="workflow-variable-textarea" />;
+  },
+}));
+
+vi.mock('../locale', () => ({
+  useInAppMessageTranslation: () => ({ t: (key: string) => key }),
+  useT: () => (key: string) => key,
+}));
+
+import { ContentConfigForm } from '../components/ContentConfigForm';
+
+const APPROVAL_VARIABLES: MetaTreeNode[] = [
+  { name: 'statusText', title: 'Status', type: 'string', paths: ['statusText'] },
+  {
+    name: 'approval',
+    title: 'Approval',
+    type: 'string',
+    paths: ['approval'],
+    children: [
+      { name: 'workflowTitle', title: 'Workflow title', type: 'string', paths: ['approval', 'workflowTitle'] },
+    ],
+  },
+];
+
+function renderForm(variableOptions?: MetaTreeNode[]) {
+  return render(
+    <Form>
+      <ContentConfigForm namePrefix={['template']} variableOptions={variableOptions} />
+    </Form>,
+  );
+}
+
+describe('in-app-message ContentConfigForm (v2)', () => {
+  beforeEach(() => {
+    holder.inputs.length = 0;
+    holder.textAreas.length = 0;
+  });
+
+  it('forwards the caller-provided variableOptions to every variable field', () => {
+    renderForm(APPROVAL_VARIABLES);
+
+    // title + desktop url + mobile url
+    expect(holder.inputs).toHaveLength(3);
+    for (const props of holder.inputs) {
+      expect(props.metaTree).toBe(APPROVAL_VARIABLES);
+    }
+    expect(holder.textAreas).toHaveLength(1);
+    expect(holder.textAreas[0].metaTree).toBe(APPROVAL_VARIABLES);
+  });
+
+  it('falls back to the canvas-derived workflow tree when no variableOptions is given', () => {
+    renderForm();
+
+    expect(holder.inputs).toHaveLength(3);
+    for (const props of holder.inputs) {
+      expect(props.metaTree).toBeUndefined();
+    }
+    expect(holder.textAreas).toHaveLength(1);
+    expect(holder.textAreas[0].metaTree).toBeUndefined();
+  });
+
+  it('honours an empty variableOptions as "no variables" rather than falling back', () => {
+    const empty: MetaTreeNode[] = [];
+    renderForm(empty);
+
+    for (const props of holder.inputs) {
+      expect(props.metaTree).toBe(empty);
+    }
+    expect(holder.textAreas[0].metaTree).toBe(empty);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/ContentConfigForm.tsx
+++ b/packages/plugins/@nocobase/plugin-notification-in-app-message/src/client-v2/components/ContentConfigForm.tsx
@@ -20,6 +20,10 @@ function withPrefix(namePrefix: Array<string | number> | undefined, ...segments:
 export function ContentConfigForm(props: ContentConfigFormProps) {
   const { t } = useInAppMessageTranslation();
   const compileT = useT();
+  // `variableOptions` is the caller's own variable tree (v1 parity: the approval message template manager passes the
+  // scope the server actually injects). Only when it is absent do we fall back to the canvas-derived workflow tree,
+  // which is what the workflow notification node wants.
+  const { variableOptions } = props;
 
   return (
     <>
@@ -28,14 +32,19 @@ export function ContentConfigForm(props: ContentConfigFormProps) {
         label={t('Message title')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={variableOptions} variableOptions={{ types: ['string'] }} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'content')}
         label={t('Message content')}
         rules={[{ required: true, message: t('The field value is required') }]}
       >
-        <WorkflowVariableTextArea autoSize={{ minRows: 10 }} placeholder="Hi," delimiters={['{{{', '}}}']} />
+        <WorkflowVariableTextArea
+          autoSize={{ minRows: 10 }}
+          metaTree={variableOptions}
+          placeholder="Hi,"
+          delimiters={['{{{', '}}}']}
+        />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'url')}
@@ -44,7 +53,7 @@ export function ContentConfigForm(props: ContentConfigFormProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/admin". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={variableOptions} variableOptions={{ types: ['string'] }} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'mobileUrl')}
@@ -53,7 +62,7 @@ export function ContentConfigForm(props: ContentConfigFormProps) {
           'Support two types of links: internal links and external links. If using an internal link, the link starts with "/", for example, "/m". If using an external link, the link starts with "http", for example, "https://example.com".',
         )}
       >
-        <WorkflowVariableInput variableOptions={{ types: ['string'] }} />
+        <WorkflowVariableInput metaTree={variableOptions} variableOptions={{ types: ['string'] }} />
       </Form.Item>
       <Form.Item
         name={withPrefix(props.namePrefix, 'options', 'duration')}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableInput.tsx
@@ -24,7 +24,7 @@
 
 import React, { useMemo } from 'react';
 import { ConfigProvider } from 'antd';
-import { VariableHybridInput } from '@nocobase/flow-engine';
+import { VariableHybridInput, type MetaTreeNode } from '@nocobase/flow-engine';
 import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from './useWorkflowVariableOptions';
 import { workflowVariableConverters } from './workflowVariableConverters';
 
@@ -40,14 +40,21 @@ export type WorkflowVariableInputProps = {
    *  `Form.Item` the status is inherited automatically. */
   status?: 'error' | 'warning';
   /** Variable-tree options forwarded to each upstream `useVariables` (types
-   *  filter, appends, depth, fieldNames). */
+   *  filter, appends, depth, fieldNames). Ignored when `metaTree` is given. */
   variableOptions?: UseWorkflowVariableOptions;
+  /** An explicit variable tree, replacing the canvas-derived one. Pass this
+   *  outside the workflow canvas — e.g. the approval message template manager,
+   *  where the renderer's scope is fixed by the server, not by upstream nodes.
+   *  An empty array is honoured as "no variables"; omit the prop to fall back
+   *  to the canvas tree. */
+  metaTree?: MetaTreeNode[];
 };
 
 export function WorkflowVariableInput(props: WorkflowVariableInputProps) {
-  const { variableOptions, disabled, ...rest } = props;
+  const { variableOptions, disabled, metaTree: metaTreeProp, ...rest } = props;
   const { componentDisabled } = ConfigProvider.useConfig();
-  const metaTree = useWorkflowVariableOptions(variableOptions);
+  const canvasMetaTree = useWorkflowVariableOptions(variableOptions);
+  const metaTree = metaTreeProp ?? canvasMetaTree;
   const tree = useMemo(() => metaTree, [metaTree]);
   return (
     <VariableHybridInput

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableTextArea.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/canvas/WorkflowVariableTextArea.tsx
@@ -11,7 +11,7 @@ import { css, cx } from '@emotion/css';
 import { Button, Input } from 'antd';
 import type { TextAreaProps } from 'antd/es/input';
 import type { TextAreaRef } from 'antd/es/input/TextArea';
-import { FlowContextSelector } from '@nocobase/flow-engine';
+import { FlowContextSelector, type MetaTreeNode } from '@nocobase/flow-engine';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { insertTextAtSelection } from './textAreaInsertion';
 import { formatWorkflowPathToValue } from './workflowVariableConverters';
@@ -20,7 +20,11 @@ import { useWorkflowVariableOptions, type UseWorkflowVariableOptions } from './u
 export interface WorkflowVariableTextAreaProps extends Omit<TextAreaProps, 'value' | 'onChange'> {
   value?: string;
   onChange?: (value: string) => void;
+  /** Ignored when `metaTree` is given. */
   variableOptions?: UseWorkflowVariableOptions;
+  /** An explicit variable tree, replacing the canvas-derived one. See
+   *  `WorkflowVariableInput` for when to reach for this. */
+  metaTree?: MetaTreeNode[];
   delimiters?: readonly [string, string];
 }
 
@@ -38,10 +42,20 @@ const codeTextAreaClassName = css`
 `;
 
 export function WorkflowVariableTextArea(props: WorkflowVariableTextAreaProps) {
-  const { value = '', onChange, variableOptions, className, style, delimiters = ['{{', '}}'], ...rest } = props;
+  const {
+    value = '',
+    onChange,
+    variableOptions,
+    metaTree: metaTreeProp,
+    className,
+    style,
+    delimiters = ['{{', '}}'],
+    ...rest
+  } = props;
   const [innerValue, setInnerValue] = useState(value);
   const inputRef = useRef<TextAreaRef>(null);
-  const metaTree = useWorkflowVariableOptions(variableOptions);
+  const canvasMetaTree = useWorkflowVariableOptions(variableOptions);
+  const metaTree = metaTreeProp ?? canvasMetaTree;
   const metaTreeGetter = useMemo(() => () => metaTree, [metaTree]);
 
   useEffect(() => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The approval message template manager (Settings → Notification manager → Approval message templates) offered the wrong variable list. The variables a template is actually authored against — `Status`, `Approval` — were missing, while workflow canvas roots that have no meaning on a standalone settings page were offered instead: `Scope variables` and `Node result` (both disabled, since there is no node context) plus `Variables and secrets`.

The in-app-message channel's v2 `ContentConfigForm` accepts a `variableOptions` prop but ignored it entirely, hardcoding `WorkflowVariableInput` / `WorkflowVariableTextArea`. Those components resolve their tree through `useWorkflowVariableOptions()`, which always returns the canvas roots (`$scopes` / `$jobsMapByNodeKey` / `$context` / `$system` / `$env`) regardless of what the caller passed. The v1 component (`src/client/components/ContentConfigForm.tsx`) does honour `variableOptions`; the wiring was lost in the v2 migration at the channel implementation layer.

### Description

- Forward `variableOptions` to all four variable fields in the in-app-message `ContentConfigForm` (message title, message content, desktop URL, mobile URL).
- Add an optional `metaTree` prop to `WorkflowVariableInput` and `WorkflowVariableTextArea` so callers outside the workflow canvas can supply their own variable tree. Omitting the prop keeps the existing canvas-derived behaviour, so workflow node config is unaffected.
- `metaTree` is resolved with `??`, so an empty array is honoured as "no variables" rather than silently falling back to the canvas tree.
- Kept the existing `{{a.b}}` serialization (`workflowVariableConverters`) and `delimiters` handling rather than swapping in flow-engine's `VariableHybridInput` directly, since stored templates depend on that format.

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the in-app message template form showing workflow canvas variables instead of the variables provided by the page. |
| 🇨🇳 Chinese | 修复站内信消息模板表单显示工作流画布变量、而非页面实际提供的变量的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
