### PR TITLE
fix(plugin-backups): stabilize frontend tests

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupRestoreComponents.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupRestoreComponents.test.tsx
@@ -126,6 +126,7 @@ describe('backup restore components', () => {
       expect(mocks.flowContext.api.request).toHaveBeenCalledWith({
         url: 'backups:restore',
         method: 'post',
+        skipNotify: true,
         data: {
           name: 'backup.zip',
           password: '',
@@ -192,6 +193,7 @@ describe('backup restore components', () => {
       expect(mocks.flowContext.api.request).toHaveBeenCalledWith({
         url: 'backups:upload',
         method: 'post',
+        skipNotify: true,
         data: expect.any(FormData),
       }),
     );

--- a/packages/plugins/@nocobase/plugin-backups/src/client/__tests__/BackupsTable.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client/__tests__/BackupsTable.test.tsx
@@ -86,11 +86,12 @@ describe('BackupsTable', () => {
   test('should handle download action', async () => {
     const user = userEvent.setup();
     render(<MockedTable />, { wrapper: Wrapper });
+    const download = await screen.findByText('Download');
     await waitFor(() => {
-      expect(screen.getAllByText('Download')[0]).toBeInTheDocument();
+      expect(download.closest('.ant-spin-container')).not.toHaveClass('ant-spin-blur');
     });
 
-    await user.click(screen.getAllByText('Download')[0]);
+    await user.click(download);
 
     await waitFor(() => {
       expect(mockRequest.history.get).toEqual(


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The `next` branch frontend test workflow had three failures in the backup plugin:

- The client-v2 restore request assertions did not include the existing `skipNotify: true` request option.
- The v1 download test could click the action while the Ant Design table was still loading and had `pointer-events: none`.

### Description
- Update the client-v2 restore and upload request expectations to include `skipNotify: true`.
- Wait for the table loading overlay to clear before clicking the download action.
- This is a test-only change and does not modify runtime behavior.

Testing:

```bash
yarn test packages/plugins/@nocobase/plugin-backups/src/client/__tests__/BackupsTable.test.tsx --run --reporter=verbose --silent
yarn test packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupRestoreComponents.test.tsx --run --reporter=verbose --silent
yarn eslint --fix packages/plugins/@nocobase/plugin-backups/src/client/__tests__/BackupsTable.test.tsx packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupRestoreComponents.test.tsx
```

### Related issues
- https://github.com/nocobase/nocobase/actions/runs/30065019154/job/89395066840
- https://github.com/nocobase/nocobase/actions/runs/30065019154/job/89395066862

### Showcase
N/A — test-only change.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved the stability and accuracy of backup plugin frontend tests. |
| 🇨🇳 Chinese | 提升备份插件前端测试的稳定性和准确性。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed — test-only change. |
| 🇨🇳 Chinese | 无需更新——仅涉及测试。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
