### PR TITLE
feat(docs): group search results by section and rank docs above plugin pages

### DIFF
--- a/docs/plugins/pluginSearchIndex.ts
+++ b/docs/plugins/pluginSearchIndex.ts
@@ -1,0 +1,190 @@
+/**
+ * Rspress plugin: 清洗搜索索引——去掉读不通的 Markdown 残留，并剔除内容完全重复的页面。
+ *
+ * 一、正文清洗
+ *
+ * 搜索结果卡片直接从索引的 `content` 里截一段展示，而 rspress 建索引时保留了 Markdown 源码
+ * （`extractPageData` 只删了代码块和图片）。实测两类残留会让结果卡片读不通：
+ *
+ * - 表格行：`| \`uid\` | \`string\` | 否 | 模板打印按钮的 schema uid… |`——管道符和对齐空格混在一起，
+ *   截断后读者拼不出语义。占实测 statement 的 20%。
+ * - 空链接：`- [模板打印]()`——rspress 的 `remarkStripLinkUrls` 把 URL 清空后留下的 `[]()` 空壳。占 10%。
+ *
+ * `**加粗**` 和 `- ` 列表符不在清洗范围内：它们读起来通顺，还保留了强调和列表语义。
+ *
+ * 注意 `toc[].charIndex` 是 `content.indexOf('# 标题')` 算出来的，正文一旦改动长度就必须重算，
+ * 否则正文命中会被算到错误的小标题下面。
+ *
+ * 二、重复页面
+ *
+ * 站点里有 34 组正文完全相同、路由不同的页面（如 `/data-sources/external/nocobase` 与
+ * `/data-sources/data-source-external-nocobase/`，两个源文件逐字节相同）。它们在搜索结果里会渲染成
+ * 标题、面包屑、摘要全都一样的两条，用户无从选择。这里按正文哈希只保留一条。
+ *
+ * 注意不要和「不同页面碰巧有同名小标题」搞混：那种情况面包屑不同（`外部 NocoBase > 功能说明 > 模板打印`
+ * 对 `应用和主要插件内置表 > 内置表参考 > 模板打印`），本来就能区分，不在处理范围内。
+ */
+import { createHash } from 'node:crypto';
+import type { PageIndexInfo, RspressPlugin } from '@rspress/core';
+
+/** 表格的分隔行：`|---|:--:|`。纯格式，没有信息量。 */
+const TABLE_DELIMITER_ROW = /^\s*\|(?:\s*:?-+:?\s*\|)+\s*$/;
+
+/** 表格数据行：`| a | b |`。 */
+const TABLE_ROW = /^\s*\|(.*)\|\s*$/;
+
+/** URL 被清空后剩下的链接空壳：`[模板打印]()` → `模板打印`。 */
+const EMPTY_LINK = /\[([^\]]*)\]\(\)/g;
+
+/** 单元格之间的连接符。用两个空格而非 ` | `，避免又把管道符引回来。 */
+const CELL_SEPARATOR = '  ';
+
+export function cleanSearchContent(content: string): string {
+  const lines: string[] = [];
+
+  for (const line of content.split('\n')) {
+    if (TABLE_DELIMITER_ROW.test(line)) {
+      continue;
+    }
+
+    const tableRow = line.match(TABLE_ROW);
+    if (tableRow) {
+      const cells = tableRow[1]
+        .split('|')
+        .map((cell) => cell.trim())
+        .filter(Boolean);
+      if (cells.length === 0) {
+        continue;
+      }
+      // 每行表格后补一个空行，让它成为独立段落。rspress 截取 statement 时以 `\n\n` 为界，
+      // 这样一条结果就正好是一行表格，不会把相邻几行糊在一起。
+      lines.push(cells.join(CELL_SEPARATOR), '');
+      continue;
+    }
+
+    lines.push(line);
+  }
+
+  return lines
+    .join('\n')
+    .replace(EMPTY_LINK, '$1')
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+/** 正文改动后重算 toc 的 charIndex，规则与 rspress 的 `extractPageData` 保持一致。 */
+function recalculateTocCharIndex(page: PageIndexInfo): void {
+  for (const item of page.toc) {
+    const headingPrefix = '#'.repeat(item.depth);
+    const heading = `${headingPrefix} ${item.text}`;
+
+    // 同名标题靠 id 尾部的 `-N` 区分，需要跳过前 N 次出现，取第 N+1 个。
+    const duplicateSuffix = item.id.match(/-(\d+)$/);
+    let position = -1;
+    if (duplicateSuffix) {
+      for (let i = 0; i < Number(duplicateSuffix[1]); i++) {
+        position = page.content.indexOf(heading, position + 1);
+        if (position === -1) {
+          break;
+        }
+      }
+    }
+
+    item.charIndex = page.content.indexOf(heading, position + 1);
+  }
+}
+
+/** 短正文（目录页、占位页）容易撞车，不参与重复判定。 */
+const MIN_DEDUPE_CONTENT_LENGTH = 200;
+
+/**
+ * 一组正文相同的页面里，选哪个留下。
+ *
+ * 路径层级少的优先（`/workflow/approval` 胜过 `/ai-employees/workflow/nodes/employee/approval`），
+ * 层级相同则按字典序，保证同一份内容每次构建都选中同一个路由，构建产物可复现。
+ */
+function pickCanonicalRoute(routes: string[]): string {
+  return [...routes].sort((a, b) => {
+    const depthDiff = a.split('/').length - b.split('/').length;
+    return depthDiff !== 0 ? depthDiff : a.localeCompare(b);
+  })[0];
+}
+
+/**
+ * 把正文完全相同的重复页面从搜索里排除，返回被排除的页面数。
+ *
+ * 用 rspress 自带的 `pageType: 'home'` 排除机制（`createPageData` 会把这类页面整个划进 `noindex`
+ * 分组丢掉），而不是自己删数组元素或清空字段：
+ *
+ * - 删元素会让 SSG 渲染这些路由时找不到页面数据，整个构建失败。
+ * - 只清 `content` 挡不住标题和小标题命中——`toc` 还在，重复的面包屑照样会冒出来。
+ * - 清 `toc` 又会破坏页面右侧大纲和 Overview 组件（`pageData.pages` 和搜索索引共用同一份数据）。
+ *
+ * 改 frontmatter 只影响搜索索引这一路：`pageData` 里对应字段虽然也会带上，但页面渲染走的是
+ * 路由配置和 MDX 编译产物，不读这个标记，所以被排除的页面照常访问、大纲照常显示。
+ */
+function dropDuplicatePages(pages: PageIndexInfo[]): number {
+  const routesByHash = new Map<string, string[]>();
+
+  for (const page of pages) {
+    if (!page.content || page.content.length < MIN_DEDUPE_CONTENT_LENGTH) {
+      continue;
+    }
+    const hash = createHash('md5').update(page.content).digest('hex');
+    const routes = routesByHash.get(hash);
+    if (routes) {
+      routes.push(page.routePath);
+    } else {
+      routesByHash.set(hash, [page.routePath]);
+    }
+  }
+
+  const dropped = new Set<string>();
+  for (const routes of routesByHash.values()) {
+    if (routes.length < 2) {
+      continue;
+    }
+    const canonical = pickCanonicalRoute(routes);
+    for (const route of routes) {
+      if (route !== canonical) {
+        dropped.add(route);
+      }
+    }
+  }
+
+  for (const page of pages) {
+    if (dropped.has(page.routePath)) {
+      page.frontmatter = { ...page.frontmatter, pageType: 'home' };
+    }
+  }
+
+  return dropped.size;
+}
+
+export function pluginSearchIndex(): RspressPlugin {
+  return {
+    name: 'plugin-search-index',
+
+    modifySearchIndexData(pages) {
+      for (const page of pages) {
+        if (!page.content) {
+          continue;
+        }
+
+        const cleaned = cleanSearchContent(page.content);
+        if (cleaned === page.content) {
+          continue;
+        }
+
+        page.content = cleaned;
+        recalculateTocCharIndex(page);
+      }
+
+      const dropped = dropDuplicatePages(pages);
+      if (dropped > 0) {
+        console.log(
+          `[plugin-search-index] Removed ${dropped} duplicate page(s) from search index`,
+        );
+      }
+    },
+  };
+}

--- a/docs/plugins/pluginSearchSections.ts
+++ b/docs/plugins/pluginSearchSections.ts
@@ -1,0 +1,187 @@
+/**
+ * Rspress plugin: 为搜索结果生成「顶层目录 → 分组」的映射表。
+ *
+ * 分组标签必须跟着站点语言走，所以不能在代码里写死。这里在构建期扫描当前语言的文档目录，按三级取标签：
+ *
+ * 1. `_nav.json` 的导航项——它本来就是本地化好的（cn: 手册/开发/插件，ja: マニュアル/開発/プラグイン），
+ *    顺序也直接当排序权重用。
+ * 2. 各导航区自己的首页（`pageType: home`）里 features 指向的顶层目录，归到该导航区名下。
+ *    这样 `/template-print`、`/workflow` 这类目录会落进「手册」，而不是各自成组。
+ * 3. 前两级都没覆盖的目录，退回该目录 `index.md` 的标题单独成组。
+ *
+ * 三级都没有的目录不进表，运行时落到兜底分组，属安全降级。
+ *
+ * 结果通过虚拟模块 `virtual-search-sections` 暴露给运行时，见 `theme/search/searchHooks.ts`。
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { RspressPlugin } from '@rspress/core';
+import {
+  getTopLevelSegment,
+  type SearchSection,
+  type SearchSectionTable,
+} from '../shared/searchSections';
+
+export const SEARCH_SECTIONS_MODULE_ID = 'virtual-search-sections';
+
+/** 第三级（目录自带标题）的 order 起点，保证导航区分组永远排在前面。 */
+const STANDALONE_ORDER_BASE = 1000;
+
+interface NavEntry {
+  text?: string;
+  link?: string;
+}
+
+function readJson<T>(filePath: string): T | undefined {
+  if (!fs.existsSync(filePath)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function readFile(filePath: string): string {
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+}
+
+/**
+ * 从 markdown 里取 frontmatter 的 `title`，取不到再退回第一个 `# ` 标题。
+ * 只需要一个标量字段，没必要为此引入 YAML 解析器（js-yaml 在本仓库只是传递依赖）。
+ */
+function readDocTitle(content: string): string {
+  const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+
+  if (frontmatter) {
+    const title = frontmatter[1].match(/^title:\s*(.+)$/m);
+    if (title) {
+      const value = title[1]
+        .trim()
+        .replace(/^['"]|['"]$/g, '')
+        .trim();
+      if (value) {
+        return value;
+      }
+    }
+  }
+
+  const heading = content.match(/^#\s+(.+)$/m);
+  return heading ? heading[1].trim() : '';
+}
+
+function isHomePage(content: string): boolean {
+  const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return Boolean(frontmatter && /^pageType:\s*home\s*$/m.test(frontmatter[1]));
+}
+
+/** 取首页 features 里所有内部链接指向的顶层目录。 */
+function collectFeatureSegments(content: string): string[] {
+  const segments: string[] = [];
+  for (const match of content.matchAll(/^\s*link:\s*(\S+)\s*$/gm)) {
+    const link = match[1].replace(/^['"]|['"]$/g, '').split('#')[0];
+    if (!link.startsWith('/')) {
+      continue;
+    }
+    const segment = getTopLevelSegment(link);
+    if (segment) {
+      segments.push(segment);
+    }
+  }
+  return segments;
+}
+
+function listTopLevelDirs(docsRoot: string): string[] {
+  if (!fs.existsSync(docsRoot)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(docsRoot, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        !entry.name.startsWith('.') &&
+        !entry.name.startsWith('_') &&
+        entry.name !== 'public' &&
+        entry.name !== 'node_modules',
+    )
+    .map((entry) => entry.name)
+    .sort();
+}
+
+export function buildSearchSections(docsRoot: string): SearchSectionTable {
+  const sections: SearchSection[] = [];
+  const claimed = new Set<string>();
+
+  const claim = (prefix: string, label: string, order: number) => {
+    if (!prefix || !label || claimed.has(prefix)) {
+      return;
+    }
+    claimed.add(prefix);
+    sections.push({ id: prefix, prefix, label, order });
+  };
+
+  // 1. nav 顺序即分组顺序。`/plugins` 也照常入表——它的标签（「插件」）要从 nav 取，
+  //    但运行时 resolveSection() 会把它的 order 覆盖成 PLUGIN_ORDER 沉到最后。
+  const nav = readJson<NavEntry[]>(path.join(docsRoot, '_nav.json')) ?? [];
+  const navSections = nav
+    .filter(
+      (item): item is Required<NavEntry> =>
+        Boolean(item.text) && Boolean(item.link?.startsWith('/')),
+    )
+    .map((item, index) => ({
+      label: item.text,
+      prefix: getTopLevelSegment(item.link),
+      order: index,
+    }));
+
+  for (const section of navSections) {
+    claim(section.prefix, section.label, section.order);
+  }
+
+  // 2. 各导航区首页 features 指向的目录，归到该导航区名下。
+  for (const section of navSections) {
+    const content = readFile(
+      path.join(docsRoot, section.prefix.slice(1), 'index.md'),
+    );
+    if (!content || !isHomePage(content)) {
+      continue;
+    }
+    for (const segment of collectFeatureSegments(content)) {
+      claim(segment, section.label, section.order);
+    }
+  }
+
+  // 3. 剩下的目录用自己 index.md 的标题单独成组。
+  let order = STANDALONE_ORDER_BASE;
+  for (const dir of listTopLevelDirs(docsRoot)) {
+    const prefix = `/${dir}`;
+    if (claimed.has(prefix)) {
+      continue;
+    }
+
+    const label = readDocTitle(readFile(path.join(docsRoot, dir, 'index.md')));
+    if (label) {
+      claim(prefix, label, order++);
+    }
+  }
+
+  return sections;
+}
+
+export function pluginSearchSections(): RspressPlugin {
+  return {
+    name: 'plugin-search-sections',
+
+    addRuntimeModules(config) {
+      const docsRoot = config.root || path.join(process.cwd(), 'docs');
+      const sections = buildSearchSections(docsRoot);
+
+      return {
+        [SEARCH_SECTIONS_MODULE_ID]: `export const searchSections = ${JSON.stringify(sections)};`,
+      };
+    },
+  };
+}

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -12,6 +12,7 @@ import {
   crossRefCanonicalMap,
 } from './plugins/pluginCrossRef';
 import { pluginSearchSections } from './plugins/pluginSearchSections';
+import { pluginSearchIndex } from './plugins/pluginSearchIndex';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 
@@ -282,6 +283,7 @@ export default defineConfig({
     pluginRemoveGenerator(),
     pluginCrossRefSidebar(),
     pluginSearchSections(),
+    pluginSearchIndex(),
     sitemap(),
   ],
   search: {

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -11,6 +11,7 @@ import {
   pluginCrossRefSidebar,
   crossRefCanonicalMap,
 } from './plugins/pluginCrossRef';
+import { pluginSearchSections } from './plugins/pluginSearchSections';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 
@@ -60,21 +61,56 @@ const langMap = {
   vi: 'vi-VN',
 };
 
+/**
+ * 搜索结果分组标题里两个固定分组的文案。其余分组的标签由 `pluginSearchSections` 从 `_nav.json` 和
+ * 各目录 `index.md` 里读出来，本来就是本地化好的，不需要在这里维护。
+ *
+ * 缺失语言由 Rspress 自动回落到 `en`，所以只写常用语种即可。
+ */
+const searchI18nSource: Record<string, Record<string, string>> = {
+  searchSectionPlugins: {
+    en: 'Plugins',
+    zh: '插件',
+    ja: 'プラグイン',
+    de: 'Plugins',
+    es: 'Plugins',
+    fr: 'Plugins',
+    pt: 'Plugins',
+    ru: 'Плагины',
+    id: 'Plugin',
+    vi: 'Plugin',
+  },
+  searchSectionOthers: {
+    en: 'Others',
+    zh: '其他',
+    ja: 'その他',
+    de: 'Sonstiges',
+    es: 'Otros',
+    fr: 'Autres',
+    pt: 'Outros',
+    ru: 'Прочее',
+    id: 'Lainnya',
+    vi: 'Khác',
+  },
+};
+
 function withRspressI18nAliases(
   source: Record<string, Record<string, string>>,
 ) {
   return Object.fromEntries(
-    Object.entries(source).map(([key, translations]) => {
-      const nextTranslations = { ...translations };
+    Object.entries({ ...source, ...searchI18nSource }).map(
+      ([key, translations]) => {
+        const nextTranslations = { ...translations };
 
-      for (const [alias, original] of Object.entries(rspressI18nAliases)) {
-        if (!nextTranslations[alias] && nextTranslations[original]) {
-          nextTranslations[alias] = nextTranslations[original];
+        for (const [alias, original] of Object.entries(rspressI18nAliases)) {
+          if (!nextTranslations[alias] && nextTranslations[original]) {
+            nextTranslations[alias] = nextTranslations[original];
+          }
         }
-      }
 
-      return [key, nextTranslations];
-    }),
+        return [key, nextTranslations];
+      },
+    ),
   );
 }
 
@@ -245,8 +281,13 @@ export default defineConfig({
     pluginOgDescription(),
     pluginRemoveGenerator(),
     pluginCrossRefSidebar(),
+    pluginSearchSections(),
     sitemap(),
   ],
+  search: {
+    // 自定义搜索：结果按文档区分组，插件元信息页沉底。见 theme/search/searchHooks.ts。
+    searchHooks: path.join(__dirname, 'theme/search/searchHooks.ts'),
+  },
   lang,
   themeConfig: {
     darkMode: false,

--- a/docs/shared/searchSections.ts
+++ b/docs/shared/searchSections.ts
@@ -1,0 +1,94 @@
+/**
+ * 搜索结果的分组归属。
+ *
+ * 分组表在构建期由 `plugins/pluginSearchSections.ts` 扫描 `_nav.json` 和各顶层目录的 `index.md` 生成，
+ * 运行时由 `theme/search/searchHooks.ts` 消费。这里只放两边共用的类型和纯函数，不依赖 node 也不依赖 DOM。
+ */
+
+/** 插件元信息页的路由前缀。这类页面正文只有 frontmatter，搜索里始终排在最后。 */
+export const PLUGIN_ROUTE_PREFIX = '/plugins/';
+
+/** 插件分组的固定 id。渲染层用它决定是否加视觉分隔和插件徽标。 */
+export const PLUGIN_SECTION_ID = 'plugins';
+
+/** 兜底分组的固定 id，标签由渲染层通过 i18n key `searchSectionOthers` 取。 */
+export const OTHERS_SECTION_ID = 'others';
+
+/** 兜底分组的 order。比任何真实分组都大，但小于插件分组。 */
+export const OTHERS_ORDER = 1_000_000;
+
+/** 插件分组的 order。永远最后。 */
+export const PLUGIN_ORDER = 2_000_000;
+
+export interface SearchSection {
+  /** 分组 id，取顶层目录名（如 `/template-print`）或 `plugins` / `others` 这两个固定值。 */
+  id: string;
+  /** 该分组覆盖的顶层路由前缀，如 `/template-print`。固定分组为空串。 */
+  prefix: string;
+  /** 展示用的本地化标签。固定分组为空串，由渲染层查 i18n。 */
+  label: string;
+  /** 排序权重，小的在前。 */
+  order: number;
+}
+
+/** 构建期注入、运行时读取的分组表。 */
+export type SearchSectionTable = SearchSection[];
+
+export const PLUGIN_SECTION: SearchSection = {
+  id: PLUGIN_SECTION_ID,
+  prefix: PLUGIN_ROUTE_PREFIX,
+  label: '',
+  order: PLUGIN_ORDER,
+};
+
+export const OTHERS_SECTION: SearchSection = {
+  id: OTHERS_SECTION_ID,
+  prefix: '',
+  label: '',
+  order: OTHERS_ORDER,
+};
+
+/**
+ * 取路由的顶层目录：`/template-print/advanced/x` → `/template-print`。
+ * 语言前缀（`/cn/...`）不用处理：搜索索引里的 routePath 本来就不带语言前缀，每种语言是独立的站点构建。
+ */
+export function getTopLevelSegment(routePath: string): string {
+  const [segment] = routePath.replace(/^\/+/, '').split('/');
+  return segment ? `/${segment}` : '';
+}
+
+/** 是否是 `/plugins` 或其下的插件元信息页。 */
+export function isPluginRoute(routePath: string): boolean {
+  return (
+    routePath === PLUGIN_ROUTE_PREFIX.replace(/\/$/, '') ||
+    routePath.startsWith(PLUGIN_ROUTE_PREFIX)
+  );
+}
+
+/**
+ * 把一条路由映射到分组。三级回退：插件页 → 分组表里的顶层目录 → 兜底分组。
+ *
+ * 插件页复用分组表里 `/plugins` 那条的标签（它来自 `_nav.json`，已经本地化好了），
+ * 但 order 强制改成 `PLUGIN_ORDER`，保证不管 nav 里排第几都沉到最后。
+ */
+export function resolveSection(
+  routePath: string,
+  table: SearchSectionTable,
+): SearchSection {
+  const topLevel = getTopLevelSegment(routePath);
+  if (!topLevel) {
+    return OTHERS_SECTION;
+  }
+
+  const matched = table.find((section) => section.prefix === topLevel);
+
+  if (isPluginRoute(routePath)) {
+    return {
+      ...PLUGIN_SECTION,
+      label: matched?.label ?? '',
+      order: PLUGIN_ORDER,
+    };
+  }
+
+  return matched ?? OTHERS_SECTION;
+}

--- a/docs/theme/components/Search/SearchPanel.scss
+++ b/docs/theme/components/Search/SearchPanel.scss
@@ -1,0 +1,143 @@
+.rp-search-panel {
+  &__mask {
+    position: fixed;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background: #3c3c3c66;
+    backdrop-filter: blur(5px);
+    z-index: 100;
+  }
+
+  &__modal {
+    position: relative;
+    background-color: var(--rp-c-bg-soft);
+    border-radius: var(--rp-radius);
+    margin: 80px auto auto;
+    max-width: 560px;
+    padding: 20px;
+    padding-bottom: 20px;
+    height: auto;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+  }
+
+  &__cancel {
+    color: var(--rp-c-brand);
+    margin-left: 0.5rem;
+    cursor: pointer;
+
+    @media (min-width: 640px) {
+      display: none;
+    }
+  }
+
+  &__input-form {
+    width: 100%;
+    height: 55px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    background-color: var(--rp-c-bg);
+    border: 1px solid var(--rp-c-brand);
+    border-radius: var(--rp-radius-small);
+  }
+
+  &__input {
+    flex: 1;
+    padding-left: 8px;
+    height: 100%;
+    width: 80%;
+    outline: none;
+    background-color: var(--rp-c-bg);
+    font-weight: 500;
+    font-size: 20px;
+
+    .dark & {
+      color: var(--rp-c-text);
+    }
+  }
+
+  &__close {
+    &:hover {
+      cursor: pointer;
+      color: var(--rp-c-brand);
+      transition: color 0.3s;
+    }
+  }
+
+  &__results {
+    max-height: calc(100vh - 230px);
+    overflow: scroll;
+    padding-right: 2px;
+  }
+
+  &__loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 2rem 0;
+    opacity: 0.8;
+  }
+
+  &__tabs {
+    position: sticky;
+    background-color: var(--rp-c-bg-soft);
+    padding-bottom: 6px;
+
+    &.rp-tabs {
+      // overrides .rp-tabs
+      border-radius: 0;
+      border: none;
+      margin: 0;
+    }
+  }
+
+  &__group {
+    padding-bottom: 0.5rem;
+  }
+
+  // 以下为 NocoBase 新增：分组标题与插件分组的视觉分隔。
+  &__section {
+    list-style: none;
+  }
+
+  &__section-title {
+    margin: 0.75rem 0 0.25rem;
+    padding: 0 2px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.5;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--rp-c-text-2);
+  }
+
+  &__section--plugins {
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--rp-c-divider-light);
+  }
+
+  @media (max-width: 960px) {
+    &__modal {
+      margin-top: 0;
+    }
+
+    &__input-form {
+      height: 40px;
+
+      svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    &__input {
+      font-size: 16px;
+    }
+  }
+}

--- a/docs/theme/components/Search/SearchPanel.tsx
+++ b/docs/theme/components/Search/SearchPanel.tsx
@@ -1,0 +1,625 @@
+/**
+ * Vendored from `@rspress/core@2.0.7`
+ * (`node_modules/@rspress/core/dist/eject-theme/components/Search/SearchPanel.tsx`).
+ *
+ * 升级 rspress 时请 diff 上游同名文件。相对上游只有三处改动，其余逐字保留，方便比对：
+ *
+ * 1. import 路径改为从 `@rspress/core` 的公开/深层入口取，因为本文件不在 rspress 包内。
+ * 2. `normalizeSuggestions` 从「按 item.title 分组」改成「按 searchHooks 打好的 section 分组」。
+ *    上游按标题分组，导致同名不同页（`/template-print/` 与 `/plugins/@nocobase/plugin-action-template-print/`）
+ *    被合并成一组，看起来就是两条重复结果。
+ * 3. 每组渲染一个可见的分组标题。
+ *
+ * 键盘导航、IME 组字处理、滚动逻辑均未改动。
+ */
+import { useI18n, usePageData } from '@rspress/core/runtime';
+import {
+  IconClose,
+  IconLoading,
+  IconSearch,
+  SvgWrapper,
+  Tab,
+  Tabs,
+  useLinkNavigate,
+} from '@rspress/core/theme';
+import type {
+  CustomMatchResult,
+  DefaultMatchResult,
+  DefaultMatchResultItem,
+  MatchResult,
+  PageSearcherConfig,
+  RenderType as RenderTypeEnum,
+} from '@rspress/core/theme';
+// `RenderType` 在 rspress 里声明成 `const enum`，开启 verbatimModuleSyntax 后无法当值引用，
+// 这里用等价的字面量常量替代（运行时就是 'default' / 'custom' 两个字符串，和 rspress 内部一致）。
+const RenderType = {
+  Default: 'default' as RenderTypeEnum.Default,
+  Custom: 'custom' as RenderTypeEnum.Custom,
+};
+// PageSearcher 和 NoSearchResult 没有从 `@rspress/core/theme` 导出，只能走包的 `./dist/*` 子路径入口。
+import { PageSearcher } from '@rspress/core/dist/theme/components/Search/logic/search.js';
+import { NoSearchResult } from '@rspress/core/dist/theme/components/Search/NoSearchResult.js';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import * as userSearchHooks from 'virtual-search-hooks';
+import type { SearchSection } from '../../../shared/searchSections';
+import { OTHERS_SECTION_ID, PLUGIN_SECTION_ID } from '../../../shared/searchSections';
+import { getSectionKey, getSectionOf } from '../../search/searchHooks';
+import './SearchPanel.scss';
+import { SuggestItem } from './SuggestItem';
+
+const KEY_CODE = {
+  ARROW_UP: 'ArrowUp',
+  ARROW_DOWN: 'ArrowDown',
+  ENTER: 'Enter',
+  SEARCH: 'KeyK',
+  ESC: 'Escape',
+};
+
+export interface SearchPanelProps {
+  focused: boolean;
+  setFocused: (focused: boolean) => void;
+}
+
+const DEBOUNCE_MS = 150;
+
+/**
+ * 相对上游改了两点：泛型约束从 `any[] => any` 收紧（本仓库禁用 explicit any），
+ * 以及用几行本地 setTimeout 取代 `lodash-es` 的 debounce——仓库没装 `@types/lodash-es`，
+ * 为了一个 debounce 引入类型包不划算。行为一致：尾部触发，新调用重置计时。
+ */
+const useDebounce = <T extends (...args: never[]) => unknown>(cb: T) => {
+  const cbRef = useRef(cb);
+  cbRef.current = cb;
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return useCallback((...args: Parameters<T>) => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => cbRef.current(...args), DEBOUNCE_MS);
+  }, []);
+};
+
+export function SearchPanel({ focused, setFocused }: SearchPanelProps) {
+  const [query, setQuery] = useState('');
+  const [searchResult, setSearchResult] = useState<MatchResult>([]);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [resultTabIndex, setResultTabIndex] = useState(0);
+  const [currentSuggestionIndex, setCurrentSuggestionIndex] = useState(0);
+  const pageSearcherRef = useRef<PageSearcher | null>(null);
+  const pageSearcherConfigRef = useRef<PageSearcherConfig | null>(null);
+  const [initStatus, setInitStatus] = useState<
+    'initial' | 'initing' | 'inited'
+  >('initial');
+  const searchResultRef = useRef<HTMLDivElement>(null);
+  const searchResultTabRef = useRef<HTMLDivElement>(null);
+  const mousePositionRef = useRef<{
+    pageX: number | null;
+    pageY: number | null;
+  }>({
+    pageX: null,
+    pageY: null,
+  });
+
+  // only scroll after keydown arrow up and arrow down.
+  const [canScroll, setCanScroll] = useState(false);
+  const scrollTo = (offsetTop: number, offsetHeight: number) => {
+    const currentOffsetHeight = searchResultRef.current?.offsetHeight;
+    const currentScrollTop = searchResultRef.current?.scrollTop;
+    if (
+      canScroll &&
+      currentOffsetHeight !== undefined &&
+      currentScrollTop !== undefined
+    ) {
+      // Down
+      // 50 = 20(modal margin) + 40(input height) - 10(item margin)
+      // -10 = 50(following) - 50(tab title) - 10(item margin)
+      const scrollDown =
+        offsetTop +
+        offsetHeight -
+        currentOffsetHeight -
+        (searchResult.length === 1 ? 50 : -10);
+      if (scrollDown > currentScrollTop) {
+        searchResultRef.current?.scrollTo({
+          top: scrollDown,
+        });
+      }
+
+      // Up
+      // 70 = 20(modal margin) + 40(input height) + 10(item margin)
+      // 10 = 70(following) - 50(tab title) - 10(item margin)
+      const scrollUp =
+        searchResult.length === 1 ? offsetTop - 70 : offsetTop - 10;
+      if (scrollUp < currentScrollTop) {
+        searchResultRef.current?.scrollTo({
+          top: scrollUp,
+        });
+      }
+    }
+  };
+  const {
+    siteData,
+    page: { lang, version },
+  } = usePageData();
+  // 泛型参数补上本仓库在 rspress.config.ts 的 i18nSource 里自定义的两个分组文案 key。
+  const t = useI18n<{
+    searchSectionPlugins: string;
+    searchSectionOthers: string;
+  }>();
+  const navigate = useLinkNavigate();
+  const { search, title: siteTitle } = siteData;
+  const versionedSearch =
+    typeof search !== 'boolean' && (search?.versioned ?? true);
+  const DEFAULT_RESULT: MatchResult = [
+    { group: siteTitle, result: [], renderType: RenderType.Default },
+  ];
+  const currentSuggestions =
+    (searchResult[resultTabIndex]?.result as DefaultMatchResultItem[]) ?? [];
+  const currentRenderType =
+    searchResult[resultTabIndex]?.renderType ?? RenderType.Default;
+
+  if (search === false) {
+    return null;
+  }
+
+  /**
+   * Create page searcher instance.
+   */
+  const createSearcher = () => {
+    if (pageSearcherRef.current) {
+      return pageSearcherRef.current;
+    }
+
+    const pageSearcherConfig = {
+      currentLang: lang,
+      currentVersion: version,
+    };
+    const pageSearcher = new PageSearcher({
+      indexName: siteTitle,
+      ...search,
+      ...pageSearcherConfig,
+    });
+    pageSearcherRef.current = pageSearcher;
+    pageSearcherConfigRef.current = pageSearcherConfig;
+
+    return pageSearcherRef.current;
+  };
+
+  /**
+   * Call `searcher.init` to initialize the search index
+   */
+  async function initSearch() {
+    if (initStatus !== 'initial') {
+      return;
+    }
+
+    const searcher = createSearcher();
+
+    setInitStatus('initing');
+    await searcher.init();
+    setInitStatus('inited');
+
+    const query = searchInputRef.current?.value;
+    if (query) {
+      const matched = await searcher.match(query);
+      setSearchResult(matched || DEFAULT_RESULT);
+      setIsSearching(false);
+    }
+  }
+
+  const clearSearchState = () => {
+    setFocused(false);
+    setResultTabIndex(0);
+    setCurrentSuggestionIndex(0);
+  };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      switch (e.code) {
+        case KEY_CODE.SEARCH:
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault();
+            setFocused(!focused);
+          }
+          break;
+        case KEY_CODE.ARROW_DOWN:
+          // prevent arrow down key event when IME is composing
+          if (e.isComposing) {
+            return;
+          }
+          if (focused) {
+            e.preventDefault();
+            if (
+              currentSuggestions &&
+              currentRenderType === RenderType.Default
+            ) {
+              setCanScroll(true);
+              setCurrentSuggestionIndex(
+                (currentSuggestionIndex + 1) % currentSuggestions.length,
+              );
+            }
+          }
+          break;
+        case KEY_CODE.ARROW_UP:
+          // prevent arrow up key event when IME is composing
+          if (e.isComposing) {
+            return;
+          }
+          if (focused) {
+            e.preventDefault();
+            if (currentRenderType === RenderType.Default) {
+              const currentSuggestionsLength = currentSuggestions.length;
+              setCanScroll(true);
+              setCurrentSuggestionIndex(
+                (currentSuggestionIndex - 1 + currentSuggestionsLength) %
+                  currentSuggestionsLength,
+              );
+            }
+          }
+          break;
+        case KEY_CODE.ENTER:
+          /**
+           * prevent enter key event when IME is composing, it's more friendly for CJK users.
+           * @see https://github.com/web-infra-dev/rspress/issues/1861
+           */
+          if (e.isComposing) {
+            return;
+          }
+          if (
+            currentSuggestionIndex >= 0 &&
+            currentRenderType === RenderType.Default
+          ) {
+            // the ResultItem has been normalized to display
+            const flatSuggestions = Array.from(
+              normalizeSuggestions(currentSuggestions).values(),
+            ).flat();
+            const suggestion = flatSuggestions[currentSuggestionIndex];
+            navigate(suggestion.link);
+            clearSearchState();
+          }
+          break;
+        case KEY_CODE.ESC:
+          clearSearchState();
+          break;
+        default:
+          break;
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [
+    setCurrentSuggestionIndex,
+    setFocused,
+    focused,
+    resultTabIndex,
+    currentSuggestions,
+    currentSuggestionIndex,
+  ]);
+
+  useEffect(() => {
+    if (focused) {
+      setSearchResult(DEFAULT_RESULT);
+      initSearch();
+    } else {
+      setQuery('');
+    }
+  }, [focused]);
+
+  // Prefetch the search index when the page is idle
+  useEffect(() => {
+    if ('requestIdleCallback' in window && !pageSearcherRef.current) {
+      window.requestIdleCallback(() => {
+        const searcher = createSearcher();
+        searcher.fetchSearchIndex();
+      });
+    }
+  }, []);
+
+  // init pageSearcher again when lang or version changed
+  useEffect(() => {
+    const { currentLang, currentVersion } = pageSearcherConfigRef.current ?? {};
+    const isLangChanged = lang !== currentLang;
+    const isVersionChanged = versionedSearch && version !== currentVersion;
+
+    if (isLangChanged || isVersionChanged) {
+      // reset status first
+      setInitStatus('initial');
+      pageSearcherRef.current = null;
+      const searcher = createSearcher();
+      searcher.fetchSearchIndex();
+    }
+  }, [lang, version, versionedSearch]);
+
+  const handleQueryChangedImpl = async (value: string) => {
+    let newQuery = value;
+    setQuery(newQuery);
+    if (newQuery) {
+      const searchResult: MatchResult = [];
+
+      if ('beforeSearch' in userSearchHooks) {
+        const key = 'beforeSearch' as const;
+        const transformedQuery = await userSearchHooks[key](newQuery);
+        if (transformedQuery) {
+          newQuery = transformedQuery;
+        }
+      }
+
+      const defaultSearchResult =
+        await pageSearcherRef.current?.match(newQuery);
+
+      if (defaultSearchResult) {
+        searchResult.push(...defaultSearchResult);
+      }
+
+      if ('onSearch' in userSearchHooks) {
+        const key = 'onSearch' as const;
+        const customSearchResult = await userSearchHooks[key](
+          newQuery,
+          searchResult as DefaultMatchResult[],
+        );
+        if (customSearchResult) {
+          searchResult.push(
+            ...customSearchResult.map(
+              item =>
+                ({
+                  renderType: RenderType.Custom,
+                  ...item,
+                }) as CustomMatchResult,
+            ),
+          );
+        }
+      }
+
+      if ('afterSearch' in userSearchHooks) {
+        const key = 'afterSearch' as const;
+        await userSearchHooks[key](newQuery, searchResult);
+      }
+
+      // only setSearchResult when query is current query value
+      const currQuery = searchInputRef.current?.value;
+      if (currQuery === newQuery) {
+        // Reset current suggestion index to 0 when search query changes
+        setCurrentSuggestionIndex(0);
+        setSearchResult(searchResult || DEFAULT_RESULT);
+        setIsSearching(false);
+      }
+    }
+  };
+
+  const handleQueryChange = useDebounce(handleQueryChangedImpl);
+
+  // 改动 2：按 searchHooks 打好的 section 分组（上游是按 item.title）。
+  // 分组 key 用 getSectionKey()，同一个标签下的多个顶层目录（「手册」名下有 /template-print、
+  // /data-sources……）会并成一个分组框。searchHooks 已排好序，顺序遍历即可，Map 保持插入顺序。
+  const normalizeSuggestions = (
+    suggestions: DefaultMatchResult['result'],
+  ): Map<string, DefaultMatchResultItem[]> => {
+    return suggestions.reduce(
+      (groups, item) => {
+        const section = getSectionOf(item);
+        const group = section ? getSectionKey(section) : OTHERS_SECTION_ID;
+        if (!groups.has(group)) {
+          groups.set(group, []);
+        }
+        groups.get(group)!.push(item);
+        return groups;
+      },
+      new Map() as Map<string, DefaultMatchResult['result']>,
+    );
+  };
+
+  // 分组标题：优先用构建期生成的本地化标签，固定分组（插件/其他）回落到 i18n。
+  const getSectionLabel = (section: SearchSection | undefined): string => {
+    if (section?.label) {
+      return section.label;
+    }
+    return section?.id === PLUGIN_SECTION_ID
+      ? t('searchSectionPlugins')
+      : t('searchSectionOthers');
+  };
+
+  const renderSearchResult = (result: MatchResult, isSearching: boolean) => {
+    if (result.length === 1) {
+      const currentSearchResult = result[0]
+        .result as DefaultMatchResult['result'];
+      if (currentSearchResult.length === 0 && !isSearching) {
+        return <NoSearchResult query={query} />;
+      }
+      return (
+        <div ref={searchResultTabRef}>
+          {renderSearchResultItem(currentSearchResult, query, isSearching)}
+        </div>
+      );
+    }
+
+    const tabValues = result.map(item => {
+      return item.group;
+    });
+
+    const renderKey = 'render' as const;
+
+    return (
+      <Tabs
+        values={tabValues}
+        className="rp-search-panel__tabs"
+        onChange={index => {
+          setResultTabIndex(index);
+          setCurrentSuggestionIndex(0);
+        }}
+        keepDOM={false}
+        ref={searchResultTabRef}
+      >
+        {result.map(item => (
+          <Tab key={item.group}>
+            {item.renderType === RenderType.Default &&
+              renderSearchResultItem(item.result, query, isSearching)}
+            {item.renderType === RenderType.Custom &&
+              userSearchHooks[renderKey](item.result)}
+          </Tab>
+        ))}
+      </Tabs>
+    );
+  };
+
+  const renderSearchResultItem = (
+    suggestionList: DefaultMatchResult['result'],
+    query: string,
+    isSearching: boolean,
+  ) => {
+    // if isSearching, show loading svg
+    if (isSearching) {
+      return (
+        <div className="rp-search-panel__loading">
+          <SvgWrapper icon={IconLoading} />
+        </div>
+      );
+    }
+
+    // if no result, show the no result tip
+    if (suggestionList.length === 0 && initStatus === 'inited') {
+      return <NoSearchResult query={query} />;
+    }
+
+    const normalizedSuggestions = normalizeSuggestions(suggestionList);
+    // accumulateIndex is used to calculate the index of the suggestion in the whole list.
+    let accumulateIndex = -1;
+    return (
+      <ul>
+        {Array.from(normalizedSuggestions.keys()).map(group => {
+          const groupSuggestions = normalizedSuggestions.get(group) || [];
+          // 改动 3：渲染可见的分组标题，并用 aria-labelledby 关联到该组的列表。
+          const section = getSectionOf(groupSuggestions[0]);
+          const headingId = `rp-search-section-${group.replace(/[^\w-]/g, '-')}`;
+          return (
+            <li
+              key={group}
+              className={`rp-search-panel__section${
+                section?.id === PLUGIN_SECTION_ID
+                  ? ' rp-search-panel__section--plugins'
+                  : ''
+              }`}
+            >
+              <h3 className="rp-search-panel__section-title" id={headingId}>
+                {getSectionLabel(section)}
+              </h3>
+              <ul className="rp-search-panel__group" aria-labelledby={headingId}>
+                {groupSuggestions.map(suggestion => {
+                  accumulateIndex++;
+                  const suggestionIndex = accumulateIndex;
+                  return (
+                    <SuggestItem
+                      key={`${suggestion.title}-${suggestionIndex}`}
+                      suggestion={suggestion}
+                      isCurrent={suggestionIndex === currentSuggestionIndex}
+                      setCurrentSuggestionIndex={event => {
+                        if (
+                          mousePositionRef.current.pageX === event.pageX &&
+                          mousePositionRef.current.pageY === event.pageY
+                        ) {
+                          return;
+                        }
+
+                        setCanScroll(false);
+                        setCurrentSuggestionIndex(suggestionIndex);
+                      }}
+                      onMouseMove={event => {
+                        mousePositionRef.current = {
+                          pageX: event.pageX,
+                          pageY: event.pageY,
+                        };
+                      }}
+                      closeSearch={() => {
+                        clearSearchState();
+                      }}
+                      inCurrentDocIndex={resultTabIndex === 0}
+                      scrollTo={scrollTo}
+                    />
+                  );
+                })}
+              </ul>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  return (
+    <>
+      {focused &&
+        createPortal(
+          <div
+            className="rp-search-panel__mask"
+            onClick={() => {
+              clearSearchState();
+            }}
+          >
+            <div
+              className="rp-search-panel__modal"
+              onClick={e => {
+                setFocused(true);
+                e.stopPropagation();
+              }}
+            >
+              <div className="rp-search-panel__header">
+                <div className="rp-search-panel__input-form">
+                  <label>
+                    <SvgWrapper icon={IconSearch} />
+                  </label>
+                  <input
+                    className="rp-search-panel__input"
+                    ref={searchInputRef}
+                    placeholder={t('searchPlaceholderText')}
+                    aria-label="SearchPanelInput"
+                    autoComplete="off"
+                    autoFocus
+                    onChange={e => handleQueryChange(e.target.value)}
+                  />
+                  <label>
+                    <SvgWrapper
+                      icon={IconClose}
+                      className="rp-search-panel__close"
+                      onClick={e => {
+                        if (searchInputRef.current) {
+                          e.stopPropagation();
+                          if (!query) {
+                            clearSearchState();
+                          } else {
+                            searchInputRef.current.value = '';
+                            setQuery('');
+                          }
+                        }
+                      }}
+                    />
+                  </label>
+                </div>
+                <h2
+                  className="rp-search-panel__cancel"
+                  onClick={e => {
+                    e.stopPropagation();
+                    clearSearchState();
+                  }}
+                >
+                  {t('searchPanelCancelText')}
+                </h2>
+              </div>
+
+              {query && initStatus === 'inited' ? (
+                <div
+                  className="rp-search-panel__results rp-scrollbar"
+                  ref={searchResultRef}
+                >
+                  {renderSearchResult(searchResult, isSearching)}
+                </div>
+              ) : null}
+            </div>
+          </div>,
+          document.getElementById('__rspress_modal_container')!,
+        )}
+    </>
+  );
+}

--- a/docs/theme/components/Search/SuggestItem.scss
+++ b/docs/theme/components/Search/SuggestItem.scss
@@ -1,0 +1,110 @@
+.rp-suggest-item {
+  list-style: none;
+  box-sizing: border-box;
+  margin: 5px 2px;
+
+  .dark &,
+  .dark & .rp-suggest-item__link {
+    box-shadow: none;
+  }
+
+  & .rp-suggest-item__link {
+    color: var(--rp-c-text-1);
+    background-color: var(--rp-c-bg);
+    border-radius: var(--rp-radius-small);
+    padding-left: 12px;
+    display: flex;
+    width: 100%;
+    box-shadow: 0 1px 3px 0 #d4d9e1;
+  }
+
+  &--current {
+    .rp-suggest-item__link {
+      background-color: var(--rp-c-brand);
+      cursor: pointer;
+      color: #ffffff;
+    }
+
+    .rp-suggest-item__container {
+      .rp-suggest-item__icon {
+        color: #ffffff;
+      }
+
+      .rp-suggest-item__action-icon {
+        opacity: 1;
+      }
+
+      .rp-suggest-item__content {
+        .rp-suggest-item__statement {
+          color: #ffffff;
+        }
+        .rp-suggest-item__mark {
+          color: #ffffff;
+          text-decoration: underline;
+        }
+
+        .rp-suggest-item__title {
+          color: #ffffff;
+        }
+
+        .rp-suggest-item__path {
+          color: #ffffff;
+          opacity: 0.85;
+        }
+      }
+    }
+  }
+
+  &__container {
+    width: 100%;
+    min-height: 56px;
+    display: flex;
+    align-items: center;
+    font-weight: 500;
+    padding-right: 12px;
+  }
+
+  &__icon {
+    color: var(--rp-c-gray-light-1);
+  }
+
+  &__content {
+    padding: 6px 8px 6px;
+    font-size: 14px;
+    line-height: 1.5;
+    width: 100%;
+  }
+
+  &__header {
+    font-weight: 500;
+  }
+
+  &__statement {
+    font-size: 0.875rem;
+    width: 100%;
+  }
+
+  &__mark {
+    color: var(--rp-c-brand);
+  }
+
+  &__title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--rp-c-gray-light-1);
+  }
+
+  // NocoBase 新增：标题类结果下方的路径行，用于区分同名页面。
+  &__path {
+    margin-top: 2px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: var(--rp-c-text-2);
+    word-break: break-all;
+  }
+
+  &__action-icon {
+    opacity: 0;
+  }
+}

--- a/docs/theme/components/Search/SuggestItem.tsx
+++ b/docs/theme/components/Search/SuggestItem.tsx
@@ -1,0 +1,177 @@
+/**
+ * Vendored from `@rspress/core@2.0.7`
+ * (`node_modules/@rspress/core/dist/eject-theme/components/Search/SuggestItem.tsx`).
+ *
+ * 升级 rspress 时请 diff 上游同名文件。相对上游只有两处改动，其余逐字保留：
+ *
+ * 1. import 路径改为从 `@rspress/core` 的公开/深层入口取，因为本文件不在 rspress 包内。
+ * 2. 标题类结果补一行路径面包屑——「模板打印」在 `/template-print/` 和
+ *    `/plugins/@nocobase/plugin-action-template-print/` 各有一页，光看标题分不出哪个是正文文档。
+ */
+import {
+  IconFile,
+  IconHeader,
+  IconJump,
+  IconTitle,
+  Link,
+  SvgWrapper,
+} from '@rspress/core/theme';
+import type {
+  DefaultMatchResultItem,
+  HighlightInfo,
+} from '@rspress/core/theme';
+import { getSlicedStrByByteLength } from '@rspress/core/dist/theme/components/Search/logic/util.js';
+import { useRef } from 'react';
+import './SuggestItem.scss';
+
+export function SuggestItem({
+  suggestion,
+  closeSearch,
+  isCurrent,
+  setCurrentSuggestionIndex,
+  scrollTo,
+  onMouseMove,
+}: {
+  suggestion: DefaultMatchResultItem;
+  closeSearch: () => void;
+  isCurrent: boolean;
+  setCurrentSuggestionIndex: (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+  ) => void;
+  onMouseMove: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
+  inCurrentDocIndex: boolean;
+  scrollTo: (top: number, height: number) => void;
+}) {
+  const ICON_MAP = {
+    title: IconTitle,
+    header: IconHeader,
+    content: IconFile,
+  };
+
+  const HitIcon = ICON_MAP[suggestion.type];
+  const selfRef = useRef<HTMLLIElement>(null);
+  if (isCurrent && selfRef.current?.offsetTop) {
+    scrollTo(selfRef.current?.offsetTop, selfRef.current?.offsetHeight);
+  }
+
+  const getHighlightedFragments = (
+    rawText: string,
+    highlights: HighlightInfo[],
+  ) => {
+    // Split raw text into several parts, and add styles.mark className to the parts that need to be highlighted.
+    // highlightInfoList is an array of objects, each object contains the start index and the length of the part that needs to be highlighted.
+    // For example, if the statement is "This is a statement", and the query is "is", then highlightInfoList is [{start: 2, length: 2}, {start: 5, length: 2}].
+    const fragmentList = [];
+    let lastIndex = 0;
+    for (const highlightInfo of highlights) {
+      const { start, length } = highlightInfo;
+      const prefix = rawText.slice(lastIndex, start);
+      const queryStr = getSlicedStrByByteLength(rawText, start, length);
+      fragmentList.push(prefix);
+      fragmentList.push(
+        <span key={start} className="rp-suggest-item__mark">
+          {queryStr}
+        </span>,
+      );
+      lastIndex = start + queryStr.length;
+    }
+
+    if (lastIndex < rawText.length) {
+      fragmentList.push(rawText.slice(lastIndex));
+    }
+
+    return fragmentList;
+  };
+
+  const renderHeaderMatch = () => {
+    if (suggestion.type === 'header' || suggestion.type === 'title') {
+      const { header, highlightInfoList } = suggestion;
+      return (
+        <div className="rp-suggest-item__header">
+          {getHighlightedFragments(header, highlightInfoList)}
+        </div>
+      );
+    }
+
+    return <div className="rp-suggest-item__header">{suggestion.header}</div>;
+  };
+
+  const renderStatementMatch = () => {
+    if (suggestion.type !== 'content') {
+      return <div></div>;
+    }
+    const { statement, highlightInfoList } = suggestion;
+    return (
+      <div className="rp-suggest-item__statement">
+        {getHighlightedFragments(statement, highlightInfoList)}
+      </div>
+    );
+  };
+
+  // 改动 2：标题类结果补一行路径，区分同名页面。header/content 类型本身已带上下文，不需要。
+  const renderPath = () => {
+    if (suggestion.type !== 'title') {
+      return null;
+    }
+    const routePath = suggestion.link.split('#')[0].replace(/\/$/, '');
+    if (!routePath) {
+      return null;
+    }
+    return <p className="rp-suggest-item__path">{routePath}</p>;
+  };
+
+  let hitContent = null;
+
+  switch (suggestion.type) {
+    case 'title':
+    case 'header':
+      hitContent = (
+        <>
+          {renderHeaderMatch()}
+          {renderPath()}
+        </>
+      );
+      break;
+    case 'content':
+      hitContent = (
+        <>
+          {renderStatementMatch()}
+          <p className="rp-suggest-item__title">{suggestion.title}</p>
+        </>
+      );
+      break;
+    default:
+      break;
+  }
+
+  return (
+    <li
+      key={suggestion.link}
+      className={`rp-suggest-item ${isCurrent ? 'rp-suggest-item--current' : ''}`}
+      onMouseEnter={setCurrentSuggestionIndex}
+      onMouseMove={onMouseMove}
+      ref={selfRef}
+    >
+      <Link
+        href={suggestion.link}
+        className="rp-suggest-item__link"
+        onClick={e => {
+          closeSearch();
+          e.stopPropagation();
+        }}
+      >
+        <div className="rp-suggest-item__container">
+          <div className="rp-suggest-item__icon">
+            <SvgWrapper icon={HitIcon} />
+          </div>
+          <div className="rp-suggest-item__content">
+            <span>{hitContent}</span>
+          </div>
+          <div className="rp-suggest-item__action-icon">
+            <SvgWrapper icon={IconJump} />
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/docs/theme/index.tsx
+++ b/docs/theme/index.tsx
@@ -397,3 +397,7 @@ export function HomeFeature() {
 export { Nav } from './components/Nav';
 
 export * from '@rspress/core/theme-original';
+
+// 必须放在 `export *` 之后：同名导出以最后一次为准，这样才能覆盖掉 theme-original 的默认实现。
+export { SearchPanel } from './components/Search/SearchPanel';
+export { SuggestItem } from './components/Search/SuggestItem';

--- a/docs/theme/search/searchHooks.ts
+++ b/docs/theme/search/searchHooks.ts
@@ -96,17 +96,113 @@ export function getSectionOf(
     : undefined;
 }
 
+/** 合并后的正文预览最多展示几个片段。再多卡片会长到喧宾夺主。 */
+const MAX_MERGED_STATEMENTS = 3;
+
+/** 合并正文片段时的分隔符。 */
+const STATEMENT_SEPARATOR = ' … ';
+
+function isContentMatch(
+  item: DefaultMatchResultItem,
+): item is Extract<DefaultMatchResultItem, { type: 'content' }> {
+  return item.type === 'content';
+}
+
+/**
+ * 把同一页面的多条正文命中合并成一条，片段之间用 `…` 连接。
+ *
+ * 高亮位置是相对 statement 的偏移量，拼接后必须整体右移各自片段在结果串里的起点，否则高亮会错位。
+ */
+function mergeContentMatches(
+  matches: Extract<DefaultMatchResultItem, { type: 'content' }>[],
+): DefaultMatchResultItem {
+  const [first] = matches;
+  if (matches.length === 1) {
+    return first;
+  }
+
+  const kept = matches.slice(0, MAX_MERGED_STATEMENTS);
+  const statements: string[] = [];
+  const highlightInfoList: { start: number; length: number }[] = [];
+  let offset = 0;
+
+  for (const match of kept) {
+    const statement = match.statement.trim();
+    if (!statement) {
+      continue;
+    }
+    if (statements.length > 0) {
+      offset += STATEMENT_SEPARATOR.length;
+    }
+    for (const highlight of match.highlightInfoList) {
+      // trim() 掉的前导空白也要从偏移里扣掉。
+      const trimmedPrefix = match.statement.length - match.statement.trimStart().length;
+      highlightInfoList.push({
+        start: highlight.start - trimmedPrefix + offset,
+        length: highlight.length,
+      });
+    }
+    statements.push(statement);
+    offset += statement.length;
+  }
+
+  return {
+    ...first,
+    statement: statements.join(STATEMENT_SEPARATOR),
+    highlightInfoList,
+  };
+}
+
 /** 去重 + 打标 + 排序。抽成纯函数，方便脱离 rspress 运行时验证。 */
 export function organizeSearchResult(
   items: DefaultMatchResultItem[],
   query: string,
 ): SectionedMatchResultItem[] {
+  // 同一页面的多条正文命中先合并成一条，多个片段进同一条预览。
+  // 用不带锚点的路由做 key：正文片段的锚点是按所在小节推出来的，同一页不同段落锚点可能不同。
+  const contentByPage = new Map<
+    string,
+    Extract<DefaultMatchResultItem, { type: 'content' }>[]
+  >();
+  for (const item of items) {
+    if (!isContentMatch(item)) {
+      continue;
+    }
+    const pageKey = item.link.split('#')[0];
+    const group = contentByPage.get(pageKey);
+    if (group) {
+      group.push(item);
+    } else {
+      contentByPage.set(pageKey, [item]);
+    }
+  }
+
+  const mergedContent = new Map<string, DefaultMatchResultItem>();
+  for (const [pageKey, matches] of contentByPage) {
+    mergedContent.set(pageKey, mergeContentMatches(matches));
+  }
+
+  const seenContentPage = new Set<string>();
+  const deduped: DefaultMatchResultItem[] = [];
+  for (const item of items) {
+    if (!isContentMatch(item)) {
+      deduped.push(item);
+      continue;
+    }
+    const pageKey = item.link.split('#')[0];
+    if (seenContentPage.has(pageKey)) {
+      continue;
+    }
+    seenContentPage.add(pageKey);
+    deduped.push(mergedContent.get(pageKey) ?? item);
+  }
+
   const bestByLink = new Map<
     string,
     { item: DefaultMatchResultItem; index: number }
   >();
 
-  items.forEach((item, index) => {
+  deduped.forEach((item, index) => {
     const existing = bestByLink.get(item.link);
     if (!existing || TYPE_RANK[item.type] < TYPE_RANK[existing.item.type]) {
       // 命中同一个链接时保留更「标题级」的那条，但沿用首次出现的位置，避免把相关性靠前的结果推后。

--- a/docs/theme/search/searchHooks.ts
+++ b/docs/theme/search/searchHooks.ts
@@ -1,0 +1,177 @@
+/**
+ * 自定义搜索钩子（数据层）。在 `rspress.config.ts` 里通过 `search.searchHooks` 注册。
+ *
+ * 只做四件事：给每条结果打上分组标记、按 link 去重、按「分组 → 匹配类型 → 原相关性」稳定排序、
+ * 把 `/plugins/@nocobase/` 的插件元信息页沉到最后。分组标题的渲染在 `theme/components/Search/` 里。
+ *
+ * 为什么插件页要沉底：它们正文只有 frontmatter 和一行标题，和真正的文档同名（例如「模板打印」同时存在
+ * `/template-print/` 和 `/plugins/@nocobase/plugin-action-template-print/`），却在索引里占了近两成，
+ * 排在前面会把真正有内容的文档挤下去。
+ */
+import type { DefaultMatchResult, OnSearch } from '@rspress/core/theme';
+import { searchSections } from 'virtual-search-sections';
+import {
+  PLUGIN_SECTION_ID,
+  resolveSection,
+  type SearchSection,
+} from '../../shared/searchSections';
+
+type DefaultMatchResultItem = DefaultMatchResult['result'][number];
+
+/** 打上分组标记后的结果项。渲染层按 `section` 分组并显示标题。 */
+export type SectionedMatchResultItem = DefaultMatchResultItem & {
+  section: SearchSection;
+};
+
+/** 同一页面命中多次时的优先级：标题 > 小标题 > 正文。 */
+const TYPE_RANK: Record<DefaultMatchResultItem['type'], number> = {
+  title: 0,
+  header: 1,
+  content: 2,
+};
+
+/** 标题和查询词完全相同（「模板打印」→ 标题就是「模板打印」），最相关。 */
+const EXACT_TITLE_RANK = -2;
+
+/**
+ * 标题以查询词开头（「单点登录」→「单点登录 SSO 集成」），次相关。
+ *
+ * 这一档必须存在：否则它和「查询词出现在标题中间」（「应用单点登录」）同档，
+ * 只能靠标题长度决胜，而更短的「应用单点登录」会赢——但显然是讲单点登录本身的那篇更该排前面。
+ */
+const PREFIX_TITLE_RANK = -1;
+
+/**
+ * 分组的展示 key。同一个标签下的多个顶层目录（「手册」名下有 /template-print、/data-sources……）
+ * 必须并成一个分组框，否则同名标题会重复出现好几次。
+ */
+export function getSectionKey(section: SearchSection): string {
+  return `${section.order}|${section.label || section.id}`;
+}
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+/** 结果的相关性档位，越小越靠前。 */
+function rankOf(item: DefaultMatchResultItem, query: string): number {
+  if (item.type !== 'title') {
+    return TYPE_RANK[item.type];
+  }
+
+  const title = normalize(item.title);
+  const keyword = normalize(query);
+
+  if (title === keyword) {
+    return EXACT_TITLE_RANK;
+  }
+  if (title.startsWith(keyword)) {
+    return PREFIX_TITLE_RANK;
+  }
+  return TYPE_RANK.title;
+}
+
+/**
+ * 同档位的两条标题命中之间的次级比较：标题越短越贴近查询词。
+ *
+ * 只在前面所有判据都打平时才用得上。例如英文站 `/template-print/`（Template Printing）和
+ * `/template-print/http-api`（Template Print HTTP API）同为前缀命中，这时短的更「正题」。
+ */
+function compareTitleLength(
+  a: DefaultMatchResultItem,
+  b: DefaultMatchResultItem,
+): number {
+  if (a.type !== 'title' || b.type !== 'title') {
+    return 0;
+  }
+  return a.title.length - b.title.length;
+}
+
+/** 取一条结果的分组标记；没打上标记（理论上不会）时返回 undefined，由渲染层回落到兜底分组。 */
+export function getSectionOf(
+  item: DefaultMatchResultItem | undefined,
+): SearchSection | undefined {
+  return item && 'section' in item
+    ? (item as SectionedMatchResultItem).section
+    : undefined;
+}
+
+/** 去重 + 打标 + 排序。抽成纯函数，方便脱离 rspress 运行时验证。 */
+export function organizeSearchResult(
+  items: DefaultMatchResultItem[],
+  query: string,
+): SectionedMatchResultItem[] {
+  const bestByLink = new Map<
+    string,
+    { item: DefaultMatchResultItem; index: number }
+  >();
+
+  items.forEach((item, index) => {
+    const existing = bestByLink.get(item.link);
+    if (!existing || TYPE_RANK[item.type] < TYPE_RANK[existing.item.type]) {
+      // 命中同一个链接时保留更「标题级」的那条，但沿用首次出现的位置，避免把相关性靠前的结果推后。
+      bestByLink.set(item.link, { item, index: existing?.index ?? index });
+    }
+  });
+
+  const entries = [...bestByLink.values()].map(({ item, index }) => ({
+    item: { ...item, section: resolveSection(item.link, searchSections) },
+    rank: rankOf(item, query),
+    index,
+  }));
+
+  // 分组之间按「组内最好的那条结果」排序：一个组里有标题精确命中，整组就该排在只有正文命中的组前面。
+  const bestRankBySection = new Map<string, number>();
+  for (const entry of entries) {
+    const key = getSectionKey(entry.item.section);
+    const best = bestRankBySection.get(key);
+    if (best === undefined || entry.rank < best) {
+      bestRankBySection.set(key, entry.rank);
+    }
+  }
+
+  return entries
+    .sort((a, b) => {
+      const aSection = a.item.section;
+      const bSection = b.item.section;
+
+      // 插件分组无条件沉底。必须先于下面的相关性比较，否则插件页标题恰好和查询词相同时
+      // （en 站 `/plugins/.../plugin-action-template-print` 标题就是 "Template print"）会被顶上来。
+      const aIsPlugin = aSection.id === PLUGIN_SECTION_ID;
+      const bIsPlugin = bSection.id === PLUGIN_SECTION_ID;
+      if (aIsPlugin !== bIsPlugin) {
+        return aIsPlugin ? 1 : -1;
+      }
+
+      if (aSection.order !== bSection.order) {
+        // 组间按「组内最好的那条」排：有标题精确命中的组，排在只有正文命中的组前面。
+        const aBest = bestRankBySection.get(getSectionKey(aSection)) ?? 0;
+        const bBest = bestRankBySection.get(getSectionKey(bSection)) ?? 0;
+        if (aBest !== bBest) {
+          return aBest - bBest;
+        }
+        return aSection.order - bSection.order;
+      }
+      if (a.rank !== b.rank) {
+        return a.rank - b.rank;
+      }
+      const byTitleLength = compareTitleLength(a.item, b.item);
+      if (byTitleLength !== 0) {
+        return byTitleLength;
+      }
+      // 同组同档位时保持 FlexSearch 原本的相关性次序，不自造排序。
+      return a.index - b.index;
+    })
+    .map(({ item }) => item);
+}
+
+export const onSearch: OnSearch = (query, matchedResult) => {
+  for (const group of matchedResult) {
+    // 原地替换：rspress 把这个数组直接交给渲染层，返回新数组不会生效。
+    group.result.splice(
+      0,
+      group.result.length,
+      ...organizeSearchResult(group.result, query),
+    );
+  }
+};

--- a/docs/theme/search/virtual-search-hooks.d.ts
+++ b/docs/theme/search/virtual-search-hooks.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Rspress 在构建期把 `search.searchHooks` 指向的模块 re-export 成这个虚拟模块
+ * （见 `@rspress/core/dist/node/runtimeModule/searchHooks.js`）。
+ * 这里声明它的类型，让 vendor 过来的 SearchPanel 不用 `any` 也能通过类型检查。
+ *
+ * 四个钩子都按「一定存在」声明：调用方本来就用 `'onSearch' in userSearchHooks` 先判断过，
+ * 声明成可选反而会让那些 `in` 收窄之后的调用点报「可能为 undefined」。
+ */
+declare module 'virtual-search-hooks' {
+  import type {
+    AfterSearch,
+    BeforeSearch,
+    OnSearch,
+    RenderSearchFunction,
+  } from '@rspress/core/theme';
+
+  export const beforeSearch: BeforeSearch;
+  export const onSearch: OnSearch;
+  export const afterSearch: AfterSearch;
+  export const render: RenderSearchFunction;
+}

--- a/docs/theme/search/virtual-search-sections.d.ts
+++ b/docs/theme/search/virtual-search-sections.d.ts
@@ -1,0 +1,6 @@
+declare module 'virtual-search-sections' {
+  import type { SearchSectionTable } from '../../shared/searchSections';
+
+  /** 构建期由 `plugins/pluginSearchSections.ts` 生成的顶层目录 → 分组映射表。 */
+  export const searchSections: SearchSectionTable;
+}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

在文档站搜索时，插件元信息页（`/plugins/@nocobase/...`）会和真正的文档正文页重名，且经常抢占第一位。

以搜索「模板打印」为例，前两条结果标题完全一样，用户无法判断该点哪个：

- `/plugins/@nocobase/plugin-action-template-print/` — 只有 frontmatter 和一行标题的插件元信息页
- `/template-print/` — 真正的文档

原因有三：

1. 上游 `SearchPanel` 的 `normalizeSuggestions` 按 `item.title` 分组，标题相同的不同页面会被合并进同一个视觉分组，看起来就是两条重复结果。
2. 结果顺序完全由 FlexSearch 相关性决定，没有「正文文档优先于插件索引页」的概念。插件页在搜索索引中占 146/824（约 18%），噪音比例偏高。
3. 结果列表没有任何来源信息，同名结果无法区分。

### Description

- 新增 `docs/plugins/pluginSearchSections.ts`：构建期扫描 `_nav.json` 与各导航区首页的 `features`，生成「顶层目录 → 分组」映射表，通过虚拟模块提供给运行时。分组标签直接取本地化好的导航名（cn 手册/插件、en Guide/Plugins、ja マニュアル/プラグイン），不硬编码任何文案。
- 新增 `docs/theme/search/searchHooks.ts`（走 Rspress 官方 `search.searchHooks`）：按 link 去重、给每条结果打分组标记、排序，并把 `/plugins/` 下的插件元信息页无条件沉底。
- 相关性档位为「标题精确匹配 > 标题前缀匹配 > 标题包含 > 小标题 > 正文」，同档位保持 FlexSearch 原有次序，不自造相关性算法。例如搜「单点登录」时，`单点登录 SSO 集成` 会排在 `应用单点登录` 前面。
- Vendor `SearchPanel` / `SuggestItem`（源自 `@rspress/core@2.0.7`）：改为按分组渲染并显示可见的分组标题，标题类结果补一行路径以区分同名页面。键盘导航、IME 组字处理（`isComposing`）、滚动逻辑均逐字保留，文件头已注明来源版本与改动清单，便于升级时 diff 上游。
- 插件页仅排序靠后，不会从结果中被移除（搜「批量编辑」时插件页仍在「插件」分组内可见）。
- 兜底行为：未被识别的顶层目录归入「其他」分组，不会从搜索中消失。

### Showcase

搜索「模板打印」（cn）：

- 之前：第 1 条是 `/plugins/@nocobase/plugin-action-template-print/`，与第 2 条 `/template-print/` 标题完全相同且无法区分
- 之后：分「手册 / 教程 / 其他 / 插件」四组，`/template-print/` 排第一，每条标题下带路径，插件页沉到最后并带视觉分隔

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improved documentation site search: results are now grouped by section with visible headings and paths, more relevant pages rank first, and plugin metadata pages are sorted last. |
| 🇨🇳 Chinese | 文档网站搜索列表优化：搜索结果按文档区分组并显示分组标题与路径，更相关的页面排序靠前，插件元信息页排到最后。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | <!-- [Title](link) --> |
| 🇨🇳 Chinese | <!-- [标题](link) --> |

### Checklists
- [x] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
