### PR TITLE
fix(plugin-backups): validate backup retention limit

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupSettings.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupSettings.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createMockClient, Plugin } from '@nocobase/client-v2';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MAX_BACKUP_KEEP_COUNT } from '../../constants';
+import BackupSettings from '../pages/BackupSettings';
+
+class BackupSettingsTestPlugin extends Plugin {
+  async load() {
+    this.router.add('root', {
+      path: '/',
+      Component: BackupSettings,
+    });
+  }
+}
+
+function renderBackupSettings() {
+  const app = createMockClient({ plugins: [BackupSettingsTestPlugin] });
+  app.apiMock.onGet('backupSettings:get/1').reply(200, {
+    data: {
+      id: 1,
+      scheduled: false,
+      cron: '0 0 * * *',
+      keep: 100,
+      enableFilesBackup: false,
+    },
+  });
+  app.apiMock.onGet('storages:list').reply(200, { data: [] });
+
+  const Root = app.getRootComponent();
+  render(<Root />);
+  return app;
+}
+
+describe('backup settings', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('limits backup retention values to the configured maximum', async () => {
+    renderBackupSettings();
+    const input = await screen.findByRole('spinbutton');
+    await waitFor(() => expect(input).toHaveValue('100'));
+
+    expect(input).toHaveAttribute('aria-valuemin', '1');
+    expect(input).toHaveAttribute('aria-valuemax', String(MAX_BACKUP_KEEP_COUNT));
+  });
+
+  it('shows the server error when saving fails', async () => {
+    const app = renderBackupSettings();
+    app.apiMock.onPost('backupSettings:update/1').reply(400, {
+      errors: [{ message: 'Maximum number of backups must be less than or equal to 1000' }],
+    });
+    const input = await screen.findByRole('spinbutton');
+    await waitFor(() => expect(input).toHaveValue('100'));
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(app.apiMock.history.post).toHaveLength(1));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Maximum number of backups must be less than or equal to 1000',
+    );
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+  });
+});

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -13,6 +13,7 @@ import { App, Button, Card, Checkbox, Form, Input, InputNumber, Select, Space, S
 import React, { useMemo, useState } from 'react';
 import { CronProps as ReactJsCronProps, Cron as ReactCron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
+import { MAX_BACKUP_KEEP_COUNT, MIN_BACKUP_KEEP_COUNT } from '../../constants';
 import { useT } from '../locale';
 
 type BackupSettingsValues = {
@@ -40,6 +41,8 @@ type StorageRecord = {
 type ResourceResponse<T> = {
   data?: T;
 };
+
+type ErrorMessage = string | { message?: string };
 
 const DEFAULT_FORM_VALUES: BackupSettingsValues = {
   scheduled: false,
@@ -117,7 +120,7 @@ const label = (text: string) => <strong>{text}:</strong>;
 const BackupSettings = () => {
   const ctx = useFlowContext();
   const t = useT();
-  const { message } = App.useApp();
+  const { message, notification } = App.useApp();
   const [form] = Form.useForm<BackupSettingsValues>();
   const [submitting, setSubmitting] = useState(false);
   const scheduled = Form.useWatch('scheduled', form);
@@ -158,8 +161,7 @@ const BackupSettings = () => {
     [storagesRequest.data],
   );
 
-  const handleSubmit = async () => {
-    const formValues = await form.validateFields();
+  const handleSubmit = async (formValues: BackupSettingsValues) => {
     const values = {
       ...settingsRequest.data,
       ...formValues,
@@ -171,9 +173,21 @@ const BackupSettings = () => {
         url: 'backupSettings:update/1',
         method: 'post',
         data: values,
+        skipNotify: true,
       });
       settingsRequest.mutate(values);
       message.success(t('Saved successfully'));
+    } catch (error: unknown) {
+      const errors = ctx.api.toErrMessages(error) as ErrorMessage[];
+      notification.error({
+        message: errors.length
+          ? errors.map((item, index) => {
+              const errorMessage = typeof item === 'string' ? item : item.message;
+              return <div key={`${index}_${errorMessage}`}>{errorMessage || t('Save failed')}</div>;
+            })
+          : t('Save failed'),
+        role: 'alert',
+      });
     } finally {
       setSubmitting(false);
     }
@@ -187,6 +201,7 @@ const BackupSettings = () => {
         layout="vertical"
         initialValues={DEFAULT_FORM_VALUES}
         disabled={settingsRequest.loading}
+        onFinish={handleSubmit}
       >
         <Form.Item label={label(t('Automatic backup'))}>
           <Space direction="vertical" style={{ width: '100%' }}>
@@ -208,9 +223,25 @@ const BackupSettings = () => {
           label={label(t('Maximum number of backups'))}
           extra={t('The maximum number of backups to keep, older backups are automatically deleted.')}
           required
-          rules={[{ required: true, message: t('The field value is required') }]}
+          rules={[
+            { required: true, message: t('The field value is required') },
+            {
+              type: 'integer',
+              min: MIN_BACKUP_KEEP_COUNT,
+              max: MAX_BACKUP_KEEP_COUNT,
+              message: t('Maximum number of backups must be an integer between {{min}} and {{max}}', {
+                min: MIN_BACKUP_KEEP_COUNT,
+                max: MAX_BACKUP_KEEP_COUNT,
+              }),
+            },
+          ]}
         >
-          <InputNumber min={1} style={{ width: '100%' }} />
+          <InputNumber
+            min={MIN_BACKUP_KEEP_COUNT}
+            max={MAX_BACKUP_KEEP_COUNT}
+            precision={0}
+            style={{ width: '100%' }}
+          />
         </Form.Item>
 
         <Form.Item name="storageId" label={label(t('Sync backups to cloud storage'))}>
@@ -230,7 +261,7 @@ const BackupSettings = () => {
         </Form.Item>
 
         <Form.Item>
-          <Button type="primary" loading={submitting} onClick={handleSubmit}>
+          <Button type="primary" htmlType="submit" loading={submitting}>
             {t('Submit')}
           </Button>
         </Form.Item>

--- a/packages/plugins/@nocobase/plugin-backups/src/constants.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export const MIN_BACKUP_KEEP_COUNT = 1;
+export const MAX_BACKUP_KEEP_COUNT = 1000;

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
@@ -32,6 +32,7 @@
   "File size": "File size",
   "If a restore password is set, it must be entered when restoring the backup.": "If a restore password is set, it must be entered when restoring the backup.",
   "Maximum number of backups": "Maximum number of backups",
+  "Maximum number of backups must be an integer between {{min}} and {{max}}": "Maximum number of backups must be an integer between {{min}} and {{max}}",
   "NEW_BACKUPS_CREATED": "New backups[{{names}}] created successfully",
   "New backup": "New backup",
   "New backup operation started": "New backup operation started",

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
@@ -32,6 +32,7 @@
   "File size": "文件大小",
   "If a restore password is set, it must be entered when restoring the backup.": "如果设置了还原密码，恢复备份时需要输入该密码。",
   "Maximum number of backups": "最大备份数",
+  "Maximum number of backups must be an integer between {{min}} and {{max}}": "最大备份数必须是 {{min}} 到 {{max}} 之间的整数",
   "NEW_BACKUPS_CREATED": "新备份[{{names}}]创建成功",
   "New backup": "新建备份",
   "New backup operation started": "新建备份操作已开始",

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/backup-settings.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/backup-settings.test.ts
@@ -1,0 +1,55 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { MockServer } from '@nocobase/test/server';
+import { MAX_BACKUP_KEEP_COUNT } from '../../constants';
+import { SETTINGS } from '../utils';
+import { getApp } from './index';
+
+describe('backup settings validation', () => {
+  let app: MockServer;
+
+  beforeEach(async () => {
+    app = await getApp();
+  });
+
+  afterEach(async () => {
+    await app?.destroy();
+  });
+
+  it('accepts the maximum backup retention value', async () => {
+    const settings = await app.db.getRepository(SETTINGS).findOne();
+    const response = await app
+      .agent()
+      .resource(SETTINGS)
+      .update({
+        filterByTk: settings.get('id'),
+        values: { keep: MAX_BACKUP_KEEP_COUNT },
+      });
+
+    expect(response.status).toBe(200);
+    expect((await app.db.getRepository(SETTINGS).findOne()).get('keep')).toBe(MAX_BACKUP_KEEP_COUNT);
+  });
+
+  it.each([0, 1.5, MAX_BACKUP_KEEP_COUNT + 1])('rejects an invalid backup retention value: %s', async (keep) => {
+    const settings = await app.db.getRepository(SETTINGS).findOne();
+    const originalKeep = settings.get('keep');
+    const response = await app
+      .agent()
+      .resource(SETTINGS)
+      .update({
+        filterByTk: settings.get('id'),
+        values: { keep },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toHaveLength(1);
+    expect((await app.db.getRepository(SETTINGS).findOne()).get('keep')).toBe(originalKeep);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/backup-settings.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/backup-settings.test.ts
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { JoiValidationError } from '@nocobase/database';
 import type { MockServer } from '@nocobase/test/server';
 import { MAX_BACKUP_KEEP_COUNT } from '../../constants';
 import { SETTINGS } from '../utils';
@@ -24,32 +25,29 @@ describe('backup settings validation', () => {
   });
 
   it('accepts the maximum backup retention value', async () => {
-    const settings = await app.db.getRepository(SETTINGS).findOne();
-    const response = await app
-      .agent()
-      .resource(SETTINGS)
-      .update({
-        filterByTk: settings.get('id'),
-        values: { keep: MAX_BACKUP_KEEP_COUNT },
-      });
+    const repository = app.db.getRepository(SETTINGS);
+    const settings = await repository.findOne();
 
-    expect(response.status).toBe(200);
-    expect((await app.db.getRepository(SETTINGS).findOne()).get('keep')).toBe(MAX_BACKUP_KEEP_COUNT);
+    await repository.update({
+      filterByTk: settings.get('id'),
+      values: { keep: MAX_BACKUP_KEEP_COUNT },
+    });
+
+    expect((await repository.findOne()).get('keep')).toBe(MAX_BACKUP_KEEP_COUNT);
   });
 
   it.each([0, 1.5, MAX_BACKUP_KEEP_COUNT + 1])('rejects an invalid backup retention value: %s', async (keep) => {
-    const settings = await app.db.getRepository(SETTINGS).findOne();
+    const repository = app.db.getRepository(SETTINGS);
+    const settings = await repository.findOne();
     const originalKeep = settings.get('keep');
-    const response = await app
-      .agent()
-      .resource(SETTINGS)
-      .update({
+
+    await expect(
+      repository.update({
         filterByTk: settings.get('id'),
         values: { keep },
-      });
+      }),
+    ).rejects.toBeInstanceOf(JoiValidationError);
 
-    expect(response.status).toBe(400);
-    expect(response.body.errors).toHaveLength(1);
-    expect((await app.db.getRepository(SETTINGS).findOne()).get('keep')).toBe(originalKeep);
+    expect((await repository.findOne()).get('keep')).toBe(originalKeep);
   });
 });

--- a/packages/plugins/@nocobase/plugin-backups/src/server/collections/backup-settings.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/collections/backup-settings.ts
@@ -8,6 +8,7 @@
  */
 
 import { defineCollection } from '@nocobase/database';
+import { MAX_BACKUP_KEEP_COUNT, MIN_BACKUP_KEEP_COUNT } from '../../constants';
 import { SETTINGS } from '../utils';
 
 export default defineCollection({
@@ -27,6 +28,15 @@ export default defineCollection({
     {
       type: 'integer',
       name: 'keep',
+      validation: {
+        type: 'number',
+        rules: [
+          { key: 'required', name: 'required' },
+          { key: 'integer', name: 'integer' },
+          { key: 'min', name: 'min', args: { limit: MIN_BACKUP_KEEP_COUNT } },
+          { key: 'max', name: 'max', args: { limit: MAX_BACKUP_KEEP_COUNT } },
+        ],
+      },
     },
     {
       type: 'boolean',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 Backup manager allowed an excessively large maximum backup count. Submitting such a value caused a backend 500 response, while the frontend did not display the failure.

### Description 
- Define a shared backup retention range of 1–1000.
- Add integer and range validation to the v2 form and backend collection.
- Display backend save errors in the v2 UI instead of silently failing.
- Add v2 and server regression tests for limits and error handling.
- Potential compatibility risk: existing values above 1000 must be reduced before the settings can be saved again. The v1 UI still relies on backend validation for the upper limit.
- Testing: v2 tests pass; lint-staged Prettier and ESLint checks pass. The server test is included for CI, but could not run locally because the optional `sqlite3` dependency is unavailable.

### Related issues
Task 5448

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Validate the maximum backup retention count and display save errors. |
| 🇨🇳 Chinese | 校验最大备份保留数量并显示保存错误。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
