### PR TITLE
fix(plugin-workflow): load all workflow revisions

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowCanvas.tsx
@@ -517,6 +517,7 @@ function RevisionsDropdown() {
         filter: { key: workflow.key },
         fields: ['id', 'createdAt', 'current', 'enabled', 'versionStats.executed'],
         sort: '-id',
+        paginate: false,
       },
     },
     {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The workflow canvas version dropdown loads workflow revisions through `workflows:list`.
Without an explicit pagination option, only the default first page is returned, so workflows with more than 20 versions cannot show all available versions in the dropdown.

### Description 
Set `paginate: false` when loading workflow revisions for the workflow canvas version dropdown.
This keeps the existing dropdown behavior while allowing all revisions for the current workflow key to be listed.

Potential risk is low because the request already fetches only a small set of fields for revisions.

Testing suggestions:
- Create a workflow with more than 20 versions.
- Open the workflow canvas version dropdown.
- Verify versions beyond the first 20 are visible and selectable.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow canvas version dropdown not showing versions beyond the first 20. |
| 🇨🇳 Chinese | 修复工作流画布版本下拉框无法显示超过前 20 个版本的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
