### PR TITLE
fix(ui-layout): guard mobile flow settings by ACL

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  ACLContext,
   BaseLayoutModel,
   ChildPageModel,
   KeepAlive,
@@ -114,6 +115,17 @@ describe('plugin-ui-layout mobile models', () => {
     window.localStorage.removeItem(FLOW_SETTINGS_PREFERENCE_STORAGE_KEY);
   });
 
+  function createAclValue(allowConfigUI = true) {
+    return {
+      loading: false,
+      data: {
+        data: { snippets: allowConfigUI ? ['ui.*'] : [] },
+        meta: {},
+      },
+      refresh: async () => undefined,
+    };
+  }
+
   function renderMobileLayoutWithRouteRepository(
     routeRepository: MobileRouteRepositoryForTest,
     options: {
@@ -126,6 +138,7 @@ describe('plugin-ui-layout mobile models', () => {
       outletElement?: React.ReactNode;
       routerBasename?: string;
       theme?: ThemeConfig;
+      allowConfigUI?: boolean;
     } = {},
   ) {
     const engine = new FlowEngine();
@@ -179,46 +192,49 @@ describe('plugin-ui-layout mobile models', () => {
       },
     });
     options.beforeRender?.(model);
+    const acl = createAclValue(options.allowConfigUI !== false);
 
     const renderResult = render(
       React.createElement(
         FlowEngineProvider,
         { engine },
         React.createElement(
-          ConfigProvider,
-          {
-            theme: options.theme,
-          },
+          ACLContext.Provider,
+          { value: acl },
           React.createElement(
-            AntdApp,
-            null,
+            ConfigProvider,
+            { theme: options.theme },
             React.createElement(
-              MemoryRouter,
-              {
-                initialEntries: options.initialEntries || [
-                  options.memoryRouterBasename ? `${options.memoryRouterBasename}/mobile` : '/v/mobile',
-                ],
-                basename: options.memoryRouterBasename,
-              },
+              AntdApp,
+              null,
               React.createElement(
-                Routes,
-                null,
-                options.outletElement
-                  ? React.createElement(
-                      Route,
-                      {
-                        path: routerRoutePath,
+                MemoryRouter,
+                {
+                  initialEntries: options.initialEntries || [
+                    options.memoryRouterBasename ? `${options.memoryRouterBasename}/mobile` : '/v/mobile',
+                  ],
+                  basename: options.memoryRouterBasename,
+                },
+                React.createElement(
+                  Routes,
+                  null,
+                  options.outletElement
+                    ? React.createElement(
+                        Route,
+                        {
+                          path: routerRoutePath,
+                          element: model.render(),
+                        },
+                        React.createElement(Route, {
+                          path: ':name',
+                          element: options.outletElement,
+                        }),
+                      )
+                    : React.createElement(Route, {
+                        path: `${routerRoutePath}/*`,
                         element: model.render(),
-                      },
-                      React.createElement(Route, {
-                        path: ':name',
-                        element: options.outletElement,
                       }),
-                    )
-                  : React.createElement(Route, {
-                      path: `${routerRoutePath}/*`,
-                      element: model.render(),
-                    }),
+                ),
               ),
             ),
           ),
@@ -1083,18 +1099,22 @@ describe('plugin-ui-layout mobile models', () => {
         FlowEngineProvider,
         { engine },
         React.createElement(
-          AntdApp,
-          null,
+          ACLContext.Provider,
+          { value: createAclValue() },
           React.createElement(
-            MemoryRouter,
-            { initialEntries: ['/v/mobile'] },
+            AntdApp,
+            null,
             React.createElement(
-              Routes,
-              null,
-              React.createElement(Route, {
-                path: '/v/mobile/*',
-                element: model.render(),
-              }),
+              MemoryRouter,
+              { initialEntries: ['/v/mobile'] },
+              React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, {
+                  path: '/v/mobile/*',
+                  element: model.render(),
+                }),
+              ),
             ),
           ),
         ),
@@ -1189,6 +1209,22 @@ describe('plugin-ui-layout mobile models', () => {
     });
   });
 
+  it('should not enable mobile design mode from a stored preference without UI configuration permission', async () => {
+    window.localStorage.setItem(FLOW_SETTINGS_PREFERENCE_STORAGE_KEY, '1');
+
+    const { engine } = renderMobileLayoutWithRouteRepository(
+      {
+        listAccessible: () => [],
+      },
+      { allowConfigUI: false },
+    );
+
+    await waitFor(() => {
+      expect(engine.context.flowSettingsEnabled).toBe(false);
+      expect(screen.queryByTestId('ui-editor-button')).not.toBeInTheDocument();
+    });
+  });
+
   it('should render hidden mobile tab items in design mode with a hidden marker', async () => {
     window.localStorage.setItem(FLOW_SETTINGS_PREFERENCE_STORAGE_KEY, '1');
 
@@ -1266,18 +1302,22 @@ describe('plugin-ui-layout mobile models', () => {
         FlowEngineProvider,
         { engine },
         React.createElement(
-          AntdApp,
-          null,
+          ACLContext.Provider,
+          { value: createAclValue() },
           React.createElement(
-            MemoryRouter,
-            { initialEntries: ['/v/mobile'] },
+            AntdApp,
+            null,
             React.createElement(
-              Routes,
-              null,
-              React.createElement(Route, {
-                path: '/v/mobile/*',
-                element: model.render(),
-              }),
+              MemoryRouter,
+              { initialEntries: ['/v/mobile'] },
+              React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, {
+                  path: '/v/mobile/*',
+                  element: model.render(),
+                }),
+              ),
             ),
           ),
         ),

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
@@ -26,6 +26,7 @@ import type { DragEndEvent } from '@dnd-kit/core';
 import { define, observable } from '@formily/reactive';
 import { css } from '@emotion/css';
 import {
+  useUIConfigurationPermissions,
   BaseLayoutModel,
   BaseLayoutRouteCoordinator,
   KeepAlive,
@@ -691,6 +692,7 @@ function useIsDesktopPreview(screenMD: number) {
 
 const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel }) => {
   const { model } = props;
+  const { allowConfigUI } = useUIConfigurationPermissions();
   const { token } = theme.useToken();
   const isDesktopPreview = useIsDesktopPreview(token.screenMD);
   const [previewSize, setPreviewSize] = useState<MobilePreviewSize>(MOBILE_PREVIEW_SIZE);
@@ -701,9 +703,8 @@ const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel
   const [flowSettingsSyncVersion, setFlowSettingsSyncVersion] = useState(0);
   const flowSettingsSyncRef = useRef(0);
   const desiredFlowSettingsEnabledRef = useRef(false);
-  const preferredFlowSettingsEnabled = flowSettingsPreference.hasStoredPreference
-    ? flowSettingsPreference.enabled
-    : isMobileMenuEmpty;
+  const preferredFlowSettingsEnabled =
+    allowConfigUI && (flowSettingsPreference.hasStoredPreference ? flowSettingsPreference.enabled : isMobileMenuEmpty);
   const className = useMemo(
     () => css`
       width: 100%;
@@ -859,19 +860,25 @@ const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel
         flowSettingsSyncRef.current += 1;
       }
     };
-  }, [model.flowEngine.flowSettings, preferredFlowSettingsEnabled]);
+  }, [allowConfigUI, model.flowEngine.flowSettings, preferredFlowSettingsEnabled]);
 
-  const handleFlowSettingsPreferenceChange = useCallback((enabled: boolean) => {
-    setFlowSettingsPreference({
-      enabled,
-      hasStoredPreference: true,
-    });
-    writeMobileFlowSettingsPreference(enabled);
-  }, []);
+  const handleFlowSettingsPreferenceChange = useCallback(
+    (enabled: boolean) => {
+      if (!allowConfigUI) {
+        return;
+      }
+      setFlowSettingsPreference({
+        enabled,
+        hasStoredPreference: true,
+      });
+      writeMobileFlowSettingsPreference(enabled);
+    },
+    [allowConfigUI],
+  );
 
   return (
     <div className={className}>
-      {isDesktopPreview ? (
+      {isDesktopPreview && allowConfigUI ? (
         <MobileDesktopModeHeader
           designModeEnabled={preferredFlowSettingsEnabled}
           model={model}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Mobile layout reads the shared UI Editor preference and enables Flow Settings without checking the active role's `ui.*` permission. This lets an unauthorized role enter mobile configuration mode when a browser preference is present.

### Description
- Gate mobile Flow Settings preference synchronization by `ui.*` permission.
- Hide the mobile desktop-preview UI Editor control for roles without that permission.
- Add a regression test for a stored UI Editor preference under an unauthorized role.

Risk: roles without UI configuration permission will no longer enter mobile configuration mode, including when the browser retains a prior editor preference.

Testing: the targeted client test could not be run because this `next` checkout has no installed `node_modules`; ESLint passed for both changed files using the available local dependency runtime.

### Related issues
- Forum topic 13468

### Showcase
Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed unauthorized roles being able to enter mobile UI configuration mode through a saved editor preference. |
| 🇨🇳 Chinese | 修复未授权角色可通过已保存的编辑偏好进入移动端 UI 配置模式的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
