### PR TITLE
fix(auth): backport #7386 clear URL token after sign-in (for 1.7.19)

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx
@@ -7,19 +7,35 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { useApp, useLocationSearch } from '@nocobase/client';
+import { useApp } from '@nocobase/client';
 import React, { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 export const AuthProvider: React.FC = (props) => {
-  const searchString = useLocationSearch();
   const app = useApp();
-  const params = new URLSearchParams(searchString);
-  const authenticator = params.get('authenticator');
-  const token = params.get('token');
-  if (token) {
-    app.apiClient.auth.setToken(token);
-    app.apiClient.auth.setAuthenticator(authenticator);
-  }
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const authenticator = params.get('authenticator');
+    const token = params.get('token');
+
+    if (token) {
+      app.apiClient.auth.setToken(token);
+      app.apiClient.auth.setAuthenticator(authenticator);
+
+      params.delete('token');
+      const newSearch = params.toString();
+      navigate(
+        {
+          pathname: location.pathname,
+          search: newSearch ? `?${newSearch}` : '',
+        },
+        { replace: true },
+      );
+    }
+  }, [location.search, app, navigate, location.pathname]);
 
   return <>{props.children}</>;
 };

--- a/packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx
@@ -27,9 +27,11 @@ export const AuthProvider: React.FC = (props) => {
 
       params.delete('token');
       const newSearch = params.toString();
+      // 避免清 token 时停在空白 /
+      const pathname = location.pathname === '/' ? '/admin' : location.pathname;
       navigate(
         {
-          pathname: location.pathname,
+          pathname,
           search: newSearch ? `?${newSearch}` : '',
         },
         { replace: true },


### PR DESCRIPTION
## 概述
将 PR #7386 回补到 v1.7.19，并补充一处最小修复，解决根路径带 token 登录时的空白页问题。

## 背景
- 我们生产环境运行的是 **NocoBase v1.7.19**，暂时无法升级
- `v1.7.19` 在通过 URL `token` 登录成功后，地址栏仍会残留 `token` 参数
- 该问题在较新版本中已由 #7386 修复，因此将其回补到 1.7.19

## 改动说明
1. 回补 #7386：在 `AuthProvider` 中读取 URL 的 `token` 后写入登录态，再通过 `navigate(..., { replace: true })` 清理 URL 中的 `token`
2. 最小额外修复：当入口为 `/?token=...` 时，清理 token 的同时跳转到 `/admin`，避免打断默认的 `/` → `/admin` 重定向，导致首次停在空白首页

修改文件：
- `packages/plugins/@nocobase/plugin-auth/src/client/AuthProvider.tsx`

## 测试计划
- [x] 访问 `/?token=<有效JWT>`：可登录成功，URL 中 `token` 被清除，不再停在空白 `/`，最终进入 `/admin` 或默认管理页
- [x] 访问 `/admin?token=<有效JWT>`：可登录成功，URL 中 `token` 被清除
- [x] 访问子页面（真实业务路径）如 `/admin/<页面uid>?token=<有效JWT>`，或带其他 query 的链接如 `/admin/<页面uid>?foo=1&token=<有效JWT>`：
  - 可登录成功
  - URL 中 `token` 被清除
  - 仍停留在原目标子页面（不会被踢回首页）
  - 其他业务参数（如有）保留
- [x] 刷新后登录态保持有效


## 关于 base 分支
本分支基于 tag `v1.7.19`（不是当前 `main` / `1.x` 最新提交）。
如 1.7.x 有更合适的维护分支，请维护者指导调整。
目标是让 1.7.19 用户也能使用该修复。

## 关联
- 原 PR：https://github.com/nocobase/nocobase/pull/7386
