### PR TITLE
fix(plugin-ai): validate AI employee attachment uploads

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/attachmentLimits.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/attachmentLimits.test.ts
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AI_EMPLOYEE_ATTACHMENT_COUNT_LIMIT,
+  AI_EMPLOYEE_ATTACHMENT_SIZE_LIMIT_DEFAULT,
+  formatAttachmentSizeLimit,
+  resolveStorageSizeLimit,
+  validateAIEmployeeAttachmentLimits,
+} from '../../ai-employees/chatbox/utils';
+
+describe('AI employee attachment limits', () => {
+  it('uses the storage size rule as the total attachment size limit', () => {
+    expect(resolveStorageSizeLimit({ size: 30 * 1024 * 1024 })).toBe(30 * 1024 * 1024);
+    expect(resolveStorageSizeLimit({})).toBe(AI_EMPLOYEE_ATTACHMENT_SIZE_LIMIT_DEFAULT);
+  });
+
+  it('limits the total size of all attachments', () => {
+    const sizeLimit = 20 * 1024 * 1024;
+    expect(
+      validateAIEmployeeAttachmentLimits([{ size: 12 * 1024 * 1024 }, { size: 9 * 1024 * 1024 }], sizeLimit),
+    ).toEqual({ type: 'size', limit: sizeLimit });
+  });
+
+  it('allows no more than ten attachments', () => {
+    const attachments = Array.from({ length: AI_EMPLOYEE_ATTACHMENT_COUNT_LIMIT + 1 }, () => ({ size: 1 }));
+    expect(validateAIEmployeeAttachmentLimits(attachments, 1024)).toEqual({
+      type: 'count',
+      limit: AI_EMPLOYEE_ATTACHMENT_COUNT_LIMIT,
+    });
+  });
+
+  it('formats the configured size limit for user-facing messages', () => {
+    expect(formatAttachmentSizeLimit(20 * 1024 * 1024)).toBe('20 MB');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/uploadAttachment.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/__tests__/chatbox/uploadAttachment.test.ts
@@ -43,4 +43,17 @@ describe('normalizeAIFileUploadAttachment', () => {
       status: 'done',
     });
   });
+
+  it('uses the local file name before the server returns an attachment', () => {
+    const uploadFile = {
+      uid: 'large-file',
+      name: 'large-file.zip',
+      status: 'error',
+    };
+
+    expect(normalizeAIFileUploadAttachment(uploadFile, uploadFile.status)).toEqual({
+      ...uploadFile,
+      filename: uploadFile.name,
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/Sender.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/Sender.tsx
@@ -124,12 +124,16 @@ export const Sender: React.FC = () => {
       return;
     }
     e.preventDefault();
+    if (!uploadProps.validateFiles([file])) {
+      return;
+    }
 
     const uid = Date.now().toString();
     const rawFile = file;
     const uploadFile = {
       uid,
       name: rawFile.name,
+      filename: rawFile.name,
       status: 'uploading',
       originFileObj: rawFile,
       percent: 0,

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useUploadFiles.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/hooks/useUploadFiles.ts
@@ -9,10 +9,17 @@
 
 import { useAPIClient, usePlugin, useRequest } from '@nocobase/client';
 import PluginFileManagerClient from '@nocobase/plugin-file-manager/client';
+import { App, Upload, type UploadProps } from 'antd';
+import { useT } from '../../../locale';
 import { useAISettingsContext } from '../../AISettingsProvider';
 import { useChat } from '../hooks/useChat';
 import { useChatConversationsStore } from '../stores/chat-conversations';
-import { normalizeAIFileUploadAttachment } from '../utils';
+import {
+  formatAttachmentSizeLimit,
+  normalizeAIFileUploadAttachment,
+  resolveStorageSizeLimit,
+  validateAIEmployeeAttachmentLimits,
+} from '../utils';
 
 export function useStorage(storage: string) {
   const name = storage ?? '';
@@ -84,20 +91,20 @@ export function useUploadProps(props: any) {
 export const useUploadFiles = () => {
   const currentConversation = useChatConversationsStore.use.currentConversation();
   const chat = useChat(currentConversation);
+  const attachments = chat.use.attachments();
   const setAttachments = chat.setAttachments;
+  const { message } = App.useApp();
+  const t = useT();
 
   const uploadProps = {
     action: 'aiFiles:create',
     onChange({ fileList }) {
       setAttachments(
         fileList.map((file) => {
-          if (file.status === 'done') {
-            if (!file?.response?.data) {
-              return file;
-            }
+          if (file.status === 'done' && file.response?.data) {
             return normalizeAIFileUploadAttachment(file.response.data, file.status);
           }
-          return file;
+          return normalizeAIFileUploadAttachment(file, file.status);
         }),
       );
     },
@@ -105,9 +112,36 @@ export const useUploadFiles = () => {
 
   const props = useUploadProps(uploadProps);
   const storageUploadProps = useStorageUploadProps(uploadProps);
+  const sizeLimit = resolveStorageSizeLimit(storageUploadProps.rules);
+  const validateFiles = (files: unknown[], showMessage = true) => {
+    const violation = validateAIEmployeeAttachmentLimits([...(attachments ?? []), ...files], sizeLimit);
+    if (!violation) {
+      return true;
+    }
+
+    if (showMessage) {
+      if (violation.type === 'count') {
+        message.error(t('You can upload up to {{count}} attachments.', { count: violation.limit }));
+      } else {
+        message.error(
+          t('The total size of attachments cannot exceed {{size}}.', {
+            size: formatAttachmentSizeLimit(violation.limit),
+          }),
+        );
+      }
+    }
+    return false;
+  };
+  const beforeUpload: NonNullable<UploadProps['beforeUpload']> = (file, selectedFiles) => {
+    const files = selectedFiles.length ? selectedFiles : [file];
+    return validateFiles(files, files[0]?.uid === file.uid) ? true : Upload.LIST_IGNORE;
+  };
+
   return {
     ...props,
     ...uploadProps,
     ...storageUploadProps,
+    beforeUpload,
+    validateFiles,
   };
 };

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/utils.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/utils.ts
@@ -78,7 +78,7 @@ export function validateAIEmployeeAttachmentLimits(
     };
   }
 
-  const totalSize = attachments.reduce((total, attachment) => total + getAttachmentSize(attachment), 0);
+  const totalSize = attachments.reduce<number>((total, attachment) => total + getAttachmentSize(attachment), 0);
   if (totalSize > sizeLimit) {
     return {
       type: 'size',

--- a/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/utils.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client/ai-employees/chatbox/utils.ts
@@ -19,17 +19,86 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
-export function normalizeAIFileUploadAttachment(fileData: unknown, status: string) {
+export function normalizeAIFileUploadAttachment(fileData: unknown, status?: string) {
   if (!isRecord(fileData)) {
     return fileData;
   }
   const meta = isRecord(fileData.meta) ? fileData.meta : undefined;
   const source = isRecord(meta?.source) ? meta.source : undefined;
+  const filename =
+    typeof fileData.filename === 'string' && fileData.filename
+      ? fileData.filename
+      : typeof fileData.name === 'string'
+        ? fileData.name
+        : undefined;
   return {
     ...fileData,
+    ...(filename ? { filename } : {}),
     ...(source ? { source } : {}),
-    status,
+    ...(status ? { status } : {}),
   };
+}
+
+export const AI_EMPLOYEE_ATTACHMENT_COUNT_LIMIT = 10;
+export const AI_EMPLOYEE_ATTACHMENT_SIZE_LIMIT_DEFAULT = 20 * 1024 * 1024;
+
+export type AttachmentLimitViolation =
+  | {
+      type: 'count';
+      limit: number;
+    }
+  | {
+      type: 'size';
+      limit: number;
+    };
+
+export function resolveStorageSizeLimit(rules: unknown): number {
+  const configuredSize = isRecord(rules) ? Number(rules.size) : Number.NaN;
+  return Number.isFinite(configuredSize) && configuredSize > 0
+    ? configuredSize
+    : AI_EMPLOYEE_ATTACHMENT_SIZE_LIMIT_DEFAULT;
+}
+
+function getAttachmentSize(value: unknown): number {
+  if (!isRecord(value)) {
+    return 0;
+  }
+  const size = Number(value.size);
+  return Number.isFinite(size) && size > 0 ? size : 0;
+}
+
+export function validateAIEmployeeAttachmentLimits(
+  attachments: unknown[],
+  sizeLimit: number,
+): AttachmentLimitViolation | null {
+  if (attachments.length > AI_EMPLOYEE_ATTACHMENT_COUNT_LIMIT) {
+    return {
+      type: 'count',
+      limit: AI_EMPLOYEE_ATTACHMENT_COUNT_LIMIT,
+    };
+  }
+
+  const totalSize = attachments.reduce((total, attachment) => total + getAttachmentSize(attachment), 0);
+  if (totalSize > sizeLimit) {
+    return {
+      type: 'size',
+      limit: sizeLimit,
+    };
+  }
+
+  return null;
+}
+
+export function formatAttachmentSizeLimit(size: number): string {
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = size;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const fractionDigits = Number.isInteger(value) ? 0 : 2;
+  return `${value.toFixed(fractionDigits)} ${units[unitIndex]}`;
 }
 
 async function replaceVariables(template, variables, localVariables = {}) {

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -255,6 +255,8 @@
   "UID": "UID",
   "Up": "Up",
   "Upload files": "Upload files",
+  "You can upload up to {{count}} attachments.": "You can upload up to {{count}} attachments.",
+  "The total size of attachments cannot exceed {{size}}.": "The total size of attachments cannot exceed {{size}}.",
   "Use skill": "Use skill",
   "Use skills": "Use skills",
   "Use workflow as a tool": "Use workflow as a tool",

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -256,6 +256,8 @@
   "UID": "唯一标识",
   "Up": "上移",
   "Upload files": "上传文件",
+  "You can upload up to {{count}} attachments.": "最多可以上传 {{count}} 个附件。",
+  "The total size of attachments cannot exceed {{size}}.": "附件总大小不能超过 {{size}}。",
   "Use skill": "使用技能",
   "Use skills": "使用技能",
   "Use workflow as a tool": "使用工作流作为工具",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI employee chat attachments did not validate the combined attachment size before uploading. Users could select oversized files or too many attachments without immediate feedback, potentially causing upload or document processing failures.

### Description
- Limit each AI employee message to 10 attachments in the client.
- Validate the combined size of existing and newly selected attachments against the selected storage's `storage.rules.size` before upload.
- Apply validation to file selection, drag-and-drop, and clipboard paste uploads.
- Keep rejected or failed local files removable by normalizing their local `name` to `filename` before a server attachment record is available.
- Add localized validation messages and client unit tests.

The validation is intentionally client-side only and does not change the AI attachment API behavior. Suggested testing: select, drop, and paste files near the configured total size and attachment count limits, then verify failed or rejected attachments can still be removed.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | AI employee chat now validates attachment count and combined size before upload |
| 🇨🇳 Chinese | AI 员工聊天现在会在上传前校验附件数量和附件总大小 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
