### PR TITLE
fix: authenticate portal registry requests

### DIFF
--- a/packages/core/cli/src/__tests__/portal-registry-sync.test.ts
+++ b/packages/core/cli/src/__tests__/portal-registry-sync.test.ts
@@ -60,6 +60,7 @@ test('configures the service Registry, installs selected items, and builds when 
     env,
     items: ['ai', 'acl'],
     build: true,
+    token: 'registry-token',
     runCommand,
     probeRegistry: vi.fn(async () => ({ ok: true, status: 200 })),
   });
@@ -74,6 +75,7 @@ test('configures the service Registry, installs selected items, and builds when 
   expect(runCommand.mock.calls[1]?.[2]?.env).toMatchObject({
     NOCOBASE_API_URL: 'http://localhost:13000/api',
     NOCOBASE_PORTAL_BASE: '/x/customer/',
+    NOCOBASE_PORTAL_REGISTRY_TOKEN: 'registry-token',
   });
   expect(runCommand.mock.calls.map(([name, args]) => [name, args])).toEqual([
     ['pnpm', ['install', '--frozen-lockfile']],
@@ -84,7 +86,12 @@ test('configures the service Registry, installs selected items, and builds when 
   const components = JSON.parse(await fsp.readFile(path.join(portalDir, 'components.json'), 'utf8'));
   expect(components.registries).toEqual({
     '@example': 'https://example.test/{name}',
-    '@nocobase': '${NOCOBASE_API_URL}/registry:get?name={name}',
+    '@nocobase': {
+      url: '${NOCOBASE_API_URL}/registry:get?name={name}',
+      headers: {
+        Authorization: 'Bearer ${NOCOBASE_PORTAL_REGISTRY_TOKEN}',
+      },
+    },
   });
 });
 

--- a/packages/core/cli/src/commands/portal/create.ts
+++ b/packages/core/cli/src/commands/portal/create.ts
@@ -12,6 +12,7 @@ import { getEnv } from '../../lib/auth-store.js';
 import { resolveDefaultConfigScope } from '../../lib/cli-home.js';
 import { translateCli } from '../../lib/cli-locale.js';
 import { ensureCrossEnvConfirmed, hasExplicitEnvSelection } from '../../lib/env-guard.js';
+import { resolveAccessToken } from '../../lib/env-auth.js';
 import { createPortalWorkspace } from '../../lib/portal-create.js';
 import { syncPortalRegistries } from '../../lib/portal-registry-sync.js';
 import { printInfo, printSuccess, printWarning } from '../../lib/ui.js';
@@ -86,7 +87,8 @@ export default class PortalCreate extends Command {
       return;
     }
 
-    const env = await getEnv(flags.env, { scope: resolveDefaultConfigScope() });
+    const scope = resolveDefaultConfigScope();
+    const env = await getEnv(flags.env, { scope });
     if (!env) {
       this.error(
         flags.env
@@ -119,11 +121,13 @@ export default class PortalCreate extends Command {
     });
 
     if (!result.installSkipped) {
+      const token = await resolveAccessToken({ envName: flags.env, baseUrl: env.apiBaseUrl, scope });
       await syncPortalRegistries({
         portal: result.portal,
         env,
         installDependencies: false,
         skipIfUnsupported: true,
+        token,
         onWarning: (message) => printWarning(message),
       });
     }

--- a/packages/core/cli/src/commands/portal/registry/sync.ts
+++ b/packages/core/cli/src/commands/portal/registry/sync.ts
@@ -12,6 +12,7 @@ import { getCurrentEnvName, getEnv } from '../../../lib/auth-store.js';
 import { resolveDefaultConfigScope } from '../../../lib/cli-home.js';
 import { translateCli } from '../../../lib/cli-locale.js';
 import { ensureCrossEnvConfirmed, hasExplicitEnvSelection } from '../../../lib/env-guard.js';
+import { resolveAccessToken } from '../../../lib/env-auth.js';
 import { syncPortalRegistries } from '../../../lib/portal-registry-sync.js';
 import { printInfo, printSuccess } from '../../../lib/ui.js';
 
@@ -85,6 +86,7 @@ export default class PortalRegistrySync extends Command {
         ),
       );
     }
+    const token = await resolveAccessToken({ envName, baseUrl: env.apiBaseUrl, scope });
 
     const result = await syncPortalRegistries({
       portal: args.portal,
@@ -94,6 +96,7 @@ export default class PortalRegistrySync extends Command {
       overwriteUi: flags['overwrite-ui'],
       diff: flags.diff,
       build: flags.build,
+      token,
     });
     if (result.status === 'diffed') {
       printInfo(

--- a/packages/core/cli/src/lib/portal-registry-sync.ts
+++ b/packages/core/cli/src/lib/portal-registry-sync.ts
@@ -23,6 +23,7 @@ import { run } from './run-npm.js';
 
 const NOCOBASE_REGISTRY_NAMESPACE = '@nocobase';
 const NOCOBASE_REGISTRY_URL = '${NOCOBASE_API_URL}/registry:get?name={name}';
+const NOCOBASE_REGISTRY_TOKEN_ENV = 'NOCOBASE_PORTAL_REGISTRY_TOKEN';
 const REGISTRY_ITEM_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 type RunOptions = {
@@ -37,7 +38,7 @@ type RunOptions = {
 type RunCommand = (name: string, args: string[], options?: RunOptions) => Promise<void>;
 type RegistryIndexItem = { name: string; targets: string[] };
 type RegistryProbeResult = { ok: boolean; status: number; statusText?: string; items?: RegistryIndexItem[] };
-type RegistryProbe = (url: string) => Promise<RegistryProbeResult>;
+type RegistryProbe = (url: string, token?: string) => Promise<RegistryProbeResult>;
 
 export type PortalRegistrySyncOptions = {
   portal: string;
@@ -49,6 +50,7 @@ export type PortalRegistrySyncOptions = {
   build?: boolean;
   installDependencies?: boolean;
   skipIfUnsupported?: boolean;
+  token?: string;
   runCommand?: RunCommand;
   probeRegistry?: RegistryProbe;
   onWarning?: (message: string) => void;
@@ -99,8 +101,13 @@ function registryListUrl(apiBaseUrl: string): string {
   return `${apiBaseUrl.replace(/\/+$/, '')}/registry:list`;
 }
 
-async function defaultProbeRegistry(url: string): Promise<RegistryProbeResult> {
-  const response = await fetch(url, { headers: { 'x-request-source': 'cli' } });
+async function defaultProbeRegistry(url: string, token?: string): Promise<RegistryProbeResult> {
+  const response = await fetch(url, {
+    headers: {
+      'x-request-source': 'cli',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+  });
   let items: RegistryIndexItem[] | undefined;
   if (response.ok) {
     const document = (await response.json()) as unknown;
@@ -145,7 +152,7 @@ async function isRegistryItemInstalled(portalDir: string, item: RegistryIndexIte
   return true;
 }
 
-async function configureNocoBaseRegistry(componentsJsonPath: string): Promise<void> {
+async function configureNocoBaseRegistry(componentsJsonPath: string, authenticated: boolean): Promise<void> {
   const raw = await readFile(componentsJsonPath, 'utf8');
   let components: Record<string, unknown>;
   try {
@@ -162,7 +169,14 @@ async function configureNocoBaseRegistry(componentsJsonPath: string): Promise<vo
   const registries = components.registries;
   components.registries = {
     ...(registries && typeof registries === 'object' && !Array.isArray(registries) ? registries : {}),
-    [NOCOBASE_REGISTRY_NAMESPACE]: NOCOBASE_REGISTRY_URL,
+    [NOCOBASE_REGISTRY_NAMESPACE]: authenticated
+      ? {
+          url: NOCOBASE_REGISTRY_URL,
+          headers: {
+            Authorization: `Bearer \${${NOCOBASE_REGISTRY_TOKEN_ENV}}`,
+          },
+        }
+      : NOCOBASE_REGISTRY_URL,
   };
   await writeFile(componentsJsonPath, `${JSON.stringify(components, null, 2)}\n`, 'utf8');
 }
@@ -226,7 +240,7 @@ export async function syncPortalRegistries(options: PortalRegistrySyncOptions): 
   const items = normalizePortalRegistryItems(options.items);
   let probe: RegistryProbeResult;
   try {
-    probe = await (options.probeRegistry ?? defaultProbeRegistry)(registryListUrl(apiBaseUrl));
+    probe = await (options.probeRegistry ?? defaultProbeRegistry)(registryListUrl(apiBaseUrl), options.token);
   } catch (error) {
     throw new Error(
       portalRegistrySyncText(
@@ -257,12 +271,15 @@ export async function syncPortalRegistries(options: PortalRegistrySyncOptions): 
     );
   }
 
-  await configureNocoBaseRegistry(componentsJsonPath);
+  await configureNocoBaseRegistry(componentsJsonPath, Boolean(options.token));
   const runCommand = options.runCommand ?? run;
   const commandEnv = buildPortalCommandEnv({
     NOCOBASE_API_URL: apiBaseUrl.replace(/\/+$/, ''),
     NOCOBASE_PORTAL_BASE: portalBase,
   });
+  const registryCommandEnv = options.token
+    ? { ...commandEnv, [NOCOBASE_REGISTRY_TOKEN_ENV]: options.token }
+    : commandEnv;
   if (
     options.installDependencies === true ||
     (options.installDependencies !== false && !(await pathExists(path.join(portalDir, 'node_modules'))))
@@ -321,11 +338,13 @@ export async function syncPortalRegistries(options: PortalRegistrySyncOptions): 
           'add',
           ...(options.diff ? items : installItems),
           '--yes',
+          // shadcn still prompts for each existing file with --yes, so non-diff installs use --overwrite and restore
+          // protected files below.
           ...(options.diff ? ['--diff'] : ['--overwrite']),
         ],
         {
           cwd: portalDir,
-          env: commandEnv,
+          env: registryCommandEnv,
           envMode: 'replace',
           errorName: 'shadcn add',
         },

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
@@ -78,6 +78,8 @@ const MULTI_PORTAL_MANAGEMENT_ACTIONS = [
   'multiPortals:deploy',
   'multiPortals:pullSource',
   'multiPortals:pushSource',
+  'registry:list',
+  'registry:get',
 ];
 
 type PortalDeployTarEntry = {
@@ -2608,7 +2610,6 @@ export class PluginMultiPortalServer extends Plugin {
     });
     this.app.acl.allow('multiPortals', 'listEnabled', 'public');
     this.app.acl.allow('multiPortals', 'listAccessible', 'loggedIn');
-    this.app.acl.allow('registry', ['list', 'get'], 'public');
     this.app.resourceManager.use(createPortalDeployUploadMiddleware(), {
       tag: 'multiPortalDeployUpload',
       after: 'acl',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Portal Registry endpoints now require portal management permission, but the Portal Registry CLI did not authenticate its discovery or download requests, causing `nb portal registry sync` to fail with 401.

### Description 
- Protect Portal Registry list and item endpoints with the existing portal management permission.
- Resolve the selected CLI environment's access token for manual and automatic Portal Registry synchronization.
- Authenticate both Registry discovery and shadcn item downloads without persisting the token in `components.json`.
- Keep compatibility with services that still expose public Registry endpoints when no token is configured.

Testing: `yarn test packages/core/cli/src/__tests__/portal-registry-sync.test.ts --single-thread` (6 tests passed).

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->
\n### Docs\n
| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [ ] Request a code review if it is necessary
