### PR TITLE
fix(plugin-ai): respect ACL for AI file access

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-files-access.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/ai-files-access.test.ts
@@ -59,6 +59,43 @@ describe('aiFiles access', () => {
     const otherAgent = await app.agent().login(otherUser.id);
     const otherPreviewResponse = await otherAgent.get(previewUrl);
 
-    expect(otherPreviewResponse.statusCode).toBe(403);
+    expect(otherPreviewResponse.statusCode).toBe(404);
+  });
+
+  it('uses aiFiles view ACL when serving file URLs', async () => {
+    const owner = await app.db.getRepository('users').create({
+      values: {
+        nickname: 'AI file ACL owner',
+        username: 'ai-file-acl-owner',
+        email: 'ai-file-acl-owner@example.com',
+      },
+    });
+    const ownerAgent = await app.agent().login(owner.id);
+    const createResponse = await ownerAgent.resource('aiFiles').create({
+      values: {
+        title: 'acl-preview',
+        filename: 'acl-preview.png',
+        mimetype: 'image/png',
+      },
+    });
+    const previewUrl = createResponse.body.data.preview;
+
+    await app.db.getRepository('roles').create({
+      values: {
+        name: 'ai-file-no-view',
+        title: 'AI file no view',
+      },
+    });
+    await app.db.getRepository('rolesUsers').create({
+      values: {
+        userId: owner.id,
+        roleName: 'ai-file-no-view',
+      },
+    });
+    await app.cache.del(`roles:${owner.id}`);
+
+    const deniedResponse = await ownerAgent.set('X-Role', 'ai-file-no-view').get(previewUrl);
+
+    expect(deniedResponse.statusCode).toBe(403);
   });
 });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/collections/ai-files.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/collections/ai-files.ts
@@ -11,6 +11,7 @@ import { defineCollection } from '@nocobase/database';
 
 export default defineCollection({
   migrationRules: ['schema-only', 'skip'],
+  asStrategyResource: true,
   name: 'aiFiles',
   dataCategory: 'business',
   createdBy: true,

--- a/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/plugin.ts
@@ -162,7 +162,6 @@ export class PluginAIServer extends Plugin {
     this.defineResources();
     this.registerMcpClientEvents();
     this.setPermissions();
-    this.registerAIFileAccessAuthorizer();
     this.registerWorkflow();
     this.registerWorkContextResolveStrategy();
     registerAIEmployeeTaskNotification(this);
@@ -276,6 +275,7 @@ export class PluginAIServer extends Plugin {
   }
 
   setPermissions() {
+    this.app.acl.appendStrategyResource('aiFiles');
     this.app.acl.registerSnippet({
       name: `pm.${this.name}.llm-services`,
       actions: ['ai:*', 'llmServices:*'],
@@ -396,27 +396,6 @@ export class PluginAIServer extends Plugin {
     return {
       aiContextDatasources: this.repository('aiContextDatasources'),
     };
-  }
-
-  private registerAIFileAccessAuthorizer() {
-    this.fileManager.registerFileAccessAuthorizer({
-      name: 'ai-files',
-      authorize: async (ctx, params) => {
-        const currentUserId = ctx.state.currentUser?.id;
-        if (params.dataSourceKey !== 'main' || params.collectionName !== 'aiFiles' || !currentUserId) {
-          return false;
-        }
-
-        const file = await ctx.db.getRepository('aiFiles').findOne({
-          filter: {
-            id: params.id,
-            createdById: currentUserId,
-          },
-          fields: ['id'],
-        });
-        return Boolean(file);
-      },
-    });
   }
 
   get fileManager(): PluginFileManagerServer {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI uploaded files were authorized through a plugin-specific file access authorizer. This bypassed the standard resource ACL path, so role-level `aiFiles:view` permissions could not fully control permanent file URL access.

### Description
This PR makes `aiFiles` a strategy resource and registers it with ACL permission strategies, so permanent file URLs are authorized through the existing `aiFiles:view` ACL filter path.

It removes the AI-specific `FileAccessAuthorizer` and adds server-side coverage for both own-file access and denial when the current role has no `aiFiles:view` permission.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| English | AI uploaded file URLs now respect standard `aiFiles:view` ACL permissions. |
| Chinese | AI 上传文件的访问链接现在会遵循标准的 `aiFiles:view` ACL 权限控制。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| English | Not needed |
| Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
