### PR TITLE
fix(plugin-field-markdown-vditor): align permanent URL upload test

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx
@@ -242,18 +242,27 @@ describe('Edit', () => {
     expect(instance.options.lang).toBe('en_US');
   });
 
-  it('shows a storage tip when the selected collection cannot upload files', async () => {
+  it('uploads with a permanent URL regardless of the legacy storage support flag', async () => {
     const check = vi.fn().mockResolvedValue({
       data: {
         data: {
           isSupportToUploadFiles: false,
           storage: {
+            id: 1,
             title: 'Local storage',
+            type: 'local',
+            rules: { size: 1024 },
           },
         },
       },
     });
     flowContext.api.resource.mockReturnValue({ check });
+    fileManagerPlugin.uploadFile.mockResolvedValueOnce({
+      data: {
+        filename: 'doc.txt',
+        url: '/files/main/main/attachments/1.txt',
+      },
+    });
     const { instance } = await renderEditor();
 
     await instance.options.upload.handler([new File(['doc'], 'doc.txt', { type: 'text/plain' })]);
@@ -262,8 +271,15 @@ describe('Edit', () => {
     expect(check).toHaveBeenCalledWith({
       fileCollectionName: 'attachments',
     });
-    expect(instance.tip).toHaveBeenCalledWith('vditor.uploadError.message:Local storage', 0);
-    expect(fileManagerPlugin.uploadFile).not.toHaveBeenCalled();
+    expect(fileManagerPlugin.uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileCollectionName: 'attachments',
+        storageId: 1,
+        storageType: 'local',
+        storageRules: { size: 1024 },
+      }),
+    );
+    expect(instance.insertValue).toHaveBeenCalledWith('[doc.txt](/files/main/main/attachments/1.txt)');
   });
 
   it('handles upload errors, empty responses and inserted markdown links', async () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The latest `develop` frontend test run failed because the Markdown Vditor test still expected uploads to stop when the legacy `isSupportToUploadFiles` flag was `false`. The current permanent URL implementation intentionally continues uploading, so the test did not configure an `uploadFile` response and failed while destructuring `undefined`.

### Description

- Update the Markdown Vditor test to cover uploads with a permanent URL regardless of the legacy storage support flag.
- Mock the successful upload response and verify the storage parameters passed to `uploadFile`.
- Verify that the returned permanent URL is inserted as a Markdown link.
- Risk is limited to test code; production behavior is unchanged.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx`

### Related issues

- https://github.com/nocobase/nocobase/actions/runs/30444269195/job/90552125467

### Showcase

N/A — test-only change.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Markdown Vditor permanent URL upload test coverage. |
| 🇨🇳 Chinese | 修复 Markdown Vditor 永久 URL 上传测试覆盖。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | 不适用 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
