### PR TITLE
fix(plugin-workflow): save jobs in batches

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -19,6 +19,8 @@ import { IJob, InstructionResult, Runner } from './instructions';
 import type { ExecutionModel, FlowNodeModel, JobModel, WorkflowModel } from './types';
 import { isWorkflowTimeoutError, WorkflowTimeoutError } from './timeout-errors';
 
+const JOB_SAVE_BATCH_SIZE = 100;
+
 export type ProcessorRunOptions = {
   rerun?: true;
   signal?: AbortSignal;
@@ -556,14 +558,17 @@ export default class Processor {
       }
       if (newJobs.length) {
         const JobsModel = this.options.plugin.db.getModel('jobs');
-        await JobsModel.bulkCreate(
-          newJobs.map((job) => job.toJSON()),
-          {
-            returning: false,
-          },
-        );
-        for (const job of newJobs) {
-          job.isNewRecord = false;
+        for (let offset = 0; offset < newJobs.length; offset += JOB_SAVE_BATCH_SIZE) {
+          const batch = newJobs.slice(offset, offset + JOB_SAVE_BATCH_SIZE);
+          await JobsModel.bulkCreate(
+            batch.map((job) => job.toJSON()),
+            {
+              returning: false,
+            },
+          );
+          for (const job of batch) {
+            job.isNewRecord = false;
+          }
         }
       }
       this.jobsToSave.clear();

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts
@@ -57,6 +57,36 @@ describe('workflow > Processor', () => {
       expect(records.length).toBe(2);
     });
 
+    it('saves new jobs in batches', async () => {
+      const node = await workflow.createNode({ type: 'echo' });
+      const execution = await workflow.createExecution({
+        key: workflow.key,
+        context: {},
+        dispatched: true,
+        status: EXECUTION_STATUS.STARTED,
+      });
+      const processor = plugin.createProcessor(execution);
+      const JobModel = db.getModel('jobs');
+      const bulkCreate = vi.spyOn(JobModel, 'bulkCreate');
+
+      for (let index = 0; index < 201; index += 1) {
+        processor.saveJob({
+          nodeId: node.id,
+          nodeKey: node.key,
+          status: JOB_STATUS.RESOLVED,
+          result: index,
+        });
+      }
+
+      await processor.exit();
+
+      expect(bulkCreate).toHaveBeenCalledTimes(3);
+      expect(bulkCreate.mock.calls[0][0]).toHaveLength(100);
+      expect(bulkCreate.mock.calls[1][0]).toHaveLength(100);
+      expect(bulkCreate.mock.calls[2][0]).toHaveLength(1);
+      expect(await execution.countJobs()).toBe(201);
+    });
+
     it('empty workflow without any nodes', async () => {
       const post = await PostRepo.create({ values: { title: 't1' } });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Large workflow executions can accumulate tens of thousands of jobs in memory. Saving all jobs with one `bulkCreate` generates an oversized SQL statement that may not return, leaving the execution active and blocking the workflow queue.

### Description 
- Save newly created workflow jobs sequentially in batches of 100.
- Mark each successful batch as persisted before continuing so a later failure does not cause the same processor instance to insert completed batches again.
- Add coverage verifying that 201 jobs are saved as batches of 100, 100, and 1, and that all records are persisted.

Each batch is committed independently, so if a later batch fails, jobs from earlier successful batches remain persisted. This replaces the previous single-statement behavior and keeps the change narrowly focused on preventing oversized inserts.

Testing suggestions:
- Run workflows producing fewer than, exactly, and more than 100 jobs.
- Run a large loop workflow and verify job inserts remain bounded and queued workflows continue after it completes.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow executions becoming blocked while saving a large number of jobs in one database operation |
| 🇨🇳 Chinese | 修复工作流执行在单次保存大量作业记录时可能阻塞的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
