### PR TITLE
fix(cli): correct settings asset path

### DIFF
--- a/packages/core/cli/src/__tests__/env-proxy.test.ts
+++ b/packages/core/cli/src/__tests__/env-proxy.test.ts
@@ -260,7 +260,7 @@ test('buildEnvProxyNginxBundle renders app.conf and index HTML with CDN-prefixed
   expect(bundle.indexV2Content).toContain('src="/console/dist/2.1.0-beta.44/v/browser-checker.js?v=1"');
   expect(bundle.indexV2Content).toContain('src="/console/dist/2.1.0-beta.44/v/assets/runtime.js"');
   expect(bundle.indexSettingsContent).toContain(`window['__nocobase_public_path__'] = "/console/";`);
-  expect(bundle.indexSettingsContent).toContain(`window['__webpack_public_path__'] = "";`);
+  expect(bundle.indexSettingsContent).toContain(`window['__webpack_public_path__'] = "/console/dist/2.1.0-beta.44/";`);
   expect(bundle.indexSettingsContent).toContain(`window['__nocobase_modern_client_prefix__'] = "admin";`);
   expect(bundle.indexSettingsContent).toContain(`window['__nocobase_app_client_entry_mode__'] = "modern-only";`);
   expect(bundle.indexSettingsContent).toContain('src="/console/dist/2.1.0-beta.44/settings/assets/runtime.js"');
@@ -284,6 +284,7 @@ test('buildEnvProxyNginxBundle omits the root redirect block for root-mounted ap
   expect(bundle.appConfigContent).toContain('location ^~ /v/ {');
   expect(bundle.appConfigContent).toContain('location ^~ /settings/assets/ {');
   expect(bundle.appConfigContent).toContain('/settings(?:/|$)');
+  expect(bundle.indexSettingsContent).toContain(`window['__webpack_public_path__'] = "/dist/2.1.0-beta.44/";`);
   expect(bundle.appConfigContent).toContain('location ^~ /files/ {');
   expect(bundle.appConfigContent.match(/location \^~ \/files\//g)).toHaveLength(1);
   expect(bundle.appConfigContent).toContain('try_files $uri /index-v1.html =404;');
@@ -705,7 +706,7 @@ test('buildEnvProxyCaddyBundle renders app.caddy and index HTML files', async ()
   expect(bundle.indexV2Content).toContain(`window['__nocobase_public_path__'] = "/console/admin/";`);
   expect(bundle.indexV2Content).toContain(`window['__nocobase_modern_client_prefix__'] = "admin";`);
   expect(bundle.indexSettingsContent).toContain(`window['__nocobase_public_path__'] = "/console/";`);
-  expect(bundle.indexSettingsContent).toContain(`window['__webpack_public_path__'] = "";`);
+  expect(bundle.indexSettingsContent).toContain(`window['__webpack_public_path__'] = "/console/dist/2.1.0-beta.44/";`);
   expect(bundle.indexSettingsContent).toContain('src="/console/dist/2.1.0-beta.44/settings/assets/runtime.js"');
 });
 

--- a/packages/core/cli/src/lib/env-proxy.ts
+++ b/packages/core/cli/src/lib/env-proxy.ts
@@ -793,7 +793,6 @@ type EnvProxyNginxRenderContext = {
   appPublicPath: string;
   backendUrl: string;
   cdnBaseUrl: string;
-  hasExplicitCdnBaseUrl: boolean;
   distPath: string;
   distRootDir: string;
   entryDir: string;
@@ -992,7 +991,7 @@ function buildNginxRuntimeConfig(
   variant: 'v1' | 'v2' | 'settings',
 ): Record<string, boolean | string> {
   return {
-    __webpack_public_path__: variant === 'settings' ? (context.hasExplicitCdnBaseUrl ? context.cdnBaseUrl : '') : context.cdnBaseUrl,
+    __webpack_public_path__: context.cdnBaseUrl,
     __nocobase_public_path__: variant === 'v2' ? context.v2PublicPath : context.appPublicPath,
     ...(variant !== 'v1' ? { __nocobase_modern_client_prefix__: context.modernClientPrefix } : {}),
     __nocobase_app_client_entry_mode__: context.appClientEntryMode,
@@ -1047,7 +1046,6 @@ async function buildEnvProxyNginxRenderContext(
     appPublicPath: source.settings.appPublicPath,
     backendUrl,
     cdnBaseUrl: ensureTrailingSlash(cdnBaseUrl),
-    hasExplicitCdnBaseUrl: Boolean(source.settings.cdnBaseUrl),
     distPath: source.settings.distPath,
     distRootDir: mappedDistRootDir,
     entryDir: mappedEntryDir,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

使用 `nb init` 部署并提取前端静态资源后，直接访问 Settings 页面会从错误的位置加载插件资源，导致页面报错、无法正常打开。

### Description 

修正 Settings 页面运行时使用的静态资源基础路径，使其在未配置 CDN、配置应用公共路径以及使用 Nginx 或 Caddy 时，都能从对应版本的资源目录加载插件文件。

补充相关回归测试，覆盖根路径部署、公共路径部署以及 Nginx、Caddy 两种代理配置。建议部署后直接访问 `/settings`，确认登录页正常显示且浏览器中没有插件资源加载错误。

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the Settings page failing to load after deploying extracted frontend assets |
| 🇨🇳 Chinese | 修复提取前端静态资源部署后 Settings 页面无法加载的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
