### PR TITLE
fix(auth): support trusted portal SSO redirects

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth/src/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/index.ts
@@ -9,13 +9,15 @@
 
 export {
   AuthModel,
+  appendAuthRedirectQuery,
   BasicAuth,
   buildRedirectPath,
   defaultTokenPolicyConfig,
   default,
   getModernClientPrefix,
   presetAuthType,
-  resolveSubAppSegment,
+  resolveAuthRedirect,
   resolveSigninPrefix,
+  resolveSubAppSegment,
 } from './server';
-export type { BuildRedirectPathOptions, ResolveSigninPrefixOptions } from './server';
+export type { BuildRedirectPathOptions, AuthRedirectOriginContext, ResolveSigninPrefixOptions } from './server';

--- a/packages/plugins/@nocobase/plugin-auth/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/index.ts
@@ -14,6 +14,8 @@ export { defaultTokenPolicyConfig } from '../constants';
 export { buildRedirectPath, getModernClientPrefix, resolveSigninPrefix } from './utils/buildRedirectPath';
 export type { BuildRedirectPathOptions, ResolveSigninPrefixOptions } from './utils/buildRedirectPath';
 export { resolveSubAppSegment } from './utils/resolveSubAppSegment';
+export { appendAuthRedirectQuery, resolveAuthRedirect } from './utils/authRedirect';
+export type { AuthRedirectOriginContext } from './utils/authRedirect';
 
 export { default } from './plugin';
 export * from '../constants';

--- a/packages/plugins/@nocobase/plugin-auth/src/server/utils/__tests__/authRedirect.test.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/utils/__tests__/authRedirect.test.ts
@@ -1,0 +1,117 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { appendAuthRedirectQuery, resolveAuthRedirect } from '../authRedirect';
+
+const originalWhitelist = process.env.CORS_ORIGIN_WHITELIST;
+
+function createContext(host = 'nocobase.example') {
+  const headers = { host };
+  return {
+    protocol: 'https',
+    headers,
+    get: (name: string) => headers[name.toLowerCase()] || '',
+    t: (key: string) => key,
+    throw: (status: number, message: string): never => {
+      throw Object.assign(new Error(message), { status });
+    },
+  };
+}
+
+afterEach(() => {
+  if (originalWhitelist === undefined) {
+    delete process.env.CORS_ORIGIN_WHITELIST;
+  } else {
+    process.env.CORS_ORIGIN_WHITELIST = originalWhitelist;
+  }
+});
+
+describe('resolveAuthRedirect', () => {
+  it('keeps NocoBase root-relative redirects and applies their runtime prefix', () => {
+    expect(
+      resolveAuthRedirect(createContext(), {
+        appPublicPath: '/nocobase',
+        subAppSegment: '/apps/crm',
+        target: '/admin/users',
+      }).target,
+    ).toBe('/nocobase/apps/crm/admin/users');
+  });
+
+  it('allows a same-origin Portal callback without adding NocoBase route prefixes', () => {
+    expect(
+      resolveAuthRedirect(createContext(), {
+        appPublicPath: '/nocobase',
+        subAppSegment: '/apps/crm',
+        target: 'https://nocobase.example/nocobase/x/apps/crm/customer/?tab=profile#details',
+      }).target,
+    ).toBe('https://nocobase.example/nocobase/x/apps/crm/customer/?tab=profile#details');
+  });
+
+  it('does not add the legacy sub-app prefix to a root-relative Portal callback', () => {
+    expect(
+      resolveAuthRedirect(createContext(), {
+        subAppSegment: '/apps/crm',
+        target: '/x/apps/crm/customer/?tab=profile#details',
+      }).target,
+    ).toBe('/x/apps/crm/customer/?tab=profile#details');
+  });
+
+  it('allows a standalone Portal dev callback only from a trusted CORS origin', () => {
+    process.env.CORS_ORIGIN_WHITELIST = 'http://localhost:5173';
+
+    expect(
+      resolveAuthRedirect(createContext(), {
+        target: 'http://localhost:5173/x/customer/',
+      }).target,
+    ).toBe('http://localhost:5173/x/customer/');
+  });
+
+  it('does not treat the CORS wildcard as a trusted SSO callback origin', () => {
+    process.env.CORS_ORIGIN_WHITELIST = '*';
+
+    expect(() =>
+      resolveAuthRedirect(createContext(), {
+        target: 'https://evil.example/steal-token',
+      }),
+    ).toThrowError('Invalid sign-in origin');
+  });
+
+  it('rejects an untrusted absolute target instead of redirecting', () => {
+    delete process.env.CORS_ORIGIN_WHITELIST;
+
+    expect(() =>
+      resolveAuthRedirect(createContext(), {
+        appPublicPath: '/nocobase',
+        target: 'https://evil.example/steal-token',
+      }),
+    ).toThrowError('Invalid sign-in origin');
+  });
+});
+
+describe('appendAuthRedirectQuery', () => {
+  it('merges callback data before the hash and replaces injected values', () => {
+    expect(
+      appendAuthRedirectQuery('/x/customer/?tab=profile&token=stale#details', {
+        authenticator: 'oidc-auth',
+        token: 'new-token',
+      }),
+    ).toBe('/x/customer/?tab=profile&token=new-token&authenticator=oidc-auth#details');
+  });
+
+  it('keeps absolute Portal callback URLs absolute', () => {
+    expect(
+      appendAuthRedirectQuery('http://localhost:5173/x/customer/', {
+        authenticator: 'saml-auth',
+        token: 'test-token',
+      }),
+    ).toBe('http://localhost:5173/x/customer/?authenticator=saml-auth&token=test-token');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-auth/src/server/utils/authRedirect.ts
+++ b/packages/plugins/@nocobase/plugin-auth/src/server/utils/authRedirect.ts
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { getCorsWhitelist, isSameOrigin, type OriginContext } from '@nocobase/utils';
+import { namespace } from '../../preset';
+import { buildRedirectPath, type BuildRedirectPathOptions } from './buildRedirectPath';
+
+export interface AuthRedirectOriginContext extends OriginContext {
+  t(key: string, options?: { ns?: string }): string;
+  throw(status: number, message: string): never;
+}
+
+function isRootRelativePath(value: string) {
+  return value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\');
+}
+
+function isPortalPath(value: string, appPublicPath?: string | null) {
+  const normalizedAppPublicPath = (appPublicPath || '').replace(/\/+$/, '');
+  const pathname = value.split(/[?#]/, 1)[0];
+  if (normalizedAppPublicPath && !pathname.startsWith(`${normalizedAppPublicPath}/`)) {
+    return false;
+  }
+  const pathnameWithinPublicPath = pathname.slice(normalizedAppPublicPath.length);
+  return pathnameWithinPublicPath === '/x' || pathnameWithinPublicPath.startsWith('/x/');
+}
+
+function resolveAbsoluteUrl(ctx: AuthRedirectOriginContext, value: string) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    ctx.throw(400, ctx.t('Invalid sign-in origin', { ns: namespace }));
+  }
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+    ctx.throw(400, ctx.t('Invalid sign-in origin', { ns: namespace }));
+  }
+  const whitelist = getCorsWhitelist();
+  if (!isSameOrigin(ctx, url.origin) && !whitelist?.has(url.origin)) {
+    ctx.throw(400, ctx.t('Invalid sign-in origin', { ns: namespace }));
+  }
+  return url;
+}
+
+function resolveSafeAuthRedirect(ctx: AuthRedirectOriginContext, target?: string | null) {
+  const value = typeof target === 'string' ? target.trim() : '';
+  if (isRootRelativePath(value)) return value;
+  return value ? resolveAbsoluteUrl(ctx, value).toString() : null;
+}
+
+/**
+ * Resolve an SSO callback target without creating an open redirect.
+ *
+ * Existing NocoBase clients use root-relative paths and still need the app
+ * public path/sub-app prefix handling provided by `buildRedirectPath`.
+ * Standalone Portal development runs on another origin, so an absolute target
+ * is also accepted when that origin is trusted by the server's CORS policy.
+ */
+export function resolveAuthRedirect(
+  ctx: AuthRedirectOriginContext,
+  { appPublicPath, subAppSegment, target }: BuildRedirectPathOptions,
+) {
+  const safeRedirect = resolveSafeAuthRedirect(ctx, target) || '/admin';
+  const resolvedTarget =
+    isRootRelativePath(safeRedirect) && !isPortalPath(safeRedirect, appPublicPath)
+      ? buildRedirectPath({ appPublicPath, subAppSegment, target: safeRedirect })
+      : safeRedirect;
+  return { safeRedirect, target: resolvedTarget };
+}
+
+/** Append or replace callback parameters while preserving query and hash. */
+export function appendAuthRedirectQuery(
+  target: string,
+  params: Record<string, string | number | boolean | null | undefined>,
+) {
+  const isAbsolute = /^[a-z][a-z\d+.-]*:/i.test(target);
+  const url = new URL(target, 'http://nocobase.local');
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
+    }
+    url.searchParams.set(key, value === null ? '' : String(value));
+  }
+  return isAbsolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

SSO initiated from a Portal application must return to that Portal without allowing redirects to untrusted origins.

### Description

- Add a shared server-side resolver for SSO callback destinations
- Accept root-relative paths and same-origin absolute URLs
- Permit cross-origin Portal development URLs only when their exact origins are trusted
- Reject invalid or untrusted destinations with a clear 400 response
- Keep `/admin` as the default only when no destination is supplied

### Related issues

### Showcase

<!-- Including any screenshots of the changes. -->

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Request a code review if it is necessary

