### PR TITLE
fix(data-source-manager): remove collections from database

### DIFF
--- a/packages/core/data-source-manager/src/sequelize-collection-manager.ts
+++ b/packages/core/data-source-manager/src/sequelize-collection-manager.ts
@@ -99,7 +99,9 @@ export class SequelizeCollectionManager implements ICollectionManager {
     return this.db.getCollection(name);
   }
 
-  removeCollection(name: string) {}
+  removeCollection(name: string) {
+    return this.db.removeCollection(name);
+  }
 
   getCollections() {
     const collectionsFilter = this.collectionsFilter();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When an external data source table is removed during schema synchronization, `SequelizeCollectionManager` did not remove the corresponding collection from the underlying database collection registry. The stale collection could remain available and cause subsequent table synchronization to use outdated metadata.

### Description

Delegate `SequelizeCollectionManager.removeCollection()` to `Database.removeCollection()` so removed external data source tables are also unregistered from the Sequelize-backed database manager.

Potential risk is limited to collection removal behavior. Existing callers now perform the removal that the method contract already implies.

Testing:
- `yarn eslint --fix packages/core/data-source-manager/src/sequelize-collection-manager.ts` passed.
- `yarn test packages/core/data-source-manager/src/__tests__/sequelize-collection-manager.test.ts --run --reporter=verbose` was attempted, but the local environment does not have the optional `sqlite3` package installed, so the test suite could not initialize the SQLite dialect.

### Related issues

N/A

### Showcase

N/A (server-side behavior change)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed external data source table synchronization leaving removed collections registered in the database manager |
| 🇨🇳 Chinese | 修复外部数据源数据表同步后已移除的数据表仍残留在数据库管理器中的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
