### PR TITLE
fix(plugin-multi-portal): handle empty type

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/layoutRegistration.strict.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/layoutRegistration.strict.test.ts
@@ -89,12 +89,26 @@ describe('Multi Portal runtime registration failures', () => {
     expect(layoutManager.registerLayout).not.toHaveBeenCalled();
   });
 
-  it('registers only no-code portals and skips every other portal type', () => {
+  it('treats empty portal types as no-code portals', () => {
+    const layoutManager = createLayoutManager();
+    const emptyTypePortals = [
+      { ...portal, uid: 'missing-type-portal', portalName: 'missingType', portalType: undefined },
+      { ...portal, uid: 'null-type-portal', portalName: 'nullType', portalType: null },
+      { ...portal, uid: 'empty-type-portal', portalName: 'emptyType', portalType: '' },
+    ];
+
+    expect(registerMultiPortalRecords(layoutManager, emptyTypePortals)).toEqual([
+      'missing-type-portal',
+      'null-type-portal',
+      'empty-type-portal',
+    ]);
+    expect(layoutManager.registerLayout).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips ai and unknown non-empty portal types', () => {
     const layoutManager = createLayoutManager();
     const skippedPortals = [
       { ...portal, uid: 'ai-portal', portalName: 'ai', portalType: 'ai' },
-      { ...portal, uid: 'missing-type-portal', portalName: 'missingType', portalType: undefined },
-      { ...portal, uid: 'empty-type-portal', portalName: 'emptyType', portalType: '' },
       { ...portal, uid: 'unknown-type-portal', portalName: 'unknownType', portalType: 'custom' },
     ];
 

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/layoutRegistration.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/layoutRegistration.ts
@@ -16,7 +16,7 @@ export { getMultiPortalRouteScopeCacheKey };
 export type MultiPortalRuntimeRecord = {
   uid: string;
   title?: string;
-  portalType?: string;
+  portalType?: string | null;
   portalName: string;
   routePath: string;
   authCheck: boolean;
@@ -74,7 +74,7 @@ const layoutModeMobileRegisterOptions = {
 } satisfies Pick<LayoutRegisterOptions, 'layoutModelClass' | 'rootPageModelClass' | 'childPageModelClass'>;
 
 function isRuntimePortal(record: MultiPortalRuntimeRecord) {
-  return record.portalType === 'no-code';
+  return (record.portalType || 'no-code') === 'no-code';
 }
 
 export function toMultiPortalLayoutRegisterOptions(record: MultiPortalRuntimeRecord): LayoutRegisterOptions | null {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

部分已有 Portal 的类型字段可能为空。Client V2 之前会跳过这些 Portal，导致对应入口和页面无法正常注册。

### Description 

当 Portal 类型为 `null`、缺失或空字符串时，按照 No-code Portal 处理并正常注册 Layout。AI Portal 和未知的非空类型仍保持原有行为，不会注册到 Client V2 Layout。

补充回归测试，覆盖三种空值形式，并验证 AI 和未知非空类型不会受到影响。

### Showcase

<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix portals with an empty type not appearing in Client V2 |
| 🇨🇳 Chinese | 修复类型为空的 Portal 无法在 Client V2 中显示的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
