### PR TITLE
feat(cli): add Swagger document commands

### DIFF
--- a/packages/core/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/core/cli/src/__tests__/bootstrap.test.ts
@@ -23,6 +23,7 @@ test('shouldSkipRuntimeBootstrap skips root help and no-arg invocations', () => 
   expect(shouldSkipRuntimeBootstrap(['resource', 'list'])).toBe(true);
   expect(shouldSkipRuntimeBootstrap(['api', 'resource', 'list'])).toBe(true);
   expect(shouldSkipRuntimeBootstrap(['api', 'resource', 'list', '--help'])).toBe(true);
+  expect(shouldSkipRuntimeBootstrap(['api', 'swagger', 'get', '--json'])).toBe(true);
 });
 
 test('shouldSkipRuntimeBootstrap still loads runtime for non-builtin commands', () => {

--- a/packages/core/cli/src/__tests__/swagger-command.test.ts
+++ b/packages/core/cli/src/__tests__/swagger-command.test.ts
@@ -1,0 +1,135 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ensureCrossEnvConfirmed: vi.fn(),
+  executeRawApiRequest: vi.fn(),
+}));
+
+vi.mock('../lib/env-guard.js', () => ({
+  ensureCrossEnvConfirmed: mocks.ensureCrossEnvConfirmed,
+}));
+
+vi.mock('../lib/api-client.js', () => ({
+  executeRawApiRequest: mocks.executeRawApiRequest,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.ensureCrossEnvConfirmed.mockResolvedValue(true);
+});
+
+test('swagger list returns normalized namespaces from the selected env', async () => {
+  const { default: SwaggerList } = await import('../commands/api/swagger/list.js');
+  const log = vi.fn();
+  mocks.executeRawApiRequest.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: {
+      data: [
+        { name: 'NocoBase API', url: '/api/swagger:get' },
+        {
+          name: 'Collection API - Orders',
+          url: '/api/swagger:get?ns=collections%2Forders',
+        },
+      ],
+    },
+  });
+
+  const command = Object.assign(Object.create(SwaggerList.prototype), {
+    argv: ['--env', 'dev', '--yes', '--json'],
+    parse: vi.fn(async () => ({
+      flags: {
+        env: 'dev',
+        yes: true,
+        'json-output': true,
+      },
+    })),
+    error: (message: string) => {
+      throw new Error(message);
+    },
+    log,
+  });
+
+  await SwaggerList.prototype.run.call(command);
+
+  expect(mocks.ensureCrossEnvConfirmed).toHaveBeenCalledWith({
+    command,
+    requestedEnv: 'dev',
+    yes: true,
+  });
+  expect(mocks.executeRawApiRequest).toHaveBeenCalledWith({
+    envName: 'dev',
+    baseUrl: undefined,
+    token: undefined,
+    role: undefined,
+    method: 'GET',
+    path: '/swagger:getUrls',
+    query: undefined,
+  });
+  expect(JSON.parse(log.mock.calls[0][0])).toEqual([
+    { name: 'NocoBase API', namespace: 'all', url: '/api/swagger:get' },
+    {
+      name: 'Collection API - Orders',
+      namespace: 'collections/orders',
+      url: '/api/swagger:get?ns=collections%2Forders',
+    },
+  ]);
+});
+
+test('swagger get prints the requested namespace as an OpenAPI document', async () => {
+  const { default: SwaggerGet } = await import('../commands/api/swagger/get.js');
+  const log = vi.fn();
+  const document = {
+    openapi: '3.0.3',
+    info: {
+      title: 'Collection API - Orders',
+      version: '1.0.0',
+    },
+    paths: {
+      '/orders:list': {},
+    },
+  };
+  mocks.executeRawApiRequest.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: document,
+  });
+
+  const command = Object.assign(Object.create(SwaggerGet.prototype), {
+    argv: ['--namespace', 'collections/orders', '--json'],
+    parse: vi.fn(async () => ({
+      flags: {
+        namespace: 'collections/orders',
+        'json-output': true,
+      },
+    })),
+    error: (message: string) => {
+      throw new Error(message);
+    },
+    log,
+  });
+
+  await SwaggerGet.prototype.run.call(command);
+
+  expect(mocks.executeRawApiRequest).toHaveBeenCalledWith({
+    envName: undefined,
+    baseUrl: undefined,
+    token: undefined,
+    role: undefined,
+    method: 'GET',
+    path: '/swagger:get',
+    query: {
+      ns: 'collections/orders',
+    },
+  });
+  expect(JSON.parse(log.mock.calls[0][0])).toEqual(document);
+});

--- a/packages/core/cli/src/commands/api/swagger/get.ts
+++ b/packages/core/cli/src/commands/api/swagger/get.ts
@@ -1,0 +1,141 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Command, Flags } from '@oclif/core';
+import { translateCli } from '../../../lib/cli-locale.js';
+import { executeSwaggerRequest, swaggerRequestFlags } from '../../../lib/swagger-command.js';
+import { renderTable } from '../../../lib/ui.js';
+
+type SwaggerDocument = {
+  openapi: string;
+  info: {
+    title?: string;
+    version?: string;
+  };
+  paths: Record<string, unknown>;
+};
+
+const swaggerText = (key: string, values?: Record<string, unknown>, fallback?: string) =>
+  translateCli(`commands.swagger.${key}`, values, { fallback });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function unwrapData(value: unknown): unknown {
+  if (!isRecord(value) || typeof value.openapi === 'string') {
+    return value;
+  }
+  return Object.prototype.hasOwnProperty.call(value, 'data') ? value.data : value;
+}
+
+function normalizeDocument(value: unknown): SwaggerDocument | undefined {
+  const document = unwrapData(value);
+  if (
+    !isRecord(document) ||
+    typeof document.openapi !== 'string' ||
+    !isRecord(document.info) ||
+    !isRecord(document.paths)
+  ) {
+    return undefined;
+  }
+
+  return document as SwaggerDocument;
+}
+
+export default class SwaggerGet extends Command {
+  static summary = 'Get a NocoBase OpenAPI document';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --json',
+    '<%= config.bin %> <%= command.id %> --namespace collections/orders --json',
+    '<%= config.bin %> <%= command.id %> --namespace plugins/ai --output ./openapi/ai.json',
+  ];
+
+  static flags = {
+    ...swaggerRequestFlags,
+    namespace: Flags.string({
+      aliases: ['ns'],
+      description: 'Document namespace, such as core, plugins/ai, or collections/orders',
+    }),
+    output: Flags.string({
+      char: 'o',
+      description: 'Write the OpenAPI document to a file',
+    }),
+    'json-output': Flags.boolean({
+      char: 'j',
+      aliases: ['json'],
+      description: 'Print the complete OpenAPI document as JSON',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SwaggerGet);
+    const namespace = flags.namespace?.trim() || undefined;
+    const response = await executeSwaggerRequest(this, flags, '/swagger:get', { ns: namespace });
+    if (!response) {
+      return;
+    }
+    if (!response.ok) {
+      const details = JSON.stringify(response.data, null, 2);
+      this.error(
+        response.status === 404
+          ? swaggerText(
+              'errors.pluginDisabled',
+              undefined,
+              'The API documentation plugin is not enabled. Enable it before requesting Swagger documents.',
+            )
+          : swaggerText(
+              'errors.requestFailed',
+              { status: response.status, details },
+              `Swagger request failed with status ${response.status}\n${details}`,
+            ),
+      );
+    }
+
+    const document = normalizeDocument(response.data);
+    if (!document) {
+      this.error(
+        swaggerText('errors.invalidDocument', undefined, 'swagger:get returned an invalid OpenAPI document.'),
+      );
+    }
+
+    const json = `${JSON.stringify(document, null, 2)}\n`;
+    if (flags.output) {
+      const outputPath = path.resolve(flags.output);
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, json);
+      this.log(
+        swaggerText('messages.saved', { output: outputPath }, `Saved Swagger document to ${outputPath}.`),
+      );
+      return;
+    }
+
+    if (flags['json-output']) {
+      this.log(json.trimEnd());
+      return;
+    }
+
+    this.log(
+      renderTable(
+        [swaggerText('table.field', undefined, 'Field'), swaggerText('table.value', undefined, 'Value')],
+        [
+          [swaggerText('fields.namespace', undefined, 'Namespace'), namespace ?? 'all'],
+          [swaggerText('fields.title', undefined, 'Title'), document.info.title ?? ''],
+          [swaggerText('fields.version', undefined, 'Version'), document.info.version ?? ''],
+          [swaggerText('fields.openapi', undefined, 'OpenAPI'), document.openapi],
+          [swaggerText('fields.paths', undefined, 'Paths'), String(Object.keys(document.paths).length)],
+        ],
+      ),
+    );
+  }
+}

--- a/packages/core/cli/src/commands/api/swagger/index.ts
+++ b/packages/core/cli/src/commands/api/swagger/index.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Command, loadHelpClass } from '@oclif/core';
+
+export default class Swagger extends Command {
+  static summary = 'Inspect the current NocoBase OpenAPI documentation';
+
+  async run(): Promise<void> {
+    await this.parse(Swagger);
+    const Help = await loadHelpClass(this.config);
+    await new Help(this.config, this.config.pjson.oclif.helpOptions ?? this.config.pjson.helpOptions).showHelp([
+      this.id ?? 'api:swagger',
+      ...this.argv,
+    ]);
+  }
+}

--- a/packages/core/cli/src/commands/api/swagger/list.ts
+++ b/packages/core/cli/src/commands/api/swagger/list.ts
@@ -1,0 +1,134 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Command, Flags } from '@oclif/core';
+import { translateCli } from '../../../lib/cli-locale.js';
+import { executeSwaggerRequest, swaggerRequestFlags } from '../../../lib/swagger-command.js';
+import { renderTable } from '../../../lib/ui.js';
+
+type SwaggerDestination = {
+  name: string;
+  namespace: string;
+  url: string;
+};
+
+const swaggerText = (key: string, values?: Record<string, unknown>, fallback?: string) =>
+  translateCli(`commands.swagger.${key}`, values, { fallback });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function unwrapData(value: unknown): unknown {
+  return isRecord(value) && Object.prototype.hasOwnProperty.call(value, 'data') ? value.data : value;
+}
+
+function readNamespace(url: string): string {
+  try {
+    return new URL(url, 'http://localhost').searchParams.get('ns') || 'all';
+  } catch {
+    return 'all';
+  }
+}
+
+function normalizeDestinations(value: unknown): SwaggerDestination[] | undefined {
+  const data = unwrapData(value);
+  if (!Array.isArray(data)) {
+    return undefined;
+  }
+
+  const destinations: SwaggerDestination[] = [];
+  for (const item of data) {
+    if (!isRecord(item) || typeof item.name !== 'string' || typeof item.url !== 'string') {
+      return undefined;
+    }
+    destinations.push({
+      name: item.name,
+      namespace: readNamespace(item.url),
+      url: item.url,
+    });
+  }
+  return destinations;
+}
+
+export default class SwaggerList extends Command {
+  static summary = 'List available NocoBase OpenAPI document namespaces';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --json',
+    '<%= config.bin %> <%= command.id %> --env dev --yes --json',
+  ];
+
+  static flags = {
+    ...swaggerRequestFlags,
+    'json-output': Flags.boolean({
+      char: 'j',
+      aliases: ['json'],
+      description: 'Print namespaces as JSON',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SwaggerList);
+    const response = await executeSwaggerRequest(this, flags, '/swagger:getUrls');
+    if (!response) {
+      return;
+    }
+    if (!response.ok) {
+      const details = JSON.stringify(response.data, null, 2);
+      this.error(
+        response.status === 404
+          ? swaggerText(
+              'errors.pluginDisabled',
+              undefined,
+              'The API documentation plugin is not enabled. Enable it before requesting Swagger documents.',
+            )
+          : swaggerText(
+              'errors.requestFailed',
+              { status: response.status, details },
+              `Swagger request failed with status ${response.status}\n${details}`,
+            ),
+      );
+    }
+
+    const destinations = normalizeDestinations(response.data);
+    if (!destinations) {
+      this.error(
+        swaggerText(
+          'errors.invalidDestinations',
+          undefined,
+          'swagger:getUrls returned an invalid destination list.',
+        ),
+      );
+    }
+
+    if (flags['json-output']) {
+      this.log(JSON.stringify(destinations, null, 2));
+      return;
+    }
+
+    if (!destinations.length) {
+      this.log(swaggerText('messages.empty', undefined, 'No Swagger document namespaces are available.'));
+      return;
+    }
+
+    this.log(
+      renderTable(
+        [
+          swaggerText('table.name', undefined, 'Name'),
+          swaggerText('table.namespace', undefined, 'Namespace'),
+          swaggerText('table.url', undefined, 'URL'),
+        ],
+        destinations.map((item) => [item.name, item.namespace, item.url]),
+      ),
+    );
+  }
+}

--- a/packages/core/cli/src/lib/bootstrap.ts
+++ b/packages/core/cli/src/lib/bootstrap.ts
@@ -92,7 +92,11 @@ function isBuiltinCommand(argv: string[]) {
   const commandTokens = argv.filter((token) => token && !token.startsWith('-'));
   const [topic, subtopic] = commandTokens;
 
-  return topic === 'env' || topic === 'resource' || (topic === 'api' && subtopic === 'resource');
+  return (
+    topic === 'env' ||
+    topic === 'resource' ||
+    (topic === 'api' && (subtopic === 'resource' || subtopic === 'swagger'))
+  );
 }
 
 export function shouldSkipRuntimeBootstrap(argv: string[]) {

--- a/packages/core/cli/src/lib/swagger-command.ts
+++ b/packages/core/cli/src/lib/swagger-command.ts
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Command, Flags } from '@oclif/core';
+import { executeRawApiRequest } from './api-client.js';
+import { ensureCrossEnvConfirmed } from './env-guard.js';
+
+export const swaggerRequestFlags = {
+  env: Flags.string({
+    char: 'e',
+    description: 'CLI env name; omitted uses the current env',
+  }),
+  yes: Flags.boolean({
+    char: 'y',
+    description: 'Confirm using --env when it targets a different env than the current env',
+    default: false,
+  }),
+  'api-base-url': Flags.string({
+    description: 'NocoBase API base URL, for example http://localhost:13000/api',
+  }),
+  role: Flags.string({
+    description: 'Role override, sent as X-Role',
+  }),
+  token: Flags.string({
+    char: 't',
+    description: 'API key or access token override',
+  }),
+};
+
+export type SwaggerRequestFlags = {
+  env?: string;
+  yes?: boolean;
+  'api-base-url'?: string;
+  role?: string;
+  token?: string;
+};
+
+export async function executeSwaggerRequest(
+  command: Command,
+  flags: SwaggerRequestFlags,
+  path: string,
+  query?: Record<string, string | undefined>,
+) {
+  const requestedEnv = flags.env?.trim() || undefined;
+  const confirmed = await ensureCrossEnvConfirmed({
+    command,
+    requestedEnv,
+    yes: flags.yes,
+  });
+  if (!confirmed) {
+    return undefined;
+  }
+
+  return executeRawApiRequest({
+    envName: requestedEnv,
+    baseUrl: flags['api-base-url'],
+    token: flags.token,
+    role: flags.role,
+    method: 'GET',
+    path,
+    query,
+  });
+}

--- a/packages/core/cli/src/locale/en-US.json
+++ b/packages/core/cli/src/locale/en-US.json
@@ -259,6 +259,32 @@
         "localSynced": "Local synced"
       }
     },
+    "swagger": {
+      "errors": {
+        "pluginDisabled": "The API documentation plugin is not enabled. Enable it before requesting Swagger documents.",
+        "requestFailed": "Swagger request failed with status {{status}}\n{{details}}",
+        "invalidDestinations": "swagger:getUrls returned an invalid destination list.",
+        "invalidDocument": "swagger:get returned an invalid OpenAPI document."
+      },
+      "messages": {
+        "empty": "No Swagger document namespaces are available.",
+        "saved": "Saved Swagger document to {{output}}."
+      },
+      "table": {
+        "name": "Name",
+        "namespace": "Namespace",
+        "url": "URL",
+        "field": "Field",
+        "value": "Value"
+      },
+      "fields": {
+        "namespace": "Namespace",
+        "title": "Title",
+        "version": "Version",
+        "openapi": "OpenAPI",
+        "paths": "Paths"
+      }
+    },
     "portalInfo": {
       "errors": {
         "envNotConfigured": "Env \"{{envName}}\" is not configured. Run `nb env add {{envName}} --api-base-url <url>` first.",

--- a/packages/core/cli/src/locale/zh-CN.json
+++ b/packages/core/cli/src/locale/zh-CN.json
@@ -259,6 +259,32 @@
         "localSynced": "本地已同步"
       }
     },
+    "swagger": {
+      "errors": {
+        "pluginDisabled": "API 文档插件尚未启用。请先启用该插件，再获取 Swagger 文档。",
+        "requestFailed": "Swagger 请求失败，状态码 {{status}}\n{{details}}",
+        "invalidDestinations": "swagger:getUrls 返回了无效的文档列表。",
+        "invalidDocument": "swagger:get 返回了无效的 OpenAPI 文档。"
+      },
+      "messages": {
+        "empty": "没有可用的 Swagger 文档命名空间。",
+        "saved": "Swagger 文档已保存到 {{output}}。"
+      },
+      "table": {
+        "name": "名称",
+        "namespace": "命名空间",
+        "url": "URL",
+        "field": "字段",
+        "value": "值"
+      },
+      "fields": {
+        "namespace": "命名空间",
+        "title": "标题",
+        "version": "版本",
+        "openapi": "OpenAPI",
+        "paths": "路径数"
+      }
+    },
     "portalInfo": {
       "errors": {
         "envNotConfigured": "env \"{{envName}}\" 尚未配置。请先运行 `nb env add {{envName}} --api-base-url <url>`。",


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

AI Portal development and other CLI workflows need a reliable way to inspect the OpenAPI documents exposed by the current NocoBase environment without enabling or bootstrapping the local application runtime.

### Description

- Add `nb api swagger list` to list available OpenAPI document namespaces.
- Add `nb api swagger get` to print or save the complete document, with optional collection or plugin namespace selection.
- Reuse CLI environment, token, role, API URL, and cross-environment confirmation behavior.
- Skip runtime bootstrap for Swagger commands and provide English and Chinese CLI messages.
- Cover namespace normalization, document retrieval, and bootstrap behavior with focused tests.

Testing suggestions:

- Run `nb api swagger list --json` against an environment with the API documentation plugin enabled.
- Run `nb api swagger get --namespace collections/<collection> --json` and verify the returned OpenAPI document.
- Verify a clear error is shown when the API documentation plugin is disabled.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
