### PR TITLE
feat(plugin-multi-portal): expose portal entry access in swagger

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/swagger/index.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/swagger/index.ts
@@ -1,0 +1,120 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export default {
+  openapi: '3.0.2',
+  info: {
+    title: 'NocoBase API - Multi-portal plugin',
+    version: '1.0.0',
+  },
+  paths: {
+    '/roles/{roleName}/multiPortals:list': {
+      get: {
+        tags: ['roles.multiPortals'],
+        summary: 'List Portals granted to a role',
+        description: 'List existing custom Portals that the role is explicitly allowed to enter.',
+        parameters: [{ $ref: '#/components/parameters/RoleNamePath' }],
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    data: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/PortalAccessTarget' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/roles/{roleName}/multiPortals:add': {
+      post: {
+        tags: ['roles.multiPortals'],
+        summary: 'Grant Portal entry access to a role',
+        description: 'Allow the role to enter one or more existing custom Portals by uid.',
+        parameters: [{ $ref: '#/components/parameters/RoleNamePath' }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/PortalAccessWrite' },
+            },
+          },
+        },
+        responses: {
+          200: { description: 'OK' },
+        },
+      },
+    },
+    '/roles/{roleName}/multiPortals:remove': {
+      post: {
+        tags: ['roles.multiPortals'],
+        summary: 'Revoke Portal entry access from a role',
+        description: 'Prevent the role from entering one or more existing custom Portals by uid.',
+        parameters: [{ $ref: '#/components/parameters/RoleNamePath' }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/PortalAccessWrite' },
+            },
+          },
+        },
+        responses: {
+          200: { description: 'OK' },
+        },
+      },
+    },
+  },
+  components: {
+    parameters: {
+      RoleNamePath: {
+        name: 'roleName',
+        in: 'path',
+        description: 'Role name.',
+        required: true,
+        schema: { type: 'string' },
+      },
+    },
+    schemas: {
+      PortalAccessWrite: {
+        type: 'object',
+        properties: {
+          values: {
+            type: 'array',
+            description: 'Portal uids.',
+            items: { type: 'string' },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        required: ['values'],
+      },
+      PortalAccessTarget: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          uid: { type: 'string' },
+          title: { type: 'string' },
+          portalName: { type: 'string' },
+          routePath: { type: 'string' },
+          portalType: { type: 'string' },
+          enabled: { type: 'boolean' },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Portal entry access is already managed through the `roles.multiPortals` association, but the enabled Multi-Portal plugin does not expose those operations in its Swagger document. CLI and AI-assisted ACL workflows therefore cannot discover or use the existing entry authorization API.

### Description
Adds Swagger definitions for listing, granting, and revoking a role's access to existing custom Portals.

The document covers only Portal entry access through `roles.multiPortals:list`, `roles.multiPortals:add`, and `roles.multiPortals:remove`. Portal route permissions are intentionally out of scope.

Validated the file with ESLint and generated the runtime command tree to confirm that only the three intended ACL commands are exposed.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
