### PR TITLE
fix(client): preserve quick-create form data in layout routes

### DIFF
--- a/packages/core/client-v2/src/layout-manager/LayoutContentRoute.tsx
+++ b/packages/core/client-v2/src/layout-manager/LayoutContentRoute.tsx
@@ -38,11 +38,12 @@ export const LayoutContentRoute = (props: LayoutContentRouteProps) => {
       id: lastMatch?.id,
       name: lastMatch?.id,
       pathname: location.pathname,
+      state: location.state,
       params: (lastMatch?.params || {}) as Record<string, string | undefined>,
       layoutRouteName: layout.routeName,
       layoutBasePathname: layoutMatch?.pathname,
     };
-  }, [layout.routeName, location.pathname, matches]);
+  }, [layout.routeName, location.pathname, location.state, matches]);
   if (!model) {
     throw new Error(`[NocoBase] Layout '${layout.routeName}' model '${layout.uid}' is not mounted.`);
   }

--- a/packages/core/client-v2/src/layout-manager/LayoutRoute.tsx
+++ b/packages/core/client-v2/src/layout-manager/LayoutRoute.tsx
@@ -71,11 +71,12 @@ export const LayoutRoute = (props: LayoutRouteProps) => {
       id: lastMatch?.id,
       name: lastMatch?.id,
       pathname: location.pathname,
+      state: location.state,
       params: lastMatchParams,
       layoutRouteName: layout.routeName,
       layoutBasePathname: layoutMatch?.pathname,
     };
-  }, [lastMatch?.id, lastMatchParams, layout.routeName, layoutMatch?.pathname, location.pathname]);
+  }, [lastMatch?.id, lastMatchParams, layout.routeName, layoutMatch?.pathname, location.pathname, location.state]);
   const { loading, data, error } = useRequest(
     async () => {
       const existingModel = flowEngine.getModel<BaseLayoutModel>(layout.uid);

--- a/packages/core/client-v2/src/layout-manager/__tests__/LayoutRoute.test.tsx
+++ b/packages/core/client-v2/src/layout-manager/__tests__/LayoutRoute.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { FlowEngine, FlowEngineProvider, observer } from '@nocobase/flow-engine';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { createMemoryRouter, Outlet, RouterProvider, useOutlet } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
@@ -103,6 +103,64 @@ describe('LayoutRoute', () => {
       rootRouteName: 'test',
       rootPageModelClass: 'TestRootPageModel',
       childPageModelClass: 'TestChildPageModel',
+    });
+  });
+
+  it('syncs updated router state when navigating to the same layout pathname', async () => {
+    const syncLayoutRoute = vi.fn();
+
+    class StateTrackingLayoutModel extends TestLayoutModel {
+      syncLayoutRoute(routeLike: Parameters<BaseLayoutModel['syncLayoutRoute']>[0]) {
+        syncLayoutRoute(routeLike);
+        return super.syncLayoutRoute(routeLike);
+      }
+    }
+
+    const stateTrackingLayout: LayoutDefinition = {
+      ...layout,
+      layoutModelClass: 'StateTrackingLayoutModel',
+    };
+    const engine = new FlowEngine();
+    engine.registerModels({ StateTrackingLayoutModel });
+    engine.context.defineProperty('app', {
+      value: {
+        layoutManager: {
+          getLayout: () => stateTrackingLayout,
+        },
+      },
+    });
+
+    const router = createMemoryRouter(
+      [
+        {
+          id: layout.routeName,
+          path: layout.routePath,
+          element: <LayoutRoute layoutRouteName="test" />,
+        },
+      ],
+      {
+        initialEntries: ['/test'],
+      },
+    );
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <RouterProvider router={router} />
+      </FlowEngineProvider>,
+    );
+
+    expect(await screen.findByTestId('layout-route')).toHaveTextContent('test');
+    syncLayoutRoute.mockClear();
+
+    const routeState = {
+      __nocobaseOpenViewInputArgs: { popup: { formData: { status: 'todo' } } },
+    };
+    await act(async () => {
+      await router.navigate('/test', { state: routeState });
+    });
+
+    await waitFor(() => {
+      expect(syncLayoutRoute).toHaveBeenCalledWith(expect.objectContaining({ state: routeState }));
     });
   });
 
@@ -410,6 +468,34 @@ describe('LayoutContentRoute', () => {
         tabUid: 'tab-1',
         viewStack: [{ viewUid: 'page-1', tabUid: 'tab-1' }, { viewUid: 'popup' }],
       });
+    });
+  });
+
+  it('syncs updated router state when navigating to the same content pathname', async () => {
+    const syncLayoutRoute = vi.fn();
+
+    class StateTrackingLayoutModel extends TestLayoutModel {
+      syncLayoutRoute(routeLike: Parameters<BaseLayoutModel['syncLayoutRoute']>[0]) {
+        syncLayoutRoute(routeLike);
+        return super.syncLayoutRoute(routeLike);
+      }
+    }
+
+    const { router } = setup('/test/page-1/view/popup', layout, StateTrackingLayoutModel);
+    await waitFor(() => {
+      expect(syncLayoutRoute).toHaveBeenCalled();
+    });
+    syncLayoutRoute.mockClear();
+
+    const routeState = {
+      __nocobaseOpenViewInputArgs: { popup: { formData: { status: 'todo' } } },
+    };
+    await act(async () => {
+      await router.navigate('/test/page-1/view/popup', { state: routeState });
+    });
+
+    await waitFor(() => {
+      expect(syncLayoutRoute).toHaveBeenCalledWith(expect.objectContaining({ state: routeState }));
     });
   });
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Kanban column quick create passes the selected group value through transient router state. The layout route components did not preserve that state while synchronizing the routed view, so the create form lost its initial group value and saved records with a null status.

### Description

- Pass `location.state` through both `LayoutRoute` and `LayoutContentRoute`.
- Re-synchronize layout routes when router state changes, including navigation to the same pathname.
- Add regression coverage for state updates in both layout route components.

Risk is limited to routed layout synchronization. The state dependency intentionally triggers synchronization when a navigation replaces transient state without changing the pathname.

Testing:

- `node node_modules/vitest/vitest.mjs packages/core/client-v2/src/layout-manager/__tests__/LayoutRoute.test.tsx --run --reporter=verbose` — 11 passed.
- Focused Kanban Playwright EF-01 — 2 passed; the created record had `status: "todo"` and the Todo column displayed two records.
- ESLint and repository pre-commit hooks passed for all changed files.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Kanban column quick create records not inheriting the selected group value |
| 🇨🇳 Chinese | 修复看板列快捷创建记录时未继承所选分组值的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
