### PR TITLE
fix(plugin-block-tree): use business field for tree search

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeBlockModel.tsx
@@ -393,7 +393,19 @@ export class TreeBlockModel extends CollectionBlockModel {
   }
 
   getTitleFieldName() {
-    return this.props?.fieldNames?.title || this.collection?.filterTargetKey;
+    const explicitTitleFieldName = this.props?.fieldNames?.title;
+    if (explicitTitleFieldName) {
+      return explicitTitleFieldName;
+    }
+
+    const collection = this.collection;
+    const collectionTitleFieldName = collection?.titleCollectionField?.name;
+    if (collectionTitleFieldName && collectionTitleFieldName !== collection?.filterTargetKey) {
+      return collectionTitleFieldName;
+    }
+
+    const businessTitleFieldName = ['name', 'code', 'title'].find((fieldName) => collection?.getField?.(fieldName));
+    return businessTitleFieldName || collectionTitleFieldName || collection?.filterTargetKey;
   }
 
   private getTreeAddChildFormDataCacheKey(actionUid: string, sourceId: any) {

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
@@ -18,6 +18,19 @@ describe('TreeBlockModel', () => {
     vi.restoreAllMocks();
   });
 
+  it('prefers a business title field when the collection title field is the primary key', () => {
+    const titleFieldName = TreeBlockModel.prototype.getTitleFieldName.call({
+      props: {},
+      collection: {
+        filterTargetKey: 'id',
+        titleCollectionField: { name: 'id' },
+        getField: (name: string) => (name === 'title' ? { name: 'title' } : undefined),
+      },
+    });
+
+    expect(titleFieldName).toBe('title');
+  });
+
   it('hides single relation entries from associated records in tree filter block menu', async () => {
     const engine = new FlowEngine();
     engine.registerModels({ TreeBlockModel });

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/components/TreeBlockView.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/components/TreeBlockView.tsx
@@ -472,17 +472,7 @@ export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => 
   const fullTreeDataRef = useRef<any[]>([]);
   const previousTreeDataRef = useRef<any[]>();
   const awaitingSearchResetRef = useRef(false);
-  const collectionFilterTargetKey = collection?.filterTargetKey;
-  const propsFieldNames = model.props?.fieldNames;
-  const fieldNames = useMemo(
-    () => ({
-      key: collectionFilterTargetKey,
-      title: propsFieldNames?.title || collectionFilterTargetKey,
-      children: 'children',
-      ...(propsFieldNames || {}),
-    }),
-    [collectionFilterTargetKey, propsFieldNames],
-  );
+  const fieldNames = model.getFieldNames();
   const titleField = fieldNames.title;
   const collectionField = collection?.getField?.(titleField);
   const titleFieldModel = model.getTitleFieldSettingsContainer().subModels.field as any;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The modern Tree block used the collection filter target key as both the node key and the default title/search field. When a collection kept its generated primary key as the title field and later added a business `title` field, text searches were applied to the primary key. A non-matching search could therefore leave placeholder tree nodes visible instead of showing an empty result.

### Description

- Prefer an explicitly configured title field.
- When the collection title field is also its filter target key, prefer an existing business field in `name`, `code`, and `title` order before falling back to the primary key.
- Reuse the model's field-name resolution in `TreeBlockView` so node rendering and search use the same field.
- Add a regression test matching the collection metadata produced by the failing E2E scenario.

Risk is limited to the default title/search field selection for Tree blocks whose collection title field is the primary key. Explicit Tree block title-field settings remain unchanged.

Testing suggestions:

1. Create a tree collection whose configured title field remains `id`, then add a string `title` field.
2. Create a Tree block and verify node titles use the business field.
3. Search for a value with no matches and verify the tree displays no nodes.
4. Clear the search and verify the original nodes return.

### Related issues

- CI reproduction: https://github.com/Charls-Wu/nocobase-e2e-ci/actions/runs/30507988363/job/90762637209

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed Tree block searches showing placeholder nodes when no business-field records matched |
| 🇨🇳 Chinese | 修复 Tree 区块搜索无匹配业务字段记录时仍显示占位节点的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
