### PR TITLE
fix(cli): use local Portal workspaces

### DIFF
--- a/docs/docs/cn/api/cli/portal/config.md
+++ b/docs/docs/cn/api/cli/portal/config.md
@@ -20,6 +20,7 @@ nb portal config <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | Portal 工作区目录，默认是当前目录 |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |

--- a/docs/docs/cn/api/cli/portal/create.md
+++ b/docs/docs/cn/api/cli/portal/create.md
@@ -20,6 +20,7 @@ nb portal create <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | 本地工作区目录，默认是 `<当前目录>/<portal>` |
 | `<portal>` | string | Portal 名称或 slug |
 | `--template` | string | 模板包、本地路径或 `file://` URL，默认是 `@nocobase/portal-template-default` |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
@@ -61,7 +62,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 `--force` 会先删除已有本地 Portal 工作区，再重新创建。这个参数适合本地工作区已经损坏、或者你明确希望重新从模板生成的情况。
 
-创建时会在本地工作区写入 `.env`、`.env.local` 和 `portal.config.json`。其中 `.env.local` 使用完整的 `apiBaseUrl`，`portal.config.json` 保存 source storage 和 Git 配置。
+创建时会在本地工作区写入 `.env`、`.env.local` 和 `portal.config.json`。其中 `.env.local` 使用完整的 `apiBaseUrl`，`portal.config.json` 保存 Portal 名称、source storage 和 Git 配置。
 
 如果模板里有 `package.json`，创建完成后会自动执行 `pnpm install`。如果模板里没有 `package.json`，会跳过依赖安装。
 

--- a/docs/docs/cn/api/cli/portal/deploy.md
+++ b/docs/docs/cn/api/cli/portal/deploy.md
@@ -20,6 +20,7 @@ nb portal deploy <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | Portal 工作区目录，默认是当前目录 |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |
@@ -42,7 +43,7 @@ nb portal deploy customer --env dev --yes
 
 `deploy` 面向已经存在的 Portal 工作区。如果本地还没有工作区，先使用 [`nb portal create`](./create.md) 创建，或者使用 [`nb portal pull`](./pull.md) 从 source storage 拉取。
 
-对于 `local` 和 `docker` env，部署会同步 Portal 记录，并直接使用本地或 volume 中的 `dist` 目录。对于 `http` env，CLI 会把 `dist` 打包上传到目标 NocoBase，再同步 Portal 记录。
+对于 `local`、`docker` 和 `http` env，CLI 都会把 `dist` 打包上传到目标 NocoBase，再同步 Portal 记录。
 
 部署时会读取本地工作区的 `portal.config.json`，并把源码配置同步到远端 Portal 记录。
 

--- a/docs/docs/cn/api/cli/portal/destroy.md
+++ b/docs/docs/cn/api/cli/portal/destroy.md
@@ -20,6 +20,7 @@ nb portal destroy <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | Portal 工作区目录，默认是当前目录 |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 跳过确认提示 |

--- a/docs/docs/cn/api/cli/portal/dev.md
+++ b/docs/docs/cn/api/cli/portal/dev.md
@@ -20,6 +20,7 @@ nb portal dev <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | Portal 工作区目录，默认是当前目录 |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |

--- a/docs/docs/cn/api/cli/portal/index.md
+++ b/docs/docs/cn/api/cli/portal/index.md
@@ -84,7 +84,7 @@ nb portal push customer -e dev --yes --message "Move customer portal source to G
 
 如果只是快速创建和开发 Portal，默认的 `nocobase` 就够了。只有当你希望把 Portal 源码纳入已有 Git 仓库、走团队代码评审或 CI 流程时，才需要选择 `git`。
 
-源码配置会写入本地工作区的 `portal.config.json`。`create`、`pull` 和 `config` 都会维护这个文件；`push` 和 `deploy` 会读取它，并按配置同步源码或部署产物。
+Portal 名称和源码配置会写入本地工作区的 `portal.config.json`。`create`、`pull` 和 `config` 都会维护这个文件；`push` 和 `deploy` 会读取它，并按配置同步源码或部署产物。
 
 ## env 类型
 
@@ -92,19 +92,21 @@ nb portal push customer -e dev --yes --message "Move customer portal source to G
 
 | env 类型 | 说明 |
 | --- | --- |
-| `local` | 本地工作区和应用 storage 在当前机器上，`pull`/`push` 对默认 `nocobase` 存储通常不需要做额外同步 |
-| `docker` | 本地工作区通过 Docker volume 和应用共享，`pull`/`push` 对默认 `nocobase` 存储通常不需要做额外同步 |
+| `local` | 本地工作区独立于应用 storage，源码和部署产物通过 API 同步 |
+| `docker` | 本地工作区不依赖 Docker volume，源码和部署产物通过 API 同步 |
 | `http` | 通过 API 同步源码和部署产物，`pull`/`push` 会下载或上传源码归档 |
 
 `ssh` env 在当前版本暂不支持 Portal 工作区管理。
 
 ## 本地工作区路径
 
-Portal 工作区会放在当前 env 的 storage 下：
+`create` 默认在当前目录下创建以 Portal 命名的子目录。第一次 `pull` 也使用这个位置；如果当前目录已经包含 `portal.config.json`，`pull` 会直接使用当前目录：
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<当前目录>/<portal>
 ```
+
+`dev`、`push`、`deploy`、`config`、`destroy`、`info` 和 `list` 默认把当前目录作为本地 Portal 工作区。所有这些命令都可以通过 `--dir <路径>` 显式指定工作区；相对路径按当前目录解析。CLI 不会从 env 的 `storagePath` 推导本地工作区。
 
 主应用的访问路径通常是：
 

--- a/docs/docs/cn/api/cli/portal/info.md
+++ b/docs/docs/cn/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | 用于显示本地文件详情的 Portal 工作区目录，默认是当前目录 |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |

--- a/docs/docs/cn/api/cli/portal/list.md
+++ b/docs/docs/cn/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | 用于检查本地同步状态的 Portal 工作区目录，默认是当前目录 |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |
 | `--json-output`, `-j` | boolean | 以 JSON 输出 Portal 记录 |

--- a/docs/docs/cn/api/cli/portal/pull.md
+++ b/docs/docs/cn/api/cli/portal/pull.md
@@ -20,6 +20,7 @@ nb portal pull <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | 本地工作区目录；省略时使用当前 Portal 工作区，否则使用 `<当前目录>/<portal>` |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |
@@ -60,7 +61,7 @@ nb portal pull customer --no-install
 
 如果 Portal 使用 Git source storage，`pull` 会 clone 配置中的仓库和分支，并复制 `--git-path` 对应目录。配置中的分支不存在时，CLI 会尝试基于仓库默认分支创建本地分支；如果配置目录不存在，命令会报错。
 
-如果 Portal 使用默认的 `nocobase` source storage，`local` 和 `docker` env 下源码通常已经在当前机器或 Docker volume 中，`pull` 会提示不需要拉取。`http` env 会通过 API 下载源码归档，并展开到本地工作区。
+如果 Portal 使用默认的 `nocobase` source storage，`local`、`docker` 和 `http` env 都会通过 API 下载源码归档，并展开到本地工作区。
 
 ## 相关命令
 

--- a/docs/docs/cn/api/cli/portal/push.md
+++ b/docs/docs/cn/api/cli/portal/push.md
@@ -20,6 +20,7 @@ nb portal push <portal> [flags]
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
+| `--dir` | string | Portal 工作区目录，默认是当前目录 |
 | `<portal>` | string | Portal 名称或 slug |
 | `--env`, `-e` | string | CLI env 名称，省略时使用当前 env |
 | `--yes`, `-y` | boolean | 当显式 `--env` 指向的 env 与当前 env 不一致时，跳过交互确认 |
@@ -53,7 +54,7 @@ nb portal push customer --message "Update customer portal"
 
 如果 Portal 使用 Git source storage，`push` 会 clone 配置中的仓库和分支，把本地 Portal 工作区复制到配置的 Git 目录，然后提交并推送。没有源码变更时不会创建 commit；如果没有传入 `--message`，默认 commit message 是 `chore(portal): update <portal>`。
 
-如果 Portal 使用默认的 `nocobase` source storage，`local` 和 `docker` env 下源码通常已经在当前机器或 Docker volume 中，`push` 会提示不需要推送。`http` env 会打包本地源码并通过 API 上传。
+如果 Portal 使用默认的 `nocobase` source storage，`local`、`docker` 和 `http` env 都会打包本地源码并通过 API 上传。
 
 ## 相关命令
 

--- a/docs/docs/de/api/cli/portal/config.md
+++ b/docs/docs/de/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/de/api/cli/portal/create.md
+++ b/docs/docs/de/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Hinweise
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Verwandte Befehle
 

--- a/docs/docs/de/api/cli/portal/deploy.md
+++ b/docs/docs/de/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Hinweise
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Verwandte Befehle
 

--- a/docs/docs/de/api/cli/portal/destroy.md
+++ b/docs/docs/de/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/de/api/cli/portal/dev.md
+++ b/docs/docs/de/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/de/api/cli/portal/index.md
+++ b/docs/docs/de/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Beim Erstellen eines Portals wählen Sie, wo der Quellcode verwaltet wird:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Modus | Beschreibung |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/de/api/cli/portal/info.md
+++ b/docs/docs/de/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/de/api/cli/portal/list.md
+++ b/docs/docs/de/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/de/api/cli/portal/pull.md
+++ b/docs/docs/de/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Hinweise
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Verwandte Befehle
 

--- a/docs/docs/de/api/cli/portal/push.md
+++ b/docs/docs/de/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Parameter | Typ | Beschreibung |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Hinweise
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Verwandte Befehle
 

--- a/docs/docs/en/api/cli/portal/config.md
+++ b/docs/docs/en/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/en/api/cli/portal/create.md
+++ b/docs/docs/en/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Notes
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Related Commands
 

--- a/docs/docs/en/api/cli/portal/deploy.md
+++ b/docs/docs/en/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Notes
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the portal record.
 
 ## Related Commands
 

--- a/docs/docs/en/api/cli/portal/destroy.md
+++ b/docs/docs/en/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/en/api/cli/portal/dev.md
+++ b/docs/docs/en/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/en/api/cli/portal/index.md
+++ b/docs/docs/en/api/cli/portal/index.md
@@ -84,7 +84,7 @@ When creating a portal, choose where the source code is managed:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Mode | Description |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/en/api/cli/portal/info.md
+++ b/docs/docs/en/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/en/api/cli/portal/list.md
+++ b/docs/docs/en/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print portal records as JSON. |

--- a/docs/docs/en/api/cli/portal/pull.md
+++ b/docs/docs/en/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Notes
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Related Commands
 

--- a/docs/docs/en/api/cli/portal/push.md
+++ b/docs/docs/en/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Notes
 
-The command reads `portal.config.json` and syncs that configuration to the remote portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Related Commands
 

--- a/docs/docs/es/api/cli/portal/config.md
+++ b/docs/docs/es/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/es/api/cli/portal/create.md
+++ b/docs/docs/es/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Notas
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Comandos relacionados
 

--- a/docs/docs/es/api/cli/portal/deploy.md
+++ b/docs/docs/es/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Notas
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Comandos relacionados
 

--- a/docs/docs/es/api/cli/portal/destroy.md
+++ b/docs/docs/es/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/es/api/cli/portal/dev.md
+++ b/docs/docs/es/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/es/api/cli/portal/index.md
+++ b/docs/docs/es/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Al crear un Portal, elige dónde se gestiona el código fuente:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Modo | Descripción |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/es/api/cli/portal/info.md
+++ b/docs/docs/es/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/es/api/cli/portal/list.md
+++ b/docs/docs/es/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/es/api/cli/portal/pull.md
+++ b/docs/docs/es/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Notas
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Comandos relacionados
 

--- a/docs/docs/es/api/cli/portal/push.md
+++ b/docs/docs/es/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Notas
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Comandos relacionados
 

--- a/docs/docs/fr/api/cli/portal/config.md
+++ b/docs/docs/fr/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/fr/api/cli/portal/create.md
+++ b/docs/docs/fr/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Notes
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Commandes liées
 

--- a/docs/docs/fr/api/cli/portal/deploy.md
+++ b/docs/docs/fr/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Notes
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Commandes liées
 

--- a/docs/docs/fr/api/cli/portal/destroy.md
+++ b/docs/docs/fr/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/fr/api/cli/portal/dev.md
+++ b/docs/docs/fr/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/fr/api/cli/portal/index.md
+++ b/docs/docs/fr/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Lors de la création d’un Portal, choisissez où le code source est géré :
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Mode | Description |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/fr/api/cli/portal/info.md
+++ b/docs/docs/fr/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/fr/api/cli/portal/list.md
+++ b/docs/docs/fr/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/fr/api/cli/portal/pull.md
+++ b/docs/docs/fr/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Notes
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Commandes liées
 

--- a/docs/docs/fr/api/cli/portal/push.md
+++ b/docs/docs/fr/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Paramètre | Type | Description |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Notes
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Commandes liées
 

--- a/docs/docs/id/api/cli/portal/config.md
+++ b/docs/docs/id/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/id/api/cli/portal/create.md
+++ b/docs/docs/id/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Catatan
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Perintah terkait
 

--- a/docs/docs/id/api/cli/portal/deploy.md
+++ b/docs/docs/id/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Catatan
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Perintah terkait
 

--- a/docs/docs/id/api/cli/portal/destroy.md
+++ b/docs/docs/id/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/id/api/cli/portal/dev.md
+++ b/docs/docs/id/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/id/api/cli/portal/index.md
+++ b/docs/docs/id/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Saat membuat Portal, pilih tempat source code dikelola:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Mode | Deskripsi |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/id/api/cli/portal/info.md
+++ b/docs/docs/id/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/id/api/cli/portal/list.md
+++ b/docs/docs/id/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/id/api/cli/portal/pull.md
+++ b/docs/docs/id/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Catatan
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Perintah terkait
 

--- a/docs/docs/id/api/cli/portal/push.md
+++ b/docs/docs/id/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Parameter | Tipe | Deskripsi |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Catatan
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Perintah terkait
 

--- a/docs/docs/ja/api/cli/portal/config.md
+++ b/docs/docs/ja/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/ja/api/cli/portal/create.md
+++ b/docs/docs/ja/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## 補足
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## 関連コマンド
 

--- a/docs/docs/ja/api/cli/portal/deploy.md
+++ b/docs/docs/ja/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## 補足
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## 関連コマンド
 

--- a/docs/docs/ja/api/cli/portal/destroy.md
+++ b/docs/docs/ja/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/ja/api/cli/portal/dev.md
+++ b/docs/docs/ja/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/ja/api/cli/portal/index.md
+++ b/docs/docs/ja/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Portal 作成時に、ソースコードの管理場所を選択できます:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | モード | 説明 |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/ja/api/cli/portal/info.md
+++ b/docs/docs/ja/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/ja/api/cli/portal/list.md
+++ b/docs/docs/ja/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/ja/api/cli/portal/pull.md
+++ b/docs/docs/ja/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## 補足
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## 関連コマンド
 

--- a/docs/docs/ja/api/cli/portal/push.md
+++ b/docs/docs/ja/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | パラメーター | 型 | 説明 |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## 補足
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## 関連コマンド
 

--- a/docs/docs/pt/api/cli/portal/config.md
+++ b/docs/docs/pt/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/pt/api/cli/portal/create.md
+++ b/docs/docs/pt/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Notas
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Comandos relacionados
 

--- a/docs/docs/pt/api/cli/portal/deploy.md
+++ b/docs/docs/pt/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Notas
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Comandos relacionados
 

--- a/docs/docs/pt/api/cli/portal/destroy.md
+++ b/docs/docs/pt/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/pt/api/cli/portal/dev.md
+++ b/docs/docs/pt/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/pt/api/cli/portal/index.md
+++ b/docs/docs/pt/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Ao criar um Portal, escolha onde o código-fonte será gerenciado:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Modo | Descrição |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/pt/api/cli/portal/info.md
+++ b/docs/docs/pt/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/pt/api/cli/portal/list.md
+++ b/docs/docs/pt/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/pt/api/cli/portal/pull.md
+++ b/docs/docs/pt/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Notas
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Comandos relacionados
 

--- a/docs/docs/pt/api/cli/portal/push.md
+++ b/docs/docs/pt/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Parâmetro | Tipo | Descrição |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Notas
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Comandos relacionados
 

--- a/docs/docs/ru/api/cli/portal/config.md
+++ b/docs/docs/ru/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/ru/api/cli/portal/create.md
+++ b/docs/docs/ru/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Примечания
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Связанные команды
 

--- a/docs/docs/ru/api/cli/portal/deploy.md
+++ b/docs/docs/ru/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Примечания
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Связанные команды
 

--- a/docs/docs/ru/api/cli/portal/destroy.md
+++ b/docs/docs/ru/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/ru/api/cli/portal/dev.md
+++ b/docs/docs/ru/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/ru/api/cli/portal/index.md
+++ b/docs/docs/ru/api/cli/portal/index.md
@@ -84,7 +84,7 @@ nb portal push customer -e dev --yes --message "Move customer portal source to G
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Режим | Описание |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/ru/api/cli/portal/info.md
+++ b/docs/docs/ru/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/ru/api/cli/portal/list.md
+++ b/docs/docs/ru/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/ru/api/cli/portal/pull.md
+++ b/docs/docs/ru/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Примечания
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Связанные команды
 

--- a/docs/docs/ru/api/cli/portal/push.md
+++ b/docs/docs/ru/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Параметр | Тип | Описание |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Примечания
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Связанные команды
 

--- a/docs/docs/vi/api/cli/portal/config.md
+++ b/docs/docs/vi/api/cli/portal/config.md
@@ -18,6 +18,7 @@ nb portal config <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/vi/api/cli/portal/create.md
+++ b/docs/docs/vi/api/cli/portal/create.md
@@ -18,6 +18,7 @@ nb portal create <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Default: `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--template` | string | Template package, local path, or `file://` URL. Default: `@nocobase/portal-template-default`. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
@@ -40,7 +41,7 @@ nb portal create customer --source-storage git --git-repo git@github.com:nocobas
 
 ## Ghi chú
 
-The command writes `.env`, `.env.local`, and `portal.config.json`. If the template contains `package.json`, it runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
+The command writes `.env`, `.env.local`, and `portal.config.json`. The config file records the Portal name and source settings. If the template contains `package.json`, the command runs `pnpm install`. Portal names must use lowercase letters, numbers, underscores, or hyphens, and start with a lowercase letter or number.
 
 ## Lệnh liên quan
 

--- a/docs/docs/vi/api/cli/portal/deploy.md
+++ b/docs/docs/vi/api/cli/portal/deploy.md
@@ -18,6 +18,7 @@ nb portal deploy <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -31,7 +32,7 @@ nb portal deploy customer --env dev --yes
 
 ## Ghi chú
 
-The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local` and `docker` envs, it syncs the Portal record and uses the local or volume-mounted `dist`; for `http` envs, it uploads the packed `dist` through the API.
+The command refreshes `.env` and `.env.local`, runs `pnpm build`, and expects `dist/index.html`. For `local`, `docker`, and `http` envs, it uploads the packed `dist` through the API and syncs the Portal record.
 
 ## Lệnh liên quan
 

--- a/docs/docs/vi/api/cli/portal/destroy.md
+++ b/docs/docs/vi/api/cli/portal/destroy.md
@@ -18,6 +18,7 @@ nb portal destroy <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip confirmation prompts. |

--- a/docs/docs/vi/api/cli/portal/dev.md
+++ b/docs/docs/vi/api/cli/portal/dev.md
@@ -18,6 +18,7 @@ nb portal dev <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/vi/api/cli/portal/index.md
+++ b/docs/docs/vi/api/cli/portal/index.md
@@ -84,7 +84,7 @@ Khi tạo Portal, hãy chọn nơi quản lý mã nguồn:
 
 For quick creation and development, the default `nocobase` storage is usually enough. Use `git` when the Portal source should be reviewed, versioned, or built through an existing team workflow.
 
-Source configuration is written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
+The Portal name and source configuration are written to `portal.config.json` in the local workspace. `create`, `pull`, and `config` maintain this file; `push` and `deploy` read it to sync source or deployment output.
 
 ## Env Types
 
@@ -92,19 +92,21 @@ Source configuration is written to `portal.config.json` in the local workspace. 
 
 | Chế độ | Mô tả |
 | --- | --- |
-| `local` | The workspace and app storage are on the current machine. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
-| `docker` | The workspace is shared with the app through a Docker volume. With default `nocobase` storage, `pull`/`push` usually do not need extra sync. |
+| `local` | The workspace is independent of app storage. Source and deployment output are synced through APIs. |
+| `docker` | The workspace does not depend on a Docker volume. Source and deployment output are synced through APIs. |
 | `http` | Source and deployment output are synced through APIs. `pull` downloads a source archive, and `push` uploads one. |
 
 `ssh` envs do not support Portal management in the current version.
 
 ## Local Workspace Path
 
-Portals are stored under the selected env storage:
+`create` defaults to a portal-named child of the current directory. The first `pull` uses the same location; if the current directory already contains `portal.config.json`, `pull` uses the current directory directly:
 
 ```text
-<storagePath>/portals/<app>/<portal>
+<current-directory>/<portal>
 ```
+
+`dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list` use the current directory as the local Portal workspace by default. Pass `--dir <path>` to any of these commands to select a workspace explicitly; relative paths are resolved from the current directory. The CLI does not derive the local workspace from the env `storagePath`.
 
 The main app access path is usually:
 

--- a/docs/docs/vi/api/cli/portal/info.md
+++ b/docs/docs/vi/api/cli/portal/info.md
@@ -18,6 +18,7 @@ nb portal info <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local file details. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |

--- a/docs/docs/vi/api/cli/portal/list.md
+++ b/docs/docs/vi/api/cli/portal/list.md
@@ -18,6 +18,7 @@ nb portal list [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace used for local sync status. Default: the current directory. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
 | `--json-output`, `-j` | boolean | Print Portal records as JSON. |

--- a/docs/docs/vi/api/cli/portal/pull.md
+++ b/docs/docs/vi/api/cli/portal/pull.md
@@ -18,6 +18,7 @@ nb portal pull <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Local workspace directory. Uses the current Portal workspace, or `<current-directory>/<portal>`. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -35,7 +36,7 @@ nb portal pull customer --no-install
 
 ## Ghi chú
 
-When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs download a source archive through the API.
+When the pulled workspace contains `package.json`, `pnpm install` runs by default. Use `--no-install` to skip it. Git source storage clones the configured repo and branch, then copies `--git-path`. With default `nocobase` storage, `local`, `docker`, and `http` envs download a source archive through the API.
 
 ## Lệnh liên quan
 

--- a/docs/docs/vi/api/cli/portal/push.md
+++ b/docs/docs/vi/api/cli/portal/push.md
@@ -18,6 +18,7 @@ nb portal push <portal> [flags]
 
 | Tham số | Kiểu | Mô tả |
 | --- | --- | --- |
+| `--dir` | string | Portal workspace directory. Default: the current directory. |
 | `<portal>` | string | Portal name or slug. |
 | `--env`, `-e` | string | CLI env name. If omitted, the current env is used. |
 | `--yes`, `-y` | boolean | Skip cross-env confirmation. |
@@ -33,7 +34,7 @@ nb portal push customer --message "Update customer portal"
 
 ## Ghi chú
 
-The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local` and `docker` envs are usually no-op; `http` envs upload a source archive through the API.
+The command reads `portal.config.json` and syncs that configuration to the remote Portal record first. Git source storage clones the configured repo, copies the local workspace into `--git-path`, commits, and pushes. With default `nocobase` storage, `local`, `docker`, and `http` envs upload a source archive through the API.
 
 ## Lệnh liên quan
 

--- a/packages/core/cli/src/__tests__/portal-configure.test.ts
+++ b/packages/core/cli/src/__tests__/portal-configure.test.ts
@@ -38,7 +38,10 @@ function createEnv(params: { storagePath: string; kind?: PortalCreateEnvLike['ki
 async function preparePortalWorkspace(storagePath: string): Promise<string> {
   const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   await fsp.mkdir(portalDir, { recursive: true });
-  await fsp.writeFile(path.join(portalDir, 'portal.config.json'), '{\n  "sourceStorage": "nocobase"\n}\n');
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    '{\n  "portal": "customer",\n  "sourceStorage": "nocobase"\n}\n',
+  );
   return portalDir;
 }
 
@@ -90,6 +93,7 @@ test('updates local Portal config and syncs remote options when the remote recor
   await expect(
     configurePortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       envName: 'prod',
       cliVersion: '1.2.3',
       env: createEnv({ storagePath }),
@@ -103,6 +107,7 @@ test('updates local Portal config and syncs remote options when the remote recor
     portalDir,
     remoteSynced: true,
     config: {
+      portal: 'customer',
       sourceStorage: 'git',
       git: {
         repo: 'git@github.com:nocobase/customer-portal.git',
@@ -112,7 +117,7 @@ test('updates local Portal config and syncs remote options when the remote recor
     },
   });
   await expect(fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8')).resolves.toBe(
-    '{\n  "sourceStorage": "git",\n  "git": {\n    "repo": "git@github.com:nocobase/customer-portal.git",\n    "branch": "main",\n    "path": "portals/customer"\n  }\n}\n',
+    '{\n  "portal": "customer",\n  "sourceStorage": "git",\n  "git": {\n    "repo": "git@github.com:nocobase/customer-portal.git",\n    "branch": "main",\n    "path": "portals/customer"\n  }\n}\n',
   );
   expect(apiRequest.mock.calls.map((call) => call[0].operation.pathTemplate)).toEqual([
     '/multiPortals:list',
@@ -128,6 +133,7 @@ test('writes local Portal config without remote sync when the remote record is m
   await expect(
     configurePortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       sourceStorage: 'nocobase',
       apiRequest,
@@ -136,7 +142,7 @@ test('writes local Portal config without remote sync when the remote record is m
     remoteSynced: false,
   });
   await expect(fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8')).resolves.toBe(
-    '{\n  "sourceStorage": "nocobase"\n}\n',
+    '{\n  "portal": "customer",\n  "sourceStorage": "nocobase"\n}\n',
   );
   expect(apiRequest).toHaveBeenCalledTimes(1);
 });
@@ -178,6 +184,7 @@ test('defaults Git path to the repository root', async () => {
   await expect(
     configurePortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       sourceStorage: 'git',
       gitRepo: 'git@github.com:nocobase/customer-portal.git',
@@ -185,6 +192,7 @@ test('defaults Git path to the repository root', async () => {
     }),
   ).resolves.toMatchObject({
     config: {
+      portal: 'customer',
       sourceStorage: 'git',
       git: {
         repo: 'git@github.com:nocobase/customer-portal.git',
@@ -194,6 +202,6 @@ test('defaults Git path to the repository root', async () => {
     },
   });
   await expect(fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8')).resolves.toBe(
-    '{\n  "sourceStorage": "git",\n  "git": {\n    "repo": "git@github.com:nocobase/customer-portal.git",\n    "branch": "main",\n    "path": "."\n  }\n}\n',
+    '{\n  "portal": "customer",\n  "sourceStorage": "git",\n  "git": {\n    "repo": "git@github.com:nocobase/customer-portal.git",\n    "branch": "main",\n    "path": "."\n  }\n}\n',
   );
 });

--- a/packages/core/cli/src/__tests__/portal-create.test.ts
+++ b/packages/core/cli/src/__tests__/portal-create.test.ts
@@ -17,12 +17,10 @@ import {
   createPortalWorkspace,
   resolvePortalAppFromApiBaseUrl,
   resolvePortalEnvApiUrl,
-  resolvePortalStoragePath,
   titleFromPortalSlug,
   validatePortalSlug,
   type PortalCreateEnvLike,
 } from '../lib/portal-create.js';
-import { NB_CLI_ROOT_ENV } from '../lib/cli-home.js';
 
 type PortalCreateRunOptions = {
   cwd?: string;
@@ -166,6 +164,7 @@ test('creates a portal from a local template', async () => {
 
   const result = await createPortalWorkspace({
     portal: 'customer',
+    directory: path.join(storagePath, 'portals', 'crm', 'customer'),
     template: templatePath,
     env: createEnv({
       storagePath,
@@ -199,6 +198,7 @@ test('creates a portal from a local template', async () => {
       'NOCOBASE_PORTAL_BASE=/console/x/apps/crm/customer/\n',
   );
   expect(JSON.parse(await fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8'))).toEqual({
+    portal: 'customer',
     sourceStorage: 'nocobase',
   });
   expect(runCommand).toHaveBeenCalledWith('pnpm', ['install'], {
@@ -220,6 +220,7 @@ test('skips pnpm install when package.json is missing', async () => {
 
   const result = await createPortalWorkspace({
     portal: 'no_package',
+    directory: path.join(storagePath, 'portals', 'main', 'no_package'),
     template: templatePath,
     env: createEnv({ storagePath }),
     runCommand,
@@ -261,6 +262,7 @@ test('downloads npm package templates with npm pack when not installed locally',
 
   await createPortalWorkspace({
     portal: 'customer',
+    directory: path.join(storagePath, 'portals', 'main', 'customer'),
     template: '@nocobase/missing-portal-template',
     env: createEnv({
       storagePath,
@@ -274,6 +276,7 @@ test('downloads npm package templates with npm pack when not installed locally',
   const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   await expect(fsp.access(path.join(portalDir, 'src', 'index.tsx'))).resolves.toBe(undefined);
   expect(JSON.parse(await fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8'))).toEqual({
+    portal: 'customer',
     sourceStorage: 'nocobase',
   });
   expect(runCommand).toHaveBeenNthCalledWith(
@@ -298,6 +301,7 @@ test('fails when the target directory exists without force', async () => {
   await expect(
     createPortalWorkspace({
       portal: 'customer',
+      directory: path.join(storagePath, 'portals', 'main', 'customer'),
       template: templatePath,
       env: createEnv({ storagePath }),
       runCommand: vi.fn().mockResolvedValue(undefined),
@@ -314,6 +318,7 @@ test('fails before resolving the template when the target directory exists witho
   await expect(
     createPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       template: path.join(storagePath, 'missing-template'),
       env: createEnv({ storagePath }),
       runCommand: vi.fn().mockResolvedValue(undefined),
@@ -329,9 +334,11 @@ test('deletes and recreates an existing target directory with force', async () =
   await writeTemplate(templatePath);
   await fsp.mkdir(portalDir, { recursive: true });
   await fsp.writeFile(path.join(portalDir, 'old.txt'), 'old');
+  await fsp.writeFile(path.join(portalDir, 'portal.config.json'), '{"portal":"customer","sourceStorage":"nocobase"}\n');
 
   await createPortalWorkspace({
     portal: 'customer',
+    directory: portalDir,
     template: templatePath,
     env: createEnv({ storagePath }),
     force: true,
@@ -342,15 +349,39 @@ test('deletes and recreates an existing target directory with force', async () =
   await expect(fsp.access(path.join(portalDir, 'src', 'index.tsx'))).resolves.toBe(undefined);
 });
 
+test('force refuses to replace a directory that is not a Portal workspace', async () => {
+  const storagePath = await makeTempDir('nocobase-cli-portal-create-storage-');
+  const templatePath = await makeTempDir('nocobase-cli-portal-create-template-');
+  const portalDir = path.join(storagePath, 'customer');
+  await writeTemplate(templatePath);
+  await fsp.mkdir(portalDir, { recursive: true });
+  await fsp.writeFile(path.join(portalDir, 'keep.txt'), 'keep');
+
+  await expect(
+    createPortalWorkspace({
+      portal: 'customer',
+      directory: portalDir,
+      template: templatePath,
+      env: createEnv({ storagePath }),
+      force: true,
+      runCommand: vi.fn().mockResolvedValue(undefined),
+    }),
+  ).rejects.toThrow(/not a Portal workspace/);
+
+  await expect(fsp.readFile(path.join(portalDir, 'keep.txt'), 'utf-8')).resolves.toBe('keep');
+});
+
 test('force keeps an existing target directory when template resolution fails', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-create-storage-');
   const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   await fsp.mkdir(portalDir, { recursive: true });
   await fsp.writeFile(path.join(portalDir, 'old.txt'), 'old');
+  await fsp.writeFile(path.join(portalDir, 'portal.config.json'), '{"portal":"customer","sourceStorage":"nocobase"}\n');
 
   await expect(
     createPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       template: path.join(storagePath, 'missing-template'),
       env: createEnv({ storagePath }),
       force: true,
@@ -359,45 +390,4 @@ test('force keeps an existing target directory when template resolution fails', 
   ).rejects.toThrow(/Portal template directory does not exist/);
 
   expect(await fsp.readFile(path.join(portalDir, 'old.txt'), 'utf-8')).toBe('old');
-});
-
-test('http envs use env source storage when no local storagePath is configured', async () => {
-  const originalStoragePath = process.env.STORAGE_PATH;
-  const originalCliRoot = process.env[NB_CLI_ROOT_ENV];
-  const cliRoot = await makeTempDir('nocobase-cli-portal-create-root-');
-  delete process.env.STORAGE_PATH;
-  process.env[NB_CLI_ROOT_ENV] = cliRoot;
-  try {
-    expect(
-      resolvePortalStoragePath(
-        createEnv({
-          kind: 'http',
-          name: 'remote1',
-          storagePath: '/tmp/fallback',
-          configuredStoragePath: '',
-        }),
-      ),
-    ).toBe(path.join(cliRoot, 'remote1', 'source', 'storage'));
-    expect(
-      resolvePortalStoragePath(
-        createEnv({
-          kind: 'http',
-          name: 'remote1',
-          storagePath: '/tmp/nocobase-storage',
-          configuredStoragePath: '/tmp/nocobase-storage',
-        }),
-      ),
-    ).toBe('/tmp/nocobase-storage');
-  } finally {
-    if (originalStoragePath === undefined) {
-      delete process.env.STORAGE_PATH;
-    } else {
-      process.env.STORAGE_PATH = originalStoragePath;
-    }
-    if (originalCliRoot === undefined) {
-      delete process.env[NB_CLI_ROOT_ENV];
-    } else {
-      process.env[NB_CLI_ROOT_ENV] = originalCliRoot;
-    }
-  }
 });

--- a/packages/core/cli/src/__tests__/portal-deploy-command.test.ts
+++ b/packages/core/cli/src/__tests__/portal-deploy-command.test.ts
@@ -136,6 +136,7 @@ test('portal deploy resolves the current env name before deploying', async () =>
     [
       {
         env,
+        directory: '/Users/chen/test6/remote1/source/storage/portals/main/cba',
         envName: 'remote1',
         cliVersion: '1.2.3',
       },

--- a/packages/core/cli/src/__tests__/portal-deploy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-deploy.test.ts
@@ -72,7 +72,10 @@ async function preparePortalWorkspace(params: {
   const portalDir = path.join(params.storagePath, 'portals', app, portal);
   await fsp.mkdir(path.join(portalDir, 'src'), { recursive: true });
   await fsp.writeFile(path.join(portalDir, 'package.json'), '{"name":"portal"}\n');
-  await fsp.writeFile(path.join(portalDir, 'portal.config.json'), '{\n  "sourceStorage": "nocobase"\n}\n');
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    `${JSON.stringify({ portal, sourceStorage: 'nocobase' }, null, 2)}\n`,
+  );
   if (params.envContent !== undefined) {
     await fsp.writeFile(path.join(portalDir, '.env'), params.envContent);
   }
@@ -126,7 +129,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
-test('updates env files, builds, and syncs the portal record locally without uploading dist', async () => {
+test('updates env files, builds, and uploads the portal dist for local envs', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
   const portalDir = await preparePortalWorkspace({
     storagePath,
@@ -143,6 +146,7 @@ test('updates env files, builds, and syncs the portal record locally without upl
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({
         kind: 'local',
         storagePath,
@@ -157,7 +161,7 @@ test('updates env files, builds, and syncs the portal record locally without upl
     portalDir,
     portalBase: '/console/x/apps/crm/customer/',
     mode: 'local',
-    uploaded: false,
+    uploaded: true,
     recordSynced: true,
   });
 
@@ -185,8 +189,9 @@ test('updates env files, builds, and syncs the portal record locally without upl
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });
-  expect(apiRequest).toHaveBeenCalledTimes(1);
-  expectPortalRecordFirstOrCreate(apiRequest.mock.calls[0][0]);
+  expect(apiRequest).toHaveBeenCalledTimes(2);
+  expect(apiRequest.mock.calls[0][0].operation.pathTemplate).toBe('/multiPortals:deploy');
+  expectPortalRecordFirstOrCreate(apiRequest.mock.calls[1][0]);
   expect(await fsp.readFile(path.join(portalDir, '.env'), 'utf-8')).toBe(
     'CUSTOM_VALUE=1\nNOCOBASE_API_URL=/console/api/__app/crm\nNOCOBASE_PORTAL_BASE=/console/x/apps/crm/customer/\n',
   );
@@ -195,14 +200,9 @@ test('updates env files, builds, and syncs the portal record locally without upl
       'LOCAL_ONLY=true\n' +
       'NOCOBASE_API_URL=http://localhost:13000/console/api/__app/crm\n',
   );
-  expectPosixMode((await fsp.stat(path.join(storagePath, 'portals'))).mode, 0o755);
-  expectPosixMode((await fsp.stat(path.join(storagePath, 'portals', 'crm'))).mode, 0o755);
-  expectPosixMode((await fsp.stat(portalDir)).mode, 0o755);
-  expectPosixMode((await fsp.stat(path.join(portalDir, 'dist'))).mode, 0o755);
-  expectPosixMode((await fsp.stat(path.join(portalDir, 'dist', 'index.html'))).mode, 0o644);
 });
 
-test('docker deploy builds and syncs the portal record without uploading dist', async () => {
+test('docker deploy builds and uploads the portal dist', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
   const portalDir = await preparePortalWorkspace({ storagePath });
   const runCommand = vi.fn(async (_name: string, _args: string[], options?: PortalDeployRunOptions) => {
@@ -214,6 +214,7 @@ test('docker deploy builds and syncs the portal record without uploading dist', 
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ kind: 'docker', storagePath }),
       runCommand,
       apiRequest,
@@ -221,16 +222,16 @@ test('docker deploy builds and syncs the portal record without uploading dist', 
   ).resolves.toMatchObject({
     portalDir,
     mode: 'docker',
-    uploaded: false,
+    uploaded: true,
     recordSynced: true,
   });
-  expect(apiRequest).toHaveBeenCalledTimes(1);
-  expectPortalRecordFirstOrCreate(apiRequest.mock.calls[0][0]);
+  expect(apiRequest).toHaveBeenCalledTimes(2);
+  expectPortalRecordFirstOrCreate(apiRequest.mock.calls[1][0]);
 });
 
 test('deploy reports a clear error when pnpm is not installed', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
-  await preparePortalWorkspace({ storagePath });
+  const portalDir = await preparePortalWorkspace({ storagePath });
   const runCommand = vi.fn(async () => {
     throw Object.assign(new Error('spawn pnpm ENOENT'), { code: 'ENOENT' });
   });
@@ -239,6 +240,7 @@ test('deploy reports a clear error when pnpm is not installed', async () => {
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ kind: 'local', storagePath }),
       runCommand,
       apiRequest,
@@ -302,6 +304,7 @@ test('http deploy builds, packs dist, and uploads it', async () => {
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       envName: 'prod',
       cliVersion: '1.2.3',
       env: createEnv({
@@ -366,7 +369,7 @@ test('http deploy builds, packs dist, and uploads it', async () => {
   });
 });
 
-test('http deploy uses env source storage when no local storagePath is configured', async () => {
+test('http deploy uses an explicit local workspace directory', async () => {
   const cliRoot = await makeTempDir('nocobase-cli-portal-deploy-root-');
   const originalCliRoot = process.env[NB_CLI_ROOT_ENV];
   process.env[NB_CLI_ROOT_ENV] = cliRoot;
@@ -382,6 +385,7 @@ test('http deploy uses env source storage when no local storagePath is configure
     await expect(
       deployPortalWorkspace({
         portal: 'customer',
+        directory: portalDir,
         envName: 'remote1',
         env: createEnv({
           kind: 'http',
@@ -413,32 +417,38 @@ test('http deploy uses env source storage when no local storagePath is configure
 
 test('fails when portal record sync fails', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
-  await preparePortalWorkspace({ storagePath });
+  const portalDir = await preparePortalWorkspace({ storagePath });
   const runCommand = vi.fn(async (_name: string, _args: string[], options?: PortalDeployRunOptions) => {
     await fsp.mkdir(path.join(String(options?.cwd), 'dist'), { recursive: true });
     await fsp.writeFile(path.join(String(options?.cwd), 'dist', 'index.html'), '<div id="root"></div>');
   });
-  const apiRequest = vi.fn(async () => ({ ok: false, status: 500, data: { errors: [{ message: 'boom' }] } }));
+  const apiRequest = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
+    .mockResolvedValueOnce({ ok: false, status: 500, data: { errors: [{ message: 'boom' }] } });
 
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       runCommand,
       apiRequest,
     }),
   ).rejects.toThrow(/Portal record sync failed with status 500/);
 
-  expect(apiRequest).toHaveBeenCalledTimes(1);
-  expectPortalRecordFirstOrCreate(apiRequest.mock.calls[0][0]);
+  expect(apiRequest).toHaveBeenCalledTimes(2);
+  expectPortalRecordFirstOrCreate(apiRequest.mock.calls[1][0]);
 });
 
 test('fails when workspace is missing', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
+  const portalDir = path.join(storagePath, 'customer');
 
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       runCommand: vi.fn(),
     }),
@@ -447,11 +457,12 @@ test('fails when workspace is missing', async () => {
 
 test('fails when build does not produce dist index', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
-  await preparePortalWorkspace({ storagePath });
+  const portalDir = await preparePortalWorkspace({ storagePath });
 
   await expect(
     deployPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       runCommand: vi.fn().mockResolvedValue(undefined),
     }),

--- a/packages/core/cli/src/__tests__/portal-destroy-command.test.ts
+++ b/packages/core/cli/src/__tests__/portal-destroy-command.test.ts
@@ -63,12 +63,13 @@ test('portal destroy resolves the current env name before destroying', async () 
   });
 
   const command = Object.assign(Object.create(PortalDestroy.prototype), {
-    argv: ['--yes'],
+    argv: ['--yes', '--dir', './cba'],
     parse: vi.fn(async () => ({
       args: { portal: 'cba' },
       flags: {
         yes: true,
         force: false,
+        dir: './cba',
       },
     })),
     config: {
@@ -89,6 +90,7 @@ test('portal destroy resolves the current env name before destroying', async () 
     [
       {
         portal: 'cba',
+        directory: './cba',
         env,
         envName: 'remote1',
         cliVersion: '1.2.3',

--- a/packages/core/cli/src/__tests__/portal-destroy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-destroy.test.ts
@@ -51,6 +51,10 @@ async function preparePortalWorkspace(params: { storagePath: string; app?: strin
   const portalDir = path.join(params.storagePath, 'portals', app, portal);
   await fsp.mkdir(path.join(portalDir, 'dist'), { recursive: true });
   await fsp.writeFile(path.join(portalDir, 'dist', 'index.html'), '<div id="root"></div>');
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    `${JSON.stringify({ portal, sourceStorage: 'nocobase' }, null, 2)}\n`,
+  );
   return portalDir;
 }
 
@@ -91,6 +95,7 @@ test('destroys the portal record and local workspace', async () => {
   await expect(
     destroyPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       envName: 'dev',
       cliVersion: '1.2.3',
       env: createEnv({
@@ -123,11 +128,13 @@ test('destroys the portal record and local workspace', async () => {
 
 test('force destroy ignores a missing portal record and workspace', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-destroy-storage-');
+  const portalDir = path.join(storagePath, 'customer');
   const apiRequest = vi.fn(async () => ({ ok: false, status: 404, data: { errors: [{ message: 'Not Found' }] } }));
 
   await expect(
     destroyPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       force: true,
       apiRequest,
@@ -143,7 +150,7 @@ test('force destroy ignores a missing portal record and workspace', async () => 
   expectPortalRecordDestroy(apiRequest.mock.calls[0][0]);
 });
 
-test('http destroy uses env source storage when no local storagePath is configured', async () => {
+test('http destroy uses an explicit local workspace directory', async () => {
   const cliRoot = await makeTempDir('nocobase-cli-portal-destroy-root-');
   const originalCliRoot = process.env[NB_CLI_ROOT_ENV];
   process.env[NB_CLI_ROOT_ENV] = cliRoot;
@@ -155,6 +162,7 @@ test('http destroy uses env source storage when no local storagePath is configur
     await expect(
       destroyPortalWorkspace({
         portal: 'customer',
+        directory: portalDir,
         envName: 'remote1',
         env: createEnv({
           kind: 'http',
@@ -184,11 +192,13 @@ test('http destroy uses env source storage when no local storagePath is configur
 
 test('fails before deleting the record when workspace is missing without force', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-destroy-storage-');
+  const portalDir = path.join(storagePath, 'customer');
   const apiRequest = vi.fn(async () => ({ ok: true, status: 200, data: { data: 1 } }));
 
   await expect(
     destroyPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       apiRequest,
     }),
@@ -205,6 +215,7 @@ test('fails when portal record destroy fails', async () => {
   await expect(
     destroyPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       apiRequest,
     }),

--- a/packages/core/cli/src/__tests__/portal-dev.test.ts
+++ b/packages/core/cli/src/__tests__/portal-dev.test.ts
@@ -62,6 +62,10 @@ async function preparePortalWorkspace(params: {
   const portalDir = path.join(params.storagePath, 'portals', app, portal);
   await fsp.mkdir(path.join(portalDir, 'src'), { recursive: true });
   await fsp.writeFile(path.join(portalDir, 'package.json'), '{"name":"portal"}\n');
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    `${JSON.stringify({ portal, sourceStorage: 'nocobase' }, null, 2)}\n`,
+  );
   if (params.envContent !== undefined) {
     await fsp.writeFile(path.join(portalDir, '.env'), params.envContent);
   }
@@ -89,6 +93,7 @@ test('updates env files and starts portal dev without building or syncing record
   await expect(
     devPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({
         kind: 'http',
         storagePath,
@@ -135,10 +140,12 @@ test('updates env files and starts portal dev without building or syncing record
 
 test('fails when Portal is missing', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-dev-storage-');
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
 
   await expect(
     devPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       runCommand: vi.fn(),
     }),
@@ -147,11 +154,17 @@ test('fails when Portal is missing', async () => {
 
 test('fails when package.json is missing', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-dev-storage-');
-  await fsp.mkdir(path.join(storagePath, 'portals', 'main', 'customer'), { recursive: true });
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
+  await fsp.mkdir(portalDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    `${JSON.stringify({ portal: 'customer', sourceStorage: 'nocobase' }, null, 2)}\n`,
+  );
 
   await expect(
     devPortalWorkspace({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath }),
       runCommand: vi.fn(),
     }),

--- a/packages/core/cli/src/__tests__/portal-list.test.ts
+++ b/packages/core/cli/src/__tests__/portal-list.test.ts
@@ -50,6 +50,10 @@ async function preparePortalWorkspace(params: { storagePath: string; app?: strin
   const portal = params.portal ?? 'customer';
   const portalDir = path.join(params.storagePath, 'portals', app, portal);
   await fsp.mkdir(portalDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    `${JSON.stringify({ portal, sourceStorage: 'nocobase' }, null, 2)}\n`,
+  );
   return portalDir;
 }
 
@@ -119,6 +123,7 @@ test('lists portal records with local workspace sync status for AI portals', asy
 
   await expect(
     listPortalWorkspaces({
+      directory: customerDir,
       envName: 'dev',
       cliVersion: '1.2.3',
       env: createEnv({
@@ -131,7 +136,7 @@ test('lists portal records with local workspace sync status for AI portals', asy
   ).resolves.toEqual({
     app: 'crm',
     mode: 'local',
-    storagePath,
+    workspaceDir: customerDir,
     items: [
       {
         uid: 'customer',
@@ -178,7 +183,7 @@ test('lists portal records with local workspace sync status for AI portals', asy
   expectPortalRecordList(apiRequest.mock.calls[0][0]);
 });
 
-test('http list uses env source storage when no local storagePath is configured', async () => {
+test('http list uses the explicit local workspace directory', async () => {
   const cliRoot = await makeTempDir('nocobase-cli-portal-list-root-');
   const originalCliRoot = process.env[NB_CLI_ROOT_ENV];
   process.env[NB_CLI_ROOT_ENV] = cliRoot;
@@ -204,6 +209,7 @@ test('http list uses env source storage when no local storagePath is configured'
 
     await expect(
       listPortalWorkspaces({
+        directory: portalDir,
         envName: 'remote1',
         env: createEnv({
           kind: 'http',
@@ -217,7 +223,7 @@ test('http list uses env source storage when no local storagePath is configured'
     ).resolves.toMatchObject({
       app: 'main',
       mode: 'http',
-      storagePath,
+      workspaceDir: portalDir,
       items: [
         expect.objectContaining({
           portalDir,

--- a/packages/core/cli/src/__tests__/portal-source.test.ts
+++ b/packages/core/cli/src/__tests__/portal-source.test.ts
@@ -68,7 +68,10 @@ function portalListData(sourceStorage = 'nocobase') {
 }
 
 async function writePortalConfig(portalDir: string, config: Record<string, unknown> = { sourceStorage: 'nocobase' }) {
-  await fsp.writeFile(path.join(portalDir, 'portal.config.json'), `${JSON.stringify(config, null, 2)}\n`);
+  await fsp.writeFile(
+    path.join(portalDir, 'portal.config.json'),
+    `${JSON.stringify({ portal: path.basename(portalDir), ...config }, null, 2)}\n`,
+  );
 }
 
 async function runGit(args: string[], cwd?: string) {
@@ -85,6 +88,7 @@ afterEach(async () => {
 
 test('pull downloads NocoBase-managed source for http envs', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-source-storage-');
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   const sourceDir = await makeTempDir('nocobase-cli-portal-source-archive-');
   await fsp.mkdir(path.join(sourceDir, 'src'), { recursive: true });
   await fsp.writeFile(path.join(sourceDir, 'src', 'index.tsx'), 'export default null;\n');
@@ -109,6 +113,7 @@ test('pull downloads NocoBase-managed source for http envs', async () => {
   await expect(
     pullPortalSource({
       portal: 'customer',
+      directory: portalDir,
       envName: 'prod',
       env: createEnv({ storagePath, kind: 'http' }),
       apiRequest,
@@ -122,14 +127,12 @@ test('pull downloads NocoBase-managed source for http envs', async () => {
     dependenciesInstalled: true,
   });
 
-  await expect(
-    fsp.readFile(path.join(storagePath, 'portals', 'main', 'customer', 'src', 'index.tsx'), 'utf-8'),
-  ).resolves.toBe('export default null;\n');
-  await expect(
-    fsp.readFile(path.join(storagePath, 'portals', 'main', 'customer', 'portal.config.json'), 'utf-8'),
-  ).resolves.toBe('{\n  "sourceStorage": "nocobase"\n}\n');
+  await expect(fsp.readFile(path.join(portalDir, 'src', 'index.tsx'), 'utf-8')).resolves.toBe('export default null;\n');
+  await expect(fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8')).resolves.toBe(
+    '{\n  "portal": "customer",\n  "sourceStorage": "nocobase"\n}\n',
+  );
   expect(runCommand).toHaveBeenCalledWith('pnpm', ['install'], {
-    cwd: path.join(storagePath, 'portals', 'main', 'customer'),
+    cwd: portalDir,
     env: expect.any(Object),
     envMode: 'replace',
     errorName: 'pnpm install',
@@ -181,6 +184,7 @@ test('push uploads NocoBase-managed source for http envs and excludes dist', asy
   await expect(
     pushPortalSource({
       portal: 'customer',
+      directory: portalDir,
       envName: 'prod',
       env: createEnv({ storagePath, kind: 'http' }),
       apiRequest,
@@ -199,38 +203,55 @@ test('push uploads NocoBase-managed source for http envs and excludes dist', asy
   ]);
 });
 
-test('local and docker NocoBase-managed source sync is a no-op', async () => {
+test('local and docker NocoBase-managed source sync uses the API', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-source-storage-');
   const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
-  await fsp.mkdir(portalDir, { recursive: true });
-  await writePortalConfig(portalDir);
-  const apiRequest = vi.fn(async () => ({ ok: true, status: 200, data: portalListData() }));
+  const sourceDir = await makeTempDir('nocobase-cli-portal-source-archive-');
+  await fsp.writeFile(path.join(sourceDir, 'package.json'), '{"name":"customer"}\n');
+  const apiRequest = vi.fn(async (options: RequestOptions) => {
+    if (options.operation.pathTemplate === '/multiPortals:list') {
+      return { ok: true, status: 200, data: portalListData() };
+    }
+    if (options.operation.pathTemplate === '/multiPortals:pullSource') {
+      await tar.create({ cwd: sourceDir, file: String(options.flags.output), gzip: true }, ['package.json']);
+      return { ok: true, status: 200, data: { output: options.flags.output } };
+    }
+    if (options.operation.pathTemplate === '/multiPortals:update') {
+      return { ok: true, status: 200, data: {} };
+    }
+    return { ok: true, status: 200, data: { data: { sourceRevision: 'local-revision' } } };
+  });
 
   await expect(
     pullPortalSource({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath, kind: 'local', apiBaseUrl: 'http://localhost:13000/api' }),
+      installDependencies: false,
       apiRequest,
     }),
   ).resolves.toMatchObject({
     mode: 'local',
-    changed: false,
+    changed: true,
   });
 
   await expect(
     pushPortalSource({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath, kind: 'docker', apiBaseUrl: 'http://localhost:13000/api' }),
       apiRequest,
     }),
   ).resolves.toMatchObject({
     mode: 'docker',
-    changed: false,
+    changed: true,
+    sourceRevision: 'local-revision',
   });
 });
 
 test('pull can skip dependency installation', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-source-storage-');
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   const sourceDir = await makeTempDir('nocobase-cli-portal-source-archive-');
   await fsp.writeFile(path.join(sourceDir, 'package.json'), '{"name":"customer"}\n');
   const runCommand = vi.fn().mockResolvedValue(undefined);
@@ -246,6 +267,7 @@ test('pull can skip dependency installation', async () => {
   await expect(
     pullPortalSource({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath, kind: 'http' }),
       installDependencies: false,
       runCommand,
@@ -259,8 +281,30 @@ test('pull can skip dependency installation', async () => {
   expect(runCommand).not.toHaveBeenCalled();
 });
 
+test('pull with force refuses to replace a directory that is not a Portal workspace', async () => {
+  const storagePath = await makeTempDir('nocobase-cli-portal-source-storage-');
+  const portalDir = path.join(storagePath, 'customer');
+  await fsp.mkdir(portalDir, { recursive: true });
+  await fsp.writeFile(path.join(portalDir, 'keep.txt'), 'keep');
+  const apiRequest = vi.fn(async () => ({ ok: true, status: 200, data: portalListData() }));
+
+  await expect(
+    pullPortalSource({
+      portal: 'customer',
+      directory: portalDir,
+      env: createEnv({ storagePath, kind: 'http' }),
+      force: true,
+      apiRequest,
+    }),
+  ).rejects.toThrow(/not a Portal workspace/);
+
+  await expect(fsp.readFile(path.join(portalDir, 'keep.txt'), 'utf-8')).resolves.toBe('keep');
+  expect(apiRequest).toHaveBeenCalledTimes(1);
+});
+
 test('pull and push Git-managed source through the configured repository path', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-source-storage-');
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   const remoteRepo = await makeTempDir('nocobase-cli-portal-git-remote-');
   const remoteRepoUrl = `file://${remoteRepo}`;
   const seedRepo = await makeTempDir('nocobase-cli-portal-git-seed-');
@@ -299,6 +343,7 @@ test('pull and push Git-managed source through the configured repository path', 
   await expect(
     pullPortalSource({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath, kind: 'http' }),
       apiRequest,
     }),
@@ -306,18 +351,18 @@ test('pull and push Git-managed source through the configured repository path', 
     sourceStorage: 'git',
     changed: true,
   });
-  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   expect(normalizeLineEndings(await fsp.readFile(path.join(portalDir, 'src', 'index.tsx'), 'utf-8'))).toBe(
     'export default "remote";\n',
   );
   await expect(fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8')).resolves.toBe(
-    `{\n  "sourceStorage": "git",\n  "git": {\n    "repo": "${remoteRepoUrl}",\n    "branch": "main",\n    "path": "customer"\n  }\n}\n`,
+    `{\n  "portal": "customer",\n  "sourceStorage": "git",\n  "git": {\n    "repo": "${remoteRepoUrl}",\n    "branch": "main",\n    "path": "customer"\n  }\n}\n`,
   );
 
   await fsp.writeFile(path.join(portalDir, 'src', 'index.tsx'), 'export default "local";\n');
   await expect(
     pushPortalSource({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath, kind: 'http' }),
       message: 'Update portal source',
       apiRequest,
@@ -381,6 +426,7 @@ test('push creates configured Git branch and uses repository root by default', a
   await expect(
     pushPortalSource({
       portal: 'customer',
+      directory: portalDir,
       env: createEnv({ storagePath, kind: 'http' }),
       message: 'Initial portal source',
       apiRequest,

--- a/packages/core/cli/src/__tests__/portal-workspace.test.ts
+++ b/packages/core/cli/src/__tests__/portal-workspace.test.ts
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+import { resolvePortalWorkspaceDirectory } from '../lib/portal-workspace.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'nocobase-cli-portal-workspace-'));
+  tempDirs.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+test('create and first pull use a portal-named directory under the current directory', async () => {
+  const cwd = await makeTempDir();
+
+  await expect(resolvePortalWorkspaceDirectory({ portal: 'ai', cwd, mode: 'create' })).resolves.toBe(
+    path.join(cwd, 'ai'),
+  );
+  await expect(resolvePortalWorkspaceDirectory({ portal: 'ai', cwd, mode: 'pull' })).resolves.toBe(
+    path.join(cwd, 'ai'),
+  );
+});
+
+test('pull and existing commands use the current Portal workspace', async () => {
+  const cwd = await makeTempDir();
+  await writeFile(path.join(cwd, 'portal.config.json'), '{"portal":"ai","sourceStorage":"nocobase"}\n');
+
+  await expect(resolvePortalWorkspaceDirectory({ portal: 'ai', cwd, mode: 'pull' })).resolves.toBe(cwd);
+  await expect(resolvePortalWorkspaceDirectory({ portal: 'ai', cwd, mode: 'existing' })).resolves.toBe(cwd);
+});
+
+test('an explicit directory overrides the current directory', async () => {
+  const cwd = await makeTempDir();
+
+  await expect(
+    resolvePortalWorkspaceDirectory({ portal: 'ai', cwd, directory: './custom-ai', mode: 'existing' }),
+  ).resolves.toBe(path.join(cwd, 'custom-ai'));
+});

--- a/packages/core/cli/src/commands/portal/config.ts
+++ b/packages/core/cli/src/commands/portal/config.ts
@@ -25,6 +25,7 @@ export default class PortalConfig extends Command {
     '<%= config.bin %> <%= command.id %> customer --source-storage nocobase',
     '<%= config.bin %> <%= command.id %> customer --source-storage git --git-repo git@github.com:nocobase/customer-portal.git',
     '<%= config.bin %> <%= command.id %> customer --git-branch main --git-path portals/customer',
+    '<%= config.bin %> <%= command.id %> customer --dir ./customer --source-storage nocobase',
   ];
 
   static override args = {
@@ -57,6 +58,9 @@ export default class PortalConfig extends Command {
     'git-path': Flags.string({
       description: 'Directory inside the Git repository for this portal; defaults to the repository root',
     }),
+    dir: Flags.string({
+      description: 'Portal workspace directory; defaults to the current directory',
+    }),
   };
 
   async run(): Promise<void> {
@@ -88,6 +92,7 @@ export default class PortalConfig extends Command {
 
     const result = await configurePortalWorkspace({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       env,
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),

--- a/packages/core/cli/src/commands/portal/create.ts
+++ b/packages/core/cli/src/commands/portal/create.ts
@@ -26,6 +26,7 @@ export default class PortalCreate extends Command {
     '<%= config.bin %> <%= command.id %> customer',
     '<%= config.bin %> <%= command.id %> customer --template @nocobase/portal-template-default',
     '<%= config.bin %> <%= command.id %> customer --env dev --yes',
+    '<%= config.bin %> <%= command.id %> customer --dir ./portals/customer',
     '<%= config.bin %> <%= command.id %> customer --source-storage git --git-repo git@github.com:nocobase/customer-portal.git',
   ];
 
@@ -56,6 +57,9 @@ export default class PortalCreate extends Command {
     force: Flags.boolean({
       description: 'Delete the existing portal and recreate it',
       default: false,
+    }),
+    dir: Flags.string({
+      description: 'Local portal workspace directory; defaults to <current-directory>/<portal>',
     }),
     'source-storage': Flags.string({
       description: 'Where portal source code is managed',
@@ -105,6 +109,7 @@ export default class PortalCreate extends Command {
 
     const result = await createPortalWorkspace({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       title: flags.title,
       template: flags.template,
       env,

--- a/packages/core/cli/src/commands/portal/deploy.ts
+++ b/packages/core/cli/src/commands/portal/deploy.ts
@@ -26,6 +26,7 @@ export default class PortalDeploy extends Command {
   static override examples = [
     '<%= config.bin %> <%= command.id %> customer',
     '<%= config.bin %> <%= command.id %> customer --env dev --yes',
+    '<%= config.bin %> <%= command.id %> customer --dir ./customer',
   ];
 
   static override args = {
@@ -44,6 +45,9 @@ export default class PortalDeploy extends Command {
       char: 'y',
       description: 'Confirm using --env when it targets a different env than the current env',
       default: false,
+    }),
+    dir: Flags.string({
+      description: 'Portal workspace directory; defaults to the current directory',
     }),
   };
 
@@ -76,6 +80,7 @@ export default class PortalDeploy extends Command {
 
     const result = await deployPortalWorkspace({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       env,
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),
@@ -86,6 +91,7 @@ export default class PortalDeploy extends Command {
     );
     const info = await listPortalWorkspaces({
       env,
+      directory: result.portalDir,
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),
     });

--- a/packages/core/cli/src/commands/portal/destroy.ts
+++ b/packages/core/cli/src/commands/portal/destroy.ts
@@ -40,7 +40,7 @@ async function ensureDestroyConfirmed(options: { command: Command; portal: strin
         message: portalDestroyText(
           'prompts.confirm',
           { portal: options.portal },
-          `Destroy portal "${options.portal}" and delete its storage directory?`,
+          `Destroy portal "${options.portal}" and delete its local workspace?`,
         ),
         default: false,
       }),
@@ -57,6 +57,7 @@ export default class PortalDestroy extends Command {
     '<%= config.bin %> <%= command.id %> customer --yes',
     '<%= config.bin %> <%= command.id %> customer --env dev --yes',
     '<%= config.bin %> <%= command.id %> customer --force --yes',
+    '<%= config.bin %> <%= command.id %> customer --dir ./customer --yes',
   ];
 
   static override args = {
@@ -79,6 +80,9 @@ export default class PortalDestroy extends Command {
     force: Flags.boolean({
       description: 'Ignore missing portal records or local files',
       default: false,
+    }),
+    dir: Flags.string({
+      description: 'Portal workspace directory; defaults to the current directory',
     }),
   };
 
@@ -120,6 +124,7 @@ export default class PortalDestroy extends Command {
 
     const result = await destroyPortalWorkspace({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       env,
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),

--- a/packages/core/cli/src/commands/portal/dev.ts
+++ b/packages/core/cli/src/commands/portal/dev.ts
@@ -24,6 +24,7 @@ export default class PortalDev extends Command {
   static override examples = [
     '<%= config.bin %> <%= command.id %> customer',
     '<%= config.bin %> <%= command.id %> customer --env dev --yes',
+    '<%= config.bin %> <%= command.id %> customer --dir ./customer',
   ];
 
   static override args = {
@@ -42,6 +43,9 @@ export default class PortalDev extends Command {
       char: 'y',
       description: 'Confirm using --env when it targets a different env than the current env',
       default: false,
+    }),
+    dir: Flags.string({
+      description: 'Portal workspace directory; defaults to the current directory',
     }),
   };
 
@@ -74,6 +78,7 @@ export default class PortalDev extends Command {
 
     await devPortalWorkspace({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       env,
       onStart: (result) => {
         printInfo(

--- a/packages/core/cli/src/commands/portal/info.ts
+++ b/packages/core/cli/src/commands/portal/info.ts
@@ -25,6 +25,7 @@ export default class PortalInfo extends Command {
     '<%= config.bin %> <%= command.id %> customer',
     '<%= config.bin %> <%= command.id %> customer --env dev --yes',
     '<%= config.bin %> <%= command.id %> customer --json',
+    '<%= config.bin %> <%= command.id %> customer --dir ./customer',
   ];
 
   static override args = {
@@ -49,6 +50,9 @@ export default class PortalInfo extends Command {
       aliases: ['json'],
       description: 'Print portal details as JSON',
       default: false,
+    }),
+    dir: Flags.string({
+      description: 'Portal workspace directory used for local file details; defaults to the current directory',
     }),
   };
 
@@ -81,6 +85,7 @@ export default class PortalInfo extends Command {
 
     const result = await listPortalWorkspaces({
       env,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),
     });

--- a/packages/core/cli/src/commands/portal/list.ts
+++ b/packages/core/cli/src/commands/portal/list.ts
@@ -32,6 +32,7 @@ export default class PortalList extends Command {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --env dev --yes',
     '<%= config.bin %> <%= command.id %> --json',
+    '<%= config.bin %> <%= command.id %> --dir ./customer',
   ];
 
   static override flags = {
@@ -49,6 +50,9 @@ export default class PortalList extends Command {
       aliases: ['json'],
       description: 'Print portal records as JSON',
       default: false,
+    }),
+    dir: Flags.string({
+      description: 'Portal workspace directory used for local sync status; defaults to the current directory',
     }),
   };
 
@@ -81,6 +85,7 @@ export default class PortalList extends Command {
 
     const result = await listPortalWorkspaces({
       env,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),
     });

--- a/packages/core/cli/src/commands/portal/pull.ts
+++ b/packages/core/cli/src/commands/portal/pull.ts
@@ -26,6 +26,7 @@ export default class PortalPull extends Command {
     '<%= config.bin %> <%= command.id %> customer --env prod --yes',
     '<%= config.bin %> <%= command.id %> customer --force',
     '<%= config.bin %> <%= command.id %> customer --no-install',
+    '<%= config.bin %> <%= command.id %> customer --dir ./portals/customer',
   ];
 
   static override args = {
@@ -53,6 +54,10 @@ export default class PortalPull extends Command {
       description: 'Run pnpm install after pulling the portal source',
       default: true,
       allowNo: true,
+    }),
+    dir: Flags.string({
+      description:
+        'Local portal workspace directory; defaults to the current workspace or <current-directory>/<portal>',
     }),
   };
 
@@ -85,6 +90,7 @@ export default class PortalPull extends Command {
 
     const result = await pullPortalSource({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       env,
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),

--- a/packages/core/cli/src/commands/portal/push.ts
+++ b/packages/core/cli/src/commands/portal/push.ts
@@ -25,6 +25,7 @@ export default class PortalPush extends Command {
     '<%= config.bin %> <%= command.id %> customer',
     '<%= config.bin %> <%= command.id %> customer --env prod --yes',
     '<%= config.bin %> <%= command.id %> customer --message "Update customer portal"',
+    '<%= config.bin %> <%= command.id %> customer --dir ./customer',
   ];
 
   static override args = {
@@ -47,6 +48,9 @@ export default class PortalPush extends Command {
     message: Flags.string({
       char: 'm',
       description: 'Source update message; used as the Git commit message for Git-managed source',
+    }),
+    dir: Flags.string({
+      description: 'Portal workspace directory; defaults to the current directory',
     }),
   };
 
@@ -79,6 +83,7 @@ export default class PortalPush extends Command {
 
     const result = await pushPortalSource({
       portal: args.portal,
+      ...(flags.dir ? { directory: flags.dir } : {}),
       env,
       envName,
       cliVersion: String(this.config.pjson.version ?? '').trim(),

--- a/packages/core/cli/src/lib/portal-config.ts
+++ b/packages/core/cli/src/lib/portal-config.ts
@@ -23,6 +23,7 @@ export type PortalGitConfig = {
 };
 
 export type PortalConfig = {
+  portal: string;
   sourceStorage: PortalSourceStorage;
   git?: PortalGitConfig;
 };
@@ -97,6 +98,12 @@ function validateGitPath(value: string): string {
 }
 
 export function buildPortalConfig(options: BuildPortalConfigOptions): PortalConfig {
+  const portal = trimValue(options.portal);
+  if (!portal) {
+    throw new Error(
+      portalConfigText('errors.portalRequired', undefined, 'Portal name is required in portal.config.json.'),
+    );
+  }
   const sourceStorage = validatePortalSourceStorage(options.sourceStorage ?? options.existingConfig?.sourceStorage);
   const hasGitOption = Boolean(trimValue(options.gitRepo) || trimValue(options.gitBranch) || trimValue(options.gitPath));
   if (sourceStorage === 'nocobase') {
@@ -109,7 +116,7 @@ export function buildPortalConfig(options: BuildPortalConfigOptions): PortalConf
         ),
       );
     }
-    return { sourceStorage };
+    return { portal, sourceStorage };
   }
 
   const repo = trimValue(options.gitRepo) || options.existingConfig?.git?.repo || '';
@@ -125,6 +132,7 @@ export function buildPortalConfig(options: BuildPortalConfigOptions): PortalConf
   }
 
   return {
+    portal,
     sourceStorage,
     git: {
       repo,
@@ -167,12 +175,25 @@ export async function readPortalConfig(portalDir: string): Promise<PortalConfig>
   const config = readObject(data);
   const git = readObject(config.git);
   return buildPortalConfig({
-    portal: path.basename(portalDir),
+    portal: trimValue(config.portal) || path.basename(portalDir),
     sourceStorage: trimValue(config.sourceStorage),
     gitRepo: trimValue(git.repo),
     gitBranch: trimValue(git.branch),
     gitPath: trimValue(git.path),
   });
+}
+
+export function assertPortalConfigMatches(config: PortalConfig, portal: string, portalDir: string): void {
+  if (config.portal === portal) {
+    return;
+  }
+  throw new Error(
+    portalConfigText(
+      'errors.workspaceMismatch',
+      { portalDir, configuredPortal: config.portal, portal },
+      `Portal workspace ${portalDir} belongs to "${config.portal}", not "${portal}".`,
+    ),
+  );
 }
 
 export async function writePortalConfig(portalDir: string, config: PortalConfig): Promise<void> {

--- a/packages/core/cli/src/lib/portal-configure.ts
+++ b/packages/core/cli/src/lib/portal-configure.ts
@@ -7,19 +7,17 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { mkdir, stat } from 'node:fs/promises';
-import path from 'node:path';
+import { stat } from 'node:fs/promises';
 import { executeApiRequest } from './api-client.js';
 import { translateCli } from './cli-locale.js';
 import {
   resolvePortalAppFromApiBaseUrl,
-  resolvePortalStoragePath,
   validatePortalSlug,
   type PortalCreateEnvLike,
 } from './portal-create.js';
 import {
   buildPortalConfig,
-  buildPortalConfigFromOptions,
+  assertPortalConfigMatches,
   readPortalConfig,
   syncPortalConfigToRemote,
   writePortalConfig,
@@ -28,6 +26,7 @@ import {
 } from './portal-config.js';
 import { findPortalListItem } from './portal-info.js';
 import { listPortalWorkspaces } from './portal-list.js';
+import { resolvePortalWorkspaceDirectory } from './portal-workspace.js';
 
 type ApiRequest = typeof executeApiRequest;
 
@@ -35,6 +34,7 @@ export type PortalConfigureEnvLike = PortalCreateEnvLike;
 
 export type PortalConfigureOptions = {
   portal: string;
+  directory?: string;
   env: PortalConfigureEnvLike;
   envName?: string;
   cliVersion?: string;
@@ -78,41 +78,6 @@ function hasConfigurationChange(options: PortalConfigureOptions): boolean {
   );
 }
 
-async function readExistingConfig(portalDir: string): Promise<PortalConfig | undefined> {
-  try {
-    return await readPortalConfig(portalDir);
-  } catch (error) {
-    const code = (error as { code?: unknown }).code;
-    if (code === 'ENOENT') {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-function buildConfigFromRemoteOptions(params: {
-  portal: string;
-  options?: Record<string, unknown>;
-  sourceStorage?: string;
-  gitRepo?: string;
-  gitBranch?: string;
-  gitPath?: string;
-}): PortalConfig | undefined {
-  if (params.options && Object.keys(params.options).length > 0) {
-    return buildPortalConfigFromOptions(params.options, params.portal);
-  }
-  if (!params.sourceStorage && !params.gitRepo && !params.gitBranch && !params.gitPath) {
-    return undefined;
-  }
-  return buildPortalConfig({
-    portal: params.portal,
-    sourceStorage: params.sourceStorage,
-    gitRepo: params.gitRepo,
-    gitBranch: params.gitBranch,
-    gitPath: params.gitPath,
-  });
-}
-
 export async function configurePortalWorkspace(options: PortalConfigureOptions): Promise<PortalConfigureResult> {
   if (!hasConfigurationChange(options)) {
     throw new Error(
@@ -126,9 +91,12 @@ export async function configurePortalWorkspace(options: PortalConfigureOptions):
 
   const portal = validatePortalSlug(options.portal);
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
-  const portalDir = path.join(storagePath, 'portals', app, portal);
+  const portalDir = await resolvePortalWorkspaceDirectory({
+    portal,
+    directory: options.directory,
+    mode: 'existing',
+  });
 
   if (!(await pathExists(portalDir))) {
     throw new Error(
@@ -142,21 +110,14 @@ export async function configurePortalWorkspace(options: PortalConfigureOptions):
 
   const list = await listPortalWorkspaces({
     env: options.env,
+    directory: portalDir,
     envName: options.envName,
     cliVersion: options.cliVersion,
     apiRequest: options.apiRequest,
   });
   const remoteItem = findPortalListItem(list.items, portal);
-  const existingConfig =
-    (await readExistingConfig(portalDir)) ??
-    buildConfigFromRemoteOptions({
-      portal,
-      options: remoteItem?.options,
-      sourceStorage: remoteItem?.sourceStorage,
-      gitRepo: remoteItem?.gitRepo,
-      gitBranch: remoteItem?.gitBranch,
-      gitPath: remoteItem?.gitPath,
-    });
+  const existingConfig = await readPortalConfig(portalDir);
+  assertPortalConfigMatches(existingConfig, portal, portalDir);
   const config = buildPortalConfig({
     portal,
     sourceStorage: options.sourceStorage,
@@ -166,7 +127,6 @@ export async function configurePortalWorkspace(options: PortalConfigureOptions):
     existingConfig,
   });
 
-  await mkdir(portalDir, { recursive: true });
   await writePortalConfig(portalDir, config);
 
   if (remoteItem) {

--- a/packages/core/cli/src/lib/portal-create.ts
+++ b/packages/core/cli/src/lib/portal-create.ts
@@ -19,16 +19,18 @@ import * as tar from 'tar';
 import { appendAppPublicPath, resolveAppPublicPath } from './app-public-path.js';
 import { executeApiRequest, type RequestOperation } from './api-client.js';
 import type { Env } from './auth-store.js';
-import { resolveEnvRelativePath } from './cli-home.js';
 import { translateCli } from './cli-locale.js';
 import { buildPortalCommandEnv } from './portal-command-env.js';
 import {
+  assertPortalConfigMatches,
   buildPortalConfig,
   mergePortalConfigIntoOptions,
+  readPortalConfig,
   writePortalConfig,
   type PortalConfig,
   type PortalSourceStorage,
 } from './portal-config.js';
+import { isPortalWorkspace, resolvePortalWorkspaceDirectory } from './portal-workspace.js';
 import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
 
 const DEFAULT_PORTAL_TEMPLATE = '@nocobase/portal-template-default';
@@ -48,6 +50,7 @@ export type PortalCreateEnvLike = Pick<Env, 'apiBaseUrl' | 'kind' | 'storagePath
 
 export type PortalCreateOptions = {
   portal: string;
+  directory?: string;
   title?: string;
   template?: string;
   env: PortalCreateEnvLike;
@@ -503,41 +506,13 @@ export function buildPortalBasePath(params: { app: string; appPublicPath: string
   return appendAppPublicPath(params.appPublicPath, segment, { trailingSlash: true });
 }
 
-export function resolvePortalStoragePath(env: PortalCreateEnvLike): string {
-  if (env.kind === 'ssh') {
+export async function createPortalWorkspace(options: PortalCreateOptions): Promise<PortalCreateResult> {
+  const portal = validatePortalSlug(options.portal);
+  if (options.env.kind === 'ssh') {
     throw new Error(
       portalCreateText('errors.sshUnsupported', undefined, 'Cannot create a portal for ssh envs in the first version.'),
     );
   }
-
-  if (env.kind === 'http' && !trimValue(env.config.storagePath)) {
-    const envName = trimValue(env.name);
-    if (envName) {
-      return path.join(resolveEnvRelativePath(envName), 'source', 'storage');
-    }
-
-    const envStoragePath = trimValue(process.env.STORAGE_PATH);
-    if (envStoragePath) {
-      return path.isAbsolute(envStoragePath) ? envStoragePath : path.resolve(process.cwd(), envStoragePath);
-    }
-    return path.resolve(process.cwd(), 'storage');
-  }
-
-  const storagePath = trimValue(env.storagePath);
-  if (storagePath) {
-    return storagePath;
-  }
-
-  const envStoragePath = trimValue(process.env.STORAGE_PATH);
-  if (envStoragePath) {
-    return path.isAbsolute(envStoragePath) ? envStoragePath : path.resolve(process.cwd(), envStoragePath);
-  }
-
-  return path.resolve(process.cwd(), 'storage');
-}
-
-export async function createPortalWorkspace(options: PortalCreateOptions): Promise<PortalCreateResult> {
-  const portal = validatePortalSlug(options.portal);
   const title = trimValue(options.title) || titleFromPortalSlug(portal);
   const portalConfig = buildPortalConfig({
     portal,
@@ -548,11 +523,14 @@ export async function createPortalWorkspace(options: PortalCreateOptions): Promi
   });
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
   const envApiUrl = resolvePortalEnvApiUrl(apiBaseUrl);
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
   const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
-  const portalParentDir = path.join(storagePath, 'portals', app);
-  const portalDir = path.join(portalParentDir, portal);
+  const portalDir = await resolvePortalWorkspaceDirectory({
+    portal,
+    directory: options.directory,
+    mode: 'create',
+  });
+  const portalParentDir = path.dirname(portalDir);
 
   assertPortalDirIsInsideParent(portalParentDir, portalDir);
   const targetExists = await pathExists(portalDir);
@@ -564,6 +542,18 @@ export async function createPortalWorkspace(options: PortalCreateOptions): Promi
         `Portal already exists: ${portalDir}\nPass --force to delete it and create a new portal.`,
       ),
     );
+  }
+  if (targetExists && options.force) {
+    if (!(await isPortalWorkspace(portalDir))) {
+      throw new Error(
+        portalCreateText(
+          'errors.forceRequiresWorkspace',
+          { portalDir },
+          `Refusing to replace ${portalDir} because it is not a Portal workspace.`,
+        ),
+      );
+    }
+    assertPortalConfigMatches(await readPortalConfig(portalDir), portal, portalDir);
   }
 
   const template = await resolvePortalTemplate(options.template, {

--- a/packages/core/cli/src/lib/portal-deploy.ts
+++ b/packages/core/cli/src/lib/portal-deploy.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { chmod, mkdir, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { chmod, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import * as tar from 'tar';
@@ -16,14 +16,19 @@ import { translateCli } from './cli-locale.js';
 import {
   buildPortalBasePath,
   resolvePortalAppFromApiBaseUrl,
-  resolvePortalStoragePath,
   titleFromPortalSlug,
   validatePortalSlug,
   type PortalCreateEnvLike,
 } from './portal-create.js';
 import { buildPortalCommandEnv } from './portal-command-env.js';
 import { updatePortalEnvFiles } from './portal-env-files.js';
-import { mergePortalConfigIntoOptions, readPortalConfig, type PortalConfig } from './portal-config.js';
+import {
+  assertPortalConfigMatches,
+  mergePortalConfigIntoOptions,
+  readPortalConfig,
+  type PortalConfig,
+} from './portal-config.js';
+import { resolvePortalWorkspaceDirectory } from './portal-workspace.js';
 import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
 
 type ApiRequest = typeof executeApiRequest;
@@ -32,6 +37,7 @@ export type PortalDeployEnvLike = PortalCreateEnvLike;
 
 export type PortalDeployOptions = {
   portal: string;
+  directory?: string;
   env: PortalDeployEnvLike;
   envName?: string;
   cliVersion?: string;
@@ -141,14 +147,14 @@ async function pathExists(target: string): Promise<boolean> {
   }
 }
 
-async function chmodPortalDistTree(targetDir: string): Promise<void> {
+async function makePortalDistPublicReadable(targetDir: string): Promise<void> {
   await chmod(targetDir, PORTAL_PUBLIC_DIR_MODE);
   const entries = await readdir(targetDir, { withFileTypes: true });
   await Promise.all(
     entries.map(async (entry) => {
       const entryPath = path.join(targetDir, entry.name);
       if (entry.isDirectory()) {
-        await chmodPortalDistTree(entryPath);
+        await makePortalDistPublicReadable(entryPath);
         return;
       }
       if (entry.isFile()) {
@@ -156,18 +162,6 @@ async function chmodPortalDistTree(targetDir: string): Promise<void> {
       }
     }),
   );
-}
-
-async function ensurePortalDistPublicReadable(params: {
-  storagePath: string;
-  app: string;
-  portalDir: string;
-  distDir: string;
-}): Promise<void> {
-  await chmod(path.join(params.storagePath, 'portals'), PORTAL_PUBLIC_DIR_MODE);
-  await chmod(path.join(params.storagePath, 'portals', params.app), PORTAL_PUBLIC_DIR_MODE);
-  await chmod(params.portalDir, PORTAL_PUBLIC_DIR_MODE);
-  await chmodPortalDistTree(params.distDir);
 }
 
 async function assertFileExists(filePath: string, message: string): Promise<void> {
@@ -285,10 +279,13 @@ async function syncMultiPortalRecord(params: {
 export async function deployPortalWorkspace(options: PortalDeployOptions): Promise<PortalDeployResult> {
   const portal = validatePortalSlug(options.portal);
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
   const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
-  const portalDir = path.join(storagePath, 'portals', app, portal);
+  const portalDir = await resolvePortalWorkspaceDirectory({
+    portal,
+    directory: options.directory,
+    mode: 'existing',
+  });
   const distDir = path.join(portalDir, 'dist');
 
   if (!(await pathExists(portalDir))) {
@@ -309,6 +306,7 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
     ),
   );
   const portalConfig = await readPortalConfig(portalDir);
+  assertPortalConfigMatches(portalConfig, portal, portalDir);
 
   await updatePortalEnvFiles({
     portalDir,
@@ -350,35 +348,8 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
       `Portal build did not produce ${path.join(distDir, 'index.html')}.`,
     ),
   );
-  await ensurePortalDistPublicReadable({
-    storagePath,
-    app,
-    portalDir,
-    distDir,
-  });
-
-  if (options.env.kind === 'local' || options.env.kind === 'docker') {
-    await syncMultiPortalRecord({
-      portal,
-      config: portalConfig,
-      envName: options.envName,
-      cliVersion: options.cliVersion,
-      apiRequest: options.apiRequest,
-    });
-
-    return {
-      app,
-      portal,
-      portalDir,
-      portalBase,
-      distDir,
-      mode: options.env.kind,
-      uploaded: false,
-      recordSynced: true,
-    };
-  }
-
-  if (options.env.kind !== 'http') {
+  await makePortalDistPublicReadable(distDir);
+  if (options.env.kind !== 'local' && options.env.kind !== 'docker' && options.env.kind !== 'http') {
     throw new Error(
       portalDeployText(
         'errors.unsupportedEnvKind',
@@ -419,7 +390,7 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
     portalBase,
     distDir,
     serverDistPath: uploadResult.distPath,
-    mode: 'http',
+    mode: options.env.kind,
     uploaded: true,
     recordSynced: true,
   };

--- a/packages/core/cli/src/lib/portal-destroy.ts
+++ b/packages/core/cli/src/lib/portal-destroy.ts
@@ -14,10 +14,11 @@ import { translateCli } from './cli-locale.js';
 import {
   buildPortalBasePath,
   resolvePortalAppFromApiBaseUrl,
-  resolvePortalStoragePath,
   validatePortalSlug,
   type PortalCreateEnvLike,
 } from './portal-create.js';
+import { assertPortalConfigMatches, readPortalConfig } from './portal-config.js';
+import { resolvePortalWorkspaceDirectory } from './portal-workspace.js';
 
 type ApiRequest = typeof executeApiRequest;
 
@@ -27,6 +28,7 @@ export type PortalDestroyMode = 'local' | 'docker' | 'http';
 
 export type PortalDestroyOptions = {
   portal: string;
+  directory?: string;
   env: PortalDestroyEnvLike;
   envName?: string;
   cliVersion?: string;
@@ -123,11 +125,14 @@ async function destroyMultiPortalRecord(params: {
 export async function destroyPortalWorkspace(options: PortalDestroyOptions): Promise<PortalDestroyResult> {
   const portal = validatePortalSlug(options.portal);
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
   const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
-  const portalParentDir = path.join(storagePath, 'portals', app);
-  const portalDir = path.join(portalParentDir, portal);
+  const portalDir = await resolvePortalWorkspaceDirectory({
+    portal,
+    directory: options.directory,
+    mode: 'existing',
+  });
+  const portalParentDir = path.dirname(portalDir);
   const mode = options.env.kind;
 
   if (mode !== 'local' && mode !== 'docker' && mode !== 'http') {
@@ -152,6 +157,9 @@ export async function destroyPortalWorkspace(options: PortalDestroyOptions): Pro
         `Portal does not exist: ${portalDir}\nPass --force to ignore missing local files.`,
       ),
     );
+  }
+  if (workspaceExists) {
+    assertPortalConfigMatches(await readPortalConfig(portalDir), portal, portalDir);
   }
 
   const recordDeleted = await destroyMultiPortalRecord({

--- a/packages/core/cli/src/lib/portal-dev.ts
+++ b/packages/core/cli/src/lib/portal-dev.ts
@@ -13,18 +13,20 @@ import { translateCli } from './cli-locale.js';
 import {
   buildPortalBasePath,
   resolvePortalAppFromApiBaseUrl,
-  resolvePortalStoragePath,
   validatePortalSlug,
   type PortalCreateEnvLike,
 } from './portal-create.js';
 import { buildPortalCommandEnv } from './portal-command-env.js';
+import { assertPortalConfigMatches, readPortalConfig } from './portal-config.js';
 import { updatePortalEnvFiles } from './portal-env-files.js';
+import { resolvePortalWorkspaceDirectory } from './portal-workspace.js';
 import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
 
 export type PortalDevEnvLike = PortalCreateEnvLike;
 
 export type PortalDevOptions = {
   portal: string;
+  directory?: string;
   env: PortalDevEnvLike;
   runCommand?: RunCommand;
   onStart?: (result: PortalDevResult) => void;
@@ -80,10 +82,13 @@ export async function devPortalWorkspace(options: PortalDevOptions): Promise<Por
       ),
     );
   }
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
   const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
-  const portalDir = path.join(storagePath, 'portals', app, portal);
+  const portalDir = await resolvePortalWorkspaceDirectory({
+    portal,
+    directory: options.directory,
+    mode: 'existing',
+  });
 
   if (!(await pathExists(portalDir))) {
     throw new Error(
@@ -94,6 +99,7 @@ export async function devPortalWorkspace(options: PortalDevOptions): Promise<Por
       ),
     );
   }
+  assertPortalConfigMatches(await readPortalConfig(portalDir), portal, portalDir);
   await assertFileExists(
     path.join(portalDir, 'package.json'),
     portalDevText(

--- a/packages/core/cli/src/lib/portal-list.ts
+++ b/packages/core/cli/src/lib/portal-list.ts
@@ -7,7 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { stat } from 'node:fs/promises';
 import path from 'node:path';
 import { appendAppPublicPath } from './app-public-path.js';
 import { executeApiRequest, type RequestOperation } from './api-client.js';
@@ -15,9 +14,10 @@ import { translateCli } from './cli-locale.js';
 import {
   buildPortalBasePath,
   resolvePortalAppFromApiBaseUrl,
-  resolvePortalStoragePath,
   type PortalCreateEnvLike,
 } from './portal-create.js';
+import { readPortalConfig, type PortalConfig } from './portal-config.js';
+import { isPortalWorkspace } from './portal-workspace.js';
 
 type ApiRequest = typeof executeApiRequest;
 
@@ -27,6 +27,7 @@ export type PortalListMode = 'local' | 'docker' | 'http';
 
 export type PortalListOptions = {
   env: PortalListEnvLike;
+  directory?: string;
   envName?: string;
   cliVersion?: string;
   apiRequest?: ApiRequest;
@@ -62,7 +63,7 @@ export type PortalOutputItem = {
 export type PortalListResult = {
   app: string;
   mode: PortalListMode;
-  storagePath: string;
+  workspaceDir: string;
   items: PortalListItem[];
 };
 
@@ -121,15 +122,6 @@ function readListData(data: unknown): Array<Record<string, unknown>> {
   }
 
   return readListData(directData);
-}
-
-async function pathExists(target: string): Promise<boolean> {
-  try {
-    await stat(target);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function buildPortalAccessUrl(apiBaseUrl: string, portalBase: string): string {
@@ -245,9 +237,12 @@ async function listMultiPortalRecords(params: {
 
 export async function listPortalWorkspaces(options: PortalListOptions): Promise<PortalListResult> {
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
   const mode = options.env.kind;
+  const workspaceDir = path.resolve(options.directory ?? process.cwd());
+  const workspaceConfig: PortalConfig | undefined = (await isPortalWorkspace(workspaceDir))
+    ? await readPortalConfig(workspaceDir)
+    : undefined;
 
   if (mode !== 'local' && mode !== 'docker' && mode !== 'http') {
     throw new Error(
@@ -276,7 +271,7 @@ export async function listPortalWorkspaces(options: PortalListOptions): Promise<
       const git = readRecordObject(options, 'git');
       const sourceStorage = trimValue(options.sourceStorage) || readRecordString(record, 'sourceStorage') || 'nocobase';
       const isAi = portalType === 'ai';
-      const portalDir = isAi ? path.join(storagePath, 'portals', app, portalName) : '';
+      const portalDir = isAi && workspaceConfig?.portal === portalName ? workspaceDir : '';
 
       return {
         uid,
@@ -299,7 +294,7 @@ export async function listPortalWorkspaces(options: PortalListOptions): Promise<
             )
           : '',
         portalDir,
-        localSynced: isAi ? await pathExists(portalDir) : null,
+        localSynced: isAi ? Boolean(portalDir) : null,
       };
     }),
   );
@@ -307,7 +302,7 @@ export async function listPortalWorkspaces(options: PortalListOptions): Promise<
   return {
     app,
     mode: listMode,
-    storagePath,
+    workspaceDir,
     items,
   };
 }

--- a/packages/core/cli/src/lib/portal-source.ts
+++ b/packages/core/cli/src/lib/portal-source.ts
@@ -19,6 +19,7 @@ import {
   buildPortalConfig,
   buildPortalConfigFromOptions,
   DEFAULT_PORTAL_GIT_PATH,
+  assertPortalConfigMatches,
   readPortalConfig,
   syncPortalConfigToRemote,
   writePortalConfig,
@@ -28,12 +29,16 @@ import { buildPortalCommandEnv } from './portal-command-env.js';
 import {
   buildPortalBasePath,
   resolvePortalAppFromApiBaseUrl,
-  resolvePortalStoragePath,
   validatePortalSlug,
   type PortalCreateEnvLike,
 } from './portal-create.js';
 import { listPortalWorkspaces } from './portal-list.js';
 import { findPortalListItem } from './portal-info.js';
+import {
+  isPortalWorkspace,
+  resolvePortalWorkspaceDirectory,
+  type PortalWorkspaceResolutionMode,
+} from './portal-workspace.js';
 import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
 
 type ApiRequest = typeof executeApiRequest;
@@ -56,6 +61,7 @@ export type PortalSourceEnvLike = PortalCreateEnvLike;
 
 export type PortalSourceOptions = {
   portal: string;
+  directory?: string;
   env: PortalSourceEnvLike;
   envName?: string;
   cliVersion?: string;
@@ -316,12 +322,18 @@ function readSourceRevision(data: unknown): string | undefined {
   return readSourceRevision((data as { data?: unknown }).data);
 }
 
-async function resolvePortalSourceContext(options: PortalSourceOptions): Promise<PortalSourceContext> {
+async function resolvePortalSourceContext(
+  options: PortalSourceOptions,
+  workspaceMode: Extract<PortalWorkspaceResolutionMode, 'pull' | 'existing'>,
+): Promise<PortalSourceContext> {
   const portal = validatePortalSlug(options.portal);
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
-  const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
-  const portalDir = path.join(storagePath, 'portals', app, portal);
+  const portalDir = await resolvePortalWorkspaceDirectory({
+    portal,
+    directory: options.directory,
+    mode: workspaceMode,
+  });
   const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
   const mode = options.env.kind;
 
@@ -337,6 +349,7 @@ async function resolvePortalSourceContext(options: PortalSourceOptions): Promise
 
   const list = await listPortalWorkspaces({
     env: options.env,
+    directory: portalDir,
     envName: options.envName,
     cliVersion: options.cliVersion,
     apiRequest: options.apiRequest,
@@ -540,7 +553,19 @@ async function pushGitPortalSource(params: {
 }
 
 export async function pullPortalSource(options: PortalSourceOptions): Promise<PortalSourceResult> {
-  const context = await resolvePortalSourceContext(options);
+  const context = await resolvePortalSourceContext(options, 'pull');
+  const targetExists = await pathExists(context.portalDir);
+  if (targetExists && (await isPortalWorkspace(context.portalDir))) {
+    assertPortalConfigMatches(await readPortalConfig(context.portalDir), context.portal, context.portalDir);
+  } else if (targetExists && options.force) {
+    throw new Error(
+      portalSourceText(
+        'errors.forceRequiresWorkspace',
+        { portalDir: context.portalDir },
+        `Refusing to replace ${context.portalDir} because it is not a Portal workspace.`,
+      ),
+    );
+  }
   const portalConfig = buildPortalConfigFromContext(context);
   const sourceContext = applyPortalConfigToContext(context, portalConfig);
   if (sourceContext.sourceStorage === 'git') {
@@ -569,17 +594,6 @@ export async function pullPortalSource(options: PortalSourceOptions): Promise<Po
         `Unsupported portal source storage: ${sourceContext.sourceStorage}`,
       ),
     );
-  }
-
-  if (sourceContext.mode === 'local' || sourceContext.mode === 'docker') {
-    return {
-      ...sourceContext,
-      changed: false,
-      noopReason:
-        sourceContext.mode === 'local'
-          ? portalSourceText('messages.localPullNoop', undefined, 'Portal source is already local.')
-          : portalSourceText('messages.dockerPullNoop', undefined, 'Portal source is already available through the Docker volume.'),
-    };
   }
 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'nocobase-cli-portal-pull-'));
@@ -630,7 +644,7 @@ export async function pullPortalSource(options: PortalSourceOptions): Promise<Po
 }
 
 export async function pushPortalSource(options: PortalSourceOptions): Promise<PortalSourceResult> {
-  const context = await resolvePortalSourceContext(options);
+  const context = await resolvePortalSourceContext(options, 'existing');
   if (!(await pathExists(context.portalDir))) {
     throw new Error(
       portalSourceText(
@@ -641,6 +655,7 @@ export async function pushPortalSource(options: PortalSourceOptions): Promise<Po
     );
   }
   const portalConfig = await readPortalConfig(context.portalDir);
+  assertPortalConfigMatches(portalConfig, context.portal, context.portalDir);
   await syncPortalConfigToRemote({
     portal: context.portal,
     config: portalConfig,
@@ -674,17 +689,6 @@ export async function pushPortalSource(options: PortalSourceOptions): Promise<Po
         `Unsupported portal source storage: ${sourceContext.sourceStorage}`,
       ),
     );
-  }
-
-  if (sourceContext.mode === 'local' || sourceContext.mode === 'docker') {
-    return {
-      ...sourceContext,
-      changed: false,
-      noopReason:
-        sourceContext.mode === 'local'
-          ? portalSourceText('messages.localPushNoop', undefined, 'Portal source is already local.')
-          : portalSourceText('messages.dockerPushNoop', undefined, 'Portal source is already available through the Docker volume.'),
-    };
   }
 
   const archive = await packPortalSource(sourceContext.portalDir);

--- a/packages/core/cli/src/lib/portal-workspace.ts
+++ b/packages/core/cli/src/lib/portal-workspace.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { stat } from 'node:fs/promises';
+import path from 'node:path';
+
+export const PORTAL_CONFIG_FILE = 'portal.config.json';
+
+export type PortalWorkspaceResolutionMode = 'create' | 'pull' | 'existing';
+
+export type PortalWorkspaceResolutionOptions = {
+  portal: string;
+  directory?: string;
+  cwd?: string;
+  mode: PortalWorkspaceResolutionMode;
+};
+
+export async function isPortalWorkspace(directory: string): Promise<boolean> {
+  try {
+    return (await stat(path.join(directory, PORTAL_CONFIG_FILE))).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function resolvePortalWorkspaceDirectory(options: PortalWorkspaceResolutionOptions): Promise<string> {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  if (options.directory) {
+    return path.resolve(cwd, options.directory);
+  }
+  if (options.mode === 'existing' || (options.mode === 'pull' && (await isPortalWorkspace(cwd)))) {
+    return cwd;
+  }
+  return path.join(cwd, options.portal);
+}

--- a/packages/core/cli/src/locale/en-US.json
+++ b/packages/core/cli/src/locale/en-US.json
@@ -185,6 +185,7 @@
         "missingApiBaseUrl": "Cannot create a portal because the selected env has no apiBaseUrl.",
         "outsideParent": "Refusing to modify a portal outside {{parentDir}}: {{portalDir}}",
         "sshUnsupported": "Cannot create a portal for ssh envs in the first version.",
+        "forceRequiresWorkspace": "Refusing to replace {{portalDir}} because it is not a Portal workspace.",
         "workspaceExists": "Portal already exists: {{portalDir}}\nPass --force to delete it and create a new portal."
       },
       "messages": {
@@ -197,12 +198,19 @@
     },
     "portalConfig": {
       "errors": {
+        "portalRequired": "Portal name is required in portal.config.json.",
+        "workspaceMismatch": "Portal workspace {{portalDir}} belongs to \"{{configuredPortal}}\", not \"{{portal}}\".",
         "invalidSourceStorage": "Invalid source storage \"{{value}}\". Use \"nocobase\" or \"git\".",
         "invalidGitPath": "--git-path must be a relative path inside the Git repository.",
         "gitOptionsForNocobaseStorage": "--git-repo, --git-branch, and --git-path can only be used with --source-storage git.",
         "gitRepoRequired": "--git-repo is required when --source-storage is git.",
         "gitRepoInvalid": "--git-repo must be a full Git remote URL.",
         "updateFailed": "Portal config update failed with status {{status}}\n{{details}}"
+      }
+    },
+    "portalSource": {
+      "errors": {
+        "forceRequiresWorkspace": "Refusing to replace {{portalDir}} because it is not a Portal workspace."
       }
     },
     "portalConfigure": {

--- a/packages/core/cli/src/locale/zh-CN.json
+++ b/packages/core/cli/src/locale/zh-CN.json
@@ -185,6 +185,7 @@
         "missingApiBaseUrl": "无法创建 Portal，因为当前 env 没有 apiBaseUrl。",
         "outsideParent": "拒绝修改 {{parentDir}} 之外的 Portal：{{portalDir}}",
         "sshUnsupported": "第一版暂不支持为 ssh env 创建 Portal。",
+        "forceRequiresWorkspace": "拒绝替换 {{portalDir}}，因为它不是 Portal 工作区。",
         "workspaceExists": "Portal 已存在：{{portalDir}}\n如需删除并重新创建，请追加 --force。"
       },
       "messages": {
@@ -197,12 +198,19 @@
     },
     "portalConfig": {
       "errors": {
+        "portalRequired": "portal.config.json 中必须包含 Portal 名称。",
+        "workspaceMismatch": "Portal 工作区 {{portalDir}} 属于 \"{{configuredPortal}}\"，不属于 \"{{portal}}\"。",
         "invalidSourceStorage": "源码存储 \"{{value}}\" 无效。请使用 \"nocobase\" 或 \"git\"。",
         "invalidGitPath": "--git-path 必须是 Git 仓库内的相对路径。",
         "gitOptionsForNocobaseStorage": "--git-repo、--git-branch 和 --git-path 只能与 --source-storage git 一起使用。",
         "gitRepoRequired": "--source-storage 为 git 时必须提供 --git-repo。",
         "gitRepoInvalid": "--git-repo 必须是完整的 Git remote URL。",
         "updateFailed": "Portal 配置更新失败，状态码 {{status}}\n{{details}}"
+      }
+    },
+    "portalSource": {
+      "errors": {
+        "forceRequiresWorkspace": "拒绝替换 {{portalDir}}，因为它不是 Portal 工作区。"
       }
     },
     "portalConfigure": {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Portal CLI commands previously derived the local workspace from the selected environment's `storagePath`. As a result, pulling a Portal from a remote environment could unexpectedly write files into an environment cache such as `~/.nocobase/.../source/storage/portals/...`, instead of a developer-controlled local project directory. There was also no CLI option for selecting another workspace path.

### Description 

- Add `--dir` to Portal commands for explicitly selecting the local workspace.
- Use `<current-directory>/<portal>` for the first `create` or `pull`. When `pull` runs inside an existing Portal workspace containing `portal.config.json`, use the current directory directly.
- Use the current directory by default for commands that operate on an existing workspace: `dev`, `push`, `deploy`, `config`, `destroy`, `info`, and `list`.
- Stop deriving Portal workspaces from the environment `storagePath` or the legacy `storage/portals/...` layout.
- Synchronize NocoBase-managed source and deployment output through the API for `local`, `docker`, and `http` environments, so local workspaces do not need to share application storage.
- Record the Portal identity in `portal.config.json`, validate it before workspace operations, and prevent `--force` from replacing a non-Portal directory.
- Update Portal CLI documentation in all maintained languages.

Potential compatibility note: scripts that previously relied on implicit environment storage paths should run from the Portal workspace or pass `--dir` explicitly.

Validation performed:

- Built `packages/core/cli` successfully.
- Passed all 13 Portal CLI test files.
- Ran ESLint with `--no-ignore --fix` on all changed TypeScript files.
- Passed documentation tree, metadata, navigation, home, and bloated-file checks.

Suggested manual verification: run `nb portal pull <portal>` from a new parent directory, then run `nb portal info <portal>` inside the downloaded workspace and with an explicit `--dir` from another directory.

### Related issues

N/A

### Showcase

N/A — CLI workspace behavior only.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Portal CLI commands now use developer-controlled local workspaces and support selecting a workspace with `--dir`, instead of storing Portal files under the environment `storagePath`. |
| 🇨🇳 Chinese | Portal CLI 命令现在使用开发者控制的本地工作区，并支持通过 `--dir` 指定工作区，不再将 Portal 文件存放到环境的 `storagePath` 下。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | [Portal CLI](https://github.com/nocobase/nocobase/blob/fix/portal-local-workspace/docs/docs/en/api/cli/portal/index.md) |
| 🇨🇳 Chinese | [Portal CLI](https://github.com/nocobase/nocobase/blob/fix/portal-local-workspace/docs/docs/cn/api/cli/portal/index.md) |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
