### PR TITLE
fix(plugin-ai): inherit modal theme

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/use-unsaved-changes-before-close.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/use-unsaved-changes-before-close.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import type { FormInstance } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUnsavedChangesBeforeClose } from '../pages/useUnsavedChangesBeforeClose';
+
+type ConfirmOptions = {
+  onCancel?: () => void;
+};
+
+type BeforeCloseHandler = () => boolean | void | Promise<boolean | void>;
+
+const mocks = vi.hoisted(() => ({
+  contextualConfirm: vi.fn(),
+  destroy: vi.fn(),
+  staticConfirm: vi.fn(),
+}));
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return {
+    ...actual,
+    App: {
+      ...actual.App,
+      useApp: () => ({ modal: { confirm: mocks.contextualConfirm } }),
+    },
+    Modal: {
+      ...actual.Modal,
+      confirm: mocks.staticConfirm,
+    },
+  };
+});
+
+describe('useUnsavedChangesBeforeClose', () => {
+  beforeEach(() => {
+    mocks.contextualConfirm.mockReset();
+    mocks.contextualConfirm.mockReturnValue({ destroy: mocks.destroy });
+    mocks.destroy.mockReset();
+    mocks.staticConfirm.mockReset();
+    mocks.staticConfirm.mockReturnValue({ destroy: mocks.destroy });
+  });
+
+  it('uses the contextual modal so the confirmation inherits the dynamic theme', async () => {
+    const view: {
+      beforeClose?: BeforeCloseHandler;
+      close: () => void;
+    } = {
+      close: vi.fn(),
+    };
+    const form = {
+      getFieldsValue: vi.fn(() => ({ nickname: 'Changed' })),
+    } as unknown as FormInstance<{ nickname: string }>;
+
+    const { unmount } = renderHook(() =>
+      useUnsavedChangesBeforeClose({
+        view,
+        form,
+        initialValues: { nickname: 'Initial' },
+        dirty: true,
+        title: 'Unsaved changes',
+        content: "Are you sure you don't want to save?",
+      }),
+    );
+
+    let closeResult: ReturnType<BeforeCloseHandler> = undefined;
+    act(() => {
+      closeResult = view.beforeClose?.();
+    });
+
+    expect(mocks.contextualConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Unsaved changes',
+        content: "Are you sure you don't want to save?",
+      }),
+    );
+    expect(mocks.staticConfirm).not.toHaveBeenCalled();
+
+    const confirmOptions = mocks.contextualConfirm.mock.calls[0][0] as ConfirmOptions;
+    act(() => {
+      confirmOptions.onCancel?.();
+    });
+
+    await expect(closeResult).resolves.toBe(false);
+    unmount();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/DatasourceSettingsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/DatasourceSettingsPage.tsx
@@ -1073,15 +1073,28 @@ export const DatasourceSettingsPage: React.FC = () => {
   );
 };
 
-const DatasourceDrawerContent: React.FC<{
+type DatasourceDrawerContentProps = {
   record?: AIContextDatasourceRecord;
   manager?: DataSourceManagerLike;
   onSubmitted: () => Promise<void>;
-}> = ({ record, manager, onSubmitted }) => {
+};
+
+const DatasourceDrawerContent: React.FC<DatasourceDrawerContentProps> = (props) => {
+  const { message } = App.useApp();
+
+  return (
+    <App component={false}>
+      <DatasourceDrawerContentInner {...props} message={message} />
+    </App>
+  );
+};
+
+const DatasourceDrawerContentInner: React.FC<
+  DatasourceDrawerContentProps & { message: ReturnType<typeof App.useApp>['message'] }
+> = ({ record, manager, onSubmitted, message }) => {
   const app = useApp();
   const ctx = useFlowContext();
   const t = useT();
-  const { message } = App.useApp();
   const { token: themeToken } = theme.useToken();
   const [form] = Form.useForm<DatasourceFormValues>();
   const [saving, setSaving] = useState(false);

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/EmployeesPage.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/EmployeesPage.tsx
@@ -1336,15 +1336,28 @@ export const EmployeesPage: React.FC = () => {
   );
 };
 
-const AIEmployeeDrawerContent: React.FC<{
+type AIEmployeeDrawerContentProps = {
   editingRecord?: SettingsAIEmployee;
   knowledgeBaseEnabled: boolean;
   onSubmitted: () => Promise<void>;
-}> = ({ editingRecord, knowledgeBaseEnabled, onSubmitted }) => {
+};
+
+const AIEmployeeDrawerContent: React.FC<AIEmployeeDrawerContentProps> = (props) => {
+  const { message } = App.useApp();
+
+  return (
+    <App component={false}>
+      <AIEmployeeDrawerContentInner {...props} message={message} />
+    </App>
+  );
+};
+
+const AIEmployeeDrawerContentInner: React.FC<
+  AIEmployeeDrawerContentProps & { message: ReturnType<typeof App.useApp>['message'] }
+> = ({ editingRecord, knowledgeBaseEnabled, onSubmitted, message }) => {
   const app = useApp();
   const ctx = useFlowContext();
   const t = useT();
-  const { message } = App.useApp();
   const [form] = Form.useForm<EmployeeFormValues>();
   const [saving, setSaving] = useState(false);
   const [activeFormTab, setActiveFormTab] = useState('profile');

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/LLMServicesPage.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/LLMServicesPage.tsx
@@ -984,15 +984,28 @@ export const LLMServicesPage: React.FC = () => {
   );
 };
 
-const LLMServiceDrawerContent: React.FC<{
+type LLMServiceDrawerContentProps = {
   providers: ProviderOption[];
   record?: LLMServiceRecord;
   onSubmitted: () => Promise<void>;
-}> = ({ providers, record, onSubmitted }) => {
+};
+
+const LLMServiceDrawerContent: React.FC<LLMServiceDrawerContentProps> = (props) => {
+  const { message } = App.useApp();
+
+  return (
+    <App component={false}>
+      <LLMServiceDrawerContentInner {...props} message={message} />
+    </App>
+  );
+};
+
+const LLMServiceDrawerContentInner: React.FC<
+  LLMServiceDrawerContentProps & { message: ReturnType<typeof App.useApp>['message'] }
+> = ({ providers, record, onSubmitted, message }) => {
   const app = useApp();
   const ctx = useFlowContext();
   const t = useT();
-  const { message } = App.useApp();
   const [form] = Form.useForm<LLMServiceFormValues>();
   const [saving, setSaving] = useState(false);
   const [formDirty, setFormDirty] = useState(false);

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/MCPSettingsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/MCPSettingsPage.tsx
@@ -961,16 +961,30 @@ export const MCPSettingsPage: React.FC = () => {
   );
 };
 
-const MCPSettingsDrawerContent: React.FC<{
+type MCPSettingsDrawerContentProps = {
   record?: MCPRecord;
   rebuilding: boolean;
   rebuildClient: () => Promise<void>;
   onSubmitted: () => Promise<void>;
-}> = ({ record, rebuilding, rebuildClient, onSubmitted }) => {
+};
+
+const MCPSettingsDrawerContent: React.FC<MCPSettingsDrawerContentProps> = (props) => {
+  const { message } = App.useApp();
+
+  return (
+    <App component={false}>
+      <MCPSettingsDrawerContentInner {...props} message={message} />
+    </App>
+  );
+};
+
+const MCPSettingsDrawerContentInner: React.FC<
+  MCPSettingsDrawerContentProps & { message: ReturnType<typeof App.useApp>['message'] }
+> = ({ record, rebuilding, rebuildClient, onSubmitted, message }) => {
   const app = useApp();
   const ctx = useFlowContext();
   const t = useT();
-  const { message, modal } = App.useApp();
+  const { modal } = App.useApp();
   const [form] = Form.useForm<MCPFormValues>();
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/useUnsavedChangesBeforeClose.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/pages/useUnsavedChangesBeforeClose.ts
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Modal } from 'antd';
+import { App } from 'antd';
 import type { FormInstance } from 'antd';
 import isEqual from 'lodash/isEqual';
 
@@ -41,6 +41,7 @@ export function useUnsavedChangesBeforeClose<Values extends object>({
   title,
   content,
 }: UseUnsavedChangesBeforeCloseOptions<Values>) {
+  const { modal } = App.useApp();
   const confirmedRef = useRef(false);
 
   const hasUnsavedChanges = useCallback(() => {
@@ -57,7 +58,7 @@ export function useUnsavedChangesBeforeClose<Values extends object>({
       }
 
       return new Promise<boolean>((resolve) => {
-        const confirmInstance = Modal.confirm({
+        const confirmInstance = modal.confirm({
           title,
           content,
           onOk: () => {
@@ -82,7 +83,7 @@ export function useUnsavedChangesBeforeClose<Values extends object>({
         view.beforeClose = previousBeforeClose;
       }
     };
-  }, [content, hasUnsavedChanges, title, view]);
+  }, [content, hasUnsavedChanges, modal, title, view]);
 
   return useCallback(() => view.close(), [view]);
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI 员工设置页面使用自定义主题时，关闭存在未保存内容的编辑面板会弹出确认框，但确认框仍显示默认主题样式，与当前页面不一致。

### Description 
让 AI 员工、模型服务、数据源和 MCP 设置中的未保存更改确认框继承当前页面主题，同时保持原有的确认、取消及保存成功提示行为。

新增针对确认框调用方式的测试，并完成相关页面测试和浏览器回归验证。

### Showcase
无需额外截图。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the theme mismatch in unsaved changes confirmation dialogs |
| 🇨🇳 Chinese | 修复未保存更改确认弹窗与当前主题不一致的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
