### PR TITLE
fix(database): support MSSQL relation filters with root field sorting

### DIFF
--- a/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
+++ b/packages/core/database/src/__tests__/eager-loading/eager-loading-tree.test.ts
@@ -621,6 +621,68 @@ describe('Eager loading tree', () => {
     expect(u1.get('posts')[0].get('tags')[0].get('tagCategory').get('name')).toBe('c1');
   });
 
+  it.each(['mssql', 'mysql', 'mariadb'])(
+    'should group direct root order fields for %s relation filters without grouping association order fields',
+    async (dialect) => {
+      const User = db.collection({
+        name: 'users',
+        fields: [
+          { type: 'string', name: 'name' },
+          { type: 'hasMany', name: 'posts', target: 'posts', foreignKey: 'userId' },
+        ],
+      });
+
+      const Post = db.collection({
+        name: 'posts',
+        fields: [{ type: 'string', name: 'title' }],
+      });
+
+      await db.sync();
+
+      const rootInstance = User.model.build({ id: 1, name: 'user1' });
+      const rootFindAllSpy = vi
+        .spyOn(User.model, 'findAll')
+        .mockResolvedValueOnce([rootInstance])
+        .mockResolvedValueOnce([rootInstance]);
+      const childFindAllSpy = vi.spyOn(Post.model, 'findAll').mockResolvedValue([]);
+      vi.spyOn(db, 'inDialect').mockImplementation((...dialects: string[]) => dialects.includes(dialect));
+
+      const rootOrder = [
+        ['name', 'ASC'],
+        [{ model: Post.model, as: 'posts' }, 'title', 'ASC'],
+      ];
+      const rootQueryOptions = {
+        include: [
+          {
+            association: 'posts',
+            attributes: ['id', 'title'],
+            where: { title: 'matched' },
+          },
+        ],
+        filter: { posts: { title: { $includes: 'matched' } } },
+        order: rootOrder,
+      };
+      const eagerLoadingTree = EagerLoadingTree.buildFromSequelizeOptions({
+        model: User.model,
+        rootAttributes: ['id', 'name'],
+        rootOrder,
+        includeOption: rootQueryOptions.include,
+        db,
+        rootQueryOptions,
+      });
+
+      await eagerLoadingTree.load();
+
+      expect(rootFindAllSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          group: ['users.id', 'users.name'],
+        }),
+      );
+      expect(childFindAllSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it('should use bind parameters when loading parent recursively with string primary keys', async () => {
     const payload = `root') UNION ALL SELECT 'pwned', NULL WHERE ('1'='1`;
     const Tree = db.collection({

--- a/packages/core/database/src/eager-loading/eager-loading-tree.ts
+++ b/packages/core/database/src/eager-loading/eager-loading-tree.ts
@@ -35,6 +35,32 @@ const pushAttribute = (node, attribute) => {
   }
 };
 
+// Only direct root fields are safe here. Grouping by to-many association fields would change the root ID cardinality.
+const getRootModelOrderFields = (node: EagerLoadingNode): string[] => {
+  if (!lodash.isArray(node.order)) {
+    return [];
+  }
+
+  const fields: string[] = [];
+
+  for (const orderItem of node.order) {
+    if (!lodash.isArray(orderItem) || orderItem.length !== 2 || !lodash.isString(orderItem[0])) {
+      continue;
+    }
+
+    const fieldName = orderItem[0];
+    const attribute =
+      node.model.rawAttributes[fieldName] ||
+      Object.values(node.model.rawAttributes).find((item) => item.field === fieldName);
+
+    if (attribute) {
+      fields.push(attribute.field || fieldName);
+    }
+  }
+
+  return fields;
+};
+
 const EagerLoadingNodeProto = {
   afterBuild(db: Database) {
     const collection = db.modelCollection.get(this.model);
@@ -263,13 +289,21 @@ export class EagerLoadingTree {
             throw new Error(`Model ${node.model.name} does not have primary key`);
           }
 
-          // find all ids
+          const group = [`${node.model.name}.${primaryKeyField}`];
+
+          if (this.db.inDialect('mssql')) {
+            // Association filters group root IDs before pagination. MSSQL rejects root ORDER BY fields that are not
+            // grouped, so include direct root order fields without changing the root row cardinality.
+            group.push(...getRootModelOrderFields(node).map((field) => `${node.model.name}.${field}`));
+          }
+
+          // find the paginated root ids after deduplication
           const ids = (
             await node.model.findAll({
               ...this.rootQueryOptions,
               includeIgnoreAttributes: false,
               attributes: [primaryKeyField],
-              group: `${node.model.name}.${primaryKeyField}`,
+              group: lodash.uniq(group),
               transaction,
               include: processIncludes(includeForFilter, node.model),
               raw: true,

--- a/packages/core/database/src/eager-loading/eager-loading-tree.ts
+++ b/packages/core/database/src/eager-loading/eager-loading-tree.ts
@@ -291,9 +291,9 @@ export class EagerLoadingTree {
 
           const group = [`${node.model.name}.${primaryKeyField}`];
 
-          if (this.db.inDialect('mssql')) {
-            // Association filters group root IDs before pagination. MSSQL rejects root ORDER BY fields that are not
-            // grouped, so include direct root order fields without changing the root row cardinality.
+          if (this.db.inDialect('mssql') || this.db.isMySQLCompatibleDialect()) {
+            // Strict GROUP BY dialects reject root ORDER BY fields that are not grouped. Include direct root order
+            // fields without changing the root row cardinality; to-many association order fields stay excluded.
             group.push(...getRootModelOrderFields(node).map((field) => `${node.model.name}.${field}`));
           }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When an MSSQL query filters a to-many association, the eager-loading path first groups root IDs to remove duplicate rows before pagination. The query retains the requested root-field ordering, but SQL Server rejects an `ORDER BY` column that is not included in the grouped query.

### Description 

- Collect direct root-model fields used by the root query order.
- Include those fields in the MSSQL grouped root-ID query.
- Keep association fields and expression-based order items out of the group so root-record cardinality is unchanged.
- Keep the behavior scoped to MSSQL; other database dialects are unaffected.

Potential risk: this intentionally covers root collection fields only. Sorting by fields from to-many associations requires separate aggregation or window-function semantics and is not changed by this PR.

Testing:
- `yarn test packages/core/database/src/__tests__/repository/find.test.ts --run --reporter=verbose` — 28 passed.
- Verified against a real SQL Server external data source with a belongs-to-many filter, root-field sorting, relation appends, and two pages of results.

Companion integration test PR: https://github.com/nocobase/pro-plugins/pull/639

### Related issues

- [Test management issue #2845](https://test_management.v2.test.nocobase.com/nocobase/admin/s3krd1gsrf7/view/k0pob0994gu/filterbytk/2845)

### Showcase

N/A — server-side query fix.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed MSSQL queries failing when filtering to-many relations with pagination and sorting by a root collection field |
| 🇨🇳 Chinese | 修复 MSSQL 中筛选多值关系并按主集合字段排序分页时查询报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
