### PR TITLE
test(plugin-backups): update backup settings request assertion

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupPages.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupPages.test.tsx
@@ -191,6 +191,7 @@ describe('backup pages', () => {
       expect(mocks.flowContext.api.request).toHaveBeenCalledWith({
         url: 'backupSettings:update/1',
         method: 'post',
+        skipNotify: true,
         data: expect.objectContaining({
           id: 1,
           keep: 5,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [x] Others

### Motivation

The backup settings request now uses `skipNotify: true` so the page can display save errors itself. The existing request assertion did not include this intentional option, causing the frontend unit test to fail.

### Description

- Add `skipNotify: true` to the expected backup settings update request.
- Keep the production implementation unchanged.
- Verified with `yarn test packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupPages.test.tsx --run --reporter=verbose` (5 tests passed).
- Runtime risk: none; this is a test-only change.

### Related issues

N/A

### Showcase

N/A (test-only change)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A (test-only change) |
| 🇨🇳 Chinese | 不需要（仅测试调整） |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary