### PR TITLE
fix(client-v2): hide device page header

### DIFF
--- a/packages/core/client-v2/src/__tests__/settings-shell.test.tsx
+++ b/packages/core/client-v2/src/__tests__/settings-shell.test.tsx
@@ -182,6 +182,41 @@ describe('SettingsShell', () => {
     expect(document.querySelector('#nocobase-embed-container')).not.toBeInTheDocument();
   });
 
+  it('does not display the Settings header on the OAuth device verification route', () => {
+    matchRoutes.mockReturnValue([
+      { route: { id: 'settingsDetails' } },
+      { route: { id: 'settingsDetails.idpOAuth.device' } },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/settings/idpOAuth/device?user_code=TKHX-NNCC']}>
+        <SettingsShell>
+          <div>device verification content</div>
+        </SettingsShell>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('device verification content')).toBeInTheDocument();
+    expect(document.querySelector('header')).toHaveStyle({ display: 'none' });
+  });
+
+  it('continues to display the Settings header on other details routes', () => {
+    matchRoutes.mockReturnValue([
+      { route: { id: 'settingsDetails' } },
+      { route: { id: 'settingsDetails.workflow.workflows.id' } },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/settings/workflow/workflows/1']}>
+        <SettingsShell>
+          <div>workflow details content</div>
+        </SettingsShell>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('banner')).toBeVisible();
+  });
+
   it('does not render the Settings header before authentication completes', () => {
     setCurrentUserAuthStatus(mockApp, 'unknown');
 

--- a/packages/core/client-v2/src/settings-app/SettingsShell.tsx
+++ b/packages/core/client-v2/src/settings-app/SettingsShell.tsx
@@ -94,10 +94,12 @@ export const SettingsShell: FC = ({ children }) => {
   const headerColors = useMemo(() => getSettingsHeaderColors(settingsToken), [settingsToken]);
   const settingsGlobalCss = useMemo(() => buildSettingsGlobalCss(settingsToken), [settingsToken]);
   const authStatus = useCurrentUserAuthStatus(app);
-  const isAuthenticationRoute = (app.router.matchRoutes(location.pathname) || []).some((match) => {
+  const routeMatches = app.router.matchRoutes(location.pathname) || [];
+  const isAuthenticationRoute = routeMatches.some((match) => {
     const routeId = match.route.id;
     return routeId === 'auth' || routeId?.startsWith('auth.') || routeId === '2fa' || routeId?.startsWith('2fa.');
   });
+  const shouldHideHeader = routeMatches.some((match) => match.route.id === 'settingsDetails.idpOAuth.device');
 
   if (isAuthenticationRoute) {
     // 登录 / 二次验证页也要套设置中心自己的主题，否则它跟的是业务端主题：
@@ -114,7 +116,7 @@ export const SettingsShell: FC = ({ children }) => {
     );
   }
 
-  const shouldShowHeader = authStatus === 'authenticated';
+  const shouldShowHeader = authStatus === 'authenticated' && !shouldHideHeader;
   const hasUserCenterModel = Boolean(app.flowEngine.getModelClass('UserCenterTopbarActionModel'));
   const userCenter = hasUserCenterModel
     ? app.flowEngine.getModel<UserCenterTopbarActionModel>(`topbar-action-${USER_CENTER_ACTION_ID}`) ||


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

OAuth 设备确认页面不应显示设置中心顶部导航。

### Description

在设备确认路由下隐藏设置中心 Header，同时保持登录鉴权及其他设置详情页面的现有行为。已补充目标场景和非回归测试。

### Showcase

无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the Settings header appears on the OAuth device verification page |
| 🇨🇳 Chinese | 修复 OAuth 设备确认页面显示设置中心顶部导航的问题 |

### Docs

不需要

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
