### PR TITLE
fix(plugin-ui-layout): keep desktop page models

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
@@ -379,8 +379,12 @@ describe('plugin-ui-layout mobile models', () => {
       uid: 'mobile-route-parent',
       use: 'RouteModel',
     });
-    routeModel.context.defineProperty('isMobileLayout', {
-      value: true,
+    routeModel.context.defineProperty('layout', {
+      value: {
+        layoutModelClass: 'MobileLayoutModel',
+        rootPageModelClass: 'MobileRootPageModel',
+        childPageModelClass: 'MobileChildPageModel',
+      },
     });
 
     const rootPage = engine.createModel({
@@ -439,7 +443,64 @@ describe('plugin-ui-layout mobile models', () => {
     expect(childPage).not.toBeInstanceOf(MobileChildPageModel);
   });
 
-  it('should resolve persisted child pages to mobile page models from mobile view input args', () => {
+  it('should keep admin layout responsive pages on standard page models', () => {
+    registerMobilePageModelResolution();
+
+    const engine = new FlowEngine();
+    engine.registerModels({
+      RootPageModel,
+      ChildPageModel,
+      MobileRootPageModel,
+      MobileChildPageModel,
+      RouteModel,
+    });
+    const routeModel = engine.createModel<RouteModel>({
+      uid: 'admin-responsive-route-parent',
+      use: 'RouteModel',
+    });
+    routeModel.context.defineProperty('isMobileLayout', {
+      value: true,
+    });
+    routeModel.context.defineProperty('layout', {
+      value: {
+        layoutModelClass: 'AdminLayoutModel',
+        rootPageModelClass: 'RootPageModel',
+        childPageModelClass: 'ChildPageModel',
+      },
+    });
+    routeModel.context.defineProperty('layoutContext', {
+      value: {
+        isMobileLayout: true,
+        layout: {
+          layoutModelClass: 'AdminLayoutModel',
+          rootPageModelClass: 'RootPageModel',
+          childPageModelClass: 'ChildPageModel',
+        },
+      },
+    });
+
+    const rootPage = engine.createModel({
+      uid: 'admin-responsive-root-page',
+      parentId: routeModel.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'RootPageModel',
+    });
+    const childPage = engine.createModel({
+      uid: 'admin-responsive-child-page',
+      parentId: routeModel.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'ChildPageModel',
+    });
+
+    expect(rootPage).toBeInstanceOf(RootPageModel);
+    expect(rootPage).not.toBeInstanceOf(MobileRootPageModel);
+    expect(childPage).toBeInstanceOf(ChildPageModel);
+    expect(childPage).not.toBeInstanceOf(MobileChildPageModel);
+  });
+
+  it('should keep persisted child pages unchanged from mobile view input args without mobile page model class', () => {
     registerMobilePageModelResolution();
 
     const engine = new FlowEngine();
@@ -467,7 +528,8 @@ describe('plugin-ui-layout mobile models', () => {
       use: 'ChildPageModel',
     });
 
-    expect(childPage.constructor).toBe(MobileChildPageModel);
+    expect(childPage).toBeInstanceOf(ChildPageModel);
+    expect(childPage).not.toBeInstanceOf(MobileChildPageModel);
   });
 
   it('should resolve persisted child pages from mobile page model class input args', () => {
@@ -529,6 +591,84 @@ describe('plugin-ui-layout mobile models', () => {
     });
 
     expect(childPage.constructor).toBe(MobileChildPageModel);
+  });
+
+  it('should keep custom child page model classes inside mobile layouts', () => {
+    registerMobilePageModelResolution();
+
+    class CustomChildPageModel extends ChildPageModel {}
+
+    const engine = new FlowEngine();
+    engine.registerModels({
+      ChildPageModel,
+      MobileChildPageModel,
+      CustomChildPageModel,
+    });
+    const actionModel = engine.createModel({
+      uid: 'mobile-layout-custom-action-parent',
+      use: 'FlowModel',
+    });
+    actionModel.context.defineProperty('layout', {
+      value: {
+        layoutModelClass: 'MobileLayoutModel',
+        childPageModelClass: 'MobileChildPageModel',
+      },
+    });
+
+    const childPage = engine.createModel({
+      uid: 'mobile-layout-custom-child-page',
+      parentId: actionModel.uid,
+      subKey: 'page',
+      subType: 'object',
+      use: 'CustomChildPageModel',
+    });
+
+    expect(childPage).toBeInstanceOf(CustomChildPageModel);
+    expect(childPage).not.toBeInstanceOf(MobileChildPageModel);
+  });
+
+  it('should preserve the original page model resolveUse static this binding', () => {
+    const patchSymbol = Symbol.for('nocobase.plugin-ui-layout.mobilePageResolutionPatched');
+    const ChildPageModelClass = ChildPageModel as typeof ChildPageModel & {
+      [key: symbol]: boolean | undefined;
+    };
+    const originalPatched = ChildPageModelClass[patchSymbol];
+    const originalResolveUse = ChildPageModelClass.resolveUse;
+    let resolvedThis: unknown;
+
+    try {
+      ChildPageModelClass[patchSymbol] = false;
+      ChildPageModelClass.resolveUse = function resolveUseWithStaticThis() {
+        resolvedThis = this;
+      };
+      registerMobilePageModelResolution();
+
+      const engine = new FlowEngine();
+      ChildPageModelClass.resolveUse?.call(
+        ChildPageModel,
+        {
+          uid: 'mobile-layout-resolve-use-this-binding',
+          use: 'CustomChildPageModel',
+        },
+        engine,
+      );
+
+      ChildPageModelClass.resolveUse?.call(
+        ChildPageModel,
+        {
+          uid: 'mobile-layout-resolve-base-this-binding',
+          subKey: 'page',
+          subType: 'object',
+          use: 'ChildPageModel',
+        },
+        engine,
+      );
+
+      expect(resolvedThis).toBe(ChildPageModel);
+    } finally {
+      ChildPageModelClass.resolveUse = originalResolveUse;
+      ChildPageModelClass[patchSymbol] = originalPatched;
+    }
   });
 
   it('should resolve persisted child pages from a mobile parent in the view engine stack', () => {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileOpenViewAction.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileOpenViewAction.test.ts
@@ -14,16 +14,39 @@ import { mobileOpenView, resolveMobileOpenViewInputArgs, resolveMobileOpenViewPa
 type OpenViewContext = Parameters<typeof resolveMobileOpenViewParams>[0];
 type OpenViewParams = Parameters<typeof resolveMobileOpenViewParams>[1];
 
-function createContext(inputArgs: Record<string, unknown>, isMobileLayout = false) {
+const mobileLayout = {
+  layoutModelClass: 'MobileLayoutModel',
+  childPageModelClass: 'MobileChildPageModel',
+};
+
+function createContext(inputArgs: Record<string, unknown>, isMobileLayout = false, layout?: typeof mobileLayout) {
   return {
     inputArgs,
     isMobileLayout,
+    ...(layout
+      ? {
+          layout,
+          layoutContext: {
+            isMobileLayout,
+            layout,
+          },
+        }
+      : {}),
   } as OpenViewContext;
+}
+
+function createMobileLayoutContext(inputArgs: Record<string, unknown>, isMobileLayout = true) {
+  return createContext(inputArgs, isMobileLayout, mobileLayout);
 }
 
 function createReadonlyContext(inputArgs: Record<string, unknown>) {
   const ctx = {
     isMobileLayout: true,
+    layout: mobileLayout,
+    layoutContext: {
+      isMobileLayout: true,
+      layout: mobileLayout,
+    },
     model: {
       context: {
         inputArgs: {},
@@ -65,6 +88,11 @@ function createContextWithModelInputArgs(inputArgs: Record<string, unknown>, mod
   return {
     inputArgs,
     isMobileLayout: true,
+    layout: mobileLayout,
+    layoutContext: {
+      isMobileLayout: true,
+      layout: mobileLayout,
+    },
     model: {
       context: modelContext,
     },
@@ -86,14 +114,66 @@ describe('mobileOpenViewAction', () => {
       pageModelClass: 'ChildPageModel',
     } as OpenViewParams;
 
-    expect(resolveMobileOpenViewParams(createContext({ isMobileLayout: true }), params)).toMatchObject({
+    expect(resolveMobileOpenViewParams(createMobileLayoutContext({ isMobileLayout: true }), params)).toMatchObject({
       mode: 'embed',
       pageModelClass: 'MobileChildPageModel',
     });
   });
 
-  it('should replace the default input page model for mobile route replays', () => {
+  it('should replace the default child page model for mobile layout route replays without layout context', () => {
+    const mobilePageSlot = document.createElement('div');
+    mobilePageSlot.className = 'nb-ui-layout-mobile-page-slot';
+    const target = document.createElement('div');
+    mobilePageSlot.appendChild(target);
+    const params = {
+      mode: 'embed',
+      pageModelClass: 'ChildPageModel',
+    } as OpenViewParams;
     const ctx = createContext({
+      activationControlledByLayout: true,
+      isMobileLayout: true,
+      target,
+    });
+
+    expect(resolveMobileOpenViewParams(ctx, params)).toMatchObject({
+      mode: 'embed',
+      pageModelClass: 'MobileChildPageModel',
+    });
+    expect(resolveMobileOpenViewInputArgs(ctx, params)).toMatchObject({
+      activationControlledByLayout: true,
+      isMobileLayout: true,
+      pageModelClass: 'MobileChildPageModel',
+    });
+  });
+
+  it('should keep the default child page model for admin layout responsive route replays', () => {
+    const params = {
+      mode: 'embed',
+      pageModelClass: 'ChildPageModel',
+    } as OpenViewParams;
+    const ctx = {
+      inputArgs: {
+        isMobileLayout: true,
+      },
+      isMobileLayout: true,
+      layout: {
+        layoutModelClass: 'AdminLayoutModel',
+        childPageModelClass: 'ChildPageModel',
+      },
+      layoutContext: {
+        isMobileLayout: true,
+        layout: {
+          layoutModelClass: 'AdminLayoutModel',
+          childPageModelClass: 'ChildPageModel',
+        },
+      },
+    } as OpenViewContext;
+
+    expect(resolveMobileOpenViewParams(ctx, params)).toBe(params);
+  });
+
+  it('should replace the default input page model for mobile route replays', () => {
+    const ctx = createMobileLayoutContext({
       isMobileLayout: true,
       pageModelClass: 'ChildPageModel',
     });
@@ -108,7 +188,7 @@ describe('mobileOpenViewAction', () => {
     const params = {
       pageModelClass: 'ChildPageModel',
     } as OpenViewParams;
-    const ctx = createContext({ isMobileLayout: true, pageModelClass: 'CustomChildPageModel' });
+    const ctx = createMobileLayoutContext({ isMobileLayout: true, pageModelClass: 'CustomChildPageModel' });
 
     expect(resolveMobileOpenViewParams(ctx, params)).toBe(params);
     expect(resolveMobileOpenViewInputArgs(ctx, params)).toBe(ctx.inputArgs);
@@ -119,7 +199,7 @@ describe('mobileOpenViewAction', () => {
       pageModelClass: 'CustomChildPageModel',
     } as OpenViewParams;
 
-    expect(resolveMobileOpenViewParams(createContext({ isMobileLayout: true }), params)).toBe(params);
+    expect(resolveMobileOpenViewParams(createMobileLayoutContext({ isMobileLayout: true }), params)).toBe(params);
   });
 
   it('should override readonly input args while delegating to the core handler', async () => {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/mobileOpenViewAction.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/mobileOpenViewAction.ts
@@ -10,6 +10,8 @@
 import { openView } from '@nocobase/client-v2';
 
 const MOBILE_CHILD_PAGE_MODEL_CLASS = 'MobileChildPageModel';
+const MOBILE_LAYOUT_MODEL_CLASS = 'MobileLayoutModel';
+const MOBILE_PAGE_SLOT_SELECTOR = '.nb-ui-layout-mobile-page-slot, .nb-ui-layout-mobile-viewport';
 const DEFAULT_CHILD_PAGE_MODEL_CLASS = 'ChildPageModel';
 
 type OpenViewHandler = NonNullable<typeof openView.handler>;
@@ -17,9 +19,16 @@ type OpenViewContext = Parameters<OpenViewHandler>[0];
 type OpenViewParams = Parameters<OpenViewHandler>[1];
 
 type MobileOpenViewInputArgs = {
+  activationControlledByLayout?: unknown;
   isMobileLayout?: boolean;
   pageModelClass?: unknown;
+  target?: unknown;
 } & Record<string, unknown>;
+
+type MobileOpenViewLayoutDefinition = {
+  layoutModelClass?: unknown;
+  childPageModelClass?: unknown;
+};
 
 type FlowContextPropertyOptions = {
   value?: unknown;
@@ -48,10 +57,44 @@ type OpenViewContextWithModel = OpenViewContext & {
   };
 };
 
+type OpenViewContextWithLayout = OpenViewContext & {
+  layout?: MobileOpenViewLayoutDefinition;
+  layoutContext?: {
+    layout?: MobileOpenViewLayoutDefinition;
+  };
+};
+
+function isMobileLayoutDefinition(layout: MobileOpenViewLayoutDefinition | undefined) {
+  return (
+    layout?.layoutModelClass === MOBILE_LAYOUT_MODEL_CLASS ||
+    layout?.childPageModelClass === MOBILE_CHILD_PAGE_MODEL_CLASS
+  );
+}
+
+function isElementInsideMobilePageSlot(target: unknown) {
+  return (
+    typeof HTMLElement !== 'undefined' && target instanceof HTMLElement && !!target.closest(MOBILE_PAGE_SLOT_SELECTOR)
+  );
+}
+
+function isMobileLayoutRouteReplay(inputArgs: MobileOpenViewInputArgs | undefined) {
+  return (
+    inputArgs?.isMobileLayout === true &&
+    inputArgs.activationControlledByLayout === true &&
+    isElementInsideMobilePageSlot(inputArgs.target)
+  );
+}
+
 function isMobileOpenViewContext(ctx: OpenViewContext) {
   const inputArgs = ctx.inputArgs as MobileOpenViewInputArgs | undefined;
+  const layoutContext = ctx as OpenViewContextWithLayout;
 
-  return inputArgs?.isMobileLayout === true || ctx.isMobileLayout === true;
+  return (
+    inputArgs?.pageModelClass === MOBILE_CHILD_PAGE_MODEL_CLASS ||
+    isMobileLayoutRouteReplay(inputArgs) ||
+    isMobileLayoutDefinition(layoutContext.layout) ||
+    isMobileLayoutDefinition(layoutContext.layoutContext?.layout)
+  );
 }
 
 function hasCustomPageModelClass(pageModelClass: unknown) {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/mobilePageModelResolution.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/mobilePageModelResolution.ts
@@ -54,15 +54,11 @@ function isMobileLayoutDefinition(layout: MobileLayoutRuntimeContext['layout'] |
   );
 }
 
-function hasMobileLayoutFlag(context: unknown, mobileModelClass: string) {
+function shouldResolveToMobilePageModel(context: unknown, mobileModelClass: string) {
   try {
     const ctx = context as MobileLayoutRuntimeContext | undefined;
 
     return (
-      ctx?.isMobileLayout === true ||
-      ctx?.layoutContext?.isMobileLayout === true ||
-      ctx?.inputArgs?.isMobileLayout === true ||
-      ctx?.view?.inputArgs?.isMobileLayout === true ||
       ctx?.inputArgs?.pageModelClass === mobileModelClass ||
       ctx?.view?.inputArgs?.pageModelClass === mobileModelClass ||
       isMobileLayoutDefinition(ctx?.layout, mobileModelClass) ||
@@ -91,8 +87,8 @@ function isMobilePageSubModel(
 
   return (
     options.subKey === 'page' &&
-    (hasMobileLayoutFlag(stackedParent?.context, mobileModelClass) ||
-      hasMobileLayoutFlag(engine.context, mobileModelClass))
+    (shouldResolveToMobilePageModel(stackedParent?.context, mobileModelClass) ||
+      shouldResolveToMobilePageModel(engine.context, mobileModelClass))
   );
 }
 
@@ -112,6 +108,11 @@ function patchPageModelResolution(ModelClass: PageModelClass, MobileModelClass: 
   const originalResolveUse = ModelClass.resolveUse;
   ModelClass.resolveUse = function resolveMobilePageModel(options, engine, parent) {
     const mobileModelClass = MobileModelClass.name;
+    const isBasePageModelRequest = options.use === ModelClass || options.use === ModelClass.name;
+    if (!isBasePageModelRequest) {
+      return originalResolveUse?.call(this, options, engine, parent);
+    }
+
     const resolved = originalResolveUse?.call(this, options, engine, parent);
     if (hasResolvedTarget(resolved)) {
       return resolved;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

在移动设备或窄屏窗口中打开 Client V2 桌面路由时，页面会误用移动端页面样式，导致桌面页面结构和内容显示异常。真正的移动端路由不受影响。

### Description

- 桌面路由在窄屏下继续使用桌面页面结构，不再仅根据屏幕宽度切换为移动端页面。
- 仅在路由明确属于移动布局时使用移动端页面，并保留移动路由恢复、显式自定义页面等既有行为。
- 补充桌面窄屏、真正移动布局、移动路由恢复和自定义页面的回归测试。

验证结果：

- `mobileModels.test.ts`：112/112 通过。
- `mobileOpenViewAction.test.ts`：9/9 通过。
- 涉及文件的 ESLint 检查和 `git diff --check` 通过。
- 浏览器验证桌面路由在 390 × 844 和 1440 × 900 下均使用桌面页面，真正的移动路由仍使用移动页面。

潜在风险集中在页面模型选择与移动路由恢复逻辑，已通过上述单元测试和浏览器场景覆盖。

### Showcase

无新增界面。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix desktop pages using mobile styles on narrow screens |
| 🇨🇳 Chinese | 修复桌面页面在窄屏下误用移动端样式的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
