### PR TITLE
fix(plugin-multi-portal): reject duplicate portal names

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/locale/en-US.json
@@ -57,6 +57,7 @@
   "No-code portal": "No-code portal",
   "Portal manager": "Portal manager",
   "Portal name": "Portal name",
+  "Portal name \"{{portalName}}\" already exists": "Portal name \"{{portalName}}\" already exists",
   "Portal name can only contain lowercase letters, numbers, hyphens, and underscores": "Portal name can only contain lowercase letters, numbers, hyphens, and underscores",
   "Portals": "Portals",
   "Refresh": "Refresh",

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/locale/zh-CN.json
@@ -57,6 +57,7 @@
   "No-code portal": "无代码门户",
   "Portal manager": "门户管理",
   "Portal name": "门户名称",
+  "Portal name \"{{portalName}}\" already exists": "门户名称“{{portalName}}”已存在",
   "Portal name can only contain lowercase letters, numbers, hyphens, and underscores": "门户名称只能包含小写英文字母、数字、连字符和下划线",
   "Portals": "门户",
   "Refresh": "刷新",

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts
@@ -788,6 +788,74 @@ describe('plugin-multi-portal server', () => {
     expect(updatedToMobile?.get('routePath')).toBe('/mobile');
   });
 
+  it('should reject duplicate portal names before collection writes', async () => {
+    app = await createMultiPortalAclMockServer();
+    await app.db.sync();
+
+    const repository = app.db.getRepository('multiPortals');
+    await repository.create({
+      values: {
+        uid: 'existing-portal',
+        title: 'Existing Portal',
+        portalType: 'no-code',
+        portalName: 'existing-portal',
+        routePath: '/existing-portal',
+        uiLayoutUid: DEFAULT_ADMIN_UI_LAYOUT.uid,
+      },
+    });
+    await repository.create({
+      values: {
+        uid: 'renamed-portal',
+        title: 'Renamed Portal',
+        portalType: 'no-code',
+        portalName: 'renamed-portal',
+        routePath: '/renamed-portal',
+        uiLayoutUid: DEFAULT_ADMIN_UI_LAYOUT.uid,
+      },
+    });
+
+    const rootUser = await app.db.getRepository('users').findOne({
+      filter: {
+        'roles.name': 'root',
+      },
+    });
+    const rootAgent = await app.agent().login(rootUser);
+    const duplicateCreateResponse = await rootAgent.resource('multiPortals').create({
+      values: {
+        uid: 'duplicate-portal',
+        title: 'Duplicate Portal',
+        portalType: 'no-code',
+        portalName: 'existing-portal',
+        routePath: '/ignored-by-normalization',
+        uiLayoutUid: DEFAULT_ADMIN_UI_LAYOUT.uid,
+      },
+    });
+    const samePortalUpdateResponse = await rootAgent.resource('multiPortals').update({
+      filterByTk: 'existing-portal',
+      values: {
+        title: 'Updated Existing Portal',
+        portalName: 'existing-portal',
+      },
+    });
+    const duplicateUpdateResponse = await rootAgent
+      .set('X-Locale', 'zh-CN')
+      .resource('multiPortals')
+      .update({
+        filterByTk: 'renamed-portal',
+        values: {
+          portalName: 'existing-portal',
+        },
+      });
+
+    expect(duplicateCreateResponse.status).toBe(409);
+    expect(duplicateCreateResponse.body.errors[0].message).toBe('Portal name "existing-portal" already exists');
+    expect(samePortalUpdateResponse.status).toBe(200);
+    expect(duplicateUpdateResponse.status).toBe(409);
+    expect(duplicateUpdateResponse.body.errors[0].message).toBe('门户名称“existing-portal”已存在');
+    expect(await repository.findOne({ filterByTk: 'duplicate-portal' })).toBeNull();
+    expect((await repository.findOne({ filterByTk: 'renamed-portal' }))?.get('portalName')).toBe('renamed-portal');
+  });
+
   it('should apply INIT_PORTAL_NAME to the fresh AI portal', async () => {
     process.env.INIT_PORTAL_TYPE = 'ai';
     process.env.INIT_PORTAL_NAME = 'workspace_home';

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
@@ -1327,6 +1327,32 @@ async function normalizeMultiPortalSlugValues(ctx: ResourcerContext, next: () =>
     values.portalName = slug;
     values.routePath = `/${slug}`;
   }
+
+  const repository = ctx.db.getRepository('multiPortals');
+  const pendingPortalNames = new Set<string>();
+  const targets = await getMultiPortalWriteTargets(ctx, ['uid']);
+  for (const { existing, values } of targets) {
+    const portalName = values.portalName;
+    if (typeof portalName !== 'string' || !portalName) {
+      continue;
+    }
+
+    if (pendingPortalNames.has(portalName)) {
+      ctx.throw(409, ctx.t('Portal name "{{portalName}}" already exists', { ns: NAMESPACE, portalName }));
+      return;
+    }
+    pendingPortalNames.add(portalName);
+
+    const conflict = await repository.findOne({
+      filter: { portalName },
+      fields: ['uid'],
+    });
+    if (conflict && conflict.get('uid') !== existing?.get('uid')) {
+      ctx.throw(409, ctx.t('Portal name "{{portalName}}" already exists', { ns: NAMESPACE, portalName }));
+      return;
+    }
+  }
+
   await next();
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Duplicate enabled Portal names can cause client-side Portal registration to fail before layouts are registered, which may surface as an application-level 404 for routes such as `/nocobase/v/admin`.

### Description

- Validate `portalName` uniqueness in the existing multi-portal pre-action middleware for create and update-style actions.
- Reject duplicate names in the same request or existing records with a localized HTTP 409 response.
- Allow updates that keep the current record's name unchanged.
- Add integration coverage for duplicate create, duplicate rename, same-record update, localization, and persistence.

Potential risks and testing suggestions:

- The check applies to Resource Action requests; direct Repository writes do not pass through the pre-action handler.
- The check-then-write flow is not atomic under concurrent requests, so the database unique constraint remains the final consistency guard.
- Existing historical duplicate records are not modified and still need manual cleanup.
- Verify create, rename, `firstOrCreate`, and `updateOrCreate` against a database with the current schema.

### Related issues

N/A

### Showcase

N/A (server-side validation only)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reject duplicate Portal names with a localized conflict response. |
| 🇨🇳 Chinese | 阻止创建或更新为重复的门户名称，并返回本地化的冲突提示。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

### Validation

- `yarn eslint --fix packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts` ✅
- Locale JSON parsing and `git diff --check` ✅
- `yarn test packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts --run --reporter=verbose` ⚠️ blocked during database initialization because the current local dependencies do not include `sqlite3`; no test assertions ran.
