### PR TITLE
fix(client-v2): remove legacy knowledge base detail redirects

### DIFF
--- a/packages/core/client-v2/src/__tests__/settings-runtime-paths.test.ts
+++ b/packages/core/client-v2/src/__tests__/settings-runtime-paths.test.ts
@@ -38,7 +38,7 @@ describe('standalone settings runtime paths', () => {
     expect(resolveStandaloneSettingsPath(app, '/nocobase/v/admin/workflow/executions/88')).toBe(
       '/nocobase/settings/workflow/executions/88',
     );
-    expect(resolveStandaloneSettingsPath(app, '/nocobase/v/admin/ai/knowledge-base/detail/k1/documents')).toBe(
+    expect(resolveStandaloneSettingsPath(app, '/nocobase/v/admin/settings/ai/knowledge-base/detail/k1/documents')).toBe(
       '/nocobase/settings/ai/knowledge-base/detail/k1/documents',
     );
   });

--- a/packages/core/client-v2/src/settings-app/runtimePaths.ts
+++ b/packages/core/client-v2/src/settings-app/runtimePaths.ts
@@ -26,7 +26,6 @@ type SettingsRuntimeApp = Pick<BaseApplication<any>, 'name'> & {
 const LEGACY_EMAIL_OAUTH_PATH = '/admin/settings/mail/oauth2';
 
 const ROUTE_MAPPINGS = [
-  { from: '/admin/ai/knowledge-base/detail', to: '/settings/ai/knowledge-base/detail' },
   { from: '/admin/workflow/executions', to: '/settings/workflow/executions' },
   { from: '/admin/workflow/workflows', to: '/settings/workflow/workflows' },
   { from: '/admin/settings', to: '/settings' },

--- a/packages/core/server/src/__tests__/gateway-settings.test.ts
+++ b/packages/core/server/src/__tests__/gateway-settings.test.ts
@@ -118,10 +118,6 @@ describe('gateway standalone settings client', () => {
       '/nocobase/modern/admin/workflow/executions/99?from=workflow',
       '/nocobase/settings/workflow/executions/99?from=workflow',
     ],
-    [
-      '/nocobase/modern/admin/ai/knowledge-base/detail/orders/documents?tab=files',
-      '/nocobase/settings/ai/knowledge-base/detail/orders/documents?tab=files',
-    ],
     ['/nocobase/modern/apps/analytics/admin/settings/workflow', '/nocobase/settings/apps/analytics/workflow'],
     [
       '/nocobase/modern/_app/analytics/admin/workflow/workflows/42',

--- a/packages/core/server/src/gateway/index.ts
+++ b/packages/core/server/src/gateway/index.ts
@@ -438,10 +438,6 @@ export class Gateway extends EventEmitter {
         to: '/admin/settings/mail/oauth2',
       },
       {
-        from: '/admin/ai/knowledge-base/detail',
-        to: '/settings/ai/knowledge-base/detail',
-      },
-      {
         from: '/admin/workflow/executions',
         to: '/settings/workflow/executions',
       },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Knowledge base detail routes now derive their path from the active Admin or Settings runtime. The previous client and gateway mappings for `/admin/ai/knowledge-base/detail/...` no longer match the generated Admin URL and would preserve an obsolete cross-runtime redirect.

### Description
- Remove the client-side special mapping from the legacy knowledge base detail path to the standalone Settings application.
- Remove the matching gateway redirect rule.
- Update runtime path and gateway tests to stop treating the old knowledge base detail URL as a supported Settings redirect.

Potential risk: saved links using `/admin/ai/knowledge-base/detail/...` are intentionally no longer redirected.

Testing suggestions:
- Verify the companion pro-plugins change opens knowledge base details in the active Admin or Settings runtime.
- Verify existing generic Settings, workflow, and email OAuth redirects continue to work.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Removed the obsolete knowledge base detail redirect that forced legacy Admin URLs into the Settings application. |
| 🇨🇳 Chinese | 移除将旧版 Admin 知识库详情地址强制跳转到 Settings 应用的过时重定向。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
