### PR TITLE
fix(plugin-ai): translate Settings tab in client v2

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/locale/de-DE.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/de-DE.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Einstellungen"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/en-US.json
@@ -572,5 +572,6 @@
   "confirmed": "Confirmed",
   "success": "Success",
   "error": "Error",
-  "GigaChat by Sber": "GigaChat by Sber"
+  "GigaChat by Sber": "GigaChat by Sber",
+  "Settings": "Settings"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/es-ES.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/es-ES.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Settings"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/fr-FR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/fr-FR.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Settings"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/hu-HU.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/hu-HU.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Beállítások"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/id-ID.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/id-ID.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Pengaturan"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/it-IT.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/it-IT.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Impostazioni"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/ja-JP.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/ja-JP.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "設定"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/ko-KR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/ko-KR.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "설정"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/nl-NL.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/nl-NL.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Instellingen"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/pt-BR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/pt-BR.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Settings"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/ru-RU.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/ru-RU.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Настройки"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/tr-TR.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/tr-TR.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Settings"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/uk-UA.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/uk-UA.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Settings"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/vi-VN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/vi-VN.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "Cài đặt"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-CN.json
@@ -578,5 +578,6 @@
   "confirmed": "已确认",
   "success": "成功",
   "error": "错误",
-  "GigaChat by Sber": "Sber 的 GigaChat 模型"
+  "GigaChat by Sber": "Sber 的 GigaChat 模型",
+  "Settings": "设置"
 }

--- a/packages/plugins/@nocobase/plugin-ai/src/locale/zh-TW.json
+++ b/packages/plugins/@nocobase/plugin-ai/src/locale/zh-TW.json
@@ -201,5 +201,6 @@
   "knowledge Base Prompt default": "From knowledge base:\n{knowledgeBaseData}\nAnswer user's question using this information.",
   "please fix the error": "please fix the error",
   "please review the code": "please review the code",
-  "references {{index}}": "references {{index}}"
+  "references {{index}}": "references {{index}}",
+  "Settings": "設定"
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The client-v2 AI settings tab translates `Settings` with the plugin namespace, but the plugin locale resources did not contain that key. As a result, non-English interfaces displayed the untranslated English label.

### Description 
Added the `Settings` translation to all 17 locale resources provided by `@nocobase/plugin-ai`, using the existing core client translations for consistency.

Risk is low because this change only extends locale JSON resources.

Testing:
- Parsed all updated locale files as JSON.
- Ran `settings-registration.test.ts` successfully (6 tests passed).

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the untranslated Settings tab in the AI plugin's client-v2 settings pages |
| 🇨🇳 Chinese | 修复 AI 插件 client-v2 设置页面中 Settings 标签未翻译的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
