### PR TITLE
fix(plugin-collection-sql): bind query variables

### DIFF
--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts
@@ -105,6 +105,74 @@ describe('sql collection', () => {
     expect(res.body.data.sources).toEqual(['testSqlCollection']);
   });
 
+  it('should bind SQL variables from API query parameters', async () => {
+    await agent.resource('collections').create({
+      values: {
+        name: 'sqlVariableSource',
+        fields: [
+          {
+            name: 'testField',
+            type: 'string',
+            interface: 'input',
+          },
+        ],
+      },
+    });
+    await agent.resource('sqlVariableSource').create({
+      values: {
+        testField: "O'Reilly",
+      },
+    });
+    await agent.resource('sqlVariableSource').create({
+      values: {
+        testField: 'other',
+      },
+    });
+
+    const source = db.queryInterface.quoteIdentifier('sqlVariableSource');
+    const field = db.queryInterface.quoteIdentifier('testField');
+    const preview = await agent.resource('sqlCollection').execute({
+      values: {
+        sql: `select * from ${source} where ${field} = {{search_query}}`,
+      },
+    });
+    expect(preview.status).toBe(200);
+    expect(preview.body.data.data).toHaveLength(0);
+
+    for (const [index, placeholder] of ['{{search_query}}', "'{{search_query}}'"].entries()) {
+      const collectionName = `parameterizedSqlCollection${index}`;
+      await agent.resource('collections').create({
+        values: {
+          name: collectionName,
+          sql: `select * from ${source} where ${field} = ${placeholder}`,
+          template: 'sql',
+          filterTargetKey: 'id',
+          fields: [
+            {
+              name: 'id',
+              type: 'bigInt',
+              interface: 'integer',
+            },
+            {
+              name: 'testField',
+              type: 'string',
+              interface: 'input',
+            },
+          ],
+        },
+      });
+
+      const res = await agent.resource(collectionName).list({
+        search_query: "O'Reilly",
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.count).toBe(1);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].testField).toBe("O'Reilly");
+    }
+  });
+
   it('sqlCollection:update', async () => {
     await agent.resource('collections').create({
       values: {

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/infer-fields.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/infer-fields.test.ts
@@ -116,4 +116,22 @@ left join roles r on ru.role_name=r.name`;
       a: {},
     });
   });
+
+  it('should infer fields with PostgreSQL full-text search syntax and SQL variables', () => {
+    const model = class extends SQLModel {};
+    model.init(null, {
+      modelName: 'users',
+      tableName: 'users',
+      sequelize: db.sequelize,
+    });
+    model.database = db;
+    model.sql = `select id, nickname from users
+where to_tsvector('english', coalesce(nickname, ''))
+@@ plainto_tsquery('english', {{search_query}})`;
+
+    expect(model.inferFields()).toMatchObject({
+      id: { type: 'bigInt', source: 'users.id' },
+      nickname: { type: 'string', source: 'users.nickname' },
+    });
+  });
 });

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/select-query.test.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/select-query.test.ts
@@ -79,6 +79,42 @@ describe('select query', () => {
       'SELECT "id", "name" FROM (SELECT * FROM "users") AS "users" WHERE "users"."id" = 1 GROUP BY "id" ORDER BY "users"."id" LIMIT 1 OFFSET 0;',
     );
   });
+
+  test.each(['{{search_query}}', "'{{search_query}}'"])('binds SQL variable %s', (placeholder) => {
+    model.sql = `SELECT * FROM "users" WHERE "name" = ${placeholder}`;
+    const options = {
+      context: {
+        action: {
+          params: {
+            search_query: "O'Reilly",
+          },
+        },
+      },
+    };
+
+    const query = queryGenerator.selectQuery('users', options, model);
+
+    expect(query).toBe('SELECT * FROM (SELECT * FROM "users" WHERE "name" = $sql_search_query) AS "users";');
+    expect(options).toMatchObject({
+      bind: {
+        sql_search_query: "O'Reilly",
+      },
+    });
+  });
+
+  test('binds missing SQL variables as null for previews', () => {
+    model.sql = 'SELECT * FROM "users" WHERE "name" = {{search_query}}';
+    const options = {};
+
+    const query = queryGenerator.selectQuery('users', options, model);
+
+    expect(query).toBe('SELECT * FROM "users" WHERE "name" = $sql_search_query;');
+    expect(options).toMatchObject({
+      bind: {
+        sql_search_query: null,
+      },
+    });
+  });
 });
 
 describe('select query with DB_TABLE_PREFIX', () => {

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/query-generator.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/query-generator.ts
@@ -11,22 +11,32 @@ import { GroupOption, Order, ProjectionAlias, WhereOptions } from 'sequelize';
 import { SQLModel } from './sql-model';
 import { lodash } from '@nocobase/utils';
 import { Collection } from '@nocobase/database';
+import { bindSQLVariables } from '../utils';
 
-export function selectQuery(
-  tableName: string,
-  options: {
-    attributes?: (string | ProjectionAlias)[];
-    where?: WhereOptions;
-    order?: Order;
-    group?: GroupOption;
-    limit?: number;
-    offset?: number;
-  },
-  model: SQLModel,
-) {
+type SQLQueryOptions = {
+  attributes?: (string | ProjectionAlias)[];
+  where?: WhereOptions;
+  order?: Order;
+  group?: GroupOption;
+  limit?: number;
+  offset?: number;
+  bind?: Record<string, unknown>;
+  context?: {
+    action?: {
+      params?: Record<string, unknown>;
+    };
+  };
+};
+
+export function selectQuery(tableName: string, options: SQLQueryOptions, model: SQLModel) {
   options = options || {};
-  if (lodash.isEmpty(options)) {
-    return `${model.sql};`;
+  const hasQueryOptions = !lodash.isEmpty(options);
+  const { sql, bind } = bindSQLVariables(model.sql, options.context?.action?.params);
+  if (!lodash.isEmpty(bind)) {
+    options.bind = { ...options.bind, ...bind };
+  }
+  if (!hasQueryOptions) {
+    return `${sql};`;
   }
   const queryItems = [];
   let attributes = options.attributes && options.attributes.slice();
@@ -70,7 +80,7 @@ export function selectQuery(
     queryItems.push(limitOrder);
   }
 
-  const query = `SELECT ${attributes.join(', ')} FROM (${model.sql}) ${this.getAliasToken()} ${this.quoteIdentifier(
+  const query = `SELECT ${attributes.join(', ')} FROM (${sql}) ${this.getAliasToken()} ${this.quoteIdentifier(
     model.name,
   )}${queryItems.join('')}`;
 

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/sql-model.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/sql-collection/sql-model.ts
@@ -9,6 +9,7 @@
 
 import { Model, sqlParser, SQLParserTypes } from '@nocobase/database';
 import { selectQuery } from './query-generator';
+import { normalizeSQLForInference } from '../utils';
 
 export class SQLModel extends Model {
   static sql: string;
@@ -76,7 +77,7 @@ export class SQLModel extends Model {
     table: string;
     columns: { name: string; as?: string }[];
   }[] {
-    let { ast: _ast } = sqlParser.parse(this.sql);
+    let { ast: _ast } = sqlParser.parse(normalizeSQLForInference(this.sql));
     if (Array.isArray(_ast)) {
       _ast = _ast[0];
     }

--- a/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-collection-sql/src/server/utils.ts
@@ -48,3 +48,21 @@ export const checkSQL = (sql: string) => {
     throw new Error('SQL statements contain dangerous keywords');
   }
 };
+
+const sqlVariablePattern = /'\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}'|\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+export const bindSQLVariables = (sql: string, variables: Record<string, unknown> = {}) => {
+  const bind: Record<string, unknown> = {};
+  const statement = sql.replace(sqlVariablePattern, (_match, quotedName: string, unquotedName: string) => {
+    const name = quotedName || unquotedName;
+    const bindName = `sql_${name}`;
+    bind[bindName] = Object.prototype.hasOwnProperty.call(variables, name) ? variables[name] : null;
+    return `$${bindName}`;
+  });
+
+  return { sql: statement, bind };
+};
+
+export const normalizeSQLForInference = (sql: string) => {
+  return sql.replace(sqlVariablePattern, 'NULL').replace(/@@/g, '=');
+};


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

SQL collections currently execute `{{variable}}` placeholders literally or reject them during preview. PostgreSQL full-text search queries using the `@@` operator can also fail field inference even though the SQL is valid for PostgreSQL.

### Description

- Convert both `{{variable}}` and `'{{variable}}'` forms into Sequelize named bind parameters sourced from API query parameters.
- Bind missing variables as `NULL` during SQL preview so parameterized statements can be confirmed before runtime values are available.
- Normalize placeholders and PostgreSQL `@@` only in the SQL copy used for field inference, leaving the executed statement unchanged.
- Add regression coverage for preview, paginated API queries, quoted and unquoted placeholders, apostrophes in values, and PostgreSQL full-text search field inference.

Compatibility note: SQL strings containing the exact `'{{name}}'` form are now treated as dynamic variables instead of literal text.

Testing suggestions:

- Confirm a SQL collection containing an unquoted `{{search_query}}` placeholder.
- Request the collection with `?search_query=value` and verify count and rows use the supplied value.
- Verify PostgreSQL full-text search statements using `@@` still infer their selected fields.

### Related issues

Fixes #10221

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix SQL collection PostgreSQL full-text search inference and dynamic query variable binding. |
| 🇨🇳 Chinese | 修复 SQL 数据表的 PostgreSQL 全文搜索字段推断和动态查询变量绑定。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

### Verification

- `yarn test packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/select-query.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/infer-fields.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-collection-sql/src/server/__tests__/actions.test.ts --run`
- `yarn eslint --fix` on all touched files
- `git diff --check`
