### PR TITLE
feat(plugin-workflow): support variable expressions in text assignments

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
@@ -11,11 +11,15 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
 import { FieldAssignValueInput } from '@nocobase/client-v2';
-import { FlowModelProvider, useFlowEngine, type FlowModel } from '@nocobase/flow-engine';
+import { FlowModelProvider, VariableHybridInput, useFlowEngine, type FlowModel } from '@nocobase/flow-engine';
 import { Button, ConfigProvider, Dropdown, Empty, Form } from 'antd';
 import type { MenuProps } from 'antd';
 import { useWorkflowVariableOptions } from '../../canvas/useWorkflowVariableOptions';
-import { formatWorkflowPathToValue, parseWorkflowValueToPath } from '../../canvas/workflowVariableConverters';
+import {
+  formatWorkflowPathToValue,
+  parseWorkflowValueToPath,
+  workflowVariableConverters,
+} from '../../canvas/workflowVariableConverters';
 import { useT } from '../../locale';
 import {
   getCollection,
@@ -29,6 +33,8 @@ type AssignedValues = Record<string, unknown>;
 type AssignedField = ReturnType<typeof getCollectionFields>[number] & { name: string };
 type WorkflowVariableTree = ReturnType<typeof useWorkflowVariableOptions>;
 export type AssignedFieldFilter = (field: AssignedField) => boolean;
+
+const VARIABLE_EXPRESSION_FIELD_TYPES: ReadonlySet<string> = new Set(['string', 'text']);
 
 const fieldItemClassName = css`
   position: relative;
@@ -205,19 +211,30 @@ export function AssignedFieldsEditor({
               layout="vertical"
               colon
             >
-              <FieldAssignValueInput
-                key={field.name}
-                targetPath={field.name}
-                value={normalizedValue[field.name]}
-                onChange={(nextValue) => updateValue(field.name, nextValue)}
-                allowRunJS={false}
-                disabled={mergedDisabled}
-                variableConverters={{
-                  resolvePathFromValue: (currentValue) =>
-                    typeof currentValue === 'string' ? parseWorkflowValueToPath(currentValue) : undefined,
-                  resolveValueFromPath: (metaTreeNode) => formatWorkflowPathToValue(metaTreeNode),
-                }}
-              />
+              {VARIABLE_EXPRESSION_FIELD_TYPES.has(field.type ?? '') ? (
+                <VariableHybridInput
+                  value={typeof normalizedValue[field.name] === 'string' ? normalizedValue[field.name] : ''}
+                  onChange={(nextValue) => updateValue(field.name, nextValue)}
+                  disabled={mergedDisabled}
+                  metaTree={workflowVariableTree}
+                  converters={workflowVariableConverters}
+                  style={{ width: '100%' }}
+                />
+              ) : (
+                <FieldAssignValueInput
+                  key={field.name}
+                  targetPath={field.name}
+                  value={normalizedValue[field.name]}
+                  onChange={(nextValue) => updateValue(field.name, nextValue)}
+                  allowRunJS={false}
+                  disabled={mergedDisabled}
+                  variableConverters={{
+                    resolvePathFromValue: (currentValue) =>
+                      typeof currentValue === 'string' ? parseWorkflowValueToPath(currentValue) : undefined,
+                    resolveValueFromPath: (metaTreeNode) => formatWorkflowPathToValue(metaTreeNode),
+                  }}
+                />
+              )}
             </Form.Item>
             <Button
               aria-label={t('Remove field')}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
@@ -91,6 +91,10 @@ function normalizeAssignedValues(values: AssignedValues | undefined): AssignedVa
   );
 }
 
+function normalizeVariableExpressionValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
 function getFieldTitle(field: AssignedField, t: (key: string) => string) {
   return t(field.uiSchema?.title ?? field.name);
 }
@@ -213,7 +217,7 @@ export function AssignedFieldsEditor({
             >
               {VARIABLE_EXPRESSION_FIELD_TYPES.has(field.type ?? '') ? (
                 <VariableHybridInput
-                  value={typeof normalizedValue[field.name] === 'string' ? normalizedValue[field.name] : ''}
+                  value={normalizeVariableExpressionValue(normalizedValue[field.name])}
                   onChange={(nextValue) => updateValue(field.name, nextValue)}
                   disabled={mergedDisabled}
                   metaTree={workflowVariableTree}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
@@ -9,10 +9,17 @@
 
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssignedFieldsEditor } from '../AssignedFieldsEditor';
 
-const { collection, createModel, mockFieldAssignValueInput, mockFlowEngine, workflowVariableTree } = vi.hoisted(() => {
+const {
+  collection,
+  createModel,
+  mockFieldAssignValueInput,
+  mockFlowEngine,
+  mockVariableHybridInput,
+  workflowVariableTree,
+} = vi.hoisted(() => {
   const workflowVariableTree = [{ name: '$jobsMapByNodeKey', title: 'Node result', paths: ['$jobsMapByNodeKey'] }];
   const collection = {
     name: 'posts',
@@ -21,6 +28,10 @@ const { collection, createModel, mockFieldAssignValueInput, mockFlowEngine, work
     getFields: vi.fn(() => [
       { name: 'title', type: 'string', uiSchema: { title: 'Title' }, interface: 'input' },
       { name: 'status', type: 'string', uiSchema: { title: 'Status' }, interface: 'select' },
+      { name: 'body', type: 'text', uiSchema: { title: 'Body' }, interface: 'textarea' },
+      { name: 'website', type: 'text', uiSchema: { title: 'Website' }, interface: 'url' },
+      { name: 'metadata', type: 'json', uiSchema: { title: 'Metadata' }, interface: 'textarea' },
+      { name: 'score', type: 'integer', uiSchema: { title: 'Score' }, interface: 'integer' },
       { name: 'author', type: 'belongsTo', uiSchema: { title: 'Author' }, interface: 'm2o' },
       { name: 'comments', type: 'hasMany', uiSchema: { title: 'Comments' }, interface: 'o2m' },
     ]),
@@ -38,6 +49,16 @@ const { collection, createModel, mockFieldAssignValueInput, mockFlowEngine, work
     collection,
     createModel,
     workflowVariableTree,
+    mockVariableHybridInput: vi.fn(
+      ({ value, onChange, disabled }: { value?: string; onChange?: (value: string) => void; disabled?: boolean }) => (
+        <input
+          aria-label={`expression-${value ?? ''}`}
+          value={value ?? ''}
+          disabled={Boolean(disabled)}
+          onChange={(event) => onChange?.(event.target.value)}
+        />
+      ),
+    ),
     mockFieldAssignValueInput: vi.fn(
       ({
         targetPath,
@@ -86,6 +107,7 @@ vi.mock('@nocobase/flow-engine', async () => {
   return {
     ...actual,
     FlowModelProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    VariableHybridInput: mockVariableHybridInput,
     useFlowEngine: () => mockFlowEngine,
   };
 });
@@ -95,6 +117,10 @@ vi.mock('../../../locale', () => ({
 }));
 
 describe('AssignedFieldsEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('edits assigned values without creating an assign form model', async () => {
     const onChange = vi.fn();
 
@@ -107,19 +133,48 @@ describe('AssignedFieldsEditor', () => {
     const model = createModel.mock.results[0].value;
     expect(model.context.defineMethod).toHaveBeenCalledWith('getPropertyMetaTree', expect.any(Function));
     expect(model.context.defineMethod.mock.calls[0][1]()).toBe(workflowVariableTree);
-    expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+    expect(mockVariableHybridInput).toHaveBeenCalledWith(
       expect.objectContaining({
-        targetPath: 'title',
-        allowRunJS: false,
+        value: 'old',
+        metaTree: workflowVariableTree,
       }),
       expect.anything(),
     );
 
-    fireEvent.change(screen.getByLabelText('value-title'), { target: { value: 'new' } });
+    fireEvent.change(screen.getByLabelText('expression-old'), { target: { value: 'new' } });
     expect(onChange).toHaveBeenLastCalledWith({ title: 'new' });
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove field' }));
     expect(onChange).toHaveBeenLastCalledWith({});
+  });
+
+  it('uses expressions for string-valued field types and keeps the field-aware selector for other types', async () => {
+    render(
+      <AssignedFieldsEditor
+        collection="posts"
+        value={{ body: 'old body', website: 'https://example.com', metadata: { enabled: true }, score: 1 }}
+        onChange={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockVariableHybridInput).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'old body', metaTree: workflowVariableTree }),
+        expect.anything(),
+      );
+      expect(mockVariableHybridInput).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'https://example.com', metaTree: workflowVariableTree }),
+        expect.anything(),
+      );
+      expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+        expect.objectContaining({ targetPath: 'metadata', value: { enabled: true } }),
+        expect.anything(),
+      );
+      expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+        expect.objectContaining({ targetPath: 'score', value: 1 }),
+        expect.anything(),
+      );
+    });
   });
 
   it('adds unassigned collection fields with constant empty values', async () => {
@@ -162,16 +217,16 @@ describe('AssignedFieldsEditor', () => {
     render(<AssignedFieldsEditor collection="posts" value={{ title: 'old' }} onChange={onChange} disabled />);
 
     await waitFor(() => {
-      expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+      expect(mockVariableHybridInput).toHaveBeenCalledWith(
         expect.objectContaining({
-          targetPath: 'title',
+          value: 'old',
           disabled: true,
         }),
         expect.anything(),
       );
     });
 
-    fireEvent.change(screen.getByLabelText('value-title'), { target: { value: 'new' } });
+    fireEvent.change(screen.getByLabelText('expression-old'), { target: { value: 'new' } });
     fireEvent.click(screen.getByRole('button', { name: 'Remove field' }));
     fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
 
@@ -180,33 +235,23 @@ describe('AssignedFieldsEditor', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('passes workflow variable converters so stored {{$context...}} values can round-trip', async () => {
-    render(
-      <AssignedFieldsEditor
-        collection="posts"
-        value={{ title: '{{$context.data.updatedAt}}' }}
-        onChange={() => undefined}
-      />,
-    );
+  it('passes stored workflow variable expressions with surrounding text to the expression editor unchanged', async () => {
+    const expression = 'Updated at: {{$context.data.updatedAt}}';
+
+    render(<AssignedFieldsEditor collection="posts" value={{ title: expression }} onChange={() => undefined} />);
 
     await waitFor(() => {
-      expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+      expect(mockVariableHybridInput).toHaveBeenCalledWith(
         expect.objectContaining({
-          targetPath: 'title',
-          variableConverters: expect.objectContaining({
-            resolvePathFromValue: expect.any(Function),
-            resolveValueFromPath: expect.any(Function),
+          value: expression,
+          converters: expect.objectContaining({
+            formatPathToValue: expect.any(Function),
+            parseValueToPath: expect.any(Function),
+            variableRegExp: expect.any(RegExp),
           }),
         }),
         expect.anything(),
       );
     });
-
-    const latestCall = mockFieldAssignValueInput.mock.calls.at(-1)?.[0];
-    expect(latestCall.variableConverters.resolvePathFromValue('{{$context.data.updatedAt}}')).toEqual([
-      '$context',
-      'data',
-      'updatedAt',
-    ]);
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Workflow create and update nodes currently use a variable-only selector when assigning collection fields. String-valued fields need to support combining literal text with one or more workflow variables.

### Description

- Use the variable expression editor for collection fields whose underlying type is `string` or `text`.
- Preserve the existing field-aware variable selector for JSON, numeric, relational, and other field types.
- Keep the existing workflow variable serialization format so saved values continue to round-trip.
- Add tests covering single-line text, multiline text, URL, JSON, numeric, disabled, and persisted mixed-expression scenarios.

Potential risk is limited to the assignment editor for `string` and `text` fields in workflow create and update nodes. Other field types keep the existing behavior.

Testing:

```bash
yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx --run --reporter=verbose
```

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Workflow create and update nodes now support combining text with variables when assigning string and text fields |
| 🇨🇳 Chinese | 工作流创建和更新节点为字符串及文本字段赋值时，现已支持将文字与变量拼接使用 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
