### PR TITLE
fix(plugin-field-sequence): repair sequences from latest batch

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-sequence/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/server/Plugin.ts
@@ -243,7 +243,11 @@ export default class PluginFieldSequenceServer extends Plugin {
               }
             };
 
-            if (primaryKeyFields.length && primaryKeyFields.length === sortablePrimaryKeyFields.length) {
+            if (
+              !app.db.inDialect('sqlite') &&
+              primaryKeyFields.length &&
+              primaryKeyFields.length === sortablePrimaryKeyFields.length
+            ) {
               await collection.repository.chunkWithCursor({
                 ...latestBatchQuery,
                 chunkSize,

--- a/packages/plugins/@nocobase/plugin-field-sequence/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/server/Plugin.ts
@@ -15,7 +15,7 @@ import { Plugin } from '@nocobase/server';
 import { Registry } from '@nocobase/utils';
 import { Pattern, SequenceField } from './fields/sequence-field';
 import _ from 'lodash';
-import { Field, Model } from '@nocobase/database';
+import { Field, FindOptions, Model } from '@nocobase/database';
 
 const asyncRandomInt = promisify(randomInt);
 
@@ -137,16 +137,11 @@ export default class PluginFieldSequenceServer extends Plugin {
             return;
           }
 
-          const [record] = await collection.model.findAll({
-            order: [[autoIncrementField?.name ?? createAtField?.name, 'DESC']],
-            limit: 1,
-          });
-          if (!record) {
-            app.log.warn(`Collection [${collection.name}] has no records. Skipping sequences repair.`);
-            return;
-          }
-
           const sequencesFieldSet = _.uniq<string>(sequencesList.map(({ field }) => field));
+          const primaryKeyFields = fields.filter((field) => field.options.primaryKey);
+          const sortablePrimaryKeyFields = primaryKeyFields.filter(
+            (field) => field.type === 'bigInt' || field.type === 'snowflakeId',
+          );
           for (const sequencesField of sequencesFieldSet) {
             const field = fieldMap[sequencesField];
             app.log.info(
@@ -167,7 +162,99 @@ export default class PluginFieldSequenceServer extends Plugin {
               continue;
             }
 
-            await (field as SequenceField).update(record, { overwrite: true });
+            const selectedFields = _.uniq([
+              field.name,
+              ...primaryKeyFields.map((primaryKeyField) => primaryKeyField.name),
+              ...(createAtField ? [createAtField.name] : []),
+            ]);
+            const latestRecordOrderField = createAtField ?? autoIncrementField;
+            const latestRecordOrder: FindOptions['order'] = [
+              [latestRecordOrderField.name, 'DESC'],
+              ...sortablePrimaryKeyFields
+                .filter((primaryKeyField) => primaryKeyField !== latestRecordOrderField)
+                .map((primaryKeyField): [string, 'DESC'] => [primaryKeyField.name, 'DESC']),
+            ];
+            const latestRecordFilter = {
+              [field.name]: { $ne: null },
+              ...(createAtField ? { [createAtField.name]: { $ne: null } } : {}),
+            };
+            const chunkSize = 1000;
+            const latestRecordQuery: FindOptions = {
+              fields: selectedFields,
+              filter: latestRecordFilter,
+              order: latestRecordOrder,
+            };
+            latestRecordQuery['parseSort'] = false;
+            const [latestCandidate] = await collection.repository.find({ ...latestRecordQuery, limit: 1 });
+            let latestRecord =
+              latestCandidate && field.match(latestCandidate.get(field.name)) ? latestCandidate : undefined;
+            let offset = 1;
+
+            while (!latestRecord && latestCandidate) {
+              const records = await collection.repository.find({
+                ...latestRecordQuery,
+                limit: chunkSize,
+                offset,
+              });
+              latestRecord = records.find((record) => field.match(record.get(field.name)));
+              if (latestRecord || records.length < chunkSize) {
+                break;
+              }
+              offset += chunkSize;
+            }
+
+            if (!latestRecord) {
+              app.log.warn(
+                `Collection [${collection.name}] field [${field.name}] has no valid sequence records. Skipping sequences repair.`,
+              );
+              continue;
+            }
+
+            const state = field.createRepairState();
+            if (!createAtField) {
+              field.collectRepairState(latestRecord, state);
+              await field.saveRepairState(state);
+              continue;
+            }
+
+            const latestCreatedAt = latestRecord.get(createAtField.name);
+            if (!(latestCreatedAt instanceof Date) || Number.isNaN(latestCreatedAt.getTime())) {
+              app.log.warn(
+                `Collection [${collection.name}] field [${field.name}] latest record has an invalid createdAt. Skipping sequences repair.`,
+              );
+              continue;
+            }
+
+            const secondStart = new Date(Math.floor(latestCreatedAt.getTime() / 1000) * 1000);
+            const secondEnd = new Date(secondStart.getTime() + 1000);
+            const latestBatchQuery: FindOptions = {
+              fields: selectedFields,
+              filter: {
+                [field.name]: { $ne: null },
+                [createAtField.name]: {
+                  $gte: secondStart,
+                  $lt: secondEnd,
+                },
+              },
+            };
+            const collectRecords = async (records: Model[]) => {
+              for (const record of records) {
+                field.collectRepairState(record, state, createAtField.name);
+              }
+            };
+
+            if (primaryKeyFields.length && primaryKeyFields.length === sortablePrimaryKeyFields.length) {
+              await collection.repository.chunkWithCursor({
+                ...latestBatchQuery,
+                chunkSize,
+                callback: collectRecords,
+              });
+            } else {
+              latestBatchQuery['parseSort'] = false;
+              await collectRecords(await collection.repository.find(latestBatchQuery));
+            }
+
+            await field.saveRepairState(state);
           }
         });
       }

--- a/packages/plugins/@nocobase/plugin-field-sequence/src/server/__tests__/sequence-field-migration.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/server/__tests__/sequence-field-migration.test.ts
@@ -246,6 +246,7 @@ describe('Should update sequence collection`s current base on business collectio
     it('Should repair when the sequence field is also the primary key', async () => {
       db.collection({
         name: 'tests',
+        autoGenId: false,
         fields: [
           ...presetField.slice(1),
           {

--- a/packages/plugins/@nocobase/plugin-field-sequence/src/server/__tests__/sequence-field-migration.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/server/__tests__/sequence-field-migration.test.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { Database, FieldOptions } from '@nocobase/database';
+import { Database, FieldOptions, Model } from '@nocobase/database';
 import { MockServer, createMockServer } from '@nocobase/test';
 
 describe('Should update sequence collection`s current base on business collections', () => {
@@ -114,6 +114,189 @@ describe('Should update sequence collection`s current base on business collectio
       });
       expect(sequences).toBeDefined();
       expect(sequences.current).toBe(5);
+    });
+
+    it('Should repair to the maximum sequence when records created at the same time are out of sequence order', async () => {
+      db.collection({
+        name: 'tests',
+        fields: [
+          ...presetField,
+          {
+            type: 'sequence',
+            name: 'sequence',
+            inputable: true,
+            patterns: [
+              {
+                type: 'integer',
+                options: {
+                  digits: 4,
+                  start: 1,
+                  cycle: null,
+                  key: 1,
+                },
+              },
+            ],
+          },
+        ],
+      });
+      await db.sync();
+
+      const testModel = db.getModel('tests');
+      const createdAt = new Date('2026-01-01T00:00:00.000Z');
+      const records: Model[] = [];
+      for (const sequence of ['0001', '0003', '0002']) {
+        records.push(
+          await testModel.create({
+            sequence,
+            createdAt,
+          }),
+        );
+      }
+
+      const sequencesRepository = db.getRepository('sequences');
+      const sequences = await sequencesRepository.findOne({
+        filter: {
+          collection: 'tests',
+          field: 'sequence',
+          key: 1,
+        },
+      });
+      expect(sequences).toBeDefined();
+      expect(sequences.current).toBe(3);
+
+      await sequencesRepository.update({
+        filterByTk: sequences.id,
+        values: {
+          current: 0,
+        },
+      });
+
+      await app.runCommand('repair');
+
+      records.push(await testModel.create());
+      const values = records.map((record) => record.get('sequence'));
+      expect(values).toEqual(['0001', '0003', '0002', '0004']);
+      expect(new Set(values).size).toBe(values.length);
+    });
+
+    it('Should use createdAt instead of a string primary key to locate the latest batch', async () => {
+      db.collection({
+        name: 'tests',
+        fields: [
+          {
+            type: 'string',
+            name: 'id',
+            primaryKey: true,
+          },
+          ...presetField.slice(1),
+          {
+            type: 'sequence',
+            name: 'sequence',
+            inputable: true,
+            patterns: [
+              {
+                type: 'integer',
+                options: {
+                  digits: 4,
+                  start: 1,
+                  cycle: null,
+                  key: 1,
+                },
+              },
+            ],
+          },
+        ],
+      });
+      await db.sync();
+
+      const testModel = db.getModel('tests');
+      const previousSecond = new Date('2026-01-01T00:00:00.900Z');
+      const latestSecond = new Date('2026-01-01T00:00:01.100Z');
+      const records = [
+        { id: 'z', sequence: '0001', createdAt: previousSecond },
+        { id: 'a', sequence: '0002', createdAt: latestSecond },
+        { id: 'b', sequence: '0004', createdAt: latestSecond },
+        { id: 'c', sequence: '0003', createdAt: latestSecond },
+      ];
+      for (const values of records) {
+        await testModel.create(values);
+      }
+
+      const sequencesRepository = db.getRepository('sequences');
+      const sequences = await sequencesRepository.findOne({
+        filter: {
+          collection: 'tests',
+          field: 'sequence',
+          key: 1,
+        },
+      });
+      await sequencesRepository.update({
+        filterByTk: sequences.id,
+        values: {
+          current: 0,
+        },
+      });
+
+      await app.runCommand('repair');
+
+      const record = await testModel.create({ id: 'next', createdAt: latestSecond });
+      expect(record.get('sequence')).toBe('0005');
+    });
+
+    it('Should repair when the sequence field is also the primary key', async () => {
+      db.collection({
+        name: 'tests',
+        fields: [
+          ...presetField.slice(1),
+          {
+            type: 'sequence',
+            name: 'sequence',
+            primaryKey: true,
+            inputable: true,
+            patterns: [
+              {
+                type: 'integer',
+                options: {
+                  digits: 4,
+                  start: 1,
+                  cycle: null,
+                  key: 1,
+                },
+              },
+            ],
+          },
+        ],
+      });
+      await db.sync();
+
+      const testModel = db.getModel('tests');
+      const createdAt = new Date('2026-01-01T00:00:00.000Z');
+      for (const sequence of ['0001', '0003', '0002']) {
+        await testModel.create({ sequence, createdAt });
+      }
+
+      const sequencesRepository = db.getRepository('sequences');
+      const sequences = await sequencesRepository.findOne({
+        filter: {
+          collection: 'tests',
+          field: 'sequence',
+          key: 1,
+        },
+      });
+      await sequencesRepository.update({
+        filterByTk: sequences.id,
+        values: {
+          current: 0,
+        },
+      });
+
+      await app.runCommand('repair');
+
+      const repairedSequence = await sequencesRepository.findOne({ filterByTk: sequences.id });
+      expect(repairedSequence.current).toBe(3);
+
+      const record = await testModel.create({ createdAt });
+      expect(record.get('sequence')).toBe('0004');
     });
 
     it('Single integer with cycle in sequences field', async () => {
@@ -376,6 +559,129 @@ describe('Should update sequence collection`s current base on business collectio
         });
         expect(sequences['lastGeneratedAt']).toStrictEqual(record['createdAt']);
       }
+    });
+  });
+
+  describe('Date pattern with daily cycle', () => {
+    beforeEach(async () => {
+      db.collection({
+        name: 'tests',
+        fields: [
+          ...presetField,
+          {
+            type: 'sequence',
+            name: 'sequence',
+            inputable: true,
+            patterns: [
+              {
+                type: 'date',
+                options: {
+                  format: 'YYYYMMDD',
+                },
+              },
+              {
+                type: 'integer',
+                options: {
+                  digits: 4,
+                  start: 1,
+                  cycle: '0 0 * * *',
+                  key: 1,
+                },
+              },
+            ],
+          },
+        ],
+      });
+      await db.sync();
+    });
+
+    it('Should repair from the restarted counter on the next day', async () => {
+      const testModel = db.getModel('tests');
+      const firstDay = new Date('2026-01-01T00:00:00.000Z');
+      const secondDay = new Date('2026-01-02T00:00:00.000Z');
+      const existingRecords = [
+        { sequence: '202601010001', createdAt: firstDay },
+        { sequence: '202601010002', createdAt: firstDay },
+        { sequence: '202601010003', createdAt: firstDay },
+        { sequence: '202601020001', createdAt: secondDay },
+      ];
+      for (const values of existingRecords) {
+        await testModel.create(values);
+      }
+
+      const sequencesRepository = db.getRepository('sequences');
+      const sequences = await sequencesRepository.findOne({
+        filter: {
+          collection: 'tests',
+          field: 'sequence',
+          key: 1,
+        },
+      });
+      expect(sequences).toBeDefined();
+      expect(sequences.current).toBe(1);
+
+      await sequencesRepository.update({
+        filterByTk: sequences.id,
+        values: {
+          current: 0,
+        },
+      });
+
+      await app.runCommand('repair');
+
+      const record = await testModel.create({ createdAt: secondDay });
+      expect(record.get('sequence')).toBe('202601020002');
+    });
+
+    it('Should repair to the maximum sequence in the latest daily cycle when records are out of order', async () => {
+      const testModel = db.getModel('tests');
+      const firstDay = new Date('2026-01-01T00:00:00.000Z');
+      const secondDay = new Date('2026-01-02T00:00:00.000Z');
+      const existingRecords = [
+        { sequence: '202601010001', createdAt: firstDay },
+        { sequence: '202601010002', createdAt: firstDay },
+        { sequence: '202601010003', createdAt: firstDay },
+        { sequence: '202601020001', createdAt: secondDay },
+        { sequence: '202601020003', createdAt: secondDay },
+        { sequence: '202601020002', createdAt: secondDay },
+      ];
+      for (const values of existingRecords) {
+        await testModel.create(values);
+      }
+
+      const sequencesRepository = db.getRepository('sequences');
+      const sequences = await sequencesRepository.findOne({
+        filter: {
+          collection: 'tests',
+          field: 'sequence',
+          key: 1,
+        },
+      });
+      expect(sequences).toBeDefined();
+      expect(sequences.current).toBe(3);
+
+      await sequencesRepository.update({
+        filterByTk: sequences.id,
+        values: {
+          current: 0,
+        },
+      });
+
+      await app.runCommand('repair');
+
+      await testModel.create({ createdAt: secondDay });
+      const records = await testModel.findAll({ order: [['id', 'ASC']] });
+      const values = records.map((record) => record.get('sequence'));
+      expect(values).toEqual([
+        '202601010001',
+        '202601010002',
+        '202601010003',
+        '202601020001',
+        '202601020003',
+        '202601020002',
+        '202601020004',
+      ]);
+      expect(new Set(values).size).toBe(values.length);
     });
   });
 

--- a/packages/plugins/@nocobase/plugin-field-sequence/src/server/fields/sequence-field.ts
+++ b/packages/plugins/@nocobase/plugin-field-sequence/src/server/fields/sequence-field.ts
@@ -73,6 +73,69 @@ function parseBigInt(str, radix = 10) {
   return negative ? -result : result;
 }
 
+export interface IntegerSequenceRepairState {
+  current: bigint;
+  lastGeneratedAt: Date;
+  cycleStart?: Date;
+  cycleEnd?: Date;
+}
+
+export type SequenceRepairState = Map<number, IntegerSequenceRepairState>;
+
+function getCycleBounds(recordTime: Date, cycle: string) {
+  const interval = parser.parseExpression(cycle, { currentDate: recordTime });
+  const previous = interval.prev();
+  const next = interval.next();
+  if (next.getTime() === recordTime.getTime()) {
+    return {
+      cycleStart: new Date(next.getTime()),
+      cycleEnd: new Date(interval.next().getTime()),
+    };
+  }
+  return {
+    cycleStart: new Date(previous.getTime()),
+    cycleEnd: new Date(next.getTime()),
+  };
+}
+
+function mergeSequenceRepairState(
+  state: IntegerSequenceRepairState | undefined,
+  current: bigint,
+  recordTime: Date,
+  cycle?: string,
+): IntegerSequenceRepairState {
+  if (!state) {
+    return {
+      current,
+      lastGeneratedAt: recordTime,
+      ...(cycle ? getCycleBounds(recordTime, cycle) : {}),
+    };
+  }
+
+  if (cycle) {
+    const cycleBounds =
+      state.cycleStart && state.cycleEnd
+        ? { cycleStart: state.cycleStart, cycleEnd: state.cycleEnd }
+        : getCycleBounds(state.lastGeneratedAt, cycle);
+    if (recordTime.getTime() >= cycleBounds.cycleEnd.getTime()) {
+      return {
+        current,
+        lastGeneratedAt: recordTime,
+        ...getCycleBounds(recordTime, cycle),
+      };
+    }
+    if (recordTime.getTime() < cycleBounds.cycleStart.getTime()) {
+      return state;
+    }
+  }
+
+  if (current > state.current) {
+    return { ...state, current, lastGeneratedAt: recordTime };
+  }
+
+  return state;
+}
+
 sequencePatterns.register('string', {
   validate(options) {
     if (!options?.value) {
@@ -518,6 +581,58 @@ export class SequenceField extends Field {
 
   match(value) {
     return typeof value === 'string' ? value.match(this.matcher) : null;
+  }
+
+  createRepairState(): SequenceRepairState {
+    return new Map();
+  }
+
+  collectRepairState(instance: Model, state: SequenceRepairState, createdAtField?: string) {
+    const { name, patterns } = this.options;
+    const matched = this.match(instance.get(name));
+    if (!matched) {
+      return;
+    }
+
+    const recordTime = instance.get(createdAtField ?? 'createdAt') as Date | null;
+    const generatedAt = recordTime ?? new Date();
+    patterns.forEach((pattern, index) => {
+      if (pattern.type !== 'integer') {
+        return;
+      }
+      const { base = 10, cycle, key } = pattern.options;
+      const current = parseBigInt(matched[index + 1], base);
+      state.set(key, mergeSequenceRepairState(state.get(key), current, generatedAt, cycle));
+    });
+  }
+
+  async saveRepairState(state: SequenceRepairState) {
+    const SeqRepo = this.database.getRepository('sequences');
+    for (const [key, values] of state) {
+      const lastSeq = await SeqRepo.findOne({
+        filter: {
+          collection: this.collection.name,
+          field: this.name,
+          key,
+        },
+      });
+      if (lastSeq) {
+        await lastSeq.update({
+          current: values.current,
+          lastGeneratedAt: values.lastGeneratedAt,
+        });
+      } else {
+        await SeqRepo.create({
+          values: {
+            collection: this.collection.name,
+            field: this.name,
+            key,
+            current: values.current,
+            lastGeneratedAt: values.lastGeneratedAt,
+          },
+        });
+      }
+    }
   }
 
   async update(instance: Model, options) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
After migrating application data, sequence repair previously restored the current value from a single latest record. When many records shared the same creation time, the record selected by sorting was not guaranteed to contain the maximum sequence value, so newly created records could receive duplicate automatic sequence values.

### Description 
- Locate the latest valid sequence record by `createdAt`, using only BigInt or NocoBase Snowflake primary keys as secondary chronological sort fields.
- Query records from the latest record's one-second time range and select only the primary key, sequence field, and `createdAt`.
- Aggregate the maximum integer state independently of record order, including date patterns and cyclic counters that restart in a new period.
- Use cursor pagination for BigInt/Snowflake primary keys, while avoiding string or sequence primary keys for chronological ordering and cursor-based repair reads.
- Add regression coverage for same-time out-of-order values, daily cycle rollover, string primary keys, and sequence fields used as primary keys.

The repair intentionally limits aggregation to the latest one-second batch to avoid scanning very large business tables. A `createdAt` index remains recommended for large collections.

Testing suggestions:
- Run the field sequence migration repair tests.
- Verify repair on collections using BigInt, string, Snowflake, and sequence primary keys.
- Verify a daily cyclic sequence continues from the maximum value in the latest cycle.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed duplicate automatic sequence values after migration when multiple records share the latest creation time |
| 🇨🇳 Chinese | 修复数据迁移后多条记录共用最新创建时间时自动编号可能重复的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
