### PR TITLE
feat(plugin-backups): support AI mode portal backups

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupSettings.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupSettings.test.tsx
@@ -31,6 +31,7 @@ function renderBackupSettings() {
       cron: '0 0 * * *',
       keep: 100,
       enableFilesBackup: false,
+      enablePortalsBackup: true,
     },
   });
   app.apiMock.onGet('storages:list').reply(200, { data: [] });
@@ -53,6 +54,13 @@ describe('backup settings', () => {
 
     expect(input).toHaveAttribute('aria-valuemin', '1');
     expect(input).toHaveAttribute('aria-valuemax', String(MAX_BACKUP_KEEP_COUNT));
+  });
+
+  it('shows independent switches for local files and portals', async () => {
+    renderBackupSettings();
+
+    expect(await screen.findByText('Backup local storage files')).toBeInTheDocument();
+    expect(screen.getByText('Backup portals')).toBeInTheDocument();
   });
 
   it('shows the server error when saving fails', async () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupSettings.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupSettings.test.tsx
@@ -60,7 +60,7 @@ describe('backup settings', () => {
     renderBackupSettings();
 
     expect(await screen.findByText('Backup local storage files')).toBeInTheDocument();
-    expect(screen.getByText('Backup portals')).toBeInTheDocument();
+    expect(screen.getByText('Backup AI mode portals')).toBeInTheDocument();
   });
 
   it('shows the server error when saving fails', async () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -252,7 +252,7 @@ const BackupSettings = () => {
           <Switch />
         </Form.Item>
 
-        <Form.Item name="enablePortalsBackup" label={t('Backup portals')} valuePropName="checked">
+        <Form.Item name="enablePortalsBackup" label={t('Backup AI mode portals')} valuePropName="checked">
           <Switch />
         </Form.Item>
 

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/pages/BackupSettings.tsx
@@ -22,6 +22,7 @@ type BackupSettingsValues = {
   keep?: number;
   storageId?: string | number;
   enableFilesBackup?: boolean;
+  enablePortalsBackup?: boolean;
   encryptionPassword?: string;
 };
 
@@ -49,6 +50,7 @@ const DEFAULT_FORM_VALUES: BackupSettingsValues = {
   cron: '0 0 * * *',
   keep: 100,
   enableFilesBackup: false,
+  enablePortalsBackup: true,
 };
 
 type BackupCronProps = Omit<ReactJsCronProps, 'setValue' | 'value'> & {
@@ -247,6 +249,10 @@ const BackupSettings = () => {
         </Form.Item>
 
         <Form.Item name="enableFilesBackup" label={t('Backup local storage files')} valuePropName="checked">
+          <Switch />
+        </Form.Item>
+
+        <Form.Item name="enablePortalsBackup" label={t('Backup portals')} valuePropName="checked">
           <Switch />
         </Form.Item>
 

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
@@ -6,7 +6,7 @@
   "Backing up": "Backing up",
   "Backup list": "Backup list",
   "Backup local storage files": "Backup local storage files",
-  "Backup portals": "Backup portals",
+  "Backup AI mode portals": "Backup AI mode portals",
   "Backup manager": "Backup manager",
   "Click or drag file to this area to upload": "Click or drag file to this area to upload",
   "Confirm the application database schema": "Confirm the application database schema",

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
@@ -6,6 +6,7 @@
   "Backing up": "Backing up",
   "Backup list": "Backup list",
   "Backup local storage files": "Backup local storage files",
+  "Backup portals": "Backup portals",
   "Backup manager": "Backup manager",
   "Click or drag file to this area to upload": "Click or drag file to this area to upload",
   "Confirm the application database schema": "Confirm the application database schema",

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
@@ -6,7 +6,7 @@
   "Backing up": "备份中",
   "Backup list": "备份列表",
   "Backup local storage files": "备份本地存储文件",
-  "Backup portals": "备份 Portal",
+  "Backup AI mode portals": "备份 AI 模式门户",
   "Backup manager": "备份管理器",
   "Click or drag file to this area to upload": "点击或拖拽文件到此区域上传",
   "Confirm the application database schema": "确认应用数据库 Schema",

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
@@ -6,6 +6,7 @@
   "Backing up": "备份中",
   "Backup list": "备份列表",
   "Backup local storage files": "备份本地存储文件",
+  "Backup portals": "备份 Portal",
   "Backup manager": "备份管理器",
   "Click or drag file to this area to upload": "点击或拖拽文件到此区域上传",
   "Confirm the application database schema": "确认应用数据库 Schema",

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/backup-settings.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/backup-settings.test.ts
@@ -36,6 +36,12 @@ describe('backup settings validation', () => {
     expect((await repository.findOne()).get('keep')).toBe(MAX_BACKUP_KEEP_COUNT);
   });
 
+  it('enables portal backups by default', async () => {
+    const settings = await app.db.getRepository(SETTINGS).findOne();
+
+    expect(settings.get('enablePortalsBackup')).toBe(true);
+  });
+
   it.each([0, 1.5, MAX_BACKUP_KEEP_COUNT + 1])('rejects an invalid backup retention value: %s', async (keep) => {
     const repository = app.db.getRepository(SETTINGS);
     const settings = await repository.findOne();

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
@@ -18,6 +18,7 @@ import * as cp from 'child_process';
 import PluginFileManagerServer from '@nocobase/plugin-file-manager';
 import yauzl from 'yauzl';
 import { EventEmitter } from 'events';
+import os from 'os';
 import { Readable, Writable } from 'stream';
 
 vi.mock('child_process', async (importOriginal) => {
@@ -78,6 +79,12 @@ async function listZipEntries(filePath: string) {
   });
 }
 
+class TestBackupManager extends BackupManager {
+  setPortalDir(portalDir: string) {
+    this.portalDir = portalDir;
+  }
+}
+
 describe('BackupManager', async () => {
   let app: MockServer;
   const defaultBackupSettings: BackupSettings = {
@@ -85,6 +92,7 @@ describe('BackupManager', async () => {
     cron: '',
     encryptionPassword: '',
     enableFilesBackup: false,
+    enablePortalsBackup: false,
     keep: 10,
   };
 
@@ -214,6 +222,30 @@ describe('BackupManager', async () => {
         app.db.collections.delete(fileCollection.name);
         await fs.promises.unlink(validFilePath).catch(() => {});
         getRepositorySpy.mockRestore();
+      }
+    });
+
+    it('should back up portals independently from local storage files', async () => {
+      const testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nocobase-backup-portals-'));
+      const portalDir = path.join(testDir, 'portals');
+      const portalFilePath = path.join(portalDir, 'customer', 'dist', 'index.html');
+      const backupManager = new TestBackupManager(app, null, defaultBackupSettings);
+      backupManager.setPortalDir(portalDir);
+
+      try {
+        await fs.promises.mkdir(path.dirname(portalFilePath), { recursive: true });
+        await fs.promises.writeFile(portalFilePath, '<html>customer portal</html>');
+
+        await backupManager.backup(backupFileBaseName, {
+          enableFilesBackup: false,
+          enablePortalsBackup: true,
+        });
+
+        const entries = await listZipEntries(finalBackupFilePath);
+        expect(entries).toContain('portals/customer/dist/index.html');
+        expect(entries.some((entry) => entry.startsWith('uploads/'))).toBe(false);
+      } finally {
+        await fs.promises.rm(testDir, { recursive: true, force: true });
       }
     });
 

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
@@ -20,6 +20,7 @@ import { RestoreManager } from '../../managers/restore';
 import backupCliResource from '../../resourcers/backup-cli';
 import backupsResource from '../../resourcers/backups';
 import { EventEmitter } from 'events';
+import os from 'os';
 import { Readable, Writable } from 'stream';
 
 let mockExecImplementation = (command, _options, callback) => {
@@ -62,7 +63,11 @@ const backupFilesFolder = storagePathJoin('backups', 'main');
 const schemaMismatchBackupFilePath = path.join(backupFilesFolder, `backup_schema_mismatch.${BACKUP_EXTENSION}`);
 const createdBackupFilePaths = new Set<string>();
 
-async function createBackupArchive(filePath: string, metadata: Record<string, any>) {
+async function createBackupArchive(
+  filePath: string,
+  metadata: Record<string, any>,
+  files: Record<string, string> = {},
+) {
   createdBackupFilePaths.add(filePath);
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
   await new Promise<void>((resolve, reject) => {
@@ -77,8 +82,17 @@ async function createBackupArchive(filePath: string, metadata: Record<string, an
     archive.pipe(output);
     archive.append('mocked database backup', { name: 'data' });
     archive.append(JSON.stringify(metadata, null, 2), { name: '_metadata.json' });
+    for (const [name, content] of Object.entries(files)) {
+      archive.append(content, { name });
+    }
     archive.finalize().catch(reject);
   });
+}
+
+class TestRestoreManager extends RestoreManager {
+  setPortalDir(portalDir: string) {
+    this.portalDir = portalDir;
+  }
 }
 
 function createBackupFile(caseName: string) {
@@ -98,6 +112,7 @@ describe('RestoreManager', () => {
     cron: '',
     encryptionPassword: '',
     enableFilesBackup: false,
+    enablePortalsBackup: false,
     keep: 10,
   };
 
@@ -325,6 +340,72 @@ describe('RestoreManager', () => {
     settings = await app.db.getRepository(SETTINGS).findOne();
     // after the restore, the backup encryption should be disabled
     expect(settings.encryptionPassword).toBe('');
+  });
+
+  it('restores portals into the current application directory and removes stale files', async () => {
+    const { backupFilePath } = createBackupFile('restore-portals');
+    const metadata = {
+      ...(await createMetadataCompatibleWithCurrentDb()),
+      enablePortalsBackup: true,
+    };
+    await createBackupArchive(backupFilePath, metadata, {
+      'portals/customer/dist/index.html': '<html>restored portal</html>',
+    });
+    const testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nocobase-restore-portals-'));
+    const portalDir = path.join(testDir, 'target-app');
+    const staleFilePath = path.join(portalDir, 'stale', 'dist', 'index.html');
+    const restoredFilePath = path.join(portalDir, 'customer', 'dist', 'index.html');
+    const restoreManager = new TestRestoreManager(createCtx(), {
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      host: 'localhost',
+      port: 5432,
+      schema: 'source_schema',
+    });
+    restoreManager.setPortalDir(portalDir);
+
+    try {
+      await fs.promises.mkdir(path.dirname(staleFilePath), { recursive: true });
+      await fs.promises.writeFile(staleFilePath, 'stale portal');
+
+      await restoreManager.restoreCLI(backupFilePath, undefined, true, true);
+
+      await expect(fs.promises.readFile(restoredFilePath, 'utf8')).resolves.toBe('<html>restored portal</html>');
+      expect(fs.existsSync(staleFilePath)).toBe(false);
+    } finally {
+      await fs.promises.rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps existing portals when restoring a legacy backup', async () => {
+    const { backupFilePath } = createBackupFile('restore-legacy-portals');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb());
+    const testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nocobase-restore-legacy-portals-'));
+    const portalDir = path.join(testDir, 'target-app');
+    const existingFilePath = path.join(portalDir, 'customer', 'dist', 'index.html');
+    const restoreManager = new TestRestoreManager(createCtx(), {
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      host: 'localhost',
+      port: 5432,
+      schema: 'source_schema',
+    });
+    restoreManager.setPortalDir(portalDir);
+
+    try {
+      await fs.promises.mkdir(path.dirname(existingFilePath), { recursive: true });
+      await fs.promises.writeFile(existingFilePath, 'existing portal');
+
+      await restoreManager.restoreCLI(backupFilePath, undefined, true, true);
+
+      await expect(fs.promises.readFile(existingFilePath, 'utf8')).resolves.toBe('existing portal');
+    } finally {
+      await fs.promises.rm(testDir, { recursive: true, force: true });
+    }
   });
 
   it('restore with tolerentMode', async () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/collections/backup-settings.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/collections/backup-settings.ts
@@ -43,6 +43,11 @@ export default defineCollection({
       name: 'enableFilesBackup',
     },
     {
+      type: 'boolean',
+      name: 'enablePortalsBackup',
+      defaultValue: true,
+    },
+    {
       type: 'belongsTo',
       name: 'storage',
       target: 'storages',

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
@@ -33,12 +33,13 @@ import {
   resolvePathWithinBase,
 } from '../utils';
 
-const BACKUP_METADATA_VERSION = 2;
+const BACKUP_METADATA_VERSION = 3;
 
 export interface BackupSettings {
   storageId?: string | number | null;
   encryptionPassword: string;
   enableFilesBackup: boolean;
+  enablePortalsBackup?: boolean;
   keep?: number;
   scheduled: boolean;
   cron: string;
@@ -85,6 +86,7 @@ export class BackupManager {
   #backupDir: string;
   #tempDir: string;
   #uploadDir: string;
+  #portalDir: string;
   #aesKeyPath: string;
 
   constructor(app: Application, ctx: ResourcerContext | null, settings: BackupSettingsInput) {
@@ -97,6 +99,7 @@ export class BackupManager {
     this.#backupDir = storagePathJoin('backups', app.name);
     this.#tempDir = storagePathJoin('tmp', 'backups', app.name);
     this.#uploadDir = storagePathJoin('uploads');
+    this.#portalDir = storagePathJoin('portals', app.name);
     this.#aesKeyPath = storagePathJoin('apps', app.name, 'aes_key.dat');
   }
 
@@ -116,16 +119,27 @@ export class BackupManager {
     this.#uploadDir = uploadDir;
   }
 
+  protected set portalDir(portalDir: string) {
+    this.#portalDir = portalDir;
+  }
+
   protected set backupTasksCacheName(backupTasksCacheName: string) {
     this.#backupTasksCacheName = backupTasksCacheName;
   }
 
   #normalizeBackupSettings(settings: BackupSettingsInput): BackupSettings {
     if (typeof settings.toJSON === 'function') {
-      return settings.toJSON() as BackupSettings;
+      const values = settings.toJSON() as BackupSettings;
+      return {
+        ...values,
+        enablePortalsBackup: values.enablePortalsBackup ?? true,
+      };
     }
 
-    return { ...settings };
+    return {
+      ...settings,
+      enablePortalsBackup: settings.enablePortalsBackup ?? true,
+    };
   }
 
   async createBackupName() {
@@ -258,6 +272,7 @@ export class BackupManager {
       ...(opts.metadata ?? {}),
       metadataVersion: BACKUP_METADATA_VERSION,
       enableFilesBackup: opts.enableFilesBackup,
+      enablePortalsBackup: opts.enablePortalsBackup,
       version: await this.app.version.get(),
       description: opts.description,
       createdBy: opts.createdBy,
@@ -363,6 +378,10 @@ export class BackupManager {
             }
           }
         }
+      }
+
+      if (opts.enablePortalsBackup && fs.existsSync(this.#portalDir)) {
+        archive.directory(this.#portalDir, 'portals');
       }
 
       // backup the aes key

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/restore.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/restore.ts
@@ -43,6 +43,7 @@ interface Metadata {
     backupClientVersion?: string;
   };
   enableFilesBackup: boolean;
+  enablePortalsBackup?: boolean;
   plugins: Array<{
     name: string;
     version: string;
@@ -70,6 +71,7 @@ export class RestoreManager {
   #backupDir: string;
   #tempDir: string;
   #uploadDir: string;
+  #portalDir: string;
   #aesKeyPath: string;
   constructor(ctx: ResourcerContext, dbOptions?: any) {
     this.ctx = ctx;
@@ -78,6 +80,7 @@ export class RestoreManager {
     this.#backupDir = storagePathJoin('backups', ctx.app.name);
     this.#tempDir = storagePathJoin('tmp', 'backups', ctx.app.name);
     this.#uploadDir = storagePathJoin('uploads');
+    this.#portalDir = storagePathJoin('portals', ctx.app.name);
     this.#aesKeyPath = storagePathJoin('apps', ctx.app.name, 'aes_key.dat');
   }
 
@@ -91,6 +94,10 @@ export class RestoreManager {
 
   protected set uploadDir(uploadDir: string) {
     this.#uploadDir = uploadDir;
+  }
+
+  protected set portalDir(portalDir: string) {
+    this.#portalDir = portalDir;
   }
 
   protected set restoreTasksCacheName(restoreTasksCacheName: string) {
@@ -155,6 +162,7 @@ export class RestoreManager {
         this.ctx.logger.warn('Tolerent mode enabled, ignoring the error and continue the upgrade.', {
           module: BACKUPS,
         });
+        await this.#restorePortals(metadata.enablePortalsBackup === true, extractedDir);
         await this.#restoreFilesAndCleanup(uploadsExist, extractedDir);
         // await sleep(5000); // wait for the client to show the error message, for debug
         await this.ctx.app.upgrade();
@@ -200,6 +208,7 @@ export class RestoreManager {
       });
       this.ctx.logger.info('Database restored successfully', { module: BACKUPS });
       // copy the uploads directory
+      await this.#restorePortals(metadata.enablePortalsBackup === true, extractedDir);
       await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
     } catch (error) {
       this.ctx.logger.error(`Error restoring backup: ${error.message}. Trying to revert the backup process`, {
@@ -258,6 +267,7 @@ export class RestoreManager {
           this.ctx.logger.warn('Tolerent mode enabled, ignoring the error and continue the upgrade.', {
             module: BACKUPS,
           });
+          await this.#restorePortals(metadata.enablePortalsBackup === true, extractedDir);
           await this.#restoreFilesAndCleanup(uploadsExist, extractedDir);
           // await sleep(5000); // wait for the client to show the error message, for debug
           await this.ctx.app.runCommand('upgrade');
@@ -511,6 +521,7 @@ export class RestoreManager {
       if (restoreUploads) {
         this.#notify(RESTORE_STEPS.UPLOADS);
       }
+      await this.#restorePortals(metadata.enablePortalsBackup === true, extractedDir);
       await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
     } catch (error) {
       await statusCache.set(taskId, {
@@ -528,6 +539,18 @@ export class RestoreManager {
       inProgress: false,
     });
     await this.ctx.app.runCommand('upgrade');
+  }
+
+  async #restorePortals(restorePortals: boolean, extractedDir: string) {
+    if (!restorePortals) {
+      return;
+    }
+
+    const portalsDir = path.join(extractedDir, 'portals');
+    await fs.rm(this.#portalDir, { recursive: true, force: true });
+    if (await fs.pathExists(portalsDir)) {
+      await fs.copy(portalsDir, this.#portalDir, { overwrite: true });
+    }
   }
 
   async #restoreFilesAndCleanup(restoreUploads: boolean, extractedDir: string) {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/plugin.ts
@@ -33,6 +33,7 @@ const DEFAULT_SETTINGS = {
     cron: '0 0 * * *',
     keep: 100,
     enableFilesBackup: true,
+    enablePortalsBackup: true,
     storageId: null,
     encryptionPassword: '',
   } satisfies BackupSettings,
@@ -203,6 +204,7 @@ export class PluginBackupsServer extends Plugin {
       cron: null,
       encryptionPassword: null,
       enableFilesBackup: false,
+      enablePortalsBackup: false,
       keep: 0,
     });
     const fileBaseName = await backupManager.createBackupName();


### PR DESCRIPTION
### This is a ...
- [x] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

AI mode portal source and deployment files are stored outside the database and local upload storage, so existing backups cannot fully restore an application that uses AI mode portals.

### Description 

- Add an independent setting for AI mode portal backups, enabled by default
- Back up the current application's AI mode portal directory without coupling it to local upload backups
- Restore AI mode portal files into the target application's storage directory and remove stale files
- Keep existing AI mode portal files unchanged when restoring older backups without portal metadata
- Add server and client tests for backup settings, archive contents, restore behavior, and backward compatibility

Restoring a backup that explicitly contains AI mode portal data replaces the target application's current portal directory.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added backup and restore support for AI mode portals with an independent setting |
| 🇨🇳 Chinese | 新增 AI 模式门户备份与恢复支持，并提供独立设置 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
