### PR TITLE
fix(plugin-workflow-javascript): close worker lifecycle gaps

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/QuickJs.js
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/QuickJs.js
@@ -127,7 +127,7 @@ async function main() {
       // The async IIFE body is queued as a microtask; drain until the promise
       // settles. Only native QuickJS promises are reachable from user code, so
       // iterating executePendingJobs is sufficient.
-      while (true) {
+      for (;;) {
         const state = context.getPromiseState(promiseHandle);
         if (state.type === 'fulfilled') {
           const valueHandle = state.value;
@@ -160,9 +160,18 @@ async function main() {
   }
 }
 
+function flushOutput() {
+  const flush = (stream) =>
+    new Promise((resolve, reject) => {
+      stream.write('', (error) => (error ? reject(error) : resolve()));
+    });
+  return Promise.all([flush(process.stdout), flush(process.stderr)]);
+}
+
 // eslint-disable-next-line promise/catch-or-return
 main()
-  .then((result) => {
+  .then(async (result) => {
+    await flushOutput();
     parentPort.postMessage({ type: 'result', result });
   })
   .catch((error) => {

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts
@@ -30,6 +30,16 @@ type ScriptConfig = { content?: string; timeout?: number; continue?: boolean; ar
 
 type ScriptArguments = Record<string, unknown> | unknown[];
 
+type WorkerOutcome =
+  | { type: 'result'; result: unknown }
+  | { type: 'error'; error: Error }
+  | { type: 'exit'; code: number }
+  | { type: 'aborted' };
+
+function isWorkerResult(message: unknown): message is { type: 'result'; result: unknown } {
+  return typeof message === 'object' && message !== null && 'type' in message && message.type === 'result';
+}
+
 export default class ScriptInstruction extends Instruction {
   /**
    * Returns the worker script path based on whether WORKFLOW_SCRIPT_MODULES is configured.
@@ -47,21 +57,9 @@ export default class ScriptInstruction extends Instruction {
     options: { logger: Logger; timeout?: number; signal?: AbortSignal },
   ) {
     const { logger, timeout, signal } = options;
-    let result: unknown;
 
     const worker = new Worker(this.workerScript, {
       workerData: { source, args, options: timeout ? { timeout } : {} },
-    });
-
-    const abortListener = () => {
-      worker.terminate();
-    };
-    signal?.addEventListener('abort', abortListener, { once: true });
-
-    worker.on('message', (message) => {
-      if (message.type === 'result') {
-        result = message.result;
-      }
     });
 
     worker.stdout.on('data', (data) => {
@@ -71,31 +69,47 @@ export default class ScriptInstruction extends Instruction {
       logger.error(data.toString());
     });
 
-    const excution = new Promise((resolve, reject) => {
-      worker.on('error', (error) => {
-        reject(error);
-      });
+    const outputClosed = Promise.all([once(worker.stdout, 'close'), once(worker.stderr, 'close')]);
+    const outcomePromise = new Promise<WorkerOutcome>((resolve) => {
+      const finish = (outcome: WorkerOutcome) => {
+        worker.removeListener('message', messageListener);
+        worker.removeListener('error', errorListener);
+        worker.removeListener('exit', exitListener);
+        signal?.removeEventListener('abort', abortListener);
+        resolve(outcome);
+      };
+      const messageListener = (message: unknown) => {
+        if (isWorkerResult(message)) {
+          finish({ type: 'result', result: message.result });
+        }
+      };
+      const errorListener = (error: Error) => {
+        finish({ type: 'error', error });
+      };
+      const exitListener = (code: number) => {
+        finish({ type: 'exit', code });
+      };
+      const abortListener = () => {
+        finish({ type: 'aborted' });
+      };
 
-      const stdoutPromise = once(worker.stdout, 'close');
-      const stderrPromise = once(worker.stderr, 'close');
-
-      worker.on('exit', (code) => {
-        Promise.all([stdoutPromise, stderrPromise])
-          .then(() => {
-            if (code !== 0) {
-              reject(new Error(`Worker stopped with exit code ${code}`));
-            }
-            resolve(result);
-          })
-          .catch(reject);
-      });
+      worker.on('message', messageListener);
+      worker.once('error', errorListener);
+      worker.once('exit', exitListener);
+      signal?.addEventListener('abort', abortListener, { once: true });
+      if (signal?.aborted) {
+        abortListener();
+      }
     });
 
+    const outcome = await outcomePromise;
     try {
-      await excution;
+      if (outcome.type !== 'exit') {
+        await worker.terminate();
+      }
+      await outputClosed;
     } catch (e) {
-      signal?.removeEventListener('abort', abortListener);
-      if (signal?.aborted) {
+      if (outcome.type === 'aborted' || signal?.aborted) {
         throw signal.reason instanceof Error ? signal.reason : new WorkflowTimeoutError();
       }
       return {
@@ -104,11 +118,27 @@ export default class ScriptInstruction extends Instruction {
       };
     }
 
-    signal?.removeEventListener('abort', abortListener);
+    if (outcome.type === 'aborted') {
+      throw signal?.reason instanceof Error ? signal.reason : new WorkflowTimeoutError();
+    }
+
+    if (outcome.type === 'error') {
+      return {
+        status: JOB_STATUS.ERROR,
+        result: outcome.error.message,
+      };
+    }
+
+    if (outcome.type === 'exit' && outcome.code !== 0) {
+      return {
+        status: JOB_STATUS.ERROR,
+        result: `Worker stopped with exit code ${outcome.code}`,
+      };
+    }
 
     return {
       status: JOB_STATUS.RESOLVED,
-      result,
+      result: outcome.type === 'result' ? outcome.result : undefined,
     };
   }
 
@@ -167,7 +197,13 @@ export default class ScriptInstruction extends Instruction {
 
     processor.logger.info(`script (#${node.id}) has been started, waiting for response...`);
 
-    await processor.exit();
+    const abortHandle = processor.createBackgroundAbortHandle();
+    try {
+      await processor.exit();
+    } catch (error) {
+      abortHandle.dispose();
+      throw error;
+    }
 
     const jobResult: IJob = {
       status: JOB_STATUS.PENDING,
@@ -175,7 +211,7 @@ export default class ScriptInstruction extends Instruction {
 
     // eslint-disable-next-line promise/catch-or-return
     (this.constructor as typeof ScriptInstruction)
-      .run(content, _args, { timeout, logger: processor.logger, signal: options?.signal })
+      .run(content, _args, { timeout, logger: processor.logger, signal: abortHandle.signal })
       .then((res) => {
         if (res.status === JOB_STATUS.RESOLVED) {
           processor.logger.info(`script (#${node.id}) get result success`);
@@ -205,6 +241,7 @@ export default class ScriptInstruction extends Instruction {
         jobResult.result = message;
       })
       .finally(() => {
+        abortHandle.dispose();
         processor.logger.debug(`script (#${node.id}) ended, resume workflow...`);
         setImmediate(async () => {
           const job = await this.workflow.db.getRepository('jobs').findOne({ filterByTk: id });

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/Vm.js
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/Vm.js
@@ -133,9 +133,18 @@ async function main() {
   return result;
 }
 
+function flushOutput() {
+  const flush = (stream) =>
+    new Promise((resolve, reject) => {
+      stream.write('', (error) => (error ? reject(error) : resolve()));
+    });
+  return Promise.all([flush(process.stdout), flush(process.stderr)]);
+}
+
 // eslint-disable-next-line promise/catch-or-return
 main()
-  .then((result) => {
+  .then(async (result) => {
+    await flushOutput();
     parentPort.postMessage({ type: 'result', result });
     // NOTE: due to `process.exit()` will break stdout, it should not be called
     // see: https://nodejs.org/api/process.html#processexitcode

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts
@@ -14,6 +14,7 @@ import { Application } from '@nocobase/server';
 import Database from '@nocobase/database';
 import { getApp, sleep } from '@nocobase/plugin-workflow-test';
 import { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
+import { vi } from 'vitest';
 import winston from 'winston';
 import { CacheTransport } from '../cache-logger';
 import ScriptInstruction from '../ScriptInstruction';
@@ -248,6 +249,87 @@ describe('workflow > instructions > script', () => {
 
       expect(result.status).toBe(JOB_STATUS.RESOLVED);
       expect(result.result).toBe(180);
+    });
+
+    it('should finish after returning a result when the script leaves an active handle', async () => {
+      const controller = new AbortController();
+      const script = `
+        const { setInterval } = require('node:timers');
+        setInterval(() => {}, 1000);
+        return 'finished';
+      `;
+      const runPromise = ScriptInstruction.run(script, [], {
+        logger,
+        timeout: 200,
+        signal: controller.signal,
+      });
+
+      try {
+        const result = await Promise.race([runPromise, sleep(1000).then(() => null)]);
+
+        expect(result).not.toBeNull();
+        expect(result?.status).toBe(JOB_STATUS.RESOLVED);
+        expect(result?.result).toBe('finished');
+      } finally {
+        controller.abort();
+        await runPromise.catch(() => undefined);
+      }
+    });
+
+    it('should abort a background script when an async workflow times out', async () => {
+      let backgroundSignal: AbortSignal | undefined;
+      const runSpy = vi.spyOn(ScriptInstruction, 'run').mockImplementation((_source, _args, options) => {
+        backgroundSignal = options.signal;
+        return new Promise((resolve) => {
+          const abort = () => resolve({ status: JOB_STATUS.ERROR, result: 'aborted' });
+          options.signal?.addEventListener('abort', abort, { once: true });
+          if (options.signal?.aborted) {
+            abort();
+          }
+        });
+      });
+
+      try {
+        await workflow.update({ sync: false, options: { timeout: 100 } });
+        await workflow.createNode({
+          type: 'script',
+          config: { content: 'return new Promise(() => {});' },
+        });
+
+        await PostRepo.create({ values: { title: 'post' } });
+
+        let execution;
+        for (let i = 0; i < 20; i++) {
+          [execution] = await workflow.getExecutions();
+          if (execution?.status === EXECUTION_STATUS.ABORTED) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        expect(execution?.status).toBe(EXECUTION_STATUS.ABORTED);
+        expect(backgroundSignal?.aborted).toBe(true);
+      } finally {
+        runSpy.mockRestore();
+      }
+    });
+
+    it('should terminate the Worker when its signal is aborted', async () => {
+      const controller = new AbortController();
+      const abortError = new Error('workflow aborted');
+      const script = `
+        const { setInterval } = require('node:timers');
+        setInterval(() => {}, 1000);
+        return new Promise(() => {});
+      `;
+      const runPromise = ScriptInstruction.run(script, [], {
+        logger,
+        signal: controller.signal,
+      });
+
+      setTimeout(() => controller.abort(abortError), 50);
+
+      await expect(runPromise).rejects.toBe(abortError);
     });
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The JavaScript workflow instruction waited for a Worker to exit naturally even after receiving a script result. If the script left an active handle such as a timer or socket, the Worker stayed alive indefinitely because the node-level timeout had already been cleared. Asynchronous workflows also lost their effective abort signal after the processor exited, so a workflow-level timeout did not terminate the background Worker.

### Description 

- Treat the first Worker result, error, exit, or abort event as the terminal outcome and explicitly terminate the Worker after receiving a result.
- Flush Worker stdout and stderr before publishing the result so forced termination does not truncate script logs.
- Keep a background abort handle for asynchronous JavaScript nodes so workflow-level timeouts remain effective after the processor exits.
- Add regression coverage for active handles after script completion, asynchronous workflow timeout propagation, and explicit signal aborts.

Potential risk: Worker shutdown timing changes after successful script completion. Existing logging, script timeout, module loading, and QuickJS security tests cover the affected paths.

Testing suggestions: run JavaScript nodes that return while leaving an active timer, and run an asynchronous workflow with a short workflow timeout and a non-settling JavaScript node.

### Related issues

N/A

### Showcase

N/A (server-side lifecycle fix)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed JavaScript workflow Workers not exiting after scripts returned or asynchronous workflows timed out |
| 🇨🇳 Chinese | 修复 JavaScript 工作流节点在脚本返回或异步工作流超时后 Worker 不退出的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
