### PR TITLE
fix(workflow): parse auto revision parameter

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/workflows.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/actions/workflows.test.ts
@@ -202,6 +202,56 @@ describe('workflow > actions > workflows', () => {
     });
   });
 
+  describe('execute', () => {
+    it('does not create a revision when autoRevision is string zero', async () => {
+      const workflow = await WorkflowModel.create({
+        type: 'collection',
+        sync: true,
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+      const post = await PostRepo.create({ values: { title: 't1' } });
+
+      const { body, status } = await agent.resource('workflows').execute({
+        filterByTk: workflow.id,
+        autoRevision: '0',
+        values: {
+          data: post.toJSON(),
+        },
+      });
+
+      expect(status).toBe(200);
+      expect(body.data).not.toHaveProperty('newVersionId');
+      await expect(WorkflowRepo.count({ filter: { key: workflow.key } })).resolves.toBe(1);
+    });
+
+    it('creates a revision when autoRevision is string one', async () => {
+      const workflow = await WorkflowModel.create({
+        type: 'collection',
+        sync: true,
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+      const post = await PostRepo.create({ values: { title: 't1' } });
+
+      const { body, status } = await agent.resource('workflows').execute({
+        filterByTk: workflow.id,
+        autoRevision: '1',
+        values: {
+          data: post.toJSON(),
+        },
+      });
+
+      expect(status).toBe(200);
+      expect(body.data.newVersionId).toBeDefined();
+      await expect(WorkflowRepo.count({ filter: { key: workflow.key } })).resolves.toBe(2);
+    });
+  });
+
   describe('destroy', () => {
     it('cascading destroy all revisions, nodes, but not executions and jobs', async () => {
       const workflow = await WorkflowModel.create({

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/actions/workflows.ts
@@ -201,7 +201,7 @@ export async function execute(context: Context, next) {
     filter: { key: workflow.key },
   });
   let newVersion;
-  if (executed == 0 && autoRevision) {
+  if (executed === 0 && Number(autoRevision) === 1) {
     newVersion = await repository.revision({
       filterByTk: workflow.id,
       filter: { key: workflow.key },


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Workflow execute query parameters arrive as strings. The previous truthy check treated `autoRevision=0` as enabled and created an unexpected workflow revision.

### Description

- Convert `autoRevision` to a number and trigger revision creation only when its value is exactly `1`.
- Add action tests proving that string `"0"` does not create a revision and string `"1"` does.
- Risk is limited to the automatic-revision gate of manual workflow execution.

Testing suggestion: execute an unexecuted workflow once with `autoRevision=0` and once with `autoRevision=1`, then compare the number of versions sharing its workflow key.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where manually executing a workflow with `autoRevision=0` could still create a new revision. |
| 🇨🇳 Chinese | 修复手动执行工作流时传入 `autoRevision=0` 仍可能创建新版本的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
