### PR TITLE
fix: portal cli and multi portal

### DIFF
--- a/packages/core/cli/src/__tests__/portal-configure.test.ts
+++ b/packages/core/cli/src/__tests__/portal-configure.test.ts
@@ -83,7 +83,7 @@ test('updates local Portal config and syncs remote options when the remote recor
     }
 
     expect(options.operation.pathTemplate).toBe('/multiPortals:update');
-    expect(options.flags.filterByTk).toBe('customer');
+    expect(options.flags.filter).toEqual({ portalName: 'customer' });
     expect(JSON.parse(String(options.flags.body))).toEqual({
       options: {
         sourceRevision: 'rev0',

--- a/packages/core/cli/src/__tests__/portal-create.test.ts
+++ b/packages/core/cli/src/__tests__/portal-create.test.ts
@@ -12,6 +12,7 @@ import os from 'node:os';
 import path from 'node:path';
 import * as tar from 'tar';
 import { afterEach, expect, test, vi } from 'vitest';
+import type { RequestOptions } from '../lib/api-client.js';
 import {
   buildPortalBasePath,
   createPortalWorkspace,
@@ -255,6 +256,47 @@ test('creates a portal with frozen pnpm install when the template includes a loc
     envMode: 'replace',
     errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
   });
+});
+
+test('creates a custom-domain sub-app portal with a root portal base', async () => {
+  const storagePath = await makeTempDir('nocobase-cli-portal-create-storage-');
+  const templatePath = await makeTempDir('nocobase-cli-portal-create-template-');
+  const runCommand = vi.fn().mockResolvedValue(undefined);
+  const apiRequest = vi.fn(async (options: RequestOptions) => {
+    if (options.operation.pathTemplate === '/app:getInfo') {
+      return { ok: true, status: 200, data: { data: { name: 'demo6' } } };
+    }
+    return { ok: true, status: 200, data: { data: { uid: 'crm' } } };
+  });
+  await writeTemplate(templatePath);
+
+  await expect(
+    createPortalWorkspace({
+      portal: 'crm',
+      template: templatePath,
+      envName: 'prod',
+      env: createEnv({
+        kind: 'http',
+        storagePath,
+        apiBaseUrl: 'https://demo6.v11.demo.nocobase.com/api',
+      }),
+      runCommand,
+      apiRequest,
+    }),
+  ).resolves.toMatchObject({
+    app: 'demo6',
+    portal: 'crm',
+    portalDir: path.join(storagePath, 'portals', 'demo6', 'crm'),
+    portalBase: '/x/crm/',
+  });
+
+  const portalDir = path.join(storagePath, 'portals', 'demo6', 'crm');
+  expect(await fsp.readFile(path.join(portalDir, '.env'), 'utf-8')).toBe(
+    'NOCOBASE_API_URL=/api\nNOCOBASE_PORTAL_BASE=/x/crm/\n',
+  );
+  expect(await fsp.readFile(path.join(portalDir, '.env.local'), 'utf-8')).toBe(
+    'NOCOBASE_API_URL=https://demo6.v11.demo.nocobase.com/api\nNOCOBASE_PORTAL_BASE=/x/crm/\n',
+  );
 });
 
 test('creates a portal even when pnpm install fails', async () => {

--- a/packages/core/cli/src/__tests__/portal-create.test.ts
+++ b/packages/core/cli/src/__tests__/portal-create.test.ts
@@ -55,6 +55,18 @@ async function writeTemplate(
   }
   await fsp.mkdir(path.join(templateDir, 'src'), { recursive: true });
   await fsp.writeFile(path.join(templateDir, 'src', 'index.tsx'), 'export default null;\n');
+  await fsp.mkdir(path.join(templateDir, 'scripts'), { recursive: true });
+  await fsp.writeFile(
+    path.join(templateDir, 'scripts', 'build-html.mjs'),
+    [
+      'const getEnvFilesForMode = (mode) => {',
+      '  return [".env", ".env.local", `.env.${mode}`, `.env.${mode}.local`].map(',
+      '    (file) => path.join(rootDir, file)',
+      '  );',
+      '};',
+      '',
+    ].join('\n'),
+  );
   await fsp.mkdir(path.join(templateDir, '.git'), { recursive: true });
   await fsp.writeFile(path.join(templateDir, '.git', 'HEAD'), 'ref: refs/heads/main\n');
   await fsp.mkdir(path.join(templateDir, 'node_modules', 'stale'), { recursive: true });
@@ -189,6 +201,8 @@ test('creates a portal from a local template', async () => {
     apiBaseUrl: 'http://localhost:13000/console/api/__app/crm',
     portalBase: '/console/x/apps/crm/customer/',
     installSkipped: false,
+    dependenciesInstalled: true,
+    installFailed: false,
   });
   await expect(fsp.access(path.join(portalDir, 'src', 'index.tsx'))).resolves.toBe(undefined);
   await expect(fsp.access(path.join(portalDir, '.git'))).rejects.toThrow();
@@ -204,14 +218,17 @@ test('creates a portal from a local template', async () => {
     'NOCOBASE_API_URL=http://localhost:13000/console/api/__app/crm\n' +
       'NOCOBASE_PORTAL_BASE=/console/x/apps/crm/customer/\n',
   );
+  const buildHtmlScript = await fsp.readFile(path.join(portalDir, 'scripts', 'build-html.mjs'), 'utf-8');
+  expect(buildHtmlScript).toContain('return [".env"].map((file) => path.join(rootDir, file));');
+  expect(buildHtmlScript).not.toContain('.env.local');
   expect(JSON.parse(await fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8'))).toEqual({
     sourceStorage: 'nocobase',
   });
-  expect(runCommand).toHaveBeenCalledWith('pnpm', ['install', '--no-frozen-lockfile', '--trust-lockfile'], {
+  expect(runCommand).toHaveBeenCalledWith('pnpm', ['install'], {
     cwd: portalDir,
     env: expect.any(Object),
     envMode: 'replace',
-    errorName: 'pnpm install --no-frozen-lockfile --trust-lockfile',
+    errorName: 'pnpm install',
   });
   expect(runCommand.mock.calls[0]?.[2]?.env).not.toHaveProperty('NOCOBASE_API_URL');
   expect(runCommand.mock.calls[0]?.[2]?.env).not.toHaveProperty('NOCOBASE_PORTAL_BASE');
@@ -238,6 +255,32 @@ test('creates a portal with frozen pnpm install when the template includes a loc
     envMode: 'replace',
     errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
   });
+});
+
+test('creates a portal even when pnpm install fails', async () => {
+  const storagePath = await makeTempDir('nocobase-cli-portal-create-storage-');
+  const templatePath = await makeTempDir('nocobase-cli-portal-create-template-');
+  const runCommand = vi.fn(async () => {
+    throw new Error('pnpm install exited with code 1');
+  });
+  await writeTemplate(templatePath);
+
+  await expect(
+    createPortalWorkspace({
+      portal: 'customer',
+      template: templatePath,
+      env: createEnv({ storagePath }),
+      runCommand,
+    }),
+  ).resolves.toMatchObject({
+    portal: 'customer',
+    installSkipped: false,
+    dependenciesInstalled: false,
+    installFailed: true,
+  });
+
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
+  await expect(fsp.access(path.join(portalDir, 'src', 'index.tsx'))).resolves.toBe(undefined);
 });
 
 test('skips pnpm install when package.json is missing', async () => {
@@ -308,12 +351,12 @@ test('downloads npm package templates with npm pack when not installed locally',
   expect(runCommand).toHaveBeenNthCalledWith(
     2,
     'pnpm',
-    ['install', '--no-frozen-lockfile', '--trust-lockfile'],
+    ['install'],
     expect.objectContaining({
       cwd: portalDir,
       env: expect.any(Object),
       envMode: 'replace',
-      errorName: 'pnpm install --no-frozen-lockfile --trust-lockfile',
+      errorName: 'pnpm install',
     }),
   );
 });

--- a/packages/core/cli/src/__tests__/portal-deploy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-deploy.test.ts
@@ -487,7 +487,7 @@ test('http deploy uses root portal base for custom-domain sub-apps', async () =>
       flags: expect.objectContaining({
         app: 'demo6',
         portal: 'crm',
-        basePath: '/x/crm/',
+        basePath: '/x/apps/demo6/crm/',
       }),
     }),
   );

--- a/packages/core/cli/src/__tests__/portal-deploy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-deploy.test.ts
@@ -73,6 +73,18 @@ async function preparePortalWorkspace(params: {
   await fsp.mkdir(path.join(portalDir, 'src'), { recursive: true });
   await fsp.writeFile(path.join(portalDir, 'package.json'), '{"name":"portal"}\n');
   await fsp.writeFile(path.join(portalDir, 'portal.config.json'), '{\n  "sourceStorage": "nocobase"\n}\n');
+  await fsp.mkdir(path.join(portalDir, 'scripts'), { recursive: true });
+  await fsp.writeFile(
+    path.join(portalDir, 'scripts', 'build-html.mjs'),
+    [
+      'const getEnvFilesForMode = (mode) => {',
+      '  return [".env", ".env.local", `.env.${mode}`, `.env.${mode}.local`].map(',
+      '    (file) => path.join(rootDir, file)',
+      '  );',
+      '};',
+      '',
+    ].join('\n'),
+  );
   if (params.envContent !== undefined) {
     await fsp.writeFile(path.join(portalDir, '.env'), params.envContent);
   }
@@ -169,11 +181,11 @@ test('updates env files, builds, and syncs the portal record locally without upl
     recordSynced: true,
   });
 
-  expect(runCommand).toHaveBeenNthCalledWith(1, 'pnpm', ['install', '--frozen-lockfile', '--trust-lockfile'], {
+  expect(runCommand).toHaveBeenNthCalledWith(1, 'pnpm', ['install'], {
     cwd: portalDir,
     env: expect.any(Object),
     envMode: 'replace',
-    errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+    errorName: 'pnpm install',
   });
   expect(runCommand).toHaveBeenNthCalledWith(2, 'pnpm', ['build'], {
     cwd: portalDir,
@@ -186,13 +198,12 @@ test('updates env files, builds, and syncs the portal record locally without upl
   });
   expect(runCommand).toHaveBeenNthCalledWith(3, 'pnpm', ['build:html'], {
     cwd: portalDir,
-    env: expect.objectContaining({
-      NOCOBASE_API_URL: 'http://localhost:13000/console/api/__app/crm',
-      NOCOBASE_PORTAL_BASE: '/console/x/apps/crm/customer/',
-    }),
+    env: expect.any(Object),
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });
+  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_API_URL');
+  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_PORTAL_BASE');
   expect(apiRequest).toHaveBeenCalledTimes(1);
   expectPortalRecordFirstOrCreate(apiRequest.mock.calls[0][0]);
   expect(await fsp.readFile(path.join(portalDir, '.env'), 'utf-8')).toBe(
@@ -203,6 +214,9 @@ test('updates env files, builds, and syncs the portal record locally without upl
       'LOCAL_ONLY=true\n' +
       'NOCOBASE_API_URL=http://localhost:13000/console/api/__app/crm\n',
   );
+  const buildHtmlScript = await fsp.readFile(path.join(portalDir, 'scripts', 'build-html.mjs'), 'utf-8');
+  expect(buildHtmlScript).toContain('return [".env"].map((file) => path.join(rootDir, file));');
+  expect(buildHtmlScript).not.toContain('.env.local');
   expectPosixMode((await fsp.stat(path.join(storagePath, 'portals'))).mode, 0o755);
   expectPosixMode((await fsp.stat(path.join(storagePath, 'portals', 'crm'))).mode, 0o755);
   expectPosixMode((await fsp.stat(portalDir)).mode, 0o755);
@@ -252,15 +266,15 @@ test('deploy reports a clear error when pnpm is not installed', async () => {
       apiRequest,
     }),
   ).rejects.toThrow(
-    "Couldn't run `pnpm install --frozen-lockfile --trust-lockfile` because the pnpm executable could not be found. Install pnpm or update `nb config set bin.pnpm <path>` and try again.",
+    "Couldn't run `pnpm install` because the pnpm executable could not be found. Install pnpm or update `nb config set bin.pnpm <path>` and try again.",
   );
 
   expect(runCommand).toHaveBeenCalledTimes(1);
   expect(runCommand).toHaveBeenCalledWith(
     'pnpm',
-    ['install', '--frozen-lockfile', '--trust-lockfile'],
+    ['install'],
     expect.objectContaining({
-      errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+      errorName: 'pnpm install',
     }),
   );
   expect(apiRequest).not.toHaveBeenCalled();
@@ -351,11 +365,11 @@ test('http deploy builds, packs dist, and uploads it', async () => {
     }),
   );
   expectPortalRecordFirstOrCreate(apiRequest.mock.calls[2][0]);
-  expect(runCommand).toHaveBeenNthCalledWith(1, 'pnpm', ['install', '--frozen-lockfile', '--trust-lockfile'], {
+  expect(runCommand).toHaveBeenNthCalledWith(1, 'pnpm', ['install'], {
     cwd: portalDir,
     env: expect.any(Object),
     envMode: 'replace',
-    errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+    errorName: 'pnpm install',
   });
   expect(runCommand).toHaveBeenNthCalledWith(2, 'pnpm', ['build'], {
     cwd: portalDir,
@@ -368,13 +382,12 @@ test('http deploy builds, packs dist, and uploads it', async () => {
   });
   expect(runCommand).toHaveBeenNthCalledWith(3, 'pnpm', ['build:html'], {
     cwd: portalDir,
-    env: expect.objectContaining({
-      NOCOBASE_API_URL: 'https://example.com/console/api/__app/crm',
-      NOCOBASE_PORTAL_BASE: '/console/x/apps/crm/customer/',
-    }),
+    env: expect.any(Object),
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });
+  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_API_URL');
+  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_PORTAL_BASE');
 });
 
 test('http deploy uses env source storage when no local storagePath is configured', async () => {

--- a/packages/core/cli/src/__tests__/portal-deploy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-deploy.test.ts
@@ -442,6 +442,72 @@ test('http deploy uses env source storage when no local storagePath is configure
   }
 });
 
+test('http deploy uses root portal base for custom-domain sub-apps', async () => {
+  const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
+  const portalDir = await preparePortalWorkspace({
+    storagePath,
+    app: 'demo6',
+    portal: 'crm',
+  });
+  const runCommand = vi.fn(async (_name: string, _args: string[], options?: PortalDeployRunOptions) => {
+    await fsp.mkdir(path.join(String(options?.cwd), 'dist'), { recursive: true });
+    await fsp.writeFile(path.join(String(options?.cwd), 'dist', 'index.html'), '<div id="root"></div>');
+  });
+  const apiRequest = vi.fn(async (options: RequestOptions) => {
+    if (options.operation.pathTemplate === '/app:getInfo') {
+      return { ok: true, status: 200, data: appInfoData('demo6') };
+    }
+    return { ok: true, status: 200, data: { data: { uid: 'crm', distPath: 'portals/demo6/crm/dist' } } };
+  });
+
+  await expect(
+    deployPortalWorkspace({
+      portal: 'crm',
+      envName: 'prod',
+      env: createEnv({
+        kind: 'http',
+        storagePath,
+        apiBaseUrl: 'https://demo6.v11.demo.nocobase.com/api',
+      }),
+      runCommand,
+      apiRequest,
+    }),
+  ).resolves.toMatchObject({
+    app: 'demo6',
+    portal: 'crm',
+    portalDir,
+    portalBase: '/x/crm/',
+    uploaded: true,
+    serverDistPath: 'portals/demo6/crm/dist',
+  });
+
+  expect(apiRequest).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      flags: expect.objectContaining({
+        app: 'demo6',
+        portal: 'crm',
+        basePath: '/x/crm/',
+      }),
+    }),
+  );
+  expect(runCommand).toHaveBeenNthCalledWith(3, 'pnpm', ['build:html'], {
+    cwd: portalDir,
+    env: expect.objectContaining({
+      NOCOBASE_API_URL: '/api',
+      NOCOBASE_PORTAL_BASE: '/x/crm/',
+    }),
+    envMode: 'replace',
+    errorName: 'pnpm build:html',
+  });
+  expect(await fsp.readFile(path.join(portalDir, '.env'), 'utf-8')).toBe(
+    'NOCOBASE_API_URL=/api\nNOCOBASE_PORTAL_BASE=/x/crm/\n',
+  );
+  expect(await fsp.readFile(path.join(portalDir, '.env.local'), 'utf-8')).toBe(
+    'NOCOBASE_API_URL=https://demo6.v11.demo.nocobase.com/api\nNOCOBASE_PORTAL_BASE=/x/crm/\n',
+  );
+});
+
 test('fails when portal record sync fails', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-deploy-storage-');
   await preparePortalWorkspace({ storagePath });

--- a/packages/core/cli/src/__tests__/portal-deploy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-deploy.test.ts
@@ -198,12 +198,13 @@ test('updates env files, builds, and syncs the portal record locally without upl
   });
   expect(runCommand).toHaveBeenNthCalledWith(3, 'pnpm', ['build:html'], {
     cwd: portalDir,
-    env: expect.any(Object),
+    env: expect.objectContaining({
+      NOCOBASE_API_URL: '/console/api/__app/crm',
+      NOCOBASE_PORTAL_BASE: '/console/x/apps/crm/customer/',
+    }),
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });
-  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_API_URL');
-  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_PORTAL_BASE');
   expect(apiRequest).toHaveBeenCalledTimes(1);
   expectPortalRecordFirstOrCreate(apiRequest.mock.calls[0][0]);
   expect(await fsp.readFile(path.join(portalDir, '.env'), 'utf-8')).toBe(
@@ -382,12 +383,13 @@ test('http deploy builds, packs dist, and uploads it', async () => {
   });
   expect(runCommand).toHaveBeenNthCalledWith(3, 'pnpm', ['build:html'], {
     cwd: portalDir,
-    env: expect.any(Object),
+    env: expect.objectContaining({
+      NOCOBASE_API_URL: '/console/api/__app/crm',
+      NOCOBASE_PORTAL_BASE: '/console/x/apps/crm/customer/',
+    }),
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });
-  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_API_URL');
-  expect(runCommand.mock.calls[2]?.[2]?.env).not.toHaveProperty('NOCOBASE_PORTAL_BASE');
 });
 
 test('http deploy uses env source storage when no local storagePath is configured', async () => {

--- a/packages/core/cli/src/__tests__/portal-destroy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-destroy.test.ts
@@ -182,7 +182,7 @@ test('http destroy uses env source storage when no local storagePath is configur
   }
 });
 
-test('fails before deleting the record when workspace is missing without force', async () => {
+test('destroys the portal record when the local workspace is missing without force', async () => {
   const storagePath = await makeTempDir('nocobase-cli-portal-destroy-storage-');
   const apiRequest = vi.fn(async () => ({ ok: true, status: 200, data: { data: 1 } }));
 
@@ -192,9 +192,14 @@ test('fails before deleting the record when workspace is missing without force',
       env: createEnv({ storagePath }),
       apiRequest,
     }),
-  ).rejects.toThrow(/Portal does not exist/);
+  ).resolves.toMatchObject({
+    portal: 'customer',
+    recordDeleted: true,
+    workspaceDeleted: false,
+  });
 
-  expect(apiRequest).not.toHaveBeenCalled();
+  expect(apiRequest).toHaveBeenCalledTimes(1);
+  expectPortalRecordDestroy(apiRequest.mock.calls[0][0]);
 });
 
 test('fails when portal record destroy fails', async () => {

--- a/packages/core/cli/src/__tests__/portal-destroy.test.ts
+++ b/packages/core/cli/src/__tests__/portal-destroy.test.ts
@@ -58,16 +58,19 @@ function expectPortalRecordDestroy(options: RequestOptions, portal = 'customer')
   expect(options).toEqual(
     expect.objectContaining({
       flags: {
-        filterByTk: portal,
+        filter: {
+          portalName: portal,
+        },
       },
       operation: expect.objectContaining({
         method: 'POST',
         pathTemplate: '/multiPortals:destroy',
         parameters: expect.arrayContaining([
           expect.objectContaining({
-            name: 'filterByTk',
-            flagName: 'filterByTk',
+            name: 'filter',
+            flagName: 'filter',
             in: 'query',
+            type: 'object',
             required: true,
           }),
         ]),

--- a/packages/core/cli/src/__tests__/portal-list.test.ts
+++ b/packages/core/cli/src/__tests__/portal-list.test.ts
@@ -292,6 +292,7 @@ test('http list uses app:getInfo app name for custom-domain local paths', async 
       expect.objectContaining({
         portalName: 'crm',
         portalDir,
+        portalUrl: 'https://demo6.v11.demo.nocobase.com/x/crm/',
         localSynced: true,
       }),
     ],

--- a/packages/core/cli/src/__tests__/portal-source.test.ts
+++ b/packages/core/cli/src/__tests__/portal-source.test.ts
@@ -243,6 +243,7 @@ test('pull uses app:getInfo app name for custom-domain http envs', async () => {
     app: 'demo6',
     portal: 'crm',
     portalDir: path.join(storagePath, 'portals', 'demo6', 'crm'),
+    portalBase: '/x/crm/',
     changed: true,
   });
 

--- a/packages/core/cli/src/__tests__/portal-source.test.ts
+++ b/packages/core/cli/src/__tests__/portal-source.test.ts
@@ -320,6 +320,7 @@ test('push uploads NocoBase-managed source for http envs and excludes dist', asy
       return { ok: true, status: 200, data: portalListData() };
     }
     if (options.operation.pathTemplate === '/multiPortals:update') {
+      expect(options.flags.filter).toEqual({ portalName: 'customer' });
       expect(JSON.parse(String(options.flags.body))).toEqual({
         options: {
           sourceStorage: 'nocobase',
@@ -633,6 +634,7 @@ test('push creates configured Git branch and uses repository root by default', a
 
   const apiRequest = vi.fn(async (options: RequestOptions) => {
     if (options.operation.pathTemplate === '/multiPortals:update') {
+      expect(options.flags.filter).toEqual({ portalName: 'customer' });
       return { ok: true, status: 200, data: { data: { uid: 'customer' } } };
     }
     return {

--- a/packages/core/cli/src/__tests__/portal-source.test.ts
+++ b/packages/core/cli/src/__tests__/portal-source.test.ts
@@ -102,6 +102,18 @@ test('pull downloads NocoBase-managed source for http envs', async () => {
   await fsp.mkdir(path.join(sourceDir, 'src'), { recursive: true });
   await fsp.writeFile(path.join(sourceDir, 'src', 'index.tsx'), 'export default null;\n');
   await fsp.writeFile(path.join(sourceDir, 'package.json'), '{"name":"customer"}\n');
+  await fsp.mkdir(path.join(sourceDir, 'scripts'), { recursive: true });
+  await fsp.writeFile(
+    path.join(sourceDir, 'scripts', 'build-html.mjs'),
+    [
+      'const getEnvFilesForMode = (mode) => {',
+      '  return [".env", ".env.local", `.env.${mode}`, `.env.${mode}.local`].map(',
+      '    (file) => path.join(rootDir, file)',
+      '  );',
+      '};',
+      '',
+    ].join('\n'),
+  );
   const runCommand = vi.fn().mockResolvedValue(undefined);
   const apiRequest = vi.fn(async (options: RequestOptions) => {
     if (options.operation.pathTemplate === '/app:getInfo') {
@@ -140,14 +152,17 @@ test('pull downloads NocoBase-managed source for http envs', async () => {
 
   const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
   await expect(fsp.readFile(path.join(portalDir, 'src', 'index.tsx'), 'utf-8')).resolves.toBe('export default null;\n');
+  const buildHtmlScript = await fsp.readFile(path.join(portalDir, 'scripts', 'build-html.mjs'), 'utf-8');
+  expect(buildHtmlScript).toContain('return [".env"].map((file) => path.join(rootDir, file));');
+  expect(buildHtmlScript).not.toContain('.env.local');
   await expect(fsp.readFile(path.join(portalDir, 'portal.config.json'), 'utf-8')).resolves.toBe(
     '{\n  "sourceStorage": "nocobase"\n}\n',
   );
-  expect(runCommand).toHaveBeenCalledWith('pnpm', ['install', '--frozen-lockfile', '--trust-lockfile'], {
+  expect(runCommand).toHaveBeenCalledWith('pnpm', ['install'], {
     cwd: portalDir,
     env: expect.any(Object),
     envMode: 'replace',
-    errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+    errorName: 'pnpm install',
   });
 
   await runGit(['init'], portalDir);
@@ -240,6 +255,50 @@ test('pull uses app:getInfo app name for custom-domain http envs', async () => {
     '/multiPortals:list',
     '/multiPortals:pullSource',
   ]);
+});
+
+test('pull completes when dependency installation fails', async () => {
+  const storagePath = await makeTempDir('nocobase-cli-portal-source-storage-');
+  const sourceDir = await makeTempDir('nocobase-cli-portal-source-install-failure-');
+  await fsp.mkdir(path.join(sourceDir, 'src'), { recursive: true });
+  await fsp.writeFile(path.join(sourceDir, 'src', 'index.tsx'), 'export default "install failed";\n');
+  await fsp.writeFile(path.join(sourceDir, 'package.json'), '{"name":"customer"}\n');
+  const runCommand = vi.fn(async () => {
+    throw new Error('pnpm install exited with code 1');
+  });
+  const apiRequest = vi.fn(async (options: RequestOptions) => {
+    if (options.operation.pathTemplate === '/app:getInfo') {
+      return { ok: true, status: 200, data: appInfoData() };
+    }
+    if (options.operation.pathTemplate === '/multiPortals:list') {
+      return { ok: true, status: 200, data: portalListData() };
+    }
+
+    expect(options.operation.pathTemplate).toBe('/multiPortals:pullSource');
+    await tar.create({ cwd: sourceDir, file: String(options.flags.output), gzip: true }, await fsp.readdir(sourceDir));
+    return { ok: true, status: 200, data: { output: options.flags.output } };
+  });
+
+  await expect(
+    pullPortalSource({
+      portal: 'customer',
+      envName: 'prod',
+      env: createEnv({ storagePath, kind: 'http' }),
+      apiRequest,
+      runCommand,
+    }),
+  ).resolves.toMatchObject({
+    portal: 'customer',
+    changed: true,
+    dependenciesInstalled: false,
+    installSkipped: false,
+    installFailed: true,
+  });
+
+  const portalDir = path.join(storagePath, 'portals', 'main', 'customer');
+  await expect(fsp.readFile(path.join(portalDir, 'src', 'index.tsx'), 'utf-8')).resolves.toBe(
+    'export default "install failed";\n',
+  );
 });
 
 test('push uploads NocoBase-managed source for http envs and excludes dist', async () => {

--- a/packages/core/cli/src/__tests__/run-npm-windows.test.ts
+++ b/packages/core/cli/src/__tests__/run-npm-windows.test.ts
@@ -300,6 +300,56 @@ test('runPnpmCommand reports a friendly error for injected pnpm runners', async 
   );
 });
 
+test('runPnpmInstallCommand retries install without trust-lockfile when the trusted attempt fails', async () => {
+  const runCommand = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('pnpm install --frozen-lockfile --trust-lockfile exited with code 1'))
+    .mockResolvedValueOnce(undefined);
+
+  const { runPnpmInstallCommand } = await import('../lib/run-npm.js');
+  await expect(
+    runPnpmInstallCommand(runCommand, ['install', '--frozen-lockfile', '--trust-lockfile'], {
+      cwd: '/tmp/portal',
+      errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+    }),
+  ).resolves.toBe(undefined);
+
+  expect(runCommand.mock.calls).toEqual([
+    [
+      'pnpm',
+      ['install', '--frozen-lockfile', '--trust-lockfile'],
+      {
+        cwd: '/tmp/portal',
+        errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+      },
+    ],
+    [
+      'pnpm',
+      ['install', '--frozen-lockfile'],
+      {
+        cwd: '/tmp/portal',
+        errorName: 'pnpm install --frozen-lockfile',
+      },
+    ],
+  ]);
+});
+
+test('runPnpmInstallCommand does not retry when pnpm is missing', async () => {
+  const runCommand = vi.fn(async () => {
+    throw Object.assign(new Error('spawn pnpm ENOENT'), { code: 'ENOENT' });
+  });
+
+  const { runPnpmInstallCommand } = await import('../lib/run-npm.js');
+  await expect(
+    runPnpmInstallCommand(runCommand, ['install', '--frozen-lockfile', '--trust-lockfile'], {
+      errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+    }),
+  ).rejects.toThrow(
+    "Couldn't run `pnpm install --frozen-lockfile --trust-lockfile` because the pnpm executable could not be found.",
+  );
+  expect(runCommand).toHaveBeenCalledTimes(1);
+});
+
 test('run reports a friendly error when Nginx is missing', async () => {
   spawnMock.mockReturnValue(erroredChild(Object.assign(new Error('spawn nginx ENOENT'), { code: 'ENOENT' })));
 

--- a/packages/core/cli/src/commands/portal/create.ts
+++ b/packages/core/cli/src/commands/portal/create.ts
@@ -13,7 +13,7 @@ import { resolveDefaultConfigScope } from '../../lib/cli-home.js';
 import { translateCli } from '../../lib/cli-locale.js';
 import { ensureCrossEnvConfirmed, hasExplicitEnvSelection } from '../../lib/env-guard.js';
 import { createPortalWorkspace } from '../../lib/portal-create.js';
-import { printInfo, printSuccess } from '../../lib/ui.js';
+import { printInfo, printSuccess, printWarning } from '../../lib/ui.js';
 
 const DEFAULT_PORTAL_TEMPLATE = '@nocobase/portal-template-default';
 const portalCreateText = (key: string, values?: Record<string, unknown>, fallback?: string) =>
@@ -134,5 +134,14 @@ export default class PortalCreate extends Command {
         `Source storage: ${result.sourceStorage}`,
       ),
     );
+    if (result.installFailed) {
+      printWarning(
+        portalCreateText(
+          'messages.installFailed',
+          { portalDir: result.portalDir },
+          `Dependency installation did not finish successfully. Run \`pnpm install\` manually in ${result.portalDir}.`,
+        ),
+      );
+    }
   }
 }

--- a/packages/core/cli/src/commands/portal/pull.ts
+++ b/packages/core/cli/src/commands/portal/pull.ts
@@ -13,7 +13,7 @@ import { resolveDefaultConfigScope } from '../../lib/cli-home.js';
 import { translateCli } from '../../lib/cli-locale.js';
 import { ensureCrossEnvConfirmed, hasExplicitEnvSelection } from '../../lib/env-guard.js';
 import { pullPortalSource } from '../../lib/portal-source.js';
-import { printInfo, printSuccess } from '../../lib/ui.js';
+import { printInfo, printSuccess, printWarning } from '../../lib/ui.js';
 
 const portalPullText = (key: string, values?: Record<string, unknown>, fallback?: string) =>
   translateCli(`commands.portalPull.${key}`, values, { fallback });
@@ -104,5 +104,14 @@ export default class PortalPull extends Command {
         `Pulled portal source "${result.portal}" into ${result.portalDir}.`,
       ),
     );
+    if (result.installFailed) {
+      printWarning(
+        portalPullText(
+          'messages.installFailed',
+          { portalDir: result.portalDir },
+          `Dependency installation did not finish successfully. Run \`pnpm install\` manually in ${result.portalDir}.`,
+        ),
+      );
+    }
   }
 }

--- a/packages/core/cli/src/lib/portal-build-html.ts
+++ b/packages/core/cli/src/lib/portal-build-html.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const BUILD_HTML_SCRIPT_PATH = path.join('scripts', 'build-html.mjs');
+const BUILD_HTML_ENV_FILES_PATTERN =
+  /return\s+\[\s*["']\.env["']\s*,\s*["']\.env\.local["']\s*,\s*`\.env\.\$\{mode\}`\s*,\s*`\.env\.\$\{mode\}\.local`\s*\]\.map\(\s*\(?file\)?\s*=>\s*path\.join\(rootDir,\s*file\)\s*\);/m;
+const BUILD_HTML_ENV_ONLY_REPLACEMENT = 'return [".env"].map((file) => path.join(rootDir, file));';
+
+export async function ensurePortalBuildHtmlReadsEnvOnly(portalDir: string): Promise<void> {
+  const scriptPath = path.join(portalDir, BUILD_HTML_SCRIPT_PATH);
+  let content: string;
+  try {
+    content = await readFile(scriptPath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const nextContent = content.replace(BUILD_HTML_ENV_FILES_PATTERN, BUILD_HTML_ENV_ONLY_REPLACEMENT);
+  if (nextContent !== content) {
+    await writeFile(scriptPath, nextContent, 'utf-8');
+  }
+}

--- a/packages/core/cli/src/lib/portal-config.ts
+++ b/packages/core/cli/src/lib/portal-config.ts
@@ -48,9 +48,10 @@ const UPDATE_PORTAL_OPERATION: RequestOperation = {
   bodyRequired: true,
   parameters: [
     {
-      name: 'filterByTk',
-      flagName: 'filterByTk',
+      name: 'filter',
+      flagName: 'filter',
       in: 'query',
+      type: 'object',
       required: true,
     },
   ],
@@ -192,7 +193,9 @@ export async function syncPortalConfigToRemote(options: {
     cliVersion: options.cliVersion ?? '',
     envName: options.envName,
     flags: {
-      filterByTk: options.portal,
+      filter: {
+        portalName: options.portal,
+      },
       body: JSON.stringify({
         options: mergePortalConfigIntoOptions(options.config, options.currentOptions),
       }),

--- a/packages/core/cli/src/lib/portal-create.ts
+++ b/packages/core/cli/src/lib/portal-create.ts
@@ -21,6 +21,7 @@ import { executeApiRequest, type RequestOperation } from './api-client.js';
 import type { Env } from './auth-store.js';
 import { resolveEnvRelativePath } from './cli-home.js';
 import { translateCli } from './cli-locale.js';
+import { ensurePortalBuildHtmlReadsEnvOnly } from './portal-build-html.js';
 import { buildPortalCommandEnv } from './portal-command-env.js';
 import {
   buildPortalConfig,
@@ -29,7 +30,7 @@ import {
   type PortalConfig,
   type PortalSourceStorage,
 } from './portal-config.js';
-import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
+import { resolvePnpmInstallCommand, run, runPnpmInstallCommand, type RunCommand } from './run-npm.js';
 
 const DEFAULT_PORTAL_TEMPLATE = '@nocobase/portal-template-default';
 const DEFAULT_PORTAL_APP_NAME = 'main';
@@ -91,6 +92,8 @@ export type PortalCreateResult = {
   portalBase: string;
   template: ResolvedPortalTemplate;
   installSkipped: boolean;
+  dependenciesInstalled: boolean;
+  installFailed: boolean;
   sourceStorage: PortalSourceStorage;
 };
 
@@ -171,20 +174,6 @@ function decodeAppSegment(value: string): string {
 
 function safeTempPrefix(parentDir: string, portal: string): string {
   return path.join(parentDir, `.${portal}-create-`);
-}
-
-async function getPortalInstallCommand(portalDir: string): Promise<{ args: string[]; errorName: string }> {
-  if (await pathExists(path.join(portalDir, 'pnpm-lock.yaml'))) {
-    return {
-      args: ['install', '--frozen-lockfile', '--trust-lockfile'],
-      errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
-    };
-  }
-
-  return {
-    args: ['install', '--no-frozen-lockfile', '--trust-lockfile'],
-    errorName: 'pnpm install --no-frozen-lockfile --trust-lockfile',
-  };
 }
 
 function assertPortalDirIsInsideParent(parentDir: string, portalDir: string): void {
@@ -651,6 +640,7 @@ export async function createPortalWorkspace(options: PortalCreateOptions): Promi
 
   try {
     await copyTemplate(template.dir, tempDir);
+    await ensurePortalBuildHtmlReadsEnvOnly(tempDir);
     await writeFile(
       path.join(tempDir, '.env'),
       [`NOCOBASE_API_URL=${envApiUrl}`, `NOCOBASE_PORTAL_BASE=${portalBase}`].join('\n') + '\n',
@@ -671,15 +661,22 @@ export async function createPortalWorkspace(options: PortalCreateOptions): Promi
     shouldCleanupTempDir = false;
 
     const hasPackageJson = await pathExists(path.join(portalDir, 'package.json'));
+    let dependenciesInstalled = false;
+    let installFailed = false;
     if (hasPackageJson) {
       const runCommand = options.runCommand ?? run;
-      const installCommand = await getPortalInstallCommand(portalDir);
-      await runPnpmCommand(runCommand, installCommand.args, {
-        cwd: portalDir,
-        env: buildPortalCommandEnv(),
-        envMode: 'replace',
-        errorName: installCommand.errorName,
-      });
+      const installCommand = await resolvePnpmInstallCommand(portalDir);
+      try {
+        await runPnpmInstallCommand(runCommand, installCommand.args, {
+          cwd: portalDir,
+          env: buildPortalCommandEnv(),
+          envMode: 'replace',
+          errorName: installCommand.errorName,
+        });
+        dependenciesInstalled = true;
+      } catch {
+        installFailed = true;
+      }
     } else {
       options.onSkipInstall?.(
         portalCreateText(
@@ -710,6 +707,8 @@ export async function createPortalWorkspace(options: PortalCreateOptions): Promi
       portalBase,
       template,
       installSkipped: !hasPackageJson,
+      dependenciesInstalled,
+      installFailed,
       sourceStorage: portalConfig.sourceStorage,
     };
   } finally {

--- a/packages/core/cli/src/lib/portal-create.ts
+++ b/packages/core/cli/src/lib/portal-create.ts
@@ -67,6 +67,7 @@ export type PortalCreateOptions = {
 export type ResolvedPortalApp = {
   app: string;
   appPublicPath: string;
+  portalBaseApp?: string;
 };
 
 export type PortalAppContextOptions = {
@@ -549,13 +550,17 @@ export async function resolvePortalAppContext(options: PortalAppContextOptions):
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
   const resolvedApp = resolvePortalAppFromApiBaseUrl(apiBaseUrl, options.env.config.appPublicPath);
   if (options.env.kind !== 'http') {
-    return resolvedApp;
+    return {
+      ...resolvedApp,
+      portalBaseApp: resolvedApp.app,
+    };
   }
 
   const serverApp = await resolvePortalAppFromServer(options);
   return {
     app: serverApp ?? resolvedApp.app,
     appPublicPath: resolvedApp.appPublicPath,
+    portalBaseApp: resolvedApp.app,
   };
 }
 
@@ -613,8 +618,8 @@ export async function createPortalWorkspace(options: PortalCreateOptions): Promi
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
   const envApiUrl = resolvePortalEnvApiUrl(apiBaseUrl);
   const storagePath = resolvePortalStoragePath(options.env);
-  const { app, appPublicPath } = await resolvePortalAppContext(options);
-  const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
+  const { app, appPublicPath, portalBaseApp } = await resolvePortalAppContext(options);
+  const portalBase = buildPortalBasePath({ app: portalBaseApp ?? app, appPublicPath, portal });
   const portalParentDir = path.join(storagePath, 'portals', app);
   const portalDir = path.join(portalParentDir, portal);
 

--- a/packages/core/cli/src/lib/portal-deploy.ts
+++ b/packages/core/cli/src/lib/portal-deploy.ts
@@ -17,6 +17,7 @@ import { ensurePortalBuildHtmlReadsEnvOnly } from './portal-build-html.js';
 import {
   buildPortalBasePath,
   resolvePortalAppContext,
+  resolvePortalEnvApiUrl,
   resolvePortalStoragePath,
   titleFromPortalSlug,
   validatePortalSlug,
@@ -286,6 +287,7 @@ async function syncMultiPortalRecord(params: {
 export async function deployPortalWorkspace(options: PortalDeployOptions): Promise<PortalDeployResult> {
   const portal = validatePortalSlug(options.portal);
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
+  const envApiUrl = resolvePortalEnvApiUrl(apiBaseUrl);
   const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath } = await resolvePortalAppContext(options);
   const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
@@ -337,7 +339,10 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
   });
   await runPnpmCommand(runCommand, ['build:html'], {
     cwd: portalDir,
-    env: buildPortalCommandEnv(),
+    env: buildPortalCommandEnv({
+      NOCOBASE_API_URL: envApiUrl,
+      NOCOBASE_PORTAL_BASE: portalBase,
+    }),
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });

--- a/packages/core/cli/src/lib/portal-deploy.ts
+++ b/packages/core/cli/src/lib/portal-deploy.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import * as tar from 'tar';
 import { executeApiRequest, type RequestOperation } from './api-client.js';
 import { translateCli } from './cli-locale.js';
+import { ensurePortalBuildHtmlReadsEnvOnly } from './portal-build-html.js';
 import {
   buildPortalBasePath,
   resolvePortalAppContext,
@@ -24,7 +25,7 @@ import {
 import { buildPortalCommandEnv } from './portal-command-env.js';
 import { updatePortalEnvFiles } from './portal-env-files.js';
 import { mergePortalConfigIntoOptions, readPortalConfig, type PortalConfig } from './portal-config.js';
-import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
+import { resolvePnpmInstallCommand, run, runPnpmCommand, runPnpmInstallCommand, type RunCommand } from './run-npm.js';
 
 type ApiRequest = typeof executeApiRequest;
 
@@ -315,13 +316,15 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
     apiBaseUrl,
     portalBase,
   });
+  await ensurePortalBuildHtmlReadsEnvOnly(portalDir);
 
   const runCommand = options.runCommand ?? run;
-  await runPnpmCommand(runCommand, ['install', '--frozen-lockfile', '--trust-lockfile'], {
+  const installCommand = await resolvePnpmInstallCommand(portalDir);
+  await runPnpmInstallCommand(runCommand, installCommand.args, {
     cwd: portalDir,
     env: buildPortalCommandEnv(),
     envMode: 'replace',
-    errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
+    errorName: installCommand.errorName,
   });
   await runPnpmCommand(runCommand, ['build'], {
     cwd: portalDir,
@@ -334,10 +337,7 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
   });
   await runPnpmCommand(runCommand, ['build:html'], {
     cwd: portalDir,
-    env: buildPortalCommandEnv({
-      NOCOBASE_API_URL: apiBaseUrl,
-      NOCOBASE_PORTAL_BASE: portalBase,
-    }),
+    env: buildPortalCommandEnv(),
     envMode: 'replace',
     errorName: 'pnpm build:html',
   });

--- a/packages/core/cli/src/lib/portal-deploy.ts
+++ b/packages/core/cli/src/lib/portal-deploy.ts
@@ -289,8 +289,8 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
   const envApiUrl = resolvePortalEnvApiUrl(apiBaseUrl);
   const storagePath = resolvePortalStoragePath(options.env);
-  const { app, appPublicPath } = await resolvePortalAppContext(options);
-  const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
+  const { app, appPublicPath, portalBaseApp } = await resolvePortalAppContext(options);
+  const portalBase = buildPortalBasePath({ app: portalBaseApp ?? app, appPublicPath, portal });
   const portalDir = path.join(storagePath, 'portals', app, portal);
   const distDir = path.join(portalDir, 'dist');
 

--- a/packages/core/cli/src/lib/portal-deploy.ts
+++ b/packages/core/cli/src/lib/portal-deploy.ts
@@ -291,6 +291,7 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
   const storagePath = resolvePortalStoragePath(options.env);
   const { app, appPublicPath, portalBaseApp } = await resolvePortalAppContext(options);
   const portalBase = buildPortalBasePath({ app: portalBaseApp ?? app, appPublicPath, portal });
+  const deployBase = buildPortalBasePath({ app, appPublicPath, portal });
   const portalDir = path.join(storagePath, 'portals', app, portal);
   const distDir = path.join(portalDir, 'dist');
 
@@ -400,7 +401,7 @@ export async function deployPortalWorkspace(options: PortalDeployOptions): Promi
       archivePath: archive.archivePath,
       app,
       portal,
-      portalBase,
+      portalBase: deployBase,
       envName: options.envName,
       cliVersion: options.cliVersion,
       apiRequest: options.apiRequest,

--- a/packages/core/cli/src/lib/portal-destroy.ts
+++ b/packages/core/cli/src/lib/portal-destroy.ts
@@ -52,9 +52,10 @@ const DESTROY_PORTAL_OPERATION: RequestOperation = {
   pathTemplate: '/multiPortals:destroy',
   parameters: [
     {
-      name: 'filterByTk',
-      flagName: 'filterByTk',
+      name: 'filter',
+      flagName: 'filter',
       in: 'query',
+      type: 'object',
       required: true,
     },
   ],
@@ -94,7 +95,9 @@ async function destroyMultiPortalRecord(params: {
     cliVersion: params.cliVersion ?? '',
     envName: params.envName,
     flags: {
-      filterByTk: params.portal,
+      filter: {
+        portalName: params.portal,
+      },
     },
     operation: DESTROY_PORTAL_OPERATION,
   });

--- a/packages/core/cli/src/lib/portal-destroy.ts
+++ b/packages/core/cli/src/lib/portal-destroy.ts
@@ -139,15 +139,6 @@ export async function destroyPortalWorkspace(options: PortalDestroyOptions): Pro
   assertPortalDirIsInsideParent(portalParentDir, portalDir);
 
   const workspaceExists = await pathExists(portalDir);
-  if (!workspaceExists && !options.force) {
-    throw new Error(
-      portalDestroyText(
-        'errors.workspaceMissing',
-        { portalDir, portal },
-        `Portal does not exist: ${portalDir}\nPass --force to ignore missing local files.`,
-      ),
-    );
-  }
 
   const recordDeleted = await destroyMultiPortalRecord({
     portal,

--- a/packages/core/cli/src/lib/portal-destroy.ts
+++ b/packages/core/cli/src/lib/portal-destroy.ts
@@ -119,8 +119,8 @@ async function destroyMultiPortalRecord(params: {
 export async function destroyPortalWorkspace(options: PortalDestroyOptions): Promise<PortalDestroyResult> {
   const portal = validatePortalSlug(options.portal);
   const storagePath = resolvePortalStoragePath(options.env);
-  const { app, appPublicPath } = await resolvePortalAppContext(options);
-  const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
+  const { app, appPublicPath, portalBaseApp } = await resolvePortalAppContext(options);
+  const portalBase = buildPortalBasePath({ app: portalBaseApp ?? app, appPublicPath, portal });
   const portalParentDir = path.join(storagePath, 'portals', app);
   const portalDir = path.join(portalParentDir, portal);
   const mode = options.env.kind;

--- a/packages/core/cli/src/lib/portal-dev.ts
+++ b/packages/core/cli/src/lib/portal-dev.ts
@@ -87,8 +87,8 @@ export async function devPortalWorkspace(options: PortalDevOptions): Promise<Por
     );
   }
   const storagePath = resolvePortalStoragePath(options.env);
-  const { app, appPublicPath } = await resolvePortalAppContext(options);
-  const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
+  const { app, appPublicPath, portalBaseApp } = await resolvePortalAppContext(options);
+  const portalBase = buildPortalBasePath({ app: portalBaseApp ?? app, appPublicPath, portal });
   const portalDir = path.join(storagePath, 'portals', app, portal);
 
   if (!(await pathExists(portalDir))) {

--- a/packages/core/cli/src/lib/portal-env-files.ts
+++ b/packages/core/cli/src/lib/portal-env-files.ts
@@ -52,8 +52,9 @@ export async function updatePortalEnvFiles(params: {
   apiBaseUrl: string;
   portalBase: string;
 }): Promise<void> {
+  const envApiUrl = resolvePortalEnvApiUrl(params.apiBaseUrl);
   await upsertPortalEnvFile(path.join(params.portalDir, '.env'), {
-    NOCOBASE_API_URL: resolvePortalEnvApiUrl(params.apiBaseUrl),
+    NOCOBASE_API_URL: envApiUrl,
     NOCOBASE_PORTAL_BASE: params.portalBase,
   });
   await upsertPortalEnvFile(path.join(params.portalDir, '.env.local'), {

--- a/packages/core/cli/src/lib/portal-list.ts
+++ b/packages/core/cli/src/lib/portal-list.ts
@@ -248,8 +248,9 @@ async function listMultiPortalRecords(params: {
 export async function listPortalWorkspaces(options: PortalListOptions): Promise<PortalListResult> {
   const apiBaseUrl = trimValue(options.env.apiBaseUrl);
   const storagePath = resolvePortalStoragePath(options.env);
-  const { app, appPublicPath } = options.appContext ?? (await resolvePortalAppContext(options));
+  const { app, appPublicPath, portalBaseApp } = options.appContext ?? (await resolvePortalAppContext(options));
   const mode = options.env.kind;
+  const baseApp = portalBaseApp ?? app;
 
   if (mode !== 'local' && mode !== 'docker' && mode !== 'http') {
     throw new Error(
@@ -296,8 +297,8 @@ export async function listPortalWorkspaces(options: PortalListOptions): Promise<
           ? buildPortalAccessUrl(
               apiBaseUrl,
               isAi
-                ? buildPortalBasePath({ app, appPublicPath, portal: portalName })
-                : buildNoCodePortalBasePath({ app, appPublicPath, routePath }),
+                ? buildPortalBasePath({ app: baseApp, appPublicPath, portal: portalName })
+                : buildNoCodePortalBasePath({ app: baseApp, appPublicPath, routePath }),
             )
           : '',
         portalDir,

--- a/packages/core/cli/src/lib/portal-source.ts
+++ b/packages/core/cli/src/lib/portal-source.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import * as tar from 'tar';
 import { executeApiRequest, type RequestOperation } from './api-client.js';
 import { translateCli } from './cli-locale.js';
+import { ensurePortalBuildHtmlReadsEnvOnly } from './portal-build-html.js';
 import {
   buildPortalConfig,
   buildPortalConfigFromOptions,
@@ -34,7 +35,7 @@ import {
 } from './portal-create.js';
 import { listPortalWorkspaces } from './portal-list.js';
 import { findPortalListItem } from './portal-info.js';
-import { run, runPnpmCommand, type RunCommand } from './run-npm.js';
+import { resolvePnpmInstallCommand, run, runPnpmCommand, runPnpmInstallCommand, type RunCommand } from './run-npm.js';
 
 type ApiRequest = typeof executeApiRequest;
 const execFileAsync = promisify(execFile);
@@ -75,6 +76,7 @@ export type PortalSourceResult = {
   changed: boolean;
   installSkipped?: boolean;
   dependenciesInstalled?: boolean;
+  installFailed?: boolean;
   sourceRevision?: string;
   noopReason?: string;
 };
@@ -319,11 +321,12 @@ async function installPortalDependencies(params: {
   portalDir: string;
   installDependencies?: boolean;
   runCommand?: RunCommand;
-}): Promise<{ dependenciesInstalled: boolean; installSkipped: boolean }> {
+}): Promise<{ dependenciesInstalled: boolean; installSkipped: boolean; installFailed: boolean }> {
   if (params.installDependencies === false) {
     return {
       dependenciesInstalled: false,
       installSkipped: true,
+      installFailed: false,
     };
   }
 
@@ -331,20 +334,31 @@ async function installPortalDependencies(params: {
     return {
       dependenciesInstalled: false,
       installSkipped: true,
+      installFailed: false,
     };
   }
 
   const runCommand = params.runCommand ?? run;
-  await runPnpmCommand(runCommand, ['install', '--frozen-lockfile', '--trust-lockfile'], {
-    cwd: params.portalDir,
-    env: buildPortalCommandEnv(),
-    envMode: 'replace',
-    errorName: 'pnpm install --frozen-lockfile --trust-lockfile',
-  });
+  const installCommand = await resolvePnpmInstallCommand(params.portalDir);
+  try {
+    await runPnpmInstallCommand(runCommand, installCommand.args, {
+      cwd: params.portalDir,
+      env: buildPortalCommandEnv(),
+      envMode: 'replace',
+      errorName: installCommand.errorName,
+    });
+  } catch {
+    return {
+      dependenciesInstalled: false,
+      installSkipped: false,
+      installFailed: true,
+    };
+  }
 
   return {
     dependenciesInstalled: true,
     installSkipped: false,
+    installFailed: false,
   };
 }
 
@@ -669,6 +683,7 @@ export async function pullPortalSource(options: PortalSourceOptions): Promise<Po
       context: sourceContext,
       force: options.force,
     });
+    await ensurePortalBuildHtmlReadsEnvOnly(sourceContext.portalDir);
     await writePortalConfig(sourceContext.portalDir, portalConfig);
     const installResult = await installPortalDependencies({
       portalDir: sourceContext.portalDir,
@@ -733,6 +748,7 @@ export async function pullPortalSource(options: PortalSourceOptions): Promise<Po
       portalDir: sourceContext.portalDir,
       force: options.force,
     });
+    await ensurePortalBuildHtmlReadsEnvOnly(sourceContext.portalDir);
     await writePortalConfig(sourceContext.portalDir, portalConfig);
     const installResult = await installPortalDependencies({
       portalDir: sourceContext.portalDir,

--- a/packages/core/cli/src/lib/portal-source.ts
+++ b/packages/core/cli/src/lib/portal-source.ts
@@ -379,9 +379,9 @@ async function resolvePortalSourceContext(options: PortalSourceOptions): Promise
   const storagePath = resolvePortalStoragePath(options.env);
   const mode = options.env.kind;
   const appContext = await resolvePortalAppContext(options);
-  const { app, appPublicPath } = appContext;
+  const { app, appPublicPath, portalBaseApp } = appContext;
   const portalDir = path.join(storagePath, 'portals', app, portal);
-  const portalBase = buildPortalBasePath({ app, appPublicPath, portal });
+  const portalBase = buildPortalBasePath({ app: portalBaseApp ?? app, appPublicPath, portal });
 
   if (mode !== 'local' && mode !== 'docker' && mode !== 'http') {
     throw new Error(

--- a/packages/core/cli/src/lib/run-npm.ts
+++ b/packages/core/cli/src/lib/run-npm.ts
@@ -147,6 +147,61 @@ export async function runPnpmCommand(
   }
 }
 
+function createInstallArgsWithoutTrustLockfile(args: string[]): string[] | undefined {
+  if (!args.includes('install') || !args.includes('--trust-lockfile')) {
+    return undefined;
+  }
+  return args.filter((arg) => arg !== '--trust-lockfile');
+}
+
+function isFriendlyMissingPnpmError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('because the pnpm executable could not be found');
+}
+
+function formatPnpmLabel(args: string[]): string {
+  return `pnpm ${args.join(' ')}`.trim();
+}
+
+export async function resolvePnpmInstallCommand(cwd: string): Promise<{ args: string[]; errorName: string }> {
+  const hasLockfile = await fsp
+    .stat(path.join(cwd, 'pnpm-lock.yaml'))
+    .then((stats) => stats.isFile())
+    .catch(() => false);
+  if (hasLockfile) {
+    const args = ['install', '--frozen-lockfile', '--trust-lockfile'];
+    return {
+      args,
+      errorName: formatPnpmLabel(args),
+    };
+  }
+
+  const args = ['install'];
+  return {
+    args,
+    errorName: formatPnpmLabel(args),
+  };
+}
+
+export async function runPnpmInstallCommand(
+  runCommand: RunCommand,
+  args: string[],
+  options: RunProcessOptions,
+): Promise<void> {
+  try {
+    await runPnpmCommand(runCommand, args, options);
+  } catch (error) {
+    const fallbackArgs = createInstallArgsWithoutTrustLockfile(args);
+    if (!fallbackArgs || isFriendlyMissingPnpmError(error)) {
+      throw error;
+    }
+    await runPnpmCommand(runCommand, fallbackArgs, {
+      ...options,
+      errorName: formatPnpmLabel(fallbackArgs),
+    });
+  }
+}
+
 function isDockerDaemonUnavailableError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return DOCKER_DAEMON_UNAVAILABLE_PATTERNS.some((pattern) => pattern.test(message));

--- a/packages/core/cli/src/locale/en-US.json
+++ b/packages/core/cli/src/locale/en-US.json
@@ -192,7 +192,8 @@
         "created": "Portal \"{{portal}}\" created at {{portalDir}}.",
         "app": "App: {{app}}",
         "base": "Base: {{base}}",
-        "sourceStorage": "Source storage: {{sourceStorage}}"
+        "sourceStorage": "Source storage: {{sourceStorage}}",
+        "installFailed": "Dependency installation did not finish successfully. Run `pnpm install` manually in {{portalDir}}."
       }
     },
     "portalConfig": {
@@ -257,6 +258,17 @@
         "path": "Local path",
         "enabled": "Enabled",
         "localSynced": "Local synced"
+      }
+    },
+    "portalPull": {
+      "errors": {
+        "envNotConfigured": "Env \"{{envName}}\" is not configured. Run `nb env add {{envName}} --api-base-url <url>` first.",
+        "noEnvConfigured": "No NocoBase env is configured yet. Run `nb init --ui` to create one first."
+      },
+      "messages": {
+        "noop": "No pull is needed.",
+        "pulled": "Pulled portal source \"{{portal}}\" into {{portalDir}}.",
+        "installFailed": "Dependency installation did not finish successfully. Run `pnpm install` manually in {{portalDir}}."
       }
     },
     "swagger": {

--- a/packages/core/cli/src/locale/zh-CN.json
+++ b/packages/core/cli/src/locale/zh-CN.json
@@ -192,7 +192,8 @@
         "created": "Portal \"{{portal}}\" 已创建：{{portalDir}}。",
         "app": "App：{{app}}",
         "base": "Base：{{base}}",
-        "sourceStorage": "源码存储：{{sourceStorage}}"
+        "sourceStorage": "源码存储：{{sourceStorage}}",
+        "installFailed": "依赖安装没有成功完成。请在 {{portalDir}} 中手动运行 `pnpm install`。"
       }
     },
     "portalConfig": {
@@ -257,6 +258,17 @@
         "path": "本地路径",
         "enabled": "启用",
         "localSynced": "本地已同步"
+      }
+    },
+    "portalPull": {
+      "errors": {
+        "envNotConfigured": "env \"{{envName}}\" 尚未配置。请先运行 `nb env add {{envName}} --api-base-url <url>`。",
+        "noEnvConfigured": "还没有配置 NocoBase env。请先运行 `nb init --ui` 创建一个。"
+      },
+      "messages": {
+        "noop": "无需执行 pull。",
+        "pulled": "Portal 源码 \"{{portal}}\" 已拉取到 {{portalDir}}。",
+        "installFailed": "依赖安装没有成功完成。请在 {{portalDir}} 中手动运行 `pnpm install`。"
       }
     },
     "swagger": {

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts
@@ -1474,10 +1474,12 @@ describe('plugin-multi-portal server', () => {
     });
     const disabledDistStat = await stat(path.join(portalDir, 'dist'));
     expect(disabledDistStat.isDirectory()).toBe(true);
-    await expect(access(path.join(portalDir, 'dist', 'index.html'))).rejects.toThrow();
+    await expect(readFile(path.join(portalDir, 'dist', 'index.html'), 'utf-8')).resolves.toBe(
+      '/console/x/storageTemplatePortal/',
+    );
   });
 
-  it('should rebuild storage portal HTML when an AI portal is re-enabled through multiPortals:update', async () => {
+  it('should keep storage portal HTML when an AI portal is disabled through multiPortals:update', async () => {
     process.env.APP_PUBLIC_PATH = '/console/';
     process.env.API_BASE_PATH = '/api';
     app = await createMultiPortalAclMockServer();
@@ -1518,7 +1520,7 @@ describe('plugin-multi-portal server', () => {
     expect(disableResponse.status).toBe(200);
     const disabledDistStat = await stat(path.join(portalDir, 'dist'));
     expect(disabledDistStat.isDirectory()).toBe(true);
-    await expect(access(portalIndex)).rejects.toThrow();
+    await expect(readFile(portalIndex, 'utf-8')).resolves.toBe('/console/x/api-toggle-storage-portal/');
 
     spawnMock.mockClear();
     const enableResponse = await rootAgent.resource('multiPortals').update({
@@ -1531,17 +1533,7 @@ describe('plugin-multi-portal server', () => {
     expect(enableResponse.status).toBe(200);
     await waitForPath(portalIndex);
     await expect(readFile(portalIndex, 'utf-8')).resolves.toBe('/console/x/api-toggle-storage-portal/');
-    expect(spawnMock).toHaveBeenCalledWith(
-      'yarn',
-      ['build:html'],
-      expect.objectContaining({
-        cwd: portalDir,
-        env: expect.objectContaining({
-          NOCOBASE_API_URL: '/console/api',
-          NOCOBASE_PORTAL_BASE: '/console/x/api-toggle-storage-portal/',
-        }),
-      }),
-    );
+    expect(spawnMock).not.toHaveBeenCalledWith('yarn', ['build:html'], expect.any(Object));
   });
 
   it('should build storage portal HTML with the sub-app portal base path', async () => {

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
@@ -3264,8 +3264,6 @@ export class PluginMultiPortalServer extends Plugin {
         }
 
         this.logPortalBuildHtml(item, 'skipped', 'the portal is disabled');
-        await this.removePortalStorageIndexHtml(item);
-        await appendPortalStorageLog(logPath, `Portal index.html removed for ${item.appName}/${item.portalName}.`);
       } catch (error) {
         await appendPortalStorageLog(
           logPath,
@@ -3317,8 +3315,6 @@ export class PluginMultiPortalServer extends Plugin {
     }
 
     this.logPortalBuildHtml(item, 'skipped', 'the portal is disabled');
-    await this.removePortalStorageIndexHtml(item);
-    await appendPortalStorageLog(logPath, `Portal index.html removed for ${item.appName}/${item.portalName}.`);
   }
 
   private async syncMultiPortalStorageItem(
@@ -3335,8 +3331,7 @@ export class PluginMultiPortalServer extends Plugin {
         previousItem &&
         (!currentItem ||
           previousItem.appName !== currentItem.appName ||
-          previousItem.portalName !== currentItem.portalName ||
-          !currentItem.enabled)
+          previousItem.portalName !== currentItem.portalName)
       ) {
         await this.removePortalStorageIndexHtml(previousItem);
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed portal CLI path resolution, deployment, and HTML build behavior for sub-app/custom-domain portals, and preserved existing portal HTML when a portal is disabled. |
| 🇨🇳 Chinese | 修复子应用/自定义域名场景下 portal CLI 的路径解析、部署与 HTML 构建行为，并在 portal 禁用时保留已有 HTML 文件。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

