### PR TITLE
fix(auth): prevent cookie fallback for API requests

### DIFF
--- a/packages/core/auth/src/__tests__/middleware.test.ts
+++ b/packages/core/auth/src/__tests__/middleware.test.ts
@@ -88,7 +88,7 @@ describe('middleware', () => {
     });
   });
 
-  describe('cookie token fallback', () => {
+  describe('cookie token scope', () => {
     function getCookieValue(cookies: string[], name: string) {
       return cookies
         .find((cookie) => cookie.startsWith(`${name}=`))
@@ -96,7 +96,7 @@ describe('middleware', () => {
         .slice(name.length + 1);
     }
 
-    it('should use auth cookie when authorization header and query token are absent', async () => {
+    it('should not use auth cookie for regular API requests', async () => {
       const user = await db.getRepository('users').findOne();
       await agent.login(user.id);
       const checkRes = await agent.resource('auth').check();
@@ -107,35 +107,8 @@ describe('middleware', () => {
         .get('/auth:check')
         .set('Cookie', [`${getAuthCookieName('authToken', app.name)}=${token}`]);
 
-      expect(res.status).toBe(200);
-      expect(res.body.data.id).toBe(user.id);
-    });
-
-    it('should read auth cookie only from the current app namespace', async () => {
-      const originalName = app.options.name;
-      app.options.name = 'subapp';
-
-      try {
-        const user = await db.getRepository('users').findOne();
-        await agent.login(user.id);
-        const checkRes = await agent.resource('auth').check();
-        const token = checkRes.request.header['Authorization'].replace('Bearer ', '');
-        const visitorAgent = app.agent();
-
-        const wrongAppCookieRes = await visitorAgent
-          .get('/auth:check')
-          .set('Cookie', [`${getAuthCookieName('authToken', 'main')}=${token}`]);
-        expect(wrongAppCookieRes.status).toBe(401);
-        expect(wrongAppCookieRes.body.errors.some((error) => error.code === AuthErrorCode.EMPTY_TOKEN)).toBe(true);
-
-        const res = await visitorAgent
-          .get('/auth:check')
-          .set('Cookie', [`${getAuthCookieName('authToken', 'subapp')}=${token}`]);
-        expect(res.status).toBe(200);
-        expect(res.body.data.id).toBe(user.id);
-      } finally {
-        app.options.name = originalName;
-      }
+      expect(res.status).toBe(401);
+      expect(res.body.errors.some((error) => error.code === AuthErrorCode.EMPTY_TOKEN)).toBe(true);
     });
 
     it('should not refresh auth cookies after successful header token check', async () => {
@@ -182,7 +155,7 @@ describe('middleware', () => {
       expect(res.body.errors.some((error) => error.code === AuthErrorCode.INVALID_TOKEN)).toBe(true);
     });
 
-    it('should require csrf token for unsafe cookie-auth requests only', async () => {
+    it('should not use auth cookie for unsafe API requests even when the csrf token matches', async () => {
       const signInRes = await app
         .agent()
         .post('/auth:signIn')
@@ -197,14 +170,12 @@ describe('middleware', () => {
       expect(cookies.join('; ')).toContain(`${getAuthCookieName('role', app.name)}=`);
 
       const blockedRes = await app.agent().post('/auth:check').set('Cookie', cookieHeader);
-      expect(blockedRes.status).toBe(403);
+      expect(blockedRes.status).toBe(401);
+      expect(blockedRes.body.errors.some((error) => error.code === AuthErrorCode.EMPTY_TOKEN)).toBe(true);
 
-      const passedRes = await app
-        .agent()
-        .post('/auth:check')
-        .set('Cookie', cookieHeader)
-        .set('X-CSRF-Token', csrfToken);
-      expect(passedRes.status).toBe(200);
+      const csrfRes = await app.agent().post('/auth:check').set('Cookie', cookieHeader).set('X-CSRF-Token', csrfToken);
+      expect(csrfRes.status).toBe(401);
+      expect(csrfRes.body.errors.some((error) => error.code === AuthErrorCode.EMPTY_TOKEN)).toBe(true);
 
       const headerTokenRes = await app
         .agent()
@@ -212,29 +183,6 @@ describe('middleware', () => {
         .set('Authorization', `Bearer ${signInRes.body.data.token}`)
         .set('Cookie', cookieHeader);
       expect(headerTokenRes.status).toBe(200);
-    });
-
-    it('should require csrf token when a cookie-auth request renews an expired token', async () => {
-      await app.authManager.tokenController.setConfig({
-        tokenExpirationTime: '1s',
-        sessionExpirationTime: '1d',
-        expiredTokenRenewLimit: '1d',
-      });
-
-      const signInRes = await app
-        .agent()
-        .post('/auth:signIn')
-        .set({ 'X-Authenticator': 'basic' })
-        .send({
-          account: process.env.INIT_ROOT_USERNAME || process.env.INIT_ROOT_EMAIL,
-          password: process.env.INIT_ROOT_PASSWORD,
-        });
-      const cookieHeader = signInRes.headers['set-cookie'].map((cookie) => cookie.split(';')[0]);
-
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-
-      const blockedRes = await app.agent().post('/auth:check').set('Cookie', cookieHeader);
-      expect(blockedRes.status).toBe(403);
     });
 
     it('should not require csrf token for unsafe query-token requests', async () => {
@@ -310,6 +258,9 @@ describe('middleware', () => {
 
         expect(res.headers['access-control-allow-origin']).toBe('https://trusted.example');
         expect(res.headers['access-control-allow-credentials']).toBe('true');
+        expect(res.headers['access-control-expose-headers'].split(',')).toEqual(
+          expect.arrayContaining(['content-disposition', 'x-new-token']),
+        );
       } finally {
         restoreEnv('CORS_ORIGIN_WHITELIST', originalWhitelist);
       }

--- a/packages/core/server/src/helper.ts
+++ b/packages/core/server/src/helper.ts
@@ -81,7 +81,7 @@ export function registerMiddlewares(app: Application, options: ApplicationOption
   app.use(
     cors({
       credentials: isWhitelistedCorsOrigin,
-      exposeHeaders: ['content-disposition'],
+      exposeHeaders: ['content-disposition', 'x-new-token'],
       origin: resolveCorsOrigin,
       ...options.cors,
     }),
@@ -118,7 +118,10 @@ export function registerMiddlewares(app: Application, options: ApplicationOption
         ctx.state.pendingAuthTokenSource = 'query';
         return ctx.query.token;
       }
-      const cookieToken = ctx.cookies.get(getAuthCookieName('authToken', app.name));
+      // Browser-driven permanent file requests cannot set Authorization headers. Keep cookie authentication scoped to
+      // the file access middleware so regular APIs never silently fall back from bearer authentication to cookies.
+      const canUseAuthCookie = Boolean(ctx.state?.fileAccess) && ['GET', 'HEAD'].includes(ctx.method);
+      const cookieToken = canUseAuthCookie ? ctx.cookies.get(getAuthCookieName('authToken', app.name)) : undefined;
       ctx.state.pendingAuthTokenSource = cookieToken ? 'cookie' : undefined;
       return cookieToken;
     };

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
@@ -1378,7 +1378,7 @@ describe('file manager > server', () => {
         }
       });
 
-      it('uses the same app auth cookies for API and APP_PUBLIC_PATH file access', async () => {
+      it('allows auth cookie fallback for APP_PUBLIC_PATH file access only', async () => {
         const originalPath = process.env.APP_PUBLIC_PATH;
         process.env.APP_PUBLIC_PATH = '/nocobase';
 
@@ -1392,8 +1392,9 @@ describe('file manager > server', () => {
             `${getAuthCookieName('authenticator', app.name)}=basic`,
           ];
 
-          const apiCheckResponse = await app.agent().get('/auth:check').set('Cookie', cookieHeader);
+          const apiCheckResponse = await app.agent().resource('auth').check().set('Cookie', cookieHeader);
           expect(apiCheckResponse.status).toBe(200);
+          expect(apiCheckResponse.body.data.id).toBeUndefined();
 
           const { body } = await agent.resource('attachments').create({
             [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
@@ -1403,6 +1404,10 @@ describe('file manager > server', () => {
           const fileResponse = await app.agent().get(body.data.url).set('Cookie', cookieHeader);
           expect(fileResponse.status).toBe(302);
           expect(fileResponse.headers.location).toBe(await plugin.getFileURL(body.data));
+
+          const headResponse = await app.agent().head(body.data.url).set('Cookie', cookieHeader);
+          expect(headResponse.status).toBe(302);
+          expect(headResponse.headers.location).toBe(await plugin.getFileURL(body.data));
         } finally {
           restoreEnv('APP_PUBLIC_PATH', originalPath);
         }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In cross-origin deployments, browsers could not read the renewed bearer token from the `x-new-token` response header. A later POST request could therefore arrive without an `Authorization` header while an authentication cookie was still present. The global cookie fallback then treated the regular API request as cookie-authenticated, causing the CSRF middleware to reject it with `Invalid CSRF token`.

### Description

- Restrict authentication-cookie fallback to `GET` and `HEAD` permanent file URL requests handled by the file access middleware.
- Keep regular API requests on explicit bearer or query-token authentication, so they no longer silently switch authentication modes.
- Expose `x-new-token` through CORS so cross-origin clients can retain renewed bearer tokens.
- Preserve cookie authentication for permanent file URLs and preserve `auth:syncCookies` behavior.

Potential compatibility risk: custom clients that intentionally relied on cookie-only authentication for regular APIs will now need to send an explicit bearer token. Browser file URLs remain compatible.

Testing performed:

- `yarn test packages/core/auth/src/__tests__/middleware.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-auth/src/server/__tests__/actions.test.ts --run`
- `yarn eslint --fix packages/core/server/src/helper.ts packages/core/auth/src/__tests__/middleware.test.ts packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts`

### Related issues

- Follow-up to #10103

### Showcase

N/A (server-side authentication fix)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed occasional `Invalid CSRF token` errors on API requests in cross-origin deployments |
| 🇨🇳 Chinese | 修复跨域部署中 API 请求偶发 `Invalid CSRF token` 错误的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
