### PR TITLE
fix(plugin-file-manager): restrict attachment uploads by environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,10 @@ NOCOBASE_PKG_PASSWORD=
 
 ################# SECURITY #################
 
+# Set to restricted to limit uploads to the built-in attachments collection to the root role.
+# Leave unset to keep the existing upload behavior.
+# FILE_MANAGER_ATTACHMENTS_UPLOAD_MODE=restricted
+
 # Comma-separated whitelist of allowed outbound HTTP request targets (IPs, CIDR ranges, hostnames, wildcard domains).
 # When set, server-side HTTP requests and every redirect destination are only allowed to the listed hosts.
 # When not set, all outbound http/https requests are allowed.

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/action.test.ts
@@ -19,6 +19,8 @@ import { getDocumentRoot, normalizeLocalStoragePath } from '../storages/local';
 const { LOCAL_STORAGE_BASE_URL, LOCAL_STORAGE_DEST = 'storage/uploads' } = process.env;
 
 const DEFAULT_LOCAL_BASE_URL = LOCAL_STORAGE_BASE_URL || `/storage/uploads`;
+const ATTACHMENTS_UPLOAD_MODE_ENV = 'FILE_MANAGER_ATTACHMENTS_UPLOAD_MODE';
+const originalAttachmentsUploadMode = process.env[ATTACHMENTS_UPLOAD_MODE_ENV];
 
 function getStorageDestPath(storage) {
   return path.join(getDocumentRoot(storage), storage.path || '');
@@ -48,6 +50,7 @@ describe('action', () => {
   let defaultStorage;
 
   beforeEach(async () => {
+    delete process.env[ATTACHMENTS_UPLOAD_MODE_ENV];
     app = await getApp();
     agent = app.agent();
     db = app.db;
@@ -71,6 +74,62 @@ describe('action', () => {
 
   afterEach(async () => {
     await app.destroy();
+    if (originalAttachmentsUploadMode === undefined) {
+      delete process.env[ATTACHMENTS_UPLOAD_MODE_ENV];
+    } else {
+      process.env[ATTACHMENTS_UPLOAD_MODE_ENV] = originalAttachmentsUploadMode;
+    }
+  });
+
+  describe('attachments upload mode', () => {
+    function useCurrentRoles(roles: string[]) {
+      app.resourcer.use(
+        async (ctx, next) => {
+          ctx.state.currentRole = roles[0];
+          ctx.state.currentRoles = roles;
+          await next();
+        },
+        {
+          tag: 'setAttachmentsUploadTestRole',
+          after: 'auth',
+          before: 'createMiddleware',
+        },
+      );
+    }
+
+    it('should keep logged-in attachment uploads enabled when the mode is not configured', async () => {
+      useCurrentRoles(['member']);
+
+      const response = await agent.resource('attachments').create({
+        [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject non-root attachment uploads in restricted mode', async () => {
+      process.env[ATTACHMENTS_UPLOAD_MODE_ENV] = 'restricted';
+      useCurrentRoles(['member']);
+      const attachmentCount = await AttachmentRepo.count();
+
+      const response = await agent.resource('attachments').create({
+        [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
+      });
+
+      expect(response.status).toBe(403);
+      expect(await AttachmentRepo.count()).toBe(attachmentCount);
+    });
+
+    it('should allow root attachment uploads in restricted mode', async () => {
+      process.env[ATTACHMENTS_UPLOAD_MODE_ENV] = 'restricted';
+      useCurrentRoles(['root']);
+
+      const response = await agent.resource('attachments').create({
+        [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
+      });
+
+      expect(response.status).toBe(200);
+    });
   });
 
   describe('create / upload', () => {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/attachments.ts
@@ -35,6 +35,15 @@ const ACTIVE_CONTENT_MIMETYPES = new Set([
   'text/xml',
 ]);
 
+const ATTACHMENTS_UPLOAD_MODE_RESTRICTED = 'restricted';
+
+function hasRootRole(ctx: Context) {
+  return (
+    ctx.state.currentRole === 'root' ||
+    (Array.isArray(ctx.state.currentRoles) && ctx.state.currentRoles.includes('root'))
+  );
+}
+
 function matchesMimePattern(mimetype: string, pattern: string | string[] = '*') {
   const normalizedPattern = pattern.toString().trim();
   if (!normalizedPattern || normalizedPattern === '*') {
@@ -230,6 +239,15 @@ export async function createMiddleware(ctx: Context, next: Next) {
 
   if (collection?.options?.template !== 'file' || !['upload', 'create', 'update'].includes(actionName)) {
     return next();
+  }
+
+  if (
+    resourceName === 'attachments' &&
+    ['upload', 'create'].includes(actionName) &&
+    process.env.FILE_MANAGER_ATTACHMENTS_UPLOAD_MODE === ATTACHMENTS_UPLOAD_MODE_RESTRICTED &&
+    !hasRootRole(ctx)
+  ) {
+    return ctx.throw(403, 'No permissions');
   }
 
   const storageName =

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/index.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/index.ts
@@ -23,7 +23,7 @@ export default function ({ app }) {
       },
     ],
   });
-  app.resourcer.use(createMiddleware, { tag: 'createMiddleware', after: 'auth' });
+  app.resourcer.use(createMiddleware, { tag: 'createMiddleware', after: ['auth', 'setCurrentRole'] });
   app.resourcer.registerActionHandler('upload', actions.create);
   app.resourcer.use(
     async (ctx, next) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The built-in `attachments` resource currently allows any authenticated user to upload files. Administrators need an emergency server-side option to restrict this upload path while a more granular authorization model is being designed.

### Description 

- Add `FILE_MANAGER_ATTACHMENTS_UPLOAD_MODE=restricted` to limit built-in `attachments:create` and `attachments:upload` requests to users whose effective roles include `root`.
- Keep the existing upload behavior when the environment variable is unset or has another value.
- Run the upload middleware after current-role resolution so the authorization decision uses the effective role state.
- Add coverage for the default behavior, non-Root rejection, and Root upload success.

Potential risk: when restricted mode is enabled, non-Root users cannot upload through existing attachment fields, regardless of their business collection permissions. Existing attachment records and deployments without this setting are unaffected.

Testing suggestions:
- Leave the variable unset and confirm a regular authenticated user can upload an attachment.
- Set the variable to `restricted` and confirm a regular user receives HTTP 403 without creating an attachment record.
- Confirm a Root user can still upload when restricted mode is enabled.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added an optional restricted attachment upload mode that only allows Root users to upload to the built-in attachments collection. |
| 🇨🇳 Chinese | 新增可选的附件限制上传模式，启用后仅允许 Root 用户向系统内置附件表上传文件。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
