### PR TITLE
fix(plugin-multi-portal): improve portal card display

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/MultiPortalsPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/MultiPortalsPage.test.tsx
@@ -670,9 +670,10 @@ describe('plugin-multi-portal settings page', () => {
     expect(within(customerPortalCard).queryByText('No-code')).not.toBeInTheDocument();
     expect(screen.getByText('No-code')).toBeInTheDocument();
     expect(screen.getByText('AI')).toBeInTheDocument();
-    // The device icon is mapped directly from the fixed uiLayoutUid, with its wording in the aria-label.
+    // No-code portals keep the device icon mapped from uiLayoutUid; AI portals do not expose a device layout.
     expect(within(customerPortalCard).getByLabelText('Mobile')).toHaveClass('anticon-mobile');
-    expect(within(developerPortalCard).getByLabelText('Desktop')).toHaveClass('anticon-desktop');
+    expect(within(developerPortalCard).queryByLabelText('Desktop')).not.toBeInTheDocument();
+    expect(within(developerPortalCard).queryByLabelText('Mobile')).not.toBeInTheDocument();
     expect(within(disabledPortalCard).getByLabelText('Desktop')).toHaveClass('anticon-desktop');
     expect(screen.queryByText('UI layout')).not.toBeInTheDocument();
     expect(screen.queryByText(/permission/i)).not.toBeInTheDocument();

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/MultiPortalsPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/MultiPortalsPage.test.tsx
@@ -684,6 +684,43 @@ describe('plugin-multi-portal settings page', () => {
     });
   });
 
+  it('should show the complete portal title when an ellipsized title is hovered', async () => {
+    const user = userEvent.setup();
+    const longTitle = 'Customer service and partner collaboration portal';
+    const resource = makeResource({
+      list: vi.fn().mockResolvedValue({
+        data: {
+          data: [{ ...portalValues, title: longTitle }],
+        },
+      }),
+    });
+    flowContext.current = {
+      api: {
+        request: vi.fn().mockResolvedValue({ data: { data: [] } }),
+        resource: vi.fn(() => resource),
+      },
+      viewer: {
+        drawer: vi.fn(),
+      },
+    };
+
+    render(
+      <AntdApp>
+        <MultiPortalsPage />
+      </AntdApp>,
+    );
+
+    const title = await screen.findByText(longTitle);
+    const titleContainer = title.parentElement as HTMLElement;
+    Object.defineProperty(titleContainer, 'clientWidth', { configurable: true, value: 100 });
+    Object.defineProperty(titleContainer, 'scrollWidth', { configurable: true, value: 200 });
+
+    await user.hover(screen.getByTestId('portal-title-tooltip-trigger'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(longTitle);
+    expect(title).toBeVisible();
+  });
+
   it('should allow deleting default portals from the gallery', async () => {
     const user = userEvent.setup();
     const resource = makeResource({

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/pages/MultiPortalsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/pages/MultiPortalsPage.tsx
@@ -817,12 +817,12 @@ const MultiPortalsPage: React.FC = () => {
           <Flex align="center" gap={token.margin}>
             <PortalCover record={record} href={href} openLabel={t('View')} />
             <div style={{ flex: 1, minWidth: 0 }}>
-              {/* The group heading says which type this is; only the device icon is added here, with its wording in the tooltip. */}
+              {/* The group heading says which type this is; no-code portals also show their device in a tooltip. */}
               <Flex align="center" gap={token.marginXXS}>
                 <Typography.Text strong ellipsis style={{ minWidth: 0 }}>
                   {record.title}
                 </Typography.Text>
-                {layoutLabel ? (
+                {isNoCode && layoutLabel ? (
                   <Tooltip title={layoutLabel}>
                     {record.uiLayoutUid === MOBILE_UI_LAYOUT_UID ? (
                       <MobileOutlined

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/pages/MultiPortalsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/pages/MultiPortalsPage.tsx
@@ -637,6 +637,25 @@ function PortalCover(props: { record: MultiPortalRecord; href: string; openLabel
   return <div style={{ flexShrink: 0 }}>{tile}</div>;
 }
 
+function PortalTitle({ title }: { title: string }) {
+  const titleRef = useRef<HTMLElement>(null);
+  const getTooltipTitle = useCallback(() => {
+    const titleElement = titleRef.current;
+    return titleElement && titleElement.scrollWidth > titleElement.clientWidth ? title : null;
+  }, [title]);
+
+  return (
+    <span style={{ display: 'block', minWidth: 0, position: 'relative' }}>
+      <Typography.Text ref={titleRef} strong ellipsis style={{ display: 'block', minWidth: 0 }}>
+        {title}
+      </Typography.Text>
+      <Tooltip title={getTooltipTitle}>
+        <span data-testid="portal-title-tooltip-trigger" style={{ inset: 0, position: 'absolute' }} />
+      </Tooltip>
+    </span>
+  );
+}
+
 const MultiPortalsPage: React.FC = () => {
   const t = useT();
   const ctx = useFlowContext();
@@ -819,9 +838,7 @@ const MultiPortalsPage: React.FC = () => {
             <div style={{ flex: 1, minWidth: 0 }}>
               {/* The group heading says which type this is; no-code portals also show their device in a tooltip. */}
               <Flex align="center" gap={token.marginXXS}>
-                <Typography.Text strong ellipsis style={{ minWidth: 0 }}>
-                  {record.title}
-                </Typography.Text>
+                <PortalTitle title={record.title} />
                 {isNoCode && layoutLabel ? (
                   <Tooltip title={layoutLabel}>
                     {record.uiLayoutUid === MOBILE_UI_LAYOUT_UID ? (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Portal 管理页面的卡片存在两个显示问题：AI Portal 会显示仅适用于无代码 Portal 的设备图标；标题过长时虽然可以通过悬浮查看完整内容，但 Tooltip 出现后卡片中的标题会消失。

### Description
- AI Portal 卡片不再显示桌面端或移动端设备图标，无代码 Portal 的设备图标保持不变。
- 标题过长时，鼠标悬浮可查看完整标题，同时卡片中的省略标题保持可见。
- 补充了相关前端测试，并在真实浏览器中验证了悬浮前后的显示效果。

改动仅影响 Portal 管理页面的卡片展示，不涉及 API 或数据结构变更。

### Showcase
已在真实浏览器中验证：长标题悬浮后，卡片标题与完整 Tooltip 会同时显示。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix device icon and long title display on Portal cards |
| 🇨🇳 Chinese | 修复 Portal 卡片的设备图标和长标题显示问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
