### PR TITLE
fix: incorrect sub table parent item variable resolving

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
@@ -3999,6 +3999,150 @@ describe('FormValueRuntime (form assign rules)', () => {
     expect(formStub.getFieldValue(['users', 0, 'user', 'id'])).toBe(1);
   });
 
+  it('assigns a to-one association from a sibling association in the same to-many row', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const secondary = { id: 2, name: 'Secondary' };
+    const formStub = createFormStub({ users: [{ user: null, secondaryUser: null }] });
+
+    const blockModel: any = {
+      uid: 'form-assign-assoc-to-many-sibling',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    const userCollection: any = { getField: () => null };
+    const userField: any = { isAssociationField: () => true, type: 'belongsTo', targetCollection: userCollection };
+    const usersItemCollection: any = {
+      getField: (name: string) => (name === 'user' || name === 'secondaryUser' ? userField : null),
+    };
+    const usersField: any = { isAssociationField: () => true, type: 'hasMany', targetCollection: usersItemCollection };
+    const collection: any = { getField: (name: string) => (name === 'users' ? usersField : null) };
+    blockCtx.defineProperty('collection', { value: collection });
+
+    const rowModel: any = {
+      uid: 'users.user:users:0',
+      isFork: true,
+      forkId: 'users:0',
+      subModels: { field: { context: { collectionField: userField } } },
+      getStepParams(flowKey: string, stepKey: string) {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') return { fieldPath: 'users.user' };
+        return undefined;
+      },
+    };
+    const rowCtx = createFieldContext(runtime);
+    rowCtx.defineProperty('blockModel', { value: blockModel });
+    rowCtx.defineProperty('collection', { value: collection });
+    rowCtx.defineProperty('fieldIndex', { value: ['users:0'] });
+    rowCtx.defineProperty('model', { value: rowModel });
+    rowModel.context = rowCtx;
+
+    blockCtx.defineProperty('engine', {
+      value: { forEachModel: (callback: (model: unknown) => void) => callback(rowModel) },
+    });
+    blockModel.context = blockCtx;
+
+    runtime.syncAssignRules([
+      {
+        key: 'r1',
+        enable: true,
+        targetPath: 'users.user',
+        mode: 'assign',
+        condition: { logic: '$and', items: [] },
+        value: '{{ ctx.item.parentItem.value.secondaryUser }}',
+      },
+    ]);
+
+    await runtime.setFormValues(blockCtx, [{ path: ['users', 0, 'secondaryUser'], value: secondary }], {
+      source: 'user',
+    });
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(secondary));
+
+    await runtime.setFormValues(blockCtx, [{ path: ['users', 0, 'user'], value: { id: 3, name: 'Manual' } }], {
+      source: 'user',
+    });
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(secondary));
+
+    const nextSecondary = { id: 4, name: 'Next secondary' };
+    await runtime.setFormValues(blockCtx, [{ path: ['users', 0, 'secondaryUser'], value: nextSecondary }], {
+      source: 'user',
+    });
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(nextSecondary));
+  });
+
+  it('preserves the PopupSubTable outer item chain for a top-level to-one association target', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const initialAssignee = { id: 2, name: 'Initial assignee' };
+    const nextAssignee = { id: 3, name: 'Next assignee' };
+    const outerValue = observable({ defaultAssignee: initialAssignee });
+    const formStub = createFormStub({ assignee: null });
+
+    const blockModel: any = {
+      uid: 'popup-sub-table-form-assign-parent-item',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    const userCollection: any = { filterTargetKey: 'id', getField: () => null };
+    const assigneeField: any = {
+      isAssociationField: () => true,
+      type: 'belongsTo',
+      targetCollection: userCollection,
+    };
+    const collection: any = { getField: (name: string) => (name === 'assignee' ? assigneeField : null) };
+    const outerItem = { index: 0, length: 1, value: outerValue };
+    blockCtx.defineProperty('collection', { value: collection });
+    blockCtx.defineProperty('item', {
+      get: () => ({
+        index: 1,
+        length: 3,
+        __is_new__: true,
+        __is_stored__: false,
+        value: blockCtx.formValues,
+        parentItem: outerItem,
+      }),
+      cache: false,
+    });
+    blockModel.context = blockCtx;
+
+    runtime.syncAssignRules([
+      {
+        key: 'assignee-from-popup-parent',
+        enable: true,
+        targetPath: 'assignee',
+        mode: 'assign',
+        condition: {
+          logic: '$and',
+          items: [
+            { path: '{{ ctx.item.parentItem.index }}', operator: '$eq', value: 1 },
+            { path: '{{ ctx.item.parentItem.length }}', operator: '$eq', value: 3 },
+            { path: '{{ ctx.item.parentItem.__is_new__ }}', operator: '$eq', value: true },
+            { path: '{{ ctx.item.parentItem.__is_stored__ }}', operator: '$eq', value: false },
+          ],
+        },
+        value: '{{ ctx.item.parentItem.parentItem.value.defaultAssignee }}',
+      },
+    ]);
+
+    await waitFor(() => expect(formStub.getFieldValue(['assignee'])).toEqual(initialAssignee));
+
+    outerValue.defaultAssignee = nextAssignee;
+    await waitFor(() => expect(formStub.getFieldValue(['assignee'])).toEqual(nextAssignee));
+  });
+
   it('does not write to to-many nested path without row index', async () => {
     const engineEmitter = new EventEmitter();
     const blockEmitter = new EventEmitter();

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
@@ -4076,6 +4076,117 @@ describe('FormValueRuntime (form assign rules)', () => {
     await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(nextSecondary));
   });
 
+  it('materializes assigned proxies so later to-many rows continue updating', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const initialSecondary = { id: 2, name: 'Initial secondary', roleCodes: ['admin'] };
+    const nextSecondary = { id: 4, name: 'Next secondary', roleCodes: ['editor'] };
+    type UserRow = {
+      user: unknown;
+      secondaryUser: typeof initialSecondary | null;
+    };
+    const store: { users: UserRow[] } = {
+      users: [{ user: null, secondaryUser: initialSecondary }],
+    };
+    type FormNamePath = Parameters<FormInstance['getFieldValue']>[0];
+    const formStub = {
+      getFieldValue: (namePath: FormNamePath) => lodashGet(store, namePath),
+      setFieldValue: (namePath: FormNamePath, value: unknown) => lodashSet(store, namePath, value),
+      // Match Ant Form: the outer store is plain, but nested values may still be reactive proxies.
+      getFieldsValue: () => store,
+      setFieldsValue: (patch: Partial<typeof store>) => lodashMerge(store, patch),
+    };
+
+    const blockModel = {
+      uid: 'form-assign-assoc-to-many-later-row-reactive-proxy',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+      context: undefined as unknown,
+    };
+
+    const runtime = new FormValueRuntime({
+      model: blockModel as unknown as ConstructorParameters<typeof FormValueRuntime>[0]['model'],
+      getForm: () => formStub as unknown as FormInstance,
+    });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    const userCollection = { getField: () => null };
+    const userField = { isAssociationField: () => true, type: 'belongsTo', targetCollection: userCollection };
+    const usersItemCollection = {
+      getField: (name: string) => (name === 'user' || name === 'secondaryUser' ? userField : null),
+    };
+    const usersField = { isAssociationField: () => true, type: 'hasMany', targetCollection: usersItemCollection };
+    const collection = { getField: (name: string) => (name === 'users' ? usersField : null) };
+    blockCtx.defineProperty('collection', { value: collection });
+
+    const createRowModel = (index: number) => {
+      const forkId = `users:${index}`;
+      const rowCtx = createFieldContext(runtime);
+      const rowModel = {
+        uid: `users.user:${forkId}`,
+        isFork: true,
+        forkId,
+        subModels: { field: { context: { collectionField: userField } } },
+        getStepParams(flowKey: string, stepKey: string) {
+          if (flowKey === 'fieldSettings' && stepKey === 'init') return { fieldPath: 'users.user' };
+          return undefined;
+        },
+        context: rowCtx,
+      };
+      rowCtx.defineProperty('blockModel', { value: blockModel });
+      rowCtx.defineProperty('collection', { value: collection });
+      rowCtx.defineProperty('fieldIndex', { value: [forkId] });
+      rowCtx.defineProperty('model', { value: rowModel });
+      return rowModel;
+    };
+    const rowModels = [createRowModel(0)];
+
+    blockCtx.defineProperty('engine', {
+      value: { forEachModel: (callback: (model: unknown) => void) => rowModels.forEach(callback) },
+    });
+    blockModel.context = blockCtx;
+
+    runtime.syncAssignRules([
+      {
+        key: 'user-from-row-sibling',
+        enable: true,
+        targetPath: 'users.user',
+        mode: 'assign',
+        condition: { logic: '$and', items: [] },
+        value: '{{ ctx.item.parentItem.value.secondaryUser }}',
+      },
+    ]);
+
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(initialSecondary));
+    const assignedUser = formStub.getFieldValue(['users', 0, 'user']);
+    const assignedRoleCodes = formStub.getFieldValue(['users', 0, 'user', 'roleCodes']);
+    expect(assignedUser.constructor).toBe(Object);
+    expect(Array.isArray(assignedRoleCodes)).toBe(true);
+    expect(assignedRoleCodes.constructor).toBe(Array);
+
+    const secondRow: UserRow = { user: null, secondaryUser: null };
+    store.users.push(secondRow);
+    const addedRows: Array<UserRow | undefined> = new Array(2);
+    addedRows[1] = secondRow;
+    expect(() => runtime.handleFormValuesChange({ users: addedRows }, store)).not.toThrow();
+
+    const row1 = createRowModel(1);
+    rowModels.push(row1);
+    engineEmitter.emit('model:mounted', { model: row1 });
+
+    secondRow.secondaryUser = nextSecondary;
+    const changedRows: Array<Partial<UserRow> | undefined> = new Array(2);
+    changedRows[1] = { secondaryUser: nextSecondary };
+    expect(0 in changedRows).toBe(false);
+
+    expect(() => runtime.handleFormValuesChange({ users: changedRows }, store)).not.toThrow();
+    await waitFor(() => expect(formStub.getFieldValue(['users', 1, 'user'])).toEqual(nextSecondary));
+    expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(initialSecondary);
+  });
+
   it('assigns a to-many association from a sibling association in the same to-many row', async () => {
     const engineEmitter = new EventEmitter();
     const blockEmitter = new EventEmitter();

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
@@ -4076,6 +4076,82 @@ describe('FormValueRuntime (form assign rules)', () => {
     await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'user'])).toEqual(nextSecondary));
   });
 
+  it('assigns a to-many association from a sibling association in the same to-many row', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const initialRoles = [{ id: 2, name: 'Initial role' }];
+    const formStub = createFormStub({ users: [{ roles: [], secondaryRoles: [] }] });
+
+    const blockModel: any = {
+      uid: 'form-assign-to-many-assoc-from-to-many-row-sibling',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    const roleCollection: any = { filterTargetKey: 'id', getField: () => null };
+    const rolesField: any = {
+      isAssociationField: () => true,
+      type: 'belongsToMany',
+      targetCollection: roleCollection,
+    };
+    const usersItemCollection: any = {
+      getField: (name: string) => (name === 'roles' || name === 'secondaryRoles' ? rolesField : null),
+    };
+    const usersField: any = { isAssociationField: () => true, type: 'hasMany', targetCollection: usersItemCollection };
+    const collection: any = { getField: (name: string) => (name === 'users' ? usersField : null) };
+    blockCtx.defineProperty('collection', { value: collection });
+
+    const rowModel: any = {
+      uid: 'users.roles:users:0',
+      isFork: true,
+      forkId: 'users:0',
+      subModels: { field: { context: { collectionField: rolesField } } },
+      getStepParams(flowKey: string, stepKey: string) {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') return { fieldPath: 'users.roles' };
+        return undefined;
+      },
+    };
+    const rowCtx = createFieldContext(runtime);
+    rowCtx.defineProperty('blockModel', { value: blockModel });
+    rowCtx.defineProperty('collection', { value: collection });
+    rowCtx.defineProperty('fieldIndex', { value: ['users:0'] });
+    rowCtx.defineProperty('model', { value: rowModel });
+    rowModel.context = rowCtx;
+
+    blockCtx.defineProperty('engine', {
+      value: { forEachModel: (callback: (model: unknown) => void) => callback(rowModel) },
+    });
+    blockModel.context = blockCtx;
+
+    runtime.syncAssignRules([
+      {
+        key: 'roles-from-row-sibling',
+        enable: true,
+        targetPath: 'users.roles',
+        mode: 'assign',
+        condition: { logic: '$and', items: [] },
+        value: '{{ ctx.item.parentItem.value.secondaryRoles }}',
+      },
+    ]);
+
+    await runtime.setFormValues(blockCtx, [{ path: ['users', 0, 'secondaryRoles'], value: initialRoles }], {
+      source: 'user',
+    });
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'roles'])).toEqual(initialRoles));
+
+    const nextRoles = [{ id: 3, name: 'Next role' }];
+    await runtime.setFormValues(blockCtx, [{ path: ['users', 0, 'secondaryRoles'], value: nextRoles }], {
+      source: 'user',
+    });
+    await waitFor(() => expect(formStub.getFieldValue(['users', 0, 'roles'])).toEqual(nextRoles));
+  });
+
   it('preserves the PopupSubTable outer item chain for a top-level to-one association target', async () => {
     const engineEmitter = new EventEmitter();
     const blockEmitter = new EventEmitter();
@@ -4141,6 +4217,73 @@ describe('FormValueRuntime (form assign rules)', () => {
 
     outerValue.defaultAssignee = nextAssignee;
     await waitFor(() => expect(formStub.getFieldValue(['assignee'])).toEqual(nextAssignee));
+  });
+
+  it('preserves the PopupSubTable outer item chain for a top-level to-many association target', async () => {
+    const engineEmitter = new EventEmitter();
+    const blockEmitter = new EventEmitter();
+    const initialReviewers = [{ id: 2, name: 'Initial reviewer' }];
+    const nextReviewers = [{ id: 3, name: 'Next reviewer' }];
+    const outerValue = observable({ defaultReviewers: initialReviewers });
+    const formStub = createFormStub({ reviewers: [] });
+
+    const blockModel: any = {
+      uid: 'popup-sub-table-form-assign-to-many-parent-item',
+      flowEngine: { emitter: engineEmitter },
+      emitter: blockEmitter,
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+    };
+
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    runtime.mount({ sync: true });
+
+    const blockCtx = createFieldContext(runtime);
+    const userCollection: any = { filterTargetKey: 'id', getField: () => null };
+    const reviewersField: any = {
+      isAssociationField: () => true,
+      type: 'belongsToMany',
+      targetCollection: userCollection,
+    };
+    const collection: any = { getField: (name: string) => (name === 'reviewers' ? reviewersField : null) };
+    const outerItem = { index: 0, length: 1, value: outerValue };
+    blockCtx.defineProperty('collection', { value: collection });
+    blockCtx.defineProperty('item', {
+      get: () => ({
+        index: 1,
+        length: 3,
+        __is_new__: true,
+        __is_stored__: false,
+        value: blockCtx.formValues,
+        parentItem: outerItem,
+      }),
+      cache: false,
+    });
+    blockModel.context = blockCtx;
+
+    runtime.syncAssignRules([
+      {
+        key: 'reviewers-from-popup-parent',
+        enable: true,
+        targetPath: 'reviewers',
+        mode: 'assign',
+        condition: {
+          logic: '$and',
+          items: [
+            { path: '{{ ctx.item.parentItem.index }}', operator: '$eq', value: 1 },
+            { path: '{{ ctx.item.parentItem.length }}', operator: '$eq', value: 3 },
+            { path: '{{ ctx.item.parentItem.__is_new__ }}', operator: '$eq', value: true },
+            { path: '{{ ctx.item.parentItem.__is_stored__ }}', operator: '$eq', value: false },
+          ],
+        },
+        value: '{{ ctx.item.parentItem.parentItem.value.defaultReviewers }}',
+      },
+    ]);
+
+    await waitFor(() => expect(formStub.getFieldValue(['reviewers'])).toEqual(initialReviewers));
+
+    outerValue.defaultReviewers = nextReviewers;
+    await waitFor(() => expect(formStub.getFieldValue(['reviewers'])).toEqual(nextReviewers));
   });
 
   it('does not write to to-many nested path without row index', async () => {

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/rules.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/rules.ts
@@ -83,6 +83,15 @@ type ToManyAggregateSourceInfo = {
   lastWrite?: FormValueWriteMeta;
 };
 
+type RuntimeItemChain = {
+  index?: number;
+  length?: number;
+  __is_new__?: boolean;
+  __is_stored__?: boolean;
+  value: unknown;
+  parentItem?: RuntimeItemChain;
+};
+
 export type RuleEngineOptions = {
   getBlockModelUid: () => string;
   getActionName: () => string | undefined;
@@ -2209,7 +2218,21 @@ export class RuleEngine {
         parentItem,
       };
     };
-    const defaultRoot = buildNode(trackingFormValues, undefined, undefined, undefined);
+    const blockCtx = this.options.getBlockContext();
+    const formRootItem = (() => {
+      try {
+        const item = blockCtx?.item as RuntimeItemChain | undefined;
+        if (!item || typeof item !== 'object') return undefined;
+        return item.value === blockCtx?.formValues ? item : undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+    const defaultRoot = {
+      ...buildNode(trackingFormValues, formRootItem?.index, formRootItem?.length, formRootItem?.parentItem),
+      __is_new__: formRootItem?.__is_new__ ?? trackingFormValues?.__is_new__,
+      __is_stored__: formRootItem?.__is_stored__ ?? trackingFormValues?.__is_stored__,
+    };
     // item 仅用于“关系字段的子路径”场景；
     // 顶层字段/非关联嵌套对象字段应使用 formValues。
     if (!targetNamePath || !Array.isArray(targetNamePath) || !targetNamePath.length) return undefined;
@@ -2219,7 +2242,9 @@ export class RuleEngine {
     const prefix: NamePath = [];
     let collection = rootCollection;
 
-    for (let i = 0; i < targetNamePath.length - 1; i++) {
+    // The target itself can be a to-one association. Keep that final association in the item chain so
+    // ctx.item.parentItem continues to point at the containing row instead of skipping directly to the form root.
+    for (let i = 0; i < targetNamePath.length; i++) {
       const seg = targetNamePath[i];
       if (typeof seg !== 'string') break;
 

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/rules.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/rules.ts
@@ -2047,7 +2047,7 @@ export class RuleEngine {
     // - parentItem：上级项（同结构，可链式 parentItem.parentItem...）
     // 计算顺序：
     // 1) 优先按 targetNamePath 从 formValues 构建“关联链 item”
-    // 2) 若无法构建（例如目标字段是顶层路径），回退到上游显式注入的 baseCtx.item
+    // 2) 若无法构建（例如目标字段是顶层非关联字段），回退到上游显式注入的 baseCtx.item
     //    （如 PopupSubTable 新增弹窗传入的 parentItem 链）
     let itemCached: any;
     let itemCachedReady = false;
@@ -2233,8 +2233,8 @@ export class RuleEngine {
       __is_new__: formRootItem?.__is_new__ ?? trackingFormValues?.__is_new__,
       __is_stored__: formRootItem?.__is_stored__ ?? trackingFormValues?.__is_stored__,
     };
-    // item 仅用于“关系字段的子路径”场景；
-    // 顶层字段/非关联嵌套对象字段应使用 formValues。
+    // item 用于“关系字段目标或其子路径”场景；
+    // 顶层非关联字段/非关联嵌套对象字段应使用 formValues。
     if (!targetNamePath || !Array.isArray(targetNamePath) || !targetNamePath.length) return undefined;
     if (!rootCollection?.getField) return undefined;
 
@@ -2242,7 +2242,7 @@ export class RuleEngine {
     const prefix: NamePath = [];
     let collection = rootCollection;
 
-    // The target itself can be a to-one association. Keep that final association in the item chain so
+    // The target itself can be an association. Keep that final association in the item chain so
     // ctx.item.parentItem continues to point at the containing row instead of skipping directly to the form root.
     for (let i = 0; i < targetNamePath.length; i++) {
       const seg = targetNamePath[i];
@@ -2256,9 +2256,12 @@ export class RuleEngine {
 
       if (toMany) {
         const next = targetNamePath[i + 1];
-        if (typeof next !== 'number') break;
-        prefix.push(next);
-        i += 1;
+        if (typeof next === 'number') {
+          prefix.push(next);
+          i += 1;
+        } else if (i !== targetNamePath.length - 1) {
+          break;
+        }
       }
 
       const targetCollection = field?.targetCollection;
@@ -2273,9 +2276,11 @@ export class RuleEngine {
       const assocEntry = assocEntries[idx];
       const value = _.get(trackingFormValues, assocEntry.path);
       const lastSeg = assocEntry.path[assocEntry.path.length - 1];
-      const index = assocEntry.toMany && typeof lastSeg === 'number' ? lastSeg : undefined;
+      const isIndexedToManyItem = assocEntry.toMany && typeof lastSeg === 'number';
+      const index = isIndexedToManyItem ? lastSeg : undefined;
       const length = (() => {
         if (!assocEntry.toMany) return undefined;
+        if (!isIndexedToManyItem) return Array.isArray(value) ? value.length : undefined;
         // assocEntry.path: [..., associationKey, rowIndex]
         const listPath = assocEntry.path.slice(0, -1);
         const list = _.get(trackingFormValues, listPath);

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/runtime.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/runtime.ts
@@ -142,13 +142,32 @@ export class FormValueRuntime {
     return this.getForm().getFieldsValue(true);
   }
 
-  private toMirrorSnapshot(value: any) {
-    const raw = isObservable(value) ? toJS(value) : value;
-    return _.cloneDeepWith(raw, (item) => {
-      if (!item || typeof item !== 'object') return undefined;
-      if (Array.isArray(item) || _.isPlainObject(item)) return undefined;
-      return item;
-    });
+  private toMirrorSnapshot<T>(value: T): T {
+    const cloneValue = (input: unknown): unknown =>
+      _.cloneDeepWith(input, (item: unknown) => {
+        if (isObservable(item)) {
+          const plainItem = toJS(item);
+          if (plainItem !== item) return cloneValue(plainItem);
+        }
+
+        // Tracking form-value array proxies hide `constructor`, while Lodash's array
+        // clone relies on it being callable.
+        if (Array.isArray(item) && typeof item.constructor !== 'function') {
+          const plainArray = new Array(item.length);
+          for (let index = 0; index < item.length; index++) {
+            if (Object.hasOwn(item, index)) {
+              plainArray[index] = cloneValue(item[index]);
+            }
+          }
+          return plainArray;
+        }
+
+        if (!item || typeof item !== 'object') return undefined;
+        if (Array.isArray(item) || _.isPlainObject(item)) return undefined;
+        return item;
+      });
+
+    return cloneValue(value) as T;
   }
 
   canApplyDefaultValuePatch(namePath: NamePath, resolved: any) {
@@ -892,11 +911,12 @@ export class FormValueRuntime {
       const changedPaths: NamePath[] = [];
 
       if (!Array.isArray(patch)) {
-        const patchEntries = Object.entries(patch || {}).filter(([pathKey, rawValue]) => {
-          if (shouldSkipByLinkageScope(pathKey)) return false;
-          const value = isObservable(rawValue) ? toJS(rawValue) : rawValue;
-          return !_.isEqual(this.getFormValueAtPath([pathKey]), value);
-        });
+        const patchEntries = Object.entries(patch || {})
+          .map(([pathKey, rawValue]) => [pathKey, this.toMirrorSnapshot(rawValue)] as const)
+          .filter(([pathKey, value]) => {
+            if (shouldSkipByLinkageScope(pathKey)) return false;
+            return !_.isEqual(this.getFormValueAtPath([pathKey]), value);
+          });
         const patchToApply = Object.fromEntries(patchEntries);
         const patchKeys = patchEntries.map(([pathKey]) => pathKey);
         if (!patchKeys.length) {
@@ -907,8 +927,7 @@ export class FormValueRuntime {
         }
         this.suppressFormCallbackDepth++;
         try {
-          for (const [pathKey, rawValue] of patchEntries) {
-            const value = isObservable(rawValue) ? toJS(rawValue) : rawValue;
+          for (const [pathKey, value] of patchEntries) {
             if (typeof form.setFieldValue === 'function') {
               form.setFieldValue(pathKey, value);
             } else if (typeof (form as any).setFields === 'function') {
@@ -969,7 +988,7 @@ export class FormValueRuntime {
         const namePath = this.resolveNamePath(callerCtx, item.path);
         const pathKey = namePathToPathKey(namePath);
         const rawValue = item.value;
-        const value = isObservable(rawValue) ? toJS(rawValue) : rawValue;
+        const value = this.toMirrorSnapshot(rawValue);
 
         if (shouldSkipByLinkageScope(pathKey)) continue;
 
@@ -1108,17 +1127,18 @@ export class FormValueRuntime {
     if (!form) return;
     if (source === 'override' && this.findUserEditedHit(pathKey)) return;
 
+    const value = this.toMirrorSnapshot(nextValue);
     const prevValue = _.get(this.valuesMirror, namePath);
-    if (_.isEqual(prevValue, nextValue)) return;
+    if (_.isEqual(prevValue, value)) return;
 
     this.writeSeq += 1;
     const writeSeq = this.writeSeq;
 
     this.suppressFormCallbackDepth++;
     try {
-      form.setFieldValue?.(namePath, nextValue);
-      _.set(this.valuesMirror, namePath, this.toMirrorSnapshot(nextValue));
-      this.syncMountedFieldModelValue(namePath, nextValue);
+      form.setFieldValue?.(namePath, value);
+      _.set(this.valuesMirror, namePath, this.toMirrorSnapshot(value));
+      this.syncMountedFieldModelValue(namePath, value);
       this.bumpChangeTick();
     } finally {
       this.suppressFormCallbackDepth--;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed parent item variables resolving to the wrong level when assigning association field values in sub-tables. |
| 🇨🇳 Chinese | 修复子表格关系字段赋值时上级项变量解析到错误层级的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
