### PR TITLE
fix(ai): show AI employee entry in all portals

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/components/ChatButton.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/components/ChatButton.tsx
@@ -25,8 +25,10 @@ const icon = new URL('../../icon.svg', import.meta.url).toString();
 export const ChatButton: React.FC = observer(() => {
   const ctx = useFlowContext<FlowRuntimeContext>();
   const t = useT();
-  const { pathname } = useLocation();
   const isV1Page = ctx?.pageInfo?.version === 'v1';
+  const { pathname } = useLocation();
+  const isV2Route = window.location.pathname.startsWith('/v/') || pathname.startsWith('/v/');
+  const isAdmin = pathname.startsWith('/admin');
   const { isMobileLayout } = useMobileLayout();
   const { token } = theme.useToken();
   const { unreadCount: unreadConversationCount } = useChatConversationActions();
@@ -72,7 +74,7 @@ export const ChatButton: React.FC = observer(() => {
     };
   }, [unreadCount]);
 
-  if (open || !aiEmployees?.length || isV1Page || isMobileLayout || !pathname.startsWith('/admin')) {
+  if (open || !aiEmployees?.length || isV1Page || (!isV2Route && !isAdmin) || isMobileLayout) {
     return null;
   }
 

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/stores/__tests__/chatbox-global-behavior.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/stores/__tests__/chatbox-global-behavior.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatButton } from '../../components/ChatButton';
 import { ChatBoxRuntimeProvider, createChatBoxRuntime, type ChatBoxRuntime } from '../runtime';
@@ -30,12 +31,6 @@ vi.mock('@nocobase/flow-engine', async () => {
     }),
   };
 });
-
-vi.mock('react-router-dom', () => ({
-  useLocation: () => ({
-    pathname: '/admin',
-  }),
-}));
 
 vi.mock('../../../../locale', () => ({
   useT: () => (text: string) => text,
@@ -78,26 +73,30 @@ vi.mock('../../hooks/useWorkflowTasks', () => ({
   }),
 }));
 
-const renderWithRuntime = (runtime: ChatBoxRuntime) => {
+const renderWithRuntime = (runtime: ChatBoxRuntime, initialEntry = '/customer1') => {
   return render(
-    <ChatBoxRuntimeProvider runtime={runtime}>
-      <ChatButton />
-    </ChatBoxRuntimeProvider>,
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <ChatBoxRuntimeProvider runtime={runtime}>
+        <ChatButton />
+      </ChatBoxRuntimeProvider>
+    </MemoryRouter>,
   );
 };
 
 describe('global chatbox behavior', () => {
   beforeEach(() => {
+    window.history.replaceState({}, '', '/v/customer1');
     mocks.getAIEmployees.mockResolvedValue(undefined);
     mocks.setResponseLoading.mockClear();
     mocks.switchAIEmployee.mockClear();
   });
 
   afterEach(() => {
+    window.history.replaceState({}, '', '/');
     mocks.getAIEmployees.mockReset();
   });
 
-  it('opens the global runtime and selects the leader employee from ChatButton', () => {
+  it('opens the global runtime from a non-default portal and selects the leader employee', () => {
     const runtime = createChatBoxRuntime();
 
     renderWithRuntime(runtime);
@@ -112,5 +111,23 @@ describe('global chatbox behavior', () => {
       nickname: 'Atlas',
       builtIn: true,
     });
+  });
+
+  it('renders the entry on /admin routes', () => {
+    window.history.replaceState({}, '', '/admin');
+    const runtime = createChatBoxRuntime();
+
+    renderWithRuntime(runtime, '/admin');
+
+    expect(screen.getByRole('button', { name: 'Open AI chat' })).toBeTruthy();
+  });
+
+  it('hides the entry outside /v/* and /admin routes', () => {
+    window.history.replaceState({}, '', '/signin');
+    const runtime = createChatBoxRuntime();
+
+    renderWithRuntime(runtime, '/signin');
+
+    expect(screen.queryByRole('button', { name: 'Open AI chat' })).toBeNull();
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The floating AI employee entry was restricted to the default admin route, so it did not appear when users opened another portal such as `/v/customer1`.

### Description
- Show the floating AI employee entry on all `/v/*` portal routes and `/admin` routes.
- Keep the entry hidden outside those routes, as well as on v1 pages, mobile layouts, and when no AI employees are available.
- Add route-visibility regression tests for a non-default portal, `/admin`, and an unsupported route.

### Related issues

None.

### Showcase

Not applicable; this change adjusts the visibility condition of an existing floating entry.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the AI employee entry not appearing in non-default portals. |
| 🇨🇳 Chinese | 修复 AI 员工入口未在非默认门户中显示的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
