### PR TITLE
feat(action): support v2 import and export field search

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
@@ -11,9 +11,10 @@ import { escapeT } from '@nocobase/flow-engine';
 import { ActionModel, ActionSceneEnum } from '@nocobase/client-v2';
 import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
-import { Cascader } from 'antd';
+import { Cascader, Spin, type CascaderProps } from 'antd';
 import React from 'react';
 import type { ButtonProps } from 'antd/es/button';
+import type { ExportFieldOption } from './buildExportFieldOptions';
 import { createLazyOptionFieldsCache } from './getOptionFields';
 import { NAMESPACE } from './locale';
 import { createExportFieldsOptionsSnapshot, normalizeExportFieldValue } from './exportFieldValue';
@@ -24,10 +25,28 @@ const exportFieldNames = {
   children: 'children',
 };
 
-const ExportFieldsCascader = (props) => {
-  const { optionsCache, value, onChange, onDropdownVisibleChange, ...others } = props;
+const SEARCH_DEBOUNCE_DELAY = 150;
+
+type ExportFieldsCascaderProps = Omit<
+  CascaderProps<ExportFieldOption, 'name', false>,
+  'fieldNames' | 'loadData' | 'onChange' | 'options' | 'showSearch' | 'value'
+> & {
+  optionsCache: ReturnType<typeof createLazyOptionFieldsCache>;
+  value?: unknown[];
+  onChange?: (value: string[] | null, selectedOptions: ExportFieldOption[]) => void;
+};
+
+export const ExportFieldsCascader = (props: ExportFieldsCascaderProps) => {
+  const { optionsCache, value, onChange, onDropdownVisibleChange, onSearch, notFoundContent, ...others } = props;
   const [cascaderOptions, setCascaderOptions] = React.useState(() => createExportFieldsOptionsSnapshot(optionsCache));
+  const [searchOptions, setSearchOptions] = React.useState<ExportFieldOption[]>([]);
+  const [searchStatus, setSearchStatus] = React.useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const lastPreloadedValueRef = React.useRef<string | null>(null);
+  const searchAbortControllerRef = React.useRef<AbortController>();
+  const searchTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
+  const searchValueRef = React.useRef('');
+  const optionsCacheRef = React.useRef(optionsCache);
+  const mountedRef = React.useRef(false);
   const cascaderValue = React.useMemo(() => normalizeExportFieldValue(value) || undefined, [value]);
 
   const refreshOptions = React.useCallback(() => {
@@ -35,8 +54,29 @@ const ExportFieldsCascader = (props) => {
   }, [optionsCache]);
 
   React.useEffect(() => {
+    optionsCacheRef.current = optionsCache;
+    searchValueRef.current = '';
+    searchAbortControllerRef.current?.abort();
+    searchAbortControllerRef.current = undefined;
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = undefined;
+    }
+    setSearchOptions([]);
+    setSearchStatus('idle');
     refreshOptions();
-  }, [refreshOptions]);
+  }, [optionsCache, refreshOptions]);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      searchAbortControllerRef.current?.abort();
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+    };
+  }, []);
 
   const getValueKey = React.useCallback((path) => {
     if (!Array.isArray(path)) {
@@ -83,11 +123,71 @@ const ExportFieldsCascader = (props) => {
   );
 
   const handleChange = React.useCallback(
-    (value) => {
-      onChange?.(normalizeExportFieldValue(value));
+    (nextValue: string[], selectedOptions: ExportFieldOption[]) => {
+      onChange?.(normalizeExportFieldValue(nextValue), selectedOptions);
     },
     [onChange],
   );
+
+  const handleSearch = React.useCallback(
+    (searchValue) => {
+      searchValueRef.current = searchValue;
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+        searchTimerRef.current = undefined;
+      }
+      searchAbortControllerRef.current?.abort();
+      searchAbortControllerRef.current = undefined;
+
+      if (!searchValue.trim()) {
+        setSearchOptions([]);
+        setSearchStatus('idle');
+      } else {
+        setSearchOptions([]);
+        setSearchStatus('loading');
+        searchTimerRef.current = setTimeout(async () => {
+          const activeOptionsCache = optionsCache;
+          const activeSearchValue = searchValue;
+          const abortController = new AbortController();
+          searchAbortControllerRef.current = abortController;
+          searchTimerRef.current = undefined;
+          try {
+            const matchedOptions = await activeOptionsCache.searchOptionsAsync(activeSearchValue, {
+              signal: abortController.signal,
+            });
+            if (
+              abortController.signal.aborted ||
+              !mountedRef.current ||
+              optionsCacheRef.current !== activeOptionsCache ||
+              searchValueRef.current !== activeSearchValue
+            ) {
+              return;
+            }
+            setSearchOptions(matchedOptions);
+            setSearchStatus('ready');
+          } catch {
+            if (
+              !abortController.signal.aborted &&
+              mountedRef.current &&
+              optionsCacheRef.current === activeOptionsCache &&
+              searchValueRef.current === activeSearchValue
+            ) {
+              setSearchOptions([]);
+              setSearchStatus('error');
+            }
+          } finally {
+            if (searchAbortControllerRef.current === abortController) {
+              searchAbortControllerRef.current = undefined;
+            }
+          }
+        }, SEARCH_DEBOUNCE_DELAY);
+      }
+      onSearch?.(searchValue);
+    },
+    [onSearch, optionsCache],
+  );
+
+  const searchIsActive = Boolean(searchValueRef.current.trim());
 
   const displayRender = React.useCallback(
     (labels, selectedOptions) => {
@@ -109,10 +209,13 @@ const ExportFieldsCascader = (props) => {
       {...others}
       value={cascaderValue}
       fieldNames={exportFieldNames}
-      options={cascaderOptions}
+      options={searchIsActive ? searchOptions : cascaderOptions}
       loadData={loadData}
+      notFoundContent={searchStatus === 'loading' ? <Spin size="small" /> : notFoundContent}
       onChange={handleChange}
       onDropdownVisibleChange={handleDropdownVisibleChange}
+      onSearch={handleSearch}
+      showSearch
       displayRender={displayRender}
     />
   );

--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/ExportFieldsCascader.test.tsx
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/ExportFieldsCascader.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nocobase/client-v2', () => {
+  class ActionModel {
+    static define() {}
+
+    static registerFlow() {}
+  }
+
+  return {
+    ActionModel,
+    ActionSceneEnum: { collection: 'collection' },
+  };
+});
+
+vi.mock('@nocobase/flow-engine', () => ({
+  escapeT: (value: string) => value,
+}));
+
+vi.mock('file-saver', () => ({
+  saveAs: vi.fn(),
+}));
+
+import { ExportFieldsCascader } from '../ExportActionModel';
+
+type SearchOptions = { signal?: AbortSignal };
+type SearchOption = { name: string; title: string; isLeaf: boolean; children?: SearchOption[] };
+
+const createOptionsCache = (
+  searchOptionsAsync: (searchValue: string, options?: SearchOptions) => Promise<SearchOption[]>,
+) => ({
+  getRootOptions: () => [{ name: 'title', title: 'Title', isLeaf: true }],
+  loadChildren: vi.fn(() => []),
+  preloadPath: vi.fn(() => false),
+  searchOptionsAsync,
+});
+
+describe('ExportFieldsCascader', () => {
+  it('shows a matching relation path after searchable options finish loading', async () => {
+    let resolveSearch = (_value: SearchOption[]) => undefined;
+    const searchPromise = new Promise<SearchOption[]>((resolve) => {
+      resolveSearch = resolve;
+    });
+    const searchOptionsAsync = vi.fn(() => searchPromise);
+    render(<ExportFieldsCascader optionsCache={createOptionsCache(searchOptionsAsync)} />);
+
+    const combobox = screen.getByRole('combobox');
+    fireEvent.mouseDown(combobox);
+    fireEvent.change(combobox, { target: { value: 'Nickname' } });
+
+    await waitFor(() => expect(searchOptionsAsync).toHaveBeenCalledTimes(1));
+    expect(document.querySelector('.ant-spin')).toBeTruthy();
+
+    await act(async () => {
+      resolveSearch([
+        {
+          name: 'user',
+          title: 'User',
+          isLeaf: false,
+          children: [{ name: 'nickname', title: 'Nickname', isLeaf: true }],
+        },
+      ]);
+      await searchPromise;
+    });
+
+    await waitFor(() => expect(document.querySelector('.ant-spin')).toBeFalsy());
+    await waitFor(() => expect(document.body.textContent).toContain('User / Nickname'));
+    expect(screen.getByRole('combobox')).toBeTruthy();
+  });
+
+  it('cancels an obsolete search when the input is cleared and changed', async () => {
+    const signals: AbortSignal[] = [];
+    const searchOptionsAsync = vi.fn((searchValue: string, options?: SearchOptions) => {
+      const signal = options?.signal;
+      if (signal) {
+        signals.push(signal);
+      }
+      if (searchValue === 'Second') {
+        return Promise.resolve([{ name: 'second', title: 'Second', isLeaf: true }]);
+      }
+      return new Promise<SearchOption[]>((resolve) => {
+        signal?.addEventListener('abort', () => resolve([]), { once: true });
+      });
+    });
+    render(<ExportFieldsCascader optionsCache={createOptionsCache(searchOptionsAsync)} />);
+
+    const combobox = screen.getByRole('combobox');
+    fireEvent.change(combobox, { target: { value: 'First' } });
+    await waitFor(() => expect(searchOptionsAsync).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(combobox, { target: { value: '' } });
+    fireEvent.change(combobox, { target: { value: 'Second' } });
+
+    await waitFor(() => expect(signals[0]?.aborted).toBe(true));
+    expect(document.querySelector('.ant-spin')).toBeTruthy();
+    await waitFor(() => expect(searchOptionsAsync).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(document.querySelector('.ant-spin')).toBeFalsy());
+  });
+
+  it('contains option search errors instead of crashing the cascader', async () => {
+    const searchOptionsAsync = vi.fn().mockRejectedValue(new Error('Failed to search fields'));
+    const { container } = render(<ExportFieldsCascader optionsCache={createOptionsCache(searchOptionsAsync)} />);
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Title' } });
+
+    await waitFor(() => expect(searchOptionsAsync).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(container.querySelector('.ant-spin')).toBeFalsy());
+    expect(screen.getByRole('combobox')).toBeTruthy();
+  });
+
+  it('cancels an active search when the cascader unmounts', async () => {
+    let activeSignal: AbortSignal | undefined;
+    const searchOptionsAsync = vi.fn((_searchValue: string, options?: SearchOptions) => {
+      activeSignal = options?.signal;
+      return new Promise<SearchOption[]>((resolve) => {
+        activeSignal?.addEventListener('abort', () => resolve([]), { once: true });
+      });
+    });
+    const { unmount } = render(<ExportFieldsCascader optionsCache={createOptionsCache(searchOptionsAsync)} />);
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Nickname' } });
+    await waitFor(() => expect(searchOptionsAsync).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    expect(activeSignal?.aborted).toBe(true);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/buildExportFieldOptions.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/buildExportFieldOptions.test.ts
@@ -323,6 +323,112 @@ describe('buildExportFieldOptions', () => {
     expect(getTargetFields).toHaveBeenCalledTimes(1);
   });
 
+  it('returns matching relation paths without hydrating the lazy browsing cache', async () => {
+    const getTargetFields = vi.fn((field) => {
+      if (field.target === 'users') {
+        return [
+          createField({ name: 'nickname' }),
+          createField({ name: 'department', interface: 'm2o', type: 'belongsTo', target: 'departments' }),
+        ];
+      }
+      if (field.target === 'departments') {
+        return [createField({ name: 'title' })];
+      }
+      return [];
+    });
+    const cache = createExportFieldLazyOptionsCache(
+      [createField({ name: 'user', interface: 'm2o', type: 'belongsTo', target: 'users' })],
+      (field) => field.name,
+      getTargetFields,
+    );
+
+    expect(getTargetFields).not.toHaveBeenCalled();
+    await expect(cache.searchOptionsAsync('title')).resolves.toMatchObject([
+      {
+        name: 'user',
+        children: [
+          {
+            name: 'department',
+            children: [{ name: 'title', isLeaf: true }],
+          },
+        ],
+      },
+    ]);
+    expect(getTargetFields).toHaveBeenCalledTimes(2);
+    expect(cache.getRootOptions()[0]).not.toHaveProperty('children');
+  });
+
+  it('allows field search to retry after an error', async () => {
+    let shouldFail = true;
+    const cache = createExportFieldLazyOptionsCache(
+      [createField({ name: 'user', interface: 'm2o', type: 'belongsTo', target: 'users' })],
+      (field) => field.name,
+      () => {
+        if (shouldFail) {
+          throw new Error('Failed to read target fields');
+        }
+        return [createField({ name: 'nickname' })];
+      },
+    );
+
+    await expect(cache.searchOptionsAsync('nickname')).rejects.toThrow('Failed to read target fields');
+    shouldFail = false;
+    await expect(cache.searchOptionsAsync('nickname')).resolves.toMatchObject([
+      {
+        name: 'user',
+        children: [{ name: 'nickname', isLeaf: true }],
+      },
+    ]);
+  });
+
+  it('limits matching search paths to avoid an unbounded result tree', async () => {
+    const relationFields = Array.from({ length: 100 }, (_, index) =>
+      createField({
+        name: `relation_${index}`,
+        interface: 'm2o',
+        type: 'belongsTo',
+        target: `target_${index}`,
+      }),
+    );
+    const getTargetFields = vi.fn((field) => [createField({ name: `${field.name}_title` })]);
+    const cache = createExportFieldLazyOptionsCache(relationFields, (field) => field.name, getTargetFields);
+
+    const results = await cache.searchOptionsAsync('title', { limit: 10 });
+
+    expect(results).toHaveLength(10);
+    expect(getTargetFields).toHaveBeenCalledTimes(10);
+    expect(cache.getRootOptions().every((option) => !option.children)).toBe(true);
+  });
+
+  it('yields to the event loop and supports cancellation during a large field search', async () => {
+    vi.useFakeTimers();
+    try {
+      const relationFields = Array.from({ length: 201 }, (_, index) =>
+        createField({
+          name: `relation_${index}`,
+          interface: 'm2o',
+          type: 'belongsTo',
+          target: `target_${index}`,
+        }),
+      );
+      const cache = createExportFieldLazyOptionsCache(
+        relationFields,
+        (field) => field.name,
+        (field) => [createField({ name: `${field.name}_title` })],
+      );
+
+      const abortController = new AbortController();
+      const searchPromise = cache.searchOptionsAsync('not-found', { signal: abortController.signal });
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      abortController.abort();
+      await vi.runAllTimersAsync();
+      await expect(searchPromise).resolves.toEqual([]);
+      expect(cache.getRootOptions().every((option) => !option.children)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('creates a new root options snapshot after lazy children are loaded', () => {
     const cache = createExportFieldLazyOptionsCache(
       [createField({ name: 'file_m2m', interface: 'm2m', type: 'belongsToMany', target: 'files' })],

--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/buildExportFieldOptions.ts
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/buildExportFieldOptions.ts
@@ -10,19 +10,45 @@
 const TO_ONE_RELATION_TYPES = ['hasOne', 'belongsTo'];
 const TO_MANY_RELATION_TYPES = ['hasMany', 'belongsToMany', 'belongsToArray'];
 const RELATION_TYPES = [...TO_ONE_RELATION_TYPES, 'hasMany', 'belongsToMany', 'belongsToArray'];
-const optionMeta = new WeakMap<object, { field: any; relationDepth: number }>();
+const PRELOAD_BATCH_SIZE = 200;
+const PRELOAD_TIME_SLICE = 8;
+const DEFAULT_SEARCH_RESULT_LIMIT = 50;
+
+export type ExportFieldOption = {
+  name: string;
+  title?: unknown;
+  schema?: unknown;
+  disabled?: boolean;
+  isLeaf?: boolean;
+  loading?: boolean;
+  children?: ExportFieldOption[];
+};
+
+type ExportFieldSearchOptions = {
+  limit?: number;
+  signal?: AbortSignal;
+};
+
+type ExportFieldSearchStackItem = {
+  option: ExportFieldOption;
+  path: ExportFieldOption[];
+};
+
+const optionMeta = new WeakMap<ExportFieldOption, { field: any; relationDepth: number }>();
+
+const waitForNextTask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 const isRelationField = (field) => field?.target && RELATION_TYPES.includes(field.type);
 const isToManyRelationField = (field) => field?.target && TO_MANY_RELATION_TYPES.includes(field.type);
 
-const createOption = (field, getTitle, disabled = false) => ({
+const createOption = (field, getTitle, disabled = false): ExportFieldOption => ({
   name: field.name,
   title: getTitle(field),
   schema: field?.uiSchema,
   disabled,
 });
 
-const createLazyOption = (field, getTitle, relationDepth = 0) => {
+const createLazyOption = (field, getTitle, relationDepth = 0): ExportFieldOption => {
   const relation = isRelationField(field);
   const option = {
     ...createOption(field, getTitle),
@@ -119,6 +145,29 @@ export const buildExportFieldLazyChildren = (option, getTitle, getTargetFields) 
   });
 };
 
+const buildSearchOptionTree = (paths: ExportFieldOption[][]): ExportFieldOption[] => {
+  const rootOptions: ExportFieldOption[] = [];
+  paths.forEach((path) => {
+    let currentOptions = rootOptions;
+    path.forEach((sourceOption, index) => {
+      const isLeaf = index === path.length - 1;
+      let targetOption = currentOptions.find((option) => option.name === sourceOption.name);
+      if (!targetOption) {
+        targetOption = {
+          ...sourceOption,
+          children: isLeaf ? undefined : [],
+        };
+        currentOptions.push(targetOption);
+      }
+      if (!isLeaf) {
+        targetOption.children ||= [];
+        currentOptions = targetOption.children;
+      }
+    });
+  });
+  return rootOptions;
+};
+
 export const createExportFieldLazyOptionsCache = (fields, getTitle, getTargetFields) => {
   const rootOptions = buildExportFieldLazyOptions(fields, getTitle);
 
@@ -165,9 +214,66 @@ export const createExportFieldLazyOptionsCache = (fields, getTitle, getTargetFie
     return changed;
   };
 
+  const searchOptionsAsync = async (
+    searchValue: string,
+    { limit = DEFAULT_SEARCH_RESULT_LIMIT, signal }: ExportFieldSearchOptions = {},
+  ) => {
+    const keyword = searchValue.trim().toLocaleLowerCase();
+    if (!keyword || signal?.aborted) {
+      return [];
+    }
+
+    const matchedPaths: ExportFieldOption[][] = [];
+    const stack: ExportFieldSearchStackItem[] = [...rootOptions].reverse().map((option) => ({ option, path: [] }));
+    const resultLimit = Math.max(1, limit);
+    let batchStartedAt = performance.now();
+    let batchSize = 0;
+
+    while (stack.length && matchedPaths.length < resultLimit) {
+      if (signal?.aborted) {
+        return [];
+      }
+
+      const current = stack.pop();
+      if (!current) {
+        break;
+      }
+      const path = [...current.path, current.option];
+      if (current.option.isLeaf) {
+        const matches = path.some((option) =>
+          String(option.title ?? '')
+            .toLocaleLowerCase()
+            .includes(keyword),
+        );
+        if (!current.option.disabled && matches) {
+          matchedPaths.push(path);
+        }
+      } else {
+        const children =
+          current.option.children || buildExportFieldLazyChildren(current.option, getTitle, getTargetFields);
+        for (let index = children.length - 1; index >= 0; index--) {
+          stack.push({ option: children[index], path });
+        }
+      }
+
+      batchSize += 1;
+      if (batchSize >= PRELOAD_BATCH_SIZE || performance.now() - batchStartedAt >= PRELOAD_TIME_SLICE) {
+        await waitForNextTask();
+        if (signal?.aborted) {
+          return [];
+        }
+        batchStartedAt = performance.now();
+        batchSize = 0;
+      }
+    }
+
+    return buildSearchOptionTree(matchedPaths);
+  };
+
   return {
     getRootOptions: () => rootOptions,
     loadChildren,
     preloadPath,
+    searchOptionsAsync,
   };
 };

--- a/packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx
@@ -549,6 +549,7 @@ ImportActionModel.registerFlow({
                         },
                         changeOnSelect: false,
                         options: data,
+                        showSearch: true,
                       },
                     },
                     title: {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

The v2 import and export action settings can contain many fields and nested association paths, but the field Cascaders did not support searching. Users had to browse the complete hierarchy manually, and eagerly loading the export relation tree would risk blocking or destabilizing the settings UI.

### Description

- Enable Ant Design Cascader search for v2 import field configuration.
- Add keyword-driven asynchronous search for v2 export fields without hydrating the normal lazy-browsing cache.
- Limit export search results to 50 matching paths.
- Debounce input by 150 ms and yield traversal work after 200 nodes or 8 ms.
- Cancel obsolete searches when the keyword is changed or cleared, the options cache changes, or the component unmounts.
- Ignore stale asynchronous results and contain search failures so they cannot crash the Cascader.
- Add unit and component tests for nested relation matches, result limits, time slicing, cancellation, unmount cleanup, and error handling.

Potential risk: an unusually wide single target collection still creates its immediate child options synchronously before the next traversal yield. Normal collection sizes are covered, but a relation-heavy collection is recommended for manual smoke testing.

Testing suggestions:

1. Open the v2 import and export action settings and search by localized field title.
2. Verify nested export fields appear as complete association paths and remain selectable.
3. Type, clear, and replace keywords rapidly and confirm stale results do not appear.
4. Close the settings UI while a search is running and confirm no error is reported.
5. Smoke-test export field search with a relation-heavy collection.

### Related issues

Task 5665

### Showcase

N/A — configuration interaction only; covered by component tests.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add field search to v2 import and export action settings. |
| 🇨🇳 Chinese | v2 导入和导出按钮的字段配置支持检索。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
