### PR TITLE
fix(async-import): ensure workflows are persisted before worker shutdown

### DIFF
--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/server/__tests__/command-task-type.test.ts
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/server/__tests__/command-task-type.test.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { parseArgv } from '../command-task-type';
+
+describe('command task type', () => {
+  it('parses the target sub-app from command arguments', () => {
+    expect(parseArgv(['import:xlsx', '--app=a_demo', '--hooks=true'])).toEqual({
+      import: 'xlsx',
+      app: 'a_demo',
+      hooks: true,
+    });
+  });
+
+  it('keeps malformed JSON arguments as strings', () => {
+    expect(parseArgv(['--context={invalid'])).toEqual({
+      context: '{invalid',
+    });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/server/command-task-type.ts
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/server/command-task-type.ts
@@ -13,6 +13,45 @@ import { Worker } from 'worker_threads';
 import path from 'path';
 import { TaskType } from './task-type';
 
+export function parseArgv(list: string[]) {
+  const argv: any = {};
+
+  for (const item of list) {
+    const match = item.match(/^--([^=]+)=(.*)$/);
+
+    if (match) {
+      const key = match[1];
+      let value: any = match[2];
+
+      if (value.startsWith('{') || value.startsWith('[')) {
+        try {
+          value = JSON.parse(value);
+        } catch (err) {
+          // ignore parse error, keep raw text
+        }
+      } else {
+        if (value === 'true') {
+          value = true;
+        } else if (value === 'false') {
+          value = false;
+        }
+      }
+
+      argv[key] = value;
+      continue;
+    }
+
+    const parts = item.split(':');
+    if (parts.length === 2) {
+      const command = parts[0];
+      const commandValue = parts[1];
+      argv[command] = commandValue;
+    }
+  }
+
+  return argv;
+}
+
 export class CommandTaskType extends TaskType {
   static type = 'command';
 
@@ -25,6 +64,7 @@ export class CommandTaskType extends TaskType {
 
   async execute() {
     const { argv } = this.record.params;
+    const parsedArgv = parseArgv(argv);
     const isDev = (process.argv[1]?.endsWith('.ts') || process.argv[1].includes('tinypool')) ?? false;
     const appRoot = process.env.APP_PACKAGE_ROOT || 'packages/core/app';
     const workerPath = path.resolve(process.cwd(), appRoot, isDev ? 'src/index.ts' : 'lib/index.js');
@@ -60,6 +100,7 @@ export class CommandTaskType extends TaskType {
           env: {
             ...process.env,
             WORKER_MODE: '-',
+            ...(parsedArgv.app && parsedArgv.app !== 'main' ? { STARTUP_SUBAPP: parsedArgv.app } : {}),
           },
         });
 

--- a/packages/plugins/@nocobase/plugin-async-task-manager/src/server/command-task-type.ts
+++ b/packages/plugins/@nocobase/plugin-async-task-manager/src/server/command-task-type.ts
@@ -13,20 +13,20 @@ import { Worker } from 'worker_threads';
 import path from 'path';
 import { TaskType } from './task-type';
 
-export function parseArgv(list: string[]) {
-  const argv: any = {};
+export function parseArgv(list: string[]): Record<string, unknown> {
+  const argv: Record<string, unknown> = {};
 
   for (const item of list) {
     const match = item.match(/^--([^=]+)=(.*)$/);
 
     if (match) {
       const key = match[1];
-      let value: any = match[2];
+      let value: unknown = match[2];
 
-      if (value.startsWith('{') || value.startsWith('[')) {
+      if (typeof value === 'string' && (value.startsWith('{') || value.startsWith('['))) {
         try {
           value = JSON.parse(value);
-        } catch (err) {
+        } catch {
           // ignore parse error, keep raw text
         }
       } else {
@@ -65,15 +65,16 @@ export class CommandTaskType extends TaskType {
   async execute() {
     const { argv } = this.record.params;
     const parsedArgv = parseArgv(argv);
+    const targetApp = typeof parsedArgv.app === 'string' ? parsedArgv.app : undefined;
     const isDev = (process.argv[1]?.endsWith('.ts') || process.argv[1].includes('tinypool')) ?? false;
     const appRoot = process.env.APP_PACKAGE_ROOT || 'packages/core/app';
     const workerPath = path.resolve(process.cwd(), appRoot, isDev ? 'src/index.ts' : 'lib/index.js');
 
-    const workerPromise = new Promise((resolve, reject) => {
+    const workerPromise = new Promise<unknown>((resolve, reject) => {
       let settled = false;
-      let successPayload: any;
+      let successPayload: unknown;
 
-      const settleOnce = (err?: Error | null, payload?: any) => {
+      const settleOnce = (err?: Error | null, payload?: unknown) => {
         if (settled) {
           return;
         }
@@ -100,7 +101,7 @@ export class CommandTaskType extends TaskType {
           env: {
             ...process.env,
             WORKER_MODE: '-',
-            ...(parsedArgv.app && parsedArgv.app !== 'main' ? { STARTUP_SUBAPP: parsedArgv.app } : {}),
+            ...(targetApp && targetApp !== 'main' ? { STARTUP_SUBAPP: targetApp } : {}),
           },
         });
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Dispatcher.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { Transaction, Transactionable } from 'sequelize';
 
@@ -46,17 +46,16 @@ export type EventOptions = {
 export default class Dispatcher {
   private ready = false;
   private executing: Promise<any> | null = null;
+  private preparing: Promise<any> | null = null;
   private pending: Pending[] = [];
   private events: CachedEvent[] = [];
   private eventsCount = 0;
 
   get idle() {
-    return this.ready && !this.executing && !this.pending.length && !this.events.length;
+    return this.ready && !this.executing && !this.preparing && !this.pending.length && !this.events.length;
   }
 
-  constructor(private readonly plugin: PluginWorkflowServer) {
-    this.prepare = this.prepare.bind(this);
-  }
+  constructor(private readonly plugin: PluginWorkflowServer) {}
 
   public readonly onQueueExecution: QueueEventOptions['process'] = async (event) => {
     const ExecutionRepo = this.plugin.db.getRepository('executions');
@@ -123,12 +122,61 @@ export default class Dispatcher {
     logger.info(`new event triggered, now events: ${this.events.length}`);
     logger.debug(`event data:`, { context });
 
-    if (this.events.length > 1) {
-      logger.info(`new event is pending to be prepared after previous preparation is finished`);
+    this.prepare();
+  }
+
+  private prepare() {
+    if (this.preparing) {
       return;
     }
 
-    setImmediate(this.prepare);
+    this.preparing = (async () => {
+      try {
+        while (this.events.length) {
+          if (this.executing && this.plugin.db.options.dialect === 'sqlite') {
+            await this.executing;
+          }
+
+          const event = this.events.shift();
+          this.eventsCount = this.events.length;
+          if (!event) continue;
+
+          const logger = this.plugin.getLogger(event[0].id);
+          logger.info(`preparing execution for event`);
+
+          try {
+            const execution = await this.createExecution(...event);
+            // NOTE: cache first execution for most cases
+            if (!execution?.dispatched) {
+              if (this.plugin.serving() && !this.executing && !this.pending.length) {
+                logger.info(`local pending list is empty, adding execution (${execution.id}) to pending list`);
+                this.pending.push({ execution });
+              } else {
+                logger.info(
+                  `instance is not serving as worker or local pending list is not empty, sending execution (${execution.id}) to queue`,
+                );
+                try {
+                  await this.plugin.app.eventQueue.publish(this.plugin.channelPendingExecution, {
+                    executionId: execution.id,
+                  });
+                } catch (qErr) {
+                  logger.error(`publishing execution (${execution.id}) to queue failed:`, { error: qErr });
+                }
+              }
+            }
+          } catch (error) {
+            logger.error(`failed to create execution:`, { error });
+          }
+        }
+      } finally {
+        this.preparing = null;
+        if (this.events.length) {
+          this.prepare();
+        } else {
+          this.dispatch();
+        }
+      }
+    })();
   }
 
   public async resume(job) {
@@ -154,17 +202,29 @@ export default class Dispatcher {
 
   public async beforeStop() {
     this.ready = false;
-    if (this.events.length) {
-      await this.prepare();
+    this.plugin.getLogger('dispatcher').info('app is stopping, draining local queues...');
+
+    while (this.preparing || this.executing || this.events.length || this.pending.length) {
+      if (this.preparing) {
+        await this.preparing;
+      }
+      if (this.executing) {
+        await this.executing;
+      }
+      if (this.events.length && !this.preparing) {
+        this.prepare();
+      }
+      if (this.pending.length && !this.executing) {
+        this.dispatch();
+      }
+      await new Promise((resolve) => setImmediate(resolve));
     }
-    if (this.executing) {
-      await this.executing;
-    }
+
+    this.plugin.getLogger('dispatcher').info('local queues drained');
   }
 
   public dispatch() {
-    if (!this.ready) {
-      this.plugin.getLogger('dispatcher').warn(`app is not ready, new dispatching will be ignored`);
+    if (!this.ready && !this.pending.length && !this.events.length) {
       return;
     }
 
@@ -174,7 +234,8 @@ export default class Dispatcher {
     }
 
     if (this.events.length) {
-      return this.prepare();
+      this.prepare();
+      return;
     }
 
     this.executing = (async () => {
@@ -188,7 +249,7 @@ export default class Dispatcher {
           this.plugin.getLogger(next[0].workflowId).info(`pending execution (${next[0].id}) ready to process`);
         }
       } else {
-        if (this.plugin.serving()) {
+        if (this.ready && this.plugin.serving()) {
           execution = await this.acquireQueueingExecution();
           if (execution) {
             next = [execution];
@@ -196,7 +257,9 @@ export default class Dispatcher {
         } else {
           this.plugin
             .getLogger('dispatcher')
-            .warn(`${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance, new dispatching will be ignored`);
+            .warn(
+              `${WORKER_JOB_WORKFLOW_PROCESS} is not serving on this instance or app not ready, new dispatching will be ignored`,
+            );
         }
       }
       if (next) {
@@ -354,56 +417,6 @@ export default class Dispatcher {
 
     return execution;
   }
-
-  private prepare = async () => {
-    if (this.executing && this.plugin.db.options.dialect === 'sqlite') {
-      await this.executing;
-    }
-
-    const event = this.events.shift();
-    this.eventsCount = this.events.length;
-    if (!event) {
-      this.plugin.getLogger('dispatcher').info(`events queue is empty, no need to prepare`);
-      return;
-    }
-
-    const logger = this.plugin.getLogger(event[0].id);
-    logger.info(`preparing execution for event`);
-
-    try {
-      const execution = await this.createExecution(...event);
-      // NOTE: cache first execution for most cases
-      if (!execution?.dispatched) {
-        if (this.plugin.serving() && !this.executing && !this.pending.length) {
-          logger.info(`local pending list is empty, adding execution (${execution.id}) to pending list`);
-          this.pending.push({ execution });
-        } else {
-          logger.info(
-            `instance is not serving as worker or local pending list is not empty, sending execution (${execution.id}) to queue`,
-          );
-          try {
-            await this.plugin.app.eventQueue.publish(this.plugin.channelPendingExecution, {
-              executionId: execution.id,
-            });
-          } catch (qErr) {
-            logger.error(`publishing execution (${execution.id}) to queue failed:`, { error: qErr });
-          }
-        }
-      }
-    } catch (error) {
-      logger.error(`failed to create execution:`, { error });
-    }
-
-    if (this.events.length) {
-      await this.prepare();
-    } else {
-      this.plugin.getLogger('dispatcher').info('no more events need to be prepared, dispatching...');
-      if (this.executing) {
-        await this.executing;
-      }
-      this.dispatch();
-    }
-  };
 
   private async acquirePendingExecution(execution: ExecutionModel): Promise<ExecutionModel | null> {
     const logger = this.plugin.getLogger(execution.workflowId);

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Plugin.test.ts
@@ -577,6 +577,43 @@ describe('workflow > Plugin', () => {
       await e3.reload();
       expect(e3.status).toBe(EXECUTION_STATUS.RESOLVED);
     });
+
+    it('beforeStop should wait for all pending and executing tasks', async () => {
+      // trigger multiple events and await their initiation to ensure DB operations are not cut off,
+      // but dispatcher will still process them asynchronously in local queues.
+      const count = 1000;
+
+      const PostModel = db.getCollection('posts').model;
+      const posts = await PostModel.bulkCreate(
+        Array(count)
+          .fill(0)
+          .map((_, index) => ({
+            title: `t${index}`,
+          })),
+        {
+          returning: true,
+        },
+      );
+
+      const w1 = await WorkflowModel.create({
+        enabled: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      for (const post of posts) {
+        await db.emitAsync('posts.afterCreateWithAssociations', post, {});
+      }
+      // stop the app immediately.
+      // dispatcher.beforeStop() should now wait for all events to be prepared and all pending executions to be processed.
+      await app.emitAsync('beforeStop', app);
+
+      const executions = await w1.getExecutions({ attributes: ['id', 'status'] });
+      expect(executions.length).toBe(count);
+    });
   });
 
   describe('options.deleteExecutionOnStatus', () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Asynchronous imports executed by command workers may target a sub-application. The worker previously started unrelated applications, and workflow shutdown could finish before triggered events had been prepared and persisted. This could leave imported records without the expected workflow executions.

### Description

- Start only the target sub-application when an asynchronous command task specifies an application name.
- Validate the target sub-application argument before starting the worker.
- Drain workflow event preparation and local execution queues before application shutdown.
- Add regression coverage for target application startup and workflow shutdown behavior.

The changes are focused server-side backports of the corresponding fixes from later branches. The main risk is worker and application shutdown ordering; the related server tests cover both paths.

### Related issues

Backports #7927 and #8894 to `v1`.

### Showcase

Not applicable (server-side fix).

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed missing workflow executions when asynchronous imports run in sub-applications |
| 🇨🇳 Chinese | 修复在子应用中异步导入时工作流执行记录丢失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
