### PR TITLE
fix(plugin-file-manager): allow logged-in attachment access

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
@@ -746,9 +746,13 @@ describe('file manager > server', () => {
         );
       });
 
-      it('requires login and file get permission to create a temporary URL', async () => {
+      it('allows logged-in users to create temporary URLs for attachments while keeping file table permissions', async () => {
         const { body } = await agent.resource('attachments').create({
           [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
+        });
+        const file = await plugin.createFileRecord({
+          collectionName: 'files',
+          filePath: path.resolve(__dirname, './files/text.txt'),
         });
         enableFileAccessACL(app);
 
@@ -758,8 +762,11 @@ describe('file manager > server', () => {
         app.acl.define({ role: 'file-denied' });
         const admin = await db.getRepository('users').findOne();
         const deniedAgent = (await app.agent().login(admin)).set('X-Role', 'file-denied');
-        const deniedResponse = await deniedAgent.post(`/attachments:createTemporaryURL/${body.data.id}`);
-        expect(deniedResponse.status).toBe(403);
+        const attachmentResponse = await deniedAgent.post(`/attachments:createTemporaryURL/${body.data.id}`);
+        expect(attachmentResponse.status).toBe(200);
+
+        const fileResponse = await deniedAgent.post(`/files:createTemporaryURL/${file.id}`);
+        expect(fileResponse.status).toBe(403);
       });
 
       it('rejects missing, expired, forged, and resource-mismatched temporary tokens', async () => {
@@ -1331,7 +1338,7 @@ describe('file manager > server', () => {
         expect(response.headers.location).toBe(await plugin.getFileURL(body.data));
       });
 
-      it('returns 403 when role cannot view attachments', async () => {
+      it('allows logged-in users to access attachments when the current role cannot view their records', async () => {
         const { body } = await agent.resource('attachments').create({
           [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
         });
@@ -1343,6 +1350,24 @@ describe('file manager > server', () => {
         const deniedAgent = (await app.agent().login(admin)).set('X-Role', 'file-denied');
 
         const response = await deniedAgent.get(body.data.url);
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(await plugin.getFileURL(body.data));
+      });
+
+      it('keeps file table access restricted by the current role', async () => {
+        const file = await plugin.createFileRecord({
+          collectionName: 'files',
+          filePath: path.resolve(__dirname, './files/text.txt'),
+        });
+        enableFileAccessACL(app);
+        app.acl.define({
+          role: 'file-denied',
+        });
+        const admin = await db.getRepository('users').findOne();
+        const deniedAgent = (await app.agent().login(admin)).set('X-Role', 'file-denied');
+
+        const response = await deniedAgent.get(file.get('url'));
 
         expect(response.status).toBe(403);
       });

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts
@@ -101,9 +101,11 @@ export async function getFile(ctx: Context, next: Next) {
   }
 
   const publicAccess = Boolean(plugin.storagesCache.get(storageId)?.options?.public);
+  const loggedInAttachmentAccess = collection.name === 'attachments' && Boolean(ctx.state.currentUser);
   if (
     !temporaryAccess &&
     !publicAccess &&
+    !loggedInAttachmentAccess &&
     !authorizedByExtension &&
     ctx.app.options.acl !== false &&
     ctx.dataSource.options?.useACL !== false &&

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/temporary-access.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/temporary-access.ts
@@ -109,7 +109,9 @@ export async function createTemporaryURLAction(ctx: Context, next: Next) {
 
   const id = ctx.action.params.filterByTk;
   let filter: object = { id };
+  const loggedInAttachmentAccess = collection.name === 'attachments' && Boolean(ctx.state.currentUser);
   if (
+    !loggedInAttachmentAccess &&
     ctx.app.options.acl !== false &&
     ctx.dataSource.options?.useACL !== false &&
     ctx.dataSource.options?.acl !== false


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
After stable file URLs were introduced, requests for files in the built-in `attachments` collection were filtered by the current role's record-level view scope. Member users therefore could not load shared system attachments, such as a logo uploaded by an administrator, even though they were authenticated.

### Description 
- Allow authenticated users to resolve stable URLs for files in the built-in `attachments` collection without applying record-level ACL filters.
- Apply the same rule when creating temporary file access URLs, so Office and other external previews remain consistent.
- Keep anonymous access checks and all custom file collection permissions unchanged.
- Add regression tests for permanent URLs, temporary URLs, anonymous access, and custom file collection isolation.

The intentional access-scope change is limited to the shared built-in `attachments` collection. Custom file collections continue to enforce their configured role and record permissions.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed shared attachments such as the system logo not loading for authenticated member users |
| 🇨🇳 Chinese | 修复已登录的成员用户无法加载系统 Logo 等共享附件的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
