### PR TITLE
refactor(plugin-workflow-javascript): queue JavaScript worker jobs

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptProcessLimiter.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptProcessLimiter.ts
@@ -1,0 +1,110 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export type JavaScriptWorkerPermit = {
+  release: () => void;
+};
+
+type WaitingRequest = {
+  resolve: (permit: JavaScriptWorkerPermit) => void;
+};
+
+const DEFAULT_PROCESS_CONCURRENCY = 2;
+
+function readPositiveInteger(value: string | undefined, defaultValue: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+export function getJavaScriptProcessConcurrency() {
+  return readPositiveInteger(process.env.WORKFLOW_JAVASCRIPT_PROCESS_CONCURRENCY, DEFAULT_PROCESS_CONCURRENCY);
+}
+
+export class JavaScriptProcessLimiter {
+  private active = 0;
+  private readonly waiting: WaitingRequest[] = [];
+
+  constructor(private limit: number) {}
+
+  getLimit() {
+    return this.limit;
+  }
+
+  setLimit(limit: number) {
+    this.limit = limit;
+    this.drain();
+  }
+
+  getActiveCount() {
+    return this.active;
+  }
+
+  getQueuedCount() {
+    return this.waiting.length;
+  }
+
+  hasCapacity() {
+    return this.active < this.limit;
+  }
+
+  async acquire(): Promise<JavaScriptWorkerPermit> {
+    if (this.hasCapacity()) {
+      return this.createPermit();
+    }
+
+    return new Promise((resolve) => {
+      this.waiting.push({ resolve });
+    });
+  }
+
+  async run<T>(callback: () => Promise<T>): Promise<T> {
+    const permit = await this.acquire();
+    try {
+      return await callback();
+    } finally {
+      permit.release();
+    }
+  }
+
+  private createPermit(): JavaScriptWorkerPermit {
+    let released = false;
+    this.active += 1;
+
+    return {
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.active -= 1;
+        this.drain();
+      },
+    };
+  }
+
+  private drain() {
+    while (this.hasCapacity() && this.waiting.length) {
+      const request = this.waiting.shift();
+      request?.resolve(this.createPermit());
+    }
+  }
+}
+
+let processLimiter: JavaScriptProcessLimiter | null = null;
+
+export function getJavaScriptProcessLimiter() {
+  const limit = getJavaScriptProcessConcurrency();
+  if (!processLimiter) {
+    processLimiter = new JavaScriptProcessLimiter(limit);
+  } else {
+    processLimiter.setLimit(limit);
+  }
+
+  return processLimiter;
+}

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskConsumer.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskConsumer.ts
@@ -1,0 +1,318 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Model } from '@nocobase/database';
+import type WorkflowPlugin from '@nocobase/plugin-workflow';
+import { EXECUTION_STATUS, JOB_STATUS, WorkflowTimeoutError, isWorkflowTimeoutError } from '@nocobase/plugin-workflow';
+import type { QueueEventOptions } from '@nocobase/server';
+
+import { getJavaScriptProcessLimiter } from './JavaScriptProcessLimiter';
+import {
+  getJavaScriptQueueMaxWait,
+  JavaScriptJobMeta,
+  JavaScriptJobSnapshot,
+  JavaScriptQueueTaskMessage,
+} from './JavaScriptTaskQueue';
+import { ScriptWorkerRunner } from './ScriptWorkerRunner';
+
+type ID = number | string;
+
+type WorkflowJob = Model & {
+  id: ID;
+  executionId: ID;
+  nodeId: ID;
+  nodeKey: string;
+  status: number;
+  result?: unknown;
+  meta?: JavaScriptJobMeta | null;
+  startedAt?: Date | null;
+  createdAt?: Date;
+  set(values: { status?: number; result?: unknown; startedAt?: Date | null }): void;
+  reload(): Promise<WorkflowJob>;
+  getExecution(): Promise<WorkflowExecution | null>;
+};
+
+type WorkflowExecution = {
+  id: ID;
+  workflowId: ID;
+  status: number;
+  expiresAt?: Date | null;
+};
+
+function isTaskMessage(message: unknown): message is JavaScriptQueueTaskMessage {
+  return typeof message === 'object' && message !== null && 'jobId' in message;
+}
+
+function isJavaScriptJobSnapshot(value: unknown): value is JavaScriptJobSnapshot {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'version' in value &&
+    value.version === 1 &&
+    'content' in value &&
+    typeof value.content === 'string' &&
+    'args' in value
+  );
+}
+
+function getJavaScriptSnapshot(job: WorkflowJob) {
+  const snapshot = job.meta?.javascript;
+  return isJavaScriptJobSnapshot(snapshot) ? snapshot : null;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stringifyResult(result: unknown) {
+  if (typeof result === 'string') {
+    return result;
+  }
+
+  try {
+    return JSON.stringify(result);
+  } catch (error) {
+    return String(result);
+  }
+}
+
+function createExecutionAbortController(workflowPlugin: WorkflowPlugin, execution: WorkflowExecution) {
+  const controller = new AbortController();
+  let timeoutGuard: NodeJS.Timeout | null = null;
+
+  const abort = (reason?: unknown) => {
+    if (!controller.signal.aborted) {
+      controller.abort(isWorkflowTimeoutError(reason) ? reason : new WorkflowTimeoutError());
+    }
+  };
+
+  const remaining = execution.expiresAt ? execution.expiresAt.getTime() - Date.now() : null;
+  if (remaining != null) {
+    if (remaining <= 0) {
+      abort();
+    } else {
+      timeoutGuard = setTimeout(abort, remaining);
+    }
+  }
+
+  workflowPlugin.registerRunningExecution(execution.id, abort);
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      if (timeoutGuard) {
+        clearTimeout(timeoutGuard);
+        timeoutGuard = null;
+      }
+      workflowPlugin.unregisterRunningExecution(execution.id);
+    },
+  };
+}
+
+export class JavaScriptTaskConsumer {
+  private ready = false;
+  private closing = false;
+  private readonly processing = new Set<Promise<void>>();
+
+  constructor(private readonly workflowPlugin: WorkflowPlugin) {}
+
+  setReady(ready: boolean) {
+    this.ready = ready;
+  }
+
+  idle() {
+    return this.ready && !this.closing && this.workflowPlugin.serving() && getJavaScriptProcessLimiter().hasCapacity();
+  }
+
+  async beforeStop() {
+    this.closing = true;
+    await Promise.allSettled(Array.from(this.processing));
+  }
+
+  readonly process: QueueEventOptions['process'] = async (message) => {
+    if (!isTaskMessage(message)) {
+      this.workflowPlugin.getLogger('javascript').warn('invalid JavaScript queue job message ignored', { message });
+      return;
+    }
+
+    const processing = getJavaScriptProcessLimiter().run(async () => {
+      await this.processWithPermit(message.jobId);
+    });
+    this.processing.add(processing);
+    try {
+      await processing;
+    } finally {
+      this.processing.delete(processing);
+    }
+  };
+
+  private async processWithPermit(jobId: ID) {
+    if (this.closing) {
+      return;
+    }
+
+    const claimed = await this.claimJob(jobId);
+    if (!claimed) {
+      return;
+    }
+
+    const { job, snapshot } = claimed;
+    const execution = await job.getExecution();
+    const logger = this.workflowPlugin.getLogger(execution?.workflowId ?? 'javascript');
+    const queueWaitMs = job.startedAt && job.createdAt ? job.startedAt.getTime() - job.createdAt.getTime() : 0;
+
+    logger.info(`JavaScript job (${job.id}) claimed for node (${job.nodeId})`, {
+      executionId: job.executionId,
+      jobId: job.id,
+      nodeId: job.nodeId,
+      queueWaitMs,
+      active: getJavaScriptProcessLimiter().getActiveCount(),
+      queued: getJavaScriptProcessLimiter().getQueuedCount(),
+    });
+
+    if (!execution || execution.status !== EXECUTION_STATUS.STARTED) {
+      await this.finishClaimedJob(job, {
+        status: JOB_STATUS.ABORTED,
+        result: `Execution (${job.executionId}) is not running`,
+      });
+      return;
+    }
+
+    if (!(await this.workflowPlugin.timeoutManager.shouldContinue(execution))) {
+      await this.finishClaimedJob(job, {
+        status: JOB_STATUS.ABORTED,
+        result: 'Execution timeout reached before JavaScript Worker started',
+      });
+      return;
+    }
+
+    const abortHandle = createExecutionAbortController(this.workflowPlugin, execution);
+
+    try {
+      const result = await ScriptWorkerRunner.run(snapshot.content, snapshot.args, {
+        timeout: snapshot.timeout,
+        logger,
+        signal: abortHandle.signal,
+      });
+
+      if (result.status === JOB_STATUS.RESOLVED) {
+        logger.info(`script (#${job.nodeId}) get result success`);
+        job.set({ status: JOB_STATUS.RESOLVED, result: result.result });
+        logger.info(`run script execution success, node id: ${job.nodeId},the result is ${result.result}`);
+      } else if (snapshot.continue) {
+        logger.warn(`script (#${job.nodeId}) get result failed, the reason is ${result.result}`);
+        job.set({ status: JOB_STATUS.RESOLVED, result: result.result });
+      } else {
+        logger.info(`script (#${job.nodeId}) get result failed, the reason is ${result.result}`);
+        job.set({ status: JOB_STATUS.ERROR, result: result.result });
+      }
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger.error(`script (#${job.nodeId}) get result failed, the reason is ${message}`);
+      job.set({
+        status: isWorkflowTimeoutError(error) ? JOB_STATUS.ABORTED : JOB_STATUS.ERROR,
+        result: message,
+      });
+    } finally {
+      abortHandle.dispose();
+    }
+
+    try {
+      await this.workflowPlugin.resume(job);
+    } catch (error) {
+      logger.error(`JavaScript job (${job.id}) failed to resume workflow execution (${job.executionId})`, { error });
+    }
+  }
+
+  private async claimJob(jobId: ID): Promise<{ job: WorkflowJob; snapshot: JavaScriptJobSnapshot } | null> {
+    const job = (await this.workflowPlugin.db.getRepository('jobs').findOne({
+      filterByTk: jobId,
+    })) as WorkflowJob | null;
+    if (!job || job.status !== JOB_STATUS.PENDING || job.startedAt != null) {
+      return null;
+    }
+
+    const snapshot = getJavaScriptSnapshot(job);
+    if (!snapshot) {
+      return null;
+    }
+
+    const maxWait = getJavaScriptQueueMaxWait();
+    if (maxWait > 0 && job.createdAt && Date.now() - job.createdAt.getTime() > maxWait) {
+      await this.failUnstartedJob(job, snapshot, `JavaScript worker queue wait timed out after ${maxWait}ms`);
+      return null;
+    }
+
+    const now = new Date();
+    const JobModel = this.workflowPlugin.db.getModel('jobs');
+    const [affected] = await JobModel.update(
+      {
+        startedAt: now,
+      },
+      {
+        where: {
+          id: job.id,
+          status: JOB_STATUS.PENDING,
+          startedAt: null,
+        },
+      },
+    );
+
+    if (!affected) {
+      return null;
+    }
+
+    const claimedJob = await job.reload();
+    return { job: claimedJob, snapshot };
+  }
+
+  private async failUnstartedJob(job: WorkflowJob, snapshot: JavaScriptJobSnapshot, message: string) {
+    const JobModel = this.workflowPlugin.db.getModel('jobs');
+    const [affected] = await JobModel.update(
+      {
+        status: snapshot.continue ? JOB_STATUS.RESOLVED : JOB_STATUS.ERROR,
+        result: message,
+      },
+      {
+        where: {
+          id: job.id,
+          status: JOB_STATUS.PENDING,
+          startedAt: null,
+        },
+      },
+    );
+
+    if (!affected) {
+      return;
+    }
+
+    await job.reload();
+    try {
+      await this.workflowPlugin.resume(job);
+    } catch (error) {
+      this.workflowPlugin
+        .getLogger('javascript')
+        .error(`JavaScript job (${job.id}) failed to resume queue timeout result`, { error });
+    }
+  }
+
+  private async finishClaimedJob(job: WorkflowJob, values: { status: number; result: unknown }) {
+    job.set({
+      status: values.status,
+      result: stringifyResult(values.result),
+    });
+    try {
+      await this.workflowPlugin.resume(job);
+    } catch (error) {
+      this.workflowPlugin
+        .getLogger('javascript')
+        .error(`JavaScript job (${job.id}) failed to resume after claim failure`, { error });
+    }
+  }
+}

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskQueue.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskQueue.ts
@@ -1,0 +1,101 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Application } from '@nocobase/server';
+import { JOB_STATUS } from '@nocobase/plugin-workflow';
+
+import type { ScriptArguments } from './ScriptWorkerRunner';
+
+export type JavaScriptJobSnapshot = {
+  version: 1;
+  content: string;
+  args: ScriptArguments;
+  timeout?: number;
+  continue?: boolean;
+};
+
+export type JavaScriptJobMeta = {
+  javascript?: JavaScriptJobSnapshot;
+  [key: string]: unknown;
+};
+
+export const WORKFLOW_JAVASCRIPT_ERROR_CODE = {
+  QUEUE_FULL: 'WORKFLOW_JAVASCRIPT_QUEUE_FULL',
+  QUEUE_TIMEOUT: 'WORKFLOW_JAVASCRIPT_QUEUE_TIMEOUT',
+  WORKFLOW_ABORTED: 'WORKFLOW_JAVASCRIPT_WORKFLOW_ABORTED',
+  SHUTDOWN: 'WORKFLOW_JAVASCRIPT_SHUTDOWN',
+} as const;
+
+const DEFAULT_QUEUE_CONCURRENCY = 2;
+const DEFAULT_MAX_PENDING = 10_000;
+const QUEUE_TASK_MAX_ATTEMPTS = 3;
+
+function readNonNegativeInteger(value: string | undefined, defaultValue: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : defaultValue;
+}
+
+function readPositiveInteger(value: string | undefined, defaultValue: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+export function getJavaScriptQueueConcurrency() {
+  return readPositiveInteger(process.env.WORKFLOW_JAVASCRIPT_QUEUE_CONCURRENCY, DEFAULT_QUEUE_CONCURRENCY);
+}
+
+export function getJavaScriptQueueMaxPending() {
+  return readNonNegativeInteger(process.env.WORKFLOW_JAVASCRIPT_QUEUE_MAX_PENDING, DEFAULT_MAX_PENDING);
+}
+
+export function getJavaScriptQueueMaxWait() {
+  return readNonNegativeInteger(process.env.WORKFLOW_JAVASCRIPT_QUEUE_MAX_WAIT, 0);
+}
+
+export type JavaScriptQueueTaskMessage = {
+  jobId: number | string;
+};
+
+export class JavaScriptQueueFullError extends Error {
+  code = WORKFLOW_JAVASCRIPT_ERROR_CODE.QUEUE_FULL;
+
+  constructor(limit: number) {
+    super(`JavaScript worker queue is full, max pending jobs: ${limit}`);
+  }
+}
+
+export class JavaScriptTaskQueue {
+  constructor(
+    private readonly app: Application,
+    private readonly channel: string,
+  ) {}
+
+  async assertCapacity() {
+    const limit = getJavaScriptQueueMaxPending();
+    if (limit <= 0) {
+      return;
+    }
+
+    const pending = await this.app.db.getRepository('jobs').count({
+      filter: {
+        status: JOB_STATUS.PENDING,
+        startedAt: null,
+      },
+    });
+    if (pending >= limit) {
+      throw new JavaScriptQueueFullError(limit);
+    }
+  }
+
+  async publish(jobId: number | string) {
+    await this.app.eventQueue.publish(this.channel, { jobId } satisfies JavaScriptQueueTaskMessage, {
+      maxRetries: QUEUE_TASK_MAX_ATTEMPTS - 1,
+    });
+  }
+}

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskRecovery.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskRecovery.ts
@@ -1,0 +1,115 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type WorkflowPlugin from '@nocobase/plugin-workflow';
+import { JOB_STATUS } from '@nocobase/plugin-workflow';
+
+import { JavaScriptJobMeta, JavaScriptTaskQueue } from './JavaScriptTaskQueue';
+
+const RECOVERY_BATCH_SIZE = 100;
+const RECOVERY_MAX_SCAN_SIZE = 1000;
+const RECOVERY_INTERVAL = 60_000;
+
+type WorkflowJob = {
+  id: number | string;
+  status: number;
+  meta?: JavaScriptJobMeta | null;
+  startedAt?: Date | null;
+};
+
+function hasJavaScriptSnapshot(job: WorkflowJob) {
+  return job.meta?.javascript?.version === 1;
+}
+
+export class JavaScriptTaskRecovery {
+  private timer: NodeJS.Timeout | null = null;
+  private ready = false;
+  private recovering: Promise<void> | null = null;
+
+  constructor(
+    private readonly workflowPlugin: WorkflowPlugin,
+    private readonly taskQueue: JavaScriptTaskQueue,
+  ) {}
+
+  start() {
+    this.ready = true;
+    this.recover();
+    this.timer = setInterval(() => {
+      this.recover();
+    }, RECOVERY_INTERVAL);
+  }
+
+  async stop() {
+    this.ready = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.recovering?.catch(() => undefined);
+  }
+
+  recover() {
+    if (!this.ready || this.recovering) {
+      return;
+    }
+
+    const recovering = this.recoverTasks()
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.recovering === recovering) {
+          this.recovering = null;
+        }
+      });
+    this.recovering = recovering;
+  }
+
+  private async recoverTasks() {
+    const logger = this.workflowPlugin.getLogger('javascript');
+    if (!this.workflowPlugin.serving()) {
+      logger.warn('workflow:process is not serving on this instance, JavaScript job recovery will be ignored');
+      return;
+    }
+
+    try {
+      await this.republishQueuedJobs();
+    } catch (error) {
+      logger.error('JavaScript job recovery failed', { error });
+    }
+  }
+
+  private async republishQueuedJobs() {
+    let cursor: number | string | null = null;
+    let scanned = 0;
+
+    while (scanned < RECOVERY_MAX_SCAN_SIZE) {
+      const jobs = (await this.workflowPlugin.db.getRepository('jobs').find({
+        filter: {
+          ...(cursor == null ? {} : { id: { $gt: cursor } }),
+          status: JOB_STATUS.PENDING,
+          startedAt: null,
+        },
+        sort: 'id',
+        limit: Math.min(RECOVERY_BATCH_SIZE, RECOVERY_MAX_SCAN_SIZE - scanned),
+      })) as WorkflowJob[];
+
+      if (!jobs.length) {
+        break;
+      }
+
+      for (const job of jobs) {
+        if (hasJavaScriptSnapshot(job)) {
+          await this.taskQueue.publish(job.id);
+        }
+      }
+
+      scanned += jobs.length;
+      cursor = jobs[jobs.length - 1].id;
+    }
+  }
+}

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts
@@ -7,139 +7,38 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { once } from 'node:events';
-import path from 'node:path';
-import { Worker } from 'node:worker_threads';
 import winston, { Logger } from 'winston';
 import Joi from 'joi';
 
-import {
-  Processor,
-  Instruction,
-  JOB_STATUS,
-  FlowNodeModel,
-  IJob,
-  WorkflowTimeoutError,
-} from '@nocobase/plugin-workflow';
+import WorkflowPlugin, { Processor, Instruction, JOB_STATUS, FlowNodeModel, IJob } from '@nocobase/plugin-workflow';
 
 import { CacheTransport } from './cache-logger';
+import { getJavaScriptProcessLimiter } from './JavaScriptProcessLimiter';
+import { JavaScriptJobSnapshot, JavaScriptQueueFullError, JavaScriptTaskQueue } from './JavaScriptTaskQueue';
+import { ScriptArguments, ScriptRunResult, ScriptWorkerRunner } from './ScriptWorkerRunner';
 
 type ScriptArgument = { name: string; value?: unknown };
 
 type ScriptConfig = { content?: string; timeout?: number; continue?: boolean; arguments?: ScriptArgument[] };
 
-type ScriptArguments = Record<string, unknown> | unknown[];
-
-type WorkerOutcome =
-  | { type: 'result'; result: unknown }
-  | { type: 'error'; error: Error }
-  | { type: 'exit'; code: number }
-  | { type: 'aborted' };
-
-function isWorkerResult(message: unknown): message is { type: 'result'; result: unknown } {
-  return typeof message === 'object' && message !== null && 'type' in message && message.type === 'result';
-}
-
 export default class ScriptInstruction extends Instruction {
-  /**
-   * Returns the worker script path based on whether WORKFLOW_SCRIPT_MODULES is configured.
-   * - WORKFLOW_SCRIPT_MODULES set: uses Node.js vm with require support (unsafe; not a security boundary)
-   * - WORKFLOW_SCRIPT_MODULES unset: uses QuickJS (WASM) for maximum security (no require, no Node.js APIs)
-   */
   static get workerScript() {
-    const hasModules = (process.env.WORKFLOW_SCRIPT_MODULES ?? '').split(',').filter(Boolean).length > 0;
-    return path.join(__dirname, hasModules ? 'Vm.js' : 'QuickJs.js');
+    return ScriptWorkerRunner.workerScript;
   }
 
   static async run(
     source: string,
     args: ScriptArguments,
     options: { logger: Logger; timeout?: number; signal?: AbortSignal },
+  ): Promise<ScriptRunResult> {
+    return getJavaScriptProcessLimiter().run(() => ScriptWorkerRunner.run(source, args, options));
+  }
+
+  constructor(
+    workflow: WorkflowPlugin,
+    private readonly taskQueue?: JavaScriptTaskQueue,
   ) {
-    const { logger, timeout, signal } = options;
-
-    const worker = new Worker(this.workerScript, {
-      workerData: { source, args, options: timeout ? { timeout } : {} },
-    });
-
-    worker.stdout.on('data', (data) => {
-      logger.info(data.toString());
-    });
-    worker.stderr.on('data', (data) => {
-      logger.error(data.toString());
-    });
-
-    const outputClosed = Promise.all([once(worker.stdout, 'close'), once(worker.stderr, 'close')]);
-    const outcomePromise = new Promise<WorkerOutcome>((resolve) => {
-      const finish = (outcome: WorkerOutcome) => {
-        worker.removeListener('message', messageListener);
-        worker.removeListener('error', errorListener);
-        worker.removeListener('exit', exitListener);
-        signal?.removeEventListener('abort', abortListener);
-        resolve(outcome);
-      };
-      const messageListener = (message: unknown) => {
-        if (isWorkerResult(message)) {
-          finish({ type: 'result', result: message.result });
-        }
-      };
-      const errorListener = (error: Error) => {
-        finish({ type: 'error', error });
-      };
-      const exitListener = (code: number) => {
-        finish({ type: 'exit', code });
-      };
-      const abortListener = () => {
-        finish({ type: 'aborted' });
-      };
-
-      worker.on('message', messageListener);
-      worker.once('error', errorListener);
-      worker.once('exit', exitListener);
-      signal?.addEventListener('abort', abortListener, { once: true });
-      if (signal?.aborted) {
-        abortListener();
-      }
-    });
-
-    const outcome = await outcomePromise;
-    try {
-      if (outcome.type !== 'exit') {
-        await worker.terminate();
-      }
-      await outputClosed;
-    } catch (e) {
-      if (outcome.type === 'aborted' || signal?.aborted) {
-        throw signal.reason instanceof Error ? signal.reason : new WorkflowTimeoutError();
-      }
-      return {
-        status: JOB_STATUS.ERROR,
-        result: e instanceof Error ? e.message : String(e),
-      };
-    }
-
-    if (outcome.type === 'aborted') {
-      throw signal?.reason instanceof Error ? signal.reason : new WorkflowTimeoutError();
-    }
-
-    if (outcome.type === 'error') {
-      return {
-        status: JOB_STATUS.ERROR,
-        result: outcome.error.message,
-      };
-    }
-
-    if (outcome.type === 'exit' && outcome.code !== 0) {
-      return {
-        status: JOB_STATUS.ERROR,
-        result: `Worker stopped with exit code ${outcome.code}`,
-      };
-    }
-
-    return {
-      status: JOB_STATUS.RESOLVED,
-      result: outcome.type === 'result' ? outcome.result : undefined,
-    };
+    super(workflow);
   }
 
   configSchema = Joi.object({
@@ -188,72 +87,63 @@ export default class ScriptInstruction extends Instruction {
       };
     }
 
+    if (!this.taskQueue) {
+      const message = 'JavaScript task queue is not ready';
+      processor.logger.error(`script (#${node.id}) queue failed, the reason is ${message}`);
+      return {
+        status: cont ? JOB_STATUS.RESOLVED : JOB_STATUS.ERROR,
+        result: message,
+      };
+    }
+
+    try {
+      await this.taskQueue.assertCapacity();
+    } catch (error) {
+      return this.getQueueFailureJob(node.id, Boolean(cont), error);
+    }
+
+    const snapshot: JavaScriptJobSnapshot = {
+      version: 1,
+      content,
+      args: _args,
+      timeout,
+      continue: cont,
+    };
+
     const { id } = processor.saveJob({
       status: JOB_STATUS.PENDING,
       nodeId: node.id,
       nodeKey: node.key,
       upstreamId: prevJob?.id ?? null,
+      startedAt: null,
+      meta: {
+        javascript: snapshot,
+      },
     });
 
-    processor.logger.info(`script (#${node.id}) has been started, waiting for response...`);
+    processor.logger.info(`script (#${node.id}) has been queued, waiting for JavaScript Worker resource...`);
 
-    const abortHandle = processor.createBackgroundAbortHandle();
+    await processor.exit();
+
     try {
-      await processor.exit();
+      await this.taskQueue.publish(id);
     } catch (error) {
-      abortHandle.dispose();
-      throw error;
+      processor.logger.error(`publishing JavaScript job (${id}) failed, recovery will republish it`, { error });
+    }
+  }
+
+  private getQueueFailureJob(nodeId: number | string, cont: boolean, error: unknown): IJob {
+    const message = error instanceof Error ? error.message : String(error);
+    if (error instanceof JavaScriptQueueFullError) {
+      this.workflow.getLogger('javascript').warn(`script (#${nodeId}) queue rejected, the reason is ${message}`);
+    } else {
+      this.workflow.getLogger('javascript').error(`script (#${nodeId}) queue failed, the reason is ${message}`);
     }
 
-    const jobResult: IJob = {
-      status: JOB_STATUS.PENDING,
+    return {
+      status: cont ? JOB_STATUS.RESOLVED : JOB_STATUS.ERROR,
+      result: message,
     };
-
-    // eslint-disable-next-line promise/catch-or-return
-    (this.constructor as typeof ScriptInstruction)
-      .run(content, _args, { timeout, logger: processor.logger, signal: abortHandle.signal })
-      .then((res) => {
-        if (res.status === JOB_STATUS.RESOLVED) {
-          processor.logger.info(`script (#${node.id}) get result success`);
-          jobResult.status = JOB_STATUS.RESOLVED;
-          jobResult.result = res.result;
-          processor.logger.info(`run script execution success, node id: ${node.id},the result is ${res.result}`);
-
-          return;
-        }
-
-        if (cont) {
-          processor.logger.warn(`script (#${node.id}) get result failed, the reason is ${res.result}`);
-          jobResult.status = JOB_STATUS.RESOLVED;
-          jobResult.result = res.result;
-
-          return;
-        }
-
-        processor.logger.info(`script (#${node.id}) get result failed, the reason is ${res.result}`);
-        jobResult.status = JOB_STATUS.ERROR;
-        jobResult.result = res.result;
-      })
-      .catch((e) => {
-        const message = e instanceof Error ? e.message : String(e);
-        processor.logger.error(`script (#${node.id}) get result failed, the reason is ${message}`);
-        jobResult.status = JOB_STATUS.ERROR;
-        jobResult.result = message;
-      })
-      .finally(() => {
-        abortHandle.dispose();
-        processor.logger.debug(`script (#${node.id}) ended, resume workflow...`);
-        setImmediate(async () => {
-          const job = await this.workflow.db.getRepository('jobs').findOne({ filterByTk: id });
-          const execution = await job.getExecution();
-          if (execution.status !== 0) {
-            processor.logger.warn(`script (#${node.id}) result discarded because execution (${execution.id}) is ended`);
-            return;
-          }
-          job.set(jobResult);
-          await this.workflow.resume(job).catch(() => {});
-        });
-      });
   }
 
   async resume(node: FlowNodeModel, job, processor: Processor) {

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptWorkerRunner.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptWorkerRunner.ts
@@ -1,0 +1,136 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { once } from 'node:events';
+import path from 'node:path';
+import { Worker } from 'node:worker_threads';
+
+import { Logger } from 'winston';
+
+import { JOB_STATUS, WorkflowTimeoutError } from '@nocobase/plugin-workflow';
+
+export type ScriptArguments = Record<string, unknown> | unknown[] | null;
+
+export type ScriptRunResult = {
+  status: number;
+  result?: unknown;
+};
+
+type WorkerOutcome =
+  | { type: 'result'; result: unknown }
+  | { type: 'error'; error: Error }
+  | { type: 'exit'; code: number }
+  | { type: 'aborted' };
+
+function isWorkerResult(message: unknown): message is { type: 'result'; result: unknown } {
+  return typeof message === 'object' && message !== null && 'type' in message && message.type === 'result';
+}
+
+export class ScriptWorkerRunner {
+  /**
+   * Returns the worker script path based on whether WORKFLOW_SCRIPT_MODULES is configured.
+   * - WORKFLOW_SCRIPT_MODULES set: uses Node.js vm with require support (unsafe; not a security boundary)
+   * - WORKFLOW_SCRIPT_MODULES unset: uses QuickJS (WASM) for maximum security (no require, no Node.js APIs)
+   */
+  static get workerScript() {
+    const hasModules = (process.env.WORKFLOW_SCRIPT_MODULES ?? '').split(',').filter(Boolean).length > 0;
+    return path.join(__dirname, hasModules ? 'Vm.js' : 'QuickJs.js');
+  }
+
+  static async run(
+    source: string,
+    args: ScriptArguments,
+    options: { logger: Logger; timeout?: number; signal?: AbortSignal },
+  ): Promise<ScriptRunResult> {
+    const { logger, timeout, signal } = options;
+
+    const worker = new Worker(this.workerScript, {
+      workerData: { source, args, options: timeout ? { timeout } : {} },
+    });
+
+    worker.stdout.on('data', (data) => {
+      logger.info(data.toString());
+    });
+    worker.stderr.on('data', (data) => {
+      logger.error(data.toString());
+    });
+
+    const outputClosed = Promise.all([once(worker.stdout, 'close'), once(worker.stderr, 'close')]);
+    const outcomePromise = new Promise<WorkerOutcome>((resolve) => {
+      const finish = (outcome: WorkerOutcome) => {
+        worker.removeListener('message', messageListener);
+        worker.removeListener('error', errorListener);
+        worker.removeListener('exit', exitListener);
+        signal?.removeEventListener('abort', abortListener);
+        resolve(outcome);
+      };
+      const messageListener = (message: unknown) => {
+        if (isWorkerResult(message)) {
+          finish({ type: 'result', result: message.result });
+        }
+      };
+      const errorListener = (error: Error) => {
+        finish({ type: 'error', error });
+      };
+      const exitListener = (code: number) => {
+        finish({ type: 'exit', code });
+      };
+      const abortListener = () => {
+        finish({ type: 'aborted' });
+      };
+
+      worker.on('message', messageListener);
+      worker.once('error', errorListener);
+      worker.once('exit', exitListener);
+      signal?.addEventListener('abort', abortListener, { once: true });
+      if (signal?.aborted) {
+        abortListener();
+      }
+    });
+
+    const outcome = await outcomePromise;
+    try {
+      if (outcome.type !== 'exit') {
+        await worker.terminate();
+      }
+      await outputClosed;
+    } catch (error) {
+      if (outcome.type === 'aborted' || signal?.aborted) {
+        throw signal.reason instanceof Error ? signal.reason : new WorkflowTimeoutError();
+      }
+      return {
+        status: JOB_STATUS.ERROR,
+        result: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    if (outcome.type === 'aborted') {
+      throw signal?.reason instanceof Error ? signal.reason : new WorkflowTimeoutError();
+    }
+
+    if (outcome.type === 'error') {
+      return {
+        status: JOB_STATUS.ERROR,
+        result: outcome.error.message,
+      };
+    }
+
+    if (outcome.type === 'exit' && outcome.code !== 0) {
+      return {
+        status: JOB_STATUS.ERROR,
+        result: `Worker stopped with exit code ${outcome.code}`,
+      };
+    }
+
+    return {
+      status: JOB_STATUS.RESOLVED,
+      result: outcome.type === 'result' ? outcome.result : undefined,
+    };
+  }
+}

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts
@@ -18,6 +18,7 @@ import { vi } from 'vitest';
 import winston from 'winston';
 import { CacheTransport } from '../cache-logger';
 import ScriptInstruction from '../ScriptInstruction';
+import { ScriptWorkerRunner } from '../ScriptWorkerRunner';
 
 import Plugin from '..';
 
@@ -210,6 +211,74 @@ describe('workflow > instructions > script', () => {
   });
 
   describe('promise and timeout', () => {
+    it('should persist, claim and consume an async JavaScript job once', async () => {
+      let resolveRun: ((result: { status: number; result: string }) => void) | undefined;
+      const runSpy = vi.spyOn(ScriptWorkerRunner, 'run').mockImplementation(() => {
+        return new Promise((resolve) => {
+          resolveRun = resolve;
+        });
+      });
+
+      try {
+        await workflow.update({ sync: false });
+        await workflow.createNode({
+          type: 'script',
+          config: {
+            arguments: [{ name: 'title', value: '{{$context.data.title}}' }],
+            content: 'return title;',
+          },
+        });
+
+        await PostRepo.create({ values: { title: 'post' } });
+
+        let execution;
+        let job;
+        for (let i = 0; i < 30; i++) {
+          [execution] = await workflow.getExecutions();
+          [job] = execution ? await execution.getJobs() : [];
+          if (job?.startedAt && runSpy.mock.calls.length === 1) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        expect(job?.status).toBe(JOB_STATUS.PENDING);
+        expect(job?.startedAt).toBeTruthy();
+        expect(job?.meta?.javascript).toMatchObject({
+          version: 1,
+          content: 'return title;',
+          args: { title: 'post' },
+        });
+        expect(runSpy).toHaveBeenCalledWith(
+          'return title;',
+          { title: 'post' },
+          expect.objectContaining({ logger: expect.any(Object) }),
+        );
+        expect(runSpy).toHaveBeenCalledTimes(1);
+
+        await app.eventQueue.publish((app.pm.get(Plugin) as Plugin).channelPendingJavaScriptTask, { jobId: job.id });
+        await sleep(100);
+        expect(runSpy).toHaveBeenCalledTimes(1);
+
+        resolveRun?.({ status: JOB_STATUS.RESOLVED, result: 'queued-result' });
+
+        for (let i = 0; i < 30; i++) {
+          [execution] = await workflow.getExecutions();
+          [job] = await execution.getJobs();
+          if (execution?.status === EXECUTION_STATUS.RESOLVED && job?.status === JOB_STATUS.RESOLVED) {
+            break;
+          }
+          await sleep(50);
+        }
+
+        expect(job.status).toBe(JOB_STATUS.RESOLVED);
+        expect(job.result).toBe('queued-result');
+        expect(execution?.status).toBe(EXECUTION_STATUS.RESOLVED);
+      } finally {
+        runSpy.mockRestore();
+      }
+    });
+
     it('should fail when Promise is reject', async () => {
       const script = `
         return Promise.reject(new Error('fail'));
@@ -278,7 +347,7 @@ describe('workflow > instructions > script', () => {
 
     it('should abort a background script when an async workflow times out', async () => {
       let backgroundSignal: AbortSignal | undefined;
-      const runSpy = vi.spyOn(ScriptInstruction, 'run').mockImplementation((_source, _args, options) => {
+      const runSpy = vi.spyOn(ScriptWorkerRunner, 'run').mockImplementation((_source, _args, options) => {
         backgroundSignal = options.signal;
         return new Promise((resolve) => {
           const abort = () => resolve({ status: JOB_STATUS.ERROR, result: 'aborted' });

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/plugin.ts
@@ -1,16 +1,57 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { Plugin } from '@nocobase/server';
 import WorkflowPlugin from '@nocobase/plugin-workflow';
 
+import { getJavaScriptProcessConcurrency } from './JavaScriptProcessLimiter';
 import ScriptInstruction from './ScriptInstruction';
+import { JavaScriptTaskConsumer } from './JavaScriptTaskConsumer';
+import { getJavaScriptQueueConcurrency, JavaScriptTaskQueue } from './JavaScriptTaskQueue';
+import { JavaScriptTaskRecovery } from './JavaScriptTaskRecovery';
 
 export class PluginWorkflowScriptServer extends Plugin {
+  private taskQueue: JavaScriptTaskQueue;
+  private taskConsumer: JavaScriptTaskConsumer;
+  private taskRecovery: JavaScriptTaskRecovery;
+
+  public get channelPendingJavaScriptTask() {
+    return `${this.name}.pendingJavaScriptTask`;
+  }
+
   async afterAdd() {}
 
   async beforeLoad() {}
 
   async load() {
     const workflowPlugin = this.app.pm.get(WorkflowPlugin) as WorkflowPlugin;
-    workflowPlugin.registerInstruction('script', ScriptInstruction);
+    this.taskQueue = new JavaScriptTaskQueue(this.app, this.channelPendingJavaScriptTask);
+    this.taskConsumer = new JavaScriptTaskConsumer(workflowPlugin);
+    this.taskRecovery = new JavaScriptTaskRecovery(workflowPlugin, this.taskQueue);
+
+    workflowPlugin.registerInstruction('script', new ScriptInstruction(workflowPlugin, this.taskQueue));
+    this.app.eventQueue.subscribe(this.channelPendingJavaScriptTask, {
+      concurrency: Math.min(getJavaScriptQueueConcurrency(), getJavaScriptProcessConcurrency()),
+      idle: () => this.taskConsumer.idle(),
+      process: this.taskConsumer.process,
+    });
+
+    this.app.on('afterStart', () => {
+      this.taskConsumer.setReady(true);
+      this.taskRecovery.start();
+    });
+
+    this.app.on('beforeStop', async () => {
+      this.taskConsumer.setReady(false);
+      await this.taskConsumer.beforeStop();
+      await this.taskRecovery.stop();
+    });
   }
 
   async install() {}

--- a/packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts
@@ -57,6 +57,10 @@ export default {
       type: 'json',
       name: 'meta',
     },
+    {
+      type: 'datetime',
+      name: 'startedAt',
+    },
     /**
      * @experimental
      */

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts
@@ -545,6 +545,10 @@ export default class Processor {
             changes.push([`result`, JSON.stringify(job.result ?? null)]);
             job.changed('result', false);
           }
+          if (job.changed('startedAt')) {
+            changes.push([`started_at`, job.startedAt]);
+            job.changed('startedAt', false);
+          }
           if (changes.length) {
             await this.options.plugin.db.sequelize.query(
               `UPDATE ${JobCollection.quotedTableName()} SET ${changes.map(([key]) => `${key} = ?`)} WHERE id='${
@@ -615,6 +619,7 @@ export default class Processor {
     const { database } = <typeof ExecutionModel>this.execution.constructor;
     const model = database.getModel('jobs');
     let job: JobModel;
+    const startedAt = Object.prototype.hasOwnProperty.call(payload, 'startedAt') ? payload.startedAt : new Date();
     if (payload instanceof model) {
       job = payload;
       job.set('updatedAt', new Date());
@@ -628,6 +633,7 @@ export default class Processor {
         status: payload.status,
         result: Object.prototype.hasOwnProperty.call(payload, 'result') ? payload.result : null,
         meta: Object.prototype.hasOwnProperty.call(payload, 'meta') ? payload.meta : null,
+        startedAt,
         updatedAt: new Date(),
       });
     } else {
@@ -635,6 +641,7 @@ export default class Processor {
         {
           ...payload,
           id: this.options.plugin.snowflake.getUniqueID().toString(),
+          startedAt,
           createdAt: new Date(),
           updatedAt: new Date(),
           executionId: this.execution.id,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/types/Job.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/types/Job.ts
@@ -18,6 +18,7 @@ export default class JobModel extends Model {
   declare status: number;
   declare result?: any;
   declare meta?: any;
+  declare startedAt?: Date | null;
 
   declare createdAt: Date;
   declare updatedAt: Date;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

JavaScript workflow nodes previously started background Workers directly after the workflow processor was suspended. A burst of asynchronous JavaScript jobs could therefore create too many Workers in the same Node.js process. This change queues asynchronous JavaScript jobs before starting Workers and uses the existing workflow `jobs` table as the durable source of truth.

### Description

- Queue asynchronous JavaScript jobs through a dedicated event queue message containing only `jobId`.
- Add `jobs.startedAt` and use `PENDING + startedAt = null` to represent jobs waiting for JavaScript Worker resources.
- Store an immutable JavaScript execution snapshot in `job.meta.javascript` so queued jobs run with the script configuration captured at submission time.
- Atomically claim queued JavaScript jobs by updating `startedAt`, preventing duplicate queue deliveries from starting the same Worker twice.
- Add per-process JavaScript Worker concurrency limiting, queue pending limit, queue wait timeout handling, and recovery for unstarted queued jobs.
- Keep already-started pending JavaScript jobs from being automatically rerun after crashes, avoiding duplicate side effects.

Potential risks:

- Existing workflow jobs now receive a default `startedAt` timestamp when saved by the processor.
- Asynchronous JavaScript jobs rely on the new `meta.javascript` snapshot for recovery and duplicate delivery handling.

### Related issues

- CRM ticket `378463634784256`

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | JavaScript workflow nodes now queue asynchronous Worker execution and limit per-process Worker concurrency to reduce resource spikes. |
| 🇨🇳 Chinese | JavaScript 工作流节点现在会队列化异步 Worker 执行，并限制单进程 Worker 并发以降低资源峰值。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

Tests:

- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts packages/plugins/@nocobase/plugin-workflow/src/server/Processor.ts packages/plugins/@nocobase/plugin-workflow/src/server/types/Job.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptInstruction.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/plugin.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptProcessLimiter.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/ScriptWorkerRunner.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskQueue.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskConsumer.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/JavaScriptTaskRecovery.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/security.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/Processor.test.ts --run --reporter=verbose`
