### PR TITLE
fix(client-v2): preserve settings theme tokens

### DIFF
--- a/packages/core/client-v2/src/__tests__/settings-shell.test.tsx
+++ b/packages/core/client-v2/src/__tests__/settings-shell.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { ConfigProvider } from 'antd';
+import { ConfigProvider, theme as antdTheme } from 'antd';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -19,6 +19,7 @@ import type { ThemeConfig } from '../theme';
 const userCenterModel = { uid: 'settings-user-center' };
 const createModel = vi.fn(() => userCenterModel);
 const matchRoutes = vi.fn(() => [{ route: { id: 'settings' } }]);
+let settingsThemeConfig: ThemeConfig | null = null;
 const mockApp = {
   flowEngine: {
     createModel,
@@ -46,6 +47,10 @@ vi.mock('../settings-app/SettingsSearch', () => ({
   SettingsSearch: () => <div data-testid="settings-search">search</div>,
 }));
 
+vi.mock('../settings-app/useSettingsThemeConfig', () => ({
+  useSettingsThemeConfig: () => settingsThemeConfig,
+}));
+
 vi.mock('../flow/admin-shell/admin-layout/HelpLite', () => ({
   HelpLite: () => <div data-testid="settings-help">help</div>,
 }));
@@ -60,8 +65,15 @@ vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   };
 });
 
+const TokenProbe = () => {
+  const { token } = antdTheme.useToken();
+
+  return <div data-testid="settings-theme-token">{`${token.marginBlock}:${token.sizeLG}`}</div>;
+};
+
 describe('SettingsShell', () => {
   beforeEach(() => {
+    settingsThemeConfig = null;
     createModel.mockClear();
     matchRoutes.mockReset();
     matchRoutes.mockReturnValue([{ route: { id: 'settings' } }]);
@@ -109,6 +121,20 @@ describe('SettingsShell', () => {
 
     // 主题编辑器里的深色顶栏只作用于业务端；设置中心固定用容器底色。
     expect(screen.getByRole('banner')).toHaveStyle({ background: '#ffffff' });
+  });
+
+  it('preserves NocoBase custom tokens in the stored compact theme', () => {
+    settingsThemeConfig = { algorithm: antdTheme.compactAlgorithm };
+
+    render(
+      <MemoryRouter initialEntries={['/settings/system-settings']}>
+        <SettingsShell>
+          <TokenProbe />
+        </SettingsShell>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('settings-theme-token')).toHaveTextContent('16:16');
   });
 
   it('places the settings content and embed container side by side below the header', () => {

--- a/packages/core/client-v2/src/settings-app/SettingsShell.tsx
+++ b/packages/core/client-v2/src/settings-app/SettingsShell.tsx
@@ -18,6 +18,7 @@ import {
 } from '../flow/models/topbar/UserCenterTopbarActionModel';
 import { useApp } from '../hooks/useApp';
 import { useCurrentUserAuthStatus } from '../nocobase-buildin-plugin/currentUserAuthStatus';
+import { addCustomAlgorithmToTheme } from '../theme/customAlgorithm';
 import { SettingsBrand } from './SettingsBrand';
 import { SettingsGroupNav } from './SettingsGroupNav';
 import { SettingsSearch } from './SettingsSearch';
@@ -79,17 +80,31 @@ export const SettingsShell: FC = ({ children }) => {
   const { token } = antdTheme.useToken();
   // 设置中心的外观由主题编辑器里那条「简约」主题记录约束；读不到才用代码里的中性配色兜底。
   const storedThemeConfig = useSettingsThemeConfig();
+  const normalizedStoredThemeConfig = useMemo(
+    () =>
+      storedThemeConfig
+        ? addCustomAlgorithmToTheme({
+            ...storedThemeConfig,
+            algorithm: Array.isArray(storedThemeConfig.algorithm)
+              ? [...storedThemeConfig.algorithm]
+              : storedThemeConfig.algorithm,
+          })
+        : storedThemeConfig,
+    [storedThemeConfig],
+  );
   // 顶栏和补丁样式要按**设置中心自己这套主题**算色，不能直接用上面那个 `token`——
   // 这个组件在自己的 ConfigProvider 外面，`token` 是业务端主题的。用它的话，业务端一切暗黑，
   // 顶栏就跟着变黑，而内容区还是简约的白，一半黑一半白。
   const settingsToken = useMemo(
-    () => (storedThemeConfig ? antdTheme.getDesignToken(storedThemeConfig) : token),
-    [storedThemeConfig, token],
+    () => (normalizedStoredThemeConfig ? antdTheme.getDesignToken(normalizedStoredThemeConfig) : token),
+    [normalizedStoredThemeConfig, token],
   );
   const settingsShellTheme = useMemo<ThemeConfig>(
     () =>
-      storedThemeConfig ? withSettingsHeaderTheme(storedThemeConfig, settingsToken) : buildSettingsNeutralTheme(token),
-    [settingsToken, storedThemeConfig, token],
+      normalizedStoredThemeConfig
+        ? withSettingsHeaderTheme(normalizedStoredThemeConfig, settingsToken)
+        : buildSettingsNeutralTheme(token),
+    [normalizedStoredThemeConfig, settingsToken, token],
   );
   const headerColors = useMemo(() => getSettingsHeaderColors(settingsToken), [settingsToken]);
   const settingsGlobalCss = useMemo(() => buildSettingsGlobalCss(settingsToken), [settingsToken]);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

在设置中心配置工作流审批时，发起人界面和审批人界面的内容会紧贴弹窗边缘，缺少正常的留白，影响配置界面的可读性。

### Description

- 在设置中心应用已保存的紧凑主题时，保留 NocoBase 提供的页面和区块间距。
- 让主题计算和实际页面渲染使用同一份主题配置，避免界面间距再次丢失。
- 增加回归测试，验证紧凑主题下仍能获得正确的区块间距。

建议测试：进入设置中心的工作流审批配置，分别打开发起人界面和审批人界面，确认内容与弹窗边缘之间保持正常留白。

### Showcase

修复后，发起人界面和审批人界面的内容恢复顶部及左右 16px 间距，弹窗本身不会叠加额外内边距。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing spacing in workflow approval configuration dialogs |
| 🇨🇳 Chinese | 修复工作流审批配置弹窗缺少内边距的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
