### PR TITLE
chore: update v1 Node.js runtime to 22

### DIFF
--- a/.github/workflows/build-internal-image.yml
+++ b/.github/workflows/build-internal-image.yml
@@ -23,10 +23,10 @@ jobs:
         ports:
           - 4873:4873
     steps:
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Get info
         id: get-info
         shell: bash

--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -86,10 +86,10 @@ jobs:
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: yarn install
       - name: Run script

--- a/.github/workflows/deploy-client-docs.yml
+++ b/.github/workflows/deploy-client-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: yarn install
       - name: Build zh-CN

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: yarn
       - run: yarn build
@@ -105,7 +105,7 @@ jobs:
   #   name: Core and plugins
   #   needs: build
   #   runs-on: ubuntu-latest
-  #   container: node:20
+  #   container: node:22
   #   services:
   #     # Label used to access the service container
   #     postgres:
@@ -203,7 +203,7 @@ jobs:
   #   name: plugin-workflow
   #   needs: build
   #   runs-on: ubuntu-latest
-  #   container: node:20
+  #   container: node:22
   #   services:
   #     # Label used to access the service container
   #     postgres:
@@ -301,7 +301,7 @@ jobs:
   #   name: plugin-workflow-approval
   #   needs: build
   #   runs-on: ubuntu-latest
-  #   container: node:20
+  #   container: node:22
   #   services:
   #     # Label used to access the service container
   #     postgres:
@@ -427,7 +427,7 @@ jobs:
   #   name: plugin-data-source-main
   #   needs: build
   #   runs-on: ubuntu-latest
-  #   container: node:20
+  #   container: node:22
   #   services:
   #     # Label used to access the service container
   #     postgres:
@@ -536,7 +536,7 @@ jobs:
   #     - uses: actions/checkout@v4
   #     - uses: actions/setup-node@v4
   #       with:
-  #         node-version: 20
+  #         node-version: 22
   #         cache: 'yarn'
   #     - run: yarn
 

--- a/.github/workflows/manual-e2e.yml
+++ b/.github/workflows/manual-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   e2e-test-postgres:
     strategy:
       matrix:
-        node_version: ['20']
+        node_version: ['22']
     runs-on: ubuntu-latest
     container: node:${{ matrix.node_version }}
     services:

--- a/.github/workflows/manual-npm-publish-license-kit.yml
+++ b/.github/workflows/manual-npm-publish-license-kit.yml
@@ -83,7 +83,7 @@ jobs:
               sudo apt-get update
               sudo apt-get install gcc-riscv64-linux-gnu -y
             build: yarn build --target riscv64gc-unknown-linux-gnu
-    name: stable - ${{ matrix.settings.target }} - node@20
+    name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/create-github-app-token@v1
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
@@ -140,7 +140,7 @@ jobs:
         uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
           architecture: x86
       - name: Install OpenSSL dev
@@ -240,7 +240,7 @@ jobs:
             target: x86_64-pc-windows-msvc
         node:
           - '18'
-          - '20'
+          - '22'
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/create-github-app-token@v1
@@ -284,7 +284,7 @@ jobs:
       matrix:
         node:
           - '18'
-          - '20'
+          - '22'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -327,7 +327,7 @@ jobs:
       matrix:
         node:
           - '18'
-          - '20'
+          - '22'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -372,7 +372,7 @@ jobs:
       matrix:
         node:
           - '18'
-          - '20'
+          - '22'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -471,7 +471,7 @@ jobs:
       matrix:
         node:
           - '18'
-          - '20'
+          - '22'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -537,7 +537,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
       - name: Install dependencies
         run: yarn install
@@ -589,7 +589,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/manual-release-develop.yml
+++ b/.github/workflows/manual-release-develop.yml
@@ -55,10 +55,10 @@ jobs:
           do
           git clone -b develop https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Checkout
         shell: bash
         run: |

--- a/.github/workflows/manual-release-next.yml
+++ b/.github/workflows/manual-release-next.yml
@@ -100,10 +100,10 @@ jobs:
           do
           git clone -b next https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Checkout
         shell: bash
         run: |

--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -74,10 +74,10 @@ jobs:
             git clone -b v1 https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
 
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Prepare git excludes + identity
         shell: bash

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -94,10 +94,10 @@ jobs:
           do
           git clone -b main https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Checkout
         shell: bash
         run: |

--- a/.github/workflows/nocobase-test-backend.yml
+++ b/.github/workflows/nocobase-test-backend.yml
@@ -44,7 +44,7 @@ jobs:
   sqlite-test:
     strategy:
       matrix:
-        node_version: ['20']
+        node_version: ['22']
         underscored: [true, false]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node_version }}
@@ -77,13 +77,13 @@ jobs:
   postgres-test:
     strategy:
       matrix:
-        node_version: ['20']
+        node_version: ['22']
         underscored: [true, false]
         schema: [public, nocobase]
         collection_schema: [public, user_schema]
         cache_redis: ['']
         include:
-          - node_version: 20
+          - node_version: 22
             underscored: true
             schema: public
             collection_schema: public
@@ -144,7 +144,7 @@ jobs:
   mysql-test:
     strategy:
       matrix:
-        node_version: ['20']
+        node_version: ['22']
         underscored: [true, false]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node_version }}
@@ -190,7 +190,7 @@ jobs:
   mariadb-test:
     strategy:
       matrix:
-        node_version: ['20']
+        node_version: ['22']
         underscored: [true, false]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node_version }}

--- a/.github/workflows/nocobase-test-frontend.yml
+++ b/.github/workflows/nocobase-test-frontend.yml
@@ -34,7 +34,7 @@ jobs:
   frontend-test:
     strategy:
       matrix:
-        node_version: ['20']
+        node_version: ['22']
     runs-on: ubuntu-latest
     container: node:${{ matrix.node_version }}
     steps:

--- a/.github/workflows/nocobase-test-windows.yml
+++ b/.github/workflows/nocobase-test-windows.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
 
       - run: yarn config set network-timeout 600000 -g
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
     needs: get-plugins
     runs-on: ubuntu-latest
     steps:
-      - name: Set Node.js 20
+      - name: Set Node.js 22
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Get info
         id: get-info
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm as builder
+FROM node:22-bookworm as builder
 ARG VERDACCIO_URL=http://host.docker.internal:10104/
 ARG COMMIT_HASH
 ARG APPEND_PRESET_LOCAL_PLUGINS
@@ -55,7 +55,7 @@ RUN cd /app \
   && tar -zcf ./nocobase.tar.gz -C /app/my-nocobase-app .
 
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pro
+++ b/Dockerfile.pro
@@ -1,4 +1,4 @@
-FROM node:20.13-bullseye as builder
+FROM node:22.13-bullseye as builder
 ARG VERDACCIO_URL=http://host.docker.internal:10104/
 ARG COMMIT_HASH
 ARG APPEND_PRESET_LOCAL_PLUGINS
@@ -43,7 +43,7 @@ RUN cd /app \
 RUN echo "${COMMIT_HASH}" > /tmp/commit_hash.txt
 
 
-FROM node:20.13-bullseye-slim
+FROM node:22.13-bullseye-slim
 RUN apt-get update && apt-get install -y nginx libaio1 \
   && apt-get install -y --no-install-recommends postgresql-common gnupg \
   && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \

--- a/docker/nocobase/Dockerfile
+++ b/docker/nocobase/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim as builder
+FROM node:22-bookworm-slim as builder
 
 ARG CNA_VERSION
 
@@ -18,7 +18,7 @@ RUN cd /app \
   && rm -rf nocobase.tar.gz \
   && tar -zcf ./nocobase.tar.gz -C /app/my-nocobase-app .
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # COPY ./sources.list /etc/apt/sources.list
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/docker/nocobase/Dockerfile-full
+++ b/docker/nocobase/Dockerfile-full
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim as builder
+FROM node:22-bookworm-slim as builder
 
 ARG CNA_VERSION=latest
 
@@ -18,7 +18,7 @@ RUN cd /app \
   && rm -rf nocobase.tar.gz \
   && tar -zcf ./nocobase.tar.gz -C /app/my-nocobase-app .
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget gnupg ca-certificates \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

The v1 build fails when Yarn resolves `@azure/core-auth@1.11.0`, because that version requires Node.js 22 while the v1 workflows still use Node.js 20. The main branch has already moved its CI and Docker runtime to Node.js 22.

### Description

- Update v1 CI, test, and release workflows from Node.js 20 to Node.js 22.
- Update Docker builder and runtime images from Node.js 20 to Node.js 22.
- Keep dependency declarations and `yarn.lock` unchanged, matching the runtime-upgrade approach used by the main branch.

Potential impact: Node.js 20 is no longer covered by these workflows or Docker images. Native dependencies should be monitored during the full CI and image builds.

Validation performed:

- Parsed all 14 modified GitHub Actions workflow files successfully.
- Reproduced the Azure engine incompatibility on Node.js 20.20.2.
- Installed the original unpinned Azure dependency successfully on Node.js 22.23.1 with Yarn 1.22.22.
- Ran `git diff --check` successfully.

A full v1 build and Docker image build have not been run locally.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Updated the v1 build and Docker runtime to Node.js 22 to support dependencies that require Node.js 22 |
| 🇨🇳 Chinese | 将 v1 构建和 Docker 运行时升级到 Node.js 22，以支持要求 Node.js 22 的依赖 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
