### PR TITLE
feat(client-v2): support after-success settings for update actions

### DIFF
--- a/packages/core/client-v2/src/flow/models/actions/UpdateRecordActionModel.tsx
+++ b/packages/core/client-v2/src/flow/models/actions/UpdateRecordActionModel.tsx
@@ -22,6 +22,11 @@ import { applyUpdateRecordAction } from './UpdateRecordActionUtils';
 // import { RemoteFlowModelRenderer } from '../../FlowPage';
 
 const SETTINGS_FLOW_KEY = 'assignSettings';
+const AFTER_SUCCESS_DEFAULT_PARAMS = {
+  successMessage: tExpr('Saved successfully'),
+  manualClose: false,
+  actionAfterSuccess: 'stay',
+};
 
 function Info() {
   const ctx = useFlowSettingsContext();
@@ -101,6 +106,10 @@ UpdateRecordActionModel.registerFlow({
       tipComponent: Info,
       validateBeforeSave: true,
     }),
+    afterSuccess: {
+      use: 'afterSuccess',
+      defaultParams: AFTER_SUCCESS_DEFAULT_PARAMS,
+    },
   },
 });
 
@@ -113,7 +122,15 @@ UpdateRecordActionModel.registerFlow({
         return getAssignFieldValuesDefaultParams(ctx, SETTINGS_FLOW_KEY);
       },
       async handler(ctx, params) {
-        await applyUpdateRecordAction(ctx, params, { settingsFlowKey: SETTINGS_FLOW_KEY });
+        const updated = await applyUpdateRecordAction(ctx, params, { settingsFlowKey: SETTINGS_FLOW_KEY });
+        if (!updated) {
+          return;
+        }
+        const savedAfterSuccess = ctx.model.getStepParams(SETTINGS_FLOW_KEY, 'afterSuccess') || {};
+        await ctx.runAction('afterSuccess', {
+          ...AFTER_SUCCESS_DEFAULT_PARAMS,
+          ...savedAfterSuccess,
+        });
       },
     },
   },

--- a/packages/core/client-v2/src/flow/models/actions/UpdateRecordActionUtils.ts
+++ b/packages/core/client-v2/src/flow/models/actions/UpdateRecordActionUtils.ts
@@ -8,8 +8,14 @@
  */
 
 import { MultiRecordResource, SingleRecordResource } from '@nocobase/flow-engine';
+import type { AxiosRequestConfig } from 'axios';
 import { dispatchEventDeep } from '../../utils';
 import { resolveAssignFieldValues } from '../blocks/assign-form/assignFieldValuesFlow';
+
+type UpdateRecordActionParams = {
+  assignedValues?: unknown;
+  requestConfig?: AxiosRequestConfig;
+};
 
 export async function refreshLinkageRulesAfterUpdate(ctx: any) {
   const blockModel = ctx?.blockModel || ctx?.model?.context?.blockModel || ctx?.model;
@@ -48,11 +54,11 @@ export async function refreshLinkageRulesAfterUpdate(ctx: any) {
 
 export async function applyUpdateRecordAction(
   ctx: any,
-  params: any,
+  params: UpdateRecordActionParams,
   options?: {
     settingsFlowKey?: string;
   },
-) {
+): Promise<boolean> {
   const settingsFlowKey = options?.settingsFlowKey || 'assignSettings';
 
   // 统一接入二次确认：如果启用则弹窗；未配置时默认不启用
@@ -62,25 +68,31 @@ export async function applyUpdateRecordAction(
 
   const assignedValues = await resolveAssignFieldValues(ctx, params?.assignedValues, 'UpdateRecordAction');
   if (!assignedValues) {
-    return;
+    return false;
   }
 
   if (!assignedValues || typeof assignedValues !== 'object' || !Object.keys(assignedValues).length) {
     ctx.message.warning(ctx.t('No assigned fields configured'));
-    return;
+    return false;
   }
   const collection = ctx.collection?.name;
   const filterByTk = ctx.collection?.getFilterByTK?.(ctx.record);
   if (!collection || typeof filterByTk === 'undefined' || filterByTk === null) {
     ctx.message.error(ctx.t('Record is required to perform this action'));
-    return;
+    return false;
   }
+  let updated = false;
   if (ctx.resource instanceof SingleRecordResource) {
     await ctx.resource.save(assignedValues, params.requestConfig);
+    updated = true;
   } else if (ctx.resource instanceof MultiRecordResource) {
     await ctx.resource.update(filterByTk, assignedValues, params.requestConfig);
+    updated = true;
+  }
+  if (!updated) {
+    return false;
   }
 
   await refreshLinkageRulesAfterUpdate(ctx);
-  ctx.message.success(ctx.t('Saved successfully'));
+  return true;
 }

--- a/packages/core/client-v2/src/flow/models/actions/__tests__/UpdateRecordActionModel.test.ts
+++ b/packages/core/client-v2/src/flow/models/actions/__tests__/UpdateRecordActionModel.test.ts
@@ -8,8 +8,9 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MultiRecordResource } from '@nocobase/flow-engine';
+import { FlowEngine, MultiRecordResource } from '@nocobase/flow-engine';
 import { applyUpdateRecordAction } from '../UpdateRecordActionUtils';
+import { UpdateRecordActionModel } from '../UpdateRecordActionModel';
 import { dispatchEventDeep } from '../../../utils';
 
 vi.mock('../../../utils', () => ({
@@ -21,7 +22,7 @@ describe('UpdateRecordActionModel apply action', () => {
     vi.clearAllMocks();
   });
 
-  it('dispatches paginationChange for action and block after successful update', async () => {
+  it('dispatches paginationChange and returns success after updating the record', async () => {
     const resource: any = Object.create(MultiRecordResource.prototype);
     resource.update = vi.fn(async () => ({}));
     resource.refresh = vi.fn(async () => {});
@@ -52,12 +53,13 @@ describe('UpdateRecordActionModel apply action', () => {
       t: (value: string) => value,
     };
 
-    await applyUpdateRecordAction(ctx, {
+    const updated = await applyUpdateRecordAction(ctx, {
       assignedValues: {
         marital_status: '已婚',
       },
     });
 
+    expect(updated).toBe(true);
     expect(resource.update).toHaveBeenCalledWith(1, { marital_status: '已婚' }, undefined);
     expect(resource.refresh).not.toHaveBeenCalled();
 
@@ -67,6 +69,76 @@ describe('UpdateRecordActionModel apply action', () => {
     expect(paginationCalls.length).toBeGreaterThan(0);
     expect(paginationCalls.some(([model]: [any]) => model === ctx.model)).toBe(true);
     expect(paginationCalls.some(([model]: [any]) => model === blockModel)).toBe(true);
-    expect(ctx.message.success).toHaveBeenCalledWith('Saved successfully');
+    expect(ctx.message.success).not.toHaveBeenCalled();
+  });
+
+  it('runs the configured after-success action only after a successful update', async () => {
+    const engine = new FlowEngine();
+    const action = new UpdateRecordActionModel({ uid: 'update-record-action', flowEngine: engine } as any);
+    action.setStepParams('assignSettings', 'confirm', { enable: false });
+    action.setStepParams('assignSettings', 'afterSuccess', {
+      successMessage: 'Record updated',
+    });
+
+    const resource: any = Object.create(MultiRecordResource.prototype);
+    resource.update = vi.fn(async () => ({}));
+    const blockModel: any = { uid: 'details-block' };
+    const runAction = vi.fn(async () => {});
+    const ctx: any = {
+      model: action,
+      blockModel,
+      runAction,
+      collection: {
+        name: 'users',
+        getFilterByTK: vi.fn(() => 1),
+      },
+      record: { id: 1 },
+      resource,
+      message: {
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+      },
+      t: (value: string) => value,
+    };
+    const handler = action.getFlow('apply')?.getStep('apply')?.serialize().handler;
+
+    await handler(ctx, { assignedValues: { status: 'active' } });
+
+    expect(runAction).toHaveBeenNthCalledWith(1, 'confirm', { enable: false });
+    expect(runAction).toHaveBeenNthCalledWith(2, 'afterSuccess', {
+      successMessage: 'Record updated',
+      manualClose: false,
+      actionAfterSuccess: 'stay',
+    });
+  });
+
+  it('does not run the after-success action when no fields are assigned', async () => {
+    const engine = new FlowEngine();
+    const action = new UpdateRecordActionModel({ uid: 'update-record-action-empty', flowEngine: engine } as any);
+    const runAction = vi.fn(async () => {});
+    const ctx: any = {
+      model: action,
+      runAction,
+      collection: {
+        name: 'users',
+        getFilterByTK: vi.fn(() => 1),
+      },
+      record: { id: 1 },
+      resource: Object.create(MultiRecordResource.prototype),
+      message: {
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+      },
+      t: (value: string) => value,
+    };
+    const handler = action.getFlow('apply')?.getStep('apply')?.serialize().handler;
+
+    await handler(ctx, { assignedValues: {} });
+
+    expect(runAction).toHaveBeenCalledTimes(1);
+    expect(runAction).toHaveBeenCalledWith('confirm', { enable: false });
+    expect(ctx.message.warning).toHaveBeenCalledWith('No assigned fields configured');
   });
 });

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/BulkUpdateActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/BulkUpdateActionModel.tsx
@@ -172,10 +172,14 @@ BulkUpdateActionModel.registerFlow({
           }
         }
 
-        try {
-          await ctx.blockModel?.resource?.refresh?.();
-        } catch (error) {
+        const logRefreshError = (error: unknown) => {
           ctx.logger?.warn?.({ err: error }, 'Failed to refresh the block after a successful bulk update');
+        };
+        try {
+          const refreshPromise = ctx.blockModel?.resource?.refresh?.();
+          refreshPromise?.catch?.(logRefreshError);
+        } catch (error) {
+          logRefreshError(error);
         }
         const savedAfterSuccess = ctx.model.getStepParams(SETTINGS_FLOW_KEY, 'afterSuccess') || {};
         await ctx.runAction('afterSuccess', {

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/BulkUpdateActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/BulkUpdateActionModel.tsx
@@ -21,6 +21,11 @@ import type { ButtonProps } from 'antd/es/button';
 import { NAMESPACE } from './locale';
 
 const SETTINGS_FLOW_KEY = 'assignSettings';
+const AFTER_SUCCESS_DEFAULT_PARAMS = {
+  successMessage: tExpr('Saved successfully'),
+  manualClose: false,
+  actionAfterSuccess: 'stay',
+};
 
 export class BulkUpdateActionModel extends ActionModel<{
   subModels: {
@@ -88,6 +93,10 @@ BulkUpdateActionModel.registerFlow({
       title: tExpr('Assign field values'),
       clearRecordContext: true,
     }),
+    afterSuccess: {
+      use: 'afterSuccess',
+      defaultParams: AFTER_SUCCESS_DEFAULT_PARAMS,
+    },
   },
 });
 
@@ -163,8 +172,16 @@ BulkUpdateActionModel.registerFlow({
           }
         }
 
-        ctx.blockModel?.resource?.refresh?.();
-        ctx.message.success(ctx.t('Saved successfully'));
+        try {
+          await ctx.blockModel?.resource?.refresh?.();
+        } catch (error) {
+          ctx.logger?.warn?.({ err: error }, 'Failed to refresh the block after a successful bulk update');
+        }
+        const savedAfterSuccess = ctx.model.getStepParams(SETTINGS_FLOW_KEY, 'afterSuccess') || {};
+        await ctx.runAction('afterSuccess', {
+          ...AFTER_SUCCESS_DEFAULT_PARAMS,
+          ...savedAfterSuccess,
+        });
       },
     },
   },

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/__tests__/BulkUpdateActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/__tests__/BulkUpdateActionModel.test.ts
@@ -170,12 +170,18 @@ describe('BulkUpdateActionModel apply action', () => {
     expect(ctx.runAction).toHaveBeenCalledTimes(1);
   });
 
-  it('runs the configured after-success action when refresh fails after updating selected records', async () => {
+  it('runs the configured after-success action before refresh settles and logs a later refresh failure', async () => {
     const engine = new FlowEngine();
     const model = new BulkUpdateActionModel({ uid: 'bulk-update-action-success', flowEngine: engine } as any);
     const update = vi.fn(async () => ({}));
     const refreshError = new Error('refresh failed');
-    const refresh = vi.fn().mockRejectedValue(refreshError);
+    let rejectRefresh: ((reason?: unknown) => void) | undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRefresh = reject;
+        }),
+    );
     const runAction = vi.fn(async () => {});
     const warn = vi.fn();
     const setProps = vi.fn();
@@ -224,14 +230,14 @@ describe('BulkUpdateActionModel apply action', () => {
     };
     const handler = model.getFlow('apply')?.getStep('apply')?.serialize().handler;
 
-    await handler(ctx, { assignedValues: { status: 'active' } });
+    const handlerPromise = handler(ctx, { assignedValues: { status: 'active' } });
+
+    await vi.waitFor(() => {
+      expect(runAction).toHaveBeenCalledTimes(2);
+    });
 
     expect(update).toHaveBeenCalled();
     expect(refresh).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(
-      { err: refreshError },
-      'Failed to refresh the block after a successful bulk update',
-    );
     expect(runAction).toHaveBeenNthCalledWith(1, 'confirm', { enable: false });
     expect(runAction).toHaveBeenNthCalledWith(2, 'afterSuccess', {
       successMessage: 'Records updated',
@@ -241,6 +247,16 @@ describe('BulkUpdateActionModel apply action', () => {
     expect(ctx.message.success).not.toHaveBeenCalled();
     expect(setProps).toHaveBeenNthCalledWith(1, { loading: true });
     expect(setProps).toHaveBeenNthCalledWith(2, { loading: false });
+
+    expect(rejectRefresh).toBeTypeOf('function');
+    rejectRefresh?.(refreshError);
+    await handlerPromise;
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        { err: refreshError },
+        'Failed to refresh the block after a successful bulk update',
+      );
+    });
   });
 
   it('does not run the after-success action when no records are selected', async () => {

--- a/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/__tests__/BulkUpdateActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-bulk-update/src/client-v2/__tests__/BulkUpdateActionModel.test.ts
@@ -167,5 +167,121 @@ describe('BulkUpdateActionModel apply action', () => {
     expect(setProps).toHaveBeenNthCalledWith(2, { loading: false });
     expect(refresh).not.toHaveBeenCalled();
     expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.runAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the configured after-success action when refresh fails after updating selected records', async () => {
+    const engine = new FlowEngine();
+    const model = new BulkUpdateActionModel({ uid: 'bulk-update-action-success', flowEngine: engine } as any);
+    const update = vi.fn(async () => ({}));
+    const refreshError = new Error('refresh failed');
+    const refresh = vi.fn().mockRejectedValue(refreshError);
+    const runAction = vi.fn(async () => {});
+    const warn = vi.fn();
+    const setProps = vi.fn();
+    const ctx: any = {
+      model: {
+        getStepParams: vi.fn((_flowKey: string, stepKey: string) => {
+          if (stepKey === 'confirm') {
+            return { enable: false };
+          }
+          if (stepKey === 'updateMode') {
+            return { value: 'selected' };
+          }
+          if (stepKey === 'afterSuccess') {
+            return {
+              successMessage: 'Records updated',
+            };
+          }
+          return undefined;
+        }),
+        setProps,
+      },
+      runAction,
+      collection: {
+        name: 'users',
+        dataSourceKey: 'main',
+        filterTargetKey: 'id',
+        getPrimaryKey: () => 'id',
+        getFilterByTK: (record: { id: number }) => record.id,
+      },
+      blockModel: {
+        resource: {
+          getSelectedRows: () => [{ id: 1 }],
+          refresh,
+        },
+      },
+      api: {
+        resource: vi.fn(() => ({ update })),
+      },
+      logger: { warn },
+      message: {
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+      },
+      t: (value: string) => value,
+    };
+    const handler = model.getFlow('apply')?.getStep('apply')?.serialize().handler;
+
+    await handler(ctx, { assignedValues: { status: 'active' } });
+
+    expect(update).toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      { err: refreshError },
+      'Failed to refresh the block after a successful bulk update',
+    );
+    expect(runAction).toHaveBeenNthCalledWith(1, 'confirm', { enable: false });
+    expect(runAction).toHaveBeenNthCalledWith(2, 'afterSuccess', {
+      successMessage: 'Records updated',
+      manualClose: false,
+      actionAfterSuccess: 'stay',
+    });
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(setProps).toHaveBeenNthCalledWith(1, { loading: true });
+    expect(setProps).toHaveBeenNthCalledWith(2, { loading: false });
+  });
+
+  it('does not run the after-success action when no records are selected', async () => {
+    const engine = new FlowEngine();
+    const model = new BulkUpdateActionModel({ uid: 'bulk-update-action-empty', flowEngine: engine } as any);
+    const runAction = vi.fn(async () => {});
+    const ctx: any = {
+      model: {
+        getStepParams: vi.fn((_flowKey: string, stepKey: string) => {
+          if (stepKey === 'updateMode') {
+            return { value: 'selected' };
+          }
+          return undefined;
+        }),
+        setProps: vi.fn(),
+      },
+      runAction,
+      collection: {
+        name: 'users',
+        filterTargetKey: 'id',
+        getPrimaryKey: () => 'id',
+      },
+      blockModel: {
+        resource: {
+          getSelectedRows: () => [],
+          refresh: vi.fn(),
+        },
+      },
+      message: {
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+      },
+      t: (value: string) => value,
+    };
+    const handler = model.getFlow('apply')?.getStep('apply')?.serialize().handler;
+
+    await handler(ctx, { assignedValues: { status: 'active' } });
+
+    expect(runAction).toHaveBeenCalledTimes(1);
+    expect(runAction).toHaveBeenCalledWith('confirm', { enable: false });
+    expect(ctx.message.error).toHaveBeenCalledWith('Please select the records to be updated');
   });
 });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/flow-surfaces.after-success.unit.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/flow-surfaces.after-success.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildActionTree } from '../flow-surfaces/builder';
+import { getNodeContract } from '../flow-surfaces/catalog';
+import { getConfigureOptionsForUse } from '../flow-surfaces/configure-options';
+import { normalizeAfterSuccess } from '../flow-surfaces/service-utils';
+
+describe('flowSurfaces update action after-success contract', () => {
+  it.each(['UpdateRecordActionModel', 'BulkUpdateActionModel'])('publishes and persists afterSuccess for %s', (use) => {
+    expect(getConfigureOptionsForUse(use).afterSuccess).toMatchObject({
+      type: 'object',
+    });
+
+    const contract = getNodeContract(use);
+    const assignSettings = contract.domains.stepParams?.groups?.assignSettings;
+    expect(assignSettings?.allowedPaths).toEqual(
+      expect.arrayContaining([
+        'afterSuccess.successMessage',
+        'afterSuccess.manualClose',
+        'afterSuccess.actionAfterSuccess',
+        'afterSuccess.redirectTo',
+      ]),
+    );
+    expect(assignSettings?.eventBindingSteps).toContain('afterSuccess');
+    expect(assignSettings?.pathSchemas?.['afterSuccess.actionAfterSuccess']?.enum).toEqual([
+      'stay',
+      'previous',
+      'redirect',
+    ]);
+
+    const action = buildActionTree({
+      use,
+      containerUse: use === 'UpdateRecordActionModel' ? 'TableActionsColumnModel' : 'TableBlockModel',
+    });
+    expect(action.stepParams?.assignSettings?.afterSuccess).toEqual({
+      successMessage: '{{t("Saved successfully")}}',
+      manualClose: false,
+      actionAfterSuccess: 'stay',
+    });
+  });
+
+  it('normalizes supported after-success values and rejects an invalid action', () => {
+    expect(
+      normalizeAfterSuccess({
+        successMessage: 'Updated',
+        manualClose: true,
+        actionAfterSuccess: 'redirect',
+        redirectTo: '/admin/updated',
+      }),
+    ).toEqual({
+      successMessage: 'Updated',
+      manualClose: true,
+      actionAfterSuccess: 'redirect',
+      redirectTo: '/admin/updated',
+    });
+
+    expect(() => normalizeAfterSuccess({ actionAfterSuccess: 'close' })).toThrow(
+      'afterSuccess.actionAfterSuccess must be stay, previous, or redirect',
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/flow-surfaces.catalog-compose.contract.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/flow-surfaces.catalog-compose.contract.test.ts
@@ -1165,10 +1165,16 @@ describe('flowSurfaces catalog + compose contract', () => {
         triggerWorkflows: {
           type: 'array',
         },
+        afterSuccess: {
+          type: 'object',
+        },
       },
     );
     expect(tableCatalog.actions.find((item: any) => item.key === 'bulkUpdate')?.configureOptions).toMatchObject({
       assignValues: {
+        type: 'object',
+      },
+      afterSuccess: {
         type: 'object',
       },
     });
@@ -7576,6 +7582,12 @@ describe('flowSurfaces catalog + compose contract', () => {
               assignValues: {
                 nickname: 'inactive',
               },
+              afterSuccess: {
+                successMessage: 'Employees archived',
+                manualClose: false,
+                actionAfterSuccess: 'redirect',
+                redirectTo: '/admin/archived-employees',
+              },
             },
           },
           {
@@ -7625,6 +7637,12 @@ describe('flowSurfaces catalog + compose contract', () => {
     expect(bulkUpdateReadback.tree.use).toBe('BulkUpdateActionModel');
     expectAssignedValuesMirrors(bulkUpdateReadback.tree, {
       nickname: 'inactive',
+    });
+    expect(bulkUpdateReadback.tree.stepParams?.assignSettings?.afterSuccess).toEqual({
+      successMessage: 'Employees archived',
+      manualClose: false,
+      actionAfterSuccess: 'redirect',
+      redirectTo: '/admin/archived-employees',
     });
 
     const { actionSurface: popupSurface, popupBlock } = await readPrimaryPopupBlock(
@@ -7701,6 +7719,11 @@ describe('flowSurfaces catalog + compose contract', () => {
               assignValues: {
                 nickname: 'active',
               },
+              afterSuccess: {
+                successMessage: 'Employee activated',
+                manualClose: true,
+                actionAfterSuccess: 'stay',
+              },
             },
           },
         ],
@@ -7756,6 +7779,11 @@ describe('flowSurfaces catalog + compose contract', () => {
     expect(updateRecordReadback.tree.stepParams?.buttonSettings?.general?.title).toBeUndefined();
     expectAssignedValuesMirrors(updateRecordReadback.tree, {
       nickname: 'active',
+    });
+    expect(updateRecordReadback.tree.stepParams?.assignSettings?.afterSuccess).toEqual({
+      successMessage: 'Employee activated',
+      manualClose: true,
+      actionAfterSuccess: 'stay',
     });
 
     const addFieldRawUnknownRes = await rootAgent.resource('flowSurfaces').addField({

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/builder.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/builder.ts
@@ -1043,6 +1043,11 @@ function buildActionDefaults(options: {
       assignFieldValues: {
         assignedValues: {},
       },
+      afterSuccess: {
+        successMessage: '{{t("Saved successfully")}}',
+        manualClose: false,
+        actionAfterSuccess: 'stay',
+      },
     };
     stepParams.apply = {
       apply: {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/catalog.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/catalog.ts
@@ -171,6 +171,21 @@ const OPEN_VIEW_PATH_SCHEMAS = {
   'openView.tryTemplate': BOOLEAN_SCHEMA,
 };
 const CONFIRM_ALLOWED_PATHS = ['confirm.enable', 'confirm.title', 'confirm.content'];
+const AFTER_SUCCESS_ALLOWED_PATHS = [
+  'afterSuccess.successMessage',
+  'afterSuccess.manualClose',
+  'afterSuccess.actionAfterSuccess',
+  'afterSuccess.redirectTo',
+];
+const AFTER_SUCCESS_PATH_SCHEMAS = {
+  'afterSuccess.successMessage': STRING_SCHEMA,
+  'afterSuccess.manualClose': BOOLEAN_SCHEMA,
+  'afterSuccess.actionAfterSuccess': {
+    type: 'string',
+    enum: ['stay', 'previous', 'redirect'],
+  },
+  'afterSuccess.redirectTo': STRING_SCHEMA,
+};
 const TABLE_COLUMN_BASE_ALLOWED_PATHS = ['title.title'];
 const TABLE_FIELD_COLUMN_ALLOWED_PATHS = [...TABLE_COLUMN_BASE_ALLOWED_PATHS, 'fieldNames.label'];
 const FILTER_FORM_ITEM_ALLOWED_PATHS = [
@@ -2065,7 +2080,7 @@ const UPDATE_RECORD_ACTION_CONTRACT = createContract({
       stepKeys: ['general', 'linkageRules'],
     },
     assignSettings: {
-      stepKeys: ['confirm', 'assignFieldValues'],
+      stepKeys: ['confirm', 'assignFieldValues', 'afterSuccess'],
     },
     apply: {
       stepKeys: ['apply'],
@@ -2084,15 +2099,17 @@ UPDATE_RECORD_ACTION_CONTRACT.domains.stepParams = groupedDomain({
       'confirm.content',
       'assignFieldValues.assignedValues',
       'assignFieldValues.assignedValues.*',
+      ...AFTER_SUCCESS_ALLOWED_PATHS,
     ],
     clearable: true,
     mergeStrategy: 'deep',
-    eventBindingSteps: ['confirm', 'assignFieldValues'],
+    eventBindingSteps: ['confirm', 'assignFieldValues', 'afterSuccess'],
     pathSchemas: {
       'confirm.enable': BOOLEAN_SCHEMA,
       'confirm.title': STRING_SCHEMA,
       'confirm.content': STRING_SCHEMA,
       'assignFieldValues.assignedValues': OBJECT_SCHEMA,
+      ...AFTER_SUCCESS_PATH_SCHEMAS,
     },
   },
   apply: {
@@ -2221,7 +2238,7 @@ const BULK_UPDATE_ACTION_CONTRACT = createContract({
       stepKeys: ['general', 'linkageRules'],
     },
     assignSettings: {
-      stepKeys: ['confirm', 'updateMode', 'assignFieldValues'],
+      stepKeys: ['confirm', 'updateMode', 'assignFieldValues', 'afterSuccess'],
     },
     apply: {
       stepKeys: ['apply'],
@@ -2238,16 +2255,18 @@ BULK_UPDATE_ACTION_CONTRACT.domains.stepParams = groupedDomain({
       'updateMode.value',
       'assignFieldValues.assignedValues',
       'assignFieldValues.assignedValues.*',
+      ...AFTER_SUCCESS_ALLOWED_PATHS,
     ],
     clearable: true,
     mergeStrategy: 'deep',
-    eventBindingSteps: ['confirm', 'updateMode', 'assignFieldValues'],
+    eventBindingSteps: ['confirm', 'updateMode', 'assignFieldValues', 'afterSuccess'],
     pathSchemas: {
       'confirm.enable': BOOLEAN_SCHEMA,
       'confirm.title': STRING_SCHEMA,
       'confirm.content': STRING_SCHEMA,
       'updateMode.value': STRING_SCHEMA,
       'assignFieldValues.assignedValues': OBJECT_SCHEMA,
+      ...AFTER_SUCCESS_PATH_SCHEMAS,
     },
   },
   apply: {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/configure-options.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/configure-options.ts
@@ -629,6 +629,17 @@ const ACTION_ASSIGN_OPTIONS: FlowSurfaceConfigureOptions = {
   updateMode: stringOption('Update mode', { example: 'overwrite' }),
 };
 
+const ACTION_AFTER_SUCCESS_OPTIONS: FlowSurfaceConfigureOptions = {
+  afterSuccess: objectOption('Action after a successful update', {
+    example: {
+      successMessage: 'Saved successfully',
+      manualClose: false,
+      actionAfterSuccess: 'stay',
+      redirectTo: '/admin/example',
+    },
+  }),
+};
+
 const ACTION_TRIGGER_WORKFLOWS_OPTIONS: FlowSurfaceConfigureOptions = {
   triggerWorkflows: arrayOption('Workflow bindings for submit/update actions', {
     example: [{ workflowKey: 'workflow-key', context: 'department' }],
@@ -821,11 +832,17 @@ function getActionConfigureOptionsByUse(use?: string): FlowSurfaceConfigureOptio
       return merged(
         ACTION_CONFIRM_OPTIONS,
         ACTION_ASSIGN_OPTIONS,
+        ACTION_AFTER_SUCCESS_OPTIONS,
         ACTION_TRIGGER_WORKFLOWS_OPTIONS,
         ACTION_LINKAGE_OPTIONS,
       );
     case 'BulkUpdateActionModel':
-      return merged(ACTION_CONFIRM_OPTIONS, ACTION_ASSIGN_OPTIONS, ACTION_LINKAGE_OPTIONS);
+      return merged(
+        ACTION_CONFIRM_OPTIONS,
+        ACTION_ASSIGN_OPTIONS,
+        ACTION_AFTER_SUCCESS_OPTIONS,
+        ACTION_LINKAGE_OPTIONS,
+      );
     case 'BulkEditActionModel':
       return merged(ACTION_EDIT_MODE_OPTIONS, ACTION_LINKAGE_OPTIONS);
     case 'DuplicateActionModel':

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service-utils.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service-utils.ts
@@ -654,6 +654,32 @@ export function normalizeSimpleConfirm(confirm: any) {
   throwBadRequest('flowSurfaces configure confirm must be a boolean or object');
 }
 
+type AfterSuccessInput = {
+  successMessage?: unknown;
+  manualClose?: unknown;
+  actionAfterSuccess?: unknown;
+  redirectTo?: unknown;
+};
+
+export function normalizeAfterSuccess(afterSuccess: unknown) {
+  if (!_.isPlainObject(afterSuccess)) {
+    throwBadRequest('flowSurfaces configure afterSuccess must be an object');
+  }
+  const input = afterSuccess as AfterSuccessInput;
+  if (
+    input.actionAfterSuccess !== undefined &&
+    !['stay', 'previous', 'redirect'].includes(String(input.actionAfterSuccess))
+  ) {
+    throwBadRequest('flowSurfaces configure afterSuccess.actionAfterSuccess must be stay, previous, or redirect');
+  }
+  return buildDefinedPayload({
+    successMessage: input.successMessage,
+    manualClose: input.manualClose,
+    actionAfterSuccess: input.actionAfterSuccess,
+    redirectTo: input.redirectTo,
+  });
+}
+
 export function assertSupportedSimpleChanges(context: string, changes: Record<string, any>, allowedKeys: string[]) {
   const unknownKeys = Object.keys(changes).filter((key) => !allowedKeys.includes(key));
   if (!unknownKeys.length) {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/flow-surfaces/service.ts
@@ -327,6 +327,7 @@ import {
   joinRequiredFieldPaths,
   normalizeBlockTitleDescription,
   normalizeBlockTitleDescriptionValue,
+  normalizeAfterSuccess,
   normalizeChartCardSettings,
   normalizeChartCardHeightModeForWrite,
   normalizeFlowSurfaceComposeKey,
@@ -24252,6 +24253,15 @@ export class FlowSurfacesService {
       } else {
         throwBadRequest(`flowSurfaces configure action '${use}' does not support confirm`);
       }
+    }
+    if (hasOwnDefined(changes, 'afterSuccess')) {
+      if (!UPDATE_ASSIGN_ACTION_USES.has(use)) {
+        throwBadRequest(`flowSurfaces configure action '${use}' does not support afterSuccess`);
+      }
+      stepParams.assignSettings = {
+        ...(stepParams.assignSettings || {}),
+        afterSuccess: normalizeAfterSuccess(changes.afterSuccess),
+      };
     }
     if (hasOwnDefined(changes, 'assignValues')) {
       const assignValues = this.normalizeActionAssignValues('configure', changes.assignValues);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

The v2 Update record and Bulk update actions only showed a fixed success message after an update. They did not expose the existing configurable "After successful submission" behavior, such as a custom message, manual message closing, staying on the current view, returning to the previous view, or redirecting.

### Description

- Add the existing `afterSuccess` settings step to `UpdateRecordActionModel` and `BulkUpdateActionModel`.
- Preserve the current default behavior: show "Saved successfully", close the message automatically, and stay on the current page or popup.
- Run `afterSuccess` only after the update API succeeds; validation failures, empty selections, and update errors do not trigger it.
- Keep Bulk update block refresh best-effort and non-blocking so refresh latency or failure cannot suppress the success behavior.
- Add FlowSurfaces configure options, contracts, normalization, builder defaults, and semantic persistence under `stepParams.assignSettings.afterSuccess`.
- Add client and server unit/contract coverage for defaults, persistence, failure paths, and non-blocking refresh behavior.

Potential risks and testing suggestions:

- Verify `stay`, `previous`, and `redirect` in page, dialog, and drawer contexts.
- Update record retains its existing behavior of waiting for linkage-rule refresh before reporting success.
- The SQLite-backed FlowSurfaces catalog/compose integration test could not initialize locally because the `sqlite3` package is unavailable; it should be covered by CI. All related pure unit and client tests passed locally.

Tests run:

- `UpdateRecordActionModel.test.ts`: 3 passed
- `BulkUpdateActionModel.test.ts`: 6 passed
- `AssignFormRefill.test.ts`: 6 passed
- `flow-surfaces.after-success.unit.test.ts`: 3 passed
- `flow-surfaces.builder.unit.test.ts`: 5 passed
- ESLint on all touched files and `git diff --check`

### Related issues

Task: task-5690

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support configurable after-success behavior for v2 Update record and Bulk update actions. |
| 🇨🇳 Chinese | v2 更新记录和批量更新操作支持配置提交成功后的提示、关闭和跳转行为。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
