### PR TITLE
fix(client-v2): expose current record in JS column event flows

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/table/JSColumnModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/JSColumnModel.tsx
@@ -9,13 +9,14 @@
 
 import { LockOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
-import type { PropertyMetaFactory } from '@nocobase/flow-engine';
+import type { FlowModelOptions, PropertyMetaFactory } from '@nocobase/flow-engine';
 import {
   Droppable,
   tExpr,
   FlowsFloatContextMenu,
   DragHandler,
   MemoFlowModelRenderer,
+  createCurrentRecordMetaFactory,
   createRecordMetaFactory,
   createRecordResolveOnServerWithLocal,
   ElementProxy,
@@ -54,6 +55,14 @@ function getRecordRenderSignature(record: any) {
 export class JSColumnModel extends TableCustomColumnModel {
   // Stable per‑instance render component to avoid remounts across re-renders
   private _RenderComponent?: React.ComponentType;
+
+  onInit(options: FlowModelOptions): void {
+    super.onInit(options);
+    this.context.defineProperty('record', {
+      meta: createCurrentRecordMetaFactory(this.context, () => this.context.collection),
+    });
+  }
+
   renderHiddenInConfig() {
     return (
       <Tooltip

--- a/packages/core/client-v2/src/flow/models/blocks/table/__tests__/JSColumnModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/__tests__/JSColumnModel.test.tsx
@@ -11,17 +11,62 @@ import { FlowEngine } from '@nocobase/flow-engine';
 import { describe, expect, it, vi } from 'vitest';
 import { JSColumnModel } from '../JSColumnModel';
 
-describe('JSColumnModel row refresh', () => {
-  it('changes renderer key and invalidates beforeRender cache when row content changes', () => {
+describe('JSColumnModel', () => {
+  it('declares current record metadata before rendering any row', async () => {
     const engine = new FlowEngine();
-    const model = new JSColumnModel({
-      uid: 'js-column-row-refresh',
-      flowEngine: engine,
+    engine.registerModels({ JSColumnModel });
+    const model = engine.createModel<JSColumnModel>({
+      use: 'JSColumnModel',
+      uid: 'js-column-record-meta',
       props: {
         width: 200,
         title: 'JS column',
       },
-    } as any);
+    });
+
+    engine.context.dataSourceManager.getDataSource('main').addCollection({
+      name: 'users',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'age', type: 'integer', interface: 'integer' },
+      ],
+    });
+
+    const collection = engine.context.dataSourceManager.getCollection('main', 'users');
+    model.context.defineProperty('collection', {
+      value: collection,
+    });
+
+    const recordNode = model.context.getPropertyMetaTree().find((node) => node.name === 'record');
+    const recordFields =
+      typeof recordNode?.children === 'function' ? await recordNode.children() : recordNode?.children || [];
+
+    expect(model.context.record).toBeUndefined();
+    expect(recordNode).toMatchObject({
+      name: 'record',
+      title: 'Current record',
+      paths: ['record'],
+    });
+    expect(recordFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'id', paths: ['record', 'id'] }),
+        expect.objectContaining({ name: 'age', paths: ['record', 'age'] }),
+      ]),
+    );
+  });
+
+  it('changes renderer key and invalidates beforeRender cache when row content changes', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ JSColumnModel });
+    const model = engine.createModel<JSColumnModel>({
+      use: 'JSColumnModel',
+      uid: 'js-column-row-refresh',
+      props: {
+        width: 200,
+        title: 'JS column',
+      },
+    });
 
     engine.context.dataSourceManager.getDataSource('main').addCollection({
       name: 'users',
@@ -39,12 +84,14 @@ describe('JSColumnModel row refresh', () => {
     });
 
     const column = model.getColumnProps();
-    const first = column.render(null, { id: 1, age: 3, workyears: 39.2 }, 0) as any;
+    const firstRecord = { id: 1, age: 3, workyears: 39.2 };
+    const first = column.render(null, firstRecord, 0) as any;
     const fork = model.getFork('1') as any;
     const invalidateFlowCache = vi.fn();
     fork.invalidateFlowCache = invalidateFlowCache;
     const second = column.render(null, { id: 1, age: 37, workyears: 39.2 }, 0) as any;
 
+    expect(fork.context.record).toEqual({ id: 1, age: 37, workyears: 39.2 });
     expect(first.key).not.toBe(second.key);
     expect(invalidateFlowCache).toHaveBeenCalledWith('beforeRender');
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The v2 JS column executes before-render event flows on per-row fork models, where `ctx.record` is available. However, the event-flow editor reads variables from the JS column master model, which did not declare Current record metadata. As a result, users could not select Current record fields while configuring trigger conditions.

### Description

- Declare meta-only Current record information on the JS column master model so the variable is available in the event-flow condition editor before any row is rendered.
- Keep actual record values and association-field server resolution scoped to per-row forks.
- Add tests covering configuration-time record metadata and runtime row-record refresh.

Potential risk is low because this change does not alter persisted flow definitions, database structures, APIs, or row-level runtime value injection. Suggested regression scenarios are regular tables, empty tables, subtables, and association fields.

Tests performed:

- `yarn eslint --fix packages/core/client-v2/src/flow/models/blocks/table/JSColumnModel.tsx packages/core/client-v2/src/flow/models/blocks/table/__tests__/JSColumnModel.test.tsx`
- `yarn test packages/core/client-v2/src/flow/models/blocks/table/__tests__/JSColumnModel.test.tsx --run --reporter=verbose`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing Current record variables in v2 JS column event-flow conditions. |
| 🇨🇳 Chinese | 修复 v2 JS 列事件流触发条件中缺少“当前记录”变量的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary