### PR TITLE
fix(data-source): mark collection FDW deprecated

### DIFF
--- a/packages/core/client/src/collection-manager/Configuration/AddCollectionAction.tsx
+++ b/packages/core/client/src/collection-manager/Configuration/AddCollectionAction.tsx
@@ -11,7 +11,7 @@ import { DownOutlined, PlusOutlined } from '@ant-design/icons';
 import { ArrayTable } from '@formily/antd-v5';
 import { ISchema, useField, useForm } from '@formily/react';
 import { uid } from '@formily/shared';
-import { Button, Dropdown, MenuProps } from 'antd';
+import { Button, Dropdown, MenuProps, Space, Tag } from 'antd';
 import { cloneDeep } from 'lodash';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -166,12 +166,17 @@ export const AddCollectionAction = (props) => {
         });
       }
       result.push({
-        label: compile(item.title),
+        label: (
+          <Space size={4}>
+            {compile(item.title)}
+            {item.deprecated ? <Tag color="warning">{t('Deprecated')}</Tag> : null}
+          </Space>
+        ),
         key: item.name,
       });
     });
     return result;
-  }, [collectionTemplates]);
+  }, [collectionTemplates, compile, t]);
   const {
     state: { category },
   } = useResourceActionContext();
@@ -189,7 +194,7 @@ export const AddCollectionAction = (props) => {
       },
       items,
     };
-  }, [category, items]);
+  }, [category, compile, getTemplate, items]);
   return (
     <RecordProvider record={record}>
       <ActionContextProvider value={{ visible, setVisible }}>

--- a/packages/core/client/src/collection-manager/templates/types.ts
+++ b/packages/core/client/src/collection-manager/templates/types.ts
@@ -29,6 +29,8 @@ export interface ICollectionTemplate {
   availableFieldInterfaces?: AvailableFieldInterfacesInclude | AvailableFieldInterfacesExclude;
   /** 是否分割线 */
   divider?: boolean;
+  /** 是否已弃用 */
+  deprecated?: boolean;
   /** 模板描述 */
   description?: string;
   /**配置字段中的操作按钮 */

--- a/packages/core/client/src/data-source/collection-template/CollectionTemplate.ts
+++ b/packages/core/client/src/data-source/collection-template/CollectionTemplate.ts
@@ -66,6 +66,8 @@ export abstract class CollectionTemplate {
   availableFieldInterfaces?: AvailableFieldInterfacesInclude & AvailableFieldInterfacesExclude;
   /** Whether it is a divider */
   divider?: boolean;
+  /** Whether it is deprecated */
+  deprecated?: boolean;
   /** Template description */
   description?: string;
   /** Configure buttons in the configuration fields */

--- a/packages/plugins/@nocobase/plugin-collection-fdw/package.json
+++ b/packages/plugins/@nocobase/plugin-collection-fdw/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://docs.nocobase.com/handbook/collection-fdw",
   "homepage.zh-CN": "https://docs-cn.nocobase.com/handbook/collection-fdw",
   "nocobase": {
+    "deprecated": true,
     "supportedVersions": [
       "1.x",
       "2.x"

--- a/packages/plugins/@nocobase/plugin-collection-fdw/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-collection-fdw/src/client-v2/plugin.tsx
@@ -37,6 +37,7 @@ export class PluginCollectionFDWClientV2 extends Plugin<any, Application> {
       title: tExpr('Connect to foreign data'),
       order: 70,
       color: 'yellow',
+      deprecated: true,
       collection: {
         options: {
           template: 'foreign',

--- a/packages/plugins/@nocobase/plugin-collection-fdw/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-collection-fdw/src/client/index.tsx
@@ -148,6 +148,7 @@ class ConnectForeignData extends CollectionTemplate {
   title = `{{t("Connect to foreign data",{ ns: "${NAMESPACE}" })}}`;
   order = 5;
   color = 'yellow';
+  deprecated = true;
   default = {
     fields: [],
     autoGenId: false,

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
@@ -2047,7 +2047,12 @@ function CollectionsPage(props: CollectionsPageProps) {
                   items: collectionTemplates.flatMap((template) => {
                     const item = {
                       key: template.name,
-                      label: compileLegacyTemplate(template.title, t),
+                      label: (
+                        <Space size={4}>
+                          {compileLegacyTemplate(template.title, t)}
+                          {template.deprecated ? <Tag color="warning">{t('Deprecated')}</Tag> : null}
+                        </Space>
+                      ),
                     };
                     return template.divider ? [{ type: 'divider' as const }, item] : [item];
                   }),

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/plugin.tsx
@@ -147,6 +147,7 @@ export interface CollectionTemplateOptions {
   order?: number;
   color?: string;
   divider?: boolean;
+  deprecated?: boolean;
   collection?: {
     options?: Record<string, any> | (() => Record<string, any>);
     fields?: CollectionTemplateField[] | (() => CollectionTemplateField[]);

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/en-US.json
@@ -57,6 +57,7 @@
   "Description": "Description",
   "Default value": "Default value",
   "Default value to current time": "Default value to current time",
+  "Deprecated": "Deprecated",
   "Double": "Double",
   "Display name": "Display name",
   "does not contain": "does not contain",

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/locale/zh-CN.json
@@ -57,6 +57,7 @@
   "Description": "描述",
   "Default value": "默认值",
   "Default value to current time": "默认为当前时间",
+  "Deprecated": "已弃用",
   "Double": "双精度",
   "Display name": "名称",
   "does not contain": "不包含",


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Make the deprecated status of Collection FDW visible wherever users discover and create collection templates.

### Description
- Mark the Collection FDW plugin as deprecated in its package metadata.
- Add deprecated template metadata and show an `Deprecated` tag in the Create collection menu.
- Existing FDW collections and functionality are unchanged.

### Related issues

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Marked Collection FDW as deprecated in the plugin manager and Create collection menu. |
| 🇨🇳 Chinese | 在插件管理器和创建数据表菜单中将 Collection FDW 标记为已弃用。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | 不涉及 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary