### PR TITLE
fix(data-source-manager): prevent clearing field interfaces

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/FieldsPage.tsx
@@ -1503,7 +1503,7 @@ export default function FieldsPage(props: FieldsPageProps) {
 
           return (
             <Select
-              allowClear
+              allowClear={false}
               value={value || undefined}
               style={{ width: '100%' }}
               popupMatchSelectWidth={false}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The UI type selector in the v2 Configure fields table displayed a clear action on hover. This could clear a selected field interface unintentionally and was easily confused with deleting a field.

### Description
- Disable clearing the UI type selector in the Configure fields table.
- Keep changing a UI type available through the dropdown and keep field deletion in the Actions column.

### Related issues
Fixes #10282

### Showcase
Not applicable: this is a one-property interaction safeguard.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevented clearing a field interface directly from the Configure fields table. |
| 🇨🇳 Chinese | 修复配置字段表格中 UI 类型可被直接清空的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
