### PR TITLE
fix(client-v2): hide app command feedback

### DIFF
--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -379,32 +379,35 @@ describe('app', () => {
     expect(screen.getByText('maintaining dialog message')).toBeInTheDocument();
   });
 
-  it('should keep current content behind maintained dialog state', async () => {
-    const CurrentPage = () => {
-      const [count, setCount] = React.useState(0);
-      return <button onClick={() => setCount((value) => value + 1)}>Current page count: {count}</button>;
-    };
+  it.each(['pm.enable', 'future.command'])(
+    'should keep current content without a default dialog while app commanding: %s',
+    async (commandName) => {
+      const CurrentPage = () => {
+        const [count, setCount] = React.useState(0);
+        return <button onClick={() => setCount((value) => value + 1)}>Current page count: {count}</button>;
+      };
 
-    class PluginHelloClient extends Plugin {
-      async load() {
-        this.router.add('root', { path: '/', Component: CurrentPage });
+      class PluginHelloClient extends Plugin {
+        async load() {
+          this.router.add('root', { path: '/', Component: CurrentPage });
+        }
       }
-    }
-    const app = createMockClient({ plugins: [PluginHelloClient] });
-    await renderApp(app);
-    fireEvent.click(screen.getByRole('button', { name: 'Current page count: 0' }));
-    expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
+      const app = createMockClient({ plugins: [PluginHelloClient] });
+      await renderApp(app);
+      fireEvent.click(screen.getByRole('button', { name: 'Current page count: 0' }));
+      expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
 
-    act(() => {
-      app.maintained = true;
-      app.maintaining = true;
-      app.error = { code: 'APP_COMMANDING', command: { name: 'pm.enable' }, message: 'starting sub applications...' };
-    });
+      act(() => {
+        app.maintained = true;
+        app.maintaining = true;
+        app.error = { code: 'APP_COMMANDING', command: { name: commandName }, message: 'starting sub applications...' };
+      });
 
-    expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByText('Enabling plugin')).toBeInTheDocument();
-  });
+      expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.queryByText(commandName === 'pm.enable' ? 'Enabling plugin' : commandName)).not.toBeInTheDocument();
+    },
+  );
 
   it('should keep current content without a dialog while app upgrading', async () => {
     const CurrentPage = () => <div>Current page</div>;
@@ -431,17 +434,22 @@ describe('app', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('should not show Try again for an app upgrade error state', async () => {
+  it.each([
+    ['upgrade', 'App upgrading'],
+    ['pm.enable', 'Enabling plugin'],
+    ['pm.disable', 'Disabling plugin'],
+    ['future.command', 'future.command'],
+  ])('should not show Try again for an app commanding error state: %s', async (commandName, title) => {
     class PluginHelloClient extends Plugin {}
     const app = createMockClient({ plugins: [PluginHelloClient] });
     app.error = Object.assign(new Error('Loading data sources...'), {
       code: 'APP_COMMANDING',
-      command: { name: 'upgrade' },
+      command: { name: commandName },
     });
 
     await renderApp(app);
 
-    expect(screen.getByText('App upgrading')).toBeInTheDocument();
+    expect(screen.getByText(title)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
   });
 

--- a/packages/core/client-v2/src/components/AppComponents.tsx
+++ b/packages/core/client-v2/src/components/AppComponents.tsx
@@ -30,8 +30,7 @@ interface AppErrorPayload {
   };
 }
 
-const isAppUpgrading = (error?: AppErrorPayload) =>
-  error?.code === 'APP_COMMANDING' && error.command?.name === 'upgrade';
+const isAppCommanding = (error?: AppErrorPayload) => error?.code === 'APP_COMMANDING';
 
 export const AppSpin = () => {
   return (
@@ -170,7 +169,7 @@ const getProps = (app: Application) => {
 export const AppError: FC<{ error: Error & { title?: string }; app: Application }> = observer(
   ({ app, error }) => {
     const props = getProps(app);
-    const upgrading = isAppUpgrading(app.error as AppErrorPayload | undefined);
+    const commanding = isAppCommanding(app.error as AppErrorPayload | undefined);
     return (
       <div>
         <Result
@@ -184,7 +183,7 @@ export const AppError: FC<{ error: Error & { title?: string }; app: Application 
           title={error?.title || app.i18n.t('App error', { ns: 'client' })}
           subTitle={app.i18n.t(error?.message)}
           extra={
-            upgrading ? null : (
+            commanding ? null : (
               <Button type="primary" key="try" onClick={() => window.location.reload()}>
                 {app.i18n.t('Try again')}
               </Button>
@@ -233,7 +232,7 @@ export const AppMaintainingDialog: FC<{ app: Application; error: Error }> = obse
     if (component) {
       return app.renderComponent(component, { app, error });
     }
-    if (isAppUpgrading(payload)) {
+    if (isAppCommanding(payload)) {
       return null;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

启用或停用插件、升级应用等操作执行期间，页面可能仍显示 `Try again` 按钮，已有页面上还可能出现额外的默认弹窗。这些反馈会让用户误以为操作已经失败，并遮挡原有页面内容。

### Description

- 应用正在执行命令时，不再显示默认维护弹窗和 `Try again` 按钮。
- 自定义维护弹窗保持原有行为，普通可恢复错误仍然保留重试入口。
- 增加启用插件、停用插件、升级应用及未来新增命令的回归测试，避免再次按命令名单遗漏场景。

本次修改不改变公开 API。建议在一个标签页中启用插件，并在执行期间刷新另一个标签页，确认执行进度正常显示且没有额外弹窗或重试按钮。

### Showcase

浏览器回归已确认：插件启用期间仍显示执行进度，但不再显示默认弹窗和 `Try again` 按钮。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide the retry button while the app is running a command |
| 🇨🇳 Chinese | 应用执行命令时不再显示重试按钮 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
