### PR TITLE
fix(plugin-multi-portal): keep portal titles raw

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/multiPortalPermissions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/multiPortalPermissions.test.tsx
@@ -32,6 +32,7 @@ const flowMocks = vi.hoisted(() => ({
     },
   },
 }));
+const defaultT = flowMocks.engine.context.t;
 
 vi.mock('@nocobase/flow-engine', async (importOriginal) => {
   const actual = (await importOriginal()) as object;
@@ -47,6 +48,7 @@ describe('plugin-multi-portal route permissions', () => {
   afterEach(() => {
     cleanup();
     flowMocks.context = undefined;
+    flowMocks.engine.context.t = defaultT;
   });
 
   it('should configure portal route permissions with the portal route dimension', async () => {
@@ -238,6 +240,47 @@ describe('plugin-multi-portal route permissions', () => {
     );
     expect(resource.routePermissionList).not.toHaveBeenCalled();
     expect(resource.routeDefaultPolicyList).not.toHaveBeenCalled();
+  });
+
+  it('should keep portal titles raw while translating route titles', async () => {
+    const resource = createMultiPortalPermissionResources({
+      portals: [
+        {
+          uid: 'main-portal',
+          title: 'Main',
+          portalType: 'no-code',
+        },
+      ],
+      routes: [
+        {
+          id: 1,
+          title: 'Main',
+        },
+      ],
+      selectedPortalUids: ['main-portal'],
+      selectedRouteIds: [],
+    });
+    const user = userEvent.setup();
+    flowMocks.context = resource.context;
+    flowMocks.engine.context.t = (key, options) => (key === 'Main' ? '主数据源' : defaultT(key, options));
+
+    render(
+      <AntdApp>
+        <MultiPortalPermissionsTab activeKey="multi-portals" activeRole={{ name: 'portal-member', title: 'Member' }} />
+      </AntdApp>,
+    );
+
+    expect(await screen.findByText('Main')).toBeInTheDocument();
+    expect(screen.queryByText('主数据源')).not.toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Allow access to Main' })).toBeChecked();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Configure routes permissions for Main' }));
+    });
+
+    const drawer = await screen.findByRole('dialog', { name: 'Configure routes permissions for Main' });
+    expect(within(drawer).getByText('主数据源')).toBeInTheDocument();
+    expect(within(drawer).getByRole('checkbox', { name: 'Allow access to 主数据源' })).not.toBeChecked();
   });
 
   it('should not expose route permissions for missing or unknown portal types', async () => {

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/permissions/MultiPortalPermissionsTab.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/permissions/MultiPortalPermissionsTab.tsx
@@ -297,6 +297,13 @@ function translateTitle(title: unknown, t: (key: string, options?: Record<string
   return t(title) || t('Unnamed');
 }
 
+function getPortalTitle(title: unknown, t: (key: string, options?: Record<string, unknown>) => string) {
+  if (typeof title !== 'string' || !title) {
+    return t('Unnamed');
+  }
+  return title;
+}
+
 function getChangedUids(currentUids: string[], nextUids: string[]) {
   const currentUidSet = new Set(currentUids);
   const nextUidSet = new Set(nextUids);
@@ -405,7 +412,7 @@ export default function MultiPortalPermissionsTab(props: PermissionTabProps) {
     () => portalService.data?.find((portal) => portal.uid === selectedPortalUid),
     [portalService.data, selectedPortalUid],
   );
-  const selectedPortalTitle = selectedPortal ? translateTitle(selectedPortal.title, t) : '';
+  const selectedPortalTitle = selectedPortal ? getPortalTitle(selectedPortal.title, t) : '';
   const selectedPortalUsesLayoutPermissions = hasLayoutRoutePermissions(selectedPortal);
   const selectedPortalSupportsRoutes = supportsRoutePermissions(selectedPortal);
   const drawerTitle = selectedPortal
@@ -597,7 +604,7 @@ export default function MultiPortalPermissionsTab(props: PermissionTabProps) {
       {
         dataIndex: 'title',
         title: t('Portal'),
-        render: (value) => translateTitle(value, t),
+        render: (value) => getPortalTitle(value, t),
       },
       {
         dataIndex: 'accessible',
@@ -606,7 +613,7 @@ export default function MultiPortalPermissionsTab(props: PermissionTabProps) {
           if (hasLayoutRoutePermissions(portal)) {
             return <Typography.Text type="secondary">{t('Managed by layout permissions')}</Typography.Text>;
           }
-          const portalTitle = translateTitle(portal.title, t);
+          const portalTitle = getPortalTitle(portal.title, t);
           return (
             <Checkbox
               aria-label={t('Allow access to {{portal}}', { portal: portalTitle })}
@@ -623,7 +630,7 @@ export default function MultiPortalPermissionsTab(props: PermissionTabProps) {
           if (!supportsRoutePermissions(portal)) {
             return <Typography.Text type="secondary">-</Typography.Text>;
           }
-          const portalTitle = translateTitle(portal.title, t);
+          const portalTitle = getPortalTitle(portal.title, t);
           return (
             <Button
               aria-label={t('Configure routes permissions for {{portal}}', { portal: portalTitle })}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

中文界面中，门户权限表会把 Portal 标题当作系统文案翻译。例如接口返回的 `Main` 会显示成“主数据源”，与实际配置的标题不一致。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- 门户标题在权限表、访问复选框、路由配置按钮和抽屉标题中按原始值显示；标题缺失时仍使用本地化的“未命名”文案。
- 路由名称继续沿用现有翻译行为，避免改变菜单与路由的显示方式。
- 补充单元测试，覆盖 Portal 与路由使用相同标题时的不同显示规则。

建议在中文界面进入“设置中心 → 用户和权限 → 角色和权限 → 权限 → 门户”，确认 `Main` 按原始标题显示。

### Showcase
<!-- Including any screenshots of the changes. -->

中文界面的门户权限表现在会原样显示 `Main`。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Keep Portal titles unchanged in role permissions |
| 🇨🇳 Chinese | 修复角色权限中 Portal 标题被错误翻译的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
