### PR TITLE
fix(client-v2): show current popup in popup subtable forms

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
@@ -28,6 +28,7 @@ import { observer } from '@formily/reactive-react';
 import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { buildRecordPickerPopupContextInputArgs, RecordPickerContent } from '../RecordPickerFieldModel';
+import { buildOpenerUids } from '../recordSelectShared';
 import { AssociationFieldModel } from '../AssociationFieldModel';
 import { adjustColumnOrder } from '../../../blocks/table/utils';
 import { isSubTableColumnFieldComponentContext } from '../SubTableFieldModel/SubTableColumnModel';
@@ -653,6 +654,7 @@ PopupSubTableFieldModel.registerFlow({
         const parentItemOptions = ctx?.getPropertyOptions?.('item');
         const itemIndex = Array.isArray(ctx.model?.props?.value) ? ctx.model.props.value.length : 0;
         const itemLength = itemIndex + 1;
+        const openerUids = buildOpenerUids(ctx, ctx.inputArgs);
         ctx.viewer.open({
           type: openMode,
           width: sizeToWidthMap[openMode][size],
@@ -669,6 +671,7 @@ PopupSubTableFieldModel.registerFlow({
             parentItemResolver: parentItemOptions?.resolveOnServer,
             itemIndex,
             itemLength,
+            openerUids,
           },
           content: () => <EditFormContent model={ctx.model} scene="create" />,
           styles: {

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/PopupSubTableFieldModel.tsx
@@ -654,6 +654,10 @@ PopupSubTableFieldModel.registerFlow({
         const parentItemOptions = ctx?.getPropertyOptions?.('item');
         const itemIndex = Array.isArray(ctx.model?.props?.value) ? ctx.model.props.value.length : 0;
         const itemLength = itemIndex + 1;
+        const associationName = ctx.collectionField?.resourceName;
+        const sourceId = parentItem?.value
+          ? ctx.collectionField?.collection?.getFilterByTK?.(parentItem.value)
+          : undefined;
         const openerUids = buildOpenerUids(ctx, ctx.inputArgs);
         ctx.viewer.open({
           type: openMode,
@@ -665,6 +669,7 @@ PopupSubTableFieldModel.registerFlow({
             scene: 'subForm',
             dataSourceKey: ctx.collection.dataSourceKey,
             collectionName: ctx.collectionField?.target,
+            ...(associationName && sourceId != null ? { associationName, sourceId } : {}),
             collectionField: ctx.collectionField,
             parentItem,
             parentItemMeta: parentItemOptions?.meta,

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/__tests__/popupContext.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/__tests__/popupContext.test.ts
@@ -23,8 +23,11 @@ function getOpenViewHandler(modelClass: typeof PopupSubTableFieldModel | typeof 
   return handler;
 }
 
-function createContext(record?: Record<string, unknown>) {
+function createContext(record?: Record<string, unknown>, parentRecord: Record<string, unknown> = { id: 1 }) {
   const open = vi.fn();
+  const sourceCollection = {
+    getFilterByTK: vi.fn((sourceRecord: Record<string, unknown>) => sourceRecord.id),
+  };
   const model = {
     uid: 'popup-subtable-uid',
     props: {
@@ -47,7 +50,7 @@ function createContext(record?: Record<string, unknown>) {
     context: {
       inputArgs: {},
       item: {
-        value: { id: 1 },
+        value: parentRecord,
       },
       view: {
         inputArgs: {
@@ -65,6 +68,8 @@ function createContext(record?: Record<string, unknown>) {
       },
       collectionField: {
         target: 'roles',
+        resourceName: 'users.roles',
+        collection: sourceCollection,
       },
       record,
       getFormValues: () => ({ id: 1 }),
@@ -74,23 +79,42 @@ function createContext(record?: Record<string, unknown>) {
 }
 
 describe('PopupSubTable popup context', () => {
-  it('passes openerUids to the add-new popup', () => {
+  it('passes popup and parent record context to the add-new popup', () => {
     const { context, open } = createContext();
     const handler = getOpenViewHandler(PopupSubTableFieldModel);
 
     handler(context, { mode: 'drawer', size: 'medium' });
 
     expect(open).toHaveBeenCalledOnce();
-    expect(open.mock.calls[0][0].inputArgs.openerUids).toEqual(['root-page-uid', 'parent-popup-uid']);
+    expect(open.mock.calls[0][0].inputArgs).toMatchObject({
+      openerUids: ['root-page-uid', 'parent-popup-uid'],
+      associationName: 'users.roles',
+      sourceId: 1,
+    });
   });
 
-  it('passes openerUids to the edit popup', () => {
+  it('passes popup and parent record context to the edit popup', () => {
     const { context, open } = createContext({ id: 2, name: 'Member' });
     const handler = getOpenViewHandler(PopupSubTableEditActionModel);
 
     handler(context, { mode: 'dialog', size: 'medium' });
 
     expect(open).toHaveBeenCalledOnce();
-    expect(open.mock.calls[0][0].inputArgs.openerUids).toEqual(['root-page-uid', 'parent-popup-uid']);
+    expect(open.mock.calls[0][0].inputArgs).toMatchObject({
+      openerUids: ['root-page-uid', 'parent-popup-uid'],
+      associationName: 'users.roles',
+      sourceId: 1,
+    });
+  });
+
+  it('does not expose a parent record reference before the parent record is persisted', () => {
+    const { context, open } = createContext(undefined, { nickname: 'Draft user' });
+    const handler = getOpenViewHandler(PopupSubTableFieldModel);
+
+    handler(context, { mode: 'drawer', size: 'medium' });
+
+    expect(open).toHaveBeenCalledOnce();
+    expect(open.mock.calls[0][0].inputArgs).not.toHaveProperty('associationName');
+    expect(open.mock.calls[0][0].inputArgs).not.toHaveProperty('sourceId');
   });
 });

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/__tests__/popupContext.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/__tests__/popupContext.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { PopupSubTableFieldModel } from '../PopupSubTableFieldModel';
+import { PopupSubTableEditActionModel } from '../actions/PopupSubTableEditActionModel';
+
+function getOpenViewHandler(modelClass: typeof PopupSubTableFieldModel | typeof PopupSubTableEditActionModel) {
+  const flow = modelClass.globalFlowRegistry.getFlow('popupSettings');
+  const step = flow?.getStep('openView');
+  const handler = step?.serialize().handler;
+
+  if (!handler) {
+    throw new Error('popupSettings.openView handler is not registered');
+  }
+
+  return handler;
+}
+
+function createContext(record?: Record<string, unknown>) {
+  const open = vi.fn();
+  const model = {
+    uid: 'popup-subtable-uid',
+    props: {
+      value: record ? [record] : [],
+    },
+    context: {
+      inputArgs: {},
+    },
+    flowEngine: {
+      context: {
+        themeToken: {
+          colorBgLayout: '#fff',
+        },
+      },
+    },
+  };
+
+  return {
+    open,
+    context: {
+      inputArgs: {},
+      item: {
+        value: { id: 1 },
+      },
+      view: {
+        inputArgs: {
+          viewUid: 'parent-popup-uid',
+          openerUids: ['root-page-uid'],
+        },
+      },
+      viewer: { open },
+      layoutContentElement: {},
+      model,
+      associationModel: model,
+      collection: {
+        dataSourceKey: 'main',
+        filterTargetKey: 'id',
+      },
+      collectionField: {
+        target: 'roles',
+      },
+      record,
+      getFormValues: () => ({ id: 1 }),
+      getPropertyOptions: () => undefined,
+    },
+  };
+}
+
+describe('PopupSubTable popup context', () => {
+  it('passes openerUids to the add-new popup', () => {
+    const { context, open } = createContext();
+    const handler = getOpenViewHandler(PopupSubTableFieldModel);
+
+    handler(context, { mode: 'drawer', size: 'medium' });
+
+    expect(open).toHaveBeenCalledOnce();
+    expect(open.mock.calls[0][0].inputArgs.openerUids).toEqual(['root-page-uid', 'parent-popup-uid']);
+  });
+
+  it('passes openerUids to the edit popup', () => {
+    const { context, open } = createContext({ id: 2, name: 'Member' });
+    const handler = getOpenViewHandler(PopupSubTableEditActionModel);
+
+    handler(context, { mode: 'dialog', size: 'medium' });
+
+    expect(open).toHaveBeenCalledOnce();
+    expect(open.mock.calls[0][0].inputArgs.openerUids).toEqual(['root-page-uid', 'parent-popup-uid']);
+  });
+});

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/actions/PopupSubTableEditActionModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/actions/PopupSubTableEditActionModel.tsx
@@ -17,6 +17,7 @@ import { capitalize } from 'lodash';
 import '../../../../base/ActionModel';
 import { ActionModel, ActionWithoutPermission } from '../../../../base/ActionModelCore';
 import { SkeletonFallback } from '../../../../../components/SkeletonFallback';
+import { buildOpenerUids } from '../../recordSelectShared';
 import { bindPopupSubTableBeforeClose } from './popupSubTableBeforeClose';
 
 function FieldWithoutPermissionPlaceholder({ targetModel, children }) {
@@ -29,7 +30,7 @@ function FieldWithoutPermissionPlaceholder({ targetModel, children }) {
     const dataSourcePrefix = `${t(dataSource.displayName || dataSource.key)} > `;
     const collectionPrefix = collection ? `${t(collection.title) || collection.name || collection.tableName} > ` : '';
     return `${dataSourcePrefix}${collectionPrefix}${name}`;
-  }, []);
+  }, [collection, dataSource.displayName, dataSource.key, name, t]);
   const { actionName } = fieldModel.forbidden || {};
   const messageValue = useMemo(() => {
     return t(
@@ -39,7 +40,7 @@ function FieldWithoutPermissionPlaceholder({ targetModel, children }) {
         actionName: t(capitalize(actionName)),
       },
     ).replaceAll('&gt;', '>');
-  }, [nameValue, t]);
+  }, [actionName, nameValue, t]);
   return <Tooltip title={messageValue}>{children}</Tooltip>;
 }
 
@@ -347,6 +348,7 @@ PopupSubTableEditActionModel.registerFlow({
             return undefined;
           }
         })();
+        const openerUids = buildOpenerUids(ctx, ctx.inputArgs);
         ctx.viewer.open({
           type: openMode,
           width: sizeToWidthMap[openMode][size],
@@ -364,6 +366,7 @@ PopupSubTableEditActionModel.registerFlow({
             parentItemResolver: parentItemOptions?.resolveOnServer,
             itemIndex,
             itemLength,
+            openerUids,
           },
           content: () => <EditFormContent model={ctx.model} />,
           styles: {

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/actions/PopupSubTableEditActionModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/PopupSubTableFieldModel/actions/PopupSubTableEditActionModel.tsx
@@ -348,6 +348,10 @@ PopupSubTableEditActionModel.registerFlow({
             return undefined;
           }
         })();
+        const associationName = ctx.collectionField?.resourceName;
+        const sourceId = parentItem?.value
+          ? ctx.collectionField?.collection?.getFilterByTK?.(parentItem.value)
+          : undefined;
         const openerUids = buildOpenerUids(ctx, ctx.inputArgs);
         ctx.viewer.open({
           type: openMode,
@@ -359,6 +363,7 @@ PopupSubTableEditActionModel.registerFlow({
             scene: 'subForm',
             dataSourceKey: ctx.collection.dataSourceKey,
             collectionName: ctx.collectionField?.target,
+            ...(associationName && sourceId != null ? { associationName, sourceId } : {}),
             collectionField: ctx.collectionField,
             record: ctx.record,
             parentItem,

--- a/packages/core/flow-engine/src/__tests__/createViewMeta.popup.test.ts
+++ b/packages/core/flow-engine/src/__tests__/createViewMeta.popup.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { FlowContext } from '../flowContext';
 import { FlowEngine } from '../flowEngine';
 import type { FlowView } from '../views/FlowView';
-import { buildPopupRuntime, createPopupMeta } from '../views/createViewMeta';
+import { buildPopupRuntime, createPopupMeta, registerPopupVariable } from '../views/createViewMeta';
 
 describe('createPopupMeta - popup variables', () => {
   function makeCtx() {
@@ -167,6 +167,7 @@ describe('createPopupMeta - popup variables', () => {
   it('buildPopupRuntime anchors current popup even when the navigation stack already has a child popup', async () => {
     const { engine, ctx } = makeCtx();
     const parentView = makeNestedPopupView('parent-popup-uid', 13);
+    parentView.inputArgs.parentItem = { value: { id: 13, phone: '9999' } };
     mockNestedPopupModels(engine);
 
     const popup = await buildPopupRuntime(ctx, parentView);
@@ -179,6 +180,7 @@ describe('createPopupMeta - popup variables', () => {
       filterByTk: 13,
       sourceId: 13,
     });
+    expect(popup?.sourceRecord).toEqual({ id: 13, phone: '9999' });
   });
 
   it('buildVariablesParams(record) keeps the parent view record when a child popup is open', async () => {
@@ -313,5 +315,86 @@ describe('createPopupMeta - popup variables', () => {
     const meta = (await createPopupMeta(ctx, anchorView)())!;
     const props = typeof meta.properties === 'function' ? await (meta.properties as any)() : meta.properties || {};
     expect(props.record).toBeUndefined();
+  });
+
+  it('uses the current parent item value for popup sourceRecord fields', async () => {
+    const { ctx } = makeCtx();
+    const parentItemResolver = vi.fn(() => false);
+    const anchorView: FlowView = {
+      type: 'dialog',
+      inputArgs: {
+        openerUids: ['opener-uid-1'],
+        viewUid: 'popup-uid',
+        dataSourceKey: 'main',
+        collectionName: 'roles',
+        associationName: 'users.roles',
+        sourceId: 1,
+        parentItem: { value: { id: 1, phone: '9999' } },
+        parentItemResolver,
+      },
+      Header: null,
+      Footer: null,
+      close: () => void 0,
+      update: () => void 0,
+    } as any;
+
+    registerPopupVariable(ctx, anchorView);
+
+    await expect(ctx.popup).resolves.toMatchObject({
+      sourceRecord: { id: 1, phone: '9999' },
+    });
+    expect(ctx.getPropertyOptions('popup')?.resolveOnServer?.('sourceRecord.phone')).toBe(false);
+    expect(parentItemResolver).toHaveBeenCalledWith('value.phone');
+  });
+
+  it('resolves a popup sourceRecord field from the current parent item without a server request', async () => {
+    const engine = new FlowEngine();
+    const ctx = engine.context;
+    const anchorView: FlowView = {
+      type: 'dialog',
+      inputArgs: {
+        openerUids: ['opener-uid-1'],
+        viewUid: 'popup-uid',
+        dataSourceKey: 'main',
+        collectionName: 'roles',
+        associationName: 'users.roles',
+        sourceId: 1,
+        parentItem: { value: { id: 1, phone: '9999' } },
+        parentItemResolver: () => false,
+      },
+      Header: null,
+      Footer: null,
+      close: () => void 0,
+      update: () => void 0,
+    } as any;
+
+    registerPopupVariable(ctx, anchorView);
+
+    await expect(ctx.resolveJsonTemplate('{{ ctx.popup.sourceRecord.phone }}')).resolves.toBe('9999');
+  });
+
+  it('keeps server resolution for popup sourceRecord association subpaths', async () => {
+    const { ctx } = makeCtx();
+    const anchorView: FlowView = {
+      type: 'dialog',
+      inputArgs: {
+        openerUids: ['opener-uid-1'],
+        viewUid: 'popup-uid',
+        dataSourceKey: 'main',
+        collectionName: 'roles',
+        associationName: 'users.roles',
+        sourceId: 1,
+        parentItem: { value: { id: 1, departmentId: 2 } },
+        parentItemResolver: (path: string) => path === 'value.department.title',
+      },
+      Header: null,
+      Footer: null,
+      close: () => void 0,
+      update: () => void 0,
+    } as any;
+
+    registerPopupVariable(ctx, anchorView);
+
+    expect(ctx.getPropertyOptions('popup')?.resolveOnServer?.('sourceRecord.department.title')).toBe(true);
   });
 });

--- a/packages/core/flow-engine/src/views/createViewMeta.ts
+++ b/packages/core/flow-engine/src/views/createViewMeta.ts
@@ -474,12 +474,14 @@ interface PopupNodeResource {
 interface PopupNode {
   uid?: string;
   resource: PopupNodeResource;
+  sourceRecord?: unknown;
   parent?: PopupNode;
 }
 
 export async function buildPopupRuntime(ctx: FlowContext, view: FlowView): Promise<PopupNode | undefined> {
   const stack = getViewStack(view);
   const currentIndex = getAnchoredViewStackIndex(view, stack);
+  const sourceRecord = view?.inputArgs?.parentItem?.value;
 
   const openerUids = view?.inputArgs?.openerUids;
   const hasOpener = Array.isArray(openerUids) && openerUids.length > 0;
@@ -502,6 +504,7 @@ export async function buildPopupRuntime(ctx: FlowContext, view: FlowView): Promi
         filterByTk: args.filterByTk,
         sourceId: args.sourceId,
       },
+      ...(typeof sourceRecord !== 'undefined' ? { sourceRecord } : {}),
     };
   }
 
@@ -530,6 +533,9 @@ export async function buildPopupRuntime(ctx: FlowContext, view: FlowView): Promi
     return node;
   };
   const currentNode = await buildNode(currentIndex);
+  if (currentNode && typeof sourceRecord !== 'undefined') {
+    currentNode.sourceRecord = sourceRecord;
+  }
   return currentNode;
 }
 
@@ -541,6 +547,30 @@ export function registerPopupVariable(ctx: FlowContext, view: FlowView) {
   // - 任意层级 parent.parent... 下的 record / sourceRecord 及其子字段
   const POPUP_SERVER_PATH_RE =
     /^(?:record|sourceRecord)(?:\.|$)|^parent(?:\.parent)*(?:\.(?:record|sourceRecord))(?:\.|$)/;
+  const shouldResolveSourceRecordOnServer = (path: string): boolean => {
+    if (path !== 'sourceRecord' && !path.startsWith('sourceRecord.')) return false;
+
+    const parentItem = view?.inputArgs?.parentItem;
+    if (typeof parentItem?.value === 'undefined') return true;
+
+    const sourcePath = path === 'sourceRecord' ? '' : path.slice('sourceRecord.'.length);
+    if (!sourcePath) return false;
+
+    const parentItemResolver = view?.inputArgs?.parentItemResolver;
+    if (typeof parentItemResolver === 'function') {
+      return parentItemResolver(`value.${sourcePath}`);
+    }
+
+    const segments = sourcePath.split('.').filter(Boolean);
+    let current = parentItem.value;
+    for (const segment of segments) {
+      if (current === null || typeof current !== 'object' || !(segment in current)) {
+        return true;
+      }
+      current = current[segment];
+    }
+    return false;
+  };
   // 始终注册 popup 变量：
   // - 若当前视图无可推断记录，仅在元信息中不呈现 record 字段；
   // - 但仍可依据 navigation 推断并展示上级弹窗信息。
@@ -549,6 +579,9 @@ export function registerPopupVariable(ctx: FlowContext, view: FlowView) {
     meta: createPopupMeta(ctx, view),
     resolveOnServer: (p: string) => {
       try {
+        if (p === 'sourceRecord' || p.startsWith('sourceRecord.')) {
+          return shouldResolveSourceRecordOnServer(p);
+        }
         return !!p && POPUP_SERVER_PATH_RE.test(p);
       } catch (_) {
         return false;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In v2 popup-editing subtables, the add-new and edit dialogs did not propagate their popup opener and association source context. As a result, `Current popup` and its `Current popup parent record` branch were missing from variable selectors such as field linkage rules.

After exposing the variable, scalar fields of `Current popup parent record` were still resolved only from the persisted parent record. This meant a linkage condition could see an old value or `undefined` instead of the value currently displayed in the parent form, so rules such as `Phone contains 999` did not match `9999`.

### Description
- Propagate `openerUids` when opening add-new and edit dialogs from popup-editing subtables.
- Propagate the owning association name and persisted parent record ID so FlowEngine can expose `Current popup parent record`.
- Reuse the existing `buildOpenerUids()` behavior already used by other association-field popups.
- Expose the current parent item as the popup `sourceRecord` runtime value.
- Resolve ordinary parent fields from the current parent form value while preserving server resolution for association subpaths.
- Add regression tests for add-new, edit, unsaved-parent, stacked-popup, local scalar resolution, and association subpath resolution.

Risk is low: the change only adds popup context metadata and adjusts the read path for popup parent variables. It does not affect data persistence, form submission, APIs, or database schemas. Server resolution remains enabled where associated records need to be fetched.

Testing suggestions:
1. Open a v2 form containing a popup-editing subtable.
2. Open both the add-new and edit dialogs.
3. Configure a field linkage rule using `Current popup / Current popup parent record / Phone` with `contains 999`.
4. Verify the rule matches when the parent form displays `Phone = 9999`.
5. Verify association subfields under `Current popup parent record` still resolve correctly.
6. Verify submitting, closing, and resetting the subtable form continue to work.

Automated verification:
- Popup subtable tests: 6 passed.
- Subtable reset tests: 3 passed.
- FlowEngine popup variable tests: 10 passed.
- ESLint/lint-staged passed for all changed files (no errors).

### Related issues

- Task 2078

### Showcase

- Before: `Current popup` was missing; after it became visible, parent scalar fields could still resolve to stale persisted values.
- After: `Current popup parent record` is available for persisted parents, and its ordinary fields use the current parent form value during linkage evaluation.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing and incorrectly resolved `Current popup` parent record variables in v2 popup-subtable add-new and edit dialogs. |
| 🇨🇳 Chinese | 修复 v2 弹窗编辑子表格的新增和编辑弹窗中缺失或取值不正确的 `Current popup` 上级记录变量。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed (bug fix only) |
| 🇨🇳 Chinese | 无需更新（仅错误修复） |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
