### PR TITLE
fix(localization): prevent ChatBox runtime crash

### DIFF
--- a/packages/plugins/@nocobase/plugin-localization/src/client-v2/pages/LocalizationPage.tsx
+++ b/packages/plugins/@nocobase/plugin-localization/src/client-v2/pages/LocalizationPage.tsx
@@ -12,7 +12,7 @@ import { css } from '@emotion/css';
 import { Schema } from '@formily/react';
 import { languageCodes } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
-import { AIEmployeeShortcut, formatModelLabel } from '@nocobase/plugin-ai/client-v2';
+import { AIEmployeeShortcut, formatModelLabel, getGlobalChatBoxRuntime } from '@nocobase/plugin-ai/client-v2';
 import type { AIEmployee, Task } from '@nocobase/plugin-ai/client-v2';
 import { useRequest } from 'ahooks';
 import {
@@ -817,6 +817,7 @@ function LinaEmployee(props: { selectedRowKeys: React.Key[] }) {
     <AIEmployeeShortcut
       aiEmployee={lina}
       tasks={tasks}
+      runtime={getGlobalChatBoxRuntime()}
       size={32}
       mask={false}
       onTaskClick={(task) => createTask(task as LocalizationTask)}


### PR DESCRIPTION
### This is a ...
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Others

### Motivation
The Localization settings page renders the Lina AI employee shortcut. In packaged deployments where the global ChatBox layout is unavailable, the shortcut had no ChatBox runtime and crashed while rendering.

### Description
- Pass the global ChatBox runtime explicitly to the Lina shortcut in the Localization page.
- Keep the shortcut functional independently of the ChatBox layout provider and plugin initialization order.

### Related issues
N/A

### Showcase
Not applicable (runtime wiring fix).

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed a crash when opening Localization settings with the Lina AI assistant entry. |
| 🇨🇳 Chinese | 修复打开带有 Lina AI 助手入口的本地化设置时发生的崩溃。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
