### PR TITLE
fix: restore secure variable resolution compatibility

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-visualization/src/client/renderer/ChartRendererProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/client/renderer/ChartRendererProvider.tsx
@@ -116,6 +116,8 @@ export const ChartRendererProvider: React.FC<ChartRendererProps> = (props) => {
             dataSource,
             collection,
             ...queryWithFilter,
+            mode: props.mode ?? 'builder',
+            variableResolution: 'legacy-schema',
             filter: removeUnparsableFilter(queryWithFilter.filter),
             dimensions: (query?.dimensions || []).map((item: DimensionProps) => {
               const dimension = { ...item };

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/api.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/api.test.ts
@@ -21,6 +21,7 @@ describe('api', () => {
   let memberToken: string;
   let rootToken: string;
   let designerToken: string;
+  let limitedToken: string;
 
   const insertChartModel = async (uid: string, template: unknown) => {
     const repository = db.getCollection('flowModels').repository as FlowModelRepository;
@@ -96,14 +97,26 @@ describe('api', () => {
         strategy: { actions: ['view'] },
       },
     });
+    await db.getRepository('roles').create({
+      values: {
+        name: 'chart-limited',
+        strategy: { actions: ['view'] },
+      },
+    });
     for (const roleName of ['member', 'chart-designer']) {
       const role = app.acl.getRole(roleName) || app.acl.define({ role: roleName });
       role.grantAction('chart_test:view', {});
     }
+    const limitedRole = app.acl.getRole('chart-limited') || app.acl.define({ role: 'chart-limited' });
+    limitedRole.grantAction('chart_test:view', {
+      fields: ['id', 'price', 'title'],
+      filter: { id: { $eq: 1 } },
+    });
     const users = db.getRepository('users');
     const root = await users.findOne();
     const member = await users.create({ values: { nickname: 'Chart member', roles: ['member'] } });
     const designer = await users.create({ values: { nickname: 'Chart designer', roles: ['chart-designer'] } });
+    const limited = await users.create({ values: { nickname: 'Chart limited', roles: ['chart-limited'] } });
 
     rootToken = await app.authManager.jwt.sign({ userId: root.id, roleName: 'root', signInTime: 'chart-root' });
     memberToken = await app.authManager.jwt.sign({
@@ -115,6 +128,11 @@ describe('api', () => {
       userId: designer.id,
       roleName: 'chart-designer',
       signInTime: 'chart-designer',
+    });
+    limitedToken = await app.authManager.jwt.sign({
+      userId: limited.id,
+      roleName: 'chart-limited',
+      signInTime: 'chart-limited',
     });
   });
 
@@ -218,6 +236,89 @@ describe('api', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data.map((row: { Title: string }) => row.Title).sort()).toEqual(['title1', 'title2']);
+  });
+
+  test('supports explicit legacy 1.x builder requests without rd', async () => {
+    const response = await requestChart(memberToken, 'member', {
+      collection: 'chart_test',
+      dataSource: 'main',
+      dimensions: [{ alias: 'Title', field: ['title'] }],
+      measures: [{ alias: 'Price', field: ['price'] }],
+      mode: 'builder',
+      variableResolution: 'legacy-schema',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data.map((row: { Title: string }) => row.Title).sort()).toEqual(['title1', 'title2']);
+  });
+
+  test('keeps row-level ACL filters in the explicit legacy lane', async () => {
+    const response = await requestChart(limitedToken, 'chart-limited', {
+      collection: 'chart_test',
+      dataSource: 'main',
+      dimensions: [{ alias: 'Title', field: ['title'] }],
+      measures: [{ alias: 'Price', field: ['price'] }],
+      mode: 'builder',
+      variableResolution: 'legacy-schema',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data).toEqual([expect.objectContaining({ Title: 'title1' })]);
+  });
+
+  test('keeps the legacy lane closed to Record descriptors and ctx paths', async () => {
+    const query = vi.spyOn(repo, 'query');
+    const base = {
+      collection: 'chart_test',
+      dataSource: 'main',
+      dimensions: [{ alias: 'Title', field: ['title'] }],
+      measures: [{ alias: 'Price', field: ['price'] }],
+      mode: 'builder',
+      variableResolution: 'legacy-schema',
+    };
+
+    const withRecord = await requestChart(memberToken, 'member', {
+      ...base,
+      contextParams: { 'view.record': { collection: 'chart_test', filterByTk: 1 } },
+    });
+    const withCtxPath = await requestChart(memberToken, 'member', {
+      ...base,
+      filter: { id: { $eq: '{{ ctx.user.id }}' } },
+    });
+
+    expect(withRecord.body.data).toEqual([]);
+    expect(withCtxPath.body.data).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+    query.mockRestore();
+  });
+
+  test('fails closed when resolved record data contains an unsupported second-stage template', async () => {
+    const uid = 'chart-secondary-unsupported-template';
+    const filter = { title: { $eq: '{{ ctx.view.record.title }}' } };
+    await insertChartModel(uid, { filter });
+    await repo.update({ filterByTk: 1, values: { title: '{{ ctx.other() }}' } });
+    const query = vi.spyOn(repo, 'query');
+
+    try {
+      const response = await requestChart(memberToken, 'member', {
+        collection: 'chart_test',
+        contextParams: {
+          'view.record': { collection: 'chart_test', dataSourceKey: 'main', filterByTk: 1 },
+        },
+        dataSource: 'main',
+        dimensions: [{ alias: 'Title', field: ['title'] }],
+        filter,
+        measures: [{ alias: 'Price', field: ['price'] }],
+        mode: 'builder',
+        rd: generateFlowModelRdFromToken(uid, memberToken),
+      });
+
+      expect(response.body.data).toEqual([]);
+      expect(query).not.toHaveBeenCalled();
+    } finally {
+      query.mockRestore();
+      await repo.update({ filterByTk: 1, values: { title: 'title1' } });
+    }
   });
 
   test.each([

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts
@@ -109,6 +109,7 @@ describe('query', () => {
           params: {
             values: {
               mode: 'sql',
+              variableResolution: 'legacy-schema',
               filter: {
                 $and: [
                   {
@@ -125,10 +126,92 @@ describe('query', () => {
       };
       await parseVariables(context, async () => {});
       const { filter } = context.action.params.values;
+      expect(context.action.params.values).not.toHaveProperty('variableResolution');
       const dateOn = filter.$and[0].createdAt.$dateOn;
       expect(new Date(dateOn).getTime()).toBeLessThanOrEqual(new Date().getTime());
       const userId = filter.$and[1].userId.$eq;
       expect(userId).toBe(user.id);
+    });
+
+    it('parses legacy schema variables in the explicit builder lane', async () => {
+      const user = await db.getRepository('users').findOne();
+      const next = vi.fn();
+      const context = {
+        ...ctx,
+        state: { currentUser: user },
+        get: (key: string) => ({ 'x-timezone': '' })[key],
+        action: {
+          params: {
+            values: {
+              mode: 'builder',
+              variableResolution: 'legacy-schema',
+              filter: {
+                $and: [{ createdAt: { $dateOn: '{{$nDate.now}}' } }, { userId: { $eq: '{{$user.id}}' } }],
+              },
+            },
+          },
+        },
+      };
+
+      await parseVariables(context, next);
+
+      expect(next).toHaveBeenCalledOnce();
+      expect(context.action.params.values).not.toHaveProperty('variableResolution');
+      expect(context.action.params.values.filter.$and[1].userId.$eq).toBe(user.id);
+      expect(new Date(context.action.params.values.filter.$and[0].createdAt.$dateOn).getTime()).toBeLessThanOrEqual(
+        Date.now(),
+      );
+    });
+
+    it.each([
+      [
+        'Record context params',
+        {
+          mode: 'builder',
+          variableResolution: 'legacy-schema',
+          contextParams: { 'view.record': { collection: 'users', filterByTk: 1 } },
+          filter: { id: { $eq: 1 } },
+        },
+      ],
+      [
+        'ctx paths',
+        {
+          mode: 'builder',
+          variableResolution: 'legacy-schema',
+          filter: { id: { $eq: '{{ ctx.user.id }}' } },
+        },
+      ],
+      [
+        'unsupported expressions',
+        {
+          mode: 'builder',
+          variableResolution: 'legacy-schema',
+          filter: { id: { $eq: '{{ ctx.other() }}' } },
+        },
+      ],
+      [
+        'an rd',
+        {
+          mode: 'builder',
+          variableResolution: 'legacy-schema',
+          rd: 'invalid-rd',
+          filter: { id: { $eq: 1 } },
+        },
+      ],
+      ['a missing mode', { variableResolution: 'legacy-schema', filter: { id: { $eq: 1 } } }],
+      ['a missing marker', { mode: 'builder', filter: { id: { $eq: 1 } } }],
+    ])('rejects a legacy request with %s', async (_title, values) => {
+      const next = vi.fn();
+      const context = {
+        ...ctx,
+        get: () => '',
+        action: { params: { values } },
+      };
+
+      await parseVariables(context, next);
+
+      expect(context.body).toEqual([]);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('should reuse flow-engine variable resolver for filter values', async () => {

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/actions/query.ts
@@ -69,24 +69,40 @@ export const queryData = async (ctx: Context, next: Next) => {
 };
 
 export const parseVariables = async (ctx: Context, next: Next) => {
-  const { mode, contextParams, rd, ...values } = ctx.action.params.values as QueryParams;
+  const { mode, contextParams, rd, variableResolution, ...values } = ctx.action.params.values as QueryParams;
   if (mode !== 'sql') {
-    const resolvedValues = await (
-      ctx.app.pm.get('flow-engine') as PluginFlowEngineServer
-    ).resolveFlowModelVariablesTemplate(ctx, {
-      contextParams,
-      rd,
-      template: values,
-    });
-    if (!resolvedValues) {
-      ctx.body = [];
-      return;
+    const flowEngine = ctx.app.pm.get('flow-engine') as PluginFlowEngineServer;
+    const isLegacyLane = mode === 'builder' && variableResolution === 'legacy-schema' && typeof rd === 'undefined';
+    if (isLegacyLane) {
+      const hasEmptyContextParams =
+        typeof contextParams === 'undefined' ||
+        (contextParams !== null &&
+          typeof contextParams === 'object' &&
+          !Array.isArray(contextParams) &&
+          Object.keys(contextParams).length === 0);
+      if (!hasEmptyContextParams || !flowEngine.isLegacyVariableTemplateSafe(values)) {
+        ctx.body = [];
+        return;
+      }
+      ctx.action.params.values = { mode, ...values };
+    } else {
+      const resolvedValues = await flowEngine.resolveFlowModelVariablesTemplate(ctx, {
+        contextParams,
+        rd,
+        template: values,
+      });
+      if (!resolvedValues) {
+        ctx.body = [];
+        return;
+      }
+      ctx.action.params.values = {
+        mode,
+        ...values,
+        ...(resolvedValues as Record<string, unknown>),
+      };
     }
-    ctx.action.params.values = {
-      mode,
-      ...values,
-      ...(resolvedValues as Record<string, unknown>),
-    };
+  } else {
+    ctx.action.params.values = { mode, ...values };
   }
 
   const { filter } = ctx.action.params.values;

--- a/packages/plugins/@nocobase/plugin-data-visualization/src/server/types.ts
+++ b/packages/plugins/@nocobase/plugin-data-visualization/src/server/types.ts
@@ -54,4 +54,5 @@ export type QueryParams = Partial<{
   };
   // Get the latest data from the database
   refresh: boolean;
+  variableResolution: 'legacy-schema';
 }>;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.test.ts
@@ -435,6 +435,43 @@ describe('plugin-flow-engine variables:resolve (no HTTP)', () => {
     expect(res.body).toEqual({ name: 'root' });
   });
 
+  it('resolves a persisted RunJS ctx.resolveJsonTemplate path for a non-configure role', async () => {
+    const flowModelUid = 'runjs-resolve-json-template-member';
+    const session = createTokenSession(1);
+    await insertFlowModel({
+      uid: flowModelUid,
+      use: 'JSBlockModel',
+      stepParams: {
+        jsSettings: {
+          runJs: {
+            code: `
+              const data = await ctx.resolveJsonTemplate({
+                role: '{{ ctx.record.roles[0].name }}',
+              });
+              ctx.render(data.role);
+            `,
+            version: 'v2',
+          },
+        },
+      },
+    });
+
+    const res = await execResolve(
+      {
+        rd: session.rd(flowModelUid),
+        template: { role: '{{ ctx.record.roles[0].name }}' },
+        contextParams: {
+          record: { dataSourceKey: 'main', collection: 'users', filterByTk: 1 },
+        },
+      },
+      1,
+      { currentRole: 'member', currentRoles: ['member'], token: session.token },
+    );
+
+    expect(res.body.role).not.toBe('{{ ctx.record.roles[0].name }}');
+    expect(typeof res.body.role).toBe('string');
+  });
+
   it('keeps the exact popup Slot gate for member and root roles', async () => {
     const flowModelUid = 'popup-moved-record-slot';
     const session = createTokenSession(1);

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -52,6 +52,37 @@ describe('persisted RunJS variable dependencies', () => {
     expect(templates).toEqual(['{{ ctx.popup.record.name }}', '{{ ctx.user.id }}']);
   });
 
+  it('collects static JSON templates from direct unshadowed ctx.resolveJsonTemplate calls', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions(`
+          const data = await ctx.resolveJsonTemplate({
+            role: '{{ ctx.record.roles[0].name }}',
+            nested: ['Role: {{ ctx.popup.record.name }}'],
+          });
+          const userId = await ctx['resolveJsonTemplate'](\`{{ ctx.user.id }}\`);
+          ctx.render(data.role + userId);
+        `),
+      ),
+    ).toEqual(['{{ ctx.record.roles[0].name }}', 'Role: {{ ctx.popup.record.name }}', '{{ ctx.user.id }}']);
+  });
+
+  it.each([
+    ['dynamic identifier', `const template = '{{ ctx.user.id }}'; await ctx.resolveJsonTemplate(template);`],
+    ['call result', `await ctx.resolveJsonTemplate(createTemplate('{{ ctx.user.id }}'));`],
+    ['shadowed ctx', `(ctx) => ctx.resolveJsonTemplate('{{ ctx.user.id }}');`],
+    ['comment', `// ctx.resolveJsonTemplate('{{ ctx.user.id }}')`],
+    ['plain code string', `const code = "ctx.resolveJsonTemplate('{{ ctx.user.id }}')";`],
+    ['object spread', `await ctx.resolveJsonTemplate({ ...value, id: '{{ ctx.user.id }}' });`],
+    ['computed key', `await ctx.resolveJsonTemplate({ ['id']: '{{ ctx.user.id }}' });`],
+    ['dynamic value', `await ctx.resolveJsonTemplate({ id: value, role: '{{ ctx.user.id }}' });`],
+    ['function value', `await ctx.resolveJsonTemplate({ id() { return '{{ ctx.user.id }}'; } });`],
+    ['template interpolation', 'await ctx.resolveJsonTemplate(`{{ ctx.user.${field} }}`);'],
+    ['array hole', `await ctx.resolveJsonTemplate(['{{ ctx.user.id }}', ,]);`],
+  ])('does not collect ctx.resolveJsonTemplate dependencies from a %s', (_title, code) => {
+    expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual([]);
+  });
+
   it.each([
     {
       title: 'dynamic arguments',
@@ -97,6 +128,17 @@ describe('persisted RunJS variable dependencies', () => {
   it.each([
     `ctx = { getVar() {} }; ctx.getVar('ctx.user.password');`,
     `ctx.getVar = () => {}; ctx.getVar('ctx.user.password');`,
+    `ctx.resolveJsonTemplate = () => {}; ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `globalThis.ctx = { resolveJsonTemplate() {} }; ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `globalThis['ctx'].resolveJsonTemplate = () => {}; ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `Object.defineProperty(globalThis, 'ctx', { value: {} }); ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `Reflect.set(globalThis, 'ctx', {}); ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `Object.assign(globalThis, { ctx: {} }); ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `const runtimeGlobal = globalThis; runtimeGlobal.ctx = {}; ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `this.ctx = {}; ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `(0, eval)("globalThis.ctx = { resolveJsonTemplate: async () => {} }"); ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `Function("globalThis.ctx = { resolveJsonTemplate: async () => {} }")(); ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
+    `new Function("globalThis.ctx = { resolveJsonTemplate: async () => {} }")(); ctx.resolveJsonTemplate('{{ ctx.user.password }}');`,
     `ctx['getVar'] ||= () => {}; ctx.getVar('ctx.user.password');`,
     `delete ctx.getVar; ctx.getVar('ctx.user.password');`,
     `Object.defineProperty(ctx, 'getVar', { value: () => {} }); ctx.getVar('ctx.user.password');`,
@@ -124,6 +166,46 @@ describe('persisted RunJS variable dependencies', () => {
         createRunJsOptions(`
           function replace(ctx) { ctx.getVar = () => {}; }
           await ctx.getVar('ctx.popup.record.name');
+        `),
+      ),
+    ).toEqual(['{{ ctx.popup.record.name }}']);
+  });
+
+  it('does not treat a shadowed globalThis reference as a runtime global rewrite', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions(`
+          function replace(globalThis) { globalThis.ctx = {}; }
+          await ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');
+        `),
+      ),
+    ).toEqual(['{{ ctx.popup.record.name }}']);
+  });
+
+  it('allows local this and shadowed dynamic execution names without widening the contract', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions(`
+          function eval() {}
+          function Function() {}
+          const helper = { value: 1, read() { return this.value; } };
+          helper.read();
+          await ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');
+        `),
+      ),
+    ).toEqual(['{{ ctx.popup.record.name }}']);
+  });
+
+  it('allows class field and static block this bindings without widening the contract', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions(`
+          class Helper {
+            value = 1;
+            read = () => this.value;
+            static { this.ready = true; }
+          }
+          await ctx.resolveJsonTemplate('{{ ctx.popup.record.name }}');
         `),
       ),
     ).toEqual(['{{ ctx.popup.record.name }}']);

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/plugin.ts
@@ -21,6 +21,7 @@ import { createFormItemRecordSlotResolvers } from './variables/form-item-record-
 import { createBuiltInRecordSlotResolvers } from './variables/record-slot-policy';
 import { getRecordSlotResolverRegistry } from './variables/record-slot-resolvers';
 import {
+  isLegacyVariableTemplateSafe,
   resolveAnalyzedVariablesBatch,
   resolveAnalyzedVariablesTemplate,
   resolveFlowModelVariablesTemplate,
@@ -66,6 +67,10 @@ export class PluginFlowEngineServer extends PluginUISchemaStorageServer {
   ) {
     this.ensureRecordSlotResolvers(ctx.app);
     return await resolveFlowModelVariablesTemplate(ctx, options);
+  }
+
+  isLegacyVariableTemplateSafe(template: JSONValue) {
+    return isLegacyVariableTemplateSafe(template);
   }
 
   async load() {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/resolve.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/resolve.ts
@@ -59,6 +59,11 @@ export async function resolveVariablesTemplate(
   return resolveAnalyzedVariablesTemplate(ctx, result.analysis, REQUEST_BOUND_RESOLVE_POLICY, bindingPlan);
 }
 
+export function isLegacyVariableTemplateSafe(template: JSONValue) {
+  const result = analyzeVariableTemplateSafely(template, { mode: 'untrusted-request' });
+  return result.ok && result.analysis.supported && result.analysis.paths.length === 0;
+}
+
 export async function resolveFlowModelVariablesTemplate(
   ctx: ResourcerContext,
   options: {
@@ -77,7 +82,7 @@ export async function resolveFlowModelVariablesTemplate(
     authorization.bindingPlan,
   );
   const remaining = analyzeVariableTemplateSafely(resolved, { mode: 'untrusted-request' });
-  if (!remaining.ok || remaining.analysis.paths.length) return;
+  if (!remaining.ok || !remaining.analysis.supported || remaining.analysis.paths.length) return;
   return resolved;
 }
 

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -38,17 +38,26 @@ type AstNode = Readonly<{
   callee?: unknown;
   computed?: boolean;
   elements?: readonly unknown[];
+  expressions?: readonly unknown[];
+  kind?: string;
   key?: unknown;
   left?: unknown;
+  method?: boolean;
+  name?: string;
   object?: unknown;
   operator?: string;
   params?: readonly unknown[];
   properties?: readonly unknown[];
   property?: unknown;
   shorthand?: boolean;
+  start?: number;
   type?: string;
   value?: unknown;
 }>;
+
+type StaticJsonValue = null | boolean | number | string | StaticJsonValue[] | { [key: string]: StaticJsonValue };
+
+type StaticJsonResult = Readonly<{ ok: true; value: StaticJsonValue }> | Readonly<{ ok: false }>;
 
 type TraversalContainer = Record<string, unknown> | unknown[];
 
@@ -73,6 +82,8 @@ export type PreparedFlowModelVariableSource =
 const RUNJS_VALUE_KEYS = new Set(['code', 'version']);
 const RUNJS_PATH_SUFFIXES = new Set(['stepParams.jsSettings.runJs', 'stepParams.clickSettings.runJs']);
 const MUTATING_CTX_METHODS = new Set(['__defineGetter__', '__defineSetter__']);
+const GLOBAL_OBJECT_NAMES = new Set(['globalThis']);
+const DYNAMIC_CODE_EXECUTION_NAMES = new Set(['eval', 'Function']);
 
 export const MAX_FLOW_MODEL_VARIABLE_SOURCE_DEPTH = 128;
 export const MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES = 10_000;
@@ -143,16 +154,13 @@ function hasCtxParameterInFunctionAncestors(ancestors: readonly AstNode[], cache
   return ancestors.some((ancestor) => functionBindsCtxParameter(ancestor, cache));
 }
 
-function isDirectCtxGetVarMember(
+function getDirectCtxMethodName(
   node: unknown,
   identifierBindings: ReturnType<typeof collectAstIdentifierBindingsFromAst>,
 ) {
   const member = unwrapAstChainExpression(node) as AstNode | undefined;
-  return (
-    member?.type === 'MemberExpression' &&
-    isUnshadowedCtxIdentifier(member.object, identifierBindings) &&
-    getAstStaticPropertyName(member) === 'getVar'
-  );
+  if (member?.type !== 'MemberExpression' || !isUnshadowedCtxIdentifier(member.object, identifierBindings)) return;
+  return getAstStaticPropertyName(member);
 }
 
 function isCtxRootedMember(node: unknown, identifierBindings: ReturnType<typeof collectAstIdentifierBindingsFromAst>) {
@@ -202,15 +210,38 @@ function isNonReferenceIdentifier(node: AstNode, parent: AstNode | undefined) {
   );
 }
 
+function thisUsesTopLevelBinding(ancestors: readonly AstNode[]) {
+  for (let index = 0; index < ancestors.length; index += 1) {
+    const ancestor = ancestors[index];
+    if (isAstFunctionLike(ancestor) && ancestor.type !== 'ArrowFunctionExpression') return false;
+    if (ancestor.type === 'StaticBlock') return false;
+    if (ancestor.type === 'PropertyDefinition' && unwrapAstChainExpression(ancestor.value) === ancestors[index + 1]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function hasUnsafeCtxUsage(ast: unknown, identifierBindings: ReturnType<typeof collectAstIdentifierBindingsFromAst>) {
   let unsafe = false;
   walkAstAncestor(ast, {
     Identifier(node: AstNode, ancestors: AstNode[]) {
-      if (!isUnshadowedCtxIdentifier(node, identifierBindings)) return;
       const parent = ancestors[ancestors.length - 2];
       if (isNonReferenceIdentifier(node, parent)) return;
+      if (
+        node.name &&
+        (GLOBAL_OBJECT_NAMES.has(node.name) || DYNAMIC_CODE_EXECUTION_NAMES.has(node.name)) &&
+        !hasAstActiveBinding(node.name, node.start || 0, identifierBindings)
+      ) {
+        unsafe = true;
+        return;
+      }
+      if (!isUnshadowedCtxIdentifier(node, identifierBindings)) return;
       if (parent?.type === 'MemberExpression' && unwrapAstChainExpression(parent.object) === node) return;
       unsafe = true;
+    },
+    ThisExpression(_node: AstNode, ancestors: AstNode[]) {
+      if (thisUsesTopLevelBinding(ancestors)) unsafe = true;
     },
     WithStatement() {
       unsafe = true;
@@ -278,7 +309,89 @@ function createValidatedGetVarTemplate(value: unknown, code: string): string | u
   return `{{ ${path} }}`;
 }
 
-function extractStaticGetVarTemplates(code: string): string[] {
+function resolveStaticJsonValue(node: unknown, code: string): StaticJsonResult {
+  const valueNode = unwrapAstChainExpression(node) as AstNode | undefined;
+  if (!valueNode) return { ok: false };
+  if (valueNode.type === 'Literal') {
+    const literalValue = valueNode.value;
+    if (literalValue === null) return { ok: true, value: null };
+    if (typeof literalValue === 'string') return { ok: true, value: literalValue };
+    if (typeof literalValue === 'boolean') return { ok: true, value: literalValue };
+    if (typeof literalValue === 'number' && Number.isFinite(literalValue)) return { ok: true, value: literalValue };
+    return { ok: false };
+  }
+  if (valueNode.type === 'TemplateLiteral' && !valueNode.expressions?.length) {
+    const value = resolveAstStaticStringValue(valueNode, code);
+    return typeof value === 'string' ? { ok: true, value } : { ok: false };
+  }
+  if (valueNode.type === 'UnaryExpression' && valueNode.operator === '-') {
+    const argument = unwrapAstChainExpression(valueNode.argument) as AstNode | undefined;
+    return argument?.type === 'Literal' && typeof argument.value === 'number' && Number.isFinite(argument.value)
+      ? { ok: true, value: -argument.value }
+      : { ok: false };
+  }
+  if (valueNode.type === 'ArrayExpression') {
+    const value: StaticJsonValue[] = [];
+    for (const element of valueNode.elements || []) {
+      if (!element || (element as AstNode).type === 'SpreadElement') return { ok: false };
+      const resolved = resolveStaticJsonValue(element, code);
+      if (!resolved.ok) return resolved;
+      value.push(resolved.value);
+    }
+    return { ok: true, value };
+  }
+  if (valueNode.type !== 'ObjectExpression') return { ok: false };
+
+  const value: Record<string, StaticJsonValue> = Object.create(null);
+  for (const propertyValue of valueNode.properties || []) {
+    const property = propertyValue as AstNode | undefined;
+    if (
+      property?.type !== 'Property' ||
+      property.computed ||
+      property.kind !== 'init' ||
+      property.method ||
+      property.shorthand
+    ) {
+      return { ok: false };
+    }
+    const keyNode = unwrapAstChainExpression(property.key) as AstNode | undefined;
+    const key =
+      keyNode?.type === 'Identifier'
+        ? keyNode.name
+        : keyNode?.type === 'Literal' && (typeof keyNode.value === 'string' || typeof keyNode.value === 'number')
+          ? String(keyNode.value)
+          : undefined;
+    if (typeof key !== 'string' || key === '__proto__' || Object.prototype.hasOwnProperty.call(value, key)) {
+      return { ok: false };
+    }
+    const resolved = resolveStaticJsonValue(property.value, code);
+    if (!resolved.ok) return resolved;
+    value[key] = resolved.value;
+  }
+  return { ok: true, value };
+}
+
+function collectValidatedResolveJsonTemplates(value: StaticJsonValue): string[] {
+  const analysis = analyzeVariableTemplate(value, { mode: 'untrusted-request' });
+  if (!analysis.supported || analysis.errors.length) return [];
+
+  const templates = new Set<string>();
+  const visit = (current: StaticJsonValue) => {
+    if (typeof current === 'string') {
+      if (analyzeVariableTemplate(current, { mode: 'untrusted-request' }).paths.length) templates.add(current);
+      return;
+    }
+    if (Array.isArray(current)) {
+      current.forEach(visit);
+      return;
+    }
+    if (current && typeof current === 'object') Object.values(current).forEach(visit);
+  };
+  visit(value);
+  return Array.from(templates);
+}
+
+function extractStaticVariableTemplates(code: string): string[] {
   const parsed = parseRunJsAuthoringAst(code);
   if (!parsed.ast) return [];
 
@@ -291,17 +404,17 @@ function extractStaticGetVarTemplates(code: string): string[] {
   const templates = new Set<string>();
   walkAstAncestor(parsed.ast, {
     CallExpression(node: AstNode, ancestors: AstNode[]) {
-      const callee = unwrapAstChainExpression(node.callee) as AstNode | undefined;
-      if (
-        callee?.type !== 'MemberExpression' ||
-        !isUnshadowedCtxIdentifier(callee.object, identifierBindings) ||
-        getAstStaticPropertyName(callee) !== 'getVar' ||
-        hasCtxParameterInFunctionAncestors(ancestors, functionCtxParameterCache)
-      ) {
+      const methodName = getDirectCtxMethodName(node.callee, identifierBindings);
+      if (hasCtxParameterInFunctionAncestors(ancestors, functionCtxParameterCache)) return;
+      if (methodName === 'getVar') {
+        const template = createValidatedGetVarTemplate(node.arguments?.[0], code);
+        if (template) templates.add(template);
         return;
       }
-      const template = createValidatedGetVarTemplate(node.arguments?.[0], code);
-      if (template) templates.add(template);
+      if (methodName !== 'resolveJsonTemplate' || node.arguments?.length !== 1) return;
+      const resolved = resolveStaticJsonValue(node.arguments[0], code);
+      if (!resolved.ok) return;
+      collectValidatedResolveJsonTemplates(resolved.value).forEach((template) => templates.add(template));
     },
   });
   return Array.from(templates);
@@ -374,7 +487,7 @@ export function prepareFlowModelVariableSource(value: unknown): PreparedFlowMode
             entryKey === 'code' ? (runJs.version === 'v2' ? '' : maskJavaScriptComments(runJs.code)) : entryValue;
           defineTraversalValue(output, entryKey, preparedEntryValue);
         }
-        extractStaticGetVarTemplates(runJs.code).forEach((template) => templates.add(template));
+        extractStaticVariableTemplates(runJs.code).forEach((template) => templates.add(template));
         continue;
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Fix compatibility and authorization regressions in server-side variable resolution. Legacy v1 Data Visualization charts without a FlowModel RD could return empty data, unsupported second-stage templates were not fully rejected, and v2 RunJS dependencies declared through the documented `ctx.resolveJsonTemplate()` API were omitted from persisted variable contracts.

### Description 

- Adds an explicit, narrowly gated legacy variable-resolution lane for v1 Data Visualization builder requests without RD, while preserving ACL checks and legacy `$user` / `$nDate` parsing.
- Keeps V2 requests without a valid model-bound RD fail-closed, and rejects legacy requests containing Record descriptors, `ctx.*` paths, or unsupported expressions.
- Rejects unsupported templates produced after the first resolution stage.
- Extracts direct static string/JSON dependencies from `ctx.resolveJsonTemplate()` with AST validation, while rejecting dynamic arguments, shadowing, ctx/global rewrites, dynamic code execution, and non-static JSON.
- Adds integration and adversarial security coverage for legacy charts, row-level ACL filters, second-stage templates, and RunJS dependency contracts.

Testing performed:

- `yarn test packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.resolve.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/query.test.ts --run`
- `yarn test packages/plugins/@nocobase/plugin-data-visualization/src/server/__tests__/api.test.ts --run`
- `yarn build @nocobase/plugin-flow-engine`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
