### PR TITLE
fix(plugin-workflow): disable execute mode before trigger selection

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowFormDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowFormDrawer.tsx
@@ -215,9 +215,9 @@ export function WorkflowFormDrawer(props: WorkflowFormDrawerProps) {
             'Execute workflow asynchronously or synchronously based on trigger type, and could not be changed after created.',
           )}
         >
-          {/* Execute mode is fixed after creation — disabled in edit mode (v1 parity),
-              and also when the trigger type forces a sync mode. */}
-          <SyncModeSelect disabled={syncLocked || mode === 'edit'} />
+          {/* Execute mode is unavailable until a trigger is selected, fixed after creation, and also locked when the
+              trigger type forces a sync mode. */}
+          <SyncModeSelect disabled={!watchedType || syncLocked || mode === 'edit'} />
         </Form.Item>
         <Form.Item name="categories" label={t('Category')}>
           <Select mode="multiple" allowClear options={categoryOptions} optionFilterProp="label" />

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowPane.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowPane.test.tsx
@@ -180,6 +180,60 @@ describe('WorkflowPane (request layer)', () => {
     );
   });
 
+  it('disables execute mode until a trigger type is selected', async () => {
+    const workflows = { create: vi.fn(), update: vi.fn() };
+    holder.ctx = makeCtx({ workflows });
+
+    renderWithApp(
+      <WorkflowFormDrawer
+        mode="create"
+        plugin={mockPlugin as unknown as React.ComponentProps<typeof WorkflowFormDrawer>['plugin']}
+        categoryOptions={[]}
+        onSubmitted={() => undefined}
+      />,
+    );
+
+    const asynchronous = screen.getByRole('radio', { name: /Asynchronously/ });
+    const synchronous = screen.getByRole('radio', { name: /Synchronously/ });
+    expect(asynchronous).toBeDisabled();
+    expect(synchronous).toBeDisabled();
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Trigger type' }));
+    fireEvent.click(await screen.findByText('Collection event'));
+
+    await waitFor(() => {
+      expect(asynchronous).toBeEnabled();
+      expect(synchronous).toBeEnabled();
+    });
+  });
+
+  it('keeps execute mode disabled and enforces a trigger-defined mode', async () => {
+    const workflows = { create: vi.fn(), update: vi.fn() };
+    holder.ctx = makeCtx({ workflows });
+    const pluginWithForcedSync = {
+      triggers: { getEntities: () => [['forced-sync', { title: 'Forced sync' }]] },
+      getTriggerOptions: (type?: string) => (type === 'forced-sync' ? { title: 'Forced sync', sync: true } : undefined),
+    };
+
+    renderWithApp(
+      <WorkflowFormDrawer
+        mode="create"
+        type="forced-sync"
+        plugin={pluginWithForcedSync as unknown as React.ComponentProps<typeof WorkflowFormDrawer>['plugin']}
+        categoryOptions={[]}
+        onSubmitted={() => undefined}
+      />,
+    );
+
+    const asynchronous = screen.getByRole('radio', { name: /Asynchronously/ });
+    const synchronous = screen.getByRole('radio', { name: /Synchronously/ });
+    await waitFor(() => {
+      expect(asynchronous).toBeDisabled();
+      expect(synchronous).toBeDisabled();
+      expect(synchronous).toBeChecked();
+    });
+  });
+
   it('fires resource.update with the correct filterByTk on submit in edit mode', async () => {
     const workflows = { create: vi.fn(), update: vi.fn().mockResolvedValue({}) };
     holder.ctx = makeCtx({ workflows });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In the v2 workflow creation drawer, Execute mode was enabled before a Trigger type was selected. This allowed users to interact with an option whose availability depends on the trigger and differed from the v1 behavior.

### Description

- Disable Execute mode until a trigger type is selected.
- Enable Execute mode after selecting a trigger that allows users to choose the execution mode.
- Keep Execute mode disabled and enforce the configured value when a trigger defines a fixed execution mode.
- Add regression coverage for the unselected and trigger-defined execution mode states.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Disable workflow execution mode selection until a trigger type is selected. |
| 🇨🇳 Chinese | 在选择触发器类型前禁用工作流执行模式选项。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
