### PR TITLE
fix(client-v2): localize mobile cancel

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
@@ -291,6 +291,7 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
             value={searchText}
             onChange={handleSearchChange}
             onCancel={handleClose}
+            cancelText={t('Cancel')}
             showCancelButton
           />
         </div>

--- a/packages/core/client-v2/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
@@ -158,8 +158,15 @@ vi.mock('antd-mobile', () => {
       mockState.popupProps = props;
       return props.visible ? <div data-testid="popup">{props.children}</div> : null;
     },
-    SearchBar: ({ value, onChange }: any) => (
-      <input data-testid="search" value={value ?? ''} onChange={(e) => onChange?.(e.target.value)} />
+    SearchBar: ({ value, onChange, onCancel, cancelText, showCancelButton }: any) => (
+      <div>
+        <input data-testid="search" value={value ?? ''} onChange={(e) => onChange?.(e.target.value)} />
+        {showCancelButton && value ? (
+          <button type="button" onClick={onCancel}>
+            {cancelText ?? '取消'}
+          </button>
+        ) : null}
+      </div>
     ),
     CheckList: MockCheckList,
   };
@@ -287,6 +294,17 @@ describe('MobileSelect in SubForm/SubTable containers', () => {
 describe('MobileLazySelect', () => {
   beforeEach(() => {
     resetMockState();
+  });
+
+  it('renders a translated cancel action after searching', () => {
+    renderMobileLazySelect();
+
+    openLazyPopup();
+    act(() => {
+      fireEvent.change(screen.getByTestId('search'), { target: { value: '11' } });
+    });
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
   it('keeps pending relation records selected until confirm', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
在英文界面中，移动端关系字段打开选择列表并输入搜索内容后，搜索框右侧仍显示中文“取消”，造成同一界面中英文混用。

### Description 
- 让移动端选择列表的取消按钮跟随系统当前语言显示。
- 增加自动化测试，覆盖英文界面搜索后显示 `Cancel` 的场景。
- 该改动不影响选项加载、选择和确认行为，也不改变现有 API。

建议测试：将系统语言切换为英文，使用移动端视口打开多选关系字段，输入搜索内容，确认搜索框右侧显示 `Cancel`，底部 `Confirm` 按钮仍可正常使用。

### Showcase
已在 `en-US` 环境使用移动端视口回归：搜索后显示 `Cancel`，不再显示中文“取消”，底部 `Confirm` 按钮保持正常。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the cancel button language in mobile selection lists |
| 🇨🇳 Chinese | 修复移动端选择列表取消按钮语言不一致的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
