### PR TITLE
feat(plugin-verification): add refresh button

### DIFF
--- a/packages/plugins/@nocobase/plugin-verification/src/client-v2/__tests__/VerifiersPage.ui.test.tsx
+++ b/packages/plugins/@nocobase/plugin-verification/src/client-v2/__tests__/VerifiersPage.ui.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VerifiersPage from '../pages/VerifiersPage';
+
+const pageMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  refresh: vi.fn(),
+  resource: {
+    create: vi.fn(),
+    destroy: vi.fn(),
+    list: vi.fn(),
+    listTypes: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('@nocobase/client-v2', () => ({
+  DrawerFormLayout: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Table: () => <div role="table" />,
+  useApp: () => ({ pm: { get: () => undefined } }),
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  randomId: () => 'v_generated',
+  useFlowContext: () => ({
+    api: {
+      resource: () => pageMocks.resource,
+    },
+    viewer: {
+      drawer: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('ahooks', () => ({
+  useMemoizedFn: (fn: unknown) => fn,
+  useRequest: (_service: () => Promise<unknown>, options?: { cacheKey?: string }) => {
+    if (options?.cacheKey) {
+      return { data: [], loading: false, refresh: vi.fn() };
+    }
+    return {
+      data: { records: [], total: 0 },
+      loading: false,
+      refresh: pageMocks.refresh,
+    };
+  },
+}));
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return {
+    ...actual,
+    App: {
+      ...actual.App,
+      useApp: () => ({ modal: { confirm: pageMocks.confirm } }),
+    },
+    theme: {
+      ...actual.theme,
+      useToken: () => ({ token: { margin: 16, marginSM: 12 } }),
+    },
+  };
+});
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+  useVerificationTranslation: () => ({ t: (value: string) => value }),
+}));
+
+vi.mock('../plugin', () => ({
+  default: class PluginVerificationClientV2 {},
+}));
+
+describe('VerifiersPage toolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes the verifier list from the refresh button', () => {
+    render(<VerifiersPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+
+    expect(pageMocks.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-verification/src/client-v2/pages/VerifiersPage.tsx
+++ b/packages/plugins/@nocobase/plugin-verification/src/client-v2/pages/VerifiersPage.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { DeleteOutlined, DownOutlined, PlusOutlined } from '@ant-design/icons';
+import { DeleteOutlined, DownOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 import { DrawerFormLayout, Table, useApp } from '@nocobase/client-v2';
 import { randomId, useFlowContext } from '@nocobase/flow-engine';
 import { useMemoizedFn, useRequest } from 'ahooks';
@@ -369,6 +369,9 @@ export default function VerifiersPage() {
   return (
     <Card variant="borderless">
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: token.marginSM, marginBottom: token.margin }}>
+        <Button icon={<ReloadOutlined />} loading={loading} onClick={refresh}>
+          {t('Refresh')}
+        </Button>
         <Button
           icon={<DeleteOutlined />}
           disabled={!selectedRowKeys.length}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

验证设置中的验证配置列表缺少手动刷新入口。当列表数据在其他页面或会话中发生变化时，管理员无法直接获取最新内容。

### Description

- 在验证配置列表的工具栏中增加“刷新”按钮。
- 刷新时复用列表当前的加载状态，避免重复操作，并保持当前分页不变。
- 增加前端回归测试，覆盖刷新按钮显示及点击后重新加载列表的行为。

本次改动仅影响验证设置列表，风险较低。建议在验证设置页面点击“刷新”，确认列表重新加载，并检查“删除”和“新增”操作仍可正常使用。

### Showcase

刷新按钮显示在验证配置列表工具栏中，位于“删除”和“新增”按钮之前。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add a refresh button to the Verification settings list |
| 🇨🇳 Chinese | 为验证设置列表添加刷新按钮 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
