### PR TITLE
fix: duplicate backups from async exports

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/auto-backup.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/auto-backup.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Application } from '@nocobase/server';
+import { PluginBackupsServer } from '../plugin';
+
+type AppEventCallback = () => void | Promise<void>;
+
+function createPlugin() {
+  const callbacks = new Map<string, AppEventCallback>();
+  const repository = {
+    findOne: vi.fn().mockResolvedValue({ scheduled: true, cron: '0 0 * * *' }),
+  };
+  const app = {
+    context: {
+      reqId: undefined,
+    },
+    log: {
+      child: vi.fn().mockReturnValue({ info: vi.fn() }),
+    },
+    cacheManager: {
+      createCache: vi.fn().mockResolvedValue(undefined),
+    },
+    acl: {
+      addFixedParams: vi.fn(),
+    },
+    resourceManager: {
+      define: vi.fn(),
+    },
+    on: vi.fn((event: string, callback: AppEventCallback) => {
+      callbacks.set(event, callback);
+    }),
+    db: {
+      getRepository: vi.fn().mockReturnValue(repository),
+    },
+  } as unknown as Application;
+
+  return {
+    callbacks,
+    plugin: new PluginBackupsServer(app, { name: 'backups' }),
+    repository,
+  };
+}
+
+describe('automatic backup scheduling', () => {
+  let originalWorkerMode: string | undefined;
+
+  beforeEach(() => {
+    originalWorkerMode = process.env.WORKER_MODE;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    if (originalWorkerMode === undefined) {
+      delete process.env.WORKER_MODE;
+    } else {
+      process.env.WORKER_MODE = originalWorkerMode;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('should not schedule automatic backups in transient command workers', async () => {
+    process.env.WORKER_MODE = '-';
+    const { callbacks, plugin, repository } = createPlugin();
+
+    await plugin.load();
+    const beforeStart = callbacks.get('beforeStart');
+    expect(beforeStart).toBeDefined();
+    await beforeStart?.();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(repository.findOne).toHaveBeenCalledOnce();
+  });
+
+  it('should continue scheduling automatic backups in regular app processes', async () => {
+    delete process.env.WORKER_MODE;
+    const { callbacks, plugin, repository } = createPlugin();
+
+    await plugin.load();
+    const beforeStart = callbacks.get('beforeStart');
+    expect(beforeStart).toBeDefined();
+    await beforeStart?.();
+
+    expect(vi.getTimerCount()).toBe(1);
+    expect(repository.findOne).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-backups/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/plugin.ts
@@ -9,7 +9,7 @@
 
 import { Cache } from '@nocobase/cache';
 import { LockAcquireError, Releaser } from '@nocobase/lock-manager';
-import { Application, InstallOptions, Plugin } from '@nocobase/server';
+import { Application, InstallOptions, isTransient, Plugin } from '@nocobase/server';
 import parser from 'cron-parser';
 import _ from 'lodash';
 import path from 'path';
@@ -159,6 +159,9 @@ export class PluginBackupsServer extends Plugin {
 
   async #createBackupTimer(model?: BackupSettings): Promise<NodeJS.Timeout | null> {
     this.#cancelBackupTimer();
+    if (isTransient()) {
+      return null;
+    }
     const backupSettings: BackupSettings = model || (await this.db.getRepository(SETTINGS).findOne());
     if (backupSettings.scheduled && backupSettings.cron) {
       const interval = parser.parseExpression(backupSettings.cron, { currentDate: new Date() });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

### Description

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicate backups from async exports |
| 🇨🇳 Chinese | 修复异步导出任务触发重复自动备份的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |      |
| 🇨🇳 Chinese |    |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [ ] Test cases are updated/provided or not needed
- [ ] Doc is updated/provided or not needed
- [ ] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
