### PR TITLE
fix(plugin-multi-portal): use access placeholder

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/multiPortalPermissions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/multiPortalPermissions.test.tsx
@@ -145,7 +145,8 @@ describe('plugin-multi-portal route permissions', () => {
       </AntdApp>,
     );
 
-    expect(await screen.findByText('Managed by layout permissions')).toBeInTheDocument();
+    const desktopPortalRow = await screen.findByRole('row', { name: /Desktop portal/ });
+    expect(within(desktopPortalRow).getByText('-')).toBeInTheDocument();
     expect(screen.queryByRole('checkbox', { name: 'Allow access to Desktop portal' })).not.toBeInTheDocument();
 
     await act(async () => {

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/permissions/MultiPortalPermissionsTab.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/permissions/MultiPortalPermissionsTab.tsx
@@ -611,7 +611,7 @@ export default function MultiPortalPermissionsTab(props: PermissionTabProps) {
         title: t('Allow access'),
         render: (_, portal) => {
           if (hasLayoutRoutePermissions(portal)) {
-            return <Typography.Text type="secondary">{t('Managed by layout permissions')}</Typography.Text>;
+            return <Typography.Text type="secondary">-</Typography.Text>;
           }
           const portalTitle = getPortalTitle(portal.title, t);
           return (

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/locale/en-US.json
@@ -108,7 +108,6 @@
   "If selected, the page will display Tab pages.": "If selected, the page will display Tab pages.",
   "If selected, the route will be displayed in the menu.": "If selected, the route will be displayed in the menu.",
   "Link": "Link",
-  "Managed by layout permissions": "Managed by layout permissions",
   "Name": "Name",
   "Page": "Page",
   "Path": "Path",

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/locale/zh-CN.json
@@ -108,7 +108,6 @@
   "If selected, the page will display Tab pages.": "勾选后，页面将显示标签页。",
   "If selected, the route will be displayed in the menu.": "勾选后，路由会在菜单中显示。",
   "Link": "链接",
-  "Managed by layout permissions": "沿用布局权限",
   "Name": "名称",
   "Page": "页面",
   "Path": "路径",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

固定管理端门户的“允许访问”状态由布局权限统一控制，在门户权限表中不能直接勾选。当前显示的说明文案相比同类不可配置项较长，需要用更简洁的方式表达该状态。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- 将固定管理端门户的“允许访问”单元格改为短横线占位符
- 清理不再使用的中英文文案
- 更新单元测试，确认占位符正常显示且访问开关仍不出现
- 权限判断和路由权限配置逻辑保持不变，本次改动仅影响页面展示

建议重点检查固定管理端门户和其他门户在权限表中的“允许访问”列展示。

### Showcase
<!-- Including any screenshots of the changes. -->

不适用，仅调整表格中的文字占位符。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show a concise placeholder when Portal access cannot be configured directly |
| 🇨🇳 Chinese | 无法直接配置门户访问权限时显示简洁占位符 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
