### PR TITLE
perf(plugin-multi-portal): optimize access check

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/lifecycle.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/lifecycle.test.ts
@@ -9,6 +9,7 @@
 
 import { AppSupervisor } from '@nocobase/server';
 import { createMockServer, type MockServer } from '@nocobase/test';
+import { isDefaultLayoutMultiPortalUid } from '../../constants';
 
 async function createLifecycleServer() {
   return createMockServer({
@@ -79,14 +80,22 @@ describe('Multi Portal seed lifecycle', () => {
       }),
     ]);
     for (const portal of portals) {
-      expect(
-        await app.db.getRepository('rolesMultiPortals').count({
-          filter: { multiPortalUid: portal.get('uid') },
-        }),
-      ).toBeGreaterThan(0);
-      const routePolicyCount = await app.db.getRepository('rolesMultiPortalRoutePolicies').count({
-        filter: { multiPortalUid: portal.get('uid'), allowNewMenu: true },
+      const portalUid = portal.get('uid');
+      const accessCount = await app.db.getRepository('rolesMultiPortals').count({
+        filter: { multiPortalUid: portalUid },
       });
+      const routePolicyCount = await app.db.getRepository('rolesMultiPortalRoutePolicies').count({
+        filter: { multiPortalUid: portalUid, allowNewMenu: true },
+      });
+
+      const usesLayoutPermissions = isDefaultLayoutMultiPortalUid(portalUid);
+      if (usesLayoutPermissions) {
+        expect(accessCount).toBe(0);
+        expect(routePolicyCount).toBe(0);
+        continue;
+      }
+
+      expect(accessCount).toBeGreaterThan(0);
       if (portal.get('portalType') === 'no-code') {
         expect(routePolicyCount).toBeGreaterThan(0);
       } else {

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/plugin.test.ts
@@ -385,10 +385,11 @@ describe('plugin-multi-portal server', () => {
       allowNull: false,
     });
     expect(collection.getField('portalName')?.options.unique).toBeUndefined();
+    const portalNameIndexField = collection.model.rawAttributes.portalName.field;
     expect(collection.options.indexes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          fields: ['routeName'],
+          fields: [portalNameIndexField],
           unique: true,
         }),
       ]),

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/portalAccessGate.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/portalAccessGate.test.ts
@@ -195,6 +195,29 @@ describe('Portal access gate for roles:check', () => {
     });
   });
 
+  it('checks granted Portal access with an existence query', async () => {
+    const repository = app.db.getRepository('rolesMultiPortals');
+    const findOneSpy = vi.spyOn(repository, 'findOne');
+    const countSpy = vi.spyOn(repository, 'count');
+
+    try {
+      const response = await allowedAgent.get('/roles:check').set('X-Portal', 'portal-access-gate');
+
+      expect(response.status).toBe(200);
+      expect(findOneSpy).toHaveBeenCalledWith({
+        fields: ['id'],
+        filter: {
+          roleName: ['portal-gate-allowed'],
+          multiPortalUid: 'portal-access-gate',
+        },
+      });
+      expect(countSpy).not.toHaveBeenCalled();
+    } finally {
+      findOneSpy.mockRestore();
+      countSpy.mockRestore();
+    }
+  });
+
   it('applies the same access gate to AI Portals', async () => {
     const [allowedResponse, deniedResponse] = await Promise.all([
       allowedAgent.get('/roles:check').set('X-Portal', 'portal-access-ai'),

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
@@ -1553,13 +1553,14 @@ async function canAccessMultiPortal(ctx: ResourcerContext, multiPortalUid: strin
     return false;
   }
 
-  const count = await ctx.db.getRepository('rolesMultiPortals').count({
+  const access = await ctx.db.getRepository('rolesMultiPortals').findOne({
+    fields: ['id'],
     filter: {
       roleName: currentRoles,
       multiPortalUid,
     },
   });
-  return count > 0;
+  return access !== null;
 }
 
 function throwPortalAccessGateError(ctx: ResourcerContext, status: number, code: string, message: string): never {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Portal 访问权限检查只需要确认是否存在一条匹配的授权记录，当前实现会统计全部匹配记录，产生了不必要的查询工作。

### Description 
将 Portal 访问权限判断改为查询第一条匹配记录，并且只读取判断所需的最小数据。授权规则和用户可见行为保持不变。

补充回归测试，覆盖授权角色的存在性查询，并验证不再执行计数查询。同时修正测试初始化，避免与当前默认 Portal 数据重复。

建议测试已授权、未授权、联合角色和 root 角色访问 Portal 时的权限判断。

### Showcase
无界面变化。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve Portal access check efficiency |
| 🇨🇳 Chinese | 提升 Portal 访问权限检查效率 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
