### PR TITLE
fix(data-source-manager): preserve formula fields during database sync

### DIFF
--- a/packages/core/data-source-manager/src/__tests__/database-data-source.test.ts
+++ b/packages/core/data-source-manager/src/__tests__/database-data-source.test.ts
@@ -206,4 +206,52 @@ describe('database data source', () => {
       },
     });
   });
+
+  it('should preserve formula field type during resync', () => {
+    const dataSource = Object.create(DatabaseDataSource.prototype) as DatabaseDataSource;
+
+    const [mergedCollection] = dataSource.mergeWithLoadedCollections(
+      [
+        {
+          name: 'metrics',
+          tableName: 'metrics',
+          fields: [
+            {
+              name: 'total',
+              field: 'total',
+              rawType: 'DOUBLE PRECISION',
+              type: 'float',
+              interface: 'number',
+            },
+          ],
+        },
+      ],
+      {
+        metrics: {
+          name: 'metrics',
+          fields: [
+            {
+              name: 'total',
+              field: 'total',
+              rawType: '',
+              type: 'formula',
+              interface: 'formula',
+              dataType: 'double',
+              engine: 'formula.js',
+              expression: 'SUM({{amount}}, {{tax}})',
+            },
+          ],
+        },
+      },
+    );
+
+    expect(mergedCollection.fields[0]).toMatchObject({
+      name: 'total',
+      type: 'formula',
+      interface: 'formula',
+      dataType: 'double',
+      engine: 'formula.js',
+      expression: 'SUM({{amount}}, {{tax}})',
+    });
+  });
 });

--- a/packages/core/data-source-manager/src/database-data-source.ts
+++ b/packages/core/data-source-manager/src/database-data-source.ts
@@ -16,6 +16,8 @@ import { Context } from '@nocobase/actions';
 import { CollectionOptions, FieldOptions } from './types';
 import { SequelizeCollectionManager } from './sequelize-collection-manager';
 
+const PRESERVED_LOGICAL_FIELD_TYPES_ON_SYNC: readonly string[] = ['formula'];
+
 export abstract class DatabaseDataSource<T extends DatabaseIntrospector = DatabaseIntrospector> extends DataSource {
   declare introspector: T;
 
@@ -125,8 +127,9 @@ export abstract class DatabaseDataSource<T extends DatabaseIntrospector = Databa
       (modelOptions.rawType
         ? fieldOptions.rawType !== modelOptions.rawType && !hasCompatibleStorageType
         : !incomingPossibleTypes.includes(modelOptions.type) && !hasCompatibleStorageType);
+    const shouldPreserveLogicalType = PRESERVED_LOGICAL_FIELD_TYPES_ON_SYNC.includes(modelOptions.type);
 
-    if (shouldUseIncomingType) {
+    if (shouldUseIncomingType && !shouldPreserveLogicalType) {
       newOptions.type = fieldOptions.type;
       newOptions.interface = fieldOptions.interface;
       newOptions.rawType = fieldOptions.rawType;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Formula fields can be inferred as ordinary numeric fields when synchronizing collection fields from the database, which removes their formula behavior in the collection metadata.

### Description
- Preserve configured formula field types and interfaces during database field synchronization
- Keep other database-synchronized field attributes unchanged
- Add a regression test covering a formula field backed by a numeric database column

The main behavioral tradeoff is that direct physical type changes to formula columns no longer downgrade those fields to ordinary field types during synchronization.

Testing suggestion: create a formula field with double storage, synchronize its collection fields from the database, and verify that it remains a formula field.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed formula fields being converted to number fields after synchronizing fields from the database |
| 🇨🇳 Chinese | 修复从数据库同步字段后公式字段变为数字字段的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
