### PR TITLE
fix: unable to create portal from local

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6712,11 +6712,6 @@
     "@nocobase/license-kit-win32-ia32-msvc" "0.3.8"
     "@nocobase/license-kit-win32-x64-msvc" "0.3.8"
 
-"@nocobase/portal-template-default@^3.0.3":
-  version "3.0.4"
-  resolved "https://registry.npmmirror.com/@nocobase/portal-template-default/-/portal-template-default-3.0.4.tgz#d256960f13607e3c9db45a3f7f9ddd754b576b6c"
-  integrity sha512-sy+MB8zVHhwvrXy0GTkjfxQYv9mHph14GZTmvIYHIYwTxtWD9VCIU5G9CFwblVGdYPNAB+Ku6P6GckgbaDeKkw==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The locally installed default Portal template was pinned to version 3.0.4 in the root lockfile. That template uses an older Portal SDK request format that is incompatible with the current Portal access gate, causing newly created local AI Portals to fail while loading permissions.

### Description

Remove the `@nocobase/portal-template-default@^3.0.3` entry from `yarn.lock` so local dependency installation can resolve a current compatible template version from the declared semver range.

Risk: the resolved template version is determined by the package registry when the dependency is installed.

Testing:

- Confirmed the template lock entry is absent.
- Confirmed the declared `^3.0.3` range accepts the current `3.0.6` release.
- Confirmed the current registry version is `3.0.6`.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the issue unable to create portal from local |
| 🇨🇳 Chinese | 修复无法从本地创建 Portal 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
