### PR TITLE
fix(plugin-multi-portal): keep portal URL slug

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/MultiPortalsPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/MultiPortalsPage.test.tsx
@@ -278,7 +278,42 @@ describe('plugin-multi-portal settings page', () => {
     expect(getMultiPortalRouteUrl(app, '/nocobase/v/customer-portal')).toBe('/nocobase/v/customer-portal');
     expect(getMultiPortalRouteUrl(app, '/nocobase/x/customer-portal', 'ai')).toBe('/nocobase/x/customer-portal');
     expect(getMultiPortalRouteUrl(app, '/nocobase/v/customer-portal', 'ai')).toBe('/nocobase/x/customer-portal');
+    expect(getMultiPortalRouteUrl(app, '/nocobase/v/x', 'ai')).toBe('/nocobase/x/x');
+    expect(getMultiPortalRouteUrl(app, '/nocobase/x/v', 'no-code')).toBe('/nocobase/v/v');
+    expect(getMultiPortalRouteUrl(app, '/x', 'ai')).toBe('/nocobase/x/x');
+    expect(getMultiPortalRouteUrl(app, '/v', 'no-code')).toBe('/nocobase/v/v');
     expect(getMultiPortalSettingsUrl(app)).toBe('/nocobase/settings');
+  });
+
+  it('should not duplicate an exact Settings basename when no public path is available', () => {
+    expect(
+      getMultiPortalSettingsUrl({
+        router: {
+          getBasename: () => '/settings',
+        },
+      }),
+    ).toBe('/settings');
+  });
+
+  it.each([
+    ['ai', '/x', '/x/x'],
+    ['ai', '/v', '/x/v'],
+    ['no-code', '/x', '/v/x'],
+    ['no-code', '/v', '/v/v'],
+  ])(
+    'should keep a portal name that equals a client route prefix for %s portals',
+    (portalType, routePath, expected) => {
+      expect(getMultiPortalRouteUrl(undefined, routePath, portalType)).toBe(expected);
+    },
+  );
+
+  it.each([
+    ['ai', '/x/x'],
+    ['ai', '/x/v'],
+    ['no-code', '/v/x'],
+    ['no-code', '/v/v'],
+  ])('should keep an already resolved %s prefix-shaped portal URL unchanged', (portalType, routeUrl) => {
+    expect(getMultiPortalRouteUrl(undefined, routeUrl, portalType)).toBe(routeUrl);
   });
 
   it('should build sub-app portal hrefs from the app-scoped basename', () => {
@@ -292,6 +327,8 @@ describe('plugin-multi-portal settings page', () => {
 
     expect(getMultiPortalRouteUrl(app, '/admin', 'no-code')).toBe('/nocobase/v/apps/a_q7xx6p75d0e/admin');
     expect(getMultiPortalRouteUrl(app, '/test', 'ai')).toBe('/nocobase/x/apps/a_q7xx6p75d0e/test');
+    expect(getMultiPortalRouteUrl(app, '/v', 'no-code')).toBe('/nocobase/v/apps/a_q7xx6p75d0e/v');
+    expect(getMultiPortalRouteUrl(app, '/x', 'ai')).toBe('/nocobase/x/apps/a_q7xx6p75d0e/x');
     expect(getMultiPortalRouteUrl(app, '/nocobase/v/apps/a_q7xx6p75d0e/v/admin', 'no-code')).toBe(
       '/nocobase/v/apps/a_q7xx6p75d0e/admin',
     );
@@ -329,6 +366,7 @@ describe('plugin-multi-portal settings page', () => {
     expect(getMultiPortalRouteUrl(app, '/customer-portal/dashboard', 'no-code')).toBe(
       '/nocobase/modern/_app/demo/customer-portal/dashboard',
     );
+    expect(getMultiPortalRouteUrl(app, '/modern', 'no-code')).toBe('/nocobase/modern/_app/demo/modern');
   });
 
   it.each(['apps', '_app'])(

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/PortalRoutesDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/__tests__/PortalRoutesDrawer.test.tsx
@@ -323,6 +323,24 @@ describe('PortalRoutesDrawer', () => {
     expect(refreshAccessible).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['v', '/v', '/v/v/dashboard'],
+    ['x', '/x', '/v/x/dashboard'],
+  ])('keeps the prefix-shaped Portal %s name in route view URLs', async (portalName, routePath, expectedHref) => {
+    renderPortalRoutes({
+      title: `${portalName} portal`,
+      uid: `${portalName}-portal`,
+      portalType: 'no-code',
+      portalName,
+      routePath,
+      uiLayoutUid: 'admin-layout-model',
+      enabled: true,
+    });
+
+    const dashboardRow = await screen.findByRole('row', { name: /Dashboard/ });
+    expect(within(dashboardRow).getByRole('link', { name: 'View Dashboard' })).toHaveAttribute('href', expectedHref);
+  });
+
   it('uses mobile route rules and persists mobile links with the portal scope', async () => {
     const { drawer } = renderPortalRoutes({
       title: 'Mobile portal',

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/pages/PortalRoutesDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/pages/PortalRoutesDrawer.tsx
@@ -269,7 +269,7 @@ function joinPortalRoutePath(portalRoutePath: string, routePath: string) {
   return `${portalRoutePath.replace(/\/+$/, '')}/${routePath.replace(/^\/+/, '')}`;
 }
 
-function getRouteAccessPath(route: NocoBaseDesktopRoute, portal: MultiPortalRecord, routes: NocoBaseDesktopRoute[]) {
+function getRouteAccessPath(route: NocoBaseDesktopRoute, portalRoutePath: string, routes: NocoBaseDesktopRoute[]) {
   if (route.type === NocoBaseDesktopRouteType.group || route.type === NocoBaseDesktopRouteType.link) {
     return '';
   }
@@ -281,9 +281,9 @@ function getRouteAccessPath(route: NocoBaseDesktopRoute, portal: MultiPortalReco
     if (!parent?.schemaUid) {
       return '';
     }
-    return joinPortalRoutePath(portal.routePath, `${parent.schemaUid}/tab/${route.schemaUid}`);
+    return joinPortalRoutePath(portalRoutePath, `${parent.schemaUid}/tab/${route.schemaUid}`);
   }
-  return joinPortalRoutePath(portal.routePath, route.schemaUid);
+  return joinPortalRoutePath(portalRoutePath, route.schemaUid);
 }
 
 function filterRoutesByKeyword(routes: NocoBaseDesktopRoute[], keyword: string, t: ReturnType<typeof useT>) {
@@ -750,7 +750,7 @@ function PortalRoutesTable({ portal }: { portal: MultiPortalRecord }) {
         title: t('Path'),
         width: 320,
         render: (_value, route) => {
-          const path = getRouteAccessPath(route, portal, routes);
+          const path = getRouteAccessPath(route, portal.routePath, routes);
           return path ? (
             <Typography.Paragraph copyable ellipsis style={{ marginBottom: 0 }}>
               {path}
@@ -764,8 +764,10 @@ function PortalRoutesTable({ portal }: { portal: MultiPortalRecord }) {
         width: 260,
         render: (_value, route) => {
           const routeTitle = getRouteTitle(route, t);
-          const accessPath = getRouteAccessPath(route, portal, routes);
-          const accessHref = accessPath ? getMultiPortalRouteUrl(ctx.app, accessPath, portal.portalType) : '';
+          const accessPath = getRouteAccessPath(route, portal.routePath, routes);
+          const accessHref = accessPath
+            ? getRouteAccessPath(route, getMultiPortalRouteUrl(ctx.app, portal.routePath, portal.portalType), routes)
+            : '';
           return (
             <Space size="small">
               <Button

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/routeUrl.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/client-v2/routeUrl.ts
@@ -64,6 +64,15 @@ function getPortalRoutePrefixes() {
   );
 }
 
+function joinPortalRoutePath(basePath: string | undefined, pathname: string) {
+  const path = normalizeRootPath(pathname);
+  // A prefix-shaped routePath is a portal slug, so it must remain as a child segment instead of being deduplicated.
+  if (getPortalRoutePrefixes().includes(path)) {
+    return `${normalizeBasePath(basePath)}${path}`;
+  }
+  return joinRoutePath(basePath, path);
+}
+
 function getPortalTypeBasePath(basePath: string | undefined, portalType?: string | null, useTrailingAppScope = true) {
   const base = normalizeBasePath(basePath);
   const portalRoutePrefix = getPortalRoutePrefix(portalType);
@@ -125,11 +134,23 @@ function normalizePortalRoutePath(
   useTrailingAppScope = true,
 ) {
   let path = normalizeRootPath(routePath);
-  for (const base of [
+  const portalRoutePrefixes = getPortalRoutePrefixes();
+  const portalTypeBasePaths = [
     getPortalTypeBasePath(basePath, portalType, useTrailingAppScope),
     getPortalTypeBasePath(basePath, getAlternativePortalType(portalType), useTrailingAppScope),
-    ...getPortalRoutePrefixes(),
-  ]) {
+  ];
+  // A resolved root URL can come from either client prefix; preserve its prefix-shaped slug while switching types.
+  for (const portalTypeBasePath of portalTypeBasePaths) {
+    const pathWithoutPortalTypeBase = stripBasePath(path, portalTypeBasePath);
+    if (pathWithoutPortalTypeBase !== path && portalRoutePrefixes.includes(pathWithoutPortalTypeBase)) {
+      return pathWithoutPortalTypeBase;
+    }
+  }
+  // routePath stores the portal slug. Preserve prefix-shaped slugs so they remain the second URL segment.
+  if (portalRoutePrefixes.includes(path)) {
+    return path;
+  }
+  for (const base of [...portalTypeBasePaths, ...portalRoutePrefixes]) {
     path = stripBasePath(path, base);
   }
   return path;
@@ -182,7 +203,7 @@ export function getMultiPortalRouteUrl(
         })
       : basename;
     const useTrailingAppScope = shouldUseTrailingAppScope(app, basePath);
-    return joinRoutePath(
+    return joinPortalRoutePath(
       getPortalTypeBasePath(basePath, portalType, useTrailingAppScope),
       normalizePortalRoutePath(normalizedRoutePath, basePath, portalType, useTrailingAppScope),
     );
@@ -193,7 +214,7 @@ export function getMultiPortalRouteUrl(
     const routeUrlBasePath = getBasePathFromRouteUrl(routeUrl, normalizedRoutePath);
     if (routeUrlBasePath !== undefined) {
       const useTrailingAppScope = shouldUseTrailingAppScope(app, routeUrlBasePath);
-      return joinRoutePath(
+      return joinPortalRoutePath(
         getPortalTypeBasePath(routeUrlBasePath, portalType, useTrailingAppScope),
         normalizePortalRoutePath(normalizedRoutePath, routeUrlBasePath, portalType, useTrailingAppScope),
       );
@@ -203,7 +224,7 @@ export function getMultiPortalRouteUrl(
 
   const publicPath = app?.getPublicPath?.();
   const useTrailingAppScope = shouldUseTrailingAppScope(app, publicPath);
-  return joinRoutePath(
+  return joinPortalRoutePath(
     getPortalTypeBasePath(publicPath, portalType, useTrailingAppScope),
     normalizePortalRoutePath(normalizedRoutePath, publicPath, portalType, useTrailingAppScope),
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

当 Portal 名称与入口前缀相同，即 AI Portal 名称为 `x` 或 No-code Portal 名称为 `v` 时，Portal 管理页会把名称段从链接中省略，错误显示为 `/x/` 或 `/v/`，导致入口 URL 不正确。正确地址应分别为 `/x/x` 和 `/v/v`。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- 修正 Portal URL 的生成逻辑，在名称与入口前缀相同时保留名称段。
- 修正 Portal 路由抽屉中的页面链接生成方式，确保从正确的 Portal 根地址追加页面路径。
- 补充 `x`、`v`、完整根地址、子应用与普通 Portal 名称等场景的回归测试。

改动仅涉及 Multi-portal 插件的 Client V2 前端代码，不修改服务端、core 或 API。建议重点验证名称为 `x`、`v` 的 Portal 卡片及其页面路由，同时确认普通名称的 Portal 地址保持不变。

### Showcase
<!-- Including any screenshots of the changes. -->

已在本地 Portal 管理页完成浏览器回归：`x` 显示为 `/x/x`，`v` 显示为 `/v/v`，普通 Portal 地址未回归。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect Portal URLs when the name is x or v |
| 🇨🇳 Chinese | 修复 Portal 名称为 x 或 v 时 URL 不正确的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
