### PR TITLE
fix(database): restore through collection endpoints after restart

### DIFF
--- a/packages/core/database/src/fields/belongs-to-many-field.ts
+++ b/packages/core/database/src/fields/belongs-to-many-field.ts
@@ -147,6 +147,8 @@ export class BelongsToManyField extends RelationField {
 
     if (database.hasCollection(through)) {
       Through = database.getCollection(through);
+      Through.options.sourceCollectionName ??= this.collection.name;
+      Through.options.targetCollectionName ??= this.target;
     } else {
       const throughCollectionOptions = {
         name: through,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Auto-created many-to-many through collections persist without `sourceCollectionName` and `targetCollectionName`. After an application restart, the through collection already exists when `BelongsToManyField.bind()` runs, so those runtime options are not restored. Migration rule conversion then treats the through collection as schema-only and omits its relation data from migration packages.

### Description

- Backfill `sourceCollectionName` and `targetCollectionName` when binding a belongs-to-many field to an existing through collection.
- Use nullish assignment so valid endpoint metadata is preserved.
- Repair historical incomplete collection metadata at runtime after an application restart.

Risk is limited to auto-created through collections whose endpoint options are missing. Existing non-null endpoint values are unchanged.

Testing suggestions:

1. Create two collections connected by a many-to-many field and insert a relation row.
2. Restart the application.
3. Generate a migration package using an overwrite rule for user-defined collections.
4. Verify the through collection remains in overwrite mode and its exported data is non-empty.

### Related issues

- Regression test: https://github.com/nocobase/plugin-migration-manager/pull/39
- Original reproduction: https://github.com/nocobase/plugin-migration-manager/pull/38

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed migration packages omitting many-to-many through-table data after an application restart |
| 🇨🇳 Chinese | 修复应用重启后迁移包遗漏多对多中间表数据的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

### Verification

- `yarn eslint --fix packages/core/database/src/fields/belongs-to-many-field.ts`
- `yarn test packages/pro-plugins/@nocobase/plugin-migration-manager/src/server/__tests__/convert-to-migration-rules.test.ts --run --reporter=verbose` — 12 tests passed using the local workspace resolver override for the existing `commander` resolution issue.
- Live restart verification on `localhost:13001`: one linked row remained; the through collection migration rule was `overwrite`; exported payload was 273 bytes and contained relation inserts.
