### PR TITLE
fix(multi-portal): support legacy portal header

### DIFF
--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/portalAccessGate.test.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/__tests__/portalAccessGate.test.ts
@@ -97,31 +97,6 @@ describe('Portal access gate for roles:check', () => {
         uiLayoutUid: 'missing-layout',
       },
     });
-    await portalRepository.create({
-      values: {
-        uid: '__default_admin__',
-        title: 'Desktop layout',
-        portalType: 'no-code',
-        portalName: 'admin',
-        routePath: '/admin',
-        authCheck: true,
-        enabled: true,
-        uiLayoutUid: ADMIN_UI_LAYOUT_UID,
-      },
-    });
-    await portalRepository.create({
-      values: {
-        uid: '__default_mobile__',
-        title: 'Mobile layout',
-        portalType: 'no-code',
-        portalName: 'mobile',
-        routePath: '/mobile',
-        authCheck: true,
-        enabled: true,
-        uiLayoutUid: MOBILE_UI_LAYOUT_UID,
-      },
-    });
-
     const roleRepository = app.db.getRepository('roles');
     await roleRepository.create({ values: { name: 'portal-gate-allowed', allowNewMultiPortal: false } });
     await roleRepository.create({ values: { name: 'portal-gate-union-other', allowNewMultiPortal: false } });
@@ -235,6 +210,22 @@ describe('Portal access gate for roles:check', () => {
     ]);
   });
 
+  it('accepts the legacy /x/ prefix from older AI Portal templates', async () => {
+    const [allowedResponse, deniedResponse] = await Promise.all([
+      allowedAgent.get('/roles:check').set('X-Portal', '/x/portal-access-ai'),
+      deniedAgent.get('/roles:check').set('X-Portal', '/x/portal-access-ai'),
+    ]);
+
+    expect(allowedResponse.status).toBe(200);
+    expect(deniedResponse.status).toBe(403);
+    expect(deniedResponse.body.errors).toEqual([
+      expect.objectContaining({
+        code: 'PORTAL_ACCESS_DENIED',
+      }),
+    ]);
+    expect(deniedResponse.body.data.portalName).toBe('portal-access-ai');
+  });
+
   it('returns a structured minimal 403 response for a denied role', async () => {
     const baseline = await deniedAgent.get('/roles:check');
     const response = await deniedAgent.get('/roles:check').set('X-Portal', 'portal-access-gate');
@@ -258,7 +249,7 @@ describe('Portal access gate for roles:check', () => {
     expect(response.body.data).not.toHaveProperty('data');
   });
 
-  it.each(['', ' ', '/x/portal-access-gate', '/v/portal-access-gate', 'Portal'])(
+  it.each(['', ' ', '/x/', '/x/portal-access-gate/extra', '/v/portal-access-gate', 'Portal'])(
     'rejects invalid X-Portal value %j',
     async (portalName) => {
       const response = await deniedAgent.get('/roles:check').set('X-Portal', portalName);

--- a/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-multi-portal/src/server/plugin.ts
@@ -1573,8 +1573,13 @@ function getRequestedPortalNameFromHeader(ctx: ResourcerContext) {
     return;
   }
 
-  const portalName = headers['x-portal'];
-  if (typeof portalName !== 'string' || !MULTI_PORTAL_SLUG_PATTERN.test(portalName)) {
+  const rawPortalName = headers['x-portal'];
+  if (typeof rawPortalName !== 'string') {
+    throwPortalAccessGateError(ctx, 400, PORTAL_CONTEXT_INVALID_CODE, 'Invalid Portal context');
+  }
+
+  const portalName = rawPortalName.startsWith('/x/') ? rawPortalName.slice('/x/'.length) : rawPortalName;
+  if (!MULTI_PORTAL_SLUG_PATTERN.test(portalName)) {
     throwPortalAccessGateError(ctx, 400, PORTAL_CONTEXT_INVALID_CODE, 'Invalid Portal context');
   }
   return portalName;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

旧版 AI 门户模板发送的门户标识包含 `/x/` 前缀，访问权限检查会将其识别为无效参数，导致门户无法正常打开。

### Description 

- 兼容旧版 AI 门户模板发送的 `/x/<portalName>` 格式，并在权限检查前还原为门户名称
- 保持当前裸门户名称格式不变，`/v/` 前缀和其他非法格式仍会被拒绝
- 增加允许访问、拒绝访问和非法格式测试

### Showcase

不涉及界面改动。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix compatibility issues when older AI Portals check access permissions |
| 🇨🇳 Chinese | 修复旧版 AI 门户检查访问权限时的兼容性问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
