### PR TITLE
fix(ai): prevent chat entry from flashing during page loading

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/components/ChatButton.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/components/ChatButton.tsx
@@ -26,7 +26,8 @@ export const ChatButton: React.FC = observer(() => {
   const app = useApp();
   const ctx = useFlowContext<FlowRuntimeContext>();
   const t = useT();
-  const isV1Page = ctx?.pageInfo?.version === 'v1';
+  const pageVersion = ctx?.pageInfo?.version;
+  const isV1Page = pageVersion === undefined || pageVersion === 'v1';
   const { pathname } = useLocation();
   const publicPath = stripModernClientPrefix(app.getPublicPath()).replace(/\/$/, '');
   const browserPathname = window.location.pathname;
@@ -36,7 +37,8 @@ export const ChatButton: React.FC = observer(() => {
       : browserPathname;
   const modernClientPath = `/${getModernClientPrefix()}`;
   const isV2Route =
-    pathnameWithoutPublicPath === modernClientPath || pathnameWithoutPublicPath.startsWith(`${modernClientPath}/`);
+    pathnameWithoutPublicPath.startsWith(`${modernClientPath}/`) &&
+    pathnameWithoutPublicPath.length > modernClientPath.length + 1;
   const isAdmin = pathname.startsWith('/admin');
   const { isMobileLayout } = useMobileLayout();
   const { token } = theme.useToken();

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/stores/__tests__/chatbox-global-behavior.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/ai-employees/chatbox/stores/__tests__/chatbox-global-behavior.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   setResponseLoading: vi.fn(),
   switchAIEmployee: vi.fn(),
   publicPath: '/',
+  pageVersion: 'v2' as 'v1' | 'v2' | undefined,
 }));
 
 vi.mock('@nocobase/flow-engine', async () => {
@@ -27,7 +28,7 @@ vi.mock('@nocobase/flow-engine', async () => {
     ...actual,
     useFlowContext: () => ({
       pageInfo: {
-        version: 'v2',
+        version: mocks.pageVersion,
       },
     }),
   };
@@ -91,6 +92,7 @@ const renderWithRuntime = (runtime: ChatBoxRuntime, initialEntry = '/customer1')
 describe('global chatbox behavior', () => {
   beforeEach(() => {
     mocks.publicPath = '/';
+    mocks.pageVersion = 'v2';
     window.history.replaceState({}, '', '/v/customer1');
     mocks.getAIEmployees.mockResolvedValue(undefined);
     mocks.setResponseLoading.mockClear();
@@ -126,6 +128,24 @@ describe('global chatbox behavior', () => {
     renderWithRuntime(runtime, '/admin');
 
     expect(screen.getByRole('button', { name: 'Open AI chat' })).toBeTruthy();
+  });
+
+  it('hides the entry while the page version is unresolved', () => {
+    mocks.pageVersion = undefined;
+    const runtime = createChatBoxRuntime();
+
+    renderWithRuntime(runtime);
+
+    expect(screen.queryByRole('button', { name: 'Open AI chat' })).toBeNull();
+  });
+
+  it('hides the entry on the modern client root route', () => {
+    window.history.replaceState({}, '', '/v/');
+    const runtime = createChatBoxRuntime();
+
+    renderWithRuntime(runtime, '/');
+
+    expect(screen.queryByRole('button', { name: 'Open AI chat' })).toBeNull();
   });
 
   it('renders the entry when the V2 public path includes the modern client prefix', () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Prevent the global AI employee chat entry from briefly appearing while a page is still resolving or when the Modern Client is at its root route.

### Description
- Treat an unresolved page version as a legacy page so the chat entry remains hidden until the page type is known.
- Require a non-root Modern Client route before rendering the global chat entry.
- Add regression coverage for unresolved page versions and the `/v/` root route.

### Related issues
N/A

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the AI employee chat entry briefly appearing while a page is loading or redirecting. |
| 🇨🇳 Chinese | 修复页面加载或跳转期间 AI 员工聊天入口短暂闪现的问题。 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
