### PR TITLE
fix(client-v2): show plugin command loading

### DIFF
--- a/packages/core/client-v2/src/__tests__/app.test.tsx
+++ b/packages/core/client-v2/src/__tests__/app.test.tsx
@@ -379,35 +379,36 @@ describe('app', () => {
     expect(screen.getByText('maintaining dialog message')).toBeInTheDocument();
   });
 
-  it.each(['pm.enable', 'future.command'])(
-    'should keep current content without a default dialog while app commanding: %s',
-    async (commandName) => {
-      const CurrentPage = () => {
-        const [count, setCount] = React.useState(0);
-        return <button onClick={() => setCount((value) => value + 1)}>Current page count: {count}</button>;
-      };
+  it.each([
+    ['pm.enable', 'Enabling plugin'],
+    ['pm.disable', 'Disabling plugin'],
+    ['future.command', 'future.command'],
+  ])('should keep current content behind the default dialog while app commanding: %s', async (commandName, title) => {
+    const CurrentPage = () => {
+      const [count, setCount] = React.useState(0);
+      return <button onClick={() => setCount((value) => value + 1)}>Current page count: {count}</button>;
+    };
 
-      class PluginHelloClient extends Plugin {
-        async load() {
-          this.router.add('root', { path: '/', Component: CurrentPage });
-        }
+    class PluginHelloClient extends Plugin {
+      async load() {
+        this.router.add('root', { path: '/', Component: CurrentPage });
       }
-      const app = createMockClient({ plugins: [PluginHelloClient] });
-      await renderApp(app);
-      fireEvent.click(screen.getByRole('button', { name: 'Current page count: 0' }));
-      expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
+    }
+    const app = createMockClient({ plugins: [PluginHelloClient] });
+    await renderApp(app);
+    fireEvent.click(screen.getByRole('button', { name: 'Current page count: 0' }));
+    expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
 
-      act(() => {
-        app.maintained = true;
-        app.maintaining = true;
-        app.error = { code: 'APP_COMMANDING', command: { name: commandName }, message: 'starting sub applications...' };
-      });
+    act(() => {
+      app.maintained = true;
+      app.maintaining = true;
+      app.error = { code: 'APP_COMMANDING', command: { name: commandName }, message: 'starting sub applications...' };
+    });
 
-      expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-      expect(screen.queryByText(commandName === 'pm.enable' ? 'Enabling plugin' : commandName)).not.toBeInTheDocument();
-    },
-  );
+    expect(screen.getByRole('button', { name: 'Current page count: 1' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
 
   it('should keep current content without a dialog while app upgrading', async () => {
     const CurrentPage = () => <div>Current page</div>;

--- a/packages/core/client-v2/src/components/AppComponents.tsx
+++ b/packages/core/client-v2/src/components/AppComponents.tsx
@@ -31,6 +31,7 @@ interface AppErrorPayload {
 }
 
 const isAppCommanding = (error?: AppErrorPayload) => error?.code === 'APP_COMMANDING';
+const isAppUpgrading = (error?: AppErrorPayload) => isAppCommanding(error) && error?.command?.name === 'upgrade';
 
 export const AppSpin = () => {
   return (
@@ -232,7 +233,7 @@ export const AppMaintainingDialog: FC<{ app: Application; error: Error }> = obse
     if (component) {
       return app.renderComponent(component, { app, error });
     }
-    if (isAppCommanding(payload)) {
+    if (isAppUpgrading(payload)) {
       return null;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

在插件管理器中启用或禁用插件时，页面本身没有 Loading 状态。此前默认 Loading 弹窗对所有应用命令都被隐藏，导致插件操作期间没有任何可见反馈，用户无法判断操作是否仍在进行。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- 当页面没有自己的 Loading 状态时，为启用、禁用及其他插件命令恢复默认 Loading 弹窗。
- 升级页面已经有 Loading 状态，继续隐藏弹窗内的 Loading，避免重复显示。
- 保持自定义维护弹窗的优先级，并保持命令执行期间不显示“Try again”的原有行为。
- 更新相关测试，覆盖启用、禁用、未知命令和升级场景。改动只调整 Loading 弹窗的显示条件，不改变 API。

已通过 Client V2 相关单元测试、插件管理器回归测试、代码检查，并在本地插件管理页面完成真实浏览器验证。

### Showcase
<!-- Including any screenshots of the changes. -->

在插件管理页面点击启用开关后，会显示“Enabling plugin”弹窗；命令结束后弹窗自动消失。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show loading feedback when enabling or disabling plugins |
| 🇨🇳 Chinese | 启用或禁用插件时显示加载反馈 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
