### PR TITLE
fix: incorrect form field value variable resolution

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/form/FormBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/FormBlockModel.tsx
@@ -77,6 +77,10 @@ export class FormBlockModel<
 > extends CollectionBlockModel<T> {
   formValueRuntime?: FormValueRuntime;
 
+  serialize() {
+    return { ...super.serialize(), variableContractType: { type: 'form', use: this.use } };
+  }
+
   private userModifiedTopLevelFields = new Set<string>();
 
   get form() {

--- a/packages/core/client-v2/src/flow/models/blocks/form/FormGridModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/form/FormGridModel.tsx
@@ -21,6 +21,10 @@ export type DefaultFormGridStructure = {
 };
 
 export class FormGridModel<T extends DefaultFormGridStructure = DefaultFormGridStructure> extends GridModel<T> {
+  serialize() {
+    return { ...super.serialize(), variableContractType: { type: 'formGrid', use: this.use } };
+  }
+
   itemFallback = (<Skeleton.Input block size="small" style={{ marginBottom: '0.5rem' }} />);
   itemSettingsMenuLevel = 2;
   itemFlowSettings = {

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/__tests__/runtime.test.ts
@@ -445,6 +445,43 @@ describe('FormValueRuntime (default rules)', () => {
 });
 
 describe('FormValueRuntime (form assign rules)', () => {
+  it('uses the form grid as the variable contract owner', async () => {
+    const engineEmitter = new EventEmitter();
+    const formStub = createFormStub({ b: 'licensed' });
+    const onResolveJsonTemplate = vi.fn();
+    const blockModel: any = {
+      uid: 'form-contract-owner',
+      subModels: { grid: { uid: 'form-contract-owner-grid' } },
+      flowEngine: { emitter: engineEmitter },
+      emitter: new EventEmitter(),
+      dispatchEvent: vi.fn(),
+      getAclActionName: () => 'create',
+    };
+    const runtime = new FormValueRuntime({ model: blockModel, getForm: () => formStub as any });
+    const blockCtx = createFieldContext(runtime);
+    const resolveJsonTemplate = blockCtx.resolveJsonTemplate.bind(blockCtx);
+    blockCtx.defineMethod('resolveJsonTemplate', async (template: unknown, options?: unknown) => {
+      onResolveJsonTemplate(options);
+      return resolveJsonTemplate(template, options);
+    });
+    blockModel.context = blockCtx;
+    runtime.mount({ sync: true });
+
+    runtime.syncAssignRules([
+      {
+        key: 'license-version',
+        enable: true,
+        targetPath: 'a',
+        mode: 'assign',
+        condition: { logic: '$and', items: [] },
+        value: '__B__',
+      },
+    ]);
+
+    await waitFor(() => expect(formStub.getFieldValue(['a'])).toBe('licensed'));
+    expect(onResolveJsonTemplate).toHaveBeenCalledWith({ contractModelUid: 'form-contract-owner-grid' });
+  });
+
   it('migrates block-level rule to field instance on mount and restores on unmount', async () => {
     const engineEmitter = new EventEmitter();
     const blockEmitter = new EventEmitter();

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/rules.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/rules.ts
@@ -8,7 +8,14 @@
  */
 
 import { isObservable, reaction, toJS } from '@formily/reactive';
-import { FlowContext, FlowModel, isRunJSValue, normalizeRunJSValue, runjsWithSafeGlobals } from '@nocobase/flow-engine';
+import {
+  FlowContext,
+  FlowModel,
+  isRunJSValue,
+  normalizeRunJSValue,
+  runjsWithSafeGlobals,
+  type ResolveJsonTemplateOptions,
+} from '@nocobase/flow-engine';
 import { getValuesByPath } from '@nocobase/shared';
 import _ from 'lodash';
 import { dayjs } from '@nocobase/utils/client';
@@ -49,6 +56,7 @@ type RuntimeRule = {
   getValue: () => any;
   getCondition?: () => any;
   getContext: () => any;
+  getContractModelUid?: () => string | undefined;
 };
 
 type ObservableBinding = {
@@ -94,6 +102,7 @@ type RuntimeItemChain = {
 
 export type RuleEngineOptions = {
   getBlockModelUid: () => string;
+  getAssignRulesModelUid: () => string | undefined;
   getActionName: () => string | undefined;
   getBlockContext: () => any;
   getEngine: () => any;
@@ -217,6 +226,7 @@ export class RuleEngine {
         getValue: () => template?.value,
         getCondition: () => template?.condition,
         getContext: () => this.options.getBlockContext(),
+        getContractModelUid: this.options.getAssignRulesModelUid,
       };
 
       this.rules.set(id, { rule, state: { deps: new Set(), depDisposers: [], runSeq: 0, scheduledAtWriteSeq: 0 } });
@@ -554,6 +564,7 @@ export class RuleEngine {
           getValue: () => template?.value,
           getCondition: () => template?.condition,
           getContext: () => this.options.getBlockContext(),
+          getContractModelUid: this.options.getAssignRulesModelUid,
         };
 
         this.rules.set(id, { rule, state: { deps: new Set(), depDisposers: [], runSeq: 0, scheduledAtWriteSeq: 0 } });
@@ -922,6 +933,7 @@ export class RuleEngine {
           getValue: () => template?.value,
           getCondition: () => template?.condition,
           getContext: () => model?.context,
+          getContractModelUid: this.options.getAssignRulesModelUid,
         };
 
         this.rules.set(id, { rule, state: { deps: new Set(), depDisposers: [], runSeq: 0, scheduledAtWriteSeq: 0 } });
@@ -1671,7 +1683,7 @@ export class RuleEngine {
       }
     }
 
-    const evalCtx = this.createRuleEvaluationContext(baseCtx, collector, targetNamePath);
+    const evalCtx = this.createRuleEvaluationContext(baseCtx, collector, targetNamePath, rule.getContractModelUid?.());
     return { collector, evalCtx, rawValue, isRunJS };
   }
 
@@ -2010,7 +2022,12 @@ export class RuleEngine {
     return canOverwrite;
   }
 
-  private createRuleEvaluationContext(baseCtx: any, collector: DepCollector, targetNamePath: NamePath | null) {
+  private createRuleEvaluationContext(
+    baseCtx: any,
+    collector: DepCollector,
+    targetNamePath: NamePath | null,
+    contractModelUid?: string,
+  ) {
     const trackingFormValues = this.options.createTrackingFormValues(collector);
     const ctx: any = new FlowContext();
     try {
@@ -2030,12 +2047,19 @@ export class RuleEngine {
     }
 
     const delegatedResolveJsonTemplate =
-      typeof ctx.resolveJsonTemplate === 'function' ? ctx.resolveJsonTemplate.bind(ctx) : undefined;
+      typeof ctx.resolveJsonTemplate === 'function'
+        ? (ctx.resolveJsonTemplate.bind(ctx) as (
+            template: unknown,
+            options?: ResolveJsonTemplateOptions,
+          ) => Promise<unknown>)
+        : undefined;
     ctx.defineMethod('resolveJsonTemplate', async (template: unknown) => {
       const tokenStore = this.createLocalTemplateTokenStore();
       const localResolved = this.resolveLocalFormValuesTemplates(baseCtx, template, collector, tokenStore);
       const nextTemplate = localResolved.matched ? localResolved.value : template;
-      const resolved = delegatedResolveJsonTemplate ? await delegatedResolveJsonTemplate(nextTemplate) : nextTemplate;
+      const resolved = delegatedResolveJsonTemplate
+        ? await delegatedResolveJsonTemplate(nextTemplate, contractModelUid ? { contractModelUid } : undefined)
+        : nextTemplate;
       return this.restoreLocalTemplateTokens(resolved, tokenStore);
     });
 

--- a/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/runtime.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/form/value-runtime/runtime.ts
@@ -81,6 +81,10 @@ export class FormValueRuntime {
 
     this.ruleEngine = new RuleEngine({
       getBlockModelUid: () => String(this.model?.uid),
+      getAssignRulesModelUid: () => {
+        const grid = this.model?.subModels?.grid;
+        return !Array.isArray(grid) && grid?.uid ? String(grid.uid) : undefined;
+      },
       getActionName: () => this.model?.getAclActionName?.() ?? this.model?.context?.actionName,
       getBlockContext: () => this.model?.context,
       getEngine: () => this.model?.context?.engine,

--- a/packages/core/flow-engine/src/__tests__/objectVariable.test.ts
+++ b/packages/core/flow-engine/src/__tests__/objectVariable.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { generateFlowModelRdFromToken } from '@nocobase/utils/client';
 import { FlowContext } from '../flowContext';
 import { FlowEngine } from '../flowEngine';
 import {
@@ -122,7 +123,10 @@ describe('objectVariable utilities', () => {
 
     // Provide API stub to intercept variables:resolve
     const calls: any[] = [];
+    const payload = Buffer.from(JSON.stringify({ userId: 1, signInTime: 'contract-owner-test' })).toString('base64url');
+    const token = `test.${payload}.sig`;
     (ctx as any).api = {
+      auth: { token },
       request: vi.fn(async ({ url, data, method }) => {
         calls.push({ url, data, method });
         const batch = (data?.values?.batch as any[]) || [];
@@ -146,13 +150,14 @@ describe('objectVariable utilities', () => {
     });
 
     const template = { x: '{{ ctx.obj.author.name }}' } as any;
-    await (ctx as any).resolveJsonTemplate(template);
+    await (ctx as any).resolveJsonTemplate(template, { contractModelUid: 'form-grid' });
 
     // Assert variables:resolve was called with proper flattened contextParams
     expect((ctx as any).api.request).toHaveBeenCalled();
     const call = calls.find((c) => c.url === 'variables:resolve');
     expect(call).toBeTruthy();
     const batch0 = call.data?.values?.batch?.[0];
+    expect(batch0?.contractRd).toBe(generateFlowModelRdFromToken('form-grid', token));
     expect(batch0?.contextParams).toBeTruthy();
     // Flattened key should be 'obj.author'
     const cp = batch0.contextParams as Record<string, any>;

--- a/packages/core/flow-engine/src/flowContext.ts
+++ b/packages/core/flow-engine/src/flowContext.ts
@@ -165,6 +165,10 @@ function inferSelectsFromUsage(paths: string[] = []): { generatedAppends?: strin
 
 type Getter<T = any> = (ctx: FlowContext) => T | Promise<T>;
 
+export type ResolveJsonTemplateOptions = {
+  contractModelUid?: string | number | null;
+};
+
 export type FlowContextDocRef = string | { url: string; title?: string };
 
 export type FlowDeprecationDoc =
@@ -3046,7 +3050,7 @@ class BaseFlowEngineContext extends FlowContext {
    * @deprecated use `resolveJsonTemplate` instead
    */
   declare renderJson: (template: JSONValue) => Promise<any>;
-  declare resolveJsonTemplate: (template: JSONValue) => Promise<any>;
+  declare resolveJsonTemplate: (template: JSONValue, options?: ResolveJsonTemplateOptions) => Promise<any>;
   declare getVar: (path: string) => Promise<any>;
   declare request: (options: RequestOptions) => Promise<any>;
   declare runjs: (code: string, variables?: Record<string, any>, options?: JSRunnerOptions) => Promise<any>;
@@ -3229,7 +3233,11 @@ export class FlowEngineContext extends BaseFlowEngineContext {
     this.defineMethod('renderJson', function (template: any) {
       return this.resolveJsonTemplate(template);
     });
-    this.defineMethod('resolveJsonTemplate', async function (this: BaseFlowEngineContext, template: any) {
+    const resolveJsonTemplate = async function (
+      this: BaseFlowEngineContext,
+      template: any,
+      options?: ResolveJsonTemplateOptions,
+    ) {
       // 提取模板使用到的变量及其子路径
       const used = extractUsedVariablePaths(template);
       const usedVarNames = Object.keys(used || {});
@@ -3398,7 +3406,12 @@ export class FlowEngineContext extends BaseFlowEngineContext {
 
         if (this.api) {
           try {
+            const contractRd = buildFlowModelResolveDescriptor(
+              this as FlowRuntimeContext<FlowModel>,
+              options?.contractModelUid,
+            );
             serverResolved = await enqueueVariablesResolve(this as FlowRuntimeContext<FlowModel>, {
+              ...(contractRd ? { contractRd } : {}),
               rd: buildFlowModelResolveDescriptor(this as FlowRuntimeContext<FlowModel>, this.model?.uid),
               template,
               contextParams: autoContextParams || {},
@@ -3411,7 +3424,8 @@ export class FlowEngineContext extends BaseFlowEngineContext {
       }
 
       return resolveExpressions(serverResolved, this);
-    });
+    };
+    this.defineMethod('resolveJsonTemplate', resolveJsonTemplate);
 
     // Helper: resolve a single ctx expression value via resolveJsonTemplate behavior.
     // Example: await ctx.getVar('ctx.record.id')

--- a/packages/core/flow-engine/src/utils/params-resolvers.ts
+++ b/packages/core/flow-engine/src/utils/params-resolvers.ts
@@ -79,6 +79,7 @@ export type JSONValue = string | { [key: string]: JSONValue } | JSONValue[];
 // =========================
 
 type BatchPayload = {
+  contractRd?: string;
   rd?: string;
   template: JSONValue;
   contextParams?: ServerContextParams | undefined;
@@ -172,6 +173,7 @@ export function enqueueVariablesResolve(ctx: FlowRuntimeContext, payload: BatchP
     try {
       const batch = items.map((it) => ({
         id: it.id,
+        contractRd: it.payload.contractRd,
         rd: it.payload.rd,
         template: it.payload.template,
         contextParams: it.payload.contextParams || {},

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -228,6 +228,139 @@ describe('variables:resolve allow-list authorization', () => {
     expect(result.contextParams).not.toHaveProperty('user');
   });
 
+  it('uses a related form grid as the assign-rules contract owner', async () => {
+    const session = createTokenSession();
+    const template = '{{ ctx.user.company.authorizedVersion }}';
+    const form = { ...createFlowModel('form-owner', {}), options: { use: 'EditFormModel' } };
+    const grid = {
+      ...createFlowModel('form-owner-grid', {}),
+      options: {
+        use: 'FormGridModel',
+        props: '{{ ctx.user.unconfigured }}',
+        stepParams: {
+          formModelSettings: {
+            assignRules: {
+              value: [
+                { value: template },
+                {
+                  value: {
+                    code: "return await ctx.getVar('ctx.user.runJsAuthorized')",
+                    version: 'v2',
+                  },
+                },
+                {
+                  value: {
+                    code: '// {{ ctx.user.password }}\nreturn 1',
+                    version: 'v2',
+                  },
+                },
+                {
+                  value: {
+                    value: [
+                      {
+                        value: {
+                          code: "return await ctx.getVar('ctx.user.nestedBusinessObject')",
+                          version: 'v2',
+                        },
+                      },
+                    ],
+                    payload: {
+                      stepParams: {
+                        jsSettings: {
+                          runJs: {
+                            code: "return await ctx.getVar('ctx.user.nestedRunJsShape')",
+                            version: 'v2',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      parentId: form.uid,
+      subKey: 'grid',
+    };
+    const field = {
+      ...createFlowModel('form-owner-field', {}),
+      options: { use: 'FormItemModel' },
+      parentId: grid.uid,
+      subKey: 'items',
+    };
+    const otherForm = { ...createFlowModel('other-form', {}), options: { use: 'EditFormModel' } };
+    const otherGrid = {
+      ...grid,
+      uid: 'other-form-grid',
+      parentId: otherForm.uid,
+    };
+    const markdownBlock = {
+      ...grid,
+      uid: 'markdown-block',
+      options: { ...grid.options, use: 'MarkdownBlockModel' },
+      parentId: 'block-grid',
+    };
+    const blockGrid = { ...createFlowModel('block-grid', {}), options: { use: 'BlockGridModel' } };
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: Object.fromEntries(
+        [form, grid, field, otherForm, otherGrid, blockGrid, markdownBlock].map((model) => [model.uid, model]),
+      ),
+    });
+
+    const allowed = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template,
+    });
+    const crossForm = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(otherGrid.uid),
+      rd: session.rd(field.uid),
+      template,
+    });
+    const unconfigured = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template: '{{ ctx.user.unconfigured }}',
+    });
+    const runJsAuthorized = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template: '{{ ctx.user.runJsAuthorized }}',
+    });
+    const runJsComment = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template: '{{ ctx.user.password }}',
+    });
+    const nestedBusinessObject = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template: '{{ ctx.user.nestedBusinessObject }}',
+    });
+    const nestedRunJsShape = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template: '{{ ctx.user.nestedRunJsShape }}',
+    });
+    const nonFormTree = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(markdownBlock.uid),
+      rd: session.rd(markdownBlock.uid),
+      template,
+    });
+
+    expect(allowed.allowed).toBe(true);
+    expect(crossForm.allowed).toBe(false);
+    expect(unconfigured.allowed).toBe(false);
+    expect(runJsAuthorized.allowed).toBe(true);
+    expect(runJsComment.allowed).toBe(false);
+    expect(nestedBusinessObject.allowed).toBe(false);
+    expect(nestedRunJsShape.allowed).toBe(false);
+    expect(nonFormTree.allowed).toBe(false);
+  });
+
   it('keeps registered variable contextParams sanitized after later validators mutate them', async () => {
     variables.register({
       name: 'evil',

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -26,7 +26,7 @@ type FakeCtxOptions = {
   allowConfigure?: boolean;
   currentRole?: string;
   fieldKinds?: Record<string, 'association' | 'field'>;
-  findModelByParentId?: (parentUid: string, options?: { subKey?: string }) => Promise<unknown>;
+  findModelNodeSnapshotByParentId?: (parentUid: string, options?: { subKey?: string }) => Promise<unknown>;
   findModelNodeSnapshotById?: (uid: string) => Promise<unknown>;
   findRoles?: () => Promise<unknown[]>;
   models?: Record<string, unknown>;
@@ -82,8 +82,8 @@ function createFakeCtx(options: FakeCtxOptions = {}) {
         if (name === 'flowModels') {
           return {
             repository: {
-              findModelByParentId:
-                options.findModelByParentId ||
+              findModelNodeSnapshotByParentId:
+                options.findModelNodeSnapshotByParentId ||
                 (async (parentUid: string, query?: { subKey?: string }) => {
                   const child = Object.values(models).find((model) => {
                     if (!model || typeof model !== 'object' || Array.isArray(model)) return false;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -26,6 +26,7 @@ type FakeCtxOptions = {
   allowConfigure?: boolean;
   currentRole?: string;
   fieldKinds?: Record<string, 'association' | 'field'>;
+  findModelByParentId?: (parentUid: string, options?: { subKey?: string }) => Promise<unknown>;
   findModelNodeSnapshotById?: (uid: string) => Promise<unknown>;
   findRoles?: () => Promise<unknown[]>;
   models?: Record<string, unknown>;
@@ -81,6 +82,16 @@ function createFakeCtx(options: FakeCtxOptions = {}) {
         if (name === 'flowModels') {
           return {
             repository: {
+              findModelByParentId:
+                options.findModelByParentId ||
+                (async (parentUid: string, query?: { subKey?: string }) => {
+                  const child = Object.values(models).find((model) => {
+                    if (!model || typeof model !== 'object' || Array.isArray(model)) return false;
+                    const node = model as { parentId?: unknown; subKey?: unknown };
+                    return node.parentId === parentUid && (!query?.subKey || node.subKey === query.subKey);
+                  });
+                  return child || null;
+                }),
               findModelNodeSnapshotById:
                 options.findModelNodeSnapshotById || (async (uid: string) => models[uid] || null),
             },
@@ -359,6 +370,171 @@ describe('variables:resolve allow-list authorization', () => {
     expect(nestedBusinessObject.allowed).toBe(false);
     expect(nestedRunJsShape.allowed).toBe(false);
     expect(nonFormTree.allowed).toBe(false);
+  });
+
+  it('supports assign rules persisted on the legacy form root', async () => {
+    const session = createTokenSession();
+    const template = '{{ ctx.user.company.authorizedVersion }}';
+    const form = {
+      ...createFlowModel('legacy-form', {}),
+      options: {
+        use: 'EditFormModel',
+        stepParams: { formModelSettings: { assignRules: { value: [{ value: template }] } } },
+      },
+    };
+    const grid = {
+      ...createFlowModel('legacy-form-grid', {}),
+      options: { use: 'FormGridModel' },
+      parentId: form.uid,
+      subKey: 'grid',
+    };
+    const field = {
+      ...createFlowModel('legacy-form-field', {}),
+      options: { use: 'FormItemModel' },
+      parentId: grid.uid,
+      subKey: 'items',
+    };
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: Object.fromEntries([form, grid, field].map((model) => [model.uid, model])),
+    });
+
+    const result = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(grid.uid),
+      rd: session.rd(field.uid),
+      template,
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it('follows a related reference form grid to its persisted assign rules', async () => {
+    const session = createTokenSession();
+    const template = '{{ ctx.user.company.authorizedVersion }}';
+    const hostForm = { ...createFlowModel('reference-host-form', {}), options: { use: 'EditFormModel' } };
+    const referenceGrid = {
+      ...createFlowModel('reference-host-grid', {}),
+      options: {
+        use: 'ReferenceFormGridModel',
+        stepParams: {
+          referenceSettings: {
+            useTemplate: {
+              mode: 'reference',
+              targetPath: 'subModels.grid',
+              targetUid: 'reference-target-form',
+              templateUid: 'reference-template',
+            },
+          },
+        },
+      },
+      parentId: hostForm.uid,
+      subKey: 'grid',
+    };
+    const targetForm = { ...createFlowModel('reference-target-form', {}), options: { use: 'FormBlockModel' } };
+    const targetGrid = {
+      ...createFlowModel('reference-target-grid', {}),
+      options: {
+        use: 'FormGridModel',
+        stepParams: { formModelSettings: { assignRules: { value: [{ value: template }] } } },
+      },
+      parentId: targetForm.uid,
+      subKey: 'grid',
+    };
+    const targetField = {
+      ...createFlowModel('reference-target-field', {}),
+      options: { use: 'FormItemModel' },
+      parentId: targetGrid.uid,
+      subKey: 'items',
+    };
+    const unrelatedForm = { ...createFlowModel('reference-unrelated-form', {}), options: { use: 'EditFormModel' } };
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: Object.fromEntries(
+        [hostForm, referenceGrid, targetForm, targetGrid, targetField, unrelatedForm].map((model) => [
+          model.uid,
+          model,
+        ]),
+      ),
+    });
+
+    const fromHost = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(referenceGrid.uid),
+      rd: session.rd(hostForm.uid),
+      template,
+    });
+    const fromTargetField = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(referenceGrid.uid),
+      rd: session.rd(targetField.uid),
+      template,
+    });
+    const fromUnrelatedForm = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(referenceGrid.uid),
+      rd: session.rd(unrelatedForm.uid),
+      template,
+    });
+
+    expect(fromHost.allowed).toBe(true);
+    expect(fromTargetField.allowed).toBe(true);
+    expect(fromUnrelatedForm.allowed).toBe(false);
+  });
+
+  it('falls back to legacy host form rules when a referenced template has none', async () => {
+    const session = createTokenSession();
+    const template = '{{ ctx.user.company.authorizedVersion }}';
+    const hostForm = {
+      ...createFlowModel('legacy-reference-host-form', {}),
+      options: {
+        use: 'EditFormModel',
+        stepParams: { formModelSettings: { assignRules: { value: [{ value: template }] } } },
+      },
+    };
+    const referenceGrid = {
+      ...createFlowModel('legacy-reference-host-grid', {}),
+      options: {
+        use: 'ReferenceFormGridModel',
+        stepParams: {
+          referenceSettings: {
+            useTemplate: {
+              targetPath: 'subModels.grid',
+              targetUid: 'legacy-reference-target-form',
+              templateUid: 'legacy-reference-template',
+            },
+          },
+        },
+      },
+      parentId: hostForm.uid,
+      subKey: 'grid',
+    };
+    const targetForm = {
+      ...createFlowModel('legacy-reference-target-form', {}),
+      options: { use: 'FormBlockModel' },
+    };
+    const targetGrid = {
+      ...createFlowModel('legacy-reference-target-grid', {}),
+      options: { use: 'FormGridModel' },
+      parentId: targetForm.uid,
+      subKey: 'grid',
+    };
+    const targetField = {
+      ...createFlowModel('legacy-reference-target-field', {}),
+      options: { use: 'FormItemModel' },
+      parentId: targetGrid.uid,
+      subKey: 'items',
+    };
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: Object.fromEntries(
+        [hostForm, referenceGrid, targetForm, targetGrid, targetField].map((model) => [model.uid, model]),
+      ),
+    });
+
+    const result = await authorizeVariablesResolve(ctx, {
+      contractRd: session.rd(referenceGrid.uid),
+      rd: session.rd(targetField.uid),
+      template,
+    });
+
+    expect(result.allowed).toBe(true);
   });
 
   it('keeps registered variable contextParams sanitized after later validators mutate them', async () => {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/plugin.ts
@@ -63,7 +63,12 @@ export class PluginFlowEngineServer extends PluginUISchemaStorageServer {
 
   async resolveFlowModelVariablesTemplate(
     ctx: ResourcerContext,
-    options: { contextParams?: Record<string, unknown>; rd?: string | number; template: JSONValue },
+    options: {
+      contractRd?: string | number;
+      contextParams?: Record<string, unknown>;
+      rd?: string | number;
+      template: JSONValue;
+    },
   ) {
     this.ensureRecordSlotResolvers(ctx.app);
     return await resolveFlowModelVariablesTemplate(ctx, options);
@@ -93,7 +98,7 @@ export class PluginFlowEngineServer extends PluginUISchemaStorageServer {
         resolve: async (ctx, next) => {
           this.ensureRecordSlotResolvers(ctx.app);
           // 仅保留两种提交方式：
-          // 1) values.batch: [{ id?, template, contextParams }]
+          // 1) values.batch: [{ id?, rd?, contractRd?, template, contextParams }]
           // 2) values.template + values.contextParams
           const raw = ctx.action?.params?.values ?? {};
           const values = typeof raw?.values !== 'undefined' ? raw.values : raw;
@@ -101,6 +106,7 @@ export class PluginFlowEngineServer extends PluginUISchemaStorageServer {
           // 批量解析分支
           if (Array.isArray(values?.batch)) {
             const batchItems = values.batch as Array<{
+              contractRd?: string;
               rd?: string;
               id?: string | number;
               template: JSONValue;
@@ -120,6 +126,7 @@ export class PluginFlowEngineServer extends PluginUISchemaStorageServer {
             for (const [index, item] of batchItems.entries()) {
               const template = item?.template ?? {};
               const authorization = await authorizeVariablesResolve(ctx as ResourcerContext, {
+                contractRd: item?.contractRd,
                 contextParams: item?.contextParams || {},
                 rd: item?.rd,
                 template,
@@ -176,6 +183,7 @@ export class PluginFlowEngineServer extends PluginUISchemaStorageServer {
           const template = values.template as JSONValue;
           const contextParams = values?.contextParams || {};
           const authorization = await authorizeVariablesResolve(ctx as ResourcerContext, {
+            contractRd: values?.contractRd,
             contextParams,
             rd: values?.rd,
             template,

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/repository.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/repository.ts
@@ -1818,7 +1818,7 @@ WHERE TreeTable.depth = 1 AND  TreeTable.ancestor = :ancestor and TreeTable.sort
     };
   }
 
-  async findModelByParentId(parentUid: string, options?: GetJsonSchemaOptions & { subKey?: string }) {
+  private async findModelUidByParentId(parentUid: string, options?: Transactionable & { subKey?: string }) {
     const r = this.database.getRepository('flowModelTreePath');
     const treePaths = await r.model.findAll({
       where: {
@@ -1840,10 +1840,22 @@ WHERE TreeTable.depth = 1 AND  TreeTable.ancestor = :ancestor and TreeTable.sort
       transaction: options?.transaction,
     });
     if (treePath?.['descendant']) {
-      // if parentUid is a leaf node, return the first child
-      return this.findModelById(treePath['descendant'], options);
+      return treePath['descendant'] as string;
     }
     return null;
+  }
+
+  async findModelNodeSnapshotByParentId(
+    parentUid: string,
+    options?: Transactionable & { subKey?: string },
+  ): Promise<FlowModelNodeSnapshot | null> {
+    const uid = await this.findModelUidByParentId(parentUid, options);
+    return uid ? this.findModelNodeSnapshotById(uid, options) : null;
+  }
+
+  async findModelByParentId(parentUid: string, options?: GetJsonSchemaOptions & { subKey?: string }) {
+    const uid = await this.findModelUidByParentId(parentUid, options);
+    return uid ? this.findModelById(uid, options) : null;
   }
 
   @transaction()

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -114,9 +114,32 @@ function readFormAssignRulesVariableSource(node: FlowModelNodeSnapshot): unknown
     : undefined;
 }
 
+function hasFlowModelUse(node: FlowModelNodeSnapshot) {
+  const use = node.options.use;
+  return typeof use === 'string' && !!use.trim();
+}
+
+function matchesVariableContractType(node: FlowModelNodeSnapshot, type: string): boolean | undefined {
+  const marker = node.options.variableContractType;
+  if (typeof marker === 'undefined') return undefined;
+  return isObject(marker) && marker.type === type && marker.use === node.options.use;
+}
+
 function isFormGridNode(node: FlowModelNodeSnapshot) {
   const use = node.options.use;
-  return node.subKey === 'grid' && typeof use === 'string' && use.endsWith('GridModel');
+  const markerMatches = matchesVariableContractType(node, 'formGrid');
+  return (
+    node.subKey === 'grid' &&
+    hasFlowModelUse(node) &&
+    (markerMatches === true ||
+      (typeof markerMatches === 'undefined' && typeof use === 'string' && use.endsWith('GridModel')))
+  );
+}
+
+function getReferenceFormUseTemplate(node: FlowModelNodeSnapshot) {
+  const stepParams = isObject(node.options.stepParams) ? node.options.stepParams : null;
+  const referenceSettings = stepParams && isObject(stepParams.referenceSettings) ? stepParams.referenceSettings : null;
+  return referenceSettings && isObject(referenceSettings.useTemplate) ? referenceSettings.useTemplate : null;
 }
 
 function isReferenceFormGridNode(node: FlowModelNodeSnapshot) {
@@ -125,10 +148,7 @@ function isReferenceFormGridNode(node: FlowModelNodeSnapshot) {
 }
 
 function getReferenceFormGridTargetUid(node: FlowModelNodeSnapshot) {
-  const stepParams = isObject(node.options.stepParams) ? node.options.stepParams : null;
-  const referenceSettings = stepParams && isObject(stepParams.referenceSettings) ? stepParams.referenceSettings : null;
-  const useTemplate =
-    referenceSettings && isObject(referenceSettings.useTemplate) ? referenceSettings.useTemplate : null;
+  const useTemplate = getReferenceFormUseTemplate(node);
   const templateUid = useTemplate && typeof useTemplate.templateUid === 'string' ? useTemplate.templateUid.trim() : '';
   if (!useTemplate || !templateUid) return '';
   const targetPath = typeof useTemplate.targetPath === 'string' ? useTemplate.targetPath.trim() : '';
@@ -138,7 +158,18 @@ function getReferenceFormGridTargetUid(node: FlowModelNodeSnapshot) {
 
 function isFormAssignRulesOwnerNode(node: FlowModelNodeSnapshot) {
   const use = node.options.use;
-  return typeof use === 'string' && (use.endsWith('FormModel') || use.endsWith('FormBlockModel'));
+  const markerMatches = matchesVariableContractType(node, 'form');
+  return (
+    hasFlowModelUse(node) &&
+    (markerMatches === true ||
+      (typeof markerMatches === 'undefined' &&
+        typeof use === 'string' &&
+        (use.endsWith('FormModel') || use.endsWith('FormBlockModel'))))
+  );
+}
+
+function isFormAssignRulesContractPair(formNode: FlowModelNodeSnapshot, gridNode: FlowModelNodeSnapshot) {
+  return isFormAssignRulesOwnerNode(formNode) && isFormGridNode(gridNode) && gridNode.parentId === formNode.uid;
 }
 
 function isFormAssignRulesRunJsValuePath(pathTail: readonly string[]) {
@@ -231,10 +262,7 @@ async function getFlowModelChildNode(ctx: ResourcerContext, parentUid: string, s
   const childCacheKey = JSON.stringify([parentUid, subKey]);
   if (cache.has(childCacheKey)) return (await cache.get(childCacheKey)) || null;
 
-  const load = (async () => {
-    const child = await getFlowModelRepository(ctx).findModelByParentId(parentUid, { subKey });
-    return isObject(child) && typeof child.uid === 'string' ? getFlowModelNode(ctx, child.uid) : null;
-  })();
+  const load = getFlowModelRepository(ctx).findModelNodeSnapshotByParentId(parentUid, { subKey });
   cache.set(childCacheKey, load);
   const child = await load;
   cache.set(childCacheKey, child);
@@ -258,13 +286,23 @@ async function loadFlowModelAncestors(ctx: ResourcerContext, currentNode: FlowMo
   return Object.freeze(ancestors);
 }
 
+async function loadFlowModelAncestorUids(ctx: ResourcerContext, currentNode: FlowModelNodeSnapshot) {
+  try {
+    return new Set((await loadFlowModelAncestors(ctx, currentNode)).map((ancestor) => ancestor.uid));
+  } catch {
+    return null;
+  }
+}
+
 async function resolveFormAssignRulesVariableSource(ctx: ResourcerContext, contractNode: FlowModelNodeSnapshot) {
   const fromGrid = readFormAssignRulesVariableSource(contractNode);
   if (typeof fromGrid !== 'undefined') return fromGrid;
   if (!contractNode.parentId) return undefined;
 
   const formNode = await getFlowModelNode(ctx, contractNode.parentId);
-  return formNode && isFormAssignRulesOwnerNode(formNode) ? readFormAssignRulesVariableSource(formNode) : undefined;
+  return formNode && isFormAssignRulesContractPair(formNode, contractNode)
+    ? readFormAssignRulesVariableSource(formNode)
+    : undefined;
 }
 
 function createRecordSlotCompilerOptions(ctx: ResourcerContext, currentNode?: FlowModelNodeSnapshot) {
@@ -425,23 +463,21 @@ async function resolveFormAssignRulesContractNode(
   if (!contractNode || !contractNode.parentId || !isFormGridNode(contractNode)) return null;
 
   const formNode = await getFlowModelNode(ctx, contractNode.parentId);
-  if (!formNode || !isFormAssignRulesOwnerNode(formNode)) return null;
-
-  let ancestorUids: ReadonlySet<string> | null = null;
-  try {
-    const ancestors = await loadFlowModelAncestors(ctx, runtimeNode);
-    ancestorUids = new Set(ancestors.map((ancestor) => ancestor.uid));
-  } catch {
-    ancestorUids = null;
-  }
+  if (!formNode || !isFormAssignRulesContractPair(formNode, contractNode)) return null;
 
   if (isReferenceFormGridNode(contractNode)) {
     const targetUid = getReferenceFormGridTargetUid(contractNode);
     if (!targetUid) return null;
     const targetFormNode = await getFlowModelNode(ctx, targetUid);
-    if (!targetFormNode || !isFormAssignRulesOwnerNode(targetFormNode)) return null;
+    if (!targetFormNode) return null;
     const targetGridNode = await getFlowModelChildNode(ctx, targetFormNode.uid, 'grid');
-    if (!targetGridNode || !isFormGridNode(targetGridNode) || isReferenceFormGridNode(targetGridNode)) return null;
+    if (
+      !targetGridNode ||
+      !isFormAssignRulesContractPair(targetFormNode, targetGridNode) ||
+      isReferenceFormGridNode(targetGridNode)
+    ) {
+      return null;
+    }
     const targetVariableSource = await resolveFormAssignRulesVariableSource(ctx, targetGridNode);
     let contractSourceNode = targetGridNode;
     if (typeof targetVariableSource === 'undefined') {
@@ -449,23 +485,24 @@ async function resolveFormAssignRulesContractNode(
       contractSourceNode = formNode;
     }
 
-    const relatedToHost =
+    const directlyRelated =
       runtimeNode.uid === contractNode.uid ||
       runtimeNode.uid === formNode.uid ||
-      ancestorUids?.has(contractNode.uid) === true;
-    const relatedToTarget =
       runtimeNode.uid === targetGridNode.uid ||
-      runtimeNode.uid === targetFormNode.uid ||
-      ancestorUids?.has(targetGridNode.uid) === true;
-    return relatedToHost || relatedToTarget ? contractSourceNode : null;
+      runtimeNode.uid === targetFormNode.uid;
+    if (directlyRelated) return contractSourceNode;
+
+    const ancestorUids = await loadFlowModelAncestorUids(ctx, runtimeNode);
+    return ancestorUids?.has(contractNode.uid) === true || ancestorUids?.has(targetGridNode.uid) === true
+      ? contractSourceNode
+      : null;
   }
 
   if (typeof (await resolveFormAssignRulesVariableSource(ctx, contractNode)) === 'undefined') return null;
-  const related =
-    runtimeNode.uid === contractNode.uid ||
-    runtimeNode.uid === formNode.uid ||
-    ancestorUids?.has(contractNode.uid) === true;
-  return related ? contractNode : null;
+  if (runtimeNode.uid === contractNode.uid || runtimeNode.uid === formNode.uid) return contractNode;
+
+  const ancestorUids = await loadFlowModelAncestorUids(ctx, runtimeNode);
+  return ancestorUids?.has(contractNode.uid) === true ? contractNode : null;
 }
 
 function createPolicy(

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -91,6 +91,7 @@ export function analyzeVariableTemplateSafely(
 }
 
 type FlowModelCacheValue = Promise<FlowModelNodeSnapshot | null> | FlowModelNodeSnapshot | null;
+type FlowModelChildCacheValue = Promise<FlowModelNodeSnapshot | null> | FlowModelNodeSnapshot | null;
 type FlowModelContractCacheValue = Promise<FlowModelVariableContract | null> | FlowModelVariableContract | null;
 type FlowModelContractSource = 'node' | 'formAssignRules';
 
@@ -105,7 +106,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function getFormAssignRulesVariableSource(node: FlowModelNodeSnapshot): unknown | undefined {
+function readFormAssignRulesVariableSource(node: FlowModelNodeSnapshot): unknown | undefined {
   const stepParams = isObject(node.options.stepParams) ? node.options.stepParams : null;
   const formModelSettings = stepParams && isObject(stepParams.formModelSettings) ? stepParams.formModelSettings : null;
   return formModelSettings && Object.prototype.hasOwnProperty.call(formModelSettings, 'assignRules')
@@ -113,14 +114,26 @@ function getFormAssignRulesVariableSource(node: FlowModelNodeSnapshot): unknown 
     : undefined;
 }
 
-function isFormAssignRulesContractNode(node: FlowModelNodeSnapshot) {
+function isFormGridNode(node: FlowModelNodeSnapshot) {
   const use = node.options.use;
-  return (
-    node.subKey === 'grid' &&
-    typeof use === 'string' &&
-    use.endsWith('FormGridModel') &&
-    typeof getFormAssignRulesVariableSource(node) !== 'undefined'
-  );
+  return node.subKey === 'grid' && typeof use === 'string' && use.endsWith('GridModel');
+}
+
+function isReferenceFormGridNode(node: FlowModelNodeSnapshot) {
+  const use = node.options.use;
+  return isFormGridNode(node) && typeof use === 'string' && use.endsWith('ReferenceFormGridModel');
+}
+
+function getReferenceFormGridTargetUid(node: FlowModelNodeSnapshot) {
+  const stepParams = isObject(node.options.stepParams) ? node.options.stepParams : null;
+  const referenceSettings = stepParams && isObject(stepParams.referenceSettings) ? stepParams.referenceSettings : null;
+  const useTemplate =
+    referenceSettings && isObject(referenceSettings.useTemplate) ? referenceSettings.useTemplate : null;
+  const templateUid = useTemplate && typeof useTemplate.templateUid === 'string' ? useTemplate.templateUid.trim() : '';
+  if (!useTemplate || !templateUid) return '';
+  const targetPath = typeof useTemplate.targetPath === 'string' ? useTemplate.targetPath.trim() : '';
+  if (targetPath && targetPath !== 'subModels.grid') return '';
+  return typeof useTemplate.targetUid === 'string' ? useTemplate.targetUid.trim() : '';
 }
 
 function isFormAssignRulesOwnerNode(node: FlowModelNodeSnapshot) {
@@ -208,6 +221,26 @@ async function getFlowModelNode(ctx: ResourcerContext, flowModelUid: string): Pr
   return model;
 }
 
+async function getFlowModelChildNode(ctx: ResourcerContext, parentUid: string, subKey: string) {
+  const state = getRequestState(ctx);
+  const cacheKey = '__variableResolveFlowModelChildCache';
+  const cache =
+    (state[cacheKey] as Map<string, FlowModelChildCacheValue> | undefined) ||
+    new Map<string, FlowModelChildCacheValue>();
+  state[cacheKey] = cache;
+  const childCacheKey = JSON.stringify([parentUid, subKey]);
+  if (cache.has(childCacheKey)) return (await cache.get(childCacheKey)) || null;
+
+  const load = (async () => {
+    const child = await getFlowModelRepository(ctx).findModelByParentId(parentUid, { subKey });
+    return isObject(child) && typeof child.uid === 'string' ? getFlowModelNode(ctx, child.uid) : null;
+  })();
+  cache.set(childCacheKey, load);
+  const child = await load;
+  cache.set(childCacheKey, child);
+  return child;
+}
+
 async function loadFlowModelAncestors(ctx: ResourcerContext, currentNode: FlowModelNodeSnapshot) {
   const ancestors: FlowModelNodeSnapshot[] = [];
   const seen = new Set([currentNode.uid]);
@@ -223,6 +256,15 @@ async function loadFlowModelAncestors(ctx: ResourcerContext, currentNode: FlowMo
     parentId = parent.parentId;
   }
   return Object.freeze(ancestors);
+}
+
+async function resolveFormAssignRulesVariableSource(ctx: ResourcerContext, contractNode: FlowModelNodeSnapshot) {
+  const fromGrid = readFormAssignRulesVariableSource(contractNode);
+  if (typeof fromGrid !== 'undefined') return fromGrid;
+  if (!contractNode.parentId) return undefined;
+
+  const formNode = await getFlowModelNode(ctx, contractNode.parentId);
+  return formNode && isFormAssignRulesOwnerNode(formNode) ? readFormAssignRulesVariableSource(formNode) : undefined;
 }
 
 function createRecordSlotCompilerOptions(ctx: ResourcerContext, currentNode?: FlowModelNodeSnapshot) {
@@ -273,7 +315,9 @@ async function createFlowModelVariableContractFromNode(
   source: FlowModelContractSource,
 ) {
   const variableSource =
-    source === 'formAssignRules' ? getFormAssignRulesVariableSource(contractNode) ?? {} : contractNode.options;
+    source === 'formAssignRules'
+      ? (await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {}
+      : contractNode.options;
   const prepared = prepareFlowModelVariableSource(
     variableSource,
     source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,
@@ -378,18 +422,50 @@ async function resolveFormAssignRulesContractNode(
   contractModelUid: string,
 ) {
   const contractNode = await getFlowModelNode(ctx, contractModelUid);
-  if (!contractNode || !contractNode.parentId || !isFormAssignRulesContractNode(contractNode)) return null;
+  if (!contractNode || !contractNode.parentId || !isFormGridNode(contractNode)) return null;
 
   const formNode = await getFlowModelNode(ctx, contractNode.parentId);
   if (!formNode || !isFormAssignRulesOwnerNode(formNode)) return null;
-  if (runtimeNode.uid === contractNode.uid || runtimeNode.uid === formNode.uid) return contractNode;
 
+  let ancestorUids: ReadonlySet<string> | null = null;
   try {
     const ancestors = await loadFlowModelAncestors(ctx, runtimeNode);
-    return ancestors.some((ancestor) => ancestor.uid === contractNode.uid) ? contractNode : null;
+    ancestorUids = new Set(ancestors.map((ancestor) => ancestor.uid));
   } catch {
-    return null;
+    ancestorUids = null;
   }
+
+  if (isReferenceFormGridNode(contractNode)) {
+    const targetUid = getReferenceFormGridTargetUid(contractNode);
+    if (!targetUid) return null;
+    const targetFormNode = await getFlowModelNode(ctx, targetUid);
+    if (!targetFormNode || !isFormAssignRulesOwnerNode(targetFormNode)) return null;
+    const targetGridNode = await getFlowModelChildNode(ctx, targetFormNode.uid, 'grid');
+    if (!targetGridNode || !isFormGridNode(targetGridNode) || isReferenceFormGridNode(targetGridNode)) return null;
+    const targetVariableSource = await resolveFormAssignRulesVariableSource(ctx, targetGridNode);
+    let contractSourceNode = targetGridNode;
+    if (typeof targetVariableSource === 'undefined') {
+      if (typeof readFormAssignRulesVariableSource(formNode) === 'undefined') return null;
+      contractSourceNode = formNode;
+    }
+
+    const relatedToHost =
+      runtimeNode.uid === contractNode.uid ||
+      runtimeNode.uid === formNode.uid ||
+      ancestorUids?.has(contractNode.uid) === true;
+    const relatedToTarget =
+      runtimeNode.uid === targetGridNode.uid ||
+      runtimeNode.uid === targetFormNode.uid ||
+      ancestorUids?.has(targetGridNode.uid) === true;
+    return relatedToHost || relatedToTarget ? contractSourceNode : null;
+  }
+
+  if (typeof (await resolveFormAssignRulesVariableSource(ctx, contractNode)) === 'undefined') return null;
+  const related =
+    runtimeNode.uid === contractNode.uid ||
+    runtimeNode.uid === formNode.uid ||
+    ancestorUids?.has(contractNode.uid) === true;
+  return related ? contractNode : null;
 }
 
 function createPolicy(

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -92,6 +92,7 @@ export function analyzeVariableTemplateSafely(
 
 type FlowModelCacheValue = Promise<FlowModelNodeSnapshot | null> | FlowModelNodeSnapshot | null;
 type FlowModelContractCacheValue = Promise<FlowModelVariableContract | null> | FlowModelVariableContract | null;
+type FlowModelContractSource = 'node' | 'formAssignRules';
 
 const MAX_FLOW_MODEL_ANCESTORS = 64;
 
@@ -102,6 +103,33 @@ export function clearVariableAllowListCache(app?: object) {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getFormAssignRulesVariableSource(node: FlowModelNodeSnapshot): unknown | undefined {
+  const stepParams = isObject(node.options.stepParams) ? node.options.stepParams : null;
+  const formModelSettings = stepParams && isObject(stepParams.formModelSettings) ? stepParams.formModelSettings : null;
+  return formModelSettings && Object.prototype.hasOwnProperty.call(formModelSettings, 'assignRules')
+    ? formModelSettings.assignRules
+    : undefined;
+}
+
+function isFormAssignRulesContractNode(node: FlowModelNodeSnapshot) {
+  const use = node.options.use;
+  return (
+    node.subKey === 'grid' &&
+    typeof use === 'string' &&
+    use.endsWith('FormGridModel') &&
+    typeof getFormAssignRulesVariableSource(node) !== 'undefined'
+  );
+}
+
+function isFormAssignRulesOwnerNode(node: FlowModelNodeSnapshot) {
+  const use = node.options.use;
+  return typeof use === 'string' && (use.endsWith('FormModel') || use.endsWith('FormBlockModel'));
+}
+
+function isFormAssignRulesRunJsValuePath(pathTail: readonly string[]) {
+  return pathTail.length === 3 && pathTail[0] === 'value' && /^\d+$/.test(pathTail[1]) && pathTail[2] === 'value';
 }
 
 function isRecordParams(value: unknown): value is RecordParams {
@@ -218,7 +246,9 @@ function createRecordSlotCompilerOptions(ctx: ResourcerContext, currentNode?: Fl
 
 async function getFlowModelVariableContract(
   ctx: ResourcerContext,
-  flowModelUid: string,
+  contractNode: FlowModelNodeSnapshot,
+  runtimeNode: FlowModelNodeSnapshot,
+  source: FlowModelContractSource,
 ): Promise<FlowModelVariableContract | null> {
   const state = getRequestState(ctx);
   const cacheKey = '__variableResolveContractCache';
@@ -226,19 +256,28 @@ async function getFlowModelVariableContract(
     (state[cacheKey] as Map<string, FlowModelContractCacheValue> | undefined) ||
     new Map<string, FlowModelContractCacheValue>();
   state[cacheKey] = cache;
-  if (cache.has(flowModelUid)) return (await cache.get(flowModelUid)) || null;
+  const contractCacheKey = JSON.stringify([source, contractNode.uid, runtimeNode.uid]);
+  if (cache.has(contractCacheKey)) return (await cache.get(contractCacheKey)) || null;
 
-  const load = createFlowModelVariableContractFromNode(ctx, flowModelUid);
-  cache.set(flowModelUid, load);
+  const load = createFlowModelVariableContractFromNode(ctx, contractNode, runtimeNode, source);
+  cache.set(contractCacheKey, load);
   const contract = await load;
-  cache.set(flowModelUid, contract);
+  cache.set(contractCacheKey, contract);
   return contract;
 }
 
-async function createFlowModelVariableContractFromNode(ctx: ResourcerContext, flowModelUid: string) {
-  const node = await getFlowModelNode(ctx, flowModelUid);
-  if (!node) return null;
-  const prepared = prepareFlowModelVariableSource(node.options);
+async function createFlowModelVariableContractFromNode(
+  ctx: ResourcerContext,
+  contractNode: FlowModelNodeSnapshot,
+  runtimeNode: FlowModelNodeSnapshot,
+  source: FlowModelContractSource,
+) {
+  const variableSource =
+    source === 'formAssignRules' ? getFormAssignRulesVariableSource(contractNode) ?? {} : contractNode.options;
+  const prepared = prepareFlowModelVariableSource(
+    variableSource,
+    source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,
+  );
   const contractSource = prepared.ok
     ? prepared.runJsTemplates.length
       ? [prepared.templateSource, ...prepared.runJsTemplates]
@@ -246,7 +285,7 @@ async function createFlowModelVariableContractFromNode(ctx: ResourcerContext, fl
     : {};
   const result = analyzeVariableTemplateSafely(contractSource, { mode: 'flow-model' });
   const analysis = result.ok ? result.analysis : analyzeVariableTemplate({}, { mode: 'flow-model' });
-  return await createFlowModelVariableContract(analysis, createRecordSlotCompilerOptions(ctx, node));
+  return await createFlowModelVariableContract(analysis, createRecordSlotCompilerOptions(ctx, runtimeNode));
 }
 
 function getCurrentRoleNames(ctx: ResourcerContext): string[] {
@@ -333,6 +372,26 @@ export async function resolveFlowModelNodeFromRequestRd(ctx: ResourcerContext, r
   return flowModelUid ? getFlowModelNode(ctx, flowModelUid) : null;
 }
 
+async function resolveFormAssignRulesContractNode(
+  ctx: ResourcerContext,
+  runtimeNode: FlowModelNodeSnapshot,
+  contractModelUid: string,
+) {
+  const contractNode = await getFlowModelNode(ctx, contractModelUid);
+  if (!contractNode || !contractNode.parentId || !isFormAssignRulesContractNode(contractNode)) return null;
+
+  const formNode = await getFlowModelNode(ctx, contractNode.parentId);
+  if (!formNode || !isFormAssignRulesOwnerNode(formNode)) return null;
+  if (runtimeNode.uid === contractNode.uid || runtimeNode.uid === formNode.uid) return contractNode;
+
+  try {
+    const ancestors = await loadFlowModelAncestors(ctx, runtimeNode);
+    return ancestors.some((ancestor) => ancestor.uid === contractNode.uid) ? contractNode : null;
+  } catch {
+    return null;
+  }
+}
+
 function createPolicy(
   allowAll = false,
   allowedPaths: ReadonlySet<string> = new Set(),
@@ -367,6 +426,7 @@ function recordBindingPlanAllowed(plan: RecordBindingPlan) {
 export async function authorizeVariablesResolve(
   ctx: ResourcerContext,
   options: {
+    contractRd?: string | number;
     contextParams?: Record<string, unknown>;
     rd?: string | number;
     template: JSONValue;
@@ -374,6 +434,8 @@ export async function authorizeVariablesResolve(
 ): Promise<AuthorizationResult> {
   let contextParams = sanitizeContextParams(options.contextParams || {});
   const flowModelUid = resolveFlowModelUidFromRequestRd(ctx, options.rd);
+  const hasContractRd = typeof options.contractRd !== 'undefined';
+  const contractModelUid = hasContractRd ? resolveFlowModelUidFromRequestRd(ctx, options.contractRd) : flowModelUid;
   const unrestrictedVariables = new Set<string>();
   let policy = createPolicy(false, new Set(), unrestrictedVariables);
   let recordSlotPolicies: RecordSlotPolicies = new Map();
@@ -457,7 +519,23 @@ export async function authorizeVariablesResolve(
     return denied(analysis, bindingPlan.contextParams, policy, recordSlotPolicies);
   }
 
-  const contract = flowModelUid ? await getFlowModelVariableContract(ctx, flowModelUid) : null;
+  let contractNode = currentNode;
+  let contractSource: FlowModelContractSource = 'node';
+  if (hasContractRd) {
+    contractNode =
+      currentNode && contractModelUid
+        ? await resolveFormAssignRulesContractNode(ctx, currentNode, contractModelUid)
+        : null;
+    contractSource = 'formAssignRules';
+    if (!contractNode) {
+      return denied(analysis, bindingPlan.contextParams, policy, recordSlotPolicies, flowModelUid || undefined);
+    }
+  }
+
+  const contract =
+    contractNode && currentNode
+      ? await getFlowModelVariableContract(ctx, contractNode, currentNode, contractSource)
+      : null;
   const allowedPaths = contract?.allowedPaths || null;
   recordSlotPolicies = contract?.recordSlots || new Map();
   policy = createPolicy(false, allowedPaths || new Set(), unrestrictedVariables);

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/resolve.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/resolve.ts
@@ -67,6 +67,7 @@ export function isLegacyVariableTemplateSafe(template: JSONValue) {
 export async function resolveFlowModelVariablesTemplate(
   ctx: ResourcerContext,
   options: {
+    contractRd?: string | number;
     contextParams?: Record<string, unknown>;
     rd?: string | number;
     template: JSONValue;

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -114,7 +114,7 @@ function readPersistedRunJsValue(entries: readonly EnumerableDataEntry[]): Persi
 }
 
 function isPersistedRunJsPath(pathTail: readonly string[]) {
-  return RUNJS_PATH_SUFFIXES.has(pathTail.join('.'));
+  return RUNJS_PATH_SUFFIXES.has(pathTail.slice(-3).join('.'));
 }
 
 function createTraversalContainer(input: object, descriptors: PropertyDescriptorMap): TraversalContainer {
@@ -420,7 +420,10 @@ function extractStaticVariableTemplates(code: string): string[] {
   return Array.from(templates);
 }
 
-export function prepareFlowModelVariableSource(value: unknown): PreparedFlowModelVariableSource {
+export function prepareFlowModelVariableSource(
+  value: unknown,
+  options: Readonly<{ isRunJsValuePath?: (pathTail: readonly string[]) => boolean }> = {},
+): PreparedFlowModelVariableSource {
   try {
     const templates = new Set<string>();
     const seen = new WeakSet<object>();
@@ -461,8 +464,8 @@ export function prepareFlowModelVariableSource(value: unknown): PreparedFlowMode
           return { ok: false };
         }
       }
-      const runJs =
-        !Array.isArray(input) && isPersistedRunJsPath(pathTail) ? readPersistedRunJsValue(entries) : undefined;
+      const runJsPath = options.isRunJsValuePath ? options.isRunJsValuePath(pathTail) : isPersistedRunJsPath(pathTail);
+      const runJs = !Array.isArray(input) && runJsPath ? readPersistedRunJsValue(entries) : undefined;
       const output = createTraversalContainer(input, descriptors);
       defineTraversalValue(parent, key, output);
 
@@ -496,12 +499,13 @@ export function prepareFlowModelVariableSource(value: unknown): PreparedFlowMode
       if (scheduledNodes > MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES) return { ok: false };
       for (let index = entries.length - 1; index >= 0; index -= 1) {
         const [entryKey, entryValue] = entries[index];
+        const nextPath = [...pathTail, entryKey];
         stack.push({
           depth: depth + 1,
           input: entryValue,
           key: entryKey,
           parent: output,
-          pathTail: [...pathTail, entryKey].slice(-3),
+          pathTail: options.isRunJsValuePath ? nextPath : nextPath.slice(-3),
         });
       }
     }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Form value assignment rules store their variable configuration on the form grid, while the rules are evaluated from form or field runtime models. After variable resolution permissions were tightened, ordinary roles could no longer resolve configured server-side variables in these rules.

### Description
- Pass separate session-bound descriptors for the runtime model and the form-grid contract owner.
- Build the variable allow-list from the persisted form assignment rules while retaining the runtime model for record-slot resolution.
- Validate that the contract grid belongs to the same form tree before granting configured variable paths.
- Keep existing behavior for calls without a contract descriptor and for roles that can configure the UI.
- Harden persisted RunJS dependency detection so nested business objects cannot expand the variable allow-list.

Testing:
- Unit tests for form assignment runtime contract propagation.
- Unit tests for client request payloads and server allow-list authorization.
- Unit tests for RunJS dependency boundaries.
- Manual verification on the reproduced page with an ordinary role.

### Related issues

Related to #9722

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect variable resolution for form field values |
| 🇨🇳 Chinese | 修复表单字段值变量解析不正确的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
