### PR TITLE
fix(gantt): use task color for short bars

### DIFF
--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx
@@ -126,4 +126,17 @@ describe('TaskItem', () => {
       expect.anything(),
     );
   });
+
+  test('uses the task color for small tasks', () => {
+    const { container } = renderTaskItem(
+      createTask('Colored Small Task', {
+        typeInternal: 'smalltask',
+        color: '#ff4d4f',
+        x1: 0,
+        x2: 16,
+      }),
+    );
+
+    expect(container.querySelector('rect')).toHaveAttribute('fill', '#ff4d4f');
+  });
 });

--- a/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/bar/bar-small.tsx
+++ b/packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/bar/bar-small.tsx
@@ -31,6 +31,7 @@ export const BarSmall: React.FC<TaskItemProps> = ({
       <BarDisplay
         x={task.x1}
         y={task.y}
+        color={task.color}
         width={task.x2 - task.x1}
         height={task.height}
         progressX={task.progressX}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Gantt tasks configured with a record color still used the default theme color when their duration was short enough to render through the `BarSmall` component.

This PR backports #10217 to `next`.

### Description

- Pass the task color to `BarDisplay` for short Gantt task bars.
- Add a component regression test covering custom colors on short tasks.

The change is limited to the short-task rendering branch and does not alter task sizing or interaction behavior.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx --run --reporter=verbose` — 4 passed.
- `yarn eslint --fix packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/bar/bar-small.tsx packages/plugins/@nocobase/plugin-gantt/src/client-v2/shared/components/task-item/__tests__/task-item.test.tsx` — passed.

### Related issues

- Backport of #10217

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed custom record colors not being applied to short Gantt task bars |
| 🇨🇳 Chinese | 修复甘特图短任务条未使用记录自定义颜色的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
