### PR TITLE
fix(cli): accept a JSON array for resource create values

### DIFF
--- a/docs/docs/cn/api/cli/api/resource/create.md
+++ b/docs/docs/cn/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "nb api resource create 命令参考：创建指定 NocoBase 资源记录。"
+description: "nb api resource create 命令参考：创建一条或多条指定 NocoBase 资源记录。"
 keywords: "nb api resource create,NocoBase CLI,创建记录,CRUD"
 ---
 
 # nb api resource create
 
-创建指定资源记录。记录内容通过 `--values` 以 JSON 对象传入。
+创建指定资源记录。记录内容通过 `--values` 以 JSON 对象传入；传 JSON 数组时可在一次请求中创建多条记录。
 
 ## 用法
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | 资源名称，必填 |
 | `--data-source` | string | 数据源 key，默认 `main` |
 | `--source-id` | string | 关联资源的源记录 ID |
-| `--values` | string | 创建记录的数据，JSON 对象，必填 |
+| `--values` | string | 创建记录的数据，JSON 对象；传 JSON 对象数组可一次创建多条记录，必填 |
 | `--whitelist` | string[] | 允许写入的字段，可重复传入或传 JSON 数组 |
 | `--blacklist` | string[] | 禁止写入的字段，可重复传入或传 JSON 数组 |
 
@@ -31,6 +31,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/de/api/cli/api/resource/create.md
+++ b/docs/docs/de/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Referenz für den Befehl nb api resource create: Datensatz für eine angegebene NocoBase-Ressource erstellen."
+description: "Referenz für den Befehl nb api resource create: einen oder mehrere Datensätze für eine angegebene NocoBase-Ressource erstellen."
 keywords: "nb api resource create,NocoBase CLI,Datensatz erstellen,CRUD"
 ---
 
 # nb api resource create
 
-Erstellt einen Datensatz der angegebenen Ressource. Der Inhalt des Datensatzes wird über `--values` als JSON-Objekt übergeben.
+Erstellt Datensätze der angegebenen Ressource. Der Inhalt wird über `--values` als JSON-Objekt übergeben; ein JSON-Array von Objekten erstellt mehrere Datensätze in einer einzigen Anfrage.
 
 ## Verwendung
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Ressourcenname, erforderlich |
 | `--data-source` | string | key der Datenquelle, Standard `main` |
 | `--source-id` | string | Quell-Datensatz-ID einer assoziierten Ressource |
-| `--values` | string | Daten des zu erstellenden Datensatzes als JSON-Objekt, erforderlich |
+| `--values` | string | Daten der zu erstellenden Datensätze als JSON-Objekt oder als JSON-Array von Objekten für mehrere Datensätze, erforderlich |
 | `--whitelist` | string[] | Felder, in die geschrieben werden darf; mehrfach übergeben oder als JSON-Array |
 | `--blacklist` | string[] | Felder, in die nicht geschrieben werden darf; mehrfach übergeben oder als JSON-Array |
 
@@ -31,6 +31,7 @@ Zusätzlich werden die allgemeinen Verbindungsparameter von [`nb api resource`](
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/en/api/cli/api/resource/create.md
+++ b/docs/docs/en/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "nb api resource create command reference: create a record in a selected NocoBase resource."
+description: "nb api resource create command reference: create one or more records in a selected NocoBase resource."
 keywords: "nb api resource create,NocoBase CLI,create record,CRUD"
 ---
 
 # nb api resource create
 
-Create a record in a selected resource. Pass record data as a JSON object through `--values`.
+Create records in a selected resource. Pass record data as a JSON object through `--values`, or as a JSON array of objects to create multiple records in a single request.
 
 ## Usage
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Resource name, required |
 | `--data-source` | string | Data source key, default `main` |
 | `--source-id` | string | Source record ID for association resources |
-| `--values` | string | Data for the new record as a JSON object, required |
+| `--values` | string | Data for the new records: a JSON object, or a JSON array of objects to create multiple records; required |
 | `--whitelist` | string[] | Fields allowed to write; repeatable or pass a JSON array |
 | `--blacklist` | string[] | Fields forbidden to write; repeatable or pass a JSON array |
 
@@ -31,6 +31,7 @@ Also supports common connection parameters from [`nb api resource`](./index.md).
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/es/api/cli/api/resource/create.md
+++ b/docs/docs/es/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Referencia del comando nb api resource create: crea un registro en el recurso NocoBase indicado."
+description: "Referencia del comando nb api resource create: crea uno o varios registros en el recurso NocoBase indicado."
 keywords: "nb api resource create,NocoBase CLI,crear registro,CRUD"
 ---
 
 # nb api resource create
 
-Crea un registro en el recurso indicado. El contenido del registro se proporciona como un objeto JSON mediante `--values`.
+Crea registros en el recurso indicado. El contenido se proporciona como un objeto JSON mediante `--values`; con un array JSON de objetos se crean varios registros en una sola petición.
 
 ## Uso
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Nombre del recurso; obligatorio |
 | `--data-source` | string | Clave de la fuente de datos; por defecto `main` |
 | `--source-id` | string | ID del registro origen para los recursos asociados |
-| `--values` | string | Datos del registro a crear como objeto JSON; obligatorio |
+| `--values` | string | Datos de los registros a crear: un objeto JSON, o un array JSON de objetos para crear varios registros; obligatorio |
 | `--whitelist` | string[] | Campos permitidos para escritura; admite valores repetidos o un array JSON |
 | `--blacklist` | string[] | Campos prohibidos para escritura; admite valores repetidos o un array JSON |
 
@@ -31,6 +31,7 @@ También admite los parámetros generales de conexión de [`nb api resource`](./
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/fr/api/cli/api/resource/create.md
+++ b/docs/docs/fr/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Référence de la commande nb api resource create : créer un enregistrement pour la ressource NocoBase indiquée."
+description: "Référence de la commande nb api resource create : créer un ou plusieurs enregistrements pour la ressource NocoBase indiquée."
 keywords: "nb api resource create,NocoBase CLI,créer un enregistrement,CRUD"
 ---
 
 # nb api resource create
 
-Créer un enregistrement pour la ressource indiquée. Le contenu de l'enregistrement est passé via `--values` sous forme d'objet JSON.
+Créer des enregistrements pour la ressource indiquée. Le contenu est passé via `--values` sous forme d'objet JSON ; un tableau JSON d'objets permet de créer plusieurs enregistrements en une seule requête.
 
 ## Utilisation
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Nom de la ressource, requis |
 | `--data-source` | string | Clé de la source de données, par défaut `main` |
 | `--source-id` | string | ID de l'enregistrement source pour une ressource d'association |
-| `--values` | string | Données de l'enregistrement à créer, objet JSON, requis |
+| `--values` | string | Données des enregistrements à créer : objet JSON, ou tableau JSON d'objets pour créer plusieurs enregistrements, requis |
 | `--whitelist` | string[] | Champs autorisés en écriture, répétable ou tableau JSON |
 | `--blacklist` | string[] | Champs interdits en écriture, répétable ou tableau JSON |
 
@@ -31,6 +31,7 @@ Les paramètres de connexion communs de [`nb api resource`](./index.md) sont ég
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/id/api/cli/api/resource/create.md
+++ b/docs/docs/id/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Referensi perintah nb api resource create: membuat record dari resource NocoBase yang ditentukan."
+description: "Referensi perintah nb api resource create: membuat satu atau beberapa record dari resource NocoBase yang ditentukan."
 keywords: "nb api resource create,NocoBase CLI,membuat record,CRUD"
 ---
 
 # nb api resource create
 
-Membuat record dari resource yang ditentukan. Konten record dimasukkan melalui `--values` sebagai objek JSON.
+Membuat record dari resource yang ditentukan. Konten record dimasukkan melalui `--values` sebagai objek JSON; array JSON berisi objek akan membuat beberapa record dalam satu request.
 
 ## Penggunaan
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Nama resource, wajib diisi |
 | `--data-source` | string | Key data source, default `main` |
 | `--source-id` | string | ID record sumber dari resource asosiasi |
-| `--values` | string | Data untuk record yang dibuat, objek JSON, wajib diisi |
+| `--values` | string | Data untuk record yang dibuat: objek JSON, atau array JSON berisi objek untuk membuat beberapa record, wajib diisi |
 | `--whitelist` | string[] | Field yang diizinkan untuk ditulis, dapat dimasukkan berulang atau berupa array JSON |
 | `--blacklist` | string[] | Field yang dilarang untuk ditulis, dapat dimasukkan berulang atau berupa array JSON |
 
@@ -31,6 +31,7 @@ Juga mendukung parameter koneksi umum dari [`nb api resource`](./index.md).
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/ja/api/cli/api/resource/create.md
+++ b/docs/docs/ja/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "nb api resource create コマンドリファレンス：指定した NocoBase リソースのレコードを作成します。"
+description: "nb api resource create コマンドリファレンス：指定した NocoBase リソースのレコードを 1 件または複数件作成します。"
 keywords: "nb api resource create,NocoBase CLI,レコード作成,CRUD"
 ---
 
 # nb api resource create
 
-指定したリソースのレコードを作成します。レコードの内容は `--values` で JSON オブジェクトとして渡します。
+指定したリソースのレコードを作成します。レコードの内容は `--values` で JSON オブジェクトとして渡します。JSON 配列を渡すと、1 回のリクエストで複数のレコードを作成できます。
 
 ## 使い方
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | リソース名（必須） |
 | `--data-source` | string | データソース key。デフォルトは `main` です |
 | `--source-id` | string | リレーションリソースのソースレコード ID |
-| `--values` | string | 作成するレコードのデータ（JSON オブジェクト、必須） |
+| `--values` | string | 作成するレコードのデータ（JSON オブジェクト、または複数レコードを作成する JSON オブジェクトの配列、必須） |
 | `--whitelist` | string[] | 書き込みを許可するフィールド。複数回指定するか、JSON 配列で渡せます |
 | `--blacklist` | string[] | 書き込みを禁止するフィールド。複数回指定するか、JSON 配列で渡せます |
 
@@ -31,6 +31,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/pt/api/cli/api/resource/create.md
+++ b/docs/docs/pt/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Referência do comando nb api resource create: cria um registro no recurso NocoBase especificado."
+description: "Referência do comando nb api resource create: cria um ou mais registros no recurso NocoBase especificado."
 keywords: "nb api resource create,NocoBase CLI,criar registro,CRUD"
 ---
 
 # nb api resource create
 
-Cria um registro no recurso especificado. O conteúdo do registro é passado como objeto JSON via `--values`.
+Cria registros no recurso especificado. O conteúdo é passado como objeto JSON via `--values`; um array JSON de objetos cria vários registros em uma única requisição.
 
 ## Uso
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Nome do recurso, obrigatório |
 | `--data-source` | string | Key da fonte de dados, padrão `main` |
 | `--source-id` | string | ID do registro de origem para recursos relacionados |
-| `--values` | string | Dados para criar o registro, objeto JSON, obrigatório |
+| `--values` | string | Dados para criar os registros: objeto JSON, ou array JSON de objetos para criar vários registros, obrigatório |
 | `--whitelist` | string[] | Campos permitidos para gravação; pode ser passado várias vezes ou como um array JSON |
 | `--blacklist` | string[] | Campos proibidos para gravação; pode ser passado várias vezes ou como um array JSON |
 
@@ -31,6 +31,7 @@ Também aceita os parâmetros gerais de conexão de [`nb api resource`](./index.
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/ru/api/cli/api/resource/create.md
+++ b/docs/docs/ru/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Справочник по команде nb api resource create: создание записи указанного ресурса NocoBase."
+description: "Справочник по команде nb api resource create: создание одной или нескольких записей указанного ресурса NocoBase."
 keywords: "nb api resource create,NocoBase CLI,создание записи,CRUD"
 ---
 
 # nb api resource create
 
-Создание записи в выбранном ресурсе. Данные записи передаются через `--values` в виде JSON-объекта.
+Создание записей в выбранном ресурсе. Данные передаются через `--values` в виде JSON-объекта; JSON-массив объектов создаёт несколько записей за один запрос.
 
 ## Использование
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Имя ресурса, обязательно |
 | `--data-source` | string | Ключ источника данных, по умолчанию `main` |
 | `--source-id` | string | ID исходной записи для ресурсов связи |
-| `--values` | string | Данные новой записи в виде JSON-объекта, обязательно |
+| `--values` | string | Данные новых записей: JSON-объект или JSON-массив объектов для создания нескольких записей, обязательно |
 | `--whitelist` | string[] | Поля из белого списка, разрешённые для записи; можно передавать несколько раз или JSON-массивом |
 | `--blacklist` | string[] | Поля из чёрного списка, запрещённые для записи; можно передавать несколько раз или JSON-массивом |
 
@@ -31,6 +31,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/docs/docs/vi/api/cli/api/resource/create.md
+++ b/docs/docs/vi/api/cli/api/resource/create.md
@@ -1,12 +1,12 @@
 ---
 title: "nb api resource create"
-description: "Tài liệu lệnh nb api resource create: tạo bản ghi cho tài nguyên NocoBase được chỉ định."
+description: "Tài liệu lệnh nb api resource create: tạo một hoặc nhiều bản ghi cho tài nguyên NocoBase được chỉ định."
 keywords: "nb api resource create,NocoBase CLI,Tạo bản ghi,CRUD"
 ---
 
 # nb api resource create
 
-Tạo bản ghi cho tài nguyên được chỉ định. Nội dung bản ghi được truyền qua `--values` ở dạng JSON object.
+Tạo bản ghi cho tài nguyên được chỉ định. Nội dung bản ghi được truyền qua `--values` ở dạng JSON object; truyền JSON array các object để tạo nhiều bản ghi trong một request.
 
 ## Cách dùng
 
@@ -21,7 +21,7 @@ nb api resource create --resource <resource> --values <json> [flags]
 | `--resource` | string | Tên tài nguyên, bắt buộc |
 | `--data-source` | string | Key của data source, mặc định `main` |
 | `--source-id` | string | ID bản ghi nguồn của tài nguyên quan hệ |
-| `--values` | string | Dữ liệu để tạo bản ghi, JSON object, bắt buộc |
+| `--values` | string | Dữ liệu để tạo bản ghi: JSON object, hoặc JSON array các object để tạo nhiều bản ghi, bắt buộc |
 | `--whitelist` | string[] | Các field được phép ghi, có thể truyền nhiều lần hoặc truyền JSON array |
 | `--blacklist` | string[] | Các field bị cấm ghi, có thể truyền nhiều lần hoặc truyền JSON array |
 
@@ -31,6 +31,7 @@ Cũng hỗ trợ các tham số kết nối chung của [`nb api resource`](./in
 
 ```bash
 nb api resource create --resource users --values '{"nickname":"Ada"}'
+nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
 nb api resource create --resource posts.comments --source-id 1 --values '{"content":"Hello"}'
 ```
 

--- a/packages/core/cli/src/__tests__/resource-command-values.test.ts
+++ b/packages/core/cli/src/__tests__/resource-command-values.test.ts
@@ -1,0 +1,147 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  executeRawApiRequest: vi.fn(),
+}));
+
+vi.mock('../lib/api-client.js', () => ({
+  executeRawApiRequest: mocks.executeRawApiRequest,
+}));
+
+import { executeResourceRequest } from '../lib/resource-request.js';
+import { buildCreateArgs, buildUpdateArgs, createFlags } from '../lib/resource-command.js';
+
+function createFlagsInput(values: string, extra: Record<string, any> = {}) {
+  return {
+    resource: 'users',
+    values,
+    ...extra,
+  };
+}
+
+test('create accepts a JSON object and passes it through unchanged', () => {
+  const args = buildCreateArgs(createFlagsInput('{"nickname":"Ada","age":36}'));
+
+  expect(args.values).toEqual({ nickname: 'Ada', age: 36 });
+  expect(Array.isArray(args.values)).toBe(false);
+});
+
+test('create keeps the rest of the object payload behavior untouched', () => {
+  const args = buildCreateArgs(
+    createFlagsInput('{"nickname":"Ada"}', {
+      'data-source': 'external',
+      'source-id': '1',
+      whitelist: ['nickname'],
+      blacklist: ['id'],
+    }),
+  );
+
+  expect(args).toEqual({
+    resource: 'users',
+    dataSource: 'external',
+    sourceId: '1',
+    values: { nickname: 'Ada' },
+    whitelist: ['nickname'],
+    blacklist: ['id'],
+  });
+});
+
+test('create accepts a JSON array so a single request can write multiple records', () => {
+  const args = buildCreateArgs(createFlagsInput('[{"nickname":"Ada"},{"nickname":"Grace"}]'));
+
+  expect(Array.isArray(args.values)).toBe(true);
+  expect(args.values).toEqual([{ nickname: 'Ada' }, { nickname: 'Grace' }]);
+});
+
+test('create accepts an empty JSON array', () => {
+  const args = buildCreateArgs(createFlagsInput('[]'));
+
+  expect(args.values).toEqual([]);
+});
+
+test('create rejects a JSON array that contains non-object items', () => {
+  expect(() => buildCreateArgs(createFlagsInput('[{"nickname":"Ada"},"Grace"]'))).toThrow(
+    '--values array items must all be JSON objects, but item 1 is not',
+  );
+  expect(() => buildCreateArgs(createFlagsInput('[null]'))).toThrow(
+    '--values array items must all be JSON objects, but item 0 is not',
+  );
+  expect(() => buildCreateArgs(createFlagsInput('[[{"nickname":"Ada"}]]'))).toThrow(
+    '--values array items must all be JSON objects, but item 0 is not',
+  );
+});
+
+test('create still rejects scalars and null with a clear message', () => {
+  for (const input of ['"Ada"', '42', 'null', 'true']) {
+    expect(() => buildCreateArgs(createFlagsInput(input))).toThrow(
+      '--values must be a JSON object, or a JSON array of objects to create multiple records',
+    );
+  }
+});
+
+test('create still rejects malformed JSON', () => {
+  expect(() => buildCreateArgs(createFlagsInput('{nickname:'))).toThrow(/^Invalid JSON for --values: /);
+});
+
+test('create documents array support on the --values flag', () => {
+  expect(createFlags.values.description).toContain('JSON array');
+});
+
+test('update keeps rejecting arrays because its values are a single field patch', () => {
+  expect(() =>
+    buildUpdateArgs({
+      resource: 'users',
+      'filter-by-tk': '1',
+      values: '[{"nickname":"Ada"}]',
+    }),
+  ).toThrow('--values must be a JSON object');
+});
+
+test('update still accepts a JSON object', () => {
+  const args = buildUpdateArgs({
+    resource: 'users',
+    'filter-by-tk': '1',
+    values: '{"nickname":"Grace"}',
+  });
+
+  expect(args.values).toEqual({ nickname: 'Grace' });
+  expect(args.filterByTk).toBe('1');
+});
+
+test('an array reaches the request body as an array, which is what the server reads as multiple records', async () => {
+  mocks.executeRawApiRequest.mockReset();
+  mocks.executeRawApiRequest.mockResolvedValue({ ok: true, status: 200, data: [] });
+
+  await executeResourceRequest({
+    action: 'create',
+    args: buildCreateArgs(createFlagsInput('[{"nickname":"Ada"},{"nickname":"Grace"}]')),
+  });
+
+  const request = mocks.executeRawApiRequest.mock.calls[0][0];
+  expect(request.method).toBe('POST');
+  expect(request.path).toBe('/users:create');
+  expect(request.body).toEqual([{ nickname: 'Ada' }, { nickname: 'Grace' }]);
+});
+
+test('an object still reaches the request body as an object', async () => {
+  mocks.executeRawApiRequest.mockReset();
+  mocks.executeRawApiRequest.mockResolvedValue({ ok: true, status: 200, data: {} });
+
+  await executeResourceRequest({
+    action: 'create',
+    args: buildCreateArgs(createFlagsInput('{"nickname":"Ada"}')),
+  });
+
+  const request = mocks.executeRawApiRequest.mock.calls[0][0];
+  expect(request.body).toEqual({ nickname: 'Ada' });
+  expect(Array.isArray(request.body)).toBe(false);
+});

--- a/packages/core/cli/src/commands/api/resource/create.ts
+++ b/packages/core/cli/src/commands/api/resource/create.ts
@@ -1,14 +1,24 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { Command } from '@oclif/core';
 import { buildCreateArgs, createFlags, runResourceCommand } from '../../../lib/resource-command.js';
 
 export default class ResourceCreate extends Command {
-  static summary = 'Create a record in a resource';
+  static summary = 'Create one or more records in a resource';
 
   static description =
-    'Create a record in a generic resource. Pass record content through --values as a JSON object.';
+    'Create records in a generic resource. Pass record content through --values as a JSON object, or as a JSON array of objects to create multiple records in a single request.';
 
   static examples = [
     `<%= config.bin %> <%= command.id %> --resource users --values '{"nickname":"Ada"}'`,
+    `<%= config.bin %> <%= command.id %> --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'`,
     `<%= config.bin %> <%= command.id %> --resource posts.comments --source-id 1 --values '{"content":"Hello"}'`,
   ];
 

--- a/packages/core/cli/src/lib/resource-command.ts
+++ b/packages/core/cli/src/lib/resource-command.ts
@@ -51,6 +51,26 @@ function parseObjectFlag(value: string | undefined, flagName: string) {
   return parsed;
 }
 
+function parseValuesFlag(value: string | undefined, flagName: string) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = parseJson<Record<string, any> | Array<Record<string, any>>>(value, flagName);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`--${flagName} must be a JSON object, or a JSON array of objects to create multiple records`);
+  }
+
+  if (Array.isArray(parsed)) {
+    const invalidIndex = parsed.findIndex((item) => !item || Array.isArray(item) || typeof item !== 'object');
+    if (invalidIndex !== -1) {
+      throw new Error(`--${flagName} array items must all be JSON objects, but item ${invalidIndex} is not`);
+    }
+  }
+
+  return parsed;
+}
+
 function parseJsonArrayFlag(value: string | undefined, flagName: string) {
   if (value === undefined) {
     return undefined;
@@ -214,7 +234,8 @@ export const createFlags = {
   ...resourceBaseFlags,
   ...resourceAssociationFlags,
   values: Flags.string({
-    description: 'Record values used by create as a JSON object.',
+    description:
+      'Record values used by create as a JSON object, or a JSON array of objects to create multiple records in one request.',
     required: true,
   }),
   whitelist: Flags.string({
@@ -336,7 +357,7 @@ export function buildGetArgs(flags: Record<string, any>): ResourceRequestArgs {
 export function buildCreateArgs(flags: Record<string, any>): ResourceRequestArgs {
   return {
     ...pickSharedArgs(flags),
-    values: parseObjectFlag(flags.values, 'values'),
+    values: parseValuesFlag(flags.values, 'values'),
     whitelist: parseStringArrayFlags(flags.whitelist, 'whitelist'),
     blacklist: parseStringArrayFlags(flags.blacklist, 'blacklist'),
   };

--- a/packages/core/cli/src/lib/resource-request.ts
+++ b/packages/core/cli/src/lib/resource-request.ts
@@ -1,3 +1,12 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
 import { executeRawApiRequest } from './api-client.js';
 
 export type ResourceAction = 'list' | 'get' | 'create' | 'update' | 'destroy' | 'query';
@@ -15,7 +24,7 @@ export interface ResourceRequestArgs {
   page?: number;
   pageSize?: number;
   paginate?: boolean;
-  values?: Record<string, any>;
+  values?: Record<string, any> | Array<Record<string, any>>;
   whitelist?: string[];
   blacklist?: string[];
   updateAssociationValues?: string[];


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

`nb api resource create` cannot create multiple records in one request:

```bash
$ nb api resource create --resource sg_permission_grants --values '[{...},{...}]'
Error: --values must be a JSON object
```

**The server has always supported an array body.** Posting an array directly to the REST API works today — I wrote 549 rows in a single `POST /api/sg_permission_grants:create` against a live instance. In the source, `Repository#create` forwards an array of values to `createMany`:

```ts
// packages/core/database/src/repository.ts
async create(options: CreateOptions) {
  if (Array.isArray(options.values)) {
    return this.createMany({ ...options, records: options.values });
  }
```

`RelationRepository#create` and `BelongsToManyRepository#create` do the same, so association resources such as `posts.comments` accept arrays too.

The restriction was purely in the CLI. `buildCreateArgs` routed `--values` through `parseObjectFlag`, whose guard rejects arrays specifically:

```ts
if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
  throw new Error(`--${flagName} must be a JSON object`);
}
```

This looks like a gap rather than a deliberate restriction — the same file already has a `parseJsonArrayFlag` helper, and `create` simply never used it. Without this, callers who need to insert many rows have to loop one request per row, which is slow and fails halfway with no record of where it stopped.

### Description

- Added `parseValuesFlag`, used only by `buildCreateArgs`. It accepts a JSON object or a JSON array of objects, and names the offending index when an array item is not an object (`--values array items must all be JSON objects, but item 1 is not`).
- Passing an object behaves exactly as before — same parsing, same payload, same errors. Scalars, `null`, and malformed JSON are still rejected; only the wording of the object-or-array message changed.
- Widened `ResourceRequestArgs['values']` to `Record<string, any> | Array<Record<string, any>>`. The value is already passed to the request body untouched, so no other change was needed on the request path.
- Updated the `create` command summary, description, `--values` flag description, and examples, plus the `nb api resource create` reference docs in all 10 languages.

**`update` deliberately keeps `parseObjectFlag`.** Its `--values` is a single field patch applied to every matched row, so an array is meaningless there. `Repository#update` does branch to `updateMany` for arrays, but that path requires a primary key inside each record and throws `filterByTk invalid` otherwise — and the relation repositories (`MultipleRelationRepository#update`, `SingleRelationRepository#update`) have no array branch at all, so an array would be silently misread as a field patch. Rejecting it in the CLI is the safer behavior, and a test pins that down.

Potential risks: low. The change only widens what `create` accepts; every previously valid input parses identically.

### Related issues

### Showcase

```bash
# still works, unchanged
nb api resource create --resource users --values '{"nickname":"Ada"}'

# now works, one request instead of N
nb api resource create --resource users --values '[{"nickname":"Ada"},{"nickname":"Grace"}]'
```

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `nb api resource create` now accepts a JSON array for `--values` to create multiple records in a single request. |
| 🇨🇳 Chinese | `nb api resource create` 的 `--values` 支持传 JSON 数组，一次请求创建多条记录。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | [nb api resource create](https://github.com/nocobase/nocobase/blob/fix/cli-resource-create-array-values/docs/docs/en/api/cli/api/resource/create.md) |
| 🇨🇳 Chinese | [nb api resource create](https://github.com/nocobase/nocobase/blob/fix/cli-resource-create-array-values/docs/docs/cn/api/cli/api/resource/create.md) |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary

---

### Verification

New test file `packages/core/cli/src/__tests__/resource-command-values.test.ts` (12 tests) covers: objects still parse and still carry `data-source` / `source-id` / `whitelist` / `blacklist` through unchanged; arrays parse; empty arrays parse; arrays containing a string, `null`, or a nested array are rejected with the item index; scalars, `null`, and malformed JSON are still rejected; the array survives all the way into the request body as an array (`executeResourceRequest` mocked at the `api-client` boundary); and `update` still rejects arrays.

Full CLI suite: **999 tests across 91 files pass**. `tsc --noEmit` on the CLI package shows the same 81 pre-existing errors as `develop` — none in the touched files. Prettier clean.

The new tests were mutation-checked — each of these was applied in turn and confirmed to turn the suite red:

| Mutation | Result |
| --- | --- |
| Revert `buildCreateArgs` to `parseObjectFlag` (restore the original bug) | 5 tests fail |
| Delete the per-item array validation | 1 test fails |
| Delete the scalar/`null` guard | 1 test fails |
| Point `buildUpdateArgs` at `parseValuesFlag` too | 1 test fails |
