### PR TITLE
fix(client-v2): preserve large decimal values

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/DisplayNumberFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/DisplayNumberFieldModel.tsx
@@ -71,7 +71,7 @@ function formatBigNumberWithSeparator(value, format = '0.00', step = 1, formatSt
   let number = value;
 
   if (formatStyle) {
-    number = new BigNumber(value).toString();
+    number = new BigNumber(value).toFixed();
   }
 
   let formattedNumber = '';

--- a/packages/core/client-v2/src/flow/models/fields/NumberFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/NumberFieldModel.tsx
@@ -20,7 +20,7 @@ function toSafeNumber(value) {
     return value;
   }
   if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
-    return new BigNumber(value).toString();
+    return new BigNumber(value).toFixed();
   } else {
     return Number(value);
   }

--- a/packages/core/client-v2/src/flow/models/fields/__tests__/DisplayNumberFieldModel.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/__tests__/DisplayNumberFieldModel.test.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatNumber } from '../DisplayNumberFieldModel';
+
+describe('formatNumber', () => {
+  it('formats a 30-digit decimal without scientific notation or precision loss', () => {
+    expect(
+      formatNumber({
+        value: '123456789012345678901234567890',
+        formatStyle: 'normal',
+        step: '1',
+      }),
+    ).toBe('123,456,789,012,345,678,901,234,567,890');
+  });
+
+  it('formats the 22-digit value from the reported v2 scenario', () => {
+    expect(
+      formatNumber({
+        value: '1234567890123458152112',
+        formatStyle: 'normal',
+        step: '1',
+      }),
+    ).toBe('1,234,567,890,123,458,152,112');
+  });
+});

--- a/packages/core/client-v2/src/flow/models/fields/__tests__/NumberFieldModel.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/__tests__/NumberFieldModel.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { InputNumberField } from '../NumberFieldModel';
+
+describe('InputNumberField', () => {
+  it('keeps the existing number value type for regular input', () => {
+    const onChange = vi.fn();
+
+    render(<InputNumberField stringMode onChange={onChange} />);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '123' } });
+
+    expect(onChange).toHaveBeenLastCalledWith(123);
+    expect(onChange).not.toHaveBeenCalledWith('123');
+  });
+
+  it('preserves a high-precision decimal string in string mode', () => {
+    const onChange = vi.fn();
+    const value = '123456789012345678901234567890';
+
+    render(<InputNumberField stringMode onChange={onChange} />);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value } });
+
+    expect(onChange).toHaveBeenLastCalledWith(value);
+    expect(screen.getByRole('spinbutton')).toHaveValue(value);
+  });
+
+  it('does not switch to scientific notation at the 22-digit boundary', () => {
+    const onChange = vi.fn();
+    const value = '1234567890123458152112';
+
+    render(<InputNumberField stringMode onChange={onChange} />);
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value } });
+
+    expect(onChange).toHaveBeenLastCalledWith(value);
+    expect(onChange).not.toHaveBeenCalledWith('1.234567890123458152112e+21');
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
V2 decimal fields convert values larger than the JavaScript safe integer range to scientific notation in the editor. After saving, the number display formatter treats that scientific-notation string as a regular decimal string and may render only the leading digit, even though the database and API retain the complete value.

### Description
- Serialize large editable number values with `BigNumber#toFixed()` so the editor keeps a regular decimal string.
- Use the same non-exponential serialization before formatting large values for display.
- Preserve the existing `number` value type for regular inputs.
- Add regression coverage for regular inputs, the reported 22-digit boundary value, and a 30-digit decimal value.

Risk is low: production behavior changes in two lines and only for values outside the JavaScript safe integer range. Existing number-format options and normal-value behavior remain unchanged. Explicitly configured unit conversion keeps its existing JavaScript-number precision behavior and is outside this fix.

Tested with:
- `yarn test packages/core/client-v2/src/flow/models/fields/__tests__/NumberFieldModel.test.tsx --run --reporter=verbose`
- `yarn test packages/core/client-v2/src/flow/models/fields/__tests__/DisplayNumberFieldModel.test.ts --run --reporter=verbose`
- `yarn eslint --fix` on all four changed files

Suggested manual verification: enter `123456789012345678901234567890` in a V2 `NUMERIC(38,0)` field, save the record, and confirm both the editor and table display retain the complete value.

### Related issues
- Task 5860: https://test_management.v2.test.nocobase.com/nocobase/admin/kbruj97dzuv/view/09d5fa415ca/filterbytk/543/view/a1989b2f48d/filterbytk/5860

### Showcase
Before: the editor changes the value to scientific notation and the table may display only `1`.

After: the editor retains the complete decimal value and the table displays `123,456,789,012,345,678,901,234,567,890`.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect editing and display of large decimal values in V2 fields. |
| 🇨🇳 Chinese | 修复 V2 字段编辑和显示超大 decimal 数值不正确的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
