### PR TITLE
fix(plugin-action-duplicate): avoid duplicate error notifications

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/DuplicateActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/DuplicateActionModel.tsx
@@ -531,8 +531,10 @@ DuplicateActionModel.registerFlow({
           );
           ctx.message.success(ctx.t('Saved successfully'));
         } catch (error) {
-          const errorMessage = error instanceof Error && error.message ? error.message : ctx.t('Save failed');
-          ctx.message.error(errorMessage);
+          if (!(error instanceof Error) || error.name !== 'ResponseError') {
+            const errorMessage = error instanceof Error && error.message ? error.message : ctx.t('Save failed');
+            ctx.message.error(errorMessage);
+          }
           throw error;
         } finally {
           ctx.model.duplicateLoading = false;

--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/DuplicateActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/DuplicateActionModel.tsx
@@ -530,6 +530,10 @@ DuplicateActionModel.registerFlow({
             params.requestConfig,
           );
           ctx.message.success(ctx.t('Saved successfully'));
+        } catch (error) {
+          const errorMessage = error instanceof Error && error.message ? error.message : ctx.t('Save failed');
+          ctx.message.error(errorMessage);
+          throw error;
         } finally {
           ctx.model.duplicateLoading = false;
           ctx.model.rerender();

--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/__tests__/DuplicateActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/__tests__/DuplicateActionModel.test.ts
@@ -203,6 +203,64 @@ describe('DuplicateActionModel', () => {
     expect(ctx.model.rerender).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    { failureStage: 'template fetch', shouldFailFetch: true },
+    { failureStage: 'record creation', shouldFailFetch: false },
+  ])('shows the error and resets loading when $failureStage fails', async ({ shouldFailFetch }) => {
+    const flow: any = createModel({ duplicateFields: ['title'] }).getFlow('duplicateSettings');
+    const step: any = flow.getStep('duplicate');
+    const handler = step.serialize().handler;
+    const error = new Error('Duplicate failed');
+    const runAction = shouldFailFetch
+      ? vi.fn().mockRejectedValue(error)
+      : vi.fn(async () => ({ data: { title: 'Copy' } }));
+    const create = shouldFailFetch ? vi.fn(async () => undefined) : vi.fn().mockRejectedValue(error);
+    const resource = {
+      setDataSourceKey: vi.fn(),
+      setResourceName: vi.fn(),
+      runAction,
+    };
+    const ctx = {
+      model: {
+        props: {
+          duplicateFields: ['title'],
+        },
+        duplicateLoading: false,
+        rerender: vi.fn(),
+      },
+      blockModel: {
+        collection: {
+          filterTargetKey: 'id',
+          dataSourceKey: 'main',
+          name: 'posts',
+        },
+        resource: {
+          create,
+        },
+      },
+      record: {
+        id: 100,
+        __collection: 'posts',
+      },
+      collection: {
+        fields: new Map([['title', { name: 'title' }]]),
+      },
+      createResource: vi.fn(() => resource),
+      message: {
+        error: vi.fn(),
+        success: vi.fn(),
+      },
+      t: (key: string) => key,
+    };
+
+    await expect(handler(ctx, {})).rejects.toThrow('Duplicate failed');
+
+    expect(ctx.message.error).toHaveBeenCalledWith('Duplicate failed');
+    expect(ctx.message.success).not.toHaveBeenCalled();
+    expect(ctx.model.duplicateLoading).toBe(false);
+    expect(ctx.model.rerender).toHaveBeenCalledTimes(2);
+  });
+
   it('delegates openView when popupTemplateUid is provided', async () => {
     const model = createModel({ duplicateFields: ['title'] });
     const flow: any = model.getFlow('popupSettings');

--- a/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/__tests__/DuplicateActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/__tests__/DuplicateActionModel.test.ts
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { FlowEngine } from '@nocobase/flow-engine';
+import { FlowEngine, ResourceError } from '@nocobase/flow-engine';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DuplicateActionModel } from '../DuplicateActionModel';
 
@@ -206,60 +206,69 @@ describe('DuplicateActionModel', () => {
   it.each([
     { failureStage: 'template fetch', shouldFailFetch: true },
     { failureStage: 'record creation', shouldFailFetch: false },
-  ])('shows the error and resets loading when $failureStage fails', async ({ shouldFailFetch }) => {
-    const flow: any = createModel({ duplicateFields: ['title'] }).getFlow('duplicateSettings');
-    const step: any = flow.getStep('duplicate');
-    const handler = step.serialize().handler;
-    const error = new Error('Duplicate failed');
-    const runAction = shouldFailFetch
-      ? vi.fn().mockRejectedValue(error)
-      : vi.fn(async () => ({ data: { title: 'Copy' } }));
-    const create = shouldFailFetch ? vi.fn(async () => undefined) : vi.fn().mockRejectedValue(error);
-    const resource = {
-      setDataSourceKey: vi.fn(),
-      setResourceName: vi.fn(),
-      runAction,
-    };
-    const ctx = {
-      model: {
-        props: {
-          duplicateFields: ['title'],
+  ])(
+    'keeps only the API error notification and resets loading when $failureStage fails',
+    async ({ shouldFailFetch }) => {
+      const flow: any = createModel({ duplicateFields: ['title'] }).getFlow('duplicateSettings');
+      const step: any = flow.getStep('duplicate');
+      const handler = step.serialize().handler;
+      const error = new ResourceError({
+        response: {
+          data: {
+            errors: [{ message: 'Duplicate failed' }],
+          },
         },
-        duplicateLoading: false,
-        rerender: vi.fn(),
-      },
-      blockModel: {
+      });
+      const runAction = shouldFailFetch
+        ? vi.fn().mockRejectedValue(error)
+        : vi.fn(async () => ({ data: { title: 'Copy' } }));
+      const create = shouldFailFetch ? vi.fn(async () => undefined) : vi.fn().mockRejectedValue(error);
+      const resource = {
+        setDataSourceKey: vi.fn(),
+        setResourceName: vi.fn(),
+        runAction,
+      };
+      const ctx = {
+        model: {
+          props: {
+            duplicateFields: ['title'],
+          },
+          duplicateLoading: false,
+          rerender: vi.fn(),
+        },
+        blockModel: {
+          collection: {
+            filterTargetKey: 'id',
+            dataSourceKey: 'main',
+            name: 'posts',
+          },
+          resource: {
+            create,
+          },
+        },
+        record: {
+          id: 100,
+          __collection: 'posts',
+        },
         collection: {
-          filterTargetKey: 'id',
-          dataSourceKey: 'main',
-          name: 'posts',
+          fields: new Map([['title', { name: 'title' }]]),
         },
-        resource: {
-          create,
+        createResource: vi.fn(() => resource),
+        message: {
+          error: vi.fn(),
+          success: vi.fn(),
         },
-      },
-      record: {
-        id: 100,
-        __collection: 'posts',
-      },
-      collection: {
-        fields: new Map([['title', { name: 'title' }]]),
-      },
-      createResource: vi.fn(() => resource),
-      message: {
-        error: vi.fn(),
-        success: vi.fn(),
-      },
-      t: (key: string) => key,
-    };
+        t: (key: string) => key,
+      };
 
-    await expect(handler(ctx, {})).rejects.toThrow('Duplicate failed');
+      await expect(handler(ctx, {})).rejects.toThrow('Duplicate failed');
 
-    expect(ctx.message.error).toHaveBeenCalledWith('Duplicate failed');
-    expect(ctx.message.success).not.toHaveBeenCalled();
-    expect(ctx.model.duplicateLoading).toBe(false);
-    expect(ctx.model.rerender).toHaveBeenCalledTimes(2);
-  });
+      expect(ctx.message.error).not.toHaveBeenCalled();
+      expect(ctx.message.success).not.toHaveBeenCalled();
+      expect(ctx.model.duplicateLoading).toBe(false);
+      expect(ctx.model.rerender).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it('delegates openView when popupTemplateUid is provided', async () => {
     const model = createModel({ duplicateFields: ['title'] });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In v2, direct Duplicate failures need visible feedback without showing both the API error notification and an additional local message for the same error.

### Description 
- Rely on the existing API notification for `ResponseError` failures to avoid duplicate error messages.
- Show the error locally only for non-response failures that do not have API notification coverage, with the translated `Save failed` message as a fallback.
- Re-throw the error after handling feedback to preserve the existing flow failure semantics.
- Keep loading-state cleanup in `finally`.
- Add regression coverage for template-fetch and record-creation failures, including the no-duplicate-message behavior.

Risk is low because the change is local to the v2 direct Duplicate action and does not alter its success path, request parameters, or data structures.

Testing:
`yarn test packages/plugins/@nocobase/plugin-action-duplicate/src/client-v2/__tests__/DuplicateActionModel.test.ts --run --reporter=verbose`

### Related issues
Task 5868

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve direct duplication failure feedback in v2 without duplicate API error messages. |
| 🇨🇳 Chinese | 优化 v2 直接复制失败提示，避免重复显示 API 错误信息。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
