### PR TITLE
fix(database): preserve normalized index field names

### DIFF
--- a/packages/core/database/src/__tests__/underscored-options.test.ts
+++ b/packages/core/database/src/__tests__/underscored-options.test.ts
@@ -214,3 +214,44 @@ describe('underscored options', () => {
     }).toThrowError();
   });
 });
+
+describe.each([
+  { underscored: true, columnName: 'test_field' },
+  { underscored: false, columnName: 'testField' },
+])('index field options with underscored=$underscored', ({ underscored, columnName }) => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = await createMockDatabase({ underscored });
+    await db.clean({ drop: true });
+  });
+
+  afterEach(async () => {
+    await db.clean({ drop: true });
+    await db.close();
+  });
+
+  it('should preserve index options and normalize the field name', async () => {
+    const collection = db.collection({
+      name: 'prefixIndexTests',
+      fields: [{ type: 'string', name: 'testField', length: 1024 }],
+      indexes: [
+        {
+          name: 'idx_prefix_index_tests_field',
+          fields: [{ name: 'testField', length: 191 }],
+        },
+      ],
+    });
+
+    await db.sync();
+
+    const indexes = await db.sequelize.getQueryInterface().showIndex(collection.getTableNameWithSchema());
+    const index = indexes.find((item) => item.name === 'idx_prefix_index_tests_field');
+    const configuredIndex = collection.model.options.indexes?.find(
+      (item) => item.name === 'idx_prefix_index_tests_field',
+    );
+
+    expect(index?.fields.map((field) => field.attribute)).toEqual([columnName]);
+    expect(configuredIndex?.fields).toEqual([{ name: columnName, length: 191 }]);
+  });
+});

--- a/packages/core/database/src/database.ts
+++ b/packages/core/database/src/database.ts
@@ -474,7 +474,7 @@ export class Database extends EventEmitter implements AsyncEmitter {
             if (index.fields) {
               index.fields = index.fields.map((field) => {
                 if (field.name) {
-                  return { name: snakeCase(field.name), ...field };
+                  return { ...field, name: snakeCase(field.name) };
                 }
                 return snakeCase(field);
               });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Prefix indexes declared with camel-case field names could target the wrong physical columns when underscored database naming was enabled.

### Description 
Preserve normalized physical field names while retaining prefix-index options such as `length`. Added coverage for both underscored naming modes and prefix lengths.

Risk is limited to index field-name normalization. Suggested verification: run `packages/core/database/src/__tests__/underscored-options.test.ts` with both naming modes.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed prefix indexes on camel-case fields when underscored database naming is enabled |
| 🇨🇳 Chinese | 修复启用数据库下划线命名时驼峰字段前缀索引创建失败的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
