### PR TITLE
fix(client): redirect denied settings tabs

### DIFF
--- a/packages/core/client-v2/src/__tests__/settings-center.test.tsx
+++ b/packages/core/client-v2/src/__tests__/settings-center.test.tsx
@@ -8,9 +8,10 @@
  */
 
 import { ACLRolesCheckProvider, createMockClient, Plugin } from '@nocobase/client-v2';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { message } from 'antd';
+import { vi } from 'vitest';
 import { AdminSettingsLayoutModel as ClientV2AdminSettingsLayoutModel } from '../settings-center';
 import { AdminSettingsLayoutModel as ClientV1AdminSettingsLayoutModel } from '../../../client/src/pm/AdminSettingsLayoutModel';
 import { NocoBaseBuildInPlugin } from '../nocobase-buildin-plugin';
@@ -326,6 +327,194 @@ describe('settings center', () => {
 
     expect(await screen.findByText('Current settings page is unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Secure settings page')).not.toBeInTheDocument();
+  });
+
+  it('should redirect a denied settings tab to the first accessible tab', async () => {
+    const renderDeniedTab = vi.fn(() => <div>Denied tab content</div>);
+
+    class ProtectedSettingsTabsPlugin extends Plugin {
+      async load() {
+        this.pluginSettingsManager.addMenuItem({ key: 'protected-tabs', title: 'Protected tabs' });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'protected-tabs',
+          key: 'a-second',
+          title: 'Second accessible tab',
+          aclSnippet: 'pm.protected-tabs.second',
+          sort: 20,
+          Component: () => <div>Second accessible tab content</div>,
+        });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'protected-tabs',
+          key: 'z-first',
+          title: 'First accessible tab',
+          aclSnippet: 'pm.protected-tabs.first',
+          sort: 10,
+          Component: () => <div>First accessible tab content</div>,
+        });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'protected-tabs',
+          key: 'denied',
+          title: 'Denied tab',
+          aclSnippet: 'pm.protected-tabs.denied',
+          sort: 30,
+          Component: renderDeniedTab,
+        });
+      }
+    }
+
+    const app = createMockClient({
+      plugins: [NocoBaseBuildInPlugin, TestAclPlugin, ProtectedSettingsTabsPlugin],
+      router: { type: 'memory', initialEntries: ['/admin/settings/protected-tabs/denied'] },
+    });
+    mockAdminRuntime(app, {
+      snippets: ['pm', '!pm.protected-tabs.denied'],
+    });
+
+    await renderApp(app);
+    await waitForGetRequests(app, ['/auth:check', 'roles:check']);
+
+    await waitFor(() => {
+      expect(app.router.router.state.location.pathname).toBe('/admin/settings/protected-tabs/z-first');
+    });
+    expect(app.router.router.state.historyAction).toBe('REPLACE');
+    expect(await screen.findByText('First accessible tab content')).toBeInTheDocument();
+    expect(screen.queryByText('Denied tab content')).not.toBeInTheDocument();
+    expect(renderDeniedTab).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await app.router.router.navigate('/admin/settings/protected-tabs/a-second');
+    });
+
+    expect(await screen.findByText('Second accessible tab content')).toBeInTheDocument();
+    expect(app.router.router.state.location.pathname).toBe('/admin/settings/protected-tabs/a-second');
+  });
+
+  it('should skip an accessible dynamic tab when its route params cannot be resolved', async () => {
+    class DynamicSettingsTabsPlugin extends Plugin {
+      async load() {
+        this.pluginSettingsManager.addMenuItem({ key: 'dynamic-tabs', title: 'Dynamic tabs' });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'dynamic-tabs',
+          key: ':name',
+          title: 'Dynamic tab',
+          aclSnippet: 'pm.dynamic-tabs.dynamic',
+          sort: 1,
+          Component: () => <div>Dynamic tab content</div>,
+        });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'dynamic-tabs',
+          key: 'fallback',
+          title: 'Static fallback tab',
+          aclSnippet: 'pm.dynamic-tabs.fallback',
+          sort: 2,
+          Component: () => <div>Static fallback tab content</div>,
+        });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'dynamic-tabs',
+          key: 'denied',
+          title: 'Denied tab',
+          aclSnippet: 'pm.dynamic-tabs.denied',
+          sort: 3,
+          Component: () => <div>Denied dynamic tab content</div>,
+        });
+      }
+    }
+
+    const app = createMockClient({
+      plugins: [NocoBaseBuildInPlugin, TestAclPlugin, DynamicSettingsTabsPlugin],
+      router: { type: 'memory', initialEntries: ['/admin/settings/dynamic-tabs/denied'] },
+    });
+    mockAdminRuntime(app, {
+      snippets: ['pm', '!pm.dynamic-tabs.denied'],
+    });
+
+    await renderApp(app);
+    await waitForGetRequests(app, ['/auth:check', 'roles:check']);
+
+    await waitFor(() => {
+      expect(app.router.router.state.location.pathname).toBe('/admin/settings/dynamic-tabs/fallback');
+    });
+    expect(await screen.findByText('Static fallback tab content')).toBeInTheDocument();
+  });
+
+  it('should preserve resolved route params when redirecting between dynamic tabs', async () => {
+    class DynamicSiblingTabsPlugin extends Plugin {
+      async load() {
+        this.pluginSettingsManager.addMenuItem({ key: 'dynamic-siblings', title: 'Dynamic sibling tabs' });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'dynamic-siblings',
+          key: ':name/channels',
+          title: 'Dynamic channels tab',
+          aclSnippet: 'pm.dynamic-siblings.channels',
+          sort: 1,
+          Component: () => <div>Dynamic channels tab content</div>,
+        });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'dynamic-siblings',
+          key: ':name/logs',
+          title: 'Dynamic logs tab',
+          aclSnippet: 'pm.dynamic-siblings.logs',
+          sort: 2,
+          Component: () => <div>Dynamic logs tab content</div>,
+        });
+      }
+    }
+
+    const app = createMockClient({
+      plugins: [NocoBaseBuildInPlugin, TestAclPlugin, DynamicSiblingTabsPlugin],
+      router: { type: 'memory', initialEntries: ['/admin/settings/dynamic-siblings/email:primary/logs'] },
+    });
+    mockAdminRuntime(app, {
+      snippets: ['pm', '!pm.dynamic-siblings.logs'],
+    });
+
+    await renderApp(app);
+    await waitForGetRequests(app, ['/auth:check', 'roles:check']);
+
+    await waitFor(() => {
+      expect(app.router.router.state.location.pathname).toBe('/admin/settings/dynamic-siblings/email:primary/channels');
+    });
+    expect(await screen.findByText('Dynamic channels tab content')).toBeInTheDocument();
+  });
+
+  it('should resolve hyphenated route param names when redirecting between dynamic tabs', async () => {
+    class HyphenatedParamTabsPlugin extends Plugin {
+      async load() {
+        this.pluginSettingsManager.addMenuItem({ key: 'hyphenated-params', title: 'Hyphenated param tabs' });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'hyphenated-params',
+          key: ':data-source/channels',
+          title: 'Hyphenated channels tab',
+          aclSnippet: 'pm.hyphenated-params.channels',
+          sort: 1,
+          Component: () => <div>Hyphenated channels tab content</div>,
+        });
+        this.pluginSettingsManager.addPageTabItem({
+          menuKey: 'hyphenated-params',
+          key: ':data-source/logs',
+          title: 'Hyphenated logs tab',
+          aclSnippet: 'pm.hyphenated-params.logs',
+          sort: 2,
+          Component: () => <div>Hyphenated logs tab content</div>,
+        });
+      }
+    }
+
+    const app = createMockClient({
+      plugins: [NocoBaseBuildInPlugin, TestAclPlugin, HyphenatedParamTabsPlugin],
+      router: { type: 'memory', initialEntries: ['/admin/settings/hyphenated-params/email/logs'] },
+    });
+    mockAdminRuntime(app, {
+      snippets: ['pm', '!pm.hyphenated-params.logs'],
+    });
+
+    await renderApp(app);
+    await waitForGetRequests(app, ['/auth:check', 'roles:check']);
+
+    await waitFor(() => {
+      expect(app.router.router.state.location.pathname).toBe('/admin/settings/hyphenated-params/email/channels');
+    });
+    expect(await screen.findByText('Hyphenated channels tab content')).toBeInTheDocument();
   });
 
   it('should keep menu visible when menu acl is denied but child page is visible', async () => {

--- a/packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx
+++ b/packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx
@@ -14,7 +14,7 @@ import { FlowModelRenderer, useFlowEngine } from '@nocobase/flow-engine';
 import { Layout, Menu, Result, theme } from 'antd';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { generatePath, Navigate, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useACLRoleContext } from '../acl';
 import { ADMIN_SETTINGS_PATH, type PluginSettingsPageType } from '../PluginSettingsManager';
 import { useApp } from '../hooks/useApp';
@@ -68,6 +68,9 @@ export const InternalAdminSettingsLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const params = useParams();
+  const routeParams = Object.fromEntries(
+    Object.entries(params).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
   const { token } = theme.useToken();
   const { t } = useTranslation();
   const { snippets = [] } = useACLRoleContext();
@@ -174,7 +177,21 @@ export const InternalAdminSettingsLayout = () => {
     return <SettingsEmpty type="route" />;
   }
 
-  if (!currentVisibleSetting && currentSetting.isAllow === false) {
+  if (currentSetting.isAllow === false) {
+    const firstVisibleTabPath = currentVisibleTabs
+      .map((tab) => getDefaultSettingsPath([tab]))
+      .filter((path): path is string => typeof path === 'string')
+      .map((path) => {
+        try {
+          return generatePath(path, routeParams);
+        } catch {
+          return null;
+        }
+      })
+      .find((path): path is string => typeof path === 'string');
+    if (firstVisibleTabPath) {
+      return <Navigate replace to={firstVisibleTabPath} />;
+    }
     return <SettingsEmpty type="route" />;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

当角色没有 Settings 页面中某个页签的访问权限时，直接访问或刷新该页签仍会停留在无权限页面，无法自动进入当前角色可以使用的设置页签。

### Description

- 当前页签无权限时，自动跳转到同一 Settings 页面中排序最靠前的可访问页签，并替换当前浏览历史记录。
- 动态路由参数无法补全时跳过该候选页签；没有可访问页签时继续显示不可用状态，避免跳转到错误页面。
- 已有权限的页签和外部链接页签保持现有行为不变。
- 补充单元测试，覆盖页签排序、权限内容不渲染、历史记录替换、动态路由参数和无可用目标等场景。

### Showcase

无。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Automatically redirect to an accessible Settings tab when the current tab is unavailable |
| 🇨🇳 Chinese | 当前 Settings 页签无权限时自动跳转到可访问页签 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
