### PR TITLE
fix(plugin-kanban): persist card detail drawer configuration

### DIFF
--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts
@@ -2363,6 +2363,32 @@ describe('KanbanBlockModel.filterCollection', () => {
     );
   });
 
+  test('card click persists the popup host before opening it in configuration mode', async () => {
+    const dispatchEvent = vi.fn().mockResolvedValue(undefined);
+    const ensureCardViewAction = vi.fn().mockResolvedValue({ uid: 'u_card_view_popup', dispatchEvent });
+
+    await KanbanBlockModel.prototype.openCard.call(
+      {
+        context: {
+          flowSettingsEnabled: true,
+          layoutContentElement: { id: 'layout-root' },
+        },
+        collection: {
+          name: 'tasks',
+          dataSourceKey: 'main',
+          getFilterByTK: (record: { id: number }) => record.id,
+        },
+        getCardOpenMode: () => 'drawer',
+        isCardClickable: () => true,
+        ensureCardViewAction,
+      },
+      { id: 1 },
+    );
+
+    expect(ensureCardViewAction).toHaveBeenCalledWith({ persist: true });
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+  });
+
   test('page size settings use the fixed dropdown options', () => {
     const flow: any = (KanbanBlockModel as any).globalFlowRegistry.getFlow('kanbanSettings');
     const step: any = flow?.steps?.pageSize;

--- a/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx
@@ -1180,7 +1180,12 @@ export class KanbanBlockModel extends CollectionBlockModel<{
       return;
     }
 
-    const action = await this.ensureCardViewAction();
+    // The drawer content is stored under the hidden card action. Persist that
+    // host before users add blocks in configuration mode so the content can be
+    // loaded again after the drawer is destroyed.
+    const action = this.context?.flowSettingsEnabled
+      ? await this.ensureCardViewAction({ persist: true })
+      : await this.ensureCardViewAction();
     if (!action || !record) {
       await this.openEmptyPopupShell({
         mode: this.getCardOpenMode(),


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Content configured in a kanban card's detail drawer was attached to a transient hidden popup action. After the drawer was closed and opened again, that content could no longer be loaded.

### Description
- Persist the hidden card detail popup host before opening the drawer in configuration mode.
- Keep normal, non-configuration card clicks free of persistence writes.
- Add a regression test for the configuration-mode popup lifecycle.

The change is limited to the client-v2 kanban card detail popup. The main risk is an additional persistence request when opening card details in configuration mode.

Tested with:
- `yarn test packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts --run --reporter=verbose` (68 tests passed)
- `yarn eslint --fix packages/plugins/@nocobase/plugin-kanban/src/client-v2/models/KanbanBlockModel.tsx packages/plugins/@nocobase/plugin-kanban/src/client-v2/__tests__/KanbanBlockModel.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed configured content disappearing after reopening a kanban card's detail drawer |
| 🇨🇳 Chinese | 修复重新打开看板卡片详情抽屉后已配置内容丢失的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
