### PR TITLE
feat(plugin-block-tree): support default sorting

### DIFF
--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeBlockModel.tsx
@@ -716,6 +716,10 @@ TreeBlockModel.registerFlow({
       use: 'dataScope',
       title: tExpr('Data scope'),
     },
+    defaultSorting: {
+      use: 'sortingRule',
+      title: tExpr('Default sorting'),
+    },
     connectFields: {
       use: treeConnectDataBlocks.name,
       title: tExpr('Connect data blocks'),

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
@@ -69,6 +69,15 @@ describe('TreeBlockModel', () => {
     expect(String(TreeFilterBlockMenuModel.meta?.searchPlaceholder)).toContain('Search');
   });
 
+  it('exposes default sorting in tree settings', () => {
+    const flow = TreeBlockModel.globalFlowRegistry.getFlow('treeSettings');
+
+    expect(flow.steps.defaultSorting).toMatchObject({
+      use: 'sortingRule',
+      title: expect.stringContaining('Default sorting'),
+    });
+  });
+
   it('keeps multi relation entries in associated records for tree filter block menu', async () => {
     const engine = new FlowEngine();
     engine.registerModels({ TreeBlockModel });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation
Tree filter blocks in the v2 client did not expose the default sorting configuration that is already available for other data blocks and supported by the tree resource contract.

### Description 
- Add the shared default sorting rule to the v2 tree block settings flow.
- Allow users to configure sortable fields, direction, and priority for tree filter records.
- Add a unit test covering the sorting setting registration.

Risk is low because this reuses the existing shared sorting action and the existing tree sorting persistence path.

Testing suggestion: create a tree filter block, configure multiple default sorting fields, and confirm root and child records use the configured order.

### Related issues

None.

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tree filter blocks now support configurable default sorting. |
| 🇨🇳 Chinese | 树筛选区块现已支持配置默认排序。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
