### PR TITLE
fix(plugin-verification): add refresh button

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-china-region/src/client-v2/__tests__/ChinaRegionFieldInterface.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-china-region/src/client-v2/__tests__/ChinaRegionFieldInterface.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { ChinaRegionFieldInterface } from '../chinaRegion';
-import { ChinaRegionFieldModel, DisplayChinaRegionFieldModel } from '../models';
+import { ChinaRegionFieldModel, ChinaRegionFilterFieldModel, DisplayChinaRegionFieldModel } from '../models';
 import PluginFieldChinaRegionClient from '../plugin';
 
 const uidMock = vi.hoisted(() => {
@@ -51,6 +51,9 @@ describe('ChinaRegionFieldInterface', () => {
       ChinaRegionFieldModel: {
         loader: expect.any(Function),
       },
+      ChinaRegionFilterFieldModel: {
+        loader: expect.any(Function),
+      },
       DisplayChinaRegionFieldModel: {
         loader: expect.any(Function),
       },
@@ -60,6 +63,10 @@ describe('ChinaRegionFieldInterface', () => {
     await expect(loaders.ChinaRegionFieldModel.loader()).resolves.toHaveProperty(
       'ChinaRegionFieldModel',
       ChinaRegionFieldModel,
+    );
+    await expect(loaders.ChinaRegionFilterFieldModel.loader()).resolves.toHaveProperty(
+      'ChinaRegionFilterFieldModel',
+      ChinaRegionFilterFieldModel,
     );
     await expect(loaders.DisplayChinaRegionFieldModel.loader()).resolves.toHaveProperty(
       'DisplayChinaRegionFieldModel',

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/layoutPermissions.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/layoutPermissions.test.tsx
@@ -320,6 +320,9 @@ describe('plugin-ui-layout route permissions', () => {
     );
 
     const reports = await screen.findByRole('checkbox', { name: 'Allow access to Reports' });
+    await waitFor(() => {
+      expect(reports).not.toHaveStyle({ pointerEvents: 'none' });
+    });
 
     await act(async () => {
       await user.click(reports);

--- a/packages/plugins/@nocobase/plugin-verification/src/client-v2/__tests__/VerifiersPage.ui.test.tsx
+++ b/packages/plugins/@nocobase/plugin-verification/src/client-v2/__tests__/VerifiersPage.ui.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VerifiersPage from '../pages/VerifiersPage';
+
+const pageMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  refresh: vi.fn(),
+  resource: {
+    create: vi.fn(),
+    destroy: vi.fn(),
+    list: vi.fn(),
+    listTypes: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('@nocobase/client-v2', () => ({
+  DrawerFormLayout: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Table: () => <div role="table" />,
+  useApp: () => ({ pm: { get: () => undefined } }),
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  randomId: () => 'v_generated',
+  useFlowContext: () => ({
+    api: {
+      resource: () => pageMocks.resource,
+    },
+    viewer: {
+      drawer: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('ahooks', () => ({
+  useMemoizedFn: (fn: unknown) => fn,
+  useRequest: (_service: () => Promise<unknown>, options?: { cacheKey?: string }) => {
+    if (options?.cacheKey) {
+      return { data: [], loading: false, refresh: vi.fn() };
+    }
+    return {
+      data: { records: [], total: 0 },
+      loading: false,
+      refresh: pageMocks.refresh,
+    };
+  },
+}));
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return {
+    ...actual,
+    App: {
+      ...actual.App,
+      useApp: () => ({ modal: { confirm: pageMocks.confirm } }),
+    },
+    theme: {
+      ...actual.theme,
+      useToken: () => ({ token: { margin: 16, marginSM: 12 } }),
+    },
+  };
+});
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+  useVerificationTranslation: () => ({ t: (value: string) => value }),
+}));
+
+vi.mock('../plugin', () => ({
+  default: class PluginVerificationClientV2 {},
+}));
+
+describe('VerifiersPage toolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes the verifier list from the refresh button', () => {
+    render(<VerifiersPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+
+    expect(pageMocks.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-verification/src/client-v2/pages/VerifiersPage.tsx
+++ b/packages/plugins/@nocobase/plugin-verification/src/client-v2/pages/VerifiersPage.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { DeleteOutlined, DownOutlined, PlusOutlined } from '@ant-design/icons';
+import { DeleteOutlined, DownOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 import { DrawerFormLayout, Table, useApp } from '@nocobase/client-v2';
 import { randomId, useFlowContext } from '@nocobase/flow-engine';
 import { useMemoizedFn, useRequest } from 'ahooks';
@@ -369,6 +369,9 @@ export default function VerifiersPage() {
   return (
     <Card variant="borderless">
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: token.marginSM, marginBottom: token.margin }}>
+        <Button icon={<ReloadOutlined />} loading={loading} onClick={refresh}>
+          {t('Refresh')}
+        </Button>
         <Button
           icon={<DeleteOutlined />}
           disabled={!selectedRowKeys.length}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Client V2 的 Verification 设置页面缺少手动刷新入口。用户需要重新加载整个页面，才能获取最新的 Verification 列表。

### Description

在 Verification 列表顶部增加刷新按钮，并放置在 Delete 按钮左侧。点击按钮会重新获取当前列表数据，刷新期间按钮会显示加载状态。

同时新增界面测试，验证刷新按钮可见且点击后会触发列表刷新。建议重点检查刷新按钮的位置、加载状态，以及新增、删除和分页功能是否保持正常。

本次改动仅影响 Verification 设置页面，风险较低。

### Showcase

刷新按钮显示在 Verification 列表顶部，位于 Delete 按钮左侧。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add a refresh button to the Verification list |
| 🇨🇳 Chinese | Verification 列表新增刷新按钮 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
