### PR TITLE
fix(plugin-ui-layout): respect mobile permissions

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  ACLContext,
   BaseLayoutModel,
   ChildPageModel,
   KeepAlive,
@@ -114,9 +115,23 @@ describe('plugin-ui-layout mobile models', () => {
     window.localStorage.removeItem(FLOW_SETTINGS_PREFERENCE_STORAGE_KEY);
   });
 
+  function createACLContextValue(allowConfigUI = true) {
+    return {
+      loading: false,
+      data: {
+        data: {
+          snippets: allowConfigUI ? ['ui.*'] : [],
+        },
+        meta: {},
+      },
+      refresh: vi.fn(async () => {}),
+    };
+  }
+
   function renderMobileLayoutWithRouteRepository(
     routeRepository: MobileRouteRepositoryForTest,
     options: {
+      allowConfigUI?: boolean;
       beforeRender?: (model: MobileLayoutModel) => void;
       api?: {
         request: (options: Record<string, unknown>) => Promise<{ data?: { data?: NocoBaseDesktopRoute[] } }>;
@@ -185,40 +200,46 @@ describe('plugin-ui-layout mobile models', () => {
         FlowEngineProvider,
         { engine },
         React.createElement(
-          ConfigProvider,
+          ACLContext.Provider,
           {
-            theme: options.theme,
+            value: createACLContextValue(options.allowConfigUI !== false),
           },
           React.createElement(
-            AntdApp,
-            null,
+            ConfigProvider,
+            {
+              theme: options.theme,
+            },
             React.createElement(
-              MemoryRouter,
-              {
-                initialEntries: options.initialEntries || [
-                  options.memoryRouterBasename ? `${options.memoryRouterBasename}/mobile` : '/v/mobile',
-                ],
-                basename: options.memoryRouterBasename,
-              },
+              AntdApp,
+              null,
               React.createElement(
-                Routes,
-                null,
-                options.outletElement
-                  ? React.createElement(
-                      Route,
-                      {
-                        path: routerRoutePath,
+                MemoryRouter,
+                {
+                  initialEntries: options.initialEntries || [
+                    options.memoryRouterBasename ? `${options.memoryRouterBasename}/mobile` : '/v/mobile',
+                  ],
+                  basename: options.memoryRouterBasename,
+                },
+                React.createElement(
+                  Routes,
+                  null,
+                  options.outletElement
+                    ? React.createElement(
+                        Route,
+                        {
+                          path: routerRoutePath,
+                          element: model.render(),
+                        },
+                        React.createElement(Route, {
+                          path: ':name',
+                          element: options.outletElement,
+                        }),
+                      )
+                    : React.createElement(Route, {
+                        path: `${routerRoutePath}/*`,
                         element: model.render(),
-                      },
-                      React.createElement(Route, {
-                        path: ':name',
-                        element: options.outletElement,
                       }),
-                    )
-                  : React.createElement(Route, {
-                      path: `${routerRoutePath}/*`,
-                      element: model.render(),
-                    }),
+                ),
               ),
             ),
           ),
@@ -1223,18 +1244,22 @@ describe('plugin-ui-layout mobile models', () => {
         FlowEngineProvider,
         { engine },
         React.createElement(
-          AntdApp,
-          null,
+          ACLContext.Provider,
+          { value: createACLContextValue() },
           React.createElement(
-            MemoryRouter,
-            { initialEntries: ['/v/mobile'] },
+            AntdApp,
+            null,
             React.createElement(
-              Routes,
-              null,
-              React.createElement(Route, {
-                path: '/v/mobile/*',
-                element: model.render(),
-              }),
+              MemoryRouter,
+              { initialEntries: ['/v/mobile'] },
+              React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, {
+                  path: '/v/mobile/*',
+                  element: model.render(),
+                }),
+              ),
             ),
           ),
         ),
@@ -1406,18 +1431,22 @@ describe('plugin-ui-layout mobile models', () => {
         FlowEngineProvider,
         { engine },
         React.createElement(
-          AntdApp,
-          null,
+          ACLContext.Provider,
+          { value: createACLContextValue() },
           React.createElement(
-            MemoryRouter,
-            { initialEntries: ['/v/mobile'] },
+            AntdApp,
+            null,
             React.createElement(
-              Routes,
-              null,
-              React.createElement(Route, {
-                path: '/v/mobile/*',
-                element: model.render(),
-              }),
+              MemoryRouter,
+              { initialEntries: ['/v/mobile'] },
+              React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, {
+                  path: '/v/mobile/*',
+                  element: model.render(),
+                }),
+              ),
             ),
           ),
         ),
@@ -2589,6 +2618,44 @@ describe('plugin-ui-layout mobile models', () => {
       });
       expect(screen.getByRole('button', { name: 'Add mobile tab' })).toBeInTheDocument();
       expect(screen.queryByText('Add block')).not.toBeInTheDocument();
+    } finally {
+      restoreBreakpoint();
+    }
+  });
+
+  it.each([
+    { title: 'without a stored preference', storedPreference: undefined },
+    { title: 'with an enabled stored preference', storedPreference: '1' },
+  ])('should hide the UI editor when the role cannot configure the interface $title', async ({ storedPreference }) => {
+    const restoreBreakpoint = mockDesktopBreakpoint();
+    const routeRepository: MobileRouteRepositoryForTest = {
+      listAccessible: () => [],
+      ensureAccessibleLoaded: vi.fn(async () => []),
+    };
+
+    try {
+      if (storedPreference) {
+        window.localStorage.setItem(FLOW_SETTINGS_PREFERENCE_STORAGE_KEY, storedPreference);
+      }
+      const { engine } = renderMobileLayoutWithRouteRepository(routeRepository, {
+        allowConfigUI: false,
+        beforeRender: (model) => {
+          // Start enabled so the assertion below proves the permission-sync effect actively disables Flow Settings.
+          model.flowEngine.flowSettings.enabled = true;
+        },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('No mobile pages yet')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('ui-editor-button')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add mobile tab' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Pad preview' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Mobile preview' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'QR code' })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(engine.context.flowSettingsEnabled).toBe(false);
+      });
     } finally {
       restoreBreakpoint();
     }

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
@@ -32,6 +32,7 @@ import {
   type LayoutDefinition,
   type RouteModel,
   type RoutePageMeta,
+  useUIConfigurationPermissions,
 } from '@nocobase/client-v2';
 import {
   DndProvider,
@@ -692,6 +693,7 @@ function useIsDesktopPreview(screenMD: number) {
 const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel }) => {
   const { model } = props;
   const { token } = theme.useToken();
+  const { allowConfigUI } = useUIConfigurationPermissions();
   const isDesktopPreview = useIsDesktopPreview(token.screenMD);
   const [previewSize, setPreviewSize] = useState<MobilePreviewSize>(MOBILE_PREVIEW_SIZE);
   const [flowSettingsPreference, setFlowSettingsPreference] = useState(() =>
@@ -701,9 +703,8 @@ const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel
   const [flowSettingsSyncVersion, setFlowSettingsSyncVersion] = useState(0);
   const flowSettingsSyncRef = useRef(0);
   const desiredFlowSettingsEnabledRef = useRef(false);
-  const preferredFlowSettingsEnabled = flowSettingsPreference.hasStoredPreference
-    ? flowSettingsPreference.enabled
-    : isMobileMenuEmpty;
+  const preferredFlowSettingsEnabled =
+    allowConfigUI && (flowSettingsPreference.hasStoredPreference ? flowSettingsPreference.enabled : isMobileMenuEmpty);
   const className = useMemo(
     () => css`
       width: 100%;
@@ -873,6 +874,7 @@ const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel
     <div className={className}>
       {isDesktopPreview ? (
         <MobileDesktopModeHeader
+          allowConfigUI={allowConfigUI}
           designModeEnabled={preferredFlowSettingsEnabled}
           model={model}
           previewSize={previewSize}
@@ -917,13 +919,14 @@ const MobileLayoutComponent = observer((props: { model: MobileLayoutModel }) => 
 
 const MobileDesktopModeHeader = observer(
   (props: {
+    allowConfigUI: boolean;
     designModeEnabled: boolean;
     model: MobileLayoutModel;
     previewSize: MobilePreviewSize;
     onDesignModeChange: (enabled: boolean) => void;
     onPreviewSizeChange: (size: MobilePreviewSize) => void;
   }) => {
-    const { designModeEnabled, model, previewSize, onDesignModeChange, onPreviewSizeChange } = props;
+    const { allowConfigUI, designModeEnabled, model, previewSize, onDesignModeChange, onPreviewSizeChange } = props;
     const { token } = theme.useToken();
     const customToken = token as typeof token & MobileLayoutThemeToken;
     const colorSettings = customToken.colorSettings || 'var(--colorSettings, #F18B62)';
@@ -985,19 +988,21 @@ const MobileDesktopModeHeader = observer(
     return (
       <header className={className}>
         <div className="nb-ui-layout-mobile-desktop-actions">
-          <Tooltip title={t('UI Editor')}>
-            <button
-              type="button"
-              className="nb-ui-layout-mobile-desktop-action nb-ui-layout-mobile-desktop-design-action"
-              data-testid="ui-editor-button"
-              aria-label={t('UI Editor')}
-              aria-pressed={designModeEnabled}
-              title={t('UI Editor')}
-              onClick={handleToggleDesignMode}
-            >
-              <HighlightOutlined style={{ color: colorTextHeaderMenu }} />
-            </button>
-          </Tooltip>
+          {allowConfigUI ? (
+            <Tooltip title={t('UI Editor')}>
+              <button
+                type="button"
+                className="nb-ui-layout-mobile-desktop-action nb-ui-layout-mobile-desktop-design-action"
+                data-testid="ui-editor-button"
+                aria-label={t('UI Editor')}
+                aria-pressed={designModeEnabled}
+                title={t('UI Editor')}
+                onClick={handleToggleDesignMode}
+              >
+                <HighlightOutlined style={{ color: colorTextHeaderMenu }} />
+              </button>
+            </Tooltip>
+          ) : null}
           <Tooltip title={t('Pad preview')}>
             <button
               type="button"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

当角色没有“配置界面”权限时，移动端页面仍会显示 UI Editor 和新增页签入口，导致无权限用户看到不应出现的界面配置操作。

### Description

- 无“配置界面”权限时，隐藏移动端 UI Editor，并确保界面配置模式保持关闭
- 同步隐藏由配置模式提供的新增移动端页签入口，同时保留 Pad、Mobile 和二维码预览操作
- 增加权限回归测试，覆盖无本地偏好和已保存开启偏好两种情况

影响范围仅限 Client V2 移动端布局；已有界面配置权限的角色保持原有行为。建议分别使用有权限和无权限角色访问移动端页面验证入口显示状态。

### Showcase

无

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide the mobile UI Editor when the current role cannot configure the interface |
| 🇨🇳 Chinese | 修复无界面配置权限的角色仍能看到移动端 UI Editor 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
