### PR TITLE
fix(action-export): serialize filters

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/ExportActionModel.tsx
@@ -305,7 +305,7 @@ ExportActionModel.registerFlow({
             title: ctx.t(title),
             appends: resource.getAppends(),
             sort: resource.getSort(),
-            filter,
+            filter: JSON.stringify(filter),
           },
         });
         const blob = new Blob([data], { type: 'application/x-xls' });

--- a/packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/ExportActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-export/src/client-v2/__tests__/ExportActionModel.test.ts
@@ -1,0 +1,75 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { ExportActionModel } from '../ExportActionModel';
+
+vi.mock('file-saver', () => ({
+  saveAs: vi.fn(),
+}));
+
+describe('ExportActionModel', () => {
+  it('serializes a nested resource filter before exporting', async () => {
+    const filter = {
+      $and: [
+        {
+          $or: [{ 'org_oho.uuid': { $eq: '1' } }, { 'org_o2m.company': { $eq: 'NocoBase' } }],
+        },
+      ],
+    };
+    const runAction = vi.fn(async () => new Uint8Array());
+    const resource = {
+      getSelectedRows: vi.fn(() => []),
+      getFilter: vi.fn(() => filter),
+      getAppends: vi.fn(() => ['org_oho', 'org_o2m']),
+      getSort: vi.fn(() => ['-createdAt']),
+      runAction,
+    };
+    const blockModel = {
+      resource,
+      collection: {
+        title: 'Users',
+        fields: new Map(),
+        filterTargetKey: 'id',
+        getFilterByTK: vi.fn(),
+      },
+    };
+    const model = new ExportActionModel({
+      uid: 'export-action',
+      flowEngine: new FlowEngine(),
+      props: { exportSettings: [] },
+    });
+    const handler = model.getFlow('exportSettings')?.getStep('export')?.serialize().handler;
+    const ctx = {
+      model: {
+        getProps: () => ({ exportSettings: [] }),
+        context: { blockModel },
+      },
+      blockModel,
+      t: (value: string) => value,
+    };
+
+    expect(handler).toBeTypeOf('function');
+    if (!handler) {
+      throw new Error('Export handler is not registered');
+    }
+
+    await handler(ctx as unknown as Parameters<typeof handler>[0], {});
+
+    expect(runAction).toHaveBeenCalledWith(
+      'export',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          filter: JSON.stringify(filter),
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

筛选表单使用关系字段同时筛选多个连接字段后，表格可以正常显示筛选结果，但导出会报错，用户无法导出当前结果。

### Description

- 导出时按接口约定传递当前筛选条件，避免复杂关系筛选条件被错误拆分。
- 补充回归测试，覆盖包含多层关系条件的表格导出。
- 改动仅影响导出请求中的筛选条件传递，不改变筛选表单、表格查询或导出接口。

建议重点验证无筛选、普通字段筛选、关系字段多条件筛选，以及勾选表格行后的导出。

### Showcase

无 UI 样式变化。已在浏览器中验证：关系字段筛选后表格保留 1 条结果，导出请求成功并下载 Excel 文件。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix table export errors after filtering by multiple relation fields |
| 🇨🇳 Chinese | 修复按多个关系字段筛选后表格导出报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
