### PR TITLE
fix(plugin-backups): keep restore loading visible

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupHooks.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupHooks.test.tsx
@@ -198,7 +198,7 @@ describe('backup hooks', () => {
       params: { task: 'task-1' },
     });
     expect(taskRef.current).toBeNull();
-    expect(hideCheckBackupMessage).toHaveBeenCalledTimes(1);
+    expect(hideCheckBackupMessage).not.toHaveBeenCalled();
     expect(mocks.notification.error).toHaveBeenCalledWith({ message: 'Restore failed', role: 'alert' });
   });
 
@@ -241,6 +241,51 @@ describe('backup hooks', () => {
     });
 
     expect(taskRef.current).toBe('task-1');
+    expect(mocks.notification.error).not.toHaveBeenCalled();
+  });
+
+  it('serializes polling and ignores a response for a replaced restore task', async () => {
+    vi.useFakeTimers();
+    const hideCheckBackupMessage = vi.fn();
+    mocks.engineContext[BACKUP_RESTORE_RUNTIME_KEY] = {
+      showCheckBackupMessage: vi.fn(),
+      hideCheckBackupMessage,
+    };
+    let resolveStatus: ((value: { data: { data: { inProgress: boolean; message: string } } }) => void) | undefined;
+    mocks.flowContext.api.request.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
+    let taskRef: React.MutableRefObject<string | null> | undefined;
+
+    render(<RestoreTaskProbe onReady={(ref) => (taskRef = ref)} />);
+    if (!taskRef) {
+      throw new Error('restore task ref is missing');
+    }
+    taskRef.current = 'task-1';
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    expect(mocks.flowContext.api.request).toHaveBeenCalledTimes(1);
+    taskRef.current = 'task-2';
+
+    await act(async () => {
+      resolveStatus?.({
+        data: {
+          data: {
+            inProgress: false,
+            message: 'stale restore error',
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(taskRef.current).toBe('task-2');
+    expect(hideCheckBackupMessage).not.toHaveBeenCalled();
     expect(mocks.notification.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupRestoreComponents.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/BackupRestoreComponents.test.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RestoreFromBackup } from '../components/RestoreFromBackup';
 import { RestoreFromLocal } from '../components/RestoreFromLocal';
+import { RestoreLoadingProvider } from '../components/RestoreLoadingProvider';
 
 const mocks = vi.hoisted(() => ({
   flowContext: {
@@ -34,6 +35,30 @@ const mocks = vi.hoisted(() => ({
     },
   },
 }));
+
+const backup = {
+  name: 'backup.zip',
+  fileSize: '10KB',
+  createdAt: '2026-07-03T00:00:00.000Z',
+  inProgress: false,
+};
+
+function RestoreRouteHarness() {
+  const [showRestore, setShowRestore] = React.useState(true);
+
+  return (
+    <>
+      <button type="button" onClick={() => setShowRestore(false)}>
+        navigate-away
+      </button>
+      {showRestore ? <RestoreFromBackup backup={backup} /> : <div>Other page</div>}
+    </>
+  );
+}
+
+function renderWithRestoreProvider(node: React.ReactNode) {
+  return render(<RestoreLoadingProvider>{node}</RestoreLoadingProvider>);
+}
 
 vi.mock('@nocobase/flow-engine', () => ({
   useFlowContext: () => mocks.flowContext,
@@ -108,16 +133,7 @@ describe('backup restore components', () => {
   });
 
   it('starts restoring from an existing backup and shows the checking message', async () => {
-    render(
-      <RestoreFromBackup
-        backup={{
-          name: 'backup.zip',
-          fileSize: '10KB',
-          createdAt: '2026-07-03T00:00:00.000Z',
-          inProgress: false,
-        }}
-      />,
-    );
+    renderWithRestoreProvider(<RestoreFromBackup backup={backup} />);
 
     fireEvent.click(screen.getByText('Restore'));
     expect(screen.getByText('Confirm the application database schema')).toBeInTheDocument();
@@ -137,10 +153,40 @@ describe('backup restore components', () => {
     );
     expect(mocks.restoreTaskId.current).toBe('restore-task-1');
     expect(mocks.showCheckBackupMessage).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Restoring backup')).toBeInTheDocument();
+  });
+
+  it('keeps restore loading mounted when the restore action subtree unmounts', async () => {
+    renderWithRestoreProvider(<RestoreRouteHarness />);
+
+    fireEvent.click(screen.getByText('Restore'));
+    fireEvent.click(screen.getByText('Submit'));
+    expect(await screen.findByText('Restoring backup')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('navigate-away'));
+
+    expect(screen.getByText('Other page')).toBeInTheDocument();
+    expect(screen.getByText('Restoring backup')).toBeInTheDocument();
+  });
+
+  it('disables every restore entry point while a restore is running', async () => {
+    renderWithRestoreProvider(
+      <>
+        <RestoreFromLocal />
+        <RestoreFromBackup backup={backup} />
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restore', exact: true }));
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(await screen.findByText('Restoring backup')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Restore', exact: true })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Restore backup from local/ })).toBeDisabled();
   });
 
   it('closes and resets the existing-backup restore dialog without submitting', () => {
-    render(
+    renderWithRestoreProvider(
       <RestoreFromBackup
         backup={{
           name: 'backup.zip',
@@ -165,7 +211,7 @@ describe('backup restore components', () => {
       }),
     );
 
-    render(
+    renderWithRestoreProvider(
       <RestoreFromBackup
         backup={{
           name: 'backup.zip',
@@ -199,7 +245,7 @@ describe('backup restore components', () => {
       },
     };
 
-    render(
+    renderWithRestoreProvider(
       <RestoreFromBackup
         backup={{
           name: 'backup.zip',
@@ -216,7 +262,7 @@ describe('backup restore components', () => {
   });
 
   it('requires a local backup file before uploading and restoring it', async () => {
-    render(<RestoreFromLocal />);
+    renderWithRestoreProvider(<RestoreFromLocal />);
 
     fireEvent.click(screen.getByText('Restore backup from local'));
     fireEvent.click(screen.getByText('Submit'));
@@ -235,12 +281,13 @@ describe('backup restore components', () => {
     );
     expect(mocks.restoreTaskId.current).toBe('restore-task-1');
     expect(mocks.showCheckBackupMessage).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Restoring backup')).toBeInTheDocument();
   });
 
   it('keeps the local restore dialog blocked when the request is interrupted', async () => {
     mocks.flowContext.api.request.mockRejectedValue(new Error('Network Error'));
 
-    render(<RestoreFromLocal />);
+    renderWithRestoreProvider(<RestoreFromLocal />);
     fireEvent.click(screen.getByText('Restore backup from local'));
     fireEvent.click(screen.getByText('select-file'));
     fireEvent.click(screen.getByText('Submit'));
@@ -252,7 +299,7 @@ describe('backup restore components', () => {
   });
 
   it('allows removing the selected local backup before submitting', () => {
-    render(<RestoreFromLocal />);
+    renderWithRestoreProvider(<RestoreFromLocal />);
 
     fireEvent.click(screen.getByText('Restore backup from local'));
     fireEvent.click(screen.getByText('select-file'));
@@ -264,7 +311,7 @@ describe('backup restore components', () => {
   });
 
   it('closes the local restore dialog without uploading', () => {
-    render(<RestoreFromLocal />);
+    renderWithRestoreProvider(<RestoreFromLocal />);
 
     fireEvent.click(screen.getByText('Restore backup from local'));
     fireEvent.click(screen.getByText('select-file'));

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/PluginBackupsClientV2.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/PluginBackupsClientV2.test.ts
@@ -13,6 +13,8 @@ import { PluginBackupsClientV2 } from '../plugin';
 
 function createPlugin(app: Record<string, unknown> = {}) {
   let runtime: BackupRestoreRuntime | undefined;
+  const use = vi.fn();
+  Object.defineProperty(app, 'use', { value: use, configurable: true });
   const defineProperty = vi.fn((key: string, descriptor: { value: BackupRestoreRuntime }) => {
     if (key === BACKUP_RESTORE_RUNTIME_KEY) {
       runtime = descriptor.value;
@@ -54,17 +56,18 @@ function createPlugin(app: Record<string, unknown> = {}) {
     t: { value: (key: string) => key, configurable: true },
   });
 
-  return { plugin, defineProperty, addMenuItem, addPageTabItem, getRuntime: () => runtime };
+  return { plugin, use, defineProperty, addMenuItem, addPageTabItem, getRuntime: () => runtime };
 }
 
 describe('PluginBackupsClientV2', () => {
   it('registers settings menu tabs and backup restore runtime', async () => {
     const setMaintaining = vi.fn();
     const app = { error: undefined, maintaining: false, setMaintaining };
-    const { plugin, defineProperty, addMenuItem, addPageTabItem, getRuntime } = createPlugin(app);
+    const { plugin, use, defineProperty, addMenuItem, addPageTabItem, getRuntime } = createPlugin(app);
 
     await plugin.load();
 
+    expect(use).toHaveBeenCalledWith(expect.any(Function));
     expect(defineProperty).toHaveBeenCalledWith(BACKUP_RESTORE_RUNTIME_KEY, { value: expect.any(Object) });
     expect(addMenuItem).toHaveBeenCalledWith({
       key: 'backups',

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/RestoreErrors.test.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/__tests__/RestoreErrors.test.tsx
@@ -8,11 +8,12 @@
  */
 
 import { createMockClient, Plugin } from '@nocobase/client-v2';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { RestoreFromBackup } from '../components/RestoreFromBackup';
 import { RestoreFromLocal } from '../components/RestoreFromLocal';
 import type { BackupFile } from '../components/BackupsTable';
+import { RestoreLoadingProvider } from '../components/RestoreLoadingProvider';
 
 const backup: BackupFile = {
   name: 'backup.nbdata',
@@ -30,6 +31,7 @@ const RestoreTestPage = () => (
 
 class RestoreTestPlugin extends Plugin {
   async load() {
+    this.app.use(RestoreLoadingProvider);
     this.router.add('root', {
       path: '/',
       Component: RestoreTestPage,
@@ -116,15 +118,27 @@ describe('backup restore errors', () => {
     expect(passwordInput).toHaveValue('wrong-password');
   });
 
-  it('closes the local restore dialog after the restore task starts successfully', async () => {
+  it('keeps restore loading visible after a background failure and through the upgrade state', async () => {
     const app = renderRestorePage();
+    type RestoreStatusMockResponse = [number, { data: { inProgress: boolean; message: string } }];
+    let resolveRestoreStatus: ((response: RestoreStatusMockResponse) => void) | undefined;
     app.apiMock.onPost('backups:upload').reply(200, {
       data: {
         task: 'restore-task',
       },
     });
+    app.apiMock.onGet('backups:restoreStatus').reply(
+      () =>
+        new Promise<RestoreStatusMockResponse>((resolve) => {
+          resolveRestoreStatus = resolve;
+        }),
+    );
 
-    fireEvent.click(await screen.findByText('Restore backup from local'));
+    const restoreFromLocal = await screen.findByText('Restore backup from local');
+    act(() => {
+      app.maintained = true;
+    });
+    fireEvent.click(restoreFromLocal);
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(fileInput, {
       target: {
@@ -135,7 +149,39 @@ describe('backup restore errors', () => {
 
     await waitFor(() => {
       expect(app.apiMock.history.post).toHaveLength(1);
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: 'Restore backup from local' })).not.toBeInTheDocument();
     });
+
+    expect(await screen.findByText('Restoring backup')).toBeInTheDocument();
+    await waitFor(() => expect(resolveRestoreStatus).toBeTypeOf('function'), { timeout: 5000 });
+    await act(async () => {
+      resolveRestoreStatus?.([
+        200,
+        {
+          data: {
+            inProgress: false,
+            message: 'Restore failed',
+          },
+        },
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText('Restore failed')).toBeInTheDocument();
+    expect(app.maintaining).toBe(true);
+    expect(app.maintained).toBe(true);
+    expect(screen.getByText('Restoring backup')).toBeInTheDocument();
+
+    act(() => {
+      app.maintained = true;
+      app.maintaining = true;
+      app.error = Object.assign(new Error('Loading data sources...'), {
+        code: 'APP_COMMANDING',
+        command: { name: 'upgrade' },
+      });
+    });
+
+    expect(screen.getByText('Restoring backup')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromBackup.tsx
@@ -12,9 +12,9 @@ import { App, Button, Form, Input, Modal } from 'antd';
 import React from 'react';
 import { useBackupAppInfo } from '../hooks/useBackupAppInfo';
 import { useCheckBackupMessage } from '../hooks/useCheckBackupMessage';
-import { useRestoreTask } from '../hooks/useRestoreTask';
 import { useT } from '../locale';
 import type { BackupFile } from './BackupsTable';
+import { useRestoreLoading } from './RestoreLoadingProvider';
 
 type RestoreTaskBody = {
   task?: string;
@@ -35,7 +35,7 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
   const [progressing, setProgressing] = React.useState(false);
   const [dbSchema, setDbSchema] = React.useState('');
   const submittingRef = React.useRef(false);
-  const restoreTaskId = useRestoreTask();
+  const { restoring, startRestoring } = useRestoreLoading();
   const { showCheckBackupMessage } = useCheckBackupMessage();
   const {
     database: { schema: currentDbSchema, dialect },
@@ -70,7 +70,10 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
           dbSchema,
         },
       });
-      restoreTaskId.current = response.data?.data?.task ?? null;
+      const taskId = response.data?.data?.task ?? null;
+      if (taskId) {
+        startRestoring(taskId);
+      }
       showCheckBackupMessage();
       setIsModalVisible(false);
       resetFields();
@@ -103,7 +106,7 @@ export const RestoreFromBackup = ({ backup }: { backup: BackupFile }) => {
 
   return (
     <>
-      <Button type="link" size="small" onClick={showModal}>
+      <Button type="link" size="small" disabled={restoring} onClick={showModal}>
         {t('Restore')}
       </Button>
       <Modal

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreFromLocal.tsx
@@ -14,8 +14,8 @@ import { App, Button, Form, Input, Modal, Upload } from 'antd';
 import React, { useState } from 'react';
 import { useBackupAppInfo } from '../hooks/useBackupAppInfo';
 import { useCheckBackupMessage } from '../hooks/useCheckBackupMessage';
-import { useRestoreTask } from '../hooks/useRestoreTask';
 import { useT } from '../locale';
+import { useRestoreLoading } from './RestoreLoadingProvider';
 
 type RestoreTaskBody = {
   task?: string;
@@ -38,7 +38,7 @@ export const RestoreFromLocal = () => {
   const [file, setFile] = useState<File | null>(null);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const submittingRef = React.useRef(false);
-  const restoreTaskId = useRestoreTask();
+  const { restoring, startRestoring } = useRestoreLoading();
   const { showCheckBackupMessage } = useCheckBackupMessage();
   const {
     database: { schema: currentDbSchema, dialect },
@@ -86,7 +86,10 @@ export const RestoreFromLocal = () => {
         data: formData,
         skipNotify: true,
       });
-      restoreTaskId.current = response.data?.data?.task ?? null;
+      const taskId = response.data?.data?.task ?? null;
+      if (taskId) {
+        startRestoring(taskId);
+      }
       showCheckBackupMessage();
       setIsModalVisible(false);
       resetFields();
@@ -124,7 +127,7 @@ export const RestoreFromLocal = () => {
 
   return (
     <>
-      <Button icon={<UploadOutlined />} onClick={showModal}>
+      <Button icon={<UploadOutlined />} disabled={restoring} onClick={showModal}>
         {t('Restore backup from local')}
       </Button>
       <Modal

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreLoadingProvider.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/components/RestoreLoadingProvider.tsx
@@ -1,0 +1,49 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Spin } from 'antd';
+import React from 'react';
+import { useRestoreTask } from '../hooks/useRestoreTask';
+import { useT } from '../locale';
+
+type RestoreLoadingContextValue = {
+  restoring: boolean;
+  startRestoring: (taskId: string) => void;
+};
+
+const RestoreLoadingContext = React.createContext<RestoreLoadingContextValue | null>(null);
+
+export const RestoreLoadingProvider = ({ children }: React.PropsWithChildren) => {
+  const t = useT();
+  const [restoring, setRestoring] = React.useState(false);
+  const restoreTaskId = useRestoreTask();
+  const startRestoring = React.useCallback(
+    (taskId: string) => {
+      restoreTaskId.current = taskId;
+      setRestoring(true);
+    },
+    [restoreTaskId],
+  );
+  const value = React.useMemo(() => ({ restoring, startRestoring }), [restoring, startRestoring]);
+
+  return (
+    <RestoreLoadingContext.Provider value={value}>
+      {children}
+      {restoring && <Spin fullscreen tip={t('Restoring backup')} />}
+    </RestoreLoadingContext.Provider>
+  );
+};
+
+export function useRestoreLoading() {
+  const context = React.useContext(RestoreLoadingContext);
+  if (!context) {
+    throw new Error('RestoreLoadingProvider is missing');
+  }
+  return context;
+}

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useRestoreTask.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/hooks/useRestoreTask.ts
@@ -7,12 +7,10 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { useApp } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
 import { App } from 'antd';
 import React, { useEffect } from 'react';
 import { NAMESPACE } from '../constants';
-import { useCheckBackupMessage } from './useCheckBackupMessage';
 
 type RestoreStatus = {
   inProgress: boolean;
@@ -23,30 +21,31 @@ type ResourceResponse<T> = {
   data?: T;
 };
 
-type BackupRuntimeApp = {
-  maintaining?: boolean;
-};
-
 export function useRestoreTask() {
   const ctx = useFlowContext();
-  const app = useApp() as BackupRuntimeApp;
   const restoreTaskId = React.useRef<string | null>(null);
   const { notification } = App.useApp();
-  const { hideCheckBackupMessage } = useCheckBackupMessage();
 
   useEffect(() => {
+    let checking = false;
+    let disposed = false;
     const checkRestoreTask = async () => {
-      if (!restoreTaskId.current) {
+      const taskId = restoreTaskId.current;
+      if (!taskId || checking) {
         return;
       }
+      checking = true;
       try {
         const response = await ctx.api.request<ResourceResponse<RestoreStatus>>({
           url: `${NAMESPACE}:restoreStatus`,
           method: 'get',
           params: {
-            task: restoreTaskId.current,
+            task: taskId,
           },
         });
+        if (disposed || restoreTaskId.current !== taskId) {
+          return;
+        }
         const status = response.data?.data;
         if (!status) {
           return;
@@ -55,16 +54,22 @@ export function useRestoreTask() {
           restoreTaskId.current = null;
         }
         if (status.message) {
-          hideCheckBackupMessage();
           notification.error({ message: status.message, role: 'alert' });
         }
       } catch (error) {
-        console.error(error);
+        if (!disposed) {
+          console.error(error);
+        }
+      } finally {
+        checking = false;
       }
     };
     const interval = setInterval(checkRestoreTask, 3000);
-    return () => clearInterval(interval);
-  }, [app.maintaining, ctx.api, hideCheckBackupMessage, notification]);
+    return () => {
+      disposed = true;
+      clearInterval(interval);
+    };
+  }, [ctx.api, notification]);
 
   return restoreTaskId;
 }

--- a/packages/plugins/@nocobase/plugin-backups/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-backups/src/client-v2/plugin.tsx
@@ -9,6 +9,7 @@
 
 import type { Application } from '@nocobase/client-v2';
 import { Plugin } from '@nocobase/client-v2';
+import { RestoreLoadingProvider } from './components/RestoreLoadingProvider';
 import { BACKUP_RESTORE_RUNTIME_KEY, BackupRestoreRuntime, NAMESPACE } from './constants';
 
 type BackupRuntimeApp = Application & {
@@ -20,6 +21,8 @@ type BackupRuntimeApp = Application & {
 export class PluginBackupsClientV2 extends Plugin<Record<string, never>, Application> {
   async load() {
     const title = this.t('Backup manager') as unknown as string;
+
+    this.app.use(RestoreLoadingProvider);
 
     this.flowEngine.context.defineProperty(BACKUP_RESTORE_RUNTIME_KEY, {
       value: this.createBackupRestoreRuntime(),

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/en-US.json
@@ -44,6 +44,7 @@
   "Restore": "Restore",
   "Restore backup from local": "Restore from local backup file",
   "Restore failed": "Restore failed",
+  "Restoring backup": "Restoring backup",
   "Restore password": "Restore password",
   "Run automatic backup on the cron schedule": "Run automatic backup on the cron schedule",
   "Settings": "Settings",

--- a/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
+++ b/packages/plugins/@nocobase/plugin-backups/src/locale/zh-CN.json
@@ -44,6 +44,7 @@
   "Restore": "还原",
   "Restore backup from local": "从本地备份还原",
   "Restore failed": "还原失败",
+  "Restoring backup": "正在还原备份",
   "Restore password": "还原密码",
   "Run automatic backup on the cron schedule": "根据 Cron 运行自动备份",
   "Settings": "设置",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

还原备份时，确认窗口关闭后到应用重新加载前，页面可能没有持续的加载提示，用户难以判断还原是否仍在进行。

### Description

- 备份还原请求受理后持续显示全屏加载提示，直到应用重新加载
- 切换设置页面或进入升级阶段时继续保留还原提示，并在还原期间禁用其他还原入口
- 避免还原状态检查重叠或旧请求覆盖当前任务，并补充现有备份、本地备份、失败及升级阶段的回归测试
- 改动仅限备份管理界面，不修改核心应用行为或公共 API

已通过备份插件 Client V2 全量测试，共 8 个测试文件、44 个用例。

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Keep loading feedback visible while restoring backups |
| 🇨🇳 Chinese | 还原备份期间持续显示加载提示 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
