### PR TITLE
fix(plugin-workflow-json-query): store query errors in job logs

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/JSONQueryInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/JSONQueryInstruction.ts
@@ -47,18 +47,14 @@ function getErrorLog(error: unknown): string {
     return message;
   }
 
-  const details =
-    error instanceof Error
-      ? {
-          ...error,
-          name: error.name,
-          message: error.message,
-          stack: error.stack,
-        }
-      : error;
-
   try {
-    return JSON.stringify(details, null, 2) || message;
+    const details = new Map<string, unknown>(Object.entries(error));
+    if (error instanceof Error) {
+      details.set('name', error.name);
+      details.set('message', error.message);
+      details.set('stack', error.stack);
+    }
+    return Array.from(details, ([key, value]) => `${key}: ${String(value)}`).join('\n') || message;
   } catch {
     return message;
   }

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/JSONQueryInstruction.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/JSONQueryInstruction.ts
@@ -34,6 +34,36 @@ interface Config {
   }[];
 }
 
+function getErrorMessage(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') {
+    return error.message;
+  }
+  return String(error);
+}
+
+function getErrorLog(error: unknown): string {
+  const message = getErrorMessage(error);
+  if (typeof error !== 'object' || error === null) {
+    return message;
+  }
+
+  const details =
+    error instanceof Error
+      ? {
+          ...error,
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        }
+      : error;
+
+  try {
+    return JSON.stringify(details, null, 2) || message;
+  } catch {
+    return message;
+  }
+}
+
 function mapModel(data, model) {
   const result = {};
   model.forEach(({ path, alias }) => {
@@ -78,9 +108,10 @@ export default class extends Instruction {
         result,
         status: JOB_STATUS.RESOLVED,
       };
-    } catch (e) {
+    } catch (error: unknown) {
       return {
-        result: e.toString(),
+        result: null,
+        log: getErrorLog(error),
         status: JOB_STATUS.ERROR,
       };
     }

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/__tests__/engine.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/__tests__/engine.test.ts
@@ -223,5 +223,37 @@ describe('json-query > engines', () => {
       expect(j1.status).toBe(JOB_STATUS.RESOLVED);
       expect(j1.result).toEqual('life');
     });
+
+    it('stores parser error message and details', async () => {
+      await workflow.createNode({
+        type: 'json-query',
+        config: {
+          engine: 'jsonata',
+          source: '{{$context.data}}',
+          expression: '(',
+        },
+      });
+
+      await CategoryRepo.create({
+        values: {
+          title: 'c1',
+        },
+      });
+
+      await sleep(500);
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toEqual(EXECUTION_STATUS.ERROR);
+      const [job] = await execution.getJobs();
+      expect(job.status).toBe(JOB_STATUS.ERROR);
+      expect(job.result).toBeNull();
+      expect(JSON.parse(job.log)).toMatchObject({
+        code: 'S0203',
+        position: 1,
+        token: '(end)',
+        value: ')',
+        message: 'Expected ")" before end of expression',
+      });
+    });
   });
 });

--- a/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/__tests__/engine.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-json-query/src/server/__tests__/engine.test.ts
@@ -247,13 +247,12 @@ describe('json-query > engines', () => {
       const [job] = await execution.getJobs();
       expect(job.status).toBe(JOB_STATUS.ERROR);
       expect(job.result).toBeNull();
-      expect(JSON.parse(job.log)).toMatchObject({
-        code: 'S0203',
-        position: 1,
-        token: '(end)',
-        value: ')',
-        message: 'Expected ")" before end of expression',
-      });
+      expect(job.log).toContain('code: S0203');
+      expect(job.log).toContain('position: 1');
+      expect(job.log).toContain('token: (end)');
+      expect(job.log).toContain('value: )');
+      expect(job.log).toContain('message: Expected ")" before end of expression');
+      expect(job.log).not.toContain('{');
     });
   });
 });


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

JSONata reports parser failures as structured plain objects. Converting those objects with `toString()` produced `[object Object]`, so workflow jobs lost the actionable error message and parser details.

### Description

- Keep the result of failed JSON Query jobs as `null`.
- Serialize query engine errors into the job `log`, preserving JSONata fields such as `message`, `code`, `position`, and `token`.
- Preserve useful details for standard `Error` instances and fall back safely when an error cannot be serialized.
- Add a regression test covering an invalid JSONata expression through the complete workflow execution and job persistence path.

Risk is limited to the error output of the JSON Query instruction. Successful query behavior is unchanged. To verify manually, run a JSON Query node with JSONata expression `(` and confirm that the job result is empty while its log contains the parser details.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed JSON Query jobs losing structured parser errors and displaying `[object Object]` |
| 🇨🇳 Chinese | 修复 JSON 查询任务丢失结构化解析错误并显示 `[object Object]` 的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
