### PR TITLE
fix(plugin-file-manager): reload video preview when switching files

### DIFF
--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/__tests__/filePreviewTypes.test.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/__tests__/filePreviewTypes.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { FilePreviewRenderer } from '../filePreviewTypes';
+
+vi.mock('@emotion/css', () => ({ css: () => '' }));
+
+vi.mock('antd', () => ({
+  Alert: ({ description }: { description?: React.ReactNode }) => <div>{description}</div>,
+  Image: () => null,
+  Modal: ({ children, open, title }: React.PropsWithChildren<{ open?: boolean; title?: React.ReactNode }>) =>
+    open ? (
+      <div>
+        <h1>{title}</h1>
+        {children}
+      </div>
+    ) : null,
+  Space: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  Spin: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  Trans: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('FilePreviewRenderer', () => {
+  it('reloads the video element when switching files', () => {
+    const files = [
+      { filename: 'first.mp4', mimetype: 'video/mp4', url: '/files/first.mp4' },
+      { filename: 'second.mp4', mimetype: 'video/mp4', url: '/files/second.mp4' },
+    ];
+    const commonProps = {
+      list: files,
+      open: true,
+      onDownload: () => undefined,
+    };
+
+    const { container, rerender } = render(<FilePreviewRenderer {...commonProps} file={files[0]} index={0} />);
+    const firstVideo = container.querySelector('video');
+
+    expect(firstVideo?.querySelector('source')?.getAttribute('src')).toBe('/files/first.mp4');
+
+    rerender(<FilePreviewRenderer {...commonProps} file={files[1]} index={1} />);
+
+    const secondVideo = container.querySelector('video');
+    expect(secondVideo?.querySelector('source')?.getAttribute('src')).toBe('/files/second.mp4');
+    expect(secondVideo).not.toBe(firstVideo);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx
@@ -962,7 +962,7 @@ const VideoPreviewer = ({ file }: FilePreviewerProps) => {
     return null;
   }
   return (
-    <video controls width="100%" height="100%">
+    <video key={src} controls width="100%" height="100%">
       <source src={src} type={file?.type || file?.mimetype} />
       {t('Your browser does not support the video tag.')}
     </video>


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When previewing video attachments, switching to the previous or next file updated the modal title and source element but continued displaying the previously loaded video.

### Description

- Remount the video element when its source URL changes so the browser loads the newly selected file.
- Add a regression test that verifies switching files replaces the video element and updates its source.
- Risk is limited to resetting the video playback state when selecting another file, which is the expected behavior.

Testing:

- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/__tests__/filePreviewTypes.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/client/previewer/__tests__/filePreviewTypes.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/filePreviewTypes.tsx packages/plugins/@nocobase/plugin-file-manager/src/client-v2/previewer/__tests__/filePreviewTypes.test.tsx`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed video previews not updating when switching between files |
| 🇨🇳 Chinese | 修复在文件之间切换时视频预览内容不更新的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A — No documentation changes required |
| 🇨🇳 Chinese | N/A — 无需更新文档 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
