### PR TITLE
fix(client-v2): clear mobile relation selection

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/mobile-components/MobileLazySelect.tsx
@@ -206,6 +206,11 @@ export function MobileLazySelect(props: Readonly<LazySelectProps>) {
         return;
       }
       const selectedId = vals[0];
+      if (selectedId === undefined) {
+        onChange(undefined as unknown as AssociationOption);
+        handleClose();
+        return;
+      }
       const record = optionMap.get(selectedId);
       if (record) {
         if (valueMode === 'value') {

--- a/packages/core/client-v2/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/mobile-components/__tests__/MobileSelect.test.tsx
@@ -307,6 +307,22 @@ describe('MobileLazySelect', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
+  it('clears the selected relation record when it is tapped again in single mode', () => {
+    const { onChange } = renderMobileLazySelect({
+      value: RELATION_OPTIONS[0],
+      multiple: false,
+    });
+
+    openLazyPopup();
+    expect(mockState.checklistProps?.value).toEqual([RELATION_OPTIONS[0].uuid]);
+
+    selectValues([]);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+  });
+
   it('keeps pending relation records selected until confirm', () => {
     const { onChange, rerender } = renderMobileLazySelect();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

在移动端使用单选关联字段时，再次点击当前已选记录后，选择弹窗虽然会关闭，但字段值仍然保留，用户无法按预期清空选择。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- 修复移动端单选关联字段取消当前选择时未同步清空字段值的问题。
- 补充回归测试，覆盖再次点击已选记录后清空值并关闭弹窗的场景。
- 改动仅作用于移动端单选关联字段的取消选择逻辑，不影响多选确认流程。
- 已在 435 × 850 移动端视口通过真实浏览器验证，建议重点回归移动端单选及多选关联字段。

### Showcase
<!-- Including any screenshots of the changes. -->

在移动端视口验证：选中关联记录后再次点击该记录，弹窗正常关闭且字段显示为空。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix mobile single-select relation fields not clearing when the selected record is tapped again |
| 🇨🇳 Chinese | 修复移动端单选关联字段再次点击已选记录后无法清空的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
