### PR TITLE
fix(plugin-action-print): register print model on V1 pages

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-print/src/client/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-action-print/src/client/__tests__/plugin.test.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { PrintActionModel } from '../../client-v2/PrintActionModel';
+import { PluginActionPrintClient } from '../index';
+
+describe('PluginActionPrintClient', () => {
+  it('registers PrintActionModel for v1 pages', async () => {
+    const registerModels = vi.fn();
+    const plugin = Object.create(PluginActionPrintClient.prototype) as PluginActionPrintClient;
+    Object.defineProperty(plugin, 'app', {
+      value: {
+        use: vi.fn(),
+        schemaSettingsManager: {
+          add: vi.fn(),
+        },
+        schemaInitializerManager: {
+          addItem: vi.fn(),
+        },
+        flowEngine: {
+          registerModels,
+        },
+      },
+    });
+
+    await plugin.load();
+
+    expect(registerModels).toHaveBeenCalledWith({ PrintActionModel });
+  });
+});

--- a/packages/plugins/@nocobase/plugin-action-print/src/client/index.tsx
+++ b/packages/plugins/@nocobase/plugin-action-print/src/client/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Plugin } from '@nocobase/client';
+import { PrintActionModel } from '../client-v2/PrintActionModel';
 import { deprecatedPrintActionSettings, printActionSettings } from './PrintAction.Settings';
 import { PrintActionPluginProvider } from './PrintActionPluginProvider';
 export class PluginActionPrintClient extends Plugin {
@@ -29,6 +30,7 @@ export class PluginActionPrintClient extends Plugin {
 
     this.app.schemaInitializerManager.addItem('details:configureActions', 'enableActions.print', initializerData);
     this.app.schemaInitializerManager.addItem('CalendarFormActionInitializers', 'enableActions.print', initializerData);
+    this.app.flowEngine.registerModels({ PrintActionModel });
   }
 }
 


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The print action on V1 pages fails with `Model class 'PrintActionModel' not found. Please register it first.` because the V1 plugin entry does not register `PrintActionModel` with its FlowEngine.

### Description

- Register `PrintActionModel` in the V1 print action plugin entry.
- Add a regression test covering model registration during V1 plugin loading.
- Keep the existing V2 lazy model registration unchanged.

Risk is low and limited to loading the existing print action model in the V1 runtime, consistent with other action plugins such as duplicate, export, and import.

Testing suggestions:

1. Open a V1 details page with the print plugin enabled.
2. Add or use an existing Print action.
3. Verify the button renders without the missing model error and opens the browser print dialog.

Automated tests and ESLint could not be executed locally because this checkout does not contain the required `nocobase-v1` and `eslint` executables in `node_modules`.

### Related issues

Task 5918

### Showcase

Not applicable. This change fixes a runtime registration error without changing the UI.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the missing print action model registration on V1 pages. |
| 🇨🇳 Chinese | 修复 V1 页面缺少打印操作模型注册的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | Not needed |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
