### PR TITLE
fix(plugin-action-import): restore v2 drag upload

### DIFF
--- a/packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx
@@ -14,6 +14,7 @@ import { ActionModel, ActionSceneEnum } from '@nocobase/client-v2';
 import { escapeT, observer } from '@nocobase/flow-engine';
 import { Alert, Button, Cascader, Space, Spin, theme, Upload } from 'antd';
 import type { ButtonProps } from 'antd/es/button';
+import type { UploadChangeParam, UploadFile } from 'antd/es/upload/interface';
 import { saveAs } from 'file-saver';
 import React from 'react';
 import { initImportSettings } from './importSupport';
@@ -26,6 +27,31 @@ const INCLUDE_FILE_TYPE = [
   'application/vnd.ms-excel',
   'application/wps-office.xlsx',
 ];
+
+type ImportUploadFile = UploadFile<unknown> & {
+  sourceFile?: File;
+};
+
+const getSourceFile = (file: ImportUploadFile) => file.originFileObj || file.sourceFile;
+
+const isExcelFile = (file: ImportUploadFile) => {
+  const sourceFile = getSourceFile(file);
+  const fileType = file.type || sourceFile?.type || '';
+  return INCLUDE_FILE_TYPE.includes(fileType);
+};
+
+const createDroppedUploadFiles = (files: File[]): ImportUploadFile[] => {
+  return Array.from(files)
+    .slice(0, 1)
+    .map((file) => ({
+      uid: `dropped-${file.name}-${file.size}-${file.lastModified}`,
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      lastModified: file.lastModified,
+      sourceFile: file,
+    }));
+};
 
 const getErrorMessageFromResponse = (payload: any): string => {
   if (!payload) {
@@ -137,31 +163,40 @@ ImportActionModel.registerFlow({
           saveAs(blob, `${ctx.t(title)}.xlsx`);
         };
 
-        const getUploadError = (fileList: any[]) => {
+        const getUploadError = (fileList: ImportUploadFile[]) => {
           if (fileList.length === 0) {
             return '';
           }
           if (fileList.length > 1) {
             return ctx.t('Only one file is allowed to be uploaded', { ns: NAMESPACE });
           }
-          const file = fileList[0] ?? {};
-          const fileType = file.type || file.originFileObj?.type;
-          if (!INCLUDE_FILE_TYPE.includes(fileType)) {
+          const file = fileList[0];
+          if (!file || !isExcelFile(file)) {
             return ctx.t('Please upload the file of Excel', { ns: NAMESPACE });
           }
           return '';
         };
 
-        const handelStartImport = async (popover, fileList: any[], setFileList: any, setUploadError: any) => {
+        const handelStartImport = async (
+          popover,
+          fileList: ImportUploadFile[],
+          setFileList: React.Dispatch<React.SetStateAction<ImportUploadFile[]>>,
+          setUploadError: React.Dispatch<React.SetStateAction<string>>,
+        ) => {
           const uploadError = getUploadError(fileList);
           setUploadError(uploadError);
           if (uploadError || !fileList.length) {
             return;
           }
 
+          const sourceFile = getSourceFile(fileList[0]);
+          if (!sourceFile) {
+            setUploadError(ctx.t('Please upload the file of Excel', { ns: NAMESPACE }));
+            return;
+          }
+
           const formData = new FormData();
-          const uploadFiles = fileList.map((file) => file.originFileObj);
-          formData.append('file', uploadFiles[0]);
+          formData.append('file', sourceFile);
           formData.append('columns', JSON.stringify(columns));
           formData.append('explain', explain);
 
@@ -206,8 +241,17 @@ ImportActionModel.registerFlow({
         const ImportDialogContent = observer(({ popover }: any) => {
           const { t } = ctx;
           const { token } = theme.useToken();
-          const [fileList, setFileList] = React.useState<any[]>([]);
+          const [fileList, setFileList] = React.useState<ImportUploadFile[]>([]);
           const [uploadError, setUploadError] = React.useState('');
+          const pendingDropTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+          React.useEffect(() => {
+            return () => {
+              if (pendingDropTimerRef.current !== undefined) {
+                clearTimeout(pendingDropTimerRef.current);
+              }
+            };
+          }, []);
 
           const renderResult = (result) => {
             if (!result) return null;
@@ -295,10 +339,34 @@ ImportActionModel.registerFlow({
           }
 
           const startImportDisabled = !fileList.length || !!uploadError;
-          const handleUploadChange = ({ fileList }: any) => {
-            const nextFileList = fileList.slice(-1);
+          const updateUploadFiles = (nextFileList: ImportUploadFile[]) => {
             setFileList(nextFileList);
             setUploadError(getUploadError(nextFileList));
+          };
+          const handleUploadChange = ({ fileList: nextFileList }: UploadChangeParam<ImportUploadFile>) => {
+            if (pendingDropTimerRef.current !== undefined) {
+              clearTimeout(pendingDropTimerRef.current);
+              pendingDropTimerRef.current = undefined;
+            }
+            updateUploadFiles(nextFileList.slice(-1));
+          };
+          const handleUploadDrop = (event: React.DragEvent<HTMLDivElement>) => {
+            const droppedFiles = Array.from(event.dataTransfer.files);
+            if (!droppedFiles.length) {
+              return;
+            }
+            event.preventDefault();
+            if (pendingDropTimerRef.current !== undefined) {
+              clearTimeout(pendingDropTimerRef.current);
+            }
+            const fallbackTimer = setTimeout(() => {
+              if (pendingDropTimerRef.current !== fallbackTimer) {
+                return;
+              }
+              pendingDropTimerRef.current = undefined;
+              updateUploadFiles(createDroppedUploadFiles(droppedFiles));
+            }, 0);
+            pendingDropTimerRef.current = fallbackTimer;
           };
 
           return (
@@ -444,6 +512,7 @@ ImportActionModel.registerFlow({
                       beforeUpload={() => false}
                       showUploadList={false}
                       onChange={handleUploadChange}
+                      onDrop={handleUploadDrop}
                     >
                       <div className="import-upload-placeholder">{t('Upload placeholder', { ns: NAMESPACE })}</div>
                     </Upload.Dragger>

--- a/packages/plugins/@nocobase/plugin-action-import/src/client-v2/__tests__/ImportActionUpload.test.tsx
+++ b/packages/plugins/@nocobase/plugin-action-import/src/client-v2/__tests__/ImportActionUpload.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+// @vitest-environment jsdom
+
+import { FlowEngine } from '@nocobase/flow-engine';
+import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ImportActionModel } from '../ImportActionModel';
+
+type TestContext = ReturnType<typeof createTestContext>;
+
+function createTestContext() {
+  const importXlsx = vi.fn().mockResolvedValue({ data: { data: { successCount: 1 } } });
+  const refresh = vi.fn().mockResolvedValue(undefined);
+  const viewerOpen = vi.fn().mockResolvedValue(undefined);
+  const resource = {
+    runAction: vi.fn(),
+    refresh,
+    getResourceName: vi.fn(() => 'posts'),
+    getSourceId: vi.fn(() => undefined),
+    getDataSourceKey: vi.fn(() => 'main'),
+  };
+  const collection = {
+    title: 'Posts',
+    name: 'posts',
+    dataSourceKey: 'main',
+  };
+
+  return {
+    model: {
+      context: {
+        blockModel: { collection, resource },
+        collection,
+        dataSourceManager: {
+          getCollectionField: vi.fn(() => ({ name: 'title', uiSchema: { title: 'Title' } })),
+        },
+      },
+      getProps: () => ({
+        importSettings: {
+          explain: '',
+          importColumns: [{ dataIndex: ['title'] }],
+        },
+        importMode: 'overwrite',
+      }),
+    },
+    api: {
+      resource: vi.fn(() => ({ importXlsx })),
+    },
+    viewer: { open: viewerOpen },
+    t: (key: string) => key,
+    importXlsx,
+    refresh,
+    viewerOpen,
+  };
+}
+
+async function renderImportDialog(ctx: TestContext) {
+  const engine = new FlowEngine();
+  engine.registerModels({ ImportActionModel });
+  const model = engine.createModel<ImportActionModel>({ use: 'ImportActionModel', uid: 'import-action-upload-test' });
+  const step = model.getFlow('importSettings')?.getStep('import')?.serialize() as
+    | { handler?: (context: TestContext) => Promise<void> }
+    | undefined;
+
+  await step?.handler?.(ctx);
+  const dialog = ctx.viewerOpen.mock.calls[0][0] as {
+    content: (popover: { close: () => void }) => React.ReactElement;
+  };
+  return render(dialog.content({ close: vi.fn() }));
+}
+
+describe('ImportActionModel upload', () => {
+  it('keeps file selection through the hidden input working', async () => {
+    const ctx = createTestContext();
+    const { container } = await renderImportDialog(ctx);
+    const file = new File(['xlsx'], 'selected.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+
+    fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+      target: { files: [file] },
+    });
+
+    expect(await screen.findByText('selected.xlsx')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start import' })).not.toBeDisabled();
+  });
+
+  it('falls back when a prevented drop does not produce an upload change', async () => {
+    const ctx = createTestContext();
+    const { container } = await renderImportDialog(ctx);
+    const file = new File(['xlsx'], 'posts.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    const dropArea = container.querySelector('.ant-upload-drag') as HTMLElement;
+    const dropEvent = createEvent.drop(dropArea, {
+      dataTransfer: { files: [file], items: [] },
+    });
+    dropEvent.preventDefault();
+
+    fireEvent(dropArea, dropEvent);
+
+    expect(await screen.findByText('posts.xlsx')).toBeTruthy();
+    const startImport = screen.getByRole('button', { name: 'Start import' });
+    expect(startImport).not.toBeDisabled();
+    fireEvent.click(startImport);
+
+    await waitFor(() => expect(ctx.importXlsx).toHaveBeenCalledOnce());
+    const request = ctx.importXlsx.mock.calls[0][0] as { values: FormData };
+    expect(request.values.get('file')).toBe(file);
+    expect(ctx.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the existing MIME validation for fallback files', async () => {
+    const ctx = createTestContext();
+    const { container } = await renderImportDialog(ctx);
+    const dropArea = container.querySelector('.ant-upload-drag') as HTMLElement;
+
+    fireEvent.drop(dropArea, {
+      dataTransfer: { files: [new File(['xlsx'], 'posts.xlsx')], items: [] },
+    });
+    expect(await screen.findByText('Please upload the file of Excel')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start import' })).toBeDisabled();
+  });
+
+  it('handles a file dropped on the inner rc-upload element exactly once', async () => {
+    const ctx = createTestContext();
+    const { container } = await renderImportDialog(ctx);
+    const file = new File(['xlsx'], 'inner.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+
+    fireEvent.drop(container.querySelector('.ant-upload-btn') as HTMLElement, {
+      dataTransfer: { files: [file], items: [], types: ['Files'] },
+    });
+    fireEvent.click(await screen.findByRole('button', { name: 'Start import' }));
+
+    await waitFor(() => expect(ctx.importXlsx).toHaveBeenCalledOnce());
+    const request = ctx.importXlsx.mock.calls[0][0] as { values: FormData };
+    expect(request.values.getAll('file')).toEqual([file]);
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In the v2 Import dialog, selecting an Excel file through the file picker works, but dropping the same file onto the upload area may not add it to the import file list. The drag event can be prevented by the inner rc-upload element without producing the expected Ant Design Upload onChange callback.

### Description

- Preserve the existing Ant Design Upload and file-picker flow as the primary path.
- Capture dropped files and apply a deferred fallback only when the standard Upload onChange callback is not produced.
- Cancel the pending fallback when the standard path succeeds or when the dialog unmounts, preventing duplicate or stale state updates.
- Keep the existing single-file behavior and Excel MIME allowlist unchanged.
- Submit the original File object for both standard selection and fallback drag handling.
- Add regression coverage for file selection, prevented-drop fallback, existing MIME validation, and the standard inner rc-upload path.

Risk scope:
- Client v2 only; no v1, server, database, migration, ACL, API contract, or localization changes.
- The fallback relies on the current Ant Design 5 / rc-upload event order and remains subordinate to the standard onChange path.

Verification:
- `yarn test packages/plugins/@nocobase/plugin-action-import/src/client-v2/__tests__/ImportActionUpload.test.tsx --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-action-import/src/client/__tests__/buildImportFieldOptions.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-action-import/src/client-v2/ImportActionModel.tsx packages/plugins/@nocobase/plugin-action-import/src/client-v2/__tests__/ImportActionUpload.test.tsx`
- `yarn build @nocobase/plugin-action-import --no-dts`
- `git diff --check`

The full declaration build is still blocked by existing plugin declaration errors around define/registerFlow/app and legacy client typings; no new declaration error from this change was reported. A browser smoke test on a running `/v/` page is recommended for file-picker, drag-and-drop, replacement, removal, and invalid-file scenarios.

### Related issues

Task 5919

### Showcase

N/A — behavior-only fix in the existing v2 Import dialog.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where files could not be imported by dragging them into the v2 Import dialog. |
| 🇨🇳 Chinese | 修复 v2 导入弹窗中拖入文件无法导入的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary