### PR TITLE
fix(client-v2): preserve filter submit behavior

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/FilterFormSubmitActionModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/FilterFormSubmitActionModel.tsx
@@ -8,8 +8,36 @@
  */
 
 import type { ButtonProps } from 'antd/es/button';
+import { reaction } from '@formily/reactive';
 import { tExpr } from '@nocobase/flow-engine';
 import { FilterFormActionModel } from './FilterFormActionModel';
+
+type FilterFormBlockState = {
+  autoTriggerFilter: boolean;
+};
+
+const mountedSubmitActions = new WeakSet<object>();
+const visibleSubmitActionsByBlock = new WeakMap<FilterFormBlockState, Set<object>>();
+const hiddenReactionDisposers = new WeakMap<object, () => void>();
+
+const syncAutoTriggerFilter = (blockModel: FilterFormBlockState, lifecycleAction: object & { hidden?: boolean }) => {
+  let visibleSubmitActions = visibleSubmitActionsByBlock.get(blockModel);
+
+  if (mountedSubmitActions.has(lifecycleAction) && !lifecycleAction.hidden) {
+    if (!visibleSubmitActions) {
+      visibleSubmitActions = new Set<object>();
+      visibleSubmitActionsByBlock.set(blockModel, visibleSubmitActions);
+    }
+    visibleSubmitActions.add(lifecycleAction);
+  } else {
+    visibleSubmitActions?.delete(lifecycleAction);
+  }
+
+  blockModel.autoTriggerFilter = Boolean(!visibleSubmitActions?.size);
+  if (!visibleSubmitActions?.size) {
+    visibleSubmitActionsByBlock.delete(blockModel);
+  }
+};
 
 export class FilterFormSubmitActionModel extends FilterFormActionModel {
   defaultProps: ButtonProps = {
@@ -17,14 +45,39 @@ export class FilterFormSubmitActionModel extends FilterFormActionModel {
     type: 'primary',
   };
 
-  onInit(options): void {
-    super.onInit(options);
-    this.context.blockModel.autoTriggerFilter = false;
+  private getLifecycleAction(): object & { hidden?: boolean } {
+    return this.context.model || this;
+  }
+
+  private syncAutoTriggerFilter(): void {
+    const blockModel = this.context.blockModel as FilterFormBlockState;
+    const lifecycleAction = this.getLifecycleAction();
+    syncAutoTriggerFilter(blockModel, lifecycleAction);
+  }
+
+  onMount(): void {
+    super.onMount();
+    const blockModel = this.context.blockModel as FilterFormBlockState;
+    const lifecycleAction = this.getLifecycleAction();
+    mountedSubmitActions.add(lifecycleAction);
+    hiddenReactionDisposers.get(lifecycleAction)?.();
+    hiddenReactionDisposers.set(
+      lifecycleAction,
+      reaction(
+        () => lifecycleAction.hidden,
+        () => syncAutoTriggerFilter(blockModel, lifecycleAction),
+      ),
+    );
+    this.syncAutoTriggerFilter();
   }
 
   onUnmount(): void {
     super.onUnmount();
-    this.context.blockModel.autoTriggerFilter = true;
+    const lifecycleAction = this.getLifecycleAction();
+    hiddenReactionDisposers.get(lifecycleAction)?.();
+    hiddenReactionDisposers.delete(lifecycleAction);
+    mountedSubmitActions.delete(lifecycleAction);
+    this.syncAutoTriggerFilter();
   }
 }
 

--- a/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/FilterFormSubmitActionModel.lifecycle.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-form/__tests__/FilterFormSubmitActionModel.lifecycle.test.ts
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { define, observable } from '@formily/reactive';
+import { describe, expect, it } from 'vitest';
+import { FilterFormSubmitActionModel } from '../FilterFormSubmitActionModel';
+
+describe('FilterFormSubmitActionModel lifecycle', () => {
+  const createAction = (blockModel: { autoTriggerFilter: boolean }, hidden = false, lifecycleAction?: object) => {
+    const action = Object.create(FilterFormSubmitActionModel.prototype) as FilterFormSubmitActionModel;
+
+    Object.defineProperty(action, 'props', {
+      value: {},
+    });
+    Object.defineProperty(action, 'context', {
+      value: { blockModel, model: lifecycleAction || action, defineProperty: () => undefined },
+    });
+    action.hidden = hidden;
+    define(action, {
+      hidden: observable,
+    });
+    action.onInit({});
+
+    return action;
+  };
+
+  it('keeps automatic filtering disabled when the submit action remounts', () => {
+    const blockModel = { autoTriggerFilter: true };
+    const action = createAction(blockModel);
+
+    action.onMount();
+    expect(blockModel.autoTriggerFilter).toBe(false);
+
+    action.onUnmount();
+    expect(blockModel.autoTriggerFilter).toBe(true);
+
+    action.onMount();
+    expect(blockModel.autoTriggerFilter).toBe(false);
+  });
+
+  it('keeps automatic filtering disabled until every mounted submit action unmounts', () => {
+    const blockModel = { autoTriggerFilter: true };
+    const firstAction = createAction(blockModel);
+    const secondAction = createAction(blockModel);
+
+    firstAction.onMount();
+    secondAction.onMount();
+    firstAction.onUnmount();
+    expect(blockModel.autoTriggerFilter).toBe(false);
+
+    secondAction.onUnmount();
+    expect(blockModel.autoTriggerFilter).toBe(true);
+  });
+
+  it('only disables automatic filtering while a visible submit action is mounted', () => {
+    const blockModel = { autoTriggerFilter: true };
+    const action = createAction(blockModel, true);
+
+    action.onMount();
+    expect(blockModel.autoTriggerFilter).toBe(true);
+
+    action.hidden = false;
+    expect(blockModel.autoTriggerFilter).toBe(false);
+
+    action.hidden = true;
+    expect(blockModel.autoTriggerFilter).toBe(true);
+  });
+
+  it('tracks fork lifecycles independently when submit actions share the same uid', () => {
+    const blockModel = { autoTriggerFilter: true };
+    const firstFork = {};
+    const secondFork = {};
+    const firstAction = createAction(blockModel, false, firstFork);
+    const secondAction = createAction(blockModel, false, secondFork);
+
+    firstAction.onMount();
+    secondAction.onMount();
+    firstAction.onUnmount();
+    expect(blockModel.autoTriggerFilter).toBe(false);
+
+    secondAction.onUnmount();
+    expect(blockModel.autoTriggerFilter).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

筛选表单配置了“筛选”按钮时，修改筛选字段后应等待用户点击按钮再刷新数据。但从同一页面进入 UI 编辑模式后，修改字段会立即刷新关联表格，导致编辑态与普通浏览态的行为不一致。

### Description

修正筛选按钮在页面模式切换、隐藏和重新显示过程中的状态维护。只要页面上仍有可见的筛选按钮，修改字段就不会自动提交；没有可见筛选按钮时，仍保留原有的即时筛选行为。

补充筛选按钮生命周期测试，覆盖重新挂载、多个筛选按钮、按钮隐藏与显示，以及同一按钮存在多个渲染实例的场景。

本次改动仅影响 Client V2 筛选表单的内部状态判断，不改变公开 API。建议重点验证普通浏览态和 UI 编辑模式下输入字段不会立即刷新、点击“筛选”后正常刷新，以及无可见筛选按钮时仍可自动筛选。

### Showcase

浏览器回归结果：普通浏览态输入 `7` 后保持 248 条，点击“筛选”后变为 42 条；UI 编辑模式输入 `71` 后保持 248 条，点击“筛选”后变为 2 条。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix filter forms refreshing automatically in UI edit mode |
| 🇨🇳 Chinese | 修复筛选表单在 UI 编辑模式下自动刷新数据的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
