### PR TITLE
fix(plugin-file-manager): preserve sub-app local file routing

### DIFF
--- a/packages/core/server/src/__tests__/gateway.test.ts
+++ b/packages/core/server/src/__tests__/gateway.test.ts
@@ -147,6 +147,21 @@ describe('gateway', () => {
       expect((req as any).originalUrl).toBe('/api/__app/demo/.well-known/oauth-authorization-server');
     });
 
+    it('should proxy local storage requests to the selected sub app', async () => {
+      const req = {
+        url: '/storage/uploads/logo.png?__appName=demo',
+        headers: {},
+      } as any;
+      const res = {} as any;
+
+      const supervisor = AppSupervisor.getInstance();
+      const proxyWeb = vi.spyOn(supervisor, 'proxyWeb').mockResolvedValue(true);
+
+      await gateway.requestHandler(req, res);
+
+      expect(proxyWeb).toHaveBeenCalledWith('demo', req, res);
+    });
+
     it('should add same middleware into app selector once', async () => {
       const fn = async (ctx, next) => {
         ctx.resolvedAppName = 'test';

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts
@@ -869,6 +869,22 @@ describe('file manager > server', () => {
         expect(response.headers.location).toBe(storageUrl);
       });
 
+      it('preserves the sub-application when redirecting to local storage', async () => {
+        await app.destroy();
+        app = await getApp({ name: 'sub-app' });
+        agent = app.agent();
+        db = app.db;
+        plugin = app.pm.get(PluginFileManagerServer) as PluginFileManagerServer;
+
+        const { body } = await agent.resource('attachments').create({
+          [FILE_FIELD_NAME]: path.resolve(__dirname, './files/text.txt'),
+        });
+        const response = await agent.get(body.data.url);
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(`${await plugin.getFileURL(body.data)}?__appName=sub-app`);
+      });
+
       it('keeps permanent URLs without extname compatible', async () => {
         const admin = await db.getRepository('users').findOne();
         const loggedAgent = await app.agent().login(admin);
@@ -1133,7 +1149,7 @@ describe('file manager > server', () => {
 
           const response = await loggedAgent.get(body.data.url);
           expect(response.status).toBe(302);
-          expect(response.headers.location).toBe(await plugin.getFileURL(body.data));
+          expect(response.headers.location).toBe(`${await plugin.getFileURL(body.data)}?__appName=subapp`);
 
           const wrongAppResponse = await loggedAgent.get(`/files/main/main/attachments/${body.data.id}`);
           expect(wrongAppResponse.status).toBe(404);
@@ -1476,7 +1492,7 @@ describe('file manager > server', () => {
             .get(file.get('url') as string)
             .set('Cookie', cookieHeader);
           expect(response.status).toBe(302);
-          expect(response.headers.location).toBe(await plugin.getFileURL(file));
+          expect(response.headers.location).toBe(`${await plugin.getFileURL(file)}?__appName=subapp`);
 
           const fileTemplateRecord = await plugin.createFileRecord({
             collectionName: 'files',
@@ -1491,7 +1507,9 @@ describe('file manager > server', () => {
             .get(fileTemplateRecord.get('url') as string)
             .set('Cookie', cookieHeader);
           expect(fileTemplateResponse.status).toBe(302);
-          expect(fileTemplateResponse.headers.location).toBe(await plugin.getFileURL(fileTemplateRecord));
+          expect(fileTemplateResponse.headers.location).toBe(
+            `${await plugin.getFileURL(fileTemplateRecord)}?__appName=subapp`,
+          );
 
           const dynamicCollectionName = 't_8jbl7u3wx4j';
           await createFileTemplateCollection(db, dynamicCollectionName);
@@ -1508,7 +1526,9 @@ describe('file manager > server', () => {
             .get(dynamicFileTemplateRecord.get('url') as string)
             .set('Cookie', cookieHeader);
           expect(dynamicFileTemplateResponse.status).toBe(302);
-          expect(dynamicFileTemplateResponse.headers.location).toBe(await plugin.getFileURL(dynamicFileTemplateRecord));
+          expect(dynamicFileTemplateResponse.headers.location).toBe(
+            `${await plugin.getFileURL(dynamicFileTemplateRecord)}?__appName=subapp`,
+          );
         } finally {
           app.options.name = originalName;
           restoreEnv('APP_PUBLIC_PATH', originalPath);

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts
@@ -27,6 +27,15 @@ type StorageFileURLResolver = {
   }) => Promise<string | undefined>;
 };
 
+function preserveSubAppInLocalURL(url: string, appName?: string) {
+  if (!appName || appName === 'main' || !url.startsWith('/') || url.startsWith('//')) {
+    return url;
+  }
+  const [urlWithoutHash, hash] = url.split('#', 2);
+  const separator = urlWithoutHash.includes('?') ? '&' : '?';
+  return `${urlWithoutHash}${separator}__appName=${encodeURIComponent(appName)}${hash ? `#${hash}` : ''}`;
+}
+
 export async function getFile(ctx: Context, next: Next) {
   const collection = ctx.dataSource.collectionManager.getCollection(ctx.action.resourceName);
   if (!collection || (collection.name !== 'attachments' && collection.options?.template !== 'file')) {
@@ -125,13 +134,14 @@ export async function getFile(ctx: Context, next: Next) {
   const download = !temporaryAccess && ctx.method === 'GET' && ctx.query.download === '1';
   const preview = download ? false : temporaryAccess ? false : Boolean(ctx.state.fileAccess?.preview);
   const dataSource = ctx.dataSource as DataSource & StorageFileURLResolver;
-  const finalUrl =
+  const storageUrl =
     (await dataSource.resolveStorageFileURL?.({
       collectionName: collection.name,
       file: getFilePlainObject(file as AttachmentModel) as Record<string, unknown>,
       preview,
       download,
     })) || (await plugin.getFileURL(file, preview, { download }));
+  const finalUrl = preserveSubAppInLocalURL(storageUrl, ctx.state.fileAccess?.appName);
   ctx.status = 302;
   ctx.redirect(finalUrl);
   await next();


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Stable file URLs include the application name, but redirects to local storage URLs dropped that context. For files in a sub-application, including the system logo, the follow-up `/storage/uploads/...` request was therefore handled as a main-application request and could resolve against the wrong storage location.

### Description 

- Preserve the sub-application name on redirects to same-origin storage URLs by appending `__appName`.
- Keep main-application redirects and absolute external storage URLs unchanged.
- Add regression coverage for file-manager redirects and gateway routing of sub-application local storage requests.

Potential risk is limited to sub-application redirects whose final storage URL is a same-origin relative path. Suggested verification is to upload and display a logo or attachment from a sub-application using the local storage engine.

Tests:

- `yarn test packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts --run` (62 passed)
- `yarn test packages/core/server/src/__tests__/gateway.test.ts --run -t selected` (1 passed, 12 skipped)
- `yarn eslint --fix packages/core/server/src/__tests__/gateway.test.ts packages/plugins/@nocobase/plugin-file-manager/src/server/actions/get-file.ts packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/server.test.ts`

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed local storage files such as logos failing to load in sub-applications after stable URL redirects |
| 🇨🇳 Chinese | 修复子应用中的 Logo 等本地存储文件在稳定 URL 重定向后无法加载的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
