### PR TITLE
fix(client-v2): correct filtered tree and details states

### DIFF
--- a/packages/core/client-v2/src/flow/models/blocks/details/DetailsBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/details/DetailsBlockModel.tsx
@@ -20,6 +20,7 @@ import {
   SingleRecordResource,
   createCurrentRecordMetaFactory,
   createRecordResolveOnServerWithLocal,
+  observer,
   tExpr,
 } from '@nocobase/flow-engine';
 import { Pagination, Space } from 'antd';
@@ -154,8 +155,8 @@ export class DetailsBlockModel extends CollectionBlockModel<{
           simple
           pageSize={1}
           showSizeChanger={false}
-          defaultCurrent={resource.getPage()}
-          total={resource.getTotalPage()}
+          current={resource.getPage()}
+          total={resource.getCount()}
           onChange={this.handlePageChange}
           style={{ display: 'inline-block' }}
         />
@@ -225,6 +226,8 @@ export class DetailsBlockModel extends CollectionBlockModel<{
     );
   }
 }
+
+export const DetailsPagination = observer(({ model }: { model: DetailsBlockModel }) => model.renderPagination());
 
 const DetailsBlockContent = ({
   model,
@@ -297,7 +300,9 @@ const DetailsBlockContent = ({
           model={gridModel}
           showFlowSettings={false}
         />
-        <div ref={paginationRef}>{model.renderPagination()}</div>
+        <div ref={paginationRef}>
+          <DetailsPagination model={model} />
+        </div>
       </div>
     </FormComponent>
   );

--- a/packages/core/client-v2/src/flow/models/blocks/details/__tests__/DetailsBlockModel.initialPaginationChangeRefresh.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/details/__tests__/DetailsBlockModel.initialPaginationChangeRefresh.test.ts
@@ -7,10 +7,12 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FlowEngine, MultiRecordResource, SingleRecordResource } from '@nocobase/flow-engine';
+import React from 'react';
 import '../../../../index';
-import { DetailsBlockModel } from '../DetailsBlockModel';
+import { DetailsBlockModel, DetailsPagination } from '../DetailsBlockModel';
 import { DetailsGridModel } from '../DetailsGridModel';
 
 function setupDetailsBlockModel(options?: { filterByTk?: string | number }) {
@@ -91,6 +93,35 @@ describe('DetailsBlockModel initial pagination refresh', () => {
     await model.dispatchEvent('beforeRender', undefined, { useCache: false });
 
     expect(dispatchSpy.mock.calls.filter(([eventName]) => eventName === 'paginationChange')).toHaveLength(1);
+  });
+
+  it('renders pagination from the current count and page after filtering', () => {
+    const { model, resource } = setupDetailsBlockModel();
+    resource.setData([{ id: 3, name: 'CC', title: 'filtered' }] as any);
+    resource.setMeta({ count: 7, page: 3, pageSize: 1, totalPage: 20 });
+
+    const paginationContainer = model.renderPagination() as any;
+    const pagination = paginationContainer.props.children;
+
+    expect(pagination.props.total).toBe(7);
+    expect(pagination.props.current).toBe(3);
+    expect(pagination.props.defaultCurrent).toBeUndefined();
+  });
+
+  it('updates the rendered pagination when filtering changes only resource metadata', () => {
+    const { model, resource } = setupDetailsBlockModel();
+    resource.setData([{ id: 1, name: 'AA', title: 'foo' }] as any);
+    resource.setMeta({ count: 7, page: 1, pageSize: 1, totalPage: 7 });
+
+    render(React.createElement(DetailsPagination, { model }));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    act(() => {
+      resource.setMeta({ count: 1, page: 1, pageSize: 1, totalPage: 1 });
+    });
+
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
   });
 
   it('uses a real single-record details model and does not emit root paginationChange on initial render', async () => {

--- a/packages/core/client-v2/src/flow/models/blocks/filter-manager/FilterManager.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-manager/FilterManager.ts
@@ -569,6 +569,9 @@ export class FilterManager {
 
         const blockModel = targetModel as CollectionBlockModel;
         const resource = (targetModel as any).resource;
+        const filterResettableTarget = targetModel as CollectionBlockModel & {
+          resetAfterFilterChange?: () => void;
+        };
 
         // 4.4 检查数据加载模式
         const loadingMode = blockModel.getDataLoadingMode();
@@ -581,6 +584,7 @@ export class FilterManager {
             resource.setPage(1);
           }
           resource.loading = false;
+          filterResettableTarget.resetAfterFilterChange?.();
           return;
         }
 
@@ -590,6 +594,7 @@ export class FilterManager {
           resource.setPage(1); // 重置到第一页
         }
         await resource.refresh();
+        filterResettableTarget.resetAfterFilterChange?.();
       } catch (error) {
         console.error(`Failed to refresh target model "${targetId}": ${error.message}`);
         return;

--- a/packages/core/client-v2/src/flow/models/blocks/filter-manager/__tests__/FilterManager.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/filter-manager/__tests__/FilterManager.test.ts
@@ -615,6 +615,46 @@ describe('FilterManager', () => {
       expect(mockTargetModel2.resource.refresh).toHaveBeenCalledTimes(1);
     });
 
+    it('should reset target interaction state after refreshing filtered data', async () => {
+      (filterManager as any).filterConfigs = [
+        {
+          filterId: 'filter-1',
+          targetId: 'target-1',
+          filterPaths: ['name'],
+          operator: '$eq',
+        },
+      ];
+
+      const refresh = vi.fn().mockResolvedValue(undefined);
+      const resetAfterFilterChange = vi.fn(() => {
+        expect(refresh).toHaveBeenCalledTimes(1);
+      });
+      const mockTargetModel = {
+        resource: {
+          addFilterGroup: vi.fn(),
+          removeFilterGroup: vi.fn(),
+          refresh,
+        },
+        setFilterActive: vi.fn(),
+        getDataLoadingMode: vi.fn().mockReturnValue('auto'),
+        resetAfterFilterChange,
+      };
+      const mockFilterModel = {
+        getFilterValue: vi.fn().mockReturnValue('test-value'),
+      };
+
+      (mockFlowModel.flowEngine.getModel as any).mockImplementation((uid: string) => {
+        if (uid === 'target-1') return mockTargetModel;
+        if (uid === 'filter-1') return mockFilterModel;
+        return null;
+      });
+
+      await filterManager.refreshTargetsByFilter('filter-1');
+
+      expect(resetAfterFilterChange).toHaveBeenCalledTimes(1);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
     it('should wait for target resource idle before refreshing', async () => {
       vi.useFakeTimers();
       (filterManager as any).filterConfigs = [

--- a/packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableBlockModel.tsx
@@ -36,7 +36,15 @@ import { BlockSceneEnum } from '../../base/BlockModel';
 import { CollectionBlockModel } from '../../base/CollectionBlockModel';
 import { QuickEditFormModel } from '../form/QuickEditFormModel';
 import { TableColumnModel } from './TableColumnModel';
-import { extractIndex, adjustColumnOrder, setNestedValue, extractIds, getRowKey, useBlockHeight } from './utils';
+import {
+  extractIndex,
+  adjustColumnOrder,
+  setNestedValue,
+  extractIds,
+  extractRowKeys,
+  getRowKey,
+  useBlockHeight,
+} from './utils';
 import { resolveTableSorterField } from './sortUtils';
 import { commonConditionHandler, ConditionBuilder } from '../../../components/ConditionBuilder';
 import { BulkDeleteActionModel } from '../../actions/BulkDeleteActionModel';
@@ -220,6 +228,22 @@ export class TableBlockModel extends CollectionBlockModel<TableBlockModelStructu
 
   get resource() {
     return super.resource as MultiRecordResource;
+  }
+
+  resetAfterFilterChange() {
+    if (!this.props.treeTable) {
+      return;
+    }
+
+    const expandAll = !!this.props.defaultExpandAllRows;
+    const expandedRowKeys = expandAll ? extractRowKeys(this.resource.getData(), this.collection.filterTargetKey) : [];
+
+    this.setProps('expandedRowKeys', expandedRowKeys);
+    this.mapSubModels('actions', (action) => {
+      if ('setExpandFlag' in action && typeof action.setExpandFlag === 'function') {
+        action.setExpandFlag(expandAll);
+      }
+    });
   }
 
   private readonly columns = observable.ref([]);

--- a/packages/core/client-v2/src/flow/models/blocks/table/TableColumnModel.tsx
+++ b/packages/core/client-v2/src/flow/models/blocks/table/TableColumnModel.tsx
@@ -27,6 +27,7 @@ import {
   ModelRenderMode,
   useFlowModel,
 } from '@nocobase/flow-engine';
+import type { FlowModel } from '@nocobase/flow-engine';
 import { useTranslation } from 'react-i18next';
 import { TableColumnProps, Tooltip, Space, InputNumber, Button, Divider } from 'antd';
 import { get, omit, capitalize } from 'lodash';
@@ -61,19 +62,28 @@ export function FieldDeletePlaceholder(props: any) {
   );
 }
 
-function FieldWithoutPermissionPlaceholder() {
+type FieldPermissionPlaceholderModel = FlowModel & {
+  fieldPath?: string;
+  forbidden?: { actionName?: string } | null;
+};
+
+export function FieldWithoutPermissionPlaceholder({
+  targetModel,
+}: {
+  targetModel?: FieldPermissionPlaceholderModel;
+} = {}) {
   const { t } = useTranslation();
-  const model: any = useFlowModel();
-  const blockModel = model.context.blockModel;
-  const collection = model.context.collectionField?.collection || blockModel.collection;
-  const dataSource = collection.dataSource;
+  const contextModel = useFlowModel<FieldPermissionPlaceholderModel>();
+  const model = targetModel || contextModel;
+  const collection = model.context.collectionField?.collection || model.context.blockModel?.collection;
+  const dataSource = collection?.dataSource;
   const name = model.context.collectionField?.name || model.fieldPath;
   const nameValue = useMemo(() => {
-    const dataSourcePrefix = `${t(dataSource.displayName || dataSource.key)} > `;
+    const dataSourcePrefix = dataSource ? `${t(dataSource.displayName || dataSource.key)} > ` : '';
     const collectionPrefix = collection ? `${t(collection.title) || collection.name || collection.tableName} > ` : '';
     return `${dataSourcePrefix}${collectionPrefix}${name}`;
-  }, [collection, dataSource.displayName, dataSource.key, name, t]);
-  const { actionName } = model.forbidden;
+  }, [collection, dataSource, name, t]);
+  const actionName = model.forbidden?.actionName || 'view';
   const messageValue = useMemo(() => {
     return t(
       `The current user only has the UI configuration permission, but don't have "{{actionName}}" permission for field "{{name}}"`,

--- a/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.filterReset.test.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/table/__tests__/TableBlockModel.filterReset.test.ts
@@ -1,0 +1,78 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { TableBlockModel } from '../TableBlockModel';
+
+describe('TableBlockModel filter reset', () => {
+  it('collapses the filtered tree when rows are not expanded by default', () => {
+    const setExpandFlag = vi.fn();
+    const setProps = vi.fn();
+    const model = {
+      props: { treeTable: true, defaultExpandAllRows: false, expandedRowKeys: [1, 2] },
+      resource: { getData: () => [{ id: 3, children: [{ id: 4 }] }] },
+      setProps,
+      mapSubModels: (_key, callback) => callback({ setExpandFlag }),
+    };
+
+    TableBlockModel.prototype.resetAfterFilterChange.call(model);
+
+    expect(setProps).toHaveBeenCalledWith('expandedRowKeys', []);
+    expect(setExpandFlag).toHaveBeenCalledWith(false);
+  });
+
+  it('expands the filtered tree when rows are expanded by default', () => {
+    const setExpandFlag = vi.fn();
+    const setProps = vi.fn();
+    const model = {
+      props: { treeTable: true, defaultExpandAllRows: true, expandedRowKeys: [1, 2] },
+      collection: { filterTargetKey: 'id' },
+      resource: { getData: () => [{ id: 3, children: [{ id: 4 }] }] },
+      setProps,
+      mapSubModels: (_key, callback) => callback({ setExpandFlag }),
+    };
+
+    TableBlockModel.prototype.resetAfterFilterChange.call(model);
+
+    expect(setProps).toHaveBeenCalledWith('expandedRowKeys', [3, 4]);
+    expect(setExpandFlag).toHaveBeenCalledWith(true);
+  });
+
+  it('uses the collection filter target key when expanding the filtered tree', () => {
+    const setProps = vi.fn();
+    const model = {
+      props: { treeTable: true, defaultExpandAllRows: true },
+      collection: { filterTargetKey: ['tenant', 'slug'] },
+      resource: {
+        getData: () => [{ tenant: 'acme', slug: 'root', children: [{ tenant: 'acme', slug: 'child' }] }],
+      },
+      setProps,
+      mapSubModels: vi.fn(),
+    };
+
+    TableBlockModel.prototype.resetAfterFilterChange.call(model);
+
+    expect(setProps).toHaveBeenCalledWith('expandedRowKeys', ['acme-root', 'acme-child']);
+  });
+
+  it('does not change expansion state for a regular table', () => {
+    const setProps = vi.fn();
+    const mapSubModels = vi.fn();
+    const model = {
+      props: { treeTable: false },
+      setProps,
+      mapSubModels,
+    };
+
+    TableBlockModel.prototype.resetAfterFilterChange.call(model);
+
+    expect(setProps).not.toHaveBeenCalled();
+    expect(mapSubModels).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/client-v2/src/flow/models/blocks/table/utils.ts
+++ b/packages/core/client-v2/src/flow/models/blocks/table/utils.ts
@@ -67,6 +67,13 @@ export function extractIds(data) {
   return ids;
 }
 
+export function extractRowKeys(data: Record<string, unknown>[], key: string | string[]) {
+  return data.flatMap((item) => {
+    const children = Array.isArray(item.children) ? extractRowKeys(item.children, key) : [];
+    return [getRowKey(item, key), ...children];
+  });
+}
+
 /**
  * 生成表格行唯一 key
  * @param record 当前行数据

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeBlockModel.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/TreeBlockModel.tsx
@@ -55,6 +55,31 @@ const getEffectiveFieldModelUse = (fieldModel: any) => {
   return fieldModel?.getStepParams?.('fieldBinding', 'use') || fieldModel?.use;
 };
 
+const applyTitleFieldViewAcl = async (
+  context: FlowModelContext,
+  fieldModel: FlowModel,
+  initParams: ReturnType<TreeBlockModel['getTitleFieldSettingsInitParams']>,
+) => {
+  if (context.skipAclCheck || typeof context.aclCheck !== 'function') {
+    return;
+  }
+
+  const actionName = 'view';
+  const allowed = await context.aclCheck({
+    dataSourceKey: initParams.dataSourceKey,
+    resourceName: initParams.collectionName,
+    actionName,
+    fields: [initParams.fieldPath],
+    allowedActions: null,
+  });
+
+  if (!allowed) {
+    fieldModel.forbidden = { actionName };
+  } else if (fieldModel.forbidden?.actionName === actionName) {
+    fieldModel.forbidden = null;
+  }
+};
+
 const getTitleFieldStepParams = (fieldModel: any, initParams: any, preservePrevious: boolean) => {
   const previousStepParams = preservePrevious ? fieldModel?.getStepParams?.() || {} : {};
   const { fieldBinding: _fieldBinding, ...stepParams } = previousStepParams;
@@ -200,10 +225,6 @@ export class TreeBlockModel extends CollectionBlockModel {
 
   onInit(options) {
     super.onInit(options);
-    this.context.defineProperty('collectionField', {
-      get: () => this.collection?.getField?.(this.getTitleFieldName()),
-      cache: false,
-    });
     this.ensureTitleFieldSettingsContainer();
     this.migrateLegacyTitleFieldSubModel();
     this.migrateLegacyActionSubModels();
@@ -499,6 +520,7 @@ export class TreeBlockModel extends CollectionBlockModel {
       currentFieldModel.setProps(nextProps);
       currentFieldModel.setStepParams(nextStepParams);
       await currentFieldModel.dispatchEvent('beforeRender', undefined, { useCache: false });
+      await applyTitleFieldViewAcl(this.context, currentFieldModel, initParams);
       if (options.persist) {
         await currentFieldModel.save?.();
         await this.save();
@@ -527,6 +549,7 @@ export class TreeBlockModel extends CollectionBlockModel {
       await fieldModel.save?.();
     }
     await fieldModel.dispatchEvent('beforeRender', undefined, { useCache: false });
+    await applyTitleFieldViewAcl(this.context, fieldModel, initParams);
     if (options.persist) {
       await this.save();
     }

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/__tests__/TreeBlockModel.test.ts
@@ -31,6 +31,36 @@ describe('TreeBlockModel', () => {
     expect(titleFieldName).toBe('title');
   });
 
+  it('keeps the block ACL scoped to the collection instead of the title field', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ TreeBlockModel, TreeTitleFieldSettingsModel });
+
+    const ds = engine.dataSourceManager.getDataSource('main');
+    ds.addCollection({
+      name: 'categories',
+      filterTargetKey: 'id',
+      fields: [
+        { name: 'id', type: 'integer', interface: 'number' },
+        { name: 'title', type: 'string', interface: 'input' },
+      ],
+    });
+
+    const model = engine.createModel<TreeBlockModel>({
+      use: 'TreeBlockModel',
+      stepParams: {
+        resourceSettings: {
+          init: {
+            dataSourceKey: 'main',
+            collectionName: 'categories',
+          },
+        },
+      },
+    });
+
+    expect(model.getTitleFieldName()).toBe('title');
+    expect(model.context.collectionField).toBeUndefined();
+  });
+
   it('hides single relation entries from associated records in tree filter block menu', async () => {
     const engine = new FlowEngine();
     engine.registerModels({ TreeBlockModel });
@@ -203,6 +233,105 @@ describe('TreeBlockModel', () => {
         },
       }),
     );
+  });
+
+  it('marks the title field model as forbidden when field view permission is denied', async () => {
+    const titleField = {
+      name: 'title',
+      collectionName: 'posts',
+      getComponentProps: () => ({}),
+    };
+    const fieldModel = {
+      hidden: false,
+      forbidden: null,
+      dispatchEvent: vi.fn(),
+      save: vi.fn(),
+    };
+    const aclCheck = vi.fn().mockResolvedValue(false);
+
+    vi.spyOn(DisplayItemModel, 'getDefaultBindingByField').mockReturnValue({
+      modelName: 'DisplayTextFieldModel',
+      defaultProps: {},
+    } as any);
+
+    await TreeBlockModel.prototype.syncTitleFieldSubModel.call(
+      {
+        collection: {
+          dataSourceKey: 'main',
+          name: 'posts',
+          getField: () => titleField,
+        },
+        context: {
+          app: {},
+          aclCheck,
+        },
+        flowEngine: {},
+        subModels: {},
+        getTitleFieldSettingsInitParams: TreeBlockModel.prototype.getTitleFieldSettingsInitParams,
+        setSubModel: vi.fn(() => fieldModel),
+      },
+      'title',
+    );
+
+    expect(aclCheck).toHaveBeenCalledWith({
+      dataSourceKey: 'main',
+      resourceName: 'posts',
+      actionName: 'view',
+      fields: ['title'],
+      allowedActions: null,
+    });
+    expect(fieldModel).toMatchObject({
+      hidden: false,
+      forbidden: { actionName: 'view' },
+    });
+  });
+
+  it('keeps other hidden state when title field view permission is restored', async () => {
+    const titleField = {
+      name: 'title',
+      collectionName: 'posts',
+      getComponentProps: () => ({}),
+    };
+    const fieldModel = {
+      use: 'DisplayTextFieldModel',
+      hidden: true,
+      forbidden: { actionName: 'view' },
+      getStepParams: vi.fn((flowKey: string, stepKey: string) => {
+        if (flowKey === 'fieldSettings' && stepKey === 'init') {
+          return { fieldPath: 'title' };
+        }
+        return undefined;
+      }),
+      setProps: vi.fn(),
+      setStepParams: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+
+    vi.spyOn(DisplayItemModel, 'getDefaultBindingByField').mockReturnValue({
+      modelName: 'DisplayTextFieldModel',
+      defaultProps: {},
+    } as any);
+
+    await TreeBlockModel.prototype.syncTitleFieldSubModel.call(
+      {
+        collection: {
+          dataSourceKey: 'main',
+          name: 'posts',
+          getField: () => titleField,
+        },
+        context: {
+          app: {},
+          aclCheck: vi.fn().mockResolvedValue(true),
+        },
+        flowEngine: {},
+        getTitleFieldSettingsContainer: () => ({ subModels: { field: fieldModel } }),
+        getTitleFieldSettingsInitParams: TreeBlockModel.prototype.getTitleFieldSettingsInitParams,
+      },
+      'title',
+    );
+
+    expect(fieldModel.hidden).toBe(true);
+    expect(fieldModel.forbidden).toBeNull();
   });
 
   it('preserves display field settings when the title field binding does not change', async () => {

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/components/TreeBlockView.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/components/TreeBlockView.tsx
@@ -9,6 +9,7 @@
 
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { css } from '@emotion/css';
+import { FieldWithoutPermissionPlaceholder } from '@nocobase/client-v2';
 import {
   createRecordMetaFactory,
   createRecordResolveOnServerWithLocal,
@@ -102,6 +103,16 @@ export const getTreeNodeTitleContent = ({
   fallbackTitle?: React.ReactNode;
 }) => {
   const isTitleFieldMissing = !collectionField && !!model.getTitleFieldName();
+
+  if (titleFieldModel?.forbidden) {
+    return (
+      <TreeNodeTitleContent
+        model={model}
+        record={node}
+        title={<FieldWithoutPermissionPlaceholder targetModel={titleFieldModel} />}
+      />
+    );
+  }
 
   if (isTitleFieldMissing) {
     return (
@@ -428,6 +439,11 @@ const TreeNodeTitleContent = ({
         className={css`
           min-width: 0;
           flex: 1;
+
+          &,
+          * {
+            cursor: pointer !important;
+          }
         `}
       >
         {model.renderTitleFieldSettings(<span>{title}</span>)}
@@ -567,15 +583,16 @@ export const TreeBlockView = observer(({ model }: { model: TreeBlockModel }) => 
 
   const renderNodeTitle = useCallback<NonNullable<TreeProps['renderNodeTitle']>>(
     (value, node, fallbackTitle) => {
-      if (!collectionField || value === null || value === undefined || value === '' || !titleFieldModel?.createFork) {
-        return getTreeNodeTitleContent({
-          model,
-          collectionField,
-          titleFieldModel,
-          value,
-          node,
-          fallbackTitle,
-        });
+      const titleContent = getTreeNodeTitleContent({
+        model,
+        collectionField,
+        titleFieldModel,
+        value,
+        node,
+        fallbackTitle,
+      });
+      if (titleContent) {
+        return titleContent;
       }
 
       const nodeKey = node?.[fieldNames.key] ?? `${titleField}-${String(value)}`;

--- a/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/components/__tests__/TreeBlockView.test.tsx
+++ b/packages/plugins/@nocobase/plugin-block-tree/src/client-v2/models/components/__tests__/TreeBlockView.test.tsx
@@ -15,6 +15,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { getTreeNodeTitleContent, getTreeTitleFieldDeletedMessage } from '../TreeBlockView';
 
@@ -57,5 +58,44 @@ describe('TreeBlockView', () => {
     }) as any;
 
     expect(result.props.title.type.name).toBe('TreeTitleFieldDeletedPlaceholder');
+  });
+
+  it('returns the table field permission placeholder when the title field is forbidden', () => {
+    const model: any = {
+      collection: {},
+      getTitleFieldName: () => 'title',
+    };
+
+    const result = getTreeNodeTitleContent({
+      model,
+      collectionField: {},
+      titleFieldModel: { forbidden: { actionName: 'view' } },
+      value: 'Secret title',
+      node: { id: 1 },
+    }) as any;
+
+    expect(result.props.title.type.name).toBe('FieldWithoutPermissionPlaceholder');
+  });
+
+  it('keeps the pointer cursor over rendered title field content', () => {
+    const model: any = {
+      collection: {},
+      context: { flowSettingsEnabled: false },
+      getTitleFieldName: () => 'title',
+      getNodeActionsContainer: () => ({ hasSubModel: () => false }),
+      renderTitleFieldSettings: (content) => content,
+    };
+
+    const result = getTreeNodeTitleContent({
+      model,
+      collectionField: {},
+      titleFieldModel: {},
+      value: 'Title',
+      node: { id: 1 },
+    });
+
+    render(result);
+
+    expect(screen.getByText('Title')).toHaveStyle({ cursor: 'pointer' });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Tree filters could leave connected tree tables in a stale expansion state, hide the whole filter block when the title field was not viewable, or render an incorrect title fallback. Filtering a details block could also leave its pagination count stale.

### Description 

- Reset filtered tree-table expansion state according to `defaultExpandAllRows`, including collections with custom or composite filter target keys.
- Keep tree filter blocks visible when users cannot view the configured title field, and render the same permission placeholder used by table fields.
- Keep the pointer cursor over rendered tree node titles.
- Make details pagination observe filtered resource metadata and display the filtered record count.
- Add regression coverage for filter refresh ordering, expansion reset, field permissions, title rendering, and details pagination metadata updates.

Risk is limited to client-v2 filter target refresh behavior, tree-table expansion state, tree filter title rendering, and details pagination rendering.

Suggested testing:

1. Connect a tree filter block to a tree table and filter records with both values of `defaultExpandAllRows`.
2. Repeat with a collection using a custom or composite filter target key.
3. Remove view permission from the tree title field and verify the block remains visible with a lock placeholder and tooltip.
4. Filter a details block and verify its pagination total updates to the filtered record count.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed tree filter permissions and connected tree-table expansion state, and corrected details pagination totals after filtering. |
| 🇨🇳 Chinese | 修复树筛选字段权限及关联树表展开状态，并修正详情区块筛选后的分页总数。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
