### PR TITLE
fix(plugin-users): show v2 user submit errors

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ChangeUserPasswordDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/ChangeUserPasswordDrawer.test.tsx
@@ -11,18 +11,21 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import ChangeUserPasswordDrawer from '../pages/ChangeUserPasswordDrawer';
 
-const { formItems, setFieldsValue, update, success, onSubmitted } = vi.hoisted(() => ({
+const { formItems, setFieldsValue, update, success, onSubmitted, toErrMessages } = vi.hoisted(() => ({
   formItems: [] as Array<Record<string, any>>,
   setFieldsValue: vi.fn(),
   update: vi.fn(),
   success: vi.fn(),
   onSubmitted: vi.fn(),
+  toErrMessages: vi.fn(),
 }));
 
 vi.mock('antd', async () => {
   const React = await import('react');
 
   return {
+    Alert: ({ message, role }: { message?: React.ReactNode; role?: string }) =>
+      React.createElement('div', { role }, message),
     Button: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) =>
       React.createElement('button', { onClick }, children),
     Col: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
@@ -66,6 +69,7 @@ vi.mock('@nocobase/flow-engine', () => ({
       },
     },
     api: {
+      toErrMessages,
       resource: () => ({
         update,
       }),
@@ -97,8 +101,12 @@ vi.mock('../components/resource', async () => {
           'button',
           {
             onClick: async () => {
-              await onSubmit({ password: 'New-password-1' });
-              await handleSubmitted();
+              try {
+                await onSubmit({ password: 'New-password-1' });
+                await handleSubmitted();
+              } catch {
+                // Keep the drawer open when submission fails.
+              }
             },
           },
           'Submit drawer',
@@ -122,6 +130,7 @@ describe('ChangeUserPasswordDrawer', () => {
     update.mockReset();
     success.mockReset();
     onSubmitted.mockReset();
+    toErrMessages.mockReset();
   });
 
   it('generates a password into the form', () => {
@@ -181,5 +190,28 @@ describe('ChangeUserPasswordDrawer', () => {
     });
     expect(success).toHaveBeenCalledWith('Saved successfully');
     expect(onSubmitted).toHaveBeenCalled();
+  });
+
+  it('shows the API error and skips submitted side effects when changing the password fails', async () => {
+    const error = new Error('Request failed');
+    update.mockRejectedValue(error);
+    toErrMessages.mockReturnValue([{ message: 'Password does not meet the policy' }]);
+
+    render(
+      <ChangeUserPasswordDrawer
+        user={{
+          id: 18,
+          username: 'alice',
+        }}
+        onSubmitted={onSubmitted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit drawer' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Password does not meet the policy');
+    expect(toErrMessages).toHaveBeenCalledWith(error);
+    expect(success).not.toHaveBeenCalled();
+    expect(onSubmitted).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/__tests__/UserFormDrawer.test.tsx
@@ -15,7 +15,7 @@ import {
   ADMIN_PROFILE_EDIT_FORM_MODEL_UID,
 } from '../shared/adminProfileFormModels';
 
-const { create, update, save, findOne, createModelAsync, submit, close, success } = vi.hoisted(() => ({
+const { create, update, save, findOne, createModelAsync, submit, close, success, toErrMessages } = vi.hoisted(() => ({
   create: vi.fn(),
   update: vi.fn(),
   save: vi.fn(),
@@ -24,6 +24,7 @@ const { create, update, save, findOne, createModelAsync, submit, close, success 
   submit: vi.fn(),
   close: vi.fn(),
   success: vi.fn(),
+  toErrMessages: vi.fn(),
 }));
 
 vi.mock('@nocobase/client-v2', async () => {
@@ -107,6 +108,7 @@ vi.mock('@nocobase/flow-engine', () => {
   };
   const flowContext = {
     api: {
+      toErrMessages,
       resource: (name: string) =>
         name === 'users'
           ? {
@@ -205,6 +207,7 @@ describe('UserFormDrawer', () => {
     save.mockReset();
     close.mockReset();
     success.mockReset();
+    toErrMessages.mockReset();
   });
 
   afterEach(() => {
@@ -308,6 +311,30 @@ describe('UserFormDrawer', () => {
 
     expect(create).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
+    expect(success).not.toHaveBeenCalled();
+    expect(onSubmitted).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('should show the API error and keep the drawer open when creating a user fails', async () => {
+    const error = new Error('Request failed');
+    create.mockRejectedValue(error);
+    toErrMessages.mockReturnValue([{ message: 'No permission to create users' }]);
+    submit.mockImplementation(async (_params, cb) => {
+      await cb?.({ username: 'alice' });
+    });
+    const onSubmitted = vi.fn();
+
+    render(<UserFormDrawer onSubmitted={onSubmitted} />);
+
+    await waitFor(() => {
+      expect(createModelAsync).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No permission to create users');
+    expect(toErrMessages).toHaveBeenCalledWith(error);
     expect(success).not.toHaveBeenCalled();
     expect(onSubmitted).not.toHaveBeenCalled();
     expect(close).not.toHaveBeenCalled();

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/ChangeUserPasswordDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/ChangeUserPasswordDrawer.tsx
@@ -10,8 +10,8 @@
 import { PasswordInput } from '@nocobase/client-v2';
 import { useFlowContext } from '@nocobase/flow-engine';
 import { useMemoizedFn } from 'ahooks';
-import { Button, Col, Form, Row } from 'antd';
-import React from 'react';
+import { Alert, Button, Col, Form, Row } from 'antd';
+import React, { useState } from 'react';
 import { ResourceFormDrawer } from '../components/resource';
 import { useT } from '../locale';
 import { PluginUsersClientV2 } from '../plugin';
@@ -30,6 +30,7 @@ export interface ChangeUserPasswordDrawerProps {
 export default function ChangeUserPasswordDrawer(props: ChangeUserPasswordDrawerProps) {
   const ctx = useFlowContext();
   const t = useT();
+  const [errorMessage, setErrorMessage] = useState('');
 
   const validatePassword = useMemoizedFn(async (_rule: unknown, value: unknown) => {
     if (typeof value !== 'string' || !value) {
@@ -51,10 +52,19 @@ export default function ChangeUserPasswordDrawer(props: ChangeUserPasswordDrawer
       submitText={t('Submit')}
       cancelText={t('Cancel')}
       onSubmit={async (values) => {
-        await ctx.api.resource('users').update({
-          filterByTk: props.user.id,
-          values,
-        });
+        setErrorMessage('');
+        try {
+          await ctx.api.resource('users').update({
+            filterByTk: props.user.id,
+            values,
+          });
+        } catch (error: unknown) {
+          const responseError = ctx.api.toErrMessages(error)?.[0];
+          setErrorMessage(
+            (typeof responseError === 'string' ? responseError : responseError?.message) || t('Save failed'),
+          );
+          throw error;
+        }
       }}
       onSubmitted={async () => {
         ctx.message.success(t('Saved successfully'));
@@ -62,28 +72,33 @@ export default function ChangeUserPasswordDrawer(props: ChangeUserPasswordDrawer
       }}
     >
       {({ form }) => (
-        <Form.Item label={t('Password')} required>
-          <Row gutter={8}>
-            <Col span={18}>
-              <Form.Item
-                name="password"
-                noStyle
-                rules={[{ required: true, message: t('Password is required') }, { validator: validatePassword }]}
-              >
-                <PasswordInput autoComplete="new-password" checkStrength />
-              </Form.Item>
-            </Col>
-            <Col span={6}>
-              <Button
-                onClick={() => {
-                  form.setFieldsValue({ password: generatePassword() });
-                }}
-              >
-                {t('Random password')}
-              </Button>
-            </Col>
-          </Row>
-        </Form.Item>
+        <>
+          {errorMessage ? (
+            <Alert type="error" showIcon message={errorMessage} role="alert" style={{ marginBottom: 16 }} />
+          ) : null}
+          <Form.Item label={t('Password')} required>
+            <Row gutter={8}>
+              <Col span={18}>
+                <Form.Item
+                  name="password"
+                  noStyle
+                  rules={[{ required: true, message: t('Password is required') }, { validator: validatePassword }]}
+                >
+                  <PasswordInput autoComplete="new-password" checkStrength />
+                </Form.Item>
+              </Col>
+              <Col span={6}>
+                <Button
+                  onClick={() => {
+                    form.setFieldsValue({ password: generatePassword() });
+                  }}
+                >
+                  {t('Random password')}
+                </Button>
+              </Col>
+            </Row>
+          </Form.Item>
+        </>
       )}
     </ResourceFormDrawer>
   );

--- a/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx
+++ b/packages/plugins/@nocobase/plugin-users/src/client-v2/pages/UserFormDrawer.tsx
@@ -19,6 +19,7 @@ import {
   type FlowModel,
 } from '@nocobase/flow-engine';
 import { useRequest } from 'ahooks';
+import { Alert } from 'antd';
 import React from 'react';
 import { useT } from '../locale';
 import type { User } from './types';
@@ -69,6 +70,10 @@ const userFormBlockClassName = css`
     box-shadow: none !important;
     background: transparent !important;
   }
+`;
+
+const userFormErrorClassName = css`
+  margin: 24px 24px 0;
 `;
 
 type PersistedFlowModelTree = CreateModelOptions & Record<string, unknown>;
@@ -198,6 +203,7 @@ export default function UserFormDrawer(props: UserFormDrawerProps) {
   const t = useT();
   const isEdit = !!user;
   const [submitting, setSubmitting] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState('');
   const [model, setModel] = React.useState<LoadedUserFormModel | null>(null);
   const title = isEdit ? t('Edit profile') : t('Add user');
 
@@ -230,21 +236,30 @@ export default function UserFormDrawer(props: UserFormDrawerProps) {
     if (!model) {
       return;
     }
+    setErrorMessage('');
     setSubmitting(true);
     try {
       let submitted = false;
       await model.submit({}, async (values) => {
         const nextValues = normalizeSubmitValues(values || {});
-        if (isEdit && user?.id != null) {
-          await ctx.api.resource('users').update({
-            filterByTk: user.id,
-            values: nextValues,
-          });
+        try {
+          if (isEdit && user?.id != null) {
+            await ctx.api.resource('users').update({
+              filterByTk: user.id,
+              values: nextValues,
+            });
+            submitted = true;
+            return;
+          }
+          await ctx.api.resource('users').create({ values: nextValues });
           submitted = true;
-          return;
+        } catch (error: unknown) {
+          const responseError = ctx.api.toErrMessages(error)?.[0];
+          setErrorMessage(
+            (typeof responseError === 'string' ? responseError : responseError?.message) || t('Save failed'),
+          );
+          throw error;
         }
-        await ctx.api.resource('users').create({ values: nextValues });
-        submitted = true;
       });
       if (!submitted) {
         throw new UserFormSubmitInterruptedError();
@@ -264,6 +279,9 @@ export default function UserFormDrawer(props: UserFormDrawerProps) {
       submitText={t('Submit')}
       cancelText={t('Cancel')}
     >
+      {errorMessage ? (
+        <Alert className={userFormErrorClassName} type="error" showIcon message={errorMessage} role="alert" />
+      ) : null}
       <div className={userFormBlockClassName}>
         {model ? (
           <FlowModelRenderer


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In the V2 users management page, backend errors returned when adding a user or changing a password were not shown in the UI, leaving users without feedback after submitting the form.

### Description

- Parse the first backend error through the existing V2 API client error parser.
- Display the backend error in an alert inside the Add user and Change password drawers.
- Keep the drawer open and skip success-side effects when submission fails.
- Add regression tests for both failure paths.

The change is limited to the two V2 user drawers and their tests. It does not change ACL behavior, the global API client, or shared drawer components.

Testing suggestions:

- Add a user with data that causes a backend validation or permission error and verify the error is visible.
- Change a user's password with data rejected by the backend and verify the error is visible.
- Verify successful submissions still show the success message and refresh the user list.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show backend errors when adding a user or changing a password in V2. |
| 🇨🇳 Chinese | V2 新建用户或修改密码失败时展示后端错误信息。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
