### PR TITLE
fix(plugin-workflow-javascript): filter task recovery candidates

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/TaskRecovery.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/TaskRecovery.ts
@@ -9,13 +9,15 @@
 
 import { Op } from 'sequelize';
 import type WorkflowPlugin from '@nocobase/plugin-workflow';
-import { JOB_STATUS, type JobModel } from '@nocobase/plugin-workflow';
+import { EXECUTION_STATUS, JOB_STATUS, type JobModel } from '@nocobase/plugin-workflow';
 
 import { SCRIPT_INSTRUCTION_TYPE } from '../common/constants';
 
 const RECOVERY_BATCH_SIZE = 100;
 const RECOVERY_MAX_SCAN_SIZE = 1000;
 const RECOVERY_INTERVAL = 60_000;
+// Give the original queue delivery a full recovery cycle before republishing the job.
+const RECOVERY_GRACE_PERIOD = RECOVERY_INTERVAL;
 
 export class TaskRecovery {
   private timer: NodeJS.Timeout | null = null;
@@ -76,7 +78,9 @@ export class TaskRecovery {
   private async republishQueuedJobs() {
     let cursor: number | string | null = null;
     let scanned = 0;
-    const staleBefore = new Date(Date.now() - 120_000);
+    const now = new Date();
+    const recoverableBefore = new Date(now.getTime() - RECOVERY_GRACE_PERIOD);
+    const staleBefore = new Date(now.getTime() - 120_000);
     const logger = this.workflowPlugin.getLogger('javascript');
     const JobModel = this.workflowPlugin.db.getModel('jobs');
 
@@ -85,6 +89,9 @@ export class TaskRecovery {
         where: {
           ...(cursor == null ? {} : { id: { [Op.gt]: cursor } }),
           status: JOB_STATUS.PENDING,
+          createdAt: {
+            [Op.lt]: recoverableBefore,
+          },
         },
         attributes: ['id', 'startedAt', 'updatedAt'],
         include: [
@@ -93,6 +100,22 @@ export class TaskRecovery {
             attributes: [],
             where: {
               type: SCRIPT_INSTRUCTION_TYPE,
+            },
+            required: true,
+          },
+          {
+            association: 'execution',
+            attributes: [],
+            where: {
+              status: EXECUTION_STATUS.STARTED,
+              [Op.or]: [
+                { expiresAt: null },
+                {
+                  expiresAt: {
+                    [Op.gt]: now,
+                  },
+                },
+              ],
             },
             required: true,
           },

--- a/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts
@@ -8,7 +8,7 @@
  */
 
 import Database from '@nocobase/database';
-import WorkflowPlugin, { JOB_STATUS } from '@nocobase/plugin-workflow';
+import WorkflowPlugin, { EXECUTION_STATUS, JOB_STATUS } from '@nocobase/plugin-workflow';
 import { getApp } from '@nocobase/plugin-workflow-test';
 import { Application } from '@nocobase/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -31,44 +31,119 @@ describe('JavaScript task queue', () => {
     await app.destroy();
   });
 
-  it('republishes unclaimed JavaScript jobs without scanning unrelated jobs or reclaiming stale jobs', async () => {
+  it('only republishes recoverable unclaimed JavaScript jobs', async () => {
     const JobModel = db.getModel('jobs');
     const NodeModel = db.getModel('flow_nodes');
+    const ExecutionModel = db.getModel('executions');
     const now = new Date();
     const stale = new Date(now.getTime() - 180_000);
+    const expired = new Date(now.getTime() - 60_000);
+    const future = new Date(now.getTime() + 60_000);
 
     await NodeModel.create({ id: '9301', type: 'delay' });
     await NodeModel.create({ id: '9302', type: SCRIPT_INSTRUCTION_TYPE });
     await NodeModel.create({ id: '9303', type: SCRIPT_INSTRUCTION_TYPE });
     await NodeModel.create({ id: '9304', type: SCRIPT_INSTRUCTION_TYPE });
+    await NodeModel.create({ id: '9307', type: SCRIPT_INSTRUCTION_TYPE });
+    await NodeModel.create({ id: '9308', type: SCRIPT_INSTRUCTION_TYPE });
+    await NodeModel.create({ id: '9309', type: SCRIPT_INSTRUCTION_TYPE });
+
+    await ExecutionModel.create({
+      id: '9101',
+      status: EXECUTION_STATUS.STARTED,
+      expiresAt: future,
+    });
+    await ExecutionModel.create({
+      id: '9102',
+      status: EXECUTION_STATUS.STARTED,
+    });
+    await ExecutionModel.create({
+      id: '9103',
+      status: EXECUTION_STATUS.STARTED,
+      expiresAt: future,
+    });
+    await ExecutionModel.create({
+      id: '9104',
+      status: EXECUTION_STATUS.STARTED,
+      expiresAt: future,
+    });
+    await ExecutionModel.create({
+      id: '9107',
+      status: EXECUTION_STATUS.RESOLVED,
+    });
+    await ExecutionModel.create({
+      id: '9108',
+      status: EXECUTION_STATUS.STARTED,
+      expiresAt: expired,
+    });
+    await ExecutionModel.create({
+      id: '9109',
+      status: EXECUTION_STATUS.STARTED,
+      expiresAt: future,
+    });
 
     await JobModel.create({
       id: '9201',
+      executionId: '9101',
       nodeId: '9301',
       status: JOB_STATUS.PENDING,
       startedAt: null,
       meta: { args: {} },
+      createdAt: stale,
     });
     await JobModel.create({
       id: '9202',
+      executionId: '9102',
       nodeId: '9302',
       status: JOB_STATUS.PENDING,
       startedAt: null,
       meta: { args: {} },
+      createdAt: stale,
     });
     await JobModel.create({
       id: '9203',
+      executionId: '9103',
       nodeId: '9303',
       status: JOB_STATUS.PENDING,
       startedAt: stale,
       meta: { args: {} },
+      createdAt: stale,
     });
     await JobModel.create({
       id: '9204',
+      executionId: '9104',
       nodeId: '9304',
       status: JOB_STATUS.PENDING,
       startedAt: now,
       meta: { args: {} },
+      createdAt: stale,
+    });
+    await JobModel.create({
+      id: '9207',
+      executionId: '9107',
+      nodeId: '9307',
+      status: JOB_STATUS.PENDING,
+      startedAt: null,
+      meta: { args: {} },
+      createdAt: stale,
+    });
+    await JobModel.create({
+      id: '9208',
+      executionId: '9108',
+      nodeId: '9308',
+      status: JOB_STATUS.PENDING,
+      startedAt: null,
+      meta: { args: {} },
+      createdAt: stale,
+    });
+    await JobModel.create({
+      id: '9209',
+      executionId: '9109',
+      nodeId: '9309',
+      status: JOB_STATUS.PENDING,
+      startedAt: null,
+      meta: { args: {} },
+      createdAt: now,
     });
     await JobModel.update({ updatedAt: stale }, { where: { id: '9203' }, silent: true });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

JavaScript task recovery currently republishes every pending, unclaimed script job without checking its age or the associated execution state. This can repeatedly enqueue jobs whose executions have already ended or expired, and can also republish newly created jobs while their original queue delivery is still active.

### Description

- Add a one-cycle recovery grace period so newly created JavaScript jobs are not immediately republished.
- Only recover jobs whose executions are still started and have not expired.
- Preserve recovery for valid long-running executions with no timeout.
- Add regression coverage for unrelated node types, claimed jobs, ended executions, expired executions, and recently created jobs.

The JavaScript task queue remains at-least-once. Duplicate deliveries of a valid recovery candidate are still guarded by the consumer's atomic job claim.

Tests:

- `yarn test packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/instruction.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow-javascript/src/server/TaskRecovery.ts packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts`

### Related issues

Related to #10280.

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed JavaScript workflow task recovery repeatedly enqueueing jobs whose executions have ended or expired. |
| 🇨🇳 Chinese | 修复 JavaScript 工作流任务恢复过程重复投递执行已结束或已超时任务的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
