### PR TITLE
feat(lock-manager): support renewable lock leases

### DIFF
--- a/packages/core/lock-manager/src/__tests__/lock-manager.test.ts
+++ b/packages/core/lock-manager/src/__tests__/lock-manager.test.ts
@@ -224,10 +224,10 @@ describe('lock manager', () => {
 
     it('tryAcquire: extends an active lease', async () => {
       const lock = await lockManager.tryAcquire('extend-test');
-      const release = await lock.acquire(100);
-      await sleep(60);
-      await lock.extend(150);
-      await sleep(70);
+      const release = await lock.acquire(500);
+      await sleep(100);
+      await lock.extend(500);
+      await sleep(200);
       await expect(lockManager.tryAcquire('extend-test')).rejects.toThrowError(LockAcquireError);
       await release();
 

--- a/packages/core/lock-manager/src/__tests__/lock-manager.test.ts
+++ b/packages/core/lock-manager/src/__tests__/lock-manager.test.ts
@@ -149,6 +149,7 @@ describe('lock manager', () => {
       await release();
       const lock = await lockManager.tryAcquire('test');
       expect(lock.acquire).toBeTypeOf('function');
+      expect(lock.extend).toBeTypeOf('function');
       expect(lock.runExclusive).toBeTypeOf('function');
 
       const order = [];
@@ -219,6 +220,19 @@ describe('lock manager', () => {
       const lock2 = await lockManager.tryAcquire('seq-test');
       const release2 = await lock2.acquire(1000);
       await release2();
+    });
+
+    it('tryAcquire: extends an active lease', async () => {
+      const lock = await lockManager.tryAcquire('extend-test');
+      const release = await lock.acquire(100);
+      await sleep(60);
+      await lock.extend(150);
+      await sleep(70);
+      await expect(lockManager.tryAcquire('extend-test')).rejects.toThrowError(LockAcquireError);
+      await release();
+
+      const nextLock = await lockManager.tryAcquire('extend-test');
+      await nextLock.release();
     });
 
     it('tryAcquire: release() abandons the pre-acquired lock without executing work', async () => {

--- a/packages/core/lock-manager/src/lock-manager.ts
+++ b/packages/core/lock-manager/src/lock-manager.ts
@@ -24,6 +24,8 @@ export type Releaser = () => void | Promise<void>;
  */
 export interface ILock {
   acquire(ttl: number): Releaser | Promise<Releaser>;
+  /** Extend the currently held lease from now, when supported by the adapter. */
+  extend?(ttl: number): void | Promise<void>;
   runExclusive<T>(fn: () => Promise<T>, ttl: number): Promise<T>;
   release(): void | Promise<void>;
 }
@@ -123,49 +125,71 @@ class LocalLockAdapter implements ILockAdapter {
       }
     }
 
-    let preAcquiredConsumed = false;
-
-    const getRelease = async (): Promise<Releaser> => {
-      const rawRelease: Releaser = !preAcquiredConsumed
-        ? ((preAcquiredConsumed = true), preAcquiredRelease)
-        : ((await mutex.acquire()) as Releaser);
-      // Idempotency guard: prevents double-release when both the TTL auto-
-      // release timer and the caller-facing releaser (or finally block) fire.
-      let released = false;
-      return () => {
-        if (!released) {
-          released = true;
-          return (rawRelease as () => void | Promise<void>)();
+    let reservation: Releaser | undefined = preAcquiredRelease;
+    let activeLease:
+      | {
+          release: Releaser;
+          timer?: ReturnType<typeof setTimeout>;
         }
-      };
+      | undefined;
+
+    const releaseLease = async (lease: NonNullable<typeof activeLease>): Promise<void> => {
+      if (activeLease !== lease) {
+        return;
+      }
+      activeLease = undefined;
+      if (lease.timer) {
+        clearTimeout(lease.timer);
+      }
+      await lease.release();
+    };
+
+    const resetTimer = (ttl: number) => {
+      if (!activeLease) {
+        throw new LockAcquireError('lock is not active');
+      }
+      const lease = activeLease;
+      if (lease.timer) {
+        clearTimeout(lease.timer);
+      }
+      lease.timer = setTimeout(() => {
+        releaseLease(lease).catch(() => undefined);
+      }, ttl);
     };
 
     return {
       release: async (): Promise<void> => {
-        const release = await getRelease();
-        await release();
+        if (reservation) {
+          const releaseReservation = reservation;
+          reservation = undefined;
+          await releaseReservation();
+          return;
+        }
+        if (activeLease) {
+          await releaseLease(activeLease);
+        }
       },
       acquire: async (ttl: number): Promise<Releaser> => {
-        const release = await getRelease();
-        const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
-          if (mutex.isLocked()) {
-            release();
-          }
-        }, ttl);
-        return () => {
-          release();
-          clearTimeout(timer);
-        };
+        const rawRelease = reservation || ((await mutex.acquire()) as Releaser);
+        reservation = undefined;
+        const lease = { release: rawRelease };
+        activeLease = lease;
+        resetTimer(ttl);
+        return () => releaseLease(lease);
+      },
+      extend: async (ttl: number): Promise<void> => {
+        resetTimer(ttl);
       },
       runExclusive: async <T>(fn: () => Promise<T>, ttl: number): Promise<T> => {
-        const release = await getRelease();
-        let timer: ReturnType<typeof setTimeout>;
+        const release = await (async () => {
+          const rawRelease = reservation || ((await mutex.acquire()) as Releaser);
+          reservation = undefined;
+          const lease = { release: rawRelease };
+          activeLease = lease;
+          resetTimer(ttl);
+          return () => releaseLease(lease);
+        })();
         try {
-          timer = setTimeout(() => {
-            if (mutex.isLocked()) {
-              release();
-            }
-          }, ttl);
           return await fn();
         } catch (e) {
           if (e === E_CANCELED) {
@@ -174,8 +198,7 @@ class LocalLockAdapter implements ILockAdapter {
             throw e;
           }
         } finally {
-          clearTimeout(timer);
-          release();
+          await release();
         }
       },
     };


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

Long-running jobs can outlive their initial lock TTL. The lock handle needs an optional renewal capability so callers can keep an active lease valid without breaking existing lock adapters.

### Description

- Add an optional `ILock.extend(ttl)` capability to preserve compatibility with existing adapters.
- Track the reservation and active lease separately in the local `tryAcquire()` implementation.
- Reset the active lease timer when it is extended.
- Make stale releasers idempotent and ensure `release()` handles both reservations and active leases.
- Await lease release in `runExclusive()` even when the callback throws.

The existing `acquire()`, `tryAcquire()`, `runExclusive()`, and `release()` APIs remain unchanged. The main compatibility risk is limited to callers that rely on the previous incorrect behavior of calling `release()` after consuming a reservation.

Tested with:

```bash
yarn test packages/core/lock-manager/src/__tests__/lock-manager.test.ts --run --reporter=verbose
```

Result: 11 passed, 2 existing tests skipped.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added renewable local lock leases and ensured try-acquired locks are released safely across reuse and errors |
| 🇨🇳 Chinese | 新增本地锁租约续期能力，并确保通过 tryAcquire 获取的锁在复用和异常场景下安全释放 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
