### PR TITLE
fix(client-v2): notify denied settings access

### DIFF
--- a/packages/core/client-v2/src/__tests__/settings-center.test.tsx
+++ b/packages/core/client-v2/src/__tests__/settings-center.test.tsx
@@ -327,6 +327,7 @@ describe('settings center', () => {
 
     expect(await screen.findByText('Current settings page is unavailable')).toBeInTheDocument();
     expect(app.router.state.location.pathname).toBe('/admin/settings/unknown');
+    expect(screen.queryByText('No permissions')).not.toBeInTheDocument();
   });
 
   it('should allow direct access to hidden page without showing menu entry', async () => {
@@ -400,6 +401,7 @@ describe('settings center', () => {
     await waitForGetRequests(app, ['/auth:check', 'roles:check']);
 
     expect(await screen.findByText('Current settings page is unavailable')).toBeInTheDocument();
+    expect(await screen.findAllByText('No permissions')).toHaveLength(1);
     expect(screen.queryByText('Secure settings page')).not.toBeInTheDocument();
     expect(app.router.state.location.pathname).toBe('/admin/settings/secure-demo');
   });
@@ -453,6 +455,7 @@ describe('settings center', () => {
     });
     expect(app.router.router.state.historyAction).toBe('REPLACE');
     expect(await screen.findByText('First accessible tab content')).toBeInTheDocument();
+    expect(await screen.findAllByText('No permissions')).toHaveLength(1);
     expect(screen.queryByText('Denied tab content')).not.toBeInTheDocument();
     expect(renderDeniedTab).not.toHaveBeenCalled();
 

--- a/packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx
+++ b/packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx
@@ -11,7 +11,7 @@ import { ApiOutlined } from '@ant-design/icons';
 import { PageHeader } from '@ant-design/pro-layout';
 import { css } from '@emotion/css';
 import { FlowModelRenderer, useFlowEngine } from '@nocobase/flow-engine';
-import { Layout, Menu, Result, theme } from 'antd';
+import { App, Layout, Menu, Result, theme } from 'antd';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, Navigate, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -73,6 +73,7 @@ export const InternalAdminSettingsLayout = () => {
   );
   const { token } = theme.useToken();
   const { t } = useTranslation();
+  const { notification } = App.useApp();
   const { snippets = [] } = useACLRoleContext();
 
   const allSettings = useMemo(
@@ -104,6 +105,7 @@ export const InternalAdminSettingsLayout = () => {
     () => matchSettingsRoute(registeredSettingsMapByPath, location.pathname),
     [location.pathname, registeredSettingsMapByPath],
   );
+  const permissionDenied = currentSetting?.isAllow === false;
   const currentVisibleSetting = useMemo(
     () => matchSettingsRoute(visibleSettingsMapByPath, location.pathname),
     [location.pathname, visibleSettingsMapByPath],
@@ -125,6 +127,18 @@ export const InternalAdminSettingsLayout = () => {
     return (currentVisibleTopLevelSetting?.children || []).filter((item) => !item.hidden) as PluginSettingsPageType[];
   }, [currentVisibleTopLevelSetting?.children]);
   const shouldShowTabs = currentVisibleTabs.length > 1 && currentVisibleTopLevelSetting?.showTabs !== false;
+
+  useEffect(() => {
+    if (!permissionDenied) {
+      return;
+    }
+
+    notification.error({
+      key: 'admin-settings-no-permission',
+      message: t('No permissions'),
+      role: 'alert',
+    });
+  }, [location.pathname, notification, permissionDenied, t]);
 
   useEffect(() => {
     const nextTitle =
@@ -177,7 +191,7 @@ export const InternalAdminSettingsLayout = () => {
     return <SettingsEmpty type="route" />;
   }
 
-  if (currentSetting.isAllow === false) {
+  if (permissionDenied) {
     const firstVisibleTabPath = currentVisibleTabs
       .map((tab) => getDefaultSettingsPath([tab]))
       .filter((path): path is string => typeof path === 'string')

--- a/packages/core/client/src/locale/en-US.json
+++ b/packages/core/client/src/locale/en-US.json
@@ -1634,6 +1634,7 @@
   "Current settings page is unavailable": "Current settings page is unavailable",
   "Failed to load plugins": "Failed to load plugins",
   "Failed to load system settings": "Failed to load system settings",
+  "No permissions": "No permissions",
   "No settings pages are currently available in Client V2. Settings registered by migrated plugins will appear here automatically.": "No settings pages are currently available in Client V2. Settings registered by migrated plugins will appear here automatically.",
   "No settings pages available": "No settings pages available",
   "The requested settings page does not exist or you do not have permission to access it.": "The requested settings page does not exist or you do not have permission to access it.",

--- a/packages/core/client/src/locale/zh-CN.json
+++ b/packages/core/client/src/locale/zh-CN.json
@@ -1676,6 +1676,7 @@
   "Current settings page is unavailable": "当前设置页不可用",
   "Failed to load plugins": "加载插件失败",
   "Failed to load system settings": "加载系统设置失败",
+  "No permissions": "没有权限",
   "No settings pages are currently available in Client V2. Settings registered by migrated plugins will appear here automatically.": "当前 Client V2 中还没有可用的设置页。已迁移插件注册的设置页会自动出现在这里。",
   "No settings pages available": "暂无可用设置页",
   "The requested settings page does not exist or you do not have permission to access it.": "请求的设置页不存在，或者你没有访问权限。"


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Client V2 blocks denied settings routes before their page requests are mounted, but it does not provide the error notification shown by Client V1. Users can therefore be redirected away from Users & Permissions without an explicit explanation.

This PR targets the `next` branch.

### Description
- Show a deduplicated Ant Design error notification when a registered Client V2 settings route is denied.
- Preserve the existing redirect, unavailable-page fallback, and server-side ACL behavior.
- Avoid reporting unknown settings routes as permission failures.
- Add English and Chinese translations for `No permissions`.
- Extend settings-center tests for denied direct access, denied-tab redirects, and unknown routes.

Current behavior and boundaries:
- This is frontend feedback only; no ACL rules, API behavior, database schema, or migrations are changed.
- The notification uses a stable key so repeated renders do not stack duplicate messages.
- Unknown routes retain the existing unavailable-page fallback without a permission notification.

Verification:
- `yarn eslint --fix packages/core/client-v2/src/settings-center/AdminSettingsLayout.tsx packages/core/client-v2/src/__tests__/settings-center.test.tsx packages/core/client/src/locale/en-US.json packages/core/client/src/locale/zh-CN.json` — passed.
- `yarn test packages/core/client-v2/src/__tests__/settings-center.test.tsx --run --reporter=verbose` — 1 test file passed, 19 tests passed.
- `git diff --check` — passed.
- Remote CI has not yet been evaluated.

Risk and review focus:
- Risk is low and limited to Client V2 settings-route feedback.
- Review the notification timing during denied-tab redirects and confirm that the stable notification key provides the desired deduplication.

### Related issues

Task 5962

### Showcase

N/A. The behavior is covered by automated settings-center tests.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Show an error notification when access to a Client V2 settings page is denied. |
| 🇨🇳 Chinese | Client V2 设置页无访问权限时显示错误通知。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary