### PR TITLE
fix(plugin-field-markdown-vditor): support dark HTML previews

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Display.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Display.tsx
@@ -8,11 +8,14 @@
  */
 
 import { removeMarkdownIframes, stripMarkdownIframes } from '@nocobase/client-v2';
+import { useFlowContext } from '@nocobase/flow-engine';
 import { Popover } from 'antd';
 import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import Vditor from 'vditor';
 import { useCDN } from './const';
 import useStyle from './style';
+
+type PreviewMode = 'dark' | 'light';
 
 function convertToText(markdownText: string) {
   const content = markdownText;
@@ -66,14 +69,17 @@ function openCustomPreview(src: string) {
   document.body.appendChild(overlay);
 }
 
-function DisplayInner(props: { value: string; style?: CSSProperties }) {
+function DisplayInner(props: { value: string; style?: CSSProperties; previewMode: PreviewMode }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { wrapSSR, componentCls, hashId } = useStyle();
   const cdn = useCDN();
 
   useEffect(() => {
     Vditor.preview(containerRef.current, props.value ?? '', {
-      mode: 'light',
+      mode: props.previewMode,
+      theme: {
+        current: props.previewMode,
+      },
       cdn,
       markdown: {
         sanitize: true,
@@ -91,7 +97,7 @@ function DisplayInner(props: { value: string; style?: CSSProperties }) {
         });
       });
     }, 0);
-  }, [props.value, cdn]);
+  }, [props.value, props.previewMode, cdn]);
 
   return wrapSSR(
     <span className={`${hashId} ${componentCls}`}>
@@ -102,6 +108,8 @@ function DisplayInner(props: { value: string; style?: CSSProperties }) {
 
 export const Display = (props) => {
   const value = props.value;
+  const flowCtx = useFlowContext();
+  const previewMode: PreviewMode = flowCtx.isDarkTheme ? 'dark' : 'light';
   const cdn = useCDN();
   const containerRef = useRef<HTMLDivElement>(null);
   const [popoverVisible, setPopoverVisible] = useState(false);
@@ -125,7 +133,10 @@ export const Display = (props) => {
         .catch(() => setText(''));
     } else {
       Vditor.preview(containerRef.current, value, {
-        mode: 'light',
+        mode: previewMode,
+        theme: {
+          current: previewMode,
+        },
         cdn,
         markdown: {
           sanitize: true,
@@ -135,7 +146,7 @@ export const Display = (props) => {
         .then(() => removeMarkdownIframes(containerRef.current))
         .catch(() => removeMarkdownIframes(containerRef.current));
     }
-  }, [value, props.ellipsis, cdn]);
+  }, [value, props.ellipsis, previewMode, cdn]);
 
   const isOverflowTooltip = useCallback(() => {
     if (!elRef.current) return false;
@@ -151,7 +162,13 @@ export const Display = (props) => {
         onOpenChange={(visible) => {
           setPopoverVisible(ellipsis && visible);
         }}
-        content={<DisplayInner value={value} style={{ maxWidth: 500, maxHeight: 400, overflowY: 'auto' }} />}
+        content={
+          <DisplayInner
+            value={value}
+            previewMode={previewMode}
+            style={{ maxWidth: 500, maxHeight: 400, overflowY: 'auto' }}
+          />
+        }
       >
         <div
           ref={elRef}
@@ -175,5 +192,5 @@ export const Display = (props) => {
       </Popover>
     );
   }
-  return <DisplayInner value={value} />;
+  return <DisplayInner value={value} previewMode={previewMode} />;
 };

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/__tests__/Display.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/__tests__/Display.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Display } from '../Display';
+
+const mocks = vi.hoisted(() => ({
+  isDarkTheme: false,
+  md2html: vi.fn(),
+  preview: vi.fn(),
+  removeMarkdownIframes: vi.fn(),
+}));
+
+vi.mock('@nocobase/client-v2', () => ({
+  removeMarkdownIframes: mocks.removeMarkdownIframes,
+  stripMarkdownIframes: (html: string) => html,
+}));
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({ isDarkTheme: mocks.isDarkTheme }),
+}));
+
+vi.mock('vditor', () => ({
+  default: {
+    md2html: mocks.md2html,
+    preview: mocks.preview,
+  },
+}));
+
+vi.mock('../const', () => ({
+  useCDN: () => 'https://cdn.example.com/vditor',
+}));
+
+vi.mock('../style', () => ({
+  default: () => ({
+    componentCls: 'nb-field-markdown-vditor',
+    hashId: 'test-hash',
+    wrapSSR: (node: React.ReactNode) => node,
+  }),
+}));
+
+describe('Markdown Vditor Display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isDarkTheme = false;
+    mocks.md2html.mockResolvedValue('');
+    mocks.preview.mockResolvedValue(undefined);
+  });
+
+  it('uses the light Vditor content theme in light mode', async () => {
+    render(<Display value="# Markdown" />);
+
+    await waitFor(() => {
+      expect(mocks.preview).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        '# Markdown',
+        expect.objectContaining({
+          mode: 'light',
+          theme: { current: 'light' },
+        }),
+      );
+    });
+  });
+
+  it('rerenders the preview with the dark content theme after a theme change', async () => {
+    const { rerender } = render(<Display value="# Markdown" />);
+
+    await waitFor(() => {
+      expect(mocks.preview).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        '# Markdown',
+        expect.objectContaining({
+          mode: 'light',
+          theme: { current: 'light' },
+        }),
+      );
+    });
+
+    mocks.preview.mockClear();
+    mocks.isDarkTheme = true;
+    rerender(<Display value="# Markdown" />);
+
+    await waitFor(() => {
+      expect(mocks.preview).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        '# Markdown',
+        expect.objectContaining({
+          mode: 'dark',
+          theme: { current: 'dark' },
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In v2 details blocks, Markdown fields configured to use HTML render mode always initialize Vditor with the light preview mode and the default light content theme. As a result, rendered Markdown elements can retain light backgrounds and colors when the application uses a dark theme.

This branch is based on `main`, and this PR targets `main`.

### Description
- Read the active dark-mode state from the v2 flow context.
- Configure both Vditor `mode` and `theme.current` for normal and popover HTML previews.
- Re-render the preview when the application theme changes.
- Add focused tests for light mode and runtime switching to dark mode.

Scope is limited to the v2 Markdown/Vditor display component. It does not change the v1 client, editor behavior, details block models, server APIs, schemas, data, permissions, or localization.

Risk is low and limited to Vditor HTML presentation. Vditor manages its content theme through a global stylesheet link, which matches the application-wide theme model. Review should focus on theme switching when multiple Markdown previews are visible.

Suggested manual check: render headings, blockquotes, tables, inline code, and code blocks in a v2 details block, then switch between light and dark themes.

#### Verification
- `yarn test packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/__tests__/Display.test.tsx --run --reporter=verbose` — passed, 2 tests.
- `yarn eslint --fix packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Display.tsx packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/__tests__/Display.test.tsx` — passed.
- `git diff --check` — passed.
- Remote CI has not run yet.
- Manual browser verification was not run locally.
- No setup, migration, or other repeatable automation behavior is changed.

### Related issues

Internal task: 5955

### Showcase

Not included.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Markdown HTML previews in v2 details blocks under dark themes. |
| 🇨🇳 Chinese | 修复 v2 详情区块中 Markdown HTML 预览在暗黑主题下显示异常的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary