### PR TITLE
fix(plugin-map): finish region selection over map markers

### DIFF
--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Block.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Block.tsx
@@ -38,7 +38,7 @@ export const AMapBlock = (props) => {
   const geometryUtils: AMap.IGeometryUtil = mapRef.current?.aMap?.GeometryUtil;
   const [selectingMode, setSelecting] = useState('');
   const t = useT();
-  const compile = (value: any) => compileTemplate(value, t);
+  const compile = useMemoizedFn((value: unknown) => compileTemplate(value, t));
   const isConnected = false;
   const doFilter = (..._args: any[]) => {};
   const selectingModeRef = useRef(selectingMode);
@@ -47,12 +47,15 @@ export const AMapBlock = (props) => {
   const labelUiSchema = fields.find((v) => v.name === marker)?.uiSchema;
   const geometryType = collectionField.interface || collectionField.type;
   const setOverlayOptions = (overlay: AMap.Polygon | AMap.Marker, state?: boolean) => {
+    if (!mapRef.current) {
+      return;
+    }
     const extData = overlay.getExtData();
     const selected = typeof state === 'undefined' ? extData.selected : !state;
     extData.selected = !selected;
     if ('setIcon' in overlay) {
       overlay.setIcon(
-        new mapRef.current!.aMap.Icon({
+        new mapRef.current.aMap.Icon({
           imageSize: [19, 32],
           image: selected ? defaultImage : selectedImage,
         } as AMap.IconOpts),
@@ -129,6 +132,7 @@ export const AMapBlock = (props) => {
         if (!data?.length) return [];
         return data.map((mapItem) => {
           const overlay = mapRef.current?.setOverlay(geometryType, mapItem, {
+            bubble: true,
             strokeColor: mapActiveColor,
             fillColor: mapActiveColor,
             cursor: 'pointer',
@@ -242,13 +246,31 @@ export const AMapBlock = (props) => {
       });
       events.forEach((e) => e());
     };
-  }, [dataSource, isMapInitialization, mapField, marker, name, primaryKey, geometryType, isConnected, lineSort]);
+  }, [
+    associationCollectionField?.interface,
+    collectionField,
+    compile,
+    dataSource,
+    geometryType,
+    isConnected,
+    isMapInitialization,
+    labelUiSchema,
+    lineSort,
+    mapField,
+    marker,
+    name,
+    onOpenView,
+    primaryKey,
+    setSelectedRecordKeys,
+    t,
+    zoom,
+  ]);
 
   useEffect(() => {
     setTimeout(() => {
       setSelectedRecordKeys([]);
     });
-  }, [dataSource]);
+  }, [dataSource, setSelectedRecordKeys]);
 
   const mapRefCallback = (instance: AMapForwardedRefProps) => {
     mapRef.current = instance;

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Map.tsx
@@ -104,6 +104,8 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     type,
   } = props;
   const t = useT();
+  const tRef = useRef(t);
+  tRef.current = t;
   const aMap = useRef<any>();
   const map = useRef<AMap.Map>();
   const mouseTool = useRef<any>();
@@ -114,6 +116,8 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
 
   const overlay = useRef<AMap.Polygon>();
   const editor = useRef(null);
+  const zoomRef = useRef(zoom);
+  zoomRef.current = zoom;
   const { navigate } = ctx.router;
   const id = useRef(`nocobase-map-${type || ''}-${Date.now().toString(32)}`);
   const { modal } = App.useApp();
@@ -131,7 +135,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
         map.current?.setZoom(zoom);
       }, 500);
     }
-  }, [zoom, map.current, block]);
+  }, [zoom, block]);
 
   const toRemoveOverlay = useMemoizedFn(() => {
     if (overlay.current) {
@@ -139,25 +143,25 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     }
   });
 
-  const setTarget = useMemoizedFn(() => {
-    if ((!disabled || block) && type !== 'point' && editor.current) {
+  const setTarget = useMemoizedFn((curType = type) => {
+    if ((!disabled || block) && curType !== 'point' && editor.current) {
       editor.current.setTarget(overlay.current);
       editor.current.open();
     }
   });
 
-  const onMapChange = useMemoizedFn((target, onlyChange = false) => {
+  const onMapChange = useMemoizedFn((target, onlyChange = false, curType = type) => {
     let nextValue = null;
 
-    if (type === 'point') {
+    if (curType === 'point') {
       const { lat, lng } = (target as AMap.Marker).getPosition();
       nextValue = [lng, lat];
-    } else if (type === 'polygon' || type === 'lineString') {
+    } else if (curType === 'polygon' || curType === 'lineString') {
       nextValue = (target as AMap.Polygon).getPath().map((item) => [item.lng, item.lat]);
       if (nextValue.length < 2) {
         return;
       }
-    } else if (type === 'circle') {
+    } else if (curType === 'circle') {
       const center = target.getCenter();
       const radius = target.getRadius();
       nextValue = [center.lng, center.lat, radius];
@@ -166,7 +170,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     if (!onlyChange) {
       toRemoveOverlay();
       overlay.current = target;
-      setTarget();
+      setTarget(curType);
     }
     onChange?.(nextValue);
   });
@@ -188,10 +192,10 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
         },
       });
       editor.current.on('adjust', function ({ target }) {
-        onMapChange(target, true);
+        onMapChange(target, true, curType);
       });
       editor.current.on('move', function ({ target }) {
-        onMapChange(target, true);
+        onMapChange(target, true, curType);
       });
       return editor.current;
     }
@@ -212,7 +216,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     if (mouseTool.current) return;
     mouseTool.current = new aMap.current.MouseTool(map.current);
     mouseTool.current.on('draw', function ({ obj }) {
-      onMapChange(obj);
+      onMapChange(obj, false, curType);
     });
     executeMouseTool(curType);
   });
@@ -265,10 +269,10 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
 
       return new aMap.current[mapping.overlay](options);
     },
-    [commonOptions],
+    [commonOptions, type, value],
   );
 
-  const setOverlay = (t = type, v = value, o?: AMap.PolylineOptions & AMap.PolygonOptions) => {
+  const setOverlay = useMemoizedFn((t = type, v = value, o?: AMap.PolylineOptions & AMap.PolygonOptions) => {
     if (!aMap.current) return;
     const nextOverlay = getOverlay(t, v, o);
     if (!nextOverlay) {
@@ -276,7 +280,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     }
     nextOverlay.setMap(map.current);
     return nextOverlay;
-  };
+  });
 
   // 编辑时
   useEffect(() => {
@@ -293,7 +297,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
       createEditor();
       setTarget();
     }
-  }, [value, needUpdateFlag, type, commonOptions, disabled, readonly]);
+  }, [value, needUpdateFlag, type, commonOptions, disabled, readonly, createEditor, setOverlay, setTarget]);
 
   // 当在编辑时，关闭 mouseTool
   useEffect(() => {
@@ -306,14 +310,14 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
       executeMouseTool();
       editor.current?.open();
     }
-  }, [disabled]);
+  }, [disabled, executeMouseTool]);
 
   // AMap.MouseTool & AMap.XXXEditor
   useEffect(() => {
     if (!aMap.current || !type || disabled) return;
     createMouseTool();
     createEditor();
-  }, [disabled, needUpdateFlag, type]);
+  }, [createEditor, createMouseTool, disabled, needUpdateFlag, type]);
 
   // 当值变更时，toggle mouseTool
   useEffect(() => {
@@ -332,7 +336,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     } else {
       executeMouseTool();
     }
-  }, [type, value]);
+  }, [executeMouseTool, onChange, toRemoveOverlay, type, value]);
 
   useEffect(() => {
     if (!accessKey || map.current) return;
@@ -351,7 +355,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
         try {
           map.current = new window.AMap.Map(id.current, {
             resizeEnable: true,
-            zoom,
+            zoom: zoomRef.current,
           } as AMap.MapOptions);
           aMap.current = AMap;
           setErrMessage('');
@@ -379,7 +383,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
           try {
             map.current = new amap.Map(id.current, {
               resizeEnable: true,
-              zoom,
+              zoom: zoomRef.current,
             } as AMap.MapOptions);
             aMap.current = amap;
             setErrMessage('');
@@ -393,7 +397,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
         (window as any).define = _define;
         const errorMessage = normalizeErrorMessage(err, defaultErrorMessage);
         if (errorMessage.includes('多个不一致的 key')) {
-          setErrMessage(t('The AccessKey is incorrect, please check it'));
+          setErrMessage(tRef.current('The AccessKey is incorrect, please check it'));
           return;
         }
         if (err && typeof err === 'object' && 'type' in err && err.type === 'error') {
@@ -412,7 +416,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
       // @ts-ignore
       AMapLoader.reset();
     };
-  }, [accessKey, type, securityJsCode]);
+  }, [accessKey, securityJsCode, type]);
 
   useImperativeHandle(ref, () => ({
     setOverlay,

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Map.tsx
@@ -68,6 +68,8 @@ const methodMapping = {
   },
 };
 
+type AMapEditableOverlay = AMap.Marker | AMap.Polygon | AMap.Polyline | AMap.Circle;
+
 export interface AMapForwardedRefProps {
   setOverlay: (t: MapEditorType, v: any, o?: AMap.PolylineOptions & AMap.PolygonOptions & AMap.MarkerOptions) => any;
   getOverlay: (t: MapEditorType, v: any, o?: AMap.PolylineOptions & AMap.PolygonOptions & AMap.MarkerOptions) => any;
@@ -150,7 +152,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
     }
   });
 
-  const onMapChange = useMemoizedFn((target, onlyChange = false, curType = type) => {
+  const onMapChange = useMemoizedFn((target: AMapEditableOverlay, onlyChange = false, curType = type) => {
     let nextValue = null;
 
     if (curType === 'point') {
@@ -162,8 +164,9 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
         return;
       }
     } else if (curType === 'circle') {
-      const center = target.getCenter();
-      const radius = target.getRadius();
+      const circle = target as AMap.Circle;
+      const center = circle.getCenter();
+      const radius = circle.getRadius();
       nextValue = [center.lng, center.lat, radius];
     }
 

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/Map.tsx
@@ -88,7 +88,7 @@ export interface AMapForwardedRefProps {
   mouseTool: () => {
     close: (clear?: boolean) => void;
   };
-  overlay: AMap.Polygon;
+  overlay: AMapEditableOverlay;
   errMessage?: string;
 }
 
@@ -116,7 +116,7 @@ export const AMapCom = React.forwardRef<AMapForwardedRefProps, AMapComponentProp
   const defaultErrorMessage = 'Something went wrong, please refresh the page and try again';
   const ctx = useFlowContext();
 
-  const overlay = useRef<AMap.Polygon>();
+  const overlay = useRef<AMapEditableOverlay>();
   const editor = useRef(null);
   const zoomRef = useRef(zoom);
   zoomRef.current = zoom;

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/__tests__/Block.test.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/__tests__/Block.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AMapBlock } from '../Block';
+
+const setOverlay = vi.hoisted(() => vi.fn());
+const pointOverlay = vi.hoisted(() => ({
+  getExtData: vi.fn(() => ({ id: 1 })),
+  off: vi.fn(),
+  on: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock('../../../../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../Map', async () => {
+  const ReactModule = await import('react');
+  return {
+    AMapCom: ReactModule.forwardRef((_props, ref) => {
+      ReactModule.useImperativeHandle(ref, () => ({
+        aMap: { GeometryUtil: {} },
+        map: {
+          getAllOverlays: vi.fn(() => [pointOverlay]),
+          setFitView: vi.fn(),
+          setZoom: vi.fn(),
+        },
+        setOverlay,
+      }));
+      return <div data-testid="amap" />;
+    }),
+  };
+});
+
+describe('AMapBlock', () => {
+  beforeEach(() => {
+    setOverlay.mockReset();
+    setOverlay.mockReturnValue(pointOverlay);
+    pointOverlay.getExtData.mockClear();
+    pointOverlay.off.mockClear();
+    pointOverlay.on.mockClear();
+    pointOverlay.remove.mockClear();
+  });
+
+  it('lets point overlay events bubble so double-click can finish polygon drawing', async () => {
+    render(
+      <AMapBlock
+        collectionField={{ interface: 'point' }}
+        dataSource={[{ id: 1, location: [120, 30] }]}
+        fields={[]}
+        mapField={['location']}
+        marker="id"
+        onOpenView={vi.fn()}
+        primaryKey="id"
+        setSelectedRecordKeys={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(setOverlay).toHaveBeenCalled());
+    expect(setOverlay.mock.calls[0][2]).toEqual(expect.objectContaining({ bubble: true }));
+  });
+});

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/__tests__/Map.test.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/AMap/__tests__/Map.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import AMapLoader from '@amap/amap-jsapi-loader';
+import { act, render, waitFor } from '@testing-library/react';
+import { App } from 'antd';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AMapCom, AMapForwardedRefProps } from '../Map';
+
+vi.mock('@amap/amap-jsapi-loader', () => ({
+  default: {
+    load: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+let drawListener: ((event: { obj: MockPolygon }) => void) | undefined;
+let polygonEditor: MockPolygonEditor;
+let mapConstructionCount = 0;
+
+class MockMap {
+  destroy = vi.fn();
+  setFitView = vi.fn();
+  setZoom = vi.fn();
+  setZoomAndCenter = vi.fn();
+
+  constructor() {
+    mapConstructionCount += 1;
+  }
+}
+
+class MockMouseTool {
+  close = vi.fn();
+  marker = vi.fn();
+  polygon = vi.fn();
+
+  on(eventName: string, listener: (event: { obj: MockPolygon }) => void) {
+    if (eventName === 'draw') {
+      drawListener = listener;
+    }
+  }
+}
+
+class MockPolygonEditor {
+  private target: MockPolygon | null = null;
+  close = vi.fn();
+  open = vi.fn();
+  on = vi.fn();
+  setTarget = vi.fn((target?: MockPolygon | null) => {
+    this.target = target || null;
+  });
+
+  constructor() {
+    polygonEditor = this;
+  }
+
+  getTarget() {
+    return this.target;
+  }
+}
+
+class MockPolygon {
+  getPath() {
+    return [
+      { lng: 120, lat: 30 },
+      { lng: 121, lat: 30 },
+      { lng: 121, lat: 31 },
+    ];
+  }
+}
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({ router: { navigate: vi.fn() } }),
+}));
+
+vi.mock('../../../../hooks', () => ({
+  useMapConfig: () => ({ accessKey: 'test-access-key' }),
+}));
+
+vi.mock('../../../../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+describe('AMapCom block drawing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    drawListener = undefined;
+    mapConstructionCount = 0;
+    Object.defineProperty(globalThis, 'AMap', {
+      configurable: true,
+      value: {
+        Map: MockMap,
+        MouseTool: MockMouseTool,
+        PolygonEditor: MockPolygonEditor,
+      },
+    });
+  });
+
+  it('initializes the map only once when the translation callback identity changes', async () => {
+    Object.defineProperty(globalThis, 'AMap', {
+      configurable: true,
+      value: undefined,
+    });
+    vi.mocked(AMapLoader.load).mockResolvedValue({
+      Map: MockMap,
+      MouseTool: MockMouseTool,
+      PolygonEditor: MockPolygonEditor,
+    } as never);
+    const mapRef = React.createRef<AMapForwardedRefProps>();
+    render(
+      <App>
+        <AMapCom ref={mapRef} block disabled mapType="amap" readonly="" type="point" zoom={13} />
+      </App>,
+    );
+
+    await waitFor(() => expect(mapRef.current?.map).toBeInstanceOf(MockMap));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    expect(mapConstructionCount).toBe(1);
+  });
+
+  it('hands a selection polygon to PolygonEditor when the configured map field is a point', async () => {
+    const mapRef = React.createRef<AMapForwardedRefProps>();
+    render(
+      <App>
+        <AMapCom ref={mapRef} block disabled mapType="amap" readonly="" type="point" zoom={13} />
+      </App>,
+    );
+
+    await waitFor(() => expect(mapRef.current?.map).toBeInstanceOf(MockMap));
+    act(() => {
+      mapRef.current?.createEditor('polygon');
+      mapRef.current?.createMouseTool('polygon');
+    });
+    const polygon = new MockPolygon();
+
+    expect(() => {
+      act(() => drawListener?.({ obj: polygon }));
+    }).not.toThrow();
+    expect(polygonEditor.setTarget).toHaveBeenCalledWith(polygon);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Block.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Block.tsx
@@ -44,7 +44,7 @@ export const GoogleMapsBlock = (props) => {
   const mapRef = useRef<GoogleMapForwardedRefProps>();
   const [selectingMode, setSelecting] = useState('');
   const t = useT();
-  const compile = (value: any) => compileTemplate(value, t);
+  const compile = useMemoizedFn((value: unknown) => compileTemplate(value, t));
   const isConnected = false;
   const doFilter = (..._args: any[]) => {};
   const [, setPrevSelected] = useState<any>(null);
@@ -120,21 +120,27 @@ export const GoogleMapsBlock = (props) => {
   }, [selectingMode]);
 
   const onSelectingComplete = useMemoizedFn(() => {
+    mapRef.current?.drawingManager?.completeDrawing();
     const overlay = selectionOverlayRef.current;
+    if (!overlay) {
+      return;
+    }
     const overlays = overlaysRef.current;
     const poly = google.maps.geometry.poly;
     const selectedOverlays = overlays.filter((o) => {
       if (o === overlay || o.get(OVERLAY_KEY) === undefined) return;
       if (o instanceof google.maps.Marker) {
-        return poly.containsLocation(o.getPosition()!, overlay!);
+        const position = o.getPosition();
+        return position ? poly.containsLocation(position, overlay) : false;
       } else if (o instanceof google.maps.Circle) {
-        return poly.containsLocation(o.getCenter()!, overlay!);
+        const center = o.getCenter();
+        return center ? poly.containsLocation(center, overlay) : false;
       } else {
         return (o as google.maps.Polygon)
           .getPath()
           .getArray()
           .some((position) => {
-            return poly.containsLocation(position, overlay!);
+            return poly.containsLocation(position, overlay);
           });
       }
     });
@@ -143,9 +149,10 @@ export const GoogleMapsBlock = (props) => {
       return o.get(OVERLAY_KEY);
     });
     setSelectedRecordKeys((lastIds) => ids.concat(lastIds));
-    overlay?.unbindAll();
-    overlay?.setMap(null);
-    mapRef.current?.drawingManager.setDrawingMode('polygon');
+    overlay.unbindAll();
+    overlay.setMap(null);
+    selectionOverlayRef.current = null;
+    mapRef.current?.drawingManager?.setDrawingMode('polygon');
   });
 
   useEffect(() => {
@@ -179,7 +186,13 @@ export const GoogleMapsBlock = (props) => {
     overlaysRef.current = overlays;
 
     const events = overlays.map((o: google.maps.MVCObject) => {
-      const onClick = (event) => {
+      const onClick = (event: google.maps.MapMouseEvent) => {
+        if (selectingModeRef.current === 'selection') {
+          const markerPosition = o instanceof google.maps.Marker ? o.getPosition() : undefined;
+          mapRef.current?.drawingManager?.handleOverlayClick(event, markerPosition);
+          return;
+        }
+
         const overlay = o as google.maps.Polygon;
         const id = overlay.get(OVERLAY_KEY);
         if (!id) return;
@@ -212,7 +225,13 @@ export const GoogleMapsBlock = (props) => {
           onOpenView(data);
         }
       };
+      const onDoubleClick = () => {
+        if (selectingModeRef.current === 'selection') {
+          mapRef.current?.drawingManager?.handleDoubleClick();
+        }
+      };
       o.addListener('click', onClick);
+      o.addListener('dblclick', onDoubleClick);
       return () => o.unbindAll();
     });
 
@@ -267,13 +286,28 @@ export const GoogleMapsBlock = (props) => {
       });
       events.forEach((e) => e());
     };
-  }, [dataSource, isMapInitialization, marker, geometryType, isConnected]);
+  }, [
+    associationCollectionField?.interface,
+    collectionField,
+    compile,
+    dataSource,
+    geometryType,
+    isConnected,
+    isMapInitialization,
+    labelUiSchema,
+    lineSort,
+    mapField,
+    marker,
+    onOpenView,
+    primaryKey,
+    t,
+  ]);
 
   useEffect(() => {
     setTimeout(() => {
       setSelectedRecordKeys([]);
     });
-  }, [dataSource]);
+  }, [dataSource, setSelectedRecordKeys]);
 
   const mapRefCallback = (instance: GoogleMapForwardedRefProps) => {
     mapRef.current = instance;

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/Map.tsx
@@ -71,6 +71,7 @@ export class GoogleMapsDrawingManager {
   private draftOverlay: google.maps.Polygon | google.maps.Polyline | google.maps.Circle | null = null;
   private draftPath: google.maps.LatLng[] = [];
   private circleCenter: google.maps.LatLng | null = null;
+  private lastClickPosition: google.maps.LatLng | null = null;
 
   constructor(options: OverlayOptions & { drawingMode?: GoogleMapsDrawingMode; map?: google.maps.Map }) {
     this.options = options;
@@ -94,6 +95,23 @@ export class GoogleMapsDrawingManager {
     this.bindMapEvents();
   }
 
+  handleClick(event: google.maps.MapMouseEvent) {
+    if (event.latLng) {
+      this.handlePositionClick(event.latLng);
+    }
+  }
+
+  handleOverlayClick(event: google.maps.MapMouseEvent, fallbackPosition?: google.maps.LatLng | null) {
+    const position = event.latLng || fallbackPosition;
+    if (position) {
+      this.handlePositionClick(position);
+    }
+  }
+
+  handleDoubleClick() {
+    this.completePathOverlay();
+  }
+
   unbindAll() {
     this.listeners.clear();
     this.clearMapEvents();
@@ -101,19 +119,31 @@ export class GoogleMapsDrawingManager {
     this.drawingMode = null;
   }
 
+  completeDrawing() {
+    if (this.drawingMode === 'polygon' || this.drawingMode === 'polyline') {
+      this.completePathOverlay();
+    } else if (this.drawingMode === 'circle') {
+      this.completeCircleOverlay();
+    }
+  }
+
   private bindMapEvents() {
     this.clearMapEvents();
     if (!this.options.map || !this.drawingMode) {
       return;
     }
+    if (this.drawingMode === 'polygon' || this.drawingMode === 'polyline') {
+      this.options.map.setOptions({
+        draggableCursor: 'crosshair',
+        disableDoubleClickZoom: true,
+      });
+    }
     this.mapListeners.push(
       this.options.map.addListener('click', (event: google.maps.MapMouseEvent) => {
-        if (event.latLng) {
-          this.handleClick(event.latLng);
-        }
+        this.handleClick(event);
       }),
       this.options.map.addListener('dblclick', () => {
-        this.completePathOverlay();
+        this.handleDoubleClick();
       }),
       this.options.map.addListener('mousemove', (event: google.maps.MapMouseEvent) => {
         if (event.latLng) {
@@ -126,6 +156,10 @@ export class GoogleMapsDrawingManager {
   private clearMapEvents() {
     this.mapListeners.forEach((listener) => listener?.remove?.());
     this.mapListeners.length = 0;
+    this.options.map?.setOptions({
+      draggableCursor: undefined,
+      disableDoubleClickZoom: false,
+    });
   }
 
   private resetDraft() {
@@ -133,9 +167,13 @@ export class GoogleMapsDrawingManager {
     this.draftOverlay = null;
     this.draftPath = [];
     this.circleCenter = null;
+    this.lastClickPosition = null;
   }
 
-  private handleClick(position: google.maps.LatLng) {
+  private handlePositionClick(position: google.maps.LatLng) {
+    if (this.shouldSkipDuplicateClick(position)) {
+      return;
+    }
     if (this.drawingMode === 'marker') {
       this.emitComplete('marker', new google.maps.Marker({ ...this.options, icon: getIcon(defaultImage), position }));
       return;
@@ -149,6 +187,16 @@ export class GoogleMapsDrawingManager {
     if (this.drawingMode === 'polygon' || this.drawingMode === 'polyline') {
       this.handlePathClick(position);
     }
+  }
+
+  private shouldSkipDuplicateClick(position: google.maps.LatLng) {
+    const isDuplicate =
+      this.lastClickPosition &&
+      this.lastClickPosition.lat() === position.lat() &&
+      this.lastClickPosition.lng() === position.lng();
+
+    this.lastClickPosition = position;
+    return isDuplicate;
   }
 
   private handlePathClick(position: google.maps.LatLng) {

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/__tests__/Block.test.tsx
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/__tests__/Block.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GoogleMapsBlock } from '../Block';
+
+const drawingManager = vi.hoisted(() => ({
+  addListener: vi.fn(() => ({ remove: vi.fn() })),
+  completeDrawing: vi.fn(),
+  handleDoubleClick: vi.fn(),
+  handleOverlayClick: vi.fn(),
+  setDrawingMode: vi.fn(),
+  unbindAll: vi.fn(),
+}));
+
+const overlayListeners = vi.hoisted(() => new Map<string, (event: unknown) => void>());
+const dataOverlay = vi.hoisted(() => ({
+  addListener: vi.fn((eventName: string, listener: (event: unknown) => void) => {
+    overlayListeners.set(eventName, listener);
+  }),
+  set: vi.fn(),
+  setMap: vi.fn(),
+  unbindAll: vi.fn(),
+}));
+
+vi.mock('../../../../locale', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../Map', async () => {
+  const ReactModule = await import('react');
+  return {
+    GoogleMapsCom: ReactModule.forwardRef((_props, ref) => {
+      ReactModule.useImperativeHandle(ref, () => ({
+        createDraw: vi.fn(() => drawingManager),
+        drawingManager,
+        map: {},
+        setFitView: vi.fn(),
+        setOverlay: vi.fn(() => dataOverlay),
+      }));
+      return <div data-testid="google-map" />;
+    }),
+  };
+});
+
+describe('GoogleMapsBlock', () => {
+  beforeEach(() => {
+    drawingManager.addListener.mockClear();
+    drawingManager.completeDrawing.mockClear();
+    drawingManager.handleDoubleClick.mockClear();
+    drawingManager.handleOverlayClick.mockClear();
+    drawingManager.setDrawingMode.mockClear();
+    drawingManager.unbindAll.mockClear();
+    overlayListeners.clear();
+    dataOverlay.addListener.mockClear();
+    dataOverlay.set.mockClear();
+    dataOverlay.setMap.mockClear();
+    dataOverlay.unbindAll.mockClear();
+    Object.defineProperty(globalThis, 'google', {
+      configurable: true,
+      value: {
+        maps: {
+          geometry: { poly: { containsLocation: vi.fn() } },
+        },
+      },
+    });
+  });
+
+  it('finishes an active polygon when confirming a selection', async () => {
+    const { container } = render(
+      <GoogleMapsBlock
+        collectionField={{ interface: 'point' }}
+        dataSource={[]}
+        fields={[]}
+        marker="id"
+        primaryKey="id"
+        setSelectedRecordKeys={vi.fn()}
+      />,
+    );
+
+    const selectionButton = container.querySelector('[data-icon="expand"]')?.closest('button');
+    if (!selectionButton) {
+      throw new Error('Selection button was not rendered');
+    }
+    fireEvent.click(selectionButton);
+    fireEvent.click(await screen.findByTitle('Confirm selection'));
+
+    expect(drawingManager.completeDrawing).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes a selection when double-clicking a data overlay', async () => {
+    const { container } = render(
+      <GoogleMapsBlock
+        collectionField={{ interface: 'point' }}
+        dataSource={[{ id: 1, location: [120, 30] }]}
+        fields={[]}
+        mapField={['location']}
+        marker="id"
+        onOpenView={vi.fn()}
+        primaryKey="id"
+        setSelectedRecordKeys={vi.fn()}
+      />,
+    );
+
+    const selectionButton = container.querySelector('[data-icon="expand"]')?.closest('button');
+    if (!selectionButton) {
+      throw new Error('Selection button was not rendered');
+    }
+    fireEvent.click(selectionButton);
+    await waitFor(() => expect(overlayListeners.has('dblclick')).toBe(true));
+    overlayListeners.get('dblclick')?.({});
+
+    expect(drawingManager.handleDoubleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/__tests__/Map.test.ts
+++ b/packages/plugins/@nocobase/plugin-map/src/client-v2/models/components/GoogleMaps/__tests__/Map.test.ts
@@ -1,0 +1,101 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GoogleMapsDrawingManager } from '../Map';
+
+class Polygon {
+  setMap = vi.fn();
+  setPath = vi.fn();
+}
+
+class Polyline {
+  setMap = vi.fn();
+  setPath = vi.fn();
+}
+
+class Circle {
+  setMap = vi.fn();
+}
+
+const createPosition = (lat: number, lng: number) =>
+  ({
+    lat: () => lat,
+    lng: () => lng,
+  }) as google.maps.LatLng;
+
+describe('GoogleMapsDrawingManager', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'google', {
+      configurable: true,
+      value: {
+        maps: {
+          Circle,
+          Polygon,
+          Polyline,
+        },
+      },
+    });
+  });
+
+  it('completes a polygon when the final double-click occurs on a point overlay', () => {
+    const mapListeners = new Map<string, (event: { latLng?: google.maps.LatLng }) => void>();
+    const setOptions = vi.fn();
+    const manager = new GoogleMapsDrawingManager({
+      drawingMode: 'polygon',
+      map: {
+        addListener: vi.fn((eventName, listener) => {
+          mapListeners.set(eventName, listener);
+          return { remove: vi.fn() };
+        }),
+        setOptions,
+      } as unknown as google.maps.Map,
+    });
+    const onComplete = vi.fn();
+    manager.addListener('overlaycomplete', onComplete);
+
+    mapListeners.get('click')?.({ latLng: createPosition(1, 1) });
+    mapListeners.get('click')?.({ latLng: createPosition(2, 2) });
+    manager.handleOverlayClick({ latLng: null } as google.maps.MapMouseEvent, createPosition(3, 3));
+    manager.handleOverlayClick({ latLng: null } as google.maps.MapMouseEvent, createPosition(3, 3));
+    manager.handleDoubleClick();
+
+    expect(onComplete).toHaveBeenCalledWith({
+      type: 'polygon',
+      overlay: expect.any(Polygon),
+    });
+    expect(setOptions).toHaveBeenCalledWith({
+      draggableCursor: 'crosshair',
+      disableDoubleClickZoom: true,
+    });
+  });
+
+  it('does not complete a polygon with only two unique positions', () => {
+    const mapListeners = new Map<string, (event: { latLng?: google.maps.LatLng }) => void>();
+    const manager = new GoogleMapsDrawingManager({
+      drawingMode: 'polygon',
+      map: {
+        addListener: vi.fn((eventName, listener) => {
+          mapListeners.set(eventName, listener);
+          return { remove: vi.fn() };
+        }),
+        setOptions: vi.fn(),
+      } as unknown as google.maps.Map,
+    });
+    const onComplete = vi.fn();
+    manager.addListener('overlaycomplete', onComplete);
+
+    mapListeners.get('click')?.({ latLng: createPosition(1, 1) });
+    manager.handleOverlayClick({ latLng: null } as google.maps.MapMouseEvent, createPosition(2, 2));
+    manager.handleOverlayClick({ latLng: null } as google.maps.MapMouseEvent, createPosition(2, 2));
+    manager.handleDoubleClick();
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

In client v2 map blocks, an existing point overlay could intercept clicks while drawing a selection polygon, preventing double-click from completing the region. AMap could also remain in a loading state after its SDK initialized because an unstable translation callback restarted the initialization effect.

### Description

- Allow AMap data-overlay events to bubble to MouseTool and preserve the polygon editor type when the configured map field is a point.
- Forward Google Maps overlay clicks and double-clicks to the drawing manager, complete active drafts from the confirmation action, and ignore adjacent duplicate coordinates created by double-click sequences.
- Keep Google Maps double-click zoom disabled only while drawing a path.
- Stabilize asynchronous AMap initialization so the map is created once and does not remain loading.
- Add regression coverage for point overlays, double-click completion, degenerate polygon prevention, and repeated AMap initialization.

Potential risk is limited to map selection interactions and drawing-manager event handling. Suggested testing: display point data in both AMap and Google Maps blocks, enter region-selection mode, finish a polygon by double-clicking on a point marker, and confirm the selected records.

### Related issues

N/A

### Showcase

N/A (interaction-only fix)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed region selection not finishing on double-click when map point data is displayed, and fixed AMap remaining in a loading state |
| 🇨🇳 Chinese | 修复地图显示点位数据时区域圈选无法双击结束，以及高德地图持续加载的问题 |

### Docs

| Language   | Link |
| ---------- | ---- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
