### PR TITLE
fix(plugin-ui-layout): scope mobile tab routes

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Display.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Display.test.tsx
@@ -30,6 +30,10 @@ vi.mock('@nocobase/client-v2', () => ({
   stripMarkdownIframes: (value: string) => value,
 }));
 
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({ isDarkTheme: false }),
+}));
+
 vi.mock('antd', async (importOriginal) => {
   const actual = await importOriginal<typeof import('antd')>();
 
@@ -86,14 +90,18 @@ describe('Display', () => {
     render(<Display value="image markdown" />);
 
     await waitFor(() =>
-      expect(Vditor.preview).toHaveBeenCalledWith(expect.any(HTMLDivElement), 'image markdown', {
-        mode: 'light',
-        cdn: 'https://cdn.example/vditor',
-        markdown: {
-          sanitize: true,
-        },
-        transform: expect.any(Function),
-      }),
+      expect(Vditor.preview).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        'image markdown',
+        expect.objectContaining({
+          mode: 'light',
+          cdn: 'https://cdn.example/vditor',
+          markdown: {
+            sanitize: true,
+          },
+          transform: expect.any(Function),
+        }),
+      ),
     );
 
     await act(async () => {
@@ -112,14 +120,18 @@ describe('Display', () => {
     render(<Display />);
 
     await waitFor(() =>
-      expect(Vditor.preview).toHaveBeenCalledWith(expect.any(HTMLDivElement), '', {
-        mode: 'light',
-        cdn: 'https://cdn.example/vditor',
-        markdown: {
-          sanitize: true,
-        },
-        transform: expect.any(Function),
-      }),
+      expect(Vditor.preview).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        '',
+        expect.objectContaining({
+          mode: 'light',
+          cdn: 'https://cdn.example/vditor',
+          markdown: {
+            sanitize: true,
+          },
+          transform: expect.any(Function),
+        }),
+      ),
     );
     expect(Vditor.md2html).not.toHaveBeenCalled();
   });
@@ -166,14 +178,18 @@ describe('Display', () => {
     fireEvent.mouseEnter(screen.getByTestId('popover'));
 
     await waitFor(() =>
-      expect(Vditor.preview).toHaveBeenCalledWith(expect.any(HTMLDivElement), 'Overflow text', {
-        mode: 'light',
-        cdn: 'https://cdn.example/vditor',
-        markdown: {
-          sanitize: true,
-        },
-        transform: expect.any(Function),
-      }),
+      expect(Vditor.preview).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        'Overflow text',
+        expect.objectContaining({
+          mode: 'light',
+          cdn: 'https://cdn.example/vditor',
+          markdown: {
+            sanitize: true,
+          },
+          transform: expect.any(Function),
+        }),
+      ),
     );
     createRangeSpy.mockRestore();
   });

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Display.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Display.test.tsx
@@ -30,24 +30,29 @@ vi.mock('@nocobase/client-v2', () => ({
   stripMarkdownIframes: (value: string) => value,
 }));
 
-vi.mock('antd', () => ({
-  Popover: ({
-    children,
-    content,
-    open,
-    onOpenChange,
-  }: {
-    children: React.ReactNode;
-    content: React.ReactNode;
-    open?: boolean;
-    onOpenChange?: (visible: boolean) => void;
-  }) => (
-    <div data-testid="popover" onMouseEnter={() => onOpenChange?.(true)}>
-      {children}
-      {open ? content : null}
-    </div>
-  ),
-}));
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+
+  return {
+    ...actual,
+    Popover: ({
+      children,
+      content,
+      open,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      content: React.ReactNode;
+      open?: boolean;
+      onOpenChange?: (visible: boolean) => void;
+    }) => (
+      <div data-testid="popover" onMouseEnter={() => onOpenChange?.(true)}>
+        {children}
+        {open ? content : null}
+      </div>
+    ),
+  };
+});
 
 vi.mock('../components/const', () => ({
   useCDN: () => 'https://cdn.example/vditor',

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/__tests__/mobileModels.test.ts
@@ -9,6 +9,7 @@
 
 import {
   ACLContext,
+  APIClient,
   BaseLayoutModel,
   ChildPageModel,
   KeepAlive,
@@ -23,6 +24,8 @@ import { NocoBaseDesktopRouteType, type NocoBaseDesktopRoute } from '@nocobase/c
 import { App as AntdApp, Card, ConfigProvider, Tabs, theme as antdTheme, type ThemeConfig } from 'antd';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import axios, { type AxiosInstance } from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import {
   createViewScopedEngine,
   FlowEngine,
@@ -134,6 +137,7 @@ describe('plugin-ui-layout mobile models', () => {
       allowConfigUI?: boolean;
       beforeRender?: (model: MobileLayoutModel) => void;
       api?: {
+        axios?: AxiosInstance;
         request: (options: Record<string, unknown>) => Promise<{ data?: { data?: NocoBaseDesktopRoute[] } }>;
       };
       initialEntries?: string[];
@@ -187,6 +191,7 @@ describe('plugin-ui-layout mobile models', () => {
       use: 'MobileLayoutModel',
       props: {
         layout: {
+          layoutModelClass: 'MobileLayoutModel',
           routeName: 'mobile',
           routePath: '/v/mobile',
           uid: 'mobile-layout-model-render-test',
@@ -1597,6 +1602,243 @@ describe('plugin-ui-layout mobile models', () => {
     unmount();
 
     expect(deactivateLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should scope desktop route upserts while the standard mobile layout is mounted', async () => {
+    const axiosInstance = axios.create();
+    const mock = new MockAdapter(axiosInstance, { onNoMatch: 'throwException' });
+    let requestParams: unknown;
+    mock.onPost(/desktopRoutes:updateOrCreate/).reply((config) => {
+      requestParams = config.params;
+      return [200, {}];
+    });
+    const api = {
+      axios: axiosInstance,
+      request: vi.fn(async () => ({ data: { data: [] } })),
+    };
+    const routeRepository: MobileRouteRepositoryForTest = {
+      listAccessible: () => [],
+      setRoutes: vi.fn(),
+      activateLayout: vi.fn(() => vi.fn()),
+    };
+
+    const { unmount } = renderMobileLayoutWithRouteRepository(routeRepository, { api });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+      layout: 'mobile-layout-model-render-test',
+    });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+          layout: 'explicit-layout',
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+      layout: 'explicit-layout',
+    });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+          portal: 'explicit-portal',
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+      portal: 'explicit-portal',
+    });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate?portal=query-portal',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+    });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate?layout[]=query-layout',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+    });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate?portal[]=query-portal',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+    });
+
+    unmount();
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+    });
+    mock.restore();
+  });
+
+  it('should serialize URLSearchParams while scoping standard mobile route upserts', async () => {
+    const apiClient = new APIClient({ baseURL: 'https://example.test/api/' });
+    const mock = new MockAdapter(apiClient.axios, { onNoMatch: 'throwException' });
+    const requestUrls: string[] = [];
+    mock.onPost('desktopRoutes:updateOrCreate').reply((config) => {
+      const paramsSerializer = config.paramsSerializer;
+      const serializeParams = typeof paramsSerializer === 'function' ? paramsSerializer : paramsSerializer?.serialize;
+      if (!serializeParams) {
+        throw new Error('Expected the APIClient params serializer to be configured.');
+      }
+
+      const requestUrl = new URL(config.url || '', config.baseURL);
+      const serializedParams = serializeParams(config.params);
+      if (serializedParams) {
+        requestUrl.search = requestUrl.search ? `${requestUrl.search.slice(1)}&${serializedParams}` : serializedParams;
+      }
+      requestUrls.push(requestUrl.toString());
+      return [200, {}];
+    });
+    const api = {
+      axios: apiClient.axios,
+      request: vi.fn(async () => ({ data: { data: [] } })),
+    };
+    const routeRepository: MobileRouteRepositoryForTest = {
+      listAccessible: () => [],
+      setRoutes: vi.fn(),
+      activateLayout: vi.fn(() => vi.fn()),
+    };
+
+    const { unmount } = renderMobileLayoutWithRouteRepository(routeRepository, { api });
+    const params = new URLSearchParams();
+    params.append('filterKeys[]', 'schemaUid');
+    params.append('filterKeys[]', 'parentId');
+
+    await apiClient.axios.post('desktopRoutes:updateOrCreate', {}, { params });
+
+    let requestUrl = new URL(requestUrls[requestUrls.length - 1]);
+    expect(requestUrl.searchParams.getAll('filterKeys[]')).toEqual(['schemaUid', 'parentId']);
+    expect(requestUrl.searchParams.get('layout')).toBe('mobile-layout-model-render-test');
+    expect(params.has('layout')).toBe(false);
+
+    const explicitLayoutParams = new URLSearchParams({ layout: 'explicit-layout' });
+    await apiClient.axios.post('desktopRoutes:updateOrCreate', {}, { params: explicitLayoutParams });
+    requestUrl = new URL(requestUrls[requestUrls.length - 1]);
+    expect(requestUrl.searchParams.get('layout')).toBe('explicit-layout');
+
+    const explicitPortalParams = new URLSearchParams({ portal: 'explicit-portal' });
+    await apiClient.axios.post('desktopRoutes:updateOrCreate', {}, { params: explicitPortalParams });
+    requestUrl = new URL(requestUrls[requestUrls.length - 1]);
+    expect(requestUrl.searchParams.get('portal')).toBe('explicit-portal');
+    expect(requestUrl.searchParams.has('layout')).toBe(false);
+
+    const explicitArrayLayoutParams = new URLSearchParams();
+    explicitArrayLayoutParams.append('layout[]', 'explicit-array-layout');
+    await apiClient.axios.post('desktopRoutes:updateOrCreate', {}, { params: explicitArrayLayoutParams });
+    requestUrl = new URL(requestUrls[requestUrls.length - 1]);
+    expect(requestUrl.searchParams.getAll('layout[]')).toEqual(['explicit-array-layout']);
+    expect(requestUrl.searchParams.has('layout')).toBe(false);
+    expect(explicitArrayLayoutParams.getAll('layout[]')).toEqual(['explicit-array-layout']);
+
+    const explicitArrayPortalParams = new URLSearchParams();
+    explicitArrayPortalParams.append('portal[]', 'explicit-array-portal');
+    await apiClient.axios.post('desktopRoutes:updateOrCreate', {}, { params: explicitArrayPortalParams });
+    requestUrl = new URL(requestUrls[requestUrls.length - 1]);
+    expect(requestUrl.searchParams.getAll('portal[]')).toEqual(['explicit-array-portal']);
+    expect(requestUrl.searchParams.has('layout')).toBe(false);
+    expect(explicitArrayPortalParams.getAll('portal[]')).toEqual(['explicit-array-portal']);
+    unmount();
+    mock.restore();
+  });
+
+  it('should not scope desktop route upserts for a mobile portal layout model', async () => {
+    const axiosInstance = axios.create();
+    const mock = new MockAdapter(axiosInstance, { onNoMatch: 'throwException' });
+    let requestParams: unknown;
+    mock.onPost('desktopRoutes:updateOrCreate').reply((config) => {
+      requestParams = config.params;
+      return [200, {}];
+    });
+    const api = {
+      axios: axiosInstance,
+      request: vi.fn(async () => ({ data: { data: [] } })),
+    };
+    const routeRepository: MobileRouteRepositoryForTest = {
+      listAccessible: () => [],
+      setRoutes: vi.fn(),
+      activateLayout: vi.fn(() => vi.fn()),
+    };
+
+    const { unmount } = renderMobileLayoutWithRouteRepository(routeRepository, {
+      api,
+      beforeRender: (model) => {
+        model.setProps({
+          ...model.props,
+          layout: {
+            ...model.props.layout,
+            layoutModelClass: 'MultiPortalMobileLayoutModel',
+          },
+        });
+      },
+    });
+
+    await axiosInstance.post(
+      'desktopRoutes:updateOrCreate',
+      {},
+      {
+        params: {
+          filterKeys: ['schemaUid'],
+        },
+      },
+    );
+    expect(requestParams).toEqual({
+      filterKeys: ['schemaUid'],
+    });
+    unmount();
+    mock.restore();
   });
 
   it('should load mobile routes once when a child route also ensures accessible routes', async () => {

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/mobileDesktopRouteWriteScope.ts
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/mobileDesktopRouteWriteScope.ts
@@ -1,0 +1,139 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { AxiosInstance } from 'axios';
+
+const DESKTOP_ROUTE_UPSERT_ACTION = 'desktopRoutes:updateOrCreate';
+const MOBILE_LAYOUT_MODEL_CLASS = 'MobileLayoutModel';
+const ROUTE_SCOPE_PARAM_NAMES = ['layout', 'portal'] as const;
+
+type MobileDesktopRouteWriteScopeModel = {
+  layout?: {
+    layoutModelClass?: unknown;
+    uid?: unknown;
+  };
+  flowEngine: {
+    context: {
+      api?: {
+        axios?: AxiosInstance;
+      };
+    };
+  };
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function toSerializableParams(params: URLSearchParams) {
+  const result: Record<string, string | string[]> = {};
+
+  params.forEach((value, originalName) => {
+    const isArrayParam = originalName.endsWith('[]');
+    const name = isArrayParam ? originalName.slice(0, -2) : originalName;
+    const currentValue = result[name];
+
+    if (currentValue === undefined) {
+      result[name] = isArrayParam ? [value] : value;
+      return;
+    }
+
+    result[name] = Array.isArray(currentValue) ? [...currentValue, value] : [currentValue, value];
+  });
+
+  return result;
+}
+
+function isDesktopRouteUpsertUrl(url: unknown) {
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  const pathname = url.split('?')[0].replace(/\/+$/, '');
+  return pathname.split('/').pop() === DESKTOP_ROUTE_UPSERT_ACTION;
+}
+
+function hasRouteScopeParam(params: URLSearchParams | Record<string, unknown>) {
+  return ROUTE_SCOPE_PARAM_NAMES.some((name) => {
+    const bracketName = `${name}[]`;
+    return params instanceof URLSearchParams
+      ? params.has(name) || params.has(bracketName)
+      : Object.prototype.hasOwnProperty.call(params, name) || Object.prototype.hasOwnProperty.call(params, bracketName);
+  });
+}
+
+function hasExplicitRouteScope(url: unknown, params: unknown) {
+  if (
+    params instanceof URLSearchParams ? hasRouteScopeParam(params) : isPlainRecord(params) && hasRouteScopeParam(params)
+  ) {
+    return true;
+  }
+
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  const query = url.split('?')[1];
+  if (!query) {
+    return false;
+  }
+
+  const queryParams = new URLSearchParams(query);
+  return hasRouteScopeParam(queryParams);
+}
+
+export function installMobileDesktopRouteWriteScope(model: MobileDesktopRouteWriteScopeModel) {
+  const layout = model.layout;
+  const layoutUid = layout?.uid;
+  if (layout?.layoutModelClass !== MOBILE_LAYOUT_MODEL_CLASS || typeof layoutUid !== 'string' || !layoutUid.trim()) {
+    return () => {};
+  }
+
+  const requestInterceptors = model.flowEngine.context.api?.axios?.interceptors.request;
+  if (!requestInterceptors) {
+    return () => {};
+  }
+
+  const interceptorId = requestInterceptors.use((config) => {
+    if (!isDesktopRouteUpsertUrl(config.url)) {
+      return config;
+    }
+
+    const hasExplicitScope = hasExplicitRouteScope(config.url, config.params);
+    if (config.params instanceof URLSearchParams) {
+      const params = toSerializableParams(config.params);
+      if (!hasExplicitScope) {
+        params.layout = layoutUid;
+      }
+      config.params = params;
+      return config;
+    }
+    if (hasExplicitScope) {
+      return config;
+    }
+    if (config.params != null && !isPlainRecord(config.params)) {
+      return config;
+    }
+
+    config.params = {
+      ...(config.params || {}),
+      layout: layoutUid,
+    };
+    return config;
+  });
+
+  return () => {
+    requestInterceptors.eject(interceptorId);
+  };
+}

--- a/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-layout/src/client-v2/models/MobileLayoutModel.tsx
@@ -70,6 +70,7 @@ import {
   installMobileLayoutRouteRepository,
   refreshMobileLayoutAccessibleRoutes,
 } from '../mobileRouteRepository';
+import { installMobileDesktopRouteWriteScope } from '../mobileDesktopRouteWriteScope';
 import {
   Icon,
   IconPicker,
@@ -784,7 +785,13 @@ const MobileLayoutComponentContent = observer((props: { model: MobileLayoutModel
     ],
   );
   useLayoutEffect(() => {
-    return installMobileLayoutRouteRepository(model);
+    const uninstallRouteRepository = installMobileLayoutRouteRepository(model);
+    const uninstallDesktopRouteWriteScope = installMobileDesktopRouteWriteScope(model);
+
+    return () => {
+      uninstallDesktopRouteWriteScope();
+      uninstallRouteRepository();
+    };
   }, [model]);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

在 Client V2 移动端页面开启 Tabs 并新增 Tab 后，该页面可能同时出现在 PC Admin 导航中，导致移动端与桌面端的页面范围混在一起。

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- 保存移动端新 Tab 时带上当前移动端布局，确保新页面只属于移动端。
- 保留调用方已经指定的桌面或 Portal 范围，以及已有的重复查询参数。
- 增加自动化测试，覆盖普通参数、URLSearchParams、数组形式参数和布局卸载后的行为。

建议重点验证：移动端新增 Tab 后可以正常打开和刷新，同时 PC Admin 导航中不会出现该移动端页面。

### Showcase
<!-- Including any screenshots of the changes. -->

修复后，移动端新 Tab 可以正常访问和刷新，PC Admin 导航不再显示该移动端页面。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix mobile pages appearing in the desktop navigation |
| 🇨🇳 Chinese | 修复移动端页面出现在桌面端导航中的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
