### PR TITLE
refactor(lock-manager): reuse lease acquisition

### DIFF
--- a/packages/core/lock-manager/src/lock-manager.ts
+++ b/packages/core/lock-manager/src/lock-manager.ts
@@ -157,6 +157,15 @@ class LocalLockAdapter implements ILockAdapter {
       }, ttl);
     };
 
+    const acquireLease = async (ttl: number): Promise<Releaser> => {
+      const rawRelease = reservation || ((await mutex.acquire()) as Releaser);
+      reservation = undefined;
+      const lease = { release: rawRelease };
+      activeLease = lease;
+      resetTimer(ttl);
+      return () => releaseLease(lease);
+    };
+
     return {
       release: async (): Promise<void> => {
         if (reservation) {
@@ -170,25 +179,13 @@ class LocalLockAdapter implements ILockAdapter {
         }
       },
       acquire: async (ttl: number): Promise<Releaser> => {
-        const rawRelease = reservation || ((await mutex.acquire()) as Releaser);
-        reservation = undefined;
-        const lease = { release: rawRelease };
-        activeLease = lease;
-        resetTimer(ttl);
-        return () => releaseLease(lease);
+        return acquireLease(ttl);
       },
       extend: async (ttl: number): Promise<void> => {
         resetTimer(ttl);
       },
       runExclusive: async <T>(fn: () => Promise<T>, ttl: number): Promise<T> => {
-        const release = await (async () => {
-          const rawRelease = reservation || ((await mutex.acquire()) as Releaser);
-          reservation = undefined;
-          const lease = { release: rawRelease };
-          activeLease = lease;
-          resetTimer(ttl);
-          return () => releaseLease(lease);
-        })();
+        const release = await acquireLease(ttl);
         try {
           return await fn();
         } catch (e) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

The renewable lease implementation introduced duplicated lease-acquisition logic and an async IIFE, which is prohibited by the repository coding standards.

### Description

- Extract a named `acquireLease()` helper for creating and activating a lease.
- Reuse the helper from both `acquire()` and `runExclusive()`.
- Remove the async IIFE without changing lock behavior.

Risk is low because this is a behavior-preserving refactor. Suggested verification is to run the lock-manager unit test suite, including renewable lease coverage.

### Related issues

Follow-up to #10368.

### Showcase

Not applicable; there are no UI changes.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Not needed; this is an internal refactor with no user-visible behavior change. |
| 🇨🇳 Chinese | 无需更新；这是不影响用户可见行为的内部重构。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed; no public API or behavior changes. |
| 🇨🇳 Chinese | 无需更新；未修改公开 API 或行为。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
