### PR TITLE
fix(flow-engine): fit dropdown to viewport

### DIFF
--- a/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
+++ b/packages/core/flow-engine/src/components/subModel/LazyDropdown.tsx
@@ -8,8 +8,8 @@
  */
 
 import { css } from '@emotion/css';
-import { ConfigProvider, Dropdown, DropdownProps, Empty, Input, InputProps, Spin } from 'antd';
-import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ConfigProvider, Dropdown, DropdownProps, Empty, Input, InputProps, Spin, theme } from 'antd';
+import React, { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useFlowEngine } from '../../provider';
 
 // ==================== Types ====================
@@ -68,16 +68,6 @@ interface ExtendedMenuInfo {
 }
 
 // ==================== Custom Hooks ====================
-
-/**
- * 计算合适的下拉菜单最大高度
- */
-const useNiceDropdownMaxHeight = () => {
-  return useMemo(() => {
-    const maxHeight = Math.min(window.innerHeight * 0.6, 400);
-    return maxHeight;
-  }, []);
-};
 
 /**
  * 处理异步菜单项加载的逻辑
@@ -555,6 +545,7 @@ const KEEP_OPEN_LABEL_STYLE: React.CSSProperties = {
 
 // 短暂保持打开状态的注册表（用于跨父节点快速重建时的恢复）
 const DROPDOWN_PERSIST_TTL_MS = 350;
+const DEFAULT_DROPDOWN_MAX_HEIGHT = 400;
 const MENU_CLOSE_DELAY = 0.3;
 const SUBMENU_MOTION_DISABLED = {
   motionEnter: false,
@@ -565,8 +556,11 @@ const dropdownPersistRegistry: Map<string, number> = new Map();
 const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownMenuProps }> = ({ menu, ...props }) => {
   const engine = useFlowEngine();
   const { getPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
+  const { token } = theme.useToken();
   const triggerId = React.useId();
+  const showArrow = Boolean(props.arrow);
   const [menuVisible, setMenuVisible] = useState(false);
+  const [dropdownMaxHeight, setDropdownMaxHeight] = useState(DEFAULT_DROPDOWN_MAX_HEIGHT);
   const [openKeys, setOpenKeys] = useState<Set<string>>(new Set());
   const [rootItems, setRootItems] = useState<Item[]>([]);
   const [rootLoading, setRootLoading] = useState(false);
@@ -578,7 +572,6 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
   const mergedOpenClassName = [props.openClassName ?? defaultOpenClassName, triggerOpenClassName]
     .filter(Boolean)
     .join(' ');
-  const dropdownMaxHeight = useNiceDropdownMaxHeight();
   const t = engine.translate.bind(engine);
 
   // 解构 menu，避免在 effect 中直接依赖整个对象，减少不必要的重跑并满足 exhaustive-deps
@@ -596,6 +589,28 @@ const LazyDropdown: React.FC<Omit<DropdownProps, 'menu'> & { menu: LazyDropdownM
   const { searchValues, inputValues, clearSearchValue, clearAllSearchValues } = searchHandlers;
   const { requestKeepOpen, shouldPreventClose } = useKeepDropdownOpen();
   useSubmenuStyles(menuVisible, dropdownMaxHeight);
+
+  useLayoutEffect(() => {
+    if (!menuVisible) return;
+
+    const updateDropdownMaxHeight = () => {
+      const trigger = document.querySelector<HTMLElement>(`.${triggerOpenClassName}`);
+      if (!trigger) return;
+
+      const triggerRect = trigger.getBoundingClientRect();
+      const placementOffset = token.marginXXS + (showArrow ? token.sizePopupArrow / 2 : 0);
+      const reservedSpace = placementOffset + token.marginXXS;
+      const availableAbove = triggerRect.top - reservedSpace;
+      const availableBelow = window.innerHeight - triggerRect.bottom - reservedSpace;
+      const nextMaxHeight = Math.min(DEFAULT_DROPDOWN_MAX_HEIGHT, Math.max(0, availableAbove, availableBelow));
+
+      setDropdownMaxHeight(nextMaxHeight);
+    };
+
+    updateDropdownMaxHeight();
+    window.addEventListener('resize', updateDropdownMaxHeight);
+    return () => window.removeEventListener('resize', updateDropdownMaxHeight);
+  }, [menuVisible, showArrow, token.marginXXS, token.sizePopupArrow, triggerOpenClassName]);
 
   const closeMenu = useCallback(() => {
     setMenuVisible(false);

--- a/packages/core/flow-engine/src/components/subModel/__tests__/LazyDropdown.test.tsx
+++ b/packages/core/flow-engine/src/components/subModel/__tests__/LazyDropdown.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { act, render, screen, userEvent, waitFor } from '@nocobase/test/client';
+import { ConfigProvider } from 'antd';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FlowEngineProvider } from '../../../provider';
+import { FlowEngine } from '../../../flowEngine';
+import LazyDropdown from '../LazyDropdown';
+
+const setViewportHeight = (height: number) => {
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: height,
+  });
+};
+
+describe('LazyDropdown', () => {
+  const originalInnerHeight = window.innerHeight;
+
+  afterEach(() => {
+    setViewportHeight(originalInnerHeight);
+    vi.restoreAllMocks();
+  });
+
+  it('uses the current viewport space when opening after the viewport height changes', async () => {
+    setViewportHeight(720);
+    const engine = new FlowEngine();
+    const user = userEvent.setup();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <LazyDropdown
+            trigger={['click']}
+            menu={{
+              items: [{ key: 'field', label: 'Field' }],
+            }}
+          >
+            <button type="button">Open fields</button>
+          </LazyDropdown>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open fields' });
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 196,
+      height: 32,
+      left: 49,
+      right: 141,
+      top: 164,
+      width: 92,
+      x: 49,
+      y: 164,
+      toJSON: () => ({}),
+    });
+    setViewportHeight(460);
+
+    await user.click(trigger);
+
+    const menu = await screen.findByRole('menu');
+    await waitFor(() => expect(menu).toHaveStyle({ maxHeight: '256px', overflowY: 'auto' }));
+  });
+
+  it('updates the available height while the dropdown is open', async () => {
+    setViewportHeight(720);
+    const engine = new FlowEngine();
+    const user = userEvent.setup();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <LazyDropdown
+            trigger={['click']}
+            menu={{
+              items: [{ key: 'field', label: 'Field' }],
+            }}
+          >
+            <button type="button">Open fields</button>
+          </LazyDropdown>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open fields' });
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 196,
+      height: 32,
+      left: 49,
+      right: 141,
+      top: 164,
+      width: 92,
+      x: 49,
+      y: 164,
+      toJSON: () => ({}),
+    });
+
+    await user.click(trigger);
+
+    const menu = await screen.findByRole('menu');
+    await waitFor(() => expect(menu).toHaveStyle({ maxHeight: '400px', overflowY: 'auto' }));
+
+    act(() => {
+      setViewportHeight(460);
+      window.dispatchEvent(new Event('resize'));
+    });
+    await waitFor(() => expect(menu).toHaveStyle({ maxHeight: '256px', overflowY: 'auto' }));
+
+    act(() => {
+      setViewportHeight(720);
+      window.dispatchEvent(new Event('resize'));
+    });
+    await waitFor(() => expect(menu).toHaveStyle({ maxHeight: '400px', overflowY: 'auto' }));
+  });
+
+  it('reserves the placement offset when the dropdown has an arrow', async () => {
+    setViewportHeight(460);
+    const engine = new FlowEngine();
+    const user = userEvent.setup();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <LazyDropdown
+            arrow
+            trigger={['click']}
+            menu={{
+              items: [{ key: 'field', label: 'Field' }],
+            }}
+          >
+            <button type="button">Open fields</button>
+          </LazyDropdown>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open fields' });
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 196,
+      height: 32,
+      left: 49,
+      right: 141,
+      top: 164,
+      width: 92,
+      x: 49,
+      y: 164,
+      toJSON: () => ({}),
+    });
+
+    await user.click(trigger);
+
+    const menu = await screen.findByRole('menu');
+    await waitFor(() => expect(menu).toHaveStyle({ maxHeight: '248px', overflowY: 'auto' }));
+  });
+
+  it('uses the space above when it is larger than the space below', async () => {
+    setViewportHeight(460);
+    const engine = new FlowEngine();
+    const user = userEvent.setup();
+
+    render(
+      <FlowEngineProvider engine={engine}>
+        <ConfigProvider>
+          <LazyDropdown
+            trigger={['click']}
+            menu={{
+              items: [{ key: 'field', label: 'Field' }],
+            }}
+          >
+            <button type="button">Open fields</button>
+          </LazyDropdown>
+        </ConfigProvider>
+      </FlowEngineProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open fields' });
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 332,
+      height: 32,
+      left: 49,
+      right: 141,
+      top: 300,
+      width: 92,
+      x: 49,
+      y: 300,
+      toJSON: () => ({}),
+    });
+
+    await user.click(trigger);
+
+    const menu = await screen.findByRole('menu');
+    await waitFor(() => expect(menu).toHaveStyle({ maxHeight: '292px', overflowY: 'auto' }));
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

当浏览器窗口或页面可用高度较低时，字段、操作等配置下拉菜单仍可能保持较大的固定高度，导致菜单底部超出可视区域，用户无法查看或操作全部选项。

### Description

- 下拉菜单打开以及浏览器窗口尺寸变化时，根据触发位置上下两侧的可用空间动态限制菜单高度。
- 保留正常窗口下的 400px 高度上限；低高度下让菜单保持在可视区域内，并通过内部滚动访问全部选项。
- 将菜单与触发器之间的默认间距和箭头占用空间纳入计算，避免边缘场景仍出现裁切。
- 增加回归测试，覆盖打开前窗口高度变化、打开期间缩放、带箭头菜单以及触发器靠近视口底部等场景。

建议重点验证普通窗口和低高度窗口中的 Fields、Actions 配置菜单，确认菜单能够自动适配可用空间，并且所有选项均可滚动访问。

### Showcase

- 修复前：1280×460 视口下，菜单底部为 600px，超出视口底部 460px。
- 修复后：同一视口下，菜单底部为 456px；滚动到底后最后一个选项仍完整显示。

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix dropdown menus being cut off in short browser windows |
| 🇨🇳 Chinese | 修复浏览器窗口较矮时下拉菜单内容显示不全的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
