### PR TITLE
fix(client): polyfill APIs for supported browsers

### DIFF
--- a/packages/core/app/client-v2/rsbuild.config.ts
+++ b/packages/core/app/client-v2/rsbuild.config.ts
@@ -199,6 +199,8 @@ export default defineConfig(({ command }) => {
     },
     output: {
       target: 'web',
+      overrideBrowserslist: ['chrome >= 87', 'edge >= 88', 'firefox >= 78', 'safari >= 14'],
+      polyfill: 'usage',
       distPath: {
         root: path.resolve(__dirname, `../dist/client/${MODERN_CLIENT_DIST_DIR}`),
         js: 'assets',

--- a/packages/core/app/client/rsbuild.config.ts
+++ b/packages/core/app/client/rsbuild.config.ts
@@ -163,6 +163,8 @@ export default defineConfig(({ command }) => {
     },
     output: {
       target: 'web',
+      overrideBrowserslist: ['chrome >= 87', 'edge >= 88', 'firefox >= 78', 'safari >= 14'],
+      polyfill: 'usage',
       distPath: {
         root: path.resolve(__dirname, '../dist/client'),
         js: 'assets',


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Some supported users still run Chrome versions earlier than 92, where modern JavaScript APIs such as `Array.prototype.at` are unavailable. The client build previously transformed syntax for these browsers but did not inject runtime API polyfills.

### Description

- Explicitly define the supported browser targets for both the v1 and v2 client builds.
- Enable Rsbuild's usage-based polyfill injection so SWC includes only the required core-js modules for the configured targets.

The primary risk is a small increase in client bundle size from the required polyfills. Both client production builds and the browser checker tests have been verified.

### Related issues

N/A

### Showcase

N/A — build configuration change only.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added runtime polyfills for modern JavaScript APIs in supported older browsers |
| 🇨🇳 Chinese | 为支持范围内的旧版浏览器补充现代 JavaScript API 运行时 Polyfill |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
