### PR TITLE
fix(client-v2): handle clearing collection filter fields

### DIFF
--- a/packages/core/client-v2/src/components/form/filter/CollectionFilterItem.tsx
+++ b/packages/core/client-v2/src/components/form/filter/CollectionFilterItem.tsx
@@ -130,8 +130,10 @@ export const CollectionFilterItem: FC<CollectionFilterItemProps> = observer(
       [operatorOptions, operator],
     );
 
-    const handleFieldChange = (next: (string | number)[]) => {
-      const path = next.map(String);
+    const handleFieldChange = (next?: (string | number)[]) => {
+      // rc-cascader emits `undefined` when its clear icon is clicked in single-select mode, despite its public type
+      // declaring an array. Treat that runtime value as an empty path so clearing the field also resets the row.
+      const path = (next ?? []).map(String);
       props.value.path = path.join('.');
       const leaf = findOptionByPath(options, path);
       props.value.operator = leaf?.operators?.[0]?.value || '';

--- a/packages/core/client-v2/src/components/form/filter/__tests__/CollectionFilterItem.test.tsx
+++ b/packages/core/client-v2/src/components/form/filter/__tests__/CollectionFilterItem.test.tsx
@@ -104,6 +104,23 @@ describe('CollectionFilterItem', () => {
     });
   });
 
+  it('clears the filter row when the selected field is cleared', async () => {
+    const value = observable({ path: 'username', operator: '$eq', value: 'alice' });
+    const collection = buildStubCollection([{ name: 'username', title: 'Username' }]);
+
+    const { container } = render(<CollectionFilterItem value={value} collection={collection} />);
+
+    const clear = container.querySelector('.ant-select-clear');
+    if (!clear) throw new Error('expected Cascader clear control to be rendered');
+    fireEvent.mouseDown(clear);
+
+    await waitFor(() => {
+      expect(value.path).toBe('');
+      expect(value.operator).toBe('');
+      expect(value.value).toBeUndefined();
+    });
+  });
+
   it('clears value when the operator changes', async () => {
     const value = observable({ path: 'username', operator: '$eq', value: 'alice' });
     const collection = buildStubCollection([{ name: 'username', title: 'Username' }]);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Clearing a selected filter field in Workflow settings caused a `TypeError` because rc-cascader emits `undefined` when its single-select clear control is used, while the field-change handler assumed it would always receive an array. The exception prevented the filter condition from being cleared.

### Description

- Normalize the rc-cascader clear value to an empty field path and reset the filter operator and value.
- Add a regression test that triggers the Cascader clear control and verifies the entire filter row state is cleared.
- Keep the behavior shared across all client-v2 `CollectionFilterItem` consumers.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an error that prevented filter conditions from being cleared in workflow settings. |
| 🇨🇳 Chinese | 修复工作流设置中无法清空筛选条件并触发报错的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
