### PR TITLE
fix(client): avoid noisy filter component lookup errors

### DIFF
--- a/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
@@ -34,6 +34,8 @@ const { DateFilterDynamicComponent: DateFilterDynamicComponentLazy } = lazy(
   'DateFilterDynamicComponent',
 );
 
+const fallbackInputComponents = new Set(['Input', 'Input.URL', 'NanoIDInput']);
+
 // 简化的本地辅助：按需获取 ctx.collection 的字段树（MetaTreeNode[]）
 async function buildCollectionLeftMetaTreeLocal(ctx: any): Promise<MetaTreeNode[]> {
   const resolve = async (sub: any): Promise<MetaTreeNode[]> => {
@@ -276,9 +278,9 @@ function createStaticInputRenderer(
           onChange={(v: unknown) => onChange?.(v as VariableFilterItemValue['value'])}
         />
       );
-    // 未内置的 x-component：尝试从 app 解析组件
+    // 未直接处理的 x-component：尝试从 app 解析组件，文本输入类组件查找失败时静默回退到 Input
     if (xComp && app?.getComponent) {
-      const Comp = app.getComponent(xComp as any);
+      const Comp = app.getComponent(xComp, !fallbackInputComponents.has(xComp));
       if (Comp) {
         return (
           <Comp
@@ -595,8 +597,14 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
 
     const renderRightValueComponent = useCallback(() => {
       // 文本类多关键词：优先使用操作符 schema 声明的组件
-      const resolved = resolveOperatorComponent(model.context.app, operator, operatorMetaList);
       const supportKeyword = operator === '$in' || operator === '$notIn';
+      const operatorComponent = currentOpMeta?.schema?.['x-component'] as string | undefined;
+      const isLocallyRenderedComponent =
+        operatorComponent === 'Select' ||
+        (typeof operatorComponent === 'string' && fallbackInputComponents.has(operatorComponent));
+      const resolved = supportKeyword
+        ? resolveOperatorComponent(model.context.app, operator, operatorMetaList, !isLocallyRenderedComponent)
+        : null;
       if (resolved && supportKeyword) {
         const { Comp, props: xProps } = resolved;
         const nextProps = { ...xProps };
@@ -642,6 +650,7 @@ export const VariableFilterItem: React.FC<VariableFilterItemProps> = observer(
       disabled,
       operator,
       operatorMetaList,
+      currentOpMeta,
       rightValue,
       staticInputRenderer,
       model.context.app,

--- a/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
@@ -158,6 +158,88 @@ describe('VariableFilterItem', () => {
     expect(value.value).toBe('abc');
   });
 
+  it.each([
+    { operator: '$includes', xComponent: 'Input' },
+    { operator: '$eq', xComponent: 'Select' },
+    { operator: '$in', xComponent: 'Select' },
+  ])('uses a silent app registry lookup for the local $xComponent control', async ({ operator, xComponent }) => {
+    const value = observable({ path: '', operator: '', value: '' }) as VariableFilterItemValue;
+    const model = CreateModel();
+    const app = model.context.app as unknown as ReturnType<typeof createMockFlowApp>;
+    const getComponent = vi.spyOn(app, 'getComponent');
+
+    (globalThis as { __TEST_PATH__?: string }).__TEST_PATH__ = 'status';
+    (globalThis as { __TEST_META__?: MetaTreeNode }).__TEST_META__ = {
+      interface: 'input',
+      uiSchema: {
+        'x-component': xComponent,
+        enum: [{ label: 'Draft', value: 'draft' }],
+        'x-filter-operators': [
+          {
+            value: operator,
+            label: 'Operator',
+            selected: true,
+            schema: {
+              'x-component': xComponent,
+              'x-component-props': xComponent === 'Select' ? { mode: operator === '$in' ? 'tags' : null } : {},
+            },
+          },
+        ],
+      },
+      paths: ['collection', 'status'],
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+    };
+
+    render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+
+    await waitFor(() => {
+      expect(value.operator).toBe(operator);
+    });
+    if (xComponent === 'Select' && operator === '$eq') {
+      expect(getComponent).not.toHaveBeenCalled();
+    } else {
+      expect(getComponent).toHaveBeenCalledWith(xComponent, false);
+    }
+  });
+
+  it('continues resolving plugin-provided keyword controls from the app registry', async () => {
+    const value = observable({ path: '', operator: '', value: '' }) as VariableFilterItemValue;
+    const model = CreateModel();
+    const app = model.context.app as unknown as ReturnType<typeof createMockFlowApp>;
+    const MultipleKeywordsInput: React.FC = () => <div data-testid="multiple-keywords-input" />;
+    app.addComponents({ MultipleKeywordsInput });
+    const getComponent = vi.spyOn(app, 'getComponent');
+
+    (globalThis as { __TEST_PATH__?: string }).__TEST_PATH__ = 'name';
+    (globalThis as { __TEST_META__?: MetaTreeNode }).__TEST_META__ = {
+      interface: 'input',
+      uiSchema: {
+        'x-component': 'Input',
+        'x-filter-operators': [
+          {
+            value: '$in',
+            label: 'Is any of',
+            selected: true,
+            schema: { 'x-component': 'MultipleKeywordsInput' },
+          },
+        ],
+      },
+      paths: ['collection', 'name'],
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+    };
+
+    render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+
+    expect(await screen.findByTestId('multiple-keywords-input')).toBeTruthy();
+    expect(getComponent).toHaveBeenCalledWith('MultipleKeywordsInput');
+  });
+
   it('passes disabled through to the left selector, operator select, and right variable input', async () => {
     const value: VariableFilterItemValue = { path: '', operator: '', value: '' };
     const model = CreateModel();

--- a/packages/core/client-v2/src/flow/internal/utils/operatorSchemaHelper.ts
+++ b/packages/core/client-v2/src/flow/internal/utils/operatorSchemaHelper.ts
@@ -20,7 +20,7 @@ type OperatorMeta = {
 };
 
 type ComponentRegistry = {
-  getComponent?: (name: string) => ComponentType<Record<string, unknown>> | undefined;
+  getComponent?: (name: string, isShowError?: boolean) => ComponentType<Record<string, unknown>> | undefined;
 };
 
 type OperatorComponentFieldModel = {
@@ -67,6 +67,7 @@ export function resolveOperatorComponent(
   app: ComponentRegistry | undefined,
   operator: string,
   operators?: OperatorMeta[],
+  isShowError = true,
 ) {
   if (!operators || !Array.isArray(operators)) return null;
   const op = operators.find((item) => item?.value === operator);
@@ -77,7 +78,7 @@ export function resolveOperatorComponent(
   if (xComp === 'DateFilterDynamicComponent') {
     Comp = DateFilterDynamicComponent as ComponentType<Record<string, unknown>>;
   } else {
-    Comp = app?.getComponent?.(xComp);
+    Comp = isShowError ? app?.getComponent?.(xComp) : app?.getComponent?.(xComp, false);
   }
   if (!Comp) return null;
   const props = isRecord(schema?.['x-component-props']) ? schema['x-component-props'] : {};


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Opening the v2 table Filter popover logs repeated Component Input not found and Component Select not found errors. The controls still work because the filter renderer falls back to local Ant Design components, so these messages are false-positive registry lookup errors that obscure real console failures.

### Description

#### Changes
- Use silent registry lookups for locally rendered fallback input components while preserving registered component overrides.
- Resolve operator schema components from the application registry only for multi-keyword operators that need that path.
- Keep normal error reporting for missing plugin-provided components.
- Add regression coverage for Input, Select, multi-value Select, and MultipleKeywordsInput.

#### Current behavior and boundaries
- This PR targets next.
- Filter values, query transformation, submit/reset behavior, resource refresh, APIs, ACL, and database behavior are unchanged.
- Desktop and mobile filter actions share the updated VariableFilterItem behavior.
- Repeated Filter opens remain side-effect free apart from rendering and no longer produce false missing-component errors for the covered local controls.

#### Verification
- yarn test packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx --run --reporter=verbose: 17 tests passed.
- LinkageFilterItem.test.tsx: 7 tests passed.
- customizeFilterRender.test.tsx: 3 tests passed.
- yarn eslint --fix on all three touched files: passed.
- Scoped TypeScript diagnostics for the touched files: no diagnostics.
- git diff --check: passed.
- The repository-wide TypeScript check remains blocked by existing unrelated type errors across the monorepo; this PR does not claim that gate passes.
- Remote CI has not run yet.

#### Risks and review focus
- Risk is low because the change is limited to optional component lookup behavior and keeps the existing fallback rendering path.
- Please review silent versus required lookup classification and plugin component override compatibility.
- A browser smoke check of opening desktop and mobile v2 table filters is still recommended.

### Related issues
Task 5996

### Showcase
The v2 table Filter popover should open without false Component Input not found or Component Select not found console errors.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed false missing-component console errors when opening v2 table filters. |
| 🇨🇳 Chinese | 修复打开 v2 表格筛选器时控制台误报组件缺失的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary