### PR TITLE
fix(client): avoid DatePicker filter lookup errors

### DIFF
--- a/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/VariableFilterItem.tsx
@@ -34,7 +34,7 @@ const { DateFilterDynamicComponent: DateFilterDynamicComponentLazy } = lazy(
   'DateFilterDynamicComponent',
 );
 
-const fallbackInputComponents = new Set(['Input', 'Input.URL', 'NanoIDInput']);
+const fallbackInputComponents = new Set(['Input', 'Input.URL', 'NanoIDInput', 'DatePicker']);
 
 // 简化的本地辅助：按需获取 ctx.collection 的字段树（MetaTreeNode[]）
 async function buildCollectionLeftMetaTreeLocal(ctx: any): Promise<MetaTreeNode[]> {
@@ -278,7 +278,7 @@ function createStaticInputRenderer(
           onChange={(v: unknown) => onChange?.(v as VariableFilterItemValue['value'])}
         />
       );
-    // 未直接处理的 x-component：尝试从 app 解析组件，文本输入类组件查找失败时静默回退到 Input
+    // 未直接处理的 x-component：尝试从 app 解析组件，可由筛选器接管的过渡组件查找失败时静默回退到 Input
     if (xComp && app?.getComponent) {
       const Comp = app.getComponent(xComp, !fallbackInputComponents.has(xComp));
       if (Comp) {

--- a/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
+++ b/packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx
@@ -47,6 +47,10 @@ vi.mock('@nocobase/flow-engine', async () => {
   return { ...actual, VariableInput: MockVariableInput };
 });
 
+vi.mock('../../../models/blocks/filter-form/fields/date-time/components/DateFilterDynamicComponent', () => ({
+  DateFilterDynamicComponent: () => <div data-testid="date-filter-dynamic-component" />,
+}));
+
 const getRenderedSelectTexts = (root: ParentNode = document.body) =>
   Array.from(root.querySelectorAll('.ant-select-selection-item')).map((node) => (node.textContent || '').trim());
 
@@ -203,6 +207,45 @@ describe('VariableFilterItem', () => {
     } else {
       expect(getComponent).toHaveBeenCalledWith(xComponent, false);
     }
+  });
+
+  it('silently handles the DatePicker field schema before the date operator component takes over', async () => {
+    const value = observable({ path: '', operator: '', value: '' }) as VariableFilterItemValue;
+    const model = CreateModel();
+    const app = model.context.app as unknown as ReturnType<typeof createMockFlowApp>;
+    const getComponent = vi.spyOn(app, 'getComponent');
+
+    (globalThis as { __TEST_PATH__?: string }).__TEST_PATH__ = 'createdAt';
+    (globalThis as { __TEST_META__?: MetaTreeNode }).__TEST_META__ = {
+      interface: 'createdAt',
+      uiSchema: {
+        'x-component': 'DatePicker',
+        'x-filter-operators': [
+          {
+            value: '$dateOn',
+            label: 'Is',
+            selected: true,
+            schema: {
+              'x-component': 'DateFilterDynamicComponent',
+              'x-component-props': { isRange: false },
+            },
+          },
+        ],
+      },
+      paths: ['collection', 'createdAt'],
+      name: 'createdAt',
+      title: 'Created at',
+      type: 'date',
+    };
+
+    render(<VariableFilterItem value={value} model={model} rightAsVariable={false} />);
+    fireEvent.click(screen.getByTestId('variable-input'));
+
+    await waitFor(() => {
+      expect(value.operator).toBe('$dateOn');
+    });
+    expect(getComponent).toHaveBeenCalledWith('DatePicker', false);
+    expect(await screen.findByTestId('date-filter-dynamic-component')).toBeInTheDocument();
   });
 
   it('continues resolving plugin-provided keyword controls from the app registry', async () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Selecting a DatePicker-backed field in a v2 table Filter briefly renders the field schema before the default date operator takes over. That transitional render performs a required application component lookup and logs `Component DatePicker not found`, even though `DateFilterDynamicComponent` subsequently renders and filtering continues to work.

### Description

#### Changes
- Treat the transitional `DatePicker` lookup as an optional fallback lookup.
- Preserve registered DatePicker component resolution and the existing final date operator renderer.
- Add regression coverage for the DatePicker field-schema transition to `DateFilterDynamicComponent`.

#### Current behavior and boundaries
- This PR targets `next` and is based on commit `1e953eb591ba630c5a98203104f381ffa2939181`.
- Opening the v2 table Filter and selecting date fields no longer emits the false missing-component error.
- Date values, operator selection, query transformation, submit/reset behavior, APIs, ACL, and database behavior are unchanged.
- Repeated Filter opens are side-effect free apart from rendering.

#### Verification
- `yarn test packages/core/client-v2/src/flow/components/filter/__tests__/VariableFilterItem.test.tsx --run --reporter=dot`: 18 tests passed.
- `yarn test packages/core/client-v2/src/components/form/filter/__tests__/DateFilterDynamicComponent.test.tsx --run --reporter=dot`: 12 tests passed.
- `yarn test packages/core/client-v2/src/flow/components/filter/__tests__/LinkageFilterItem.test.tsx --run --reporter=dot`: 7 tests passed.
- `yarn test packages/core/client-v2/src/flow/models/blocks/filter-manager/flow-actions/__tests__/customizeFilterRender.test.tsx --run --reporter=dot`: 3 tests passed.
- ESLint on both touched files: passed, including the pre-commit hook.
- `git diff --check`: passed.
- Remote CI is pending and is not claimed as passed.

#### Risks and review focus
- Risk is low because the change only controls error reporting for one optional registry lookup.
- Registered DatePicker overrides are still resolved first.
- Review focus: classification of DatePicker as a silent transitional fallback.
- A browser smoke check of desktop and mobile v2 table filters is still recommended.

### Related issues
Task 5996. Follow-up to #10389.

### Showcase
Selecting Created at or another DatePicker-backed field in a v2 table Filter should no longer log `Component DatePicker not found`; the date filter control should continue to render normally.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed a false DatePicker missing-component error in v2 table filters. |
| 🇨🇳 Chinese | 修复 v2 表格筛选器误报 DatePicker 组件缺失的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary