### PR TITLE
fix: resolve aliased and dynamic RunJS variables

### DIFF
--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -10,7 +10,7 @@
 import type { ResourcerContext } from '@nocobase/resourcer';
 import { generateFlowModelRd } from '@nocobase/utils';
 import { vi } from 'vitest';
-import type { VariablePathRef } from '../template/variable-expression';
+import { analyzeVariableTemplate, type VariablePathRef } from '../template/variable-expression';
 import { authorizeVariablesResolve } from '../variables/allow-list';
 import { createFormItemRecordSlotResolvers } from '../variables/form-item-record-slot-resolvers';
 import { createBuiltInRecordSlotResolvers } from '../variables/record-slot-policy';
@@ -844,7 +844,254 @@ describe('variables:resolve allow-list authorization', () => {
   });
 
   it.each([
-    ['dynamic argument', `const path = 'ctx.popup.record.name'; await ctx.getVar(path);`],
+    ['ctx.getVar', `const abc = 'ctx.record.ccw'; await ctx.getVar(abc);`],
+    ['ctx.resolveJsonTemplate', `const abc = '{{ ctx.record.ccw }}'; await ctx.resolveJsonTemplate(abc);`],
+  ])('authorizes a persisted RunJS path passed through a const alias to %s', async (_title, code) => {
+    const session = createTokenSession();
+    const modelUid = `runjs-const-alias-${Buffer.from(code).toString('hex').slice(0, 12)}`;
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: { [modelUid]: createJsBlockModel(modelUid, code) },
+    });
+
+    const result = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.ccw }}',
+      contextParams: {
+        record: { dataSourceKey: 'main', collection: 'users', filterByTk: 1 },
+      },
+    });
+
+    expect(result.allowed).toBe(true);
+    if (!result.allowed) return;
+    expect(result.policy.allowedPaths.has(result.analysis.paths[0].canonicalKey)).toBe(true);
+    expect(result.bindingPlan.bindings).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ collection: 'users', filterByTk: 1 }),
+        prefix: [],
+      }),
+    ]);
+  });
+
+  it.each([
+    ['dot root', 'await ctx.getVar(`ctx.${root}.id`);'],
+    ['computed root', 'await ctx.getVar(`ctx[${root}].id`);'],
+  ])('fails closed for a dynamic RunJS variable root written with a %s', async (syntax, code) => {
+    const session = createTokenSession();
+    const modelUid = `runjs-dynamic-root-${syntax.replace(/ /g, '-')}`;
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: { [modelUid]: createJsBlockModel(modelUid, code) },
+    });
+    const rd = session.rd(modelUid);
+
+    const results = await Promise.all(
+      ['user', 'headers', 'record'].map((root) =>
+        authorizeVariablesResolve(ctx, {
+          rd,
+          template: `{{ ctx.${root}.id }}`,
+        }),
+      ),
+    );
+
+    expect(results.map((result) => result.allowed)).toEqual([false, false, false]);
+  });
+
+  it('authorizes only the dynamic portion of a persisted RunJS ctx.getVar path', async () => {
+    const session = createTokenSession();
+    const modelUid = 'runjs-dynamic-field-path';
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: {
+        [modelUid]: createJsBlockModel(modelUid, `const a = 'ccw'; await ctx.getVar(\`ctx.record.\${a}\`);`),
+      },
+    });
+    const contextParams = {
+      record: { dataSourceKey: 'main', collection: 'users', filterByTk: 1 },
+    };
+
+    const configuredField = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.ccw }}',
+      contextParams,
+    });
+    const anotherDynamicField = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.nickname }}',
+      contextParams,
+    });
+    const changedStaticPrefix = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.user.ccw }}',
+      contextParams,
+    });
+    const insertedPathSegment = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.profile.password }}',
+      contextParams,
+    });
+
+    expect([
+      configuredField.allowed,
+      anotherDynamicField.allowed,
+      changedStaticPrefix.allowed,
+      insertedPathSegment.allowed,
+    ]).toEqual([true, true, false, false]);
+    if (!anotherDynamicField.allowed) return;
+    expect(anotherDynamicField.policy.allowedPaths.has(anotherDynamicField.analysis.paths[0].canonicalKey)).toBe(true);
+    expect(anotherDynamicField.bindingPlan.bindings).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ collection: 'users', filterByTk: 1 }),
+        prefix: [],
+      }),
+    ]);
+  });
+
+  it('authorizes a dynamic RunJS array index without allowing static suffix changes', async () => {
+    const session = createTokenSession();
+    const modelUid = 'runjs-dynamic-index-path';
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: {
+        [modelUid]: createJsBlockModel(
+          modelUid,
+          `const i = 0;
+           const path = \`ctx.popup.record.plan_task[\${i}].containment_handler.name_ad\`;
+           await ctx.getVar(path);`,
+        ),
+      },
+    });
+    const contextParams = {
+      'popup.record': { dataSourceKey: 'main', collection: 'users', filterByTk: 1 },
+    };
+
+    const allowed = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.popup.record.plan_task[3].containment_handler.name_ad }}',
+      contextParams,
+    });
+    const changedSuffix = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.popup.record.plan_task[3].containment_handler.password }}',
+      contextParams,
+    });
+    const insertedPathSegments = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.popup.record.plan_task[0].password[0].containment_handler.name_ad }}',
+      contextParams,
+    });
+
+    expect([allowed.allowed, changedSuffix.allowed, insertedPathSegments.allowed]).toEqual([true, false, false]);
+    if (!allowed.allowed) return;
+    expect(allowed.bindingPlan.bindings).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ collection: 'users', filterByTk: 1 }),
+        prefix: ['record'],
+      }),
+    ]);
+  });
+
+  it('keeps static path segments between multiple RunJS template interpolations', async () => {
+    const session = createTokenSession();
+    const modelUid = 'runjs-multiple-dynamic-path-segments';
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: {
+        [modelUid]: createJsBlockModel(
+          modelUid,
+          `const a = 'profile';
+           const b = 'name';
+           await ctx.getVar(\`ctx.record.\${a}.fixed.\${b}\`);`,
+        ),
+      },
+    });
+    const contextParams = {
+      record: { dataSourceKey: 'main', collection: 'users', filterByTk: 1 },
+    };
+
+    const allowed = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.contact.fixed.nickname }}',
+      contextParams,
+    });
+    const commentBypass = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.foo/* .fixed. */.bar.secret }}',
+      contextParams,
+    });
+    const stringKeyBypass = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.foo[".fixed."].secret }}',
+      contextParams,
+    });
+
+    expect([allowed.allowed, commentBypass.allowed, stringKeyBypass.allowed]).toEqual([true, false, false]);
+  });
+
+  it.each([
+    {
+      title: 'double-quoted bracket key',
+      code: 'await ctx.getVar(`ctx.record["[${value}]"]`);',
+      allowedTemplate: '{{ ctx.record["[name]"] }}',
+      changedStaticTemplate: '{{ ctx.record["prefix[name]"] }}',
+    },
+    {
+      title: 'single-quoted bracket key with static affixes',
+      code: "await ctx.getVar(`ctx.record['foo[${value}]bar']`);",
+      allowedTemplate: '{{ ctx.record["foo[name]bar"] }}',
+      changedStaticTemplate: '{{ ctx.record["foo[name]suffix"] }}',
+    },
+    {
+      title: 'computed key with multiple interpolations',
+      code: 'await ctx.getVar(`ctx.record[${prefix}${suffix}]`);',
+      allowedTemplate: '{{ ctx.record.combined }}',
+      changedStaticTemplate: '{{ ctx.user.combined }}',
+    },
+  ])('authorizes a RunJS $title without allowing the dynamic hole to cross a path segment', async (testCase) => {
+    const session = createTokenSession();
+    const modelUid = `runjs-interpolated-bracket-${testCase.title}`;
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: { [modelUid]: createJsBlockModel(modelUid, testCase.code) },
+    });
+    const contextParams = {
+      record: { dataSourceKey: 'main', collection: 'users', filterByTk: 1 },
+    };
+
+    const allowed = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: testCase.allowedTemplate,
+      contextParams,
+    });
+    const changedStaticPart = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: testCase.changedStaticTemplate,
+      contextParams,
+    });
+    const crossedPathSegment = await authorizeVariablesResolve(ctx, {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.record.combined.secret }}',
+      contextParams,
+    });
+
+    expect([allowed.allowed, changedStaticPart.allowed, crossedPathSegment.allowed]).toEqual([true, false, false]);
+  });
+
+  it.each([
+    ['mutable argument', `let path = 'ctx.popup.record.name'; await ctx.getVar(path);`],
+    ['mutable dynamic argument', 'let path = `ctx.popup.record.${field}`; await ctx.getVar(path);'],
+    ['call result argument', `const path = createPath('ctx.popup.record.name'); await ctx.getVar(path);`],
+    [
+      'object member argument',
+      `const holder = { path: 'ctx.popup.record.name' }; const path = holder.path; await ctx.getVar(path);`,
+    ],
+    [
+      'object destructuring argument',
+      `const holder = { path: 'ctx.popup.record.name' };
+       Object.assign(holder, { path: 'ctx.user.id' });
+       const { path } = holder;
+       await ctx.getVar(path);`,
+    ],
     ['shadowed ctx', `(ctx) => ctx.getVar('ctx.popup.record.name');`],
     ['plain string', `const text = "ctx.getVar('ctx.popup.record.name')";`],
     ['multiple paths', `await ctx.getVar('ctx.user.id || ctx.popup.record.name');`],
@@ -865,6 +1112,18 @@ describe('variables:resolve allow-list authorization', () => {
     ],
     ['dynamic with scope', `with ({ ctx: { getVar() {} } }) ctx.getVar('ctx.popup.record.name');`],
     ['later ctx parameter', `function f(value = ctx.getVar('ctx.popup.record.name'), ctx) {}`],
+    [
+      'later static path parameter',
+      `const path = 'ctx.popup.record.name'; function f(value = ctx.getVar(path), path) {}`,
+    ],
+    [
+      'later dynamic path parameter',
+      'const path = `ctx.popup.record.${field}`; function f(value = ctx.getVar(path), path) {}',
+    ],
+    [
+      'later template parameter',
+      `const template = '{{ ctx.popup.record.name }}'; function f(value = ctx.resolveJsonTemplate(template), template) {}`,
+    ],
   ])('does not authorize persisted RunJS with a %s', async (_title, code) => {
     const session = createTokenSession();
     const modelUid = `runjs-denied-${Buffer.from(code).toString('hex').slice(0, 12)}`;
@@ -1097,6 +1356,71 @@ describe('variables:resolve allow-list authorization', () => {
 
     expect(findRoles).toHaveBeenCalledTimes(1);
     expect(findModelNodeSnapshotById).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not expose the cached contract allow-list through a returned policy', async () => {
+    const session = createTokenSession();
+    const modelUid = 'request-contract-allowed-path-isolation';
+    const findModelNodeSnapshotById = vi.fn(async () => createFlowModel(modelUid, '{{ ctx.record.name }}'));
+    const ctx = createFakeCtx({
+      findModelNodeSnapshotById,
+      token: session.token,
+    });
+    const rd = session.rd(modelUid);
+    const first = await authorizeVariablesResolve(ctx, {
+      rd,
+      template: '{{ ctx.record.name }}',
+    });
+
+    expect(first.allowed).toBe(true);
+    if (!first.allowed) return;
+    const injectedPath = analyzeVariableTemplate('{{ ctx.record.password }}', {
+      mode: 'untrusted-request',
+    }).paths[0].canonicalKey;
+    (first.policy.allowedPaths as Set<string>).add(injectedPath);
+
+    const second = await authorizeVariablesResolve(ctx, {
+      rd,
+      template: '{{ ctx.record.password }}',
+    });
+
+    expect(second.allowed).toBe(false);
+    expect(findModelNodeSnapshotById).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not expose cached record slot policies through an authorization result', async () => {
+    const session = createTokenSession();
+    const modelUid = 'request-contract-record-slot-isolation';
+    const findModelNodeSnapshotById = vi.fn(async () => createFlowModel(modelUid, '{{ ctx.record.name }}'));
+    const ctx = createFakeCtx({
+      findModelNodeSnapshotById,
+      token: session.token,
+    });
+    const rd = session.rd(modelUid);
+    const first = await authorizeVariablesResolve(ctx, {
+      rd,
+      template: '{{ ctx.record.name }}',
+    });
+
+    expect(first.allowed).toBe(true);
+    if (!first.allowed) return;
+    const recordPath = first.analysis.paths[0].canonicalKey;
+    const recordPolicy = first.recordSlotPolicies.get(recordPath);
+    expect(recordPolicy).toBeDefined();
+    if (!recordPolicy) return;
+    const injectedPath = analyzeVariableTemplate('{{ ctx.record.password }}', {
+      mode: 'untrusted-request',
+    }).paths[0].canonicalKey;
+    (first.recordSlotPolicies as Map<string, typeof recordPolicy>).set(injectedPath, recordPolicy);
+
+    const second = await authorizeVariablesResolve(ctx, {
+      rd,
+      template: '{{ ctx.record.name }}',
+    });
+
+    expect(second.allowed).toBe(true);
+    expect(second.recordSlotPolicies.has(injectedPath)).toBe(false);
+    expect(findModelNodeSnapshotById).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed only around request template analysis', async () => {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -239,6 +239,115 @@ describe('variables:resolve allow-list authorization', () => {
     expect(result.contextParams).not.toHaveProperty('user');
   });
 
+  it.each(['grid', 'form'])('authorizes form linkage variables persisted on the %s', async (owner) => {
+    const session = createTokenSession();
+    const template = {
+      value: [
+        {
+          enable: true,
+          condition: { logic: '$and', items: [] },
+          actions: [
+            {
+              name: 'linkageAssignField',
+              params: {
+                value: [
+                  { enable: true, mode: 'default', targetPath: 'staffname', value: '{{ ctx.popup.record.staffseq }}' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const stepParams = { eventSettings: { linkageRules: template } };
+    const form = {
+      ...createFlowModel('linkage-form', '{{ ctx.popup.record.formField }}'),
+      options: {
+        use: 'EditFormModel',
+        props: '{{ ctx.popup.record.formField }}',
+        ...(owner === 'form' ? { stepParams } : {}),
+      },
+    };
+    const grid = {
+      ...createFlowModel('linkage-grid', {}),
+      options: {
+        use: 'FormGridModel',
+        props: '{{ ctx.popup.record.gridField }}',
+        ...(owner === 'grid' ? { stepParams } : {}),
+      },
+      parentId: form.uid,
+      subKey: 'grid',
+    };
+    const field = {
+      ...createFlowModel('linkage-field', '{{ ctx.popup.record.childField }}'),
+      parentId: grid.uid,
+      subKey: 'items',
+    };
+    const unrelatedForm = { ...createFlowModel('unrelated-linkage-form', {}), options: { use: 'EditFormModel' } };
+    const models = Object.fromEntries([form, grid, field, unrelatedForm].map((model) => [model.uid, model]));
+    const ctx = createFakeCtx({ token: session.token, models });
+    const contextParams = {
+      'popup.record': { dataSourceKey: 'main', collection: 'users', filterByTk: '1' },
+    };
+    const request = { rd: session.rd(form.uid), template, contextParams };
+
+    const member = await authorizeVariablesResolve(ctx, request);
+    const admin = await authorizeVariablesResolve(
+      createFakeCtx({ currentRole: 'root', token: session.token, models }),
+      request,
+    );
+    const ownField = await authorizeVariablesResolve(ctx, {
+      ...request,
+      template: '{{ ctx.popup.record.formField }}',
+    });
+    const unrelated = await authorizeVariablesResolve(ctx, { ...request, rd: session.rd(unrelatedForm.uid) });
+
+    expect(member.allowed).toBe(true);
+    expect(admin.allowed).toBe(true);
+    expect(ownField.allowed).toBe(true);
+    expect(unrelated.allowed).toBe(false);
+    if (!member.allowed) return;
+    expect(member.bindingPlan.bindings).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ collection: 'users', filterByTk: '1' }),
+        prefix: ['record'],
+      }),
+    ]);
+
+    for (const fieldName of ['unconfigured', 'gridField', 'childField']) {
+      const result = await authorizeVariablesResolve(ctx, {
+        ...request,
+        template: '{{ ctx.popup.record.' + fieldName + ' }}',
+      });
+      expect(result.allowed).toBe(false);
+    }
+  });
+
+  it.each([
+    ['DetailsBlockModel', 'FormGridModel'],
+    ['EditFormModel', 'DetailsBlockModel'],
+  ])('does not inherit linkage rules for an unrelated %s/%s pair', async (formUse, gridUse) => {
+    const session = createTokenSession();
+    const template = '{{ ctx.popup.record.staffseq }}';
+    const form = { ...createFlowModel('non-form-linkage', {}), options: { use: formUse } };
+    const grid = {
+      ...createFlowModel('non-form-linkage-grid', {}),
+      options: { use: gridUse, stepParams: { eventSettings: { linkageRules: { value: template } } } },
+      parentId: form.uid,
+      subKey: 'grid',
+    };
+    const result = await authorizeVariablesResolve(
+      createFakeCtx({ token: session.token, models: { [form.uid]: form, [grid.uid]: grid } }),
+      {
+        rd: session.rd(form.uid),
+        template,
+        contextParams: { 'popup.record': { collection: 'users', filterByTk: '1' } },
+      },
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+
   it('uses a related form grid as the assign-rules contract owner', async () => {
     const session = createTokenSession();
     const template = '{{ ctx.user.company.authorizedVersion }}';

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.allow-list.test.ts
@@ -10,6 +10,11 @@
 import type { ResourcerContext } from '@nocobase/resourcer';
 import { generateFlowModelRd } from '@nocobase/utils';
 import { vi } from 'vitest';
+import {
+  MAX_RUNJS_SOURCES_PER_REQUEST,
+  MAX_RUNJS_SOURCE_LENGTH,
+  MAX_RUNJS_TOTAL_SOURCE_LENGTH,
+} from '../flow-surfaces/runjs-authoring/runtime/constants';
 import { analyzeVariableTemplate, type VariablePathRef } from '../template/variable-expression';
 import { authorizeVariablesResolve } from '../variables/allow-list';
 import { createFormItemRecordSlotResolvers } from '../variables/form-item-record-slot-resolvers';
@@ -1579,6 +1584,92 @@ describe('variables:resolve allow-list authorization', () => {
     expect(result.allowed).toBe(false);
     expect(result.policy.allowedPaths.size).toBe(0);
   });
+
+  it.each([
+    ['single source', 1, MAX_RUNJS_SOURCE_LENGTH + 1],
+    ['source count', MAX_RUNJS_SOURCES_PER_REQUEST + 1, 100],
+    ['aggregate source length', 5, Math.floor(MAX_RUNJS_TOTAL_SOURCE_LENGTH / 5) + 1],
+  ])('keeps independent model variables when the RunJS %s exceeds its AST limit', async (_title, count, length) => {
+    const session = createTokenSession();
+    const modelUid = 'runjs-budget';
+    const model = createJsBlockModel(modelUid, '');
+    const sources = Array.from(
+      { length: count },
+      (_, index) =>
+        createJsBlockModel('budget-source-' + index, "await ctx.getVar('ctx.record.scriptOnly');".padEnd(length))
+          .options,
+    );
+    const ctx = createFakeCtx({
+      token: session.token,
+      models: {
+        [modelUid]: {
+          ...model,
+          options: { ...model.options, props: { value: '{{ ctx.popup.record.id }}', sources } },
+        },
+      },
+    });
+    const request = {
+      rd: session.rd(modelUid),
+      template: '{{ ctx.popup.record.id }}',
+      contextParams: { 'popup.record': { collection: 'users', filterByTk: '1' } },
+    };
+
+    const allowed = await authorizeVariablesResolve(ctx, request);
+    const unconfigured = await authorizeVariablesResolve(ctx, {
+      ...request,
+      template: '{{ ctx.popup.record.secret }}',
+    });
+
+    expect(allowed.allowed).toBe(true);
+    expect(unconfigured.allowed).toBe(false);
+    if (!allowed.allowed) return;
+    expect(allowed.bindingPlan.bindings).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({ collection: 'users', filterByTk: '1' }),
+        prefix: ['record'],
+      }),
+    ]);
+  });
+
+  it.each(['option', 'events', 'defaultParams'])(
+    'keeps configured variables in 70 KiB legacy %s scripts available to members',
+    async (source) => {
+      const session = createTokenSession();
+      const modelUid = 'large-legacy-' + source;
+      const code = "const value = '{{ ctx.popup.record.staffseq }}';".padEnd(70 * 1024);
+      const sourceOptions =
+        source === 'defaultParams'
+          ? { flowRegistry: { custom: { steps: { run: { use: 'runjs', defaultParams: { code } } } } } }
+          : { stepParams: { chartSettings: { configure: { chart: { [source]: { raw: code } } } } } };
+      const ctx = createFakeCtx({
+        token: session.token,
+        models: {
+          [modelUid]: {
+            ...createFlowModel(modelUid, {}),
+            options: { use: 'ChartBlockModel', props: { value: '{{ ctx.popup.record.id }}' }, ...sourceOptions },
+          },
+        },
+      });
+      const request = {
+        rd: session.rd(modelUid),
+        contextParams: { 'popup.record': { collection: 'users', filterByTk: '1' } },
+      };
+
+      const independent = await authorizeVariablesResolve(ctx, { ...request, template: '{{ ctx.popup.record.id }}' });
+      const configured = await authorizeVariablesResolve(ctx, {
+        ...request,
+        template: '{{ ctx.popup.record.staffseq }}',
+      });
+      const unconfigured = await authorizeVariablesResolve(ctx, {
+        ...request,
+        template: '{{ ctx.popup.record.secret }}',
+      });
+
+      expect(independent.allowed).toBe(true);
+      expect(configured.allowed).toBe(true);
+      expect(unconfigured.allowed).toBe(false);
+    },
+  );
 
   it('uses an empty allow-list when flow model options exceed the preparation limit', async () => {
     const session = createTokenSession();

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -19,6 +19,7 @@ import {
   MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES,
   MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH,
   MAX_FLOW_MODEL_VARIABLE_TOTAL_STRING_LENGTH,
+  matchesRunJsVariablePathPattern,
   prepareFlowModelVariableSource,
 } from '../variables/runjs-variable-dependencies';
 
@@ -30,6 +31,12 @@ function createRunJsOptions(code: string, version: string | null = 'v2', setting
       },
     },
   };
+}
+
+function parseVariablePath(path: string) {
+  const ref = analyzeVariableTemplate(`{{ ${path} }}`, { mode: 'flow-model' }).paths[0];
+  if (!ref) throw new Error(`Expected a valid variable path: ${path}`);
+  return ref;
 }
 
 describe('persisted RunJS variable dependencies', () => {
@@ -52,7 +59,130 @@ describe('persisted RunJS variable dependencies', () => {
     expect(templates).toEqual(['{{ ctx.popup.record.name }}', '{{ ctx.user.id }}']);
   });
 
-  it('collects static JSON templates from direct unshadowed ctx.resolveJsonTemplate calls', () => {
+  it('collects ctx.getVar and ctx.resolveJsonTemplate paths from const string alias chains', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions(`
+          const path = 'ctx.record.ccw';
+          const pathAlias = path;
+          const template = '{{ ctx.record.name }}';
+          const templateAlias = template;
+          await ctx.getVar(path);
+          await ctx.getVar(pathAlias);
+          await ctx.resolveJsonTemplate(template);
+          await ctx.resolveJsonTemplate(templateAlias);
+        `),
+      ),
+    ).toEqual(['{{ ctx.record.ccw }}', '{{ ctx.record.name }}']);
+  });
+
+  it('collects constrained dynamic ctx.getVar path patterns', () => {
+    const prepared = prepareFlowModelVariableSource(
+      createRunJsOptions(`
+        const a = 'ccw';
+        await ctx.getVar(\`ctx.record.\${a}\`);
+        const index = 0;
+        const path = \`ctx.popup.record.plan_task[\${index}].containment_handler.name_ad\`;
+        await ctx.getVar(path);
+      `),
+    );
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(prepared.runJsPathPatterns).toEqual([
+      {
+        segments: [
+          { kind: 'static', value: 'record' },
+          { kind: 'dynamic', parts: ['', ''] },
+        ],
+      },
+      {
+        segments: [
+          { kind: 'static', value: 'popup' },
+          { kind: 'static', value: 'record' },
+          { kind: 'static', value: 'plan_task' },
+          { kind: 'dynamic', parts: ['', ''] },
+          { kind: 'static', value: 'containment_handler' },
+          { kind: 'static', value: 'name_ad' },
+        ],
+      },
+    ]);
+
+    const [recordFieldPattern, taskPattern] = prepared.runJsPathPatterns;
+    expect(matchesRunJsVariablePathPattern(parseVariablePath('ctx.record.ccw'), recordFieldPattern)).toBe(true);
+    expect(matchesRunJsVariablePathPattern(parseVariablePath('ctx.record[0]'), recordFieldPattern)).toBe(true);
+    expect(matchesRunJsVariablePathPattern(parseVariablePath('ctx.user.ccw'), recordFieldPattern)).toBe(false);
+    expect(matchesRunJsVariablePathPattern(parseVariablePath('ctx.record.ccw.name'), recordFieldPattern)).toBe(false);
+
+    expect(
+      matchesRunJsVariablePathPattern(
+        parseVariablePath('ctx.popup.record.plan_task["task-a"].containment_handler.name_ad'),
+        taskPattern,
+      ),
+    ).toBe(true);
+    expect(
+      matchesRunJsVariablePathPattern(
+        parseVariablePath('ctx.popup.record.plan_task[0].containment_handler.name_ad'),
+        taskPattern,
+      ),
+    ).toBe(true);
+    expect(
+      matchesRunJsVariablePathPattern(
+        parseVariablePath('ctx.user.record.plan_task[0].containment_handler.name_ad'),
+        taskPattern,
+      ),
+    ).toBe(false);
+    expect(
+      matchesRunJsVariablePathPattern(
+        parseVariablePath('ctx.popup.user.plan_task[0].containment_handler.name_ad'),
+        taskPattern,
+      ),
+    ).toBe(false);
+    expect(
+      matchesRunJsVariablePathPattern(
+        parseVariablePath('ctx.popup.record.plan_task[0].containment_handler.other'),
+        taskPattern,
+      ),
+    ).toBe(false);
+    expect(
+      matchesRunJsVariablePathPattern(
+        parseVariablePath('ctx.popup.record.plan_task[0].extra.containment_handler.name_ad'),
+        taskPattern,
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    ['dot root', 'await ctx.getVar(`ctx.${root}.id`);'],
+    ['bracket root', 'await ctx.getVar(`ctx[${root}].id`);'],
+  ])('does not collect a dynamic ctx.getVar path pattern from a %s', (_title, code) => {
+    const prepared = prepareFlowModelVariableSource(createRunJsOptions(code));
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(prepared.runJsPathPatterns).toEqual([]);
+  });
+
+  it.each([
+    ['let binding', 'let path = `ctx.record.${field}`; await ctx.getVar(path);'],
+    ['call result', 'const path = createPath(`ctx.record.${field}`); await ctx.getVar(path);'],
+    ['object member', 'const holder = { path: `ctx.record.${field}` }; await ctx.getVar(holder.path);'],
+    [
+      'destructuring',
+      'const holder = { path: `ctx.record.${field}` }; const { path } = holder; await ctx.getVar(path);',
+    ],
+  ])('rejects a dynamic ctx.getVar path from a %s', (_title, code) => {
+    const prepared = prepareFlowModelVariableSource(createRunJsOptions(code));
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(prepared.runJsPathPatterns).toEqual([]);
+  });
+
+  it('collects direct object and array literals passed to ctx.resolveJsonTemplate', () => {
     expect(
       collectPersistedRunJsVariableTemplates(
         createRunJsOptions(`
@@ -60,15 +190,51 @@ describe('persisted RunJS variable dependencies', () => {
             role: '{{ ctx.record.roles[0].name }}',
             nested: ['Role: {{ ctx.popup.record.name }}'],
           });
+          await ctx.resolveJsonTemplate([{ owner: '{{ ctx.record.owner.id }}' }]);
           const userId = await ctx['resolveJsonTemplate'](\`{{ ctx.user.id }}\`);
           ctx.render(data.role + userId);
         `),
       ),
-    ).toEqual(['{{ ctx.record.roles[0].name }}', 'Role: {{ ctx.popup.record.name }}', '{{ ctx.user.id }}']);
+    ).toEqual([
+      '{{ ctx.record.roles[0].name }}',
+      'Role: {{ ctx.popup.record.name }}',
+      '{{ ctx.record.owner.id }}',
+      '{{ ctx.user.id }}',
+    ]);
   });
 
   it.each([
-    ['dynamic identifier', `const template = '{{ ctx.user.id }}'; await ctx.resolveJsonTemplate(template);`],
+    [
+      'object identifier alias',
+      `const template = { name: '{{ ctx.user.id }}' };
+       await ctx.resolveJsonTemplate(template);`,
+    ],
+    [
+      'array identifier alias',
+      `const template = ['{{ ctx.user.id }}'];
+       await ctx.resolveJsonTemplate(template);`,
+    ],
+    ['let string alias', `let template = '{{ ctx.user.id }}'; await ctx.resolveJsonTemplate(template);`],
+    [
+      'call result alias',
+      `const template = createTemplate('{{ ctx.user.id }}'); await ctx.resolveJsonTemplate(template);`,
+    ],
+    [
+      'object member alias',
+      `const holder = { template: '{{ ctx.user.id }}' }; await ctx.resolveJsonTemplate(holder.template);`,
+    ],
+    [
+      'destructured alias',
+      `const holder = { template: '{{ ctx.user.id }}' };
+       const { template } = holder;
+       await ctx.resolveJsonTemplate(template);`,
+    ],
+  ])('rejects ctx.resolveJsonTemplate dependencies from a %s', (_title, code) => {
+    expect(collectPersistedRunJsVariableTemplates(createRunJsOptions(code))).toEqual([]);
+  });
+
+  it.each([
+    ['mutable identifier', `let template = '{{ ctx.user.id }}'; await ctx.resolveJsonTemplate(template);`],
     ['call result', `await ctx.resolveJsonTemplate(createTemplate('{{ ctx.user.id }}'));`],
     ['shadowed ctx', `(ctx) => ctx.resolveJsonTemplate('{{ ctx.user.id }}');`],
     ['comment', `// ctx.resolveJsonTemplate('{{ ctx.user.id }}')`],
@@ -85,8 +251,12 @@ describe('persisted RunJS variable dependencies', () => {
 
   it.each([
     {
-      title: 'dynamic arguments',
-      value: createRunJsOptions(`const path = 'ctx.popup.record.name'; await ctx.getVar(path);`),
+      title: 'mutable arguments',
+      value: createRunJsOptions(`let path = 'ctx.popup.record.name'; await ctx.getVar(path);`),
+    },
+    {
+      title: 'call result arguments',
+      value: createRunJsOptions(`const path = createPath('ctx.popup.record.name'); await ctx.getVar(path);`),
     },
     {
       title: 'shadowed ctx parameters',

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/__tests__/variables.runjs-dependencies.test.ts
@@ -391,15 +391,47 @@ describe('persisted RunJS variable dependencies', () => {
     ).toEqual(['{{ ctx.popup.record.name }}']);
   });
 
-  it('fails the whole dependency collection closed when a RunJS source exceeds its limit', () => {
+  it('skips oversized AST sources without losing other RunJS dependencies', () => {
     expect(
       collectPersistedRunJsVariableTemplates({
-        valid: createRunJsOptions(`await ctx.getVar('ctx.user.id');`),
-        oversized: createRunJsOptions(
-          `${' '.repeat(MAX_RUNJS_SOURCE_LENGTH + 1)}await ctx.getVar('ctx.popup.record.name');`,
-        ),
+        valid: createRunJsOptions("await ctx.getVar('ctx.user.id');"),
+        oversized: createRunJsOptions("await ctx.getVar('ctx.popup.record.name');".padEnd(MAX_RUNJS_SOURCE_LENGTH + 1)),
+        later: createRunJsOptions("await ctx.getVar('ctx.view.record.title');"),
       }),
-    ).toEqual([]);
+    ).toEqual(['{{ ctx.user.id }}', '{{ ctx.view.record.title }}']);
+  });
+
+  it('extracts dependencies at the exact AST source length limit', () => {
+    expect(
+      collectPersistedRunJsVariableTemplates(
+        createRunJsOptions("await ctx.getVar('ctx.user.id');".padEnd(MAX_RUNJS_SOURCE_LENGTH)),
+      ),
+    ).toEqual(['{{ ctx.user.id }}']);
+  });
+
+  it.each(['v1', 'v2'])('preserves %s template semantics when a script exceeds the AST limit', (version) => {
+    const code = [
+      '// {{ ctx.user.password }}',
+      "const value = '{{ ctx.popup.record.staffseq }}';",
+      "await ctx.getVar('ctx.view.record.name');",
+    ]
+      .join('\n')
+      .padEnd(MAX_RUNJS_SOURCE_LENGTH + 1);
+    const prepared = prepareFlowModelVariableSource({
+      independent: '{{ ctx.popup.record.id }}',
+      ...createRunJsOptions(code, version),
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([]);
+    expect(prepared.runJsPathPatterns).toEqual([]);
+    expect(
+      analyzeVariableTemplate(prepared.templateSource, { mode: 'flow-model' }).paths.map((path) => path.runtimeKey),
+    ).toEqual([
+      JSON.stringify(['popup', 'record', 'id']),
+      ...(version === 'v1' ? [JSON.stringify(['popup', 'record', 'staffseq'])] : []),
+    ]);
   });
 
   it('screens v2 RunJS code from generic template analysis while preserving static getVar dependencies', () => {
@@ -444,25 +476,50 @@ describe('persisted RunJS variable dependencies', () => {
     ]);
   });
 
-  it('fails closed when the RunJS source count exceeds its aggregate limit', () => {
-    const sources = Object.fromEntries(
-      Array.from({ length: MAX_RUNJS_SOURCES_PER_REQUEST + 1 }, (_, index) => [
-        `source${index}`,
-        createRunJsOptions(''),
-      ]),
+  it('limits the number of AST sources without discarding configured templates', () => {
+    const sources = Array.from({ length: MAX_RUNJS_SOURCES_PER_REQUEST + 1 }, (_, index) =>
+      createRunJsOptions("await ctx.getVar('ctx.record.field" + index + "');"),
     );
+    const prepared = prepareFlowModelVariableSource({ independent: '{{ ctx.user.id }}', sources });
 
-    expect(prepareFlowModelVariableSource(sources)).toEqual({ ok: false });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toHaveLength(MAX_RUNJS_SOURCES_PER_REQUEST);
+    expect(prepared.runJsTemplates).toContain('{{ ctx.record.field99 }}');
+    expect(prepared.runJsTemplates).not.toContain('{{ ctx.record.field100 }}');
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['user', 'id']),
+    ]);
   });
 
-  it('fails closed when the aggregate RunJS source length exceeds its limit', () => {
-    const code = ' '.repeat(Math.floor(MAX_RUNJS_TOTAL_SOURCE_LENGTH / 5) + 1);
-    const sources = Object.fromEntries(
-      Array.from({ length: 5 }, (_, index) => [`source${index}`, createRunJsOptions(code)]),
+  it('limits aggregate AST source length without discarding configured templates', () => {
+    const sources = Array.from({ length: MAX_RUNJS_TOTAL_SOURCE_LENGTH / MAX_RUNJS_SOURCE_LENGTH + 1 }, (_, index) =>
+      createRunJsOptions(("await ctx.getVar('ctx.record.field" + index + "');").padEnd(MAX_RUNJS_SOURCE_LENGTH)),
     );
+    const prepared = prepareFlowModelVariableSource({ independent: '{{ ctx.user.id }}', sources });
 
-    expect(code.length).toBeLessThan(MAX_RUNJS_SOURCE_LENGTH);
-    expect(prepareFlowModelVariableSource(sources)).toEqual({ ok: false });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.runJsTemplates).toEqual([
+      '{{ ctx.record.field0 }}',
+      '{{ ctx.record.field1 }}',
+      '{{ ctx.record.field2 }}',
+      '{{ ctx.record.field3 }}',
+    ]);
+    expect(analyzeVariableTemplate(prepared.templateSource).paths.map((path) => path.runtimeKey)).toEqual([
+      JSON.stringify(['user', 'id']),
+    ]);
+  });
+
+  it('still rejects scripts exceeding the model string budget', () => {
+    expect(
+      prepareFlowModelVariableSource(createRunJsOptions(' '.repeat(MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH + 1))),
+    ).toEqual({ ok: false });
+    expect(
+      prepareFlowModelVariableSource(
+        Array.from({ length: 5 }, () => createRunJsOptions(' '.repeat(MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH))),
+      ),
+    ).toEqual({ ok: false });
   });
 
   it('fails closed when a flat ordinary object exceeds the node limit', () => {

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -30,7 +30,7 @@ import {
   type ValidateContextParamsResult,
   variables,
 } from './registry';
-import { prepareFlowModelVariableSource } from './runjs-variable-dependencies';
+import { matchesRunJsVariablePathPattern, prepareFlowModelVariableSource } from './runjs-variable-dependencies';
 
 type RecordParams = {
   appends?: unknown;
@@ -367,7 +367,11 @@ async function createFlowModelVariableContractFromNode(
     : {};
   const result = analyzeVariableTemplateSafely(contractSource, { mode: 'flow-model' });
   const analysis = result.ok ? result.analysis : analyzeVariableTemplate({}, { mode: 'flow-model' });
-  return await createFlowModelVariableContract(analysis, createRecordSlotCompilerOptions(ctx, runtimeNode));
+  const contract = await createFlowModelVariableContract(analysis, createRecordSlotCompilerOptions(ctx, runtimeNode));
+  return Object.freeze({
+    ...contract,
+    allowedPathPatterns: prepared.ok ? prepared.runJsPathPatterns : [],
+  });
 }
 
 function getCurrentRoleNames(ctx: ResourcerContext): string[] {
@@ -650,27 +654,34 @@ export async function authorizeVariablesResolve(
       ? await getFlowModelVariableContract(ctx, contractNode, currentNode, contractSource)
       : null;
   const allowedPaths = contract?.allowedPaths || null;
-  recordSlotPolicies = contract?.recordSlots || new Map();
-  policy = createPolicy(false, allowedPaths || new Set(), unrestrictedVariables);
+  const allowedPathPatterns = contract?.allowedPathPatterns || [];
+  const requestAllowedPaths = new Set(allowedPaths || []);
+  const dynamicallyAllowedPaths = new Set<string>();
+  recordSlotPolicies = new Map(contract?.recordSlots || []);
+  policy = createPolicy(false, requestAllowedPaths, unrestrictedVariables);
   if (flowModelRequiredVars.size > 0 && !allowedPaths) {
     return denied(analysis, bindingPlan.contextParams, policy, recordSlotPolicies, flowModelUid || undefined);
   }
 
   for (const path of analysis.paths) {
     if (unrestrictedVariables.has(path.varName)) continue;
-    if (!allowedPaths?.has(path.canonicalKey)) {
+    if (allowedPaths?.has(path.canonicalKey)) continue;
+    if (!allowedPathPatterns.some((pathPattern) => matchesRunJsVariablePathPattern(path, pathPattern))) {
       return denied(analysis, bindingPlan.contextParams, policy, recordSlotPolicies, flowModelUid || undefined);
     }
+    requestAllowedPaths.add(path.canonicalKey);
+    dynamicallyAllowedPaths.add(path.canonicalKey);
   }
 
-  if (unrestrictedVariables.size) {
+  policy = createPolicy(false, requestAllowedPaths, unrestrictedVariables);
+  if (unrestrictedVariables.size || dynamicallyAllowedPaths.size) {
     const requestPolicies = await compileRecordSlotPolicies(
       analysis,
       createRecordSlotCompilerOptions(ctx, currentNode || undefined),
     );
     const mergedPolicies = new Map(recordSlotPolicies);
     for (const path of analysis.paths) {
-      if (!unrestrictedVariables.has(path.varName)) continue;
+      if (!unrestrictedVariables.has(path.varName) && !dynamicallyAllowedPaths.has(path.canonicalKey)) continue;
       const requestPolicy = requestPolicies.get(path.canonicalKey);
       if (requestPolicy) mergedPolicies.set(path.canonicalKey, requestPolicy);
     }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/allow-list.ts
@@ -352,10 +352,21 @@ async function createFlowModelVariableContractFromNode(
   runtimeNode: FlowModelNodeSnapshot,
   source: FlowModelContractSource,
 ) {
-  const variableSource =
+  let variableSource =
     source === 'formAssignRules'
       ? (await resolveFormAssignRulesVariableSource(ctx, contractNode)) ?? {}
       : contractNode.options;
+  if (source === 'node' && isFormAssignRulesOwnerNode(contractNode)) {
+    const grid = await getFlowModelChildNode(ctx, contractNode.uid, 'grid');
+    if (grid && isFormAssignRulesContractPair(contractNode, grid)) {
+      const stepParams = isObject(grid.options.stepParams) ? grid.options.stepParams : null;
+      const eventSettings = stepParams && isObject(stepParams.eventSettings) ? stepParams.eventSettings : null;
+      const linkageRules = eventSettings?.linkageRules;
+      if (typeof linkageRules !== 'undefined') {
+        variableSource = [variableSource, { stepParams: { eventSettings: { linkageRules } } }];
+      }
+    }
+  }
   const prepared = prepareFlowModelVariableSource(
     variableSource,
     source === 'formAssignRules' ? { isRunJsValuePath: isFormAssignRulesRunJsValuePath } : undefined,

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/record-slot-policy.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/record-slot-policy.ts
@@ -9,6 +9,7 @@
 
 import type { Application } from '@nocobase/server';
 import type { AnalyzedTemplate } from '../template/variable-expression';
+import type { RunJsVariablePathPattern } from './runjs-variable-dependencies';
 import {
   getRecordSlotResolverRegistry,
   type RecordSlotResolved,
@@ -20,6 +21,7 @@ export type RecordSlotPolicy = RecordSlotResolved;
 export type RecordSlotPolicies = ReadonlyMap<string, RecordSlotPolicy>;
 
 export type FlowModelVariableContract = Readonly<{
+  allowedPathPatterns: readonly RunJsVariablePathPattern[];
   allowedPaths: ReadonlySet<string>;
   recordSlots: RecordSlotPolicies;
 }>;
@@ -93,6 +95,7 @@ export async function createFlowModelVariableContract(
   options: CompileRecordSlotPoliciesOptions,
 ): Promise<FlowModelVariableContract> {
   return Object.freeze({
+    allowedPathPatterns: [],
     allowedPaths: new Set(analysis.paths.map((path) => path.canonicalKey)),
     recordSlots: await compileRecordSlotPolicies(analysis, options),
   });

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -9,15 +9,20 @@
 
 import { isAstFunctionLike, unwrapAstChainExpression } from '../flow-surfaces/runjs-authoring/ast/bindings';
 import { maskJavaScriptComments } from '../flow-surfaces/runjs-authoring/ast/source';
-import { collectAstIdentifierBindingsFromAst } from '../flow-surfaces/runjs-authoring/ast/static-bindings';
+import {
+  collectAstIdentifierBindingsFromAst,
+  collectStaticFilterValueBindingsFromAst,
+} from '../flow-surfaces/runjs-authoring/ast/static-bindings';
 import {
   collectAstPatternBindingIdentifiers,
   getAstMemberRootIdentifier,
   getAstStaticPropertyName,
   hasAstActiveBinding,
   isUnshadowedCtxIdentifier,
+  resolveAstAliasBinding,
   resolveAstStaticStringValue,
 } from '../flow-surfaces/runjs-authoring/ast/static-values';
+import type { AstIdentifierBinding, StaticFilterValueBinding } from '../flow-surfaces/runjs-authoring/internal-types';
 import { parseRunJsAuthoringAst } from '../flow-surfaces/runjs-authoring/ast/parser';
 import { walkAstAncestor, walkAstSimple } from '../flow-surfaces/runjs-authoring/ast/walk';
 import {
@@ -25,7 +30,7 @@ import {
   MAX_RUNJS_SOURCE_LENGTH,
   MAX_RUNJS_TOTAL_SOURCE_LENGTH,
 } from '../flow-surfaces/runjs-authoring/runtime/constants';
-import { analyzeVariableTemplate } from '../template/variable-expression';
+import { analyzeVariableTemplate, type VariablePathRef } from '../template/variable-expression';
 
 type PersistedRunJsValue = Readonly<{
   code: string;
@@ -39,6 +44,8 @@ type AstNode = Readonly<{
   computed?: boolean;
   elements?: readonly unknown[];
   expressions?: readonly unknown[];
+  id?: unknown;
+  init?: unknown;
   kind?: string;
   key?: unknown;
   left?: unknown;
@@ -49,6 +56,7 @@ type AstNode = Readonly<{
   params?: readonly unknown[];
   properties?: readonly unknown[];
   property?: unknown;
+  quasis?: readonly Readonly<{ value?: Readonly<{ cooked?: string | null; raw?: string }> }>[];
   shorthand?: boolean;
   start?: number;
   type?: string;
@@ -74,10 +82,19 @@ type EnumerableDataEntry = readonly [key: string, value: unknown];
 export type PreparedFlowModelVariableSource =
   | Readonly<{
       ok: true;
+      runJsPathPatterns: readonly RunJsVariablePathPattern[];
       runJsTemplates: readonly string[];
       templateSource: unknown;
     }>
   | Readonly<{ ok: false }>;
+
+type RunJsVariablePathSegmentPattern =
+  | Readonly<{ kind: 'dynamic'; parts: readonly string[] }>
+  | Readonly<{ kind: 'static'; value: string | number }>;
+
+export type RunJsVariablePathPattern = Readonly<{
+  segments: readonly RunJsVariablePathSegmentPattern[];
+}>;
 
 const RUNJS_VALUE_KEYS = new Set(['code', 'version']);
 const RUNJS_PATH_SUFFIXES = new Set(['stepParams.jsSettings.runJs', 'stepParams.clickSettings.runJs']);
@@ -284,8 +301,8 @@ function hasCtxMutation(ast: unknown, identifierBindings: ReturnType<typeof coll
   return mutated;
 }
 
-function createValidatedGetVarTemplate(value: unknown, code: string): string | undefined {
-  const path = resolveAstStaticStringValue(value, code)?.trim();
+function analyzeValidatedGetVarPath(value: string): Readonly<{ path: string; ref: VariablePathRef }> | undefined {
+  const path = value.trim();
   if (!path) return;
   const template = `{{${path}}}`;
   const analysis = analyzeVariableTemplate(template, { mode: 'flow-model' });
@@ -306,23 +323,285 @@ function createValidatedGetVarTemplate(value: unknown, code: string): string | u
   ) {
     return;
   }
-  return `{{ ${path} }}`;
+  return { path, ref: variablePath };
 }
 
-function resolveStaticJsonValue(node: unknown, code: string): StaticJsonResult {
+function createValidatedGetVarTemplateFromPath(value: string): string | undefined {
+  const validated = analyzeValidatedGetVarPath(value);
+  return validated ? `{{ ${validated.path} }}` : undefined;
+}
+
+function createValidatedGetVarTemplate(
+  value: unknown,
+  code: string,
+  staticValueBindings: StaticFilterValueBinding[],
+  identifierBindings: AstIdentifierBinding[],
+): string | undefined {
+  const path = resolveConstString(value, code, staticValueBindings, identifierBindings);
+  return typeof path === 'string' ? createValidatedGetVarTemplateFromPath(path) : undefined;
+}
+
+function resolveConstString(
+  value: unknown,
+  code: string,
+  staticValueBindings: StaticFilterValueBinding[],
+  identifierBindings: AstIdentifierBinding[],
+  seen: Set<StaticFilterValueBinding> = new Set(),
+): string | undefined {
+  const valueNode = unwrapAstChainExpression(value) as AstNode | undefined;
+  if (!valueNode) return;
+  const directValue = resolveAstStaticStringValue(valueNode, code);
+  if (typeof directValue === 'string') return directValue;
+  if (valueNode.type !== 'Identifier' || !valueNode.name) return;
+  const binding = resolveAstAliasBinding(valueNode.name, valueNode.start || 0, staticValueBindings, identifierBindings);
+  if (!binding || seen.has(binding)) return;
+  seen.add(binding);
+  return resolveConstString(binding.valueNode, code, staticValueBindings, identifierBindings, seen);
+}
+
+function collectConstIdentifierValueBindings(
+  ast: unknown,
+  code: string,
+  identifierBindings: AstIdentifierBinding[],
+): StaticFilterValueBinding[] {
+  const simpleInitializers = new WeakMap<object, Set<string>>();
+  walkAstAncestor(ast, {
+    VariableDeclarator(node: AstNode, ancestors: AstNode[]) {
+      const declaration = ancestors[ancestors.length - 2];
+      const id = unwrapAstChainExpression(node.id) as AstNode | undefined;
+      const initializer = unwrapAstChainExpression(node.init);
+      if (
+        declaration?.type !== 'VariableDeclaration' ||
+        declaration.kind !== 'const' ||
+        id?.type !== 'Identifier' ||
+        !initializer ||
+        typeof initializer !== 'object'
+      ) {
+        return;
+      }
+      if (!id.name) return;
+      const names = simpleInitializers.get(initializer) || new Set<string>();
+      names.add(id.name);
+      simpleInitializers.set(initializer, names);
+    },
+  });
+  return collectStaticFilterValueBindingsFromAst(ast, code, identifierBindings).filter((binding) => {
+    const valueNode = unwrapAstChainExpression(binding.valueNode);
+    return !!valueNode && typeof valueNode === 'object' && simpleInitializers.get(valueNode)?.has(binding.name);
+  });
+}
+
+function resolveDynamicTemplateLiteral(
+  node: unknown,
+  staticValueBindings: StaticFilterValueBinding[],
+  identifierBindings: AstIdentifierBinding[],
+  seen: Set<StaticFilterValueBinding> = new Set(),
+): AstNode | undefined {
+  const valueNode = unwrapAstChainExpression(node) as AstNode | undefined;
+  if (!valueNode) return;
+  if (valueNode.type === 'TemplateLiteral' && valueNode.expressions?.length) return valueNode;
+  if (valueNode.type !== 'Identifier' || !valueNode.name) return;
+
+  const binding = resolveAstAliasBinding(valueNode.name, valueNode.start || 0, staticValueBindings, identifierBindings);
+  if (!binding || seen.has(binding)) return;
+  seen.add(binding);
+  return resolveDynamicTemplateLiteral(binding.valueNode, staticValueBindings, identifierBindings, seen);
+}
+
+function createDynamicPathSentinel(index: number, parts: readonly string[]) {
+  let suffix = 0;
+  let sentinel = `__nocobase_dynamic_path_${index}_${suffix}__`;
+  while (parts.some((part) => part.includes(sentinel))) {
+    suffix += 1;
+    sentinel = `__nocobase_dynamic_path_${index}_${suffix}__`;
+  }
+  return sentinel;
+}
+
+function getDynamicOnlyBracketValue(value: string, sentinels: readonly string[]) {
+  const matchedSentinels = new Set<string>();
+  const dynamicParts: string[] = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    if (/\s/.test(value[cursor])) {
+      cursor += 1;
+      continue;
+    }
+    const sentinel = sentinels.find(
+      (candidate) => !matchedSentinels.has(candidate) && value.startsWith(candidate, cursor),
+    );
+    if (!sentinel) return;
+    matchedSentinels.add(sentinel);
+    dynamicParts.push(sentinel);
+    cursor += sentinel.length;
+  }
+  return dynamicParts.length ? dynamicParts.join('') : undefined;
+}
+
+function quoteDynamicOnlyBracketSegments(value: string, sentinels: readonly string[]) {
+  const brackets: Array<{ end: number; start: number }> = [];
+  const bracketStarts: number[] = [];
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (character === '\\') {
+        index += 1;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '[') {
+      bracketStarts.push(index);
+      continue;
+    }
+    if (character !== ']' || !bracketStarts.length) continue;
+    brackets.push({ start: bracketStarts.pop() as number, end: index });
+  }
+
+  let candidate = value;
+  for (const bracket of brackets.sort((left, right) => right.start - left.start)) {
+    const dynamicValue = getDynamicOnlyBracketValue(candidate.slice(bracket.start + 1, bracket.end), sentinels);
+    if (!dynamicValue) continue;
+    candidate = `${candidate.slice(0, bracket.start + 1)}${JSON.stringify(dynamicValue)}${candidate.slice(
+      bracket.end,
+    )}`;
+  }
+  return candidate;
+}
+
+function createPathSegmentPattern(
+  value: string | number,
+  sentinels: readonly string[],
+  matchedSentinels: Set<string>,
+): RunJsVariablePathSegmentPattern | undefined {
+  if (typeof value === 'number') return Object.freeze({ kind: 'static', value });
+
+  const occurrences = sentinels
+    .map((sentinel) => ({ index: value.indexOf(sentinel), sentinel }))
+    .filter((occurrence) => occurrence.index >= 0)
+    .sort((left, right) => left.index - right.index);
+  if (!occurrences.length) return Object.freeze({ kind: 'static', value });
+
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const occurrence of occurrences) {
+    if (
+      matchedSentinels.has(occurrence.sentinel) ||
+      value.indexOf(occurrence.sentinel, occurrence.index + occurrence.sentinel.length) >= 0 ||
+      occurrence.index < cursor
+    ) {
+      return;
+    }
+    parts.push(value.slice(cursor, occurrence.index));
+    cursor = occurrence.index + occurrence.sentinel.length;
+    matchedSentinels.add(occurrence.sentinel);
+  }
+  parts.push(value.slice(cursor));
+  return Object.freeze({ kind: 'dynamic', parts: Object.freeze(parts) });
+}
+
+function getFunctionParameterEnvironmentNames(ancestors: readonly AstNode[]) {
+  const names = new Set<string>();
+  for (let index = 0; index < ancestors.length - 1; index += 1) {
+    const ancestor = ancestors[index];
+    if (!isAstFunctionLike(ancestor)) continue;
+    if (!(ancestor.params || []).includes(ancestors[index + 1])) continue;
+    for (const parameter of ancestor.params || []) {
+      collectAstPatternBindingIdentifiers(parameter, (name: string) => names.add(name));
+    }
+  }
+  return names;
+}
+
+function hasFunctionParameterBindingInArgument(argument: unknown, ancestors: readonly AstNode[]) {
+  const parameterNames = getFunctionParameterEnvironmentNames(ancestors);
+  if (!parameterNames.size || !argument) return false;
+  let matched = false;
+  walkAstAncestor(argument, {
+    Identifier(node: AstNode, argumentAncestors: AstNode[]) {
+      const parent = argumentAncestors[argumentAncestors.length - 2];
+      if (!isNonReferenceIdentifier(node, parent) && node.name && parameterNames.has(node.name)) matched = true;
+    },
+  });
+  return matched;
+}
+
+function createValidatedGetVarPathPattern(
+  value: unknown,
+  staticValueBindings: StaticFilterValueBinding[],
+  identifierBindings: AstIdentifierBinding[],
+): RunJsVariablePathPattern | undefined {
+  const templateLiteral = resolveDynamicTemplateLiteral(value, staticValueBindings, identifierBindings);
+  if (!templateLiteral) return;
+
+  const parts = (templateLiteral.quasis || []).map((quasi) => quasi.value?.cooked ?? quasi.value?.raw ?? '');
+  if (parts.length !== (templateLiteral.expressions?.length || 0) + 1) return;
+  parts[0] = parts[0].trimStart();
+  parts[parts.length - 1] = parts[parts.length - 1].trimEnd();
+  const sentinels = parts.slice(0, -1).map((_part, index) => createDynamicPathSentinel(index, parts));
+
+  let candidate = parts[0];
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    candidate += sentinels[index] + parts[index + 1];
+  }
+  candidate = quoteDynamicOnlyBracketSegments(candidate, sentinels);
+  const validated = analyzeValidatedGetVarPath(candidate);
+  if (!validated) return;
+  if (sentinels.some((sentinel) => validated.ref.varName.includes(sentinel))) return;
+  const matchedSentinels = new Set<string>();
+  const segments = [validated.ref.varName, ...validated.ref.runtimeSegments].map((segment) =>
+    createPathSegmentPattern(segment, sentinels, matchedSentinels),
+  );
+  if (segments.some((segment) => !segment) || matchedSentinels.size !== sentinels.length) return;
+  return Object.freeze({
+    segments: Object.freeze(segments as RunJsVariablePathSegmentPattern[]),
+  });
+}
+
+export function matchesRunJsVariablePathPattern(pathRef: VariablePathRef, pattern: RunJsVariablePathPattern) {
+  const values = [pathRef.varName, ...pathRef.runtimeSegments];
+  if (values.length !== pattern.segments.length) return false;
+  return pattern.segments.every((segment, index) => {
+    const value = values[index];
+    if (segment.kind === 'static') return value === segment.value;
+    if (typeof value === 'number') return segment.parts.every((part) => part.length === 0);
+    if (!value.startsWith(segment.parts[0])) return false;
+
+    let cursor = segment.parts[0].length;
+    for (let partIndex = 1; partIndex < segment.parts.length - 1; partIndex += 1) {
+      const nextIndex = value.indexOf(segment.parts[partIndex], cursor);
+      if (nextIndex < 0) return false;
+      cursor = nextIndex + segment.parts[partIndex].length;
+    }
+    const suffix = segment.parts[segment.parts.length - 1];
+    const suffixStart = value.length - suffix.length;
+    return suffixStart >= cursor && value.startsWith(suffix, suffixStart);
+  });
+}
+
+function resolveStaticJsonValue(
+  node: unknown,
+  code: string,
+  staticValueBindings: StaticFilterValueBinding[],
+  identifierBindings: AstIdentifierBinding[],
+): StaticJsonResult {
   const valueNode = unwrapAstChainExpression(node) as AstNode | undefined;
   if (!valueNode) return { ok: false };
+  const stringValue = resolveConstString(valueNode, code, staticValueBindings, identifierBindings);
+  if (typeof stringValue === 'string') return { ok: true, value: stringValue };
+  if (valueNode.type === 'Identifier') return { ok: false };
   if (valueNode.type === 'Literal') {
     const literalValue = valueNode.value;
     if (literalValue === null) return { ok: true, value: null };
-    if (typeof literalValue === 'string') return { ok: true, value: literalValue };
     if (typeof literalValue === 'boolean') return { ok: true, value: literalValue };
     if (typeof literalValue === 'number' && Number.isFinite(literalValue)) return { ok: true, value: literalValue };
     return { ok: false };
-  }
-  if (valueNode.type === 'TemplateLiteral' && !valueNode.expressions?.length) {
-    const value = resolveAstStaticStringValue(valueNode, code);
-    return typeof value === 'string' ? { ok: true, value } : { ok: false };
   }
   if (valueNode.type === 'UnaryExpression' && valueNode.operator === '-') {
     const argument = unwrapAstChainExpression(valueNode.argument) as AstNode | undefined;
@@ -334,7 +613,7 @@ function resolveStaticJsonValue(node: unknown, code: string): StaticJsonResult {
     const value: StaticJsonValue[] = [];
     for (const element of valueNode.elements || []) {
       if (!element || (element as AstNode).type === 'SpreadElement') return { ok: false };
-      const resolved = resolveStaticJsonValue(element, code);
+      const resolved = resolveStaticJsonValue(element, code, staticValueBindings, identifierBindings);
       if (!resolved.ok) return resolved;
       value.push(resolved.value);
     }
@@ -364,7 +643,7 @@ function resolveStaticJsonValue(node: unknown, code: string): StaticJsonResult {
     if (typeof key !== 'string' || key === '__proto__' || Object.prototype.hasOwnProperty.call(value, key)) {
       return { ok: false };
     }
-    const resolved = resolveStaticJsonValue(property.value, code);
+    const resolved = resolveStaticJsonValue(property.value, code, staticValueBindings, identifierBindings);
     if (!resolved.ok) return resolved;
     value[key] = resolved.value;
   }
@@ -391,33 +670,60 @@ function collectValidatedResolveJsonTemplates(value: StaticJsonValue): string[] 
   return Array.from(templates);
 }
 
-function extractStaticVariableTemplates(code: string): string[] {
+function extractStaticVariableDependencies(code: string): Readonly<{
+  pathPatterns: readonly RunJsVariablePathPattern[];
+  templates: readonly string[];
+}> {
   const parsed = parseRunJsAuthoringAst(code);
-  if (!parsed.ast) return [];
+  if (!parsed.ast) return { pathPatterns: [], templates: [] };
 
   const identifierBindings = collectAstIdentifierBindingsFromAst(parsed.ast, code);
   if (hasUnsafeCtxUsage(parsed.ast, identifierBindings) || hasCtxMutation(parsed.ast, identifierBindings)) {
-    return [];
+    return { pathPatterns: [], templates: [] };
   }
 
+  const staticValueBindings = collectConstIdentifierValueBindings(parsed.ast, code, identifierBindings);
   const functionCtxParameterCache = new WeakMap<object, boolean>();
+  const pathPatterns = new Map<string, RunJsVariablePathPattern>();
   const templates = new Set<string>();
   walkAstAncestor(parsed.ast, {
     CallExpression(node: AstNode, ancestors: AstNode[]) {
       const methodName = getDirectCtxMethodName(node.callee, identifierBindings);
-      if (hasCtxParameterInFunctionAncestors(ancestors, functionCtxParameterCache)) return;
+      if (
+        hasCtxParameterInFunctionAncestors(ancestors, functionCtxParameterCache) ||
+        hasFunctionParameterBindingInArgument(node.arguments?.[0], ancestors)
+      ) {
+        return;
+      }
       if (methodName === 'getVar') {
-        const template = createValidatedGetVarTemplate(node.arguments?.[0], code);
+        const pathPattern = createValidatedGetVarPathPattern(
+          node.arguments?.[0],
+          staticValueBindings,
+          identifierBindings,
+        );
+        if (pathPattern) {
+          pathPatterns.set(JSON.stringify(pathPattern), pathPattern);
+          return;
+        }
+        const template = createValidatedGetVarTemplate(
+          node.arguments?.[0],
+          code,
+          staticValueBindings,
+          identifierBindings,
+        );
         if (template) templates.add(template);
         return;
       }
       if (methodName !== 'resolveJsonTemplate' || node.arguments?.length !== 1) return;
-      const resolved = resolveStaticJsonValue(node.arguments[0], code);
+      const resolved = resolveStaticJsonValue(node.arguments[0], code, staticValueBindings, identifierBindings);
       if (!resolved.ok) return;
       collectValidatedResolveJsonTemplates(resolved.value).forEach((template) => templates.add(template));
     },
   });
-  return Array.from(templates);
+  return {
+    pathPatterns: Array.from(pathPatterns.values()),
+    templates: Array.from(templates),
+  };
 }
 
 export function prepareFlowModelVariableSource(
@@ -425,6 +731,7 @@ export function prepareFlowModelVariableSource(
   options: Readonly<{ isRunJsValuePath?: (pathTail: readonly string[]) => boolean }> = {},
 ): PreparedFlowModelVariableSource {
   try {
+    const pathPatterns = new Map<string, RunJsVariablePathPattern>();
     const templates = new Set<string>();
     const seen = new WeakSet<object>();
     const root: Record<string, unknown> = Object.create(null);
@@ -490,7 +797,9 @@ export function prepareFlowModelVariableSource(
             entryKey === 'code' ? (runJs.version === 'v2' ? '' : maskJavaScriptComments(runJs.code)) : entryValue;
           defineTraversalValue(output, entryKey, preparedEntryValue);
         }
-        extractStaticVariableTemplates(runJs.code).forEach((template) => templates.add(template));
+        const dependencies = extractStaticVariableDependencies(runJs.code);
+        dependencies.templates.forEach((template) => templates.add(template));
+        dependencies.pathPatterns.forEach((pattern) => pathPatterns.set(JSON.stringify(pattern), pattern));
         continue;
       }
 
@@ -510,7 +819,12 @@ export function prepareFlowModelVariableSource(
       }
     }
 
-    return { ok: true, runJsTemplates: Array.from(templates), templateSource: root.value };
+    return {
+      ok: true,
+      runJsPathPatterns: Array.from(pathPatterns.values()),
+      runJsTemplates: Array.from(templates),
+      templateSource: root.value,
+    };
   } catch {
     return { ok: false };
   }

--- a/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
+++ b/packages/plugins/@nocobase/plugin-flow-engine/src/server/variables/runjs-variable-dependencies.ts
@@ -778,17 +778,12 @@ export function prepareFlowModelVariableSource(
 
       if (runJs) {
         scheduledNodes += entries.length;
-        sourceCount += 1;
         totalStringLength += runJs.code.length + (runJs.version?.length || 0);
-        totalSourceLength += runJs.code.length;
         if (
           scheduledNodes > MAX_FLOW_MODEL_VARIABLE_SOURCE_NODES ||
           runJs.code.length > MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH ||
           (runJs.version != null && runJs.version.length > MAX_FLOW_MODEL_VARIABLE_STRING_LENGTH) ||
-          totalStringLength > MAX_FLOW_MODEL_VARIABLE_TOTAL_STRING_LENGTH ||
-          sourceCount > MAX_RUNJS_SOURCES_PER_REQUEST ||
-          runJs.code.length > MAX_RUNJS_SOURCE_LENGTH ||
-          totalSourceLength > MAX_RUNJS_TOTAL_SOURCE_LENGTH
+          totalStringLength > MAX_FLOW_MODEL_VARIABLE_TOTAL_STRING_LENGTH
         ) {
           return { ok: false };
         }
@@ -797,6 +792,16 @@ export function prepareFlowModelVariableSource(
             entryKey === 'code' ? (runJs.version === 'v2' ? '' : maskJavaScriptComments(runJs.code)) : entryValue;
           defineTraversalValue(output, entryKey, preparedEntryValue);
         }
+        // AST limits only skip dependency extraction; configured templates still use the model's string budget.
+        if (
+          sourceCount >= MAX_RUNJS_SOURCES_PER_REQUEST ||
+          runJs.code.length > MAX_RUNJS_SOURCE_LENGTH ||
+          totalSourceLength + runJs.code.length > MAX_RUNJS_TOTAL_SOURCE_LENGTH
+        ) {
+          continue;
+        }
+        sourceCount += 1;
+        totalSourceLength += runJs.code.length;
         const dependencies = extractStaticVariableDependencies(runJs.code);
         dependencies.templates.forEach((template) => templates.add(template));
         dependencies.pathPatterns.forEach((pattern) => pathPatterns.set(JSON.stringify(pattern), pattern));


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
RunJS code can pass a variable path through a `const` string alias, such as `ctx.getVar(abc)` when `abc` contains `ctx.record.ccw`, or construct a path with a dynamic segment such as ``ctx.getVar(`ctx.record.${a}`)``. The server-side dependency analysis did not recognize these valid dependencies, so authorized REST variable-resolution requests could be rejected.

### Description 
This change:

- Resolves `const` string alias chains passed to `ctx.getVar()` and `ctx.resolveJsonTemplate()`.
- Supports constrained dynamic path segments and dynamic array indexes in RunJS `ctx.getVar()` paths.
- Keeps fixed roots, static path segments, suffixes, and path depth enforced by the allow-list; dynamic roots and unsupported expressions continue to fail closed.
- Copies request-specific allow-list paths and record-slot policies before adding dynamically matched paths, preventing request data from mutating the cached contract.
- Adds regression coverage for aliases, dynamic segments, bracket keys, static-path enforcement, and request isolation.

Potential risk is limited to the new static analysis and matching logic. Expressions that cannot be proven safe remain rejected.

Validation completed:

- `variables.runjs-dependencies.test.ts`: 84/84 passed
- `variables.allow-list.test.ts`: 96/96 passed
- `variables.record-slot-policy.test.ts`: 12/12 passed
- Targeted ESLint: passed
- `git diff --check`: passed

### Related issues
N/A

### Showcase
N/A (server-side fix)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where RunJS variables using const aliases or dynamic path segments could not be resolved |
| 🇨🇳 Chinese | 修复 RunJS 变量使用 const 别名或动态路径片段时无法解析的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
