### PR TITLE
fix: incorrect encryption field key backup

### DIFF
--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/backup.test.ts
@@ -12,7 +12,7 @@ import { BackupManager, BackupSettings } from '../../managers/backup';
 import { MockServer } from '@nocobase/test';
 import path from 'path';
 import { storagePathJoin } from '@nocobase/utils';
-import { BACKUP_EXTENSION, METADATA_EXTENSION, SETTINGS } from '../../utils';
+import { BACKUP_EXTENSION, ENCRYPTION_FIELD_KEYS_DIRECTORY, METADATA_EXTENSION, SETTINGS } from '../../utils';
 import fs from 'fs';
 import * as cp from 'child_process';
 import PluginFileManagerServer from '@nocobase/plugin-file-manager';
@@ -56,9 +56,13 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 const backupFileBaseName = 'backup_for_unit_tests';
-const backupFilesFolder = storagePathJoin('backups', 'main');
+const backupAppName = 'backup-manager-unit-tests';
+const backupFilesFolder = storagePathJoin('backups', backupAppName);
 const finalBackupFilePath = path.join(backupFilesFolder, `${backupFileBaseName}.${BACKUP_EXTENSION}`);
 const finalMetadataFilePath = path.join(backupFilesFolder, `${backupFileBaseName}${METADATA_EXTENSION}`);
+const encryptionFieldKeysFolder = storagePathJoin('apps', backupAppName, ENCRYPTION_FIELD_KEYS_DIRECTORY);
+const encryptionFieldKey = Buffer.alloc(32, 1).toString('base64');
+const secondaryEncryptionFieldKey = Buffer.alloc(32, 2).toString('base64');
 
 async function listZipEntries(filePath: string) {
   return await new Promise<string[]>((resolve, reject) => {
@@ -89,13 +93,15 @@ describe('BackupManager', async () => {
   };
 
   beforeEach(async () => {
-    app = await getApp();
+    app = await getApp({ name: backupAppName });
     await fs.promises.mkdir(backupFilesFolder, { recursive: true });
     await fs.promises.unlink(finalBackupFilePath).catch(() => {});
+    await fs.promises.rm(encryptionFieldKeysFolder, { recursive: true, force: true });
   });
 
   afterEach(async () => {
     await app.destroy();
+    await fs.promises.rm(encryptionFieldKeysFolder, { recursive: true, force: true });
   });
 
   afterAll(async () => {
@@ -114,6 +120,8 @@ describe('BackupManager', async () => {
       await backupManager.backup(backupFileBaseName);
       const files = await fs.promises.readdir(backupFilesFolder);
       expect(files).toContain(`${backupFileBaseName}.${BACKUP_EXTENSION}`);
+      const entries = await listZipEntries(finalBackupFilePath);
+      expect(entries).toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/`);
     });
 
     it('should generate a backup file with encryption', async () => {
@@ -124,6 +132,51 @@ describe('BackupManager', async () => {
       await backupManager.backup(backupFileBaseName);
       const files = await fs.promises.readdir(backupFilesFolder);
       expect(files).toContain(`${backupFileBaseName}.nbdata`);
+    });
+
+    it('should include all encryption field keys in the backup', async () => {
+      const encryptionFieldKeyFile = path.join(encryptionFieldKeysFolder, 'prime.key');
+      const secondaryEncryptionFieldKeyFile = path.join(encryptionFieldKeysFolder, 'secondary.key');
+      await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+      await fs.promises.writeFile(encryptionFieldKeyFile, encryptionFieldKey);
+      await fs.promises.writeFile(secondaryEncryptionFieldKeyFile, secondaryEncryptionFieldKey);
+
+      const backupManager = new BackupManager(app, null, defaultBackupSettings);
+      await backupManager.backup(backupFileBaseName);
+
+      const entries = await listZipEntries(finalBackupFilePath);
+      expect(entries).toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/prime.key`);
+      expect(entries).toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/secondary.key`);
+    });
+
+    it('should only include regular key files in the backup', async () => {
+      const ignoredTextFile = path.join(encryptionFieldKeysFolder, 'ignored.txt');
+      const nestedKeyDirectory = path.join(encryptionFieldKeysFolder, 'nested');
+      const nestedKeyFile = path.join(nestedKeyDirectory, 'nested.key');
+      const keyDirectory = path.join(encryptionFieldKeysFolder, 'directory.key');
+      const symlinkTargetFile = path.join(encryptionFieldKeysFolder, 'symlink-target');
+      const symlinkKeyFile = path.join(encryptionFieldKeysFolder, 'symlink.key');
+      await fs.promises.mkdir(nestedKeyDirectory, { recursive: true });
+      await fs.promises.mkdir(keyDirectory);
+      await fs.promises.writeFile(path.join(encryptionFieldKeysFolder, 'valid.key'), encryptionFieldKey);
+      await fs.promises.writeFile(ignoredTextFile, 'not a key');
+      await fs.promises.writeFile(nestedKeyFile, encryptionFieldKey);
+      await fs.promises.writeFile(symlinkTargetFile, encryptionFieldKey);
+      if (process.platform !== 'win32') {
+        await fs.promises.symlink(symlinkTargetFile, symlinkKeyFile);
+      }
+
+      const backupManager = new BackupManager(app, null, defaultBackupSettings);
+      await backupManager.backup(backupFileBaseName);
+
+      const entries = await listZipEntries(finalBackupFilePath);
+      expect(entries).toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/valid.key`);
+      expect(entries).not.toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/ignored.txt`);
+      expect(entries).not.toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/nested/nested.key`);
+      expect(entries).not.toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/directory.key`);
+      if (process.platform !== 'win32') {
+        expect(entries).not.toContain(`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/symlink.key`);
+      }
     });
 
     it('should upload using configured cloud storage when backup options omit storageId', async () => {
@@ -231,7 +284,7 @@ describe('BackupManager', async () => {
         getTableNameWithSchemaAsString: () => 'business_records',
       };
       const fakeApp = {
-        name: 'main',
+        name: backupAppName,
         db: {
           options: {
             dialect: 'mysql',
@@ -461,7 +514,8 @@ describe('BackupManager', async () => {
 
     it('should reject sibling files that only match the backup directory prefix', async () => {
       const backupManager = new BackupManager(app, null, defaultBackupSettings);
-      const siblingDir = path.join(path.dirname(backupFilesFolder), 'main_evil');
+      const siblingDirectoryName = `${backupAppName}_evil`;
+      const siblingDir = path.join(path.dirname(backupFilesFolder), siblingDirectoryName);
       const siblingFileName = 'prefix-collision.nbdata';
       const siblingFilePath = path.join(siblingDir, siblingFileName);
 
@@ -469,7 +523,7 @@ describe('BackupManager', async () => {
         await fs.promises.mkdir(siblingDir, { recursive: true });
         await fs.promises.writeFile(siblingFilePath, 'malicious sibling file');
 
-        await expect(backupManager.destroy(`../main_evil/${siblingFileName}`)).rejects.toThrow(
+        await expect(backupManager.destroy(`../${siblingDirectoryName}/${siblingFileName}`)).rejects.toThrow(
           /(FILE_NOT_FOUND|not found)/,
         );
         await expect(fs.promises.readFile(siblingFilePath, 'utf8')).resolves.toBe('malicious sibling file');
@@ -524,7 +578,8 @@ describe('BackupManager', async () => {
 
     it('should reject sibling files that only match the backup directory prefix', async () => {
       const backupManager = new BackupManager(app, null, defaultBackupSettings);
-      const siblingDir = path.join(path.dirname(backupFilesFolder), 'main_evil');
+      const siblingDirectoryName = `${backupAppName}_evil`;
+      const siblingDir = path.join(path.dirname(backupFilesFolder), siblingDirectoryName);
       const siblingFileName = 'prefix-collision.nbdata';
       const siblingFilePath = path.join(siblingDir, siblingFileName);
 
@@ -532,7 +587,7 @@ describe('BackupManager', async () => {
         await fs.promises.mkdir(siblingDir, { recursive: true });
         await fs.promises.writeFile(siblingFilePath, 'malicious sibling file');
 
-        await expect(backupManager.createReadStream(`../main_evil/${siblingFileName}`)).rejects.toThrow(
+        await expect(backupManager.createReadStream(`../${siblingDirectoryName}/${siblingFileName}`)).rejects.toThrow(
           /(FILE_NOT_FOUND|not found)/,
         );
       } finally {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/__tests__/managers/restore.test.ts
@@ -11,7 +11,7 @@ import * as cp from 'child_process';
 import archiver from 'archiver';
 import path from 'path';
 import { storagePathJoin } from '@nocobase/utils';
-import { BACKUP_EXTENSION, getDBVersion, SETTINGS } from '../../utils';
+import { BACKUP_EXTENSION, ENCRYPTION_FIELD_KEYS_DIRECTORY, getDBVersion, SETTINGS } from '../../utils';
 import { getApp } from '..';
 import fs from 'fs';
 import { MockServer, sleep } from '@nocobase/test/server';
@@ -58,11 +58,23 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
-const backupFilesFolder = storagePathJoin('backups', 'main');
+const restoreAppName = 'restore-manager-unit-tests';
+const backupFilesFolder = storagePathJoin('backups', restoreAppName);
 const schemaMismatchBackupFilePath = path.join(backupFilesFolder, `backup_schema_mismatch.${BACKUP_EXTENSION}`);
+const encryptionFieldKeysFolder = storagePathJoin('apps', restoreAppName, ENCRYPTION_FIELD_KEYS_DIRECTORY);
+const encryptionFieldKeysParentFolder = path.dirname(encryptionFieldKeysFolder);
+const restoreTempFolder = storagePathJoin('tmp', 'backups', restoreAppName);
 const createdBackupFilePaths = new Set<string>();
+const sourceEncryptionFieldKey = Buffer.alloc(32, 1).toString('base64');
+const existingEncryptionFieldKey = Buffer.alloc(32, 2).toString('base64');
+const tolerentModeUploadFileName = `${restoreAppName}-tolerent-mode.txt`;
+const tolerentModeUploadFilePath = storagePathJoin('uploads', tolerentModeUploadFileName);
 
-async function createBackupArchive(filePath: string, metadata: Record<string, any>) {
+async function createBackupArchive(
+  filePath: string,
+  metadata: Record<string, unknown>,
+  extraFiles: Record<string, string> = {},
+) {
   createdBackupFilePaths.add(filePath);
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
   await new Promise<void>((resolve, reject) => {
@@ -77,6 +89,9 @@ async function createBackupArchive(filePath: string, metadata: Record<string, an
     archive.pipe(output);
     archive.append('mocked database backup', { name: 'data' });
     archive.append(JSON.stringify(metadata, null, 2), { name: '_metadata.json' });
+    for (const [name, content] of Object.entries(extraFiles)) {
+      archive.append(content, { name });
+    }
     archive.finalize().catch(reject);
   });
 }
@@ -91,6 +106,38 @@ function createBackupFile(caseName: string) {
   };
 }
 
+async function expectNoExtractedDirectory(backupFileBaseName: string) {
+  const entries = await fs.promises.readdir(restoreTempFolder, { withFileTypes: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  });
+  expect(entries.some((entry) => entry.isDirectory() && entry.name.startsWith(`${backupFileBaseName}-`))).toBe(false);
+}
+
+async function findEncryptionFieldKeysReplacementDirectories() {
+  const entries = await fs.promises.readdir(encryptionFieldKeysParentFolder, { withFileTypes: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  });
+  return entries
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        (entry.name.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`) ||
+          entry.name.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`)),
+    )
+    .map((entry) => path.join(encryptionFieldKeysParentFolder, entry.name));
+}
+
+async function cleanupEncryptionFieldKeysReplacementDirectories() {
+  const directories = await findEncryptionFieldKeysReplacementDirectories();
+  await Promise.all(directories.map((directory) => fs.promises.rm(directory, { recursive: true, force: true })));
+}
+
 describe('RestoreManager', () => {
   let app: MockServer;
   const defaultBackupSettings: BackupSettings = {
@@ -102,9 +149,13 @@ describe('RestoreManager', () => {
   };
 
   beforeEach(async () => {
-    app = await getApp();
+    app = await getApp({ name: restoreAppName });
     await fs.promises.mkdir(backupFilesFolder, { recursive: true });
     await fs.promises.unlink(schemaMismatchBackupFilePath).catch(() => {});
+    await fs.promises.rm(encryptionFieldKeysFolder, { recursive: true, force: true });
+    await cleanupEncryptionFieldKeysReplacementDirectories();
+    await fs.promises.rm(restoreTempFolder, { recursive: true, force: true });
+    await fs.promises.rm(tolerentModeUploadFilePath, { force: true });
 
     mockExecImplementation = (command, _options, callback) => {
       if (command.includes('-f')) {
@@ -169,6 +220,10 @@ describe('RestoreManager', () => {
       await fs.promises.unlink(backupFilePath).catch(() => {});
     }
     createdBackupFilePaths.clear();
+    await fs.promises.rm(encryptionFieldKeysFolder, { recursive: true, force: true });
+    await cleanupEncryptionFieldKeysReplacementDirectories();
+    await fs.promises.rm(restoreTempFolder, { recursive: true, force: true });
+    await fs.promises.rm(tolerentModeUploadFilePath, { force: true });
   });
 
   afterAll(async () => {
@@ -210,6 +265,18 @@ describe('RestoreManager', () => {
         body: requestBody,
       },
     };
+  }
+
+  function createRestoreManager() {
+    return new RestoreManager(createCtx(), {
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      host: 'localhost',
+      port: 5432,
+      schema: 'source_schema',
+    });
   }
 
   function createStatusCache() {
@@ -254,7 +321,8 @@ describe('RestoreManager', () => {
       i18n: app.i18n,
     };
     const restoreManager = new RestoreManager(ctx);
-    const siblingDir = path.join(path.dirname(backupFilesFolder), 'main_evil');
+    const siblingDirectoryName = `${restoreAppName}_evil`;
+    const siblingDir = path.join(path.dirname(backupFilesFolder), siblingDirectoryName);
     const siblingFileName = `prefix-collision.${BACKUP_EXTENSION}`;
     const siblingFilePath = path.join(siblingDir, siblingFileName);
 
@@ -262,9 +330,9 @@ describe('RestoreManager', () => {
       await fs.promises.mkdir(siblingDir, { recursive: true });
       await fs.promises.writeFile(siblingFilePath, 'malicious sibling file');
 
-      await expect(restoreManager.restoreFromBackup(`../main_evil/${siblingFileName}`, 'task_id')).rejects.toThrow(
-        /(FILE_NOT_FOUND|not found)/,
-      );
+      await expect(
+        restoreManager.restoreFromBackup(`../${siblingDirectoryName}/${siblingFileName}`, 'task_id'),
+      ).rejects.toThrow(/(FILE_NOT_FOUND|not found)/);
     } finally {
       await fs.promises.unlink(siblingFilePath).catch(() => {});
       await fs.promises.rm(siblingDir, { recursive: true, force: true }).catch(() => {});
@@ -327,9 +395,945 @@ describe('RestoreManager', () => {
     expect(settings.encryptionPassword).toBe('');
   });
 
+  it('should restore encryption field keys through the CLI restore flow', async () => {
+    const { backupFileBaseName, backupFilePath } = createBackupFile('restore-cli-encryption-field-keys');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(restoredKeyFile, existingEncryptionFieldKey);
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restoreCLI(backupFilePath);
+
+    await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    expect(fs.existsSync(existingKeyFile)).toBe(false);
+    await expectNoExtractedDirectory(backupFileBaseName);
+  });
+
+  it('should replace encryption field keys before upgrading and ignore invalid entries', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const secondaryKeyFile = path.join(encryptionFieldKeysFolder, 'secondary.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    const ignoredTextFile = path.join(encryptionFieldKeysFolder, 'ignored.txt');
+    const nestedKeyFile = path.join(encryptionFieldKeysFolder, 'nested', 'nested.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/secondary.key`]: existingEncryptionFieldKey,
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/ignored.txt`]: 'not a key',
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/nested/nested.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(path.dirname(nestedKeyFile), { recursive: true });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    await fs.promises.writeFile(restoredKeyFile, existingEncryptionFieldKey);
+    await fs.promises.writeFile(ignoredTextFile, 'existing text');
+    await fs.promises.writeFile(nestedKeyFile, 'existing nested key');
+    let restoredKeyAtUpgrade: string | undefined;
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockImplementation(async () => {
+      restoredKeyAtUpgrade = await fs.promises.readFile(restoredKeyFile, 'utf8');
+    });
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id');
+
+    await vi.waitFor(async () => {
+      expect(runCommandSpy).toHaveBeenCalledWith('upgrade');
+      await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    });
+    expect(restoredKeyAtUpgrade).toBe(sourceEncryptionFieldKey);
+    await expect(fs.promises.readFile(secondaryKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    expect(fs.existsSync(existingKeyFile)).toBe(false);
+    expect(fs.existsSync(ignoredTextFile)).toBe(false);
+    expect(fs.existsSync(nestedKeyFile)).toBe(false);
+  });
+
+  it('should preserve existing encryption field keys when restoring a legacy backup', async () => {
+    const { backupFilePath } = createBackupFile('restore-legacy-encryption-field-keys');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb());
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id');
+
+    await vi.waitFor(() => {
+      expect(runCommandSpy).toHaveBeenCalledWith('upgrade');
+    });
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+  });
+
+  it('should clear existing encryption field keys when the backup contains an empty key directory', async () => {
+    const { backupFilePath } = createBackupFile('restore-empty-encryption-field-keys');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/`]: '',
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restoreCLI(backupFilePath);
+
+    await expect(fs.promises.readdir(encryptionFieldKeysFolder)).resolves.toEqual([]);
+  });
+
+  it('should not restore stale extracted encryption field keys from a legacy backup', async () => {
+    const { backupFileBaseName, backupFilePath } = createBackupFile('restore-legacy-with-stale-extracted-key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    const staleExtractedKeyFile = path.join(
+      restoreTempFolder,
+      backupFileBaseName,
+      ENCRYPTION_FIELD_KEYS_DIRECTORY,
+      'stale.key',
+    );
+    const staleTargetKeyFile = path.join(encryptionFieldKeysFolder, 'stale.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb());
+    await fs.promises.mkdir(path.dirname(staleExtractedKeyFile), { recursive: true });
+    await fs.promises.writeFile(staleExtractedKeyFile, sourceEncryptionFieldKey);
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id');
+
+    await vi.waitFor(() => {
+      expect(runCommandSpy).toHaveBeenCalledWith('upgrade');
+    });
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    expect(fs.existsSync(staleTargetKeyFile)).toBe(false);
+  });
+
+  it('should set restrictive permissions on restored encryption field keys', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const { backupFilePath } = createBackupFile('restore-encryption-field-key-permissions');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id');
+
+    await vi.waitFor(async () => {
+      expect(runCommandSpy).toHaveBeenCalledWith('upgrade');
+      expect(fs.existsSync(restoredKeyFile)).toBe(true);
+    });
+    const directoryMode = (await fs.promises.stat(encryptionFieldKeysFolder)).mode & 0o777;
+    const fileMode = (await fs.promises.stat(restoredKeyFile)).mode & 0o777;
+    expect(directoryMode).toBe(0o700);
+    expect(fileMode).toBe(0o600);
+  });
+
+  it('should replace encryption field keys without renaming across filesystems', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-same-filesystem');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      if (path.dirname(oldPath.toString()) !== path.dirname(newPath.toString())) {
+        const error = new Error('Cross-device link not permitted') as NodeJS.ErrnoException;
+        error.code = 'EXDEV';
+        throw error;
+      }
+      await rename(oldPath, newPath);
+    });
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restoreCLI(backupFilePath);
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    expect(fs.existsSync(existingKeyFile)).toBe(false);
+  });
+
+  it('should preserve previous encryption field keys when installation and rollback both fail', async () => {
+    const { backupFileBaseName, backupFilePath } = createBackupFile('restore-encryption-field-keys-rollback-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    const revertDatabaseFile = path.join(restoreTempFolder, 'before-restore', 'data');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    await fs.promises.mkdir(path.dirname(revertDatabaseFile), { recursive: true });
+    await fs.promises.writeFile(revertDatabaseFile, 'mocked database backup');
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const source = oldPath.toString();
+      const destination = newPath.toString();
+      if (
+        destination === encryptionFieldKeysFolder &&
+        source.startsWith(path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`))
+      ) {
+        throw new Error('mock rollback failure');
+      }
+      if (
+        destination === encryptionFieldKeysFolder &&
+        source.startsWith(path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`))
+      ) {
+        throw new Error('mock installation failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+
+    try {
+      const restoreManager = createRestoreManager();
+      await expect(restoreManager.restoreCLI(backupFilePath)).rejects.toThrow(
+        'Failed to roll back the encryption field keys',
+      );
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    if (!previousDirectory) {
+      throw new Error('Previous encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+    expect(fs.existsSync(encryptionFieldKeysFolder)).toBe(false);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`The keys were preserved at "${previousDirectory}"`),
+      expect.any(Object),
+    );
+    await expectNoExtractedDirectory(backupFileBaseName);
+  });
+
+  it('should fail CLI restore when restored encryption field keys cannot be activated', async () => {
+    const { backupFilePath } = createBackupFile('restore-cli-encryption-field-keys-activation-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const sourceName = path.basename(oldPath.toString());
+      if (
+        newPath.toString() === encryptionFieldKeysFolder &&
+        sourceName.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`) &&
+        !sourceName.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`)
+      ) {
+        throw new Error('mock encryption field key activation failure');
+      }
+      await rename(oldPath, newPath);
+    });
+
+    try {
+      const restoreManager = createRestoreManager();
+      await expect(restoreManager.restoreCLI(backupFilePath, undefined, false, true)).rejects.toThrow(
+        'Failed to activate the restored encryption field keys',
+      );
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const restoredDirectory = replacementDirectories.find(
+      (directory) =>
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`) &&
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`),
+    );
+    expect(restoredDirectory).toBeDefined();
+    if (!restoredDirectory) {
+      throw new Error('Restored encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(restoredDirectory, 'source.key'), 'utf8')).resolves.toBe(
+      sourceEncryptionFieldKey,
+    );
+  });
+
+  it('should stop recovery when encryption field key staging fails and the database is not reverted', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-staging-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const copyFile = fs.promises.copyFile.bind(fs.promises);
+    const copyFileSpy = vi.spyOn(fs.promises, 'copyFile').mockImplementation(async (source, destination, mode) => {
+      if (destination.toString().endsWith(`${path.sep}source.key`)) {
+        throw new Error('mock encryption field key staging failure');
+      }
+      await copyFile(source, destination, mode);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id', undefined, false, true);
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Restored encryption field keys are unavailable'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      copyFileSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).not.toHaveBeenCalled();
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+  });
+
+  it('should preserve uploads and the AES key when encryption field key staging fails', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-staging-failure-file-order');
+    const uploadFileName = `${restoreAppName}-staging-failure.txt`;
+    const uploadFilePath = storagePathJoin('uploads', uploadFileName);
+    const aesKeyPath = storagePathJoin('apps', restoreAppName, 'aes_key.dat');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    const revertDatabaseFile = path.join(restoreTempFolder, 'before-restore', 'data');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`uploads/${uploadFileName}`]: 'restored upload',
+      'aes_key.dat': 'restored AES key',
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.mkdir(path.dirname(uploadFilePath), { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    await fs.promises.writeFile(uploadFilePath, 'existing upload');
+    await fs.promises.writeFile(aesKeyPath, 'existing AES key');
+    await fs.promises.mkdir(path.dirname(revertDatabaseFile), { recursive: true });
+    await fs.promises.writeFile(revertDatabaseFile, 'mocked database backup');
+    const copyFile = fs.promises.copyFile.bind(fs.promises);
+    const copyFileSpy = vi.spyOn(fs.promises, 'copyFile').mockImplementation(async (source, destination, mode) => {
+      if (destination.toString().endsWith(`${path.sep}source.key`)) {
+        throw new Error('mock encryption field key staging failure');
+      }
+      await copyFile(source, destination, mode);
+    });
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restoreCLI(backupFilePath);
+
+      await expect(fs.promises.readFile(uploadFilePath, 'utf8')).resolves.toBe('existing upload');
+      await expect(fs.promises.readFile(aesKeyPath, 'utf8')).resolves.toBe('existing AES key');
+      await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    } finally {
+      copyFileSpy.mockRestore();
+      await fs.promises.rm(uploadFilePath, { force: true });
+      await fs.promises.rm(aesKeyPath, { force: true });
+    }
+  });
+
+  it('should stop recovery when active encryption field keys cannot be preserved', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-preserve-active-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      if (
+        oldPath.toString() === encryptionFieldKeysFolder &&
+        path.basename(newPath.toString()).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`)
+      ) {
+        throw new Error('mock preserving active encryption field keys failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id', undefined, false, true);
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to preserve the active encryption field keys'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).not.toHaveBeenCalled();
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const restoredDirectory = replacementDirectories.find(
+      (directory) =>
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`) &&
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`),
+    );
+    expect(restoredDirectory).toBeDefined();
+    if (!restoredDirectory) {
+      throw new Error('Restored encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(restoredDirectory, 'source.key'), 'utf8')).resolves.toBe(
+      sourceEncryptionFieldKey,
+    );
+  });
+
+  it('should stop recovery when encryption field key installation and rollback both fail', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-installation-rollback-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const source = oldPath.toString();
+      const destination = newPath.toString();
+      if (
+        destination === encryptionFieldKeysFolder &&
+        (source.startsWith(
+          path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+        ) ||
+          source.startsWith(path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`)))
+      ) {
+        throw new Error('mock encryption field key installation and rollback failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id');
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to roll back encryption field keys.'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).not.toHaveBeenCalled();
+    expect(fs.existsSync(encryptionFieldKeysFolder)).toBe(false);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    if (!previousDirectory) {
+      throw new Error('Previous encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+  });
+
+  it('should stop recovery and preserve both key sets when installation fails and database revert is skipped', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-installation-failure-skip-revert');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const source = oldPath.toString();
+      const destination = newPath.toString();
+      if (
+        destination === encryptionFieldKeysFolder &&
+        (source.startsWith(
+          path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+        ) ||
+          source.startsWith(path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`)))
+      ) {
+        throw new Error('mock encryption field key activation failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id', undefined, false, true);
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to activate the restored encryption field keys.'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).not.toHaveBeenCalled();
+    expect(fs.existsSync(encryptionFieldKeysFolder)).toBe(false);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    const restoredDirectory = replacementDirectories.find(
+      (directory) =>
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`) &&
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    expect(restoredDirectory).toBeDefined();
+    if (!previousDirectory || !restoredDirectory) {
+      throw new Error('Encryption field key recovery directories were not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+    await expect(fs.promises.readFile(path.join(restoredDirectory, 'source.key'), 'utf8')).resolves.toBe(
+      sourceEncryptionFieldKey,
+    );
+  });
+
+  it('should stop recovery and preserve both key sets when installation and database revert both fail', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-installation-and-db-revert-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    const revertDatabaseFile = path.join(restoreTempFolder, 'before-restore', 'data');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    let installationFailed = false;
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const source = oldPath.toString();
+      const destination = newPath.toString();
+      if (
+        destination === encryptionFieldKeysFolder &&
+        (source.startsWith(
+          path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+        ) ||
+          source.startsWith(path.join(encryptionFieldKeysParentFolder, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`)))
+      ) {
+        if (!installationFailed) {
+          installationFailed = true;
+          await fs.promises.rm(revertDatabaseFile, { force: true });
+        }
+        throw new Error('mock encryption field key activation failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id');
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to activate the restored encryption field keys.'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).not.toHaveBeenCalled();
+    expect(fs.existsSync(encryptionFieldKeysFolder)).toBe(false);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    const restoredDirectory = replacementDirectories.find(
+      (directory) =>
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`) &&
+        !path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    expect(restoredDirectory).toBeDefined();
+    if (!previousDirectory || !restoredDirectory) {
+      throw new Error('Encryption field key recovery directories were not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+    await expect(fs.promises.readFile(path.join(restoredDirectory, 'source.key'), 'utf8')).resolves.toBe(
+      sourceEncryptionFieldKey,
+    );
+  });
+
+  it('should restore previous encryption field keys when upgrade fails and the database is reverted', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-upgrade-failure');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockRejectedValueOnce(new Error('mock upgrade failure'))
+      .mockResolvedValue(undefined);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id');
+
+    await vi.waitFor(() => {
+      expect(runCommandSpy).toHaveBeenCalledTimes(2);
+    });
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    expect(fs.existsSync(restoredKeyFile)).toBe(false);
+  });
+
+  it('should stop recovery when restored encryption field keys cannot be moved for rollback', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-active-rollback-failure');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      if (
+        oldPath.toString() === encryptionFieldKeysFolder &&
+        path.basename(newPath.toString()).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`)
+      ) {
+        throw new Error('mock active keys rollback failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockRejectedValueOnce(new Error('mock upgrade failure'))
+      .mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id');
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to remove the restored encryption field keys while rolling back.'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).toHaveBeenCalledTimes(1);
+    await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    if (!previousDirectory) {
+      throw new Error('Previous encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+  });
+
+  it('should stop recovery and reactivate restored keys when previous encryption field keys cannot be restored', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-previous-rollback-failure');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      if (
+        newPath.toString() === encryptionFieldKeysFolder &&
+        path.basename(oldPath.toString()).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`)
+      ) {
+        throw new Error('mock previous keys rollback failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockRejectedValueOnce(new Error('mock upgrade failure'))
+      .mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id');
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('The restored keys remain active.'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).toHaveBeenCalledTimes(1);
+    await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    if (!previousDirectory) {
+      throw new Error('Previous encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+  });
+
+  it('should stop recovery and preserve both key sets when encryption field key rollback cannot reactivate either set', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-complete-rollback-failure');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const sourceName = path.basename(oldPath.toString());
+      if (
+        newPath.toString() === encryptionFieldKeysFolder &&
+        (sourceName.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`) ||
+          sourceName.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`))
+      ) {
+        throw new Error('mock encryption field keys reactivation failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const loggerErrorSpy = vi.spyOn(app.logger, 'error');
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockRejectedValueOnce(new Error('mock upgrade failure'))
+      .mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id');
+
+      await vi.waitFor(() => {
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('but could not be reinstalled'),
+          expect.any(Object),
+        );
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(runCommandSpy).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(encryptionFieldKeysFolder)).toBe(false);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    const discardedDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    expect(discardedDirectory).toBeDefined();
+    if (!previousDirectory || !discardedDirectory) {
+      throw new Error('Encryption field key rollback directories were not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+    await expect(fs.promises.readFile(path.join(discardedDirectory, 'source.key'), 'utf8')).resolves.toBe(
+      sourceEncryptionFieldKey,
+    );
+  });
+
+  it('should keep restored encryption field keys when database revert is skipped after an upgrade failure', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-skip-revert');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockRejectedValueOnce(new Error('mock upgrade failure'))
+      .mockResolvedValue(undefined);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id', undefined, false, true);
+
+    await vi.waitFor(() => {
+      expect(runCommandSpy).toHaveBeenCalledTimes(2);
+    });
+    await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    expect(fs.existsSync(existingKeyFile)).toBe(false);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    if (!previousDirectory) {
+      throw new Error('Previous encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+  });
+
+  it('should keep restored encryption field keys when database revert fails after an upgrade failure', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-revert-failure');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    const revertDatabaseFile = path.join(restoreTempFolder, 'before-restore', 'data');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockImplementationOnce(async () => {
+        await fs.promises.rm(revertDatabaseFile, { force: true });
+        throw new Error('mock upgrade failure');
+      })
+      .mockResolvedValue(undefined);
+
+    const restoreManager = createRestoreManager();
+    await restoreManager.restore(backupFilePath, 'task_id');
+
+    await vi.waitFor(() => {
+      expect(runCommandSpy).toHaveBeenCalledTimes(2);
+    });
+    await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+    expect(fs.existsSync(existingKeyFile)).toBe(false);
+    const replacementDirectories = await findEncryptionFieldKeysReplacementDirectories();
+    const previousDirectory = replacementDirectories.find((directory) =>
+      path.basename(directory).startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`),
+    );
+    expect(previousDirectory).toBeDefined();
+    if (!previousDirectory) {
+      throw new Error('Previous encryption field keys directory was not preserved');
+    }
+    await expect(fs.promises.readFile(path.join(previousDirectory, 'existing.key'), 'utf8')).resolves.toBe(
+      existingEncryptionFieldKey,
+    );
+  });
+
+  it('should revert encryption field keys even when restore diagnostics fail', async () => {
+    const { backupFilePath } = createBackupFile('restore-encryption-field-keys-diagnostics-failure');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const querySpy = vi.spyOn(app.db.sequelize, 'query').mockRejectedValueOnce(new Error('mock diagnostics failure'));
+    const runCommandSpy = vi
+      .spyOn(app, 'runCommand')
+      .mockRejectedValueOnce(new Error('mock upgrade failure'))
+      .mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id', undefined, true);
+
+      await vi.waitFor(() => {
+        expect(runCommandSpy).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      querySpy.mockRestore();
+    }
+
+    await expect(fs.promises.readFile(existingKeyFile, 'utf8')).resolves.toBe(existingEncryptionFieldKey);
+    expect(fs.existsSync(restoredKeyFile)).toBe(false);
+  });
+
+  it('should activate staged encryption field keys before continuing a tolerent restore', async () => {
+    const { backupFilePath } = createBackupFile('restore-tolerent-mode-encryption-field-key-installation-failure');
+    const restoredKeyFile = path.join(encryptionFieldKeysFolder, 'source.key');
+    const existingKeyFile = path.join(encryptionFieldKeysFolder, 'existing.key');
+    await createBackupArchive(backupFilePath, await createMetadataCompatibleWithCurrentDb(), {
+      [`${ENCRYPTION_FIELD_KEYS_DIRECTORY}/source.key`]: sourceEncryptionFieldKey,
+    });
+    await fs.promises.mkdir(encryptionFieldKeysFolder, { recursive: true });
+    await fs.promises.writeFile(existingKeyFile, existingEncryptionFieldKey);
+    const rename = fs.promises.rename.bind(fs.promises);
+    let installationFailed = false;
+    const renameSpy = vi.spyOn(fs.promises, 'rename').mockImplementation(async (oldPath, newPath) => {
+      const sourceName = path.basename(oldPath.toString());
+      if (
+        !installationFailed &&
+        newPath.toString() === encryptionFieldKeysFolder &&
+        sourceName.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`) &&
+        !sourceName.startsWith(`.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-`)
+      ) {
+        installationFailed = true;
+        throw new Error('ignored encryption field key installation failure');
+      }
+      await rename(oldPath, newPath);
+    });
+    const runCommandSpy = vi.spyOn(app, 'runCommand').mockResolvedValue(undefined);
+
+    try {
+      const restoreManager = createRestoreManager();
+      await restoreManager.restore(backupFilePath, 'task_id', undefined, true);
+
+      await vi.waitFor(async () => {
+        expect(runCommandSpy).toHaveBeenCalledTimes(1);
+        await expect(fs.promises.readFile(restoredKeyFile, 'utf8')).resolves.toBe(sourceEncryptionFieldKey);
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(fs.existsSync(existingKeyFile)).toBe(false);
+    await expect(findEncryptionFieldKeysReplacementDirectories()).resolves.toEqual([]);
+  });
+
   it('restore with tolerentMode', async () => {
-    const { backupFilePath } = createBackupFile('restore-tolerent-mode');
-    await createBackupArchive(backupFilePath, createMetadata());
+    const { backupFileBaseName, backupFilePath } = createBackupFile('restore-tolerent-mode');
+    await createBackupArchive(backupFilePath, createMetadata(), {
+      [`uploads/${tolerentModeUploadFileName}`]: 'restored upload',
+    });
     const ctx = {
       app: app,
       logger: app.logger,
@@ -363,6 +1367,8 @@ describe('RestoreManager', () => {
     await vi.waitFor(() => {
       expect(runCommandSpy).toHaveBeenCalledTimes(2);
     });
+    await expect(fs.promises.readFile(tolerentModeUploadFilePath, 'utf8')).resolves.toBe('restored upload');
+    await expectNoExtractedDirectory(backupFileBaseName);
     settings = await app.db.getRepository(SETTINGS).findOne();
     // after the restore, the backup encryption should be disabled
     expect(settings.encryptionPassword).toBe('');
@@ -383,6 +1389,7 @@ describe('RestoreManager', () => {
     await expect(
       restoreManager.restore(schemaMismatchBackupFilePath, 'task_id', undefined, true, true),
     ).rejects.toThrow(/database schema mismatch/i);
+    await expectNoExtractedDirectory('backup_schema_mismatch');
   });
 
   it('allows PostgreSQL schema mismatch with force schema restore', async () => {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/backup.ts
@@ -25,6 +25,7 @@ import {
   BACKUPS,
   BACKUP_EXTENSION,
   BACKUP_TASKS_CACHE_NAME,
+  ENCRYPTION_FIELD_KEYS_DIRECTORY,
   FILE_ENCRYPTION_SALT,
   METADATA_EXTENSION,
   PLUGIN_BACKUPS_NAME,
@@ -75,6 +76,11 @@ type BackupSettingsInput = BackupSettings & {
   toJSON?: () => Partial<BackupSettings>;
 };
 
+type EncryptionFieldKeyBackup = {
+  name: string;
+  content: Buffer;
+};
+
 export class BackupManager {
   app: Application;
   ctx: ResourcerContext | null; // when triggered by cron job, ctx is null
@@ -86,6 +92,7 @@ export class BackupManager {
   #tempDir: string;
   #uploadDir: string;
   #aesKeyPath: string;
+  #encryptionFieldKeysPath: string;
 
   constructor(app: Application, ctx: ResourcerContext | null, settings: BackupSettingsInput) {
     this.app = app;
@@ -98,6 +105,7 @@ export class BackupManager {
     this.#tempDir = storagePathJoin('tmp', 'backups', app.name);
     this.#uploadDir = storagePathJoin('uploads');
     this.#aesKeyPath = storagePathJoin('apps', app.name, 'aes_key.dat');
+    this.#encryptionFieldKeysPath = storagePathJoin('apps', app.name, ENCRYPTION_FIELD_KEYS_DIRECTORY);
   }
 
   protected set backupPrefix(backupPrefix: string) {
@@ -203,11 +211,12 @@ export class BackupManager {
         includeTables: opts.includeTables,
         excludeTables: opts.excludeTables,
       });
+      const encryptionFieldKeys = await this.#readEncryptionFieldKeys();
       // save the metadata
       await this.#metadataBackup(opts, contentPath);
       // 3. compress the backup files
       const password = opts.encryptionPassword || undefined;
-      const filePath = await this.#compressFiles(contentPath, fileBaseName, password, opts);
+      const filePath = await this.#compressFiles(contentPath, fileBaseName, password, opts, encryptionFieldKeys);
       // upload files first, if success, then do the cleanup
       await this.#uploadFiles(filePath, opts.storageId);
       return filePath;
@@ -280,7 +289,13 @@ export class BackupManager {
     }
   }
 
-  async #compressFiles(dir: string, fileBaseName: string, password: string | undefined, opts: BackupSettings) {
+  async #compressFiles(
+    dir: string,
+    fileBaseName: string,
+    password: string | undefined,
+    opts: BackupSettings,
+    encryptionFieldKeys: EncryptionFieldKeyBackup[],
+  ) {
     const archive = archiver('zip', {
       zlib: { level: 9 },
     });
@@ -370,6 +385,9 @@ export class BackupManager {
         archive.file(this.#aesKeyPath, { name: 'aes_key.dat' });
       }
 
+      // backup the encryption field keys
+      this.#appendEncryptionFieldKeys(archive, encryptionFieldKeys);
+
       // Finalize the archive
       await archive.finalize();
 
@@ -383,6 +401,51 @@ export class BackupManager {
       outputFileStream.close();
     }
     return filePath;
+  }
+
+  #appendEncryptionFieldKeys(archive: ReturnType<typeof archiver>, encryptionFieldKeys: EncryptionFieldKeyBackup[]) {
+    // Keep an explicit directory entry so a new backup with no keys can be distinguished from a legacy backup.
+    archive.append(Buffer.alloc(0), { name: `${ENCRYPTION_FIELD_KEYS_DIRECTORY}/` });
+    for (const encryptionFieldKey of encryptionFieldKeys) {
+      archive.append(encryptionFieldKey.content, {
+        name: path.posix.join(ENCRYPTION_FIELD_KEYS_DIRECTORY, encryptionFieldKey.name),
+      });
+    }
+  }
+
+  async #readEncryptionFieldKeys(): Promise<EncryptionFieldKeyBackup[]> {
+    try {
+      const directoryStat = await fsPromises.lstat(this.#encryptionFieldKeysPath);
+      if (!directoryStat.isDirectory()) {
+        return [];
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsPromises.readdir(this.#encryptionFieldKeysPath, { withFileTypes: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return [];
+      }
+      throw error;
+    }
+
+    return Promise.all(
+      entries
+        .filter((entry) => entry.isFile() && path.extname(entry.name) === '.key')
+        .sort((left, right) => left.name.localeCompare(right.name))
+        .map(async (entry) => ({
+          name: entry.name,
+          content: await fsPromises.readFile(path.join(this.#encryptionFieldKeysPath, entry.name)),
+        })),
+    );
   }
 
   #getLocalFileForBackup(collectionName: string, file: any) {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/managers/restore.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/managers/restore.ts
@@ -21,6 +21,7 @@ import {
   Extractor,
   BACKUP_EXTENSION,
   BACKUPS,
+  ENCRYPTION_FIELD_KEYS_DIRECTORY,
   FILE_ENCRYPTION_SALT,
   getDBVersion,
   PLUGIN_BACKUPS_NAME,
@@ -50,6 +51,26 @@ interface Metadata {
   }>;
 }
 
+interface EncryptionFieldKeysRestoreState {
+  previousPath?: string;
+  restoredPath?: string;
+  previousKeysActive?: boolean;
+  restoreFailed?: boolean;
+}
+
+class RestoreDataError extends Error {
+  encryptionFieldKeysRestore?: EncryptionFieldKeysRestoreState;
+
+  constructor(error: unknown, encryptionFieldKeysRestore?: EncryptionFieldKeysRestoreState) {
+    super(error instanceof Error ? error.message : String(error));
+    this.name = 'RestoreDataError';
+    this.encryptionFieldKeysRestore = encryptionFieldKeysRestore;
+    if (error instanceof Error && error.stack) {
+      this.stack = error.stack;
+    }
+  }
+}
+
 export interface RestoreOptions {
   forceSchemaRestore?: boolean;
   skipDropAllTables?: boolean;
@@ -71,6 +92,7 @@ export class RestoreManager {
   #tempDir: string;
   #uploadDir: string;
   #aesKeyPath: string;
+  #encryptionFieldKeysPath: string;
   constructor(ctx: ResourcerContext, dbOptions?: any) {
     this.ctx = ctx;
     this.#dbAdapter = getDBAdapter(dbOptions || ctx.app.db.options);
@@ -79,6 +101,7 @@ export class RestoreManager {
     this.#tempDir = storagePathJoin('tmp', 'backups', ctx.app.name);
     this.#uploadDir = storagePathJoin('uploads');
     this.#aesKeyPath = storagePathJoin('apps', ctx.app.name, 'aes_key.dat');
+    this.#encryptionFieldKeysPath = storagePathJoin('apps', ctx.app.name, ENCRYPTION_FIELD_KEYS_DIRECTORY);
   }
 
   protected set backupDir(backupDir: string) {
@@ -128,39 +151,72 @@ export class RestoreManager {
   ) {
     await this.#dbAdapter.check('restore');
     const extractedDir = await this.#decompressFiles(filePath, password);
-    const backupFiles = await fsPromises.readdir(extractedDir);
-    const dbFile = backupFiles.find((file) => file === 'data');
-    const metadataFile = backupFiles.find((file) => file === '_metadata.json');
-    const uploadsExist = backupFiles.includes('uploads');
-    if (!dbFile || !metadataFile) {
-      this.ctx.logger.error('Not a valid backup file', { module: BACKUPS });
-      throw new Error(this.#t('Not a valid backup file'));
-    }
-    // check the metadata file
-    const metadata = await this.#parseMetadataFile(path.join(extractedDir, metadataFile), tolerentMode, options);
     try {
-      await this.#restoreDataCLI(extractedDir, dbFile, uploadsExist, metadata, options);
-    } catch (error) {
-      const dbVersion = await getDBVersion(this.ctx.app.db);
-      const restoreClientVersion = await this.#dbAdapter.clientVersion('restore');
-      this.ctx.logger.error(
-        `Error restoring backup: "${error.message}".
-        Database Version: backup[${metadata.database.version}], current[${dbVersion}],
-        Client Version: backup[${metadata.database.backupClientVersion}], restore[${restoreClientVersion}]
-        `,
-        { module: BACKUPS },
-      );
-      if (tolerentMode && error.message.includes('ignored')) {
-        // if the error was ignored by db client
-        this.ctx.logger.warn('Tolerent mode enabled, ignoring the error and continue the upgrade.', {
-          module: BACKUPS,
-        });
-        await this.#restoreFilesAndCleanup(uploadsExist, extractedDir);
-        // await sleep(5000); // wait for the client to show the error message, for debug
-        await this.ctx.app.upgrade();
-      } else if (!skipRevertOnError) {
-        await this.#revertDbRestore();
+      const backupFiles = await fsPromises.readdir(extractedDir);
+      const dbFile = backupFiles.find((file) => file === 'data');
+      const metadataFile = backupFiles.find((file) => file === '_metadata.json');
+      const uploadsExist = backupFiles.includes('uploads');
+      if (!dbFile || !metadataFile) {
+        this.ctx.logger.error('Not a valid backup file', { module: BACKUPS });
+        throw new Error(this.#t('Not a valid backup file'));
       }
+      // check the metadata file
+      const metadata = await this.#parseMetadataFile(path.join(extractedDir, metadataFile), tolerentMode, options);
+      try {
+        await this.#restoreDataCLI(extractedDir, dbFile, uploadsExist, metadata, options);
+      } catch (error) {
+        const restoreError = error instanceof RestoreDataError ? error : new RestoreDataError(error, undefined);
+        await this.#logRestoreError(restoreError, metadata);
+        if (tolerentMode && restoreError.message.includes('ignored')) {
+          // if the error was ignored by db client
+          this.ctx.logger.warn('Tolerent mode enabled, ignoring the error and continue the upgrade.', {
+            module: BACKUPS,
+          });
+          const encryptionFieldKeysRestore = await this.#restoreFilesForTolerentMode(
+            uploadsExist,
+            extractedDir,
+            restoreError.encryptionFieldKeysRestore,
+          );
+          // await sleep(5000); // wait for the client to show the error message, for debug
+          await this.ctx.app.upgrade();
+          await this.#commitEncryptionFieldKeysRestore(encryptionFieldKeysRestore);
+        } else if (!skipRevertOnError) {
+          const databaseReverted = await this.#revertDbRestore();
+          if (databaseReverted) {
+            const encryptionFieldKeysReverted = await this.#rollbackEncryptionFieldKeysRestore(
+              restoreError.encryptionFieldKeysRestore,
+            );
+            if (!encryptionFieldKeysReverted) {
+              throw new RestoreDataError(
+                'Failed to roll back the encryption field keys',
+                restoreError.encryptionFieldKeysRestore,
+              );
+            }
+          } else {
+            const encryptionFieldKeysActivated = await this.#activateRestoredEncryptionFieldKeys(
+              restoreError.encryptionFieldKeysRestore,
+            );
+            if (!encryptionFieldKeysActivated) {
+              throw new RestoreDataError(
+                'Failed to activate the restored encryption field keys',
+                restoreError.encryptionFieldKeysRestore,
+              );
+            }
+          }
+        } else {
+          const encryptionFieldKeysActivated = await this.#activateRestoredEncryptionFieldKeys(
+            restoreError.encryptionFieldKeysRestore,
+          );
+          if (!encryptionFieldKeysActivated) {
+            throw new RestoreDataError(
+              'Failed to activate the restored encryption field keys',
+              restoreError.encryptionFieldKeysRestore,
+            );
+          }
+        }
+      }
+    } finally {
+      await this.#cleanupExtractedDir(extractedDir);
     }
   }
 
@@ -186,6 +242,7 @@ export class RestoreManager {
     options?: RestoreOptions,
   ): Promise<void> {
     const tmpBackupDir = path.join(this.#tempDir, 'before-restore');
+    let encryptionFieldKeysRestore: EncryptionFieldKeysRestoreState | undefined;
     try {
       await fs.mkdir(tmpBackupDir, { recursive: true });
       // ensure the app cleaned before restoring the database
@@ -200,12 +257,15 @@ export class RestoreManager {
       });
       this.ctx.logger.info('Database restored successfully', { module: BACKUPS });
       // copy the uploads directory
-      await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
+      encryptionFieldKeysRestore = await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
+      await this.#commitEncryptionFieldKeysRestore(encryptionFieldKeysRestore);
     } catch (error) {
-      this.ctx.logger.error(`Error restoring backup: ${error.message}. Trying to revert the backup process`, {
+      const restoreError =
+        error instanceof RestoreDataError ? error : new RestoreDataError(error, encryptionFieldKeysRestore);
+      this.ctx.logger.error(`Error restoring backup: ${restoreError.message}. Trying to revert the backup process`, {
         module: BACKUPS,
       });
-      throw error;
+      throw restoreError;
     }
   }
 
@@ -232,56 +292,87 @@ export class RestoreManager {
   ): Promise<void> {
     await this.#dbAdapter.check('restore');
     const extractedDir = await this.#decompressFiles(filePath, password);
-    const backupFiles = await fsPromises.readdir(extractedDir);
-    const dbFile = backupFiles.find((file) => file === 'data');
-    const metadataFile = backupFiles.find((file) => file === '_metadata.json');
-    const uploadsExist = backupFiles.includes('uploads');
-    if (!dbFile || !metadataFile) {
-      this.ctx.logger.error('Not a valid backup file', { module: BACKUPS });
-      throw new Error(this.#t('Not a valid backup file'));
-    }
-    // check the metadata file
-    const metadata = await this.#parseMetadataFile(path.join(extractedDir, metadataFile), tolerentMode, options);
-    this.#restoreData(extractedDir, dbFile, uploadsExist, taskId, metadata, options).catch(async (error) => {
-      try {
-        const dbVersion = await getDBVersion(this.ctx.app.db);
-        const restoreClientVersion = await this.#dbAdapter.clientVersion('restore');
-        this.ctx.logger.error(
-          `Error restoring backup: "${error.message}".
-          Database Version: backup[${metadata.database.version}], current[${dbVersion}],
-          Client Version: backup[${metadata.database.backupClientVersion}], restore[${restoreClientVersion}]
-          `,
-          { module: BACKUPS },
-        );
-        if (tolerentMode && error.message.includes('ignored')) {
-          // if the error was ignored by db client
-          this.ctx.logger.warn('Tolerent mode enabled, ignoring the error and continue the upgrade.', {
-            module: BACKUPS,
-          });
-          await this.#restoreFilesAndCleanup(uploadsExist, extractedDir);
-          // await sleep(5000); // wait for the client to show the error message, for debug
-          await this.ctx.app.runCommand('upgrade');
-        } else {
-          if (!tolerentMode && this.#isPostgresLikeDialect(this.#dbAdapter.dbOpts.dialect)) {
-            const backupClientVersion = Number(toMajorVersion(metadata.database.backupClientVersion));
-            const dbServerVersion = Number(toMajorVersion(dbVersion));
-            if (backupClientVersion > 16 && dbServerVersion <= 16) {
-              // pg_dump 17 introduced some incompatible options, give user a friendly message
-              const statusCache = await this.getStatusCache();
-              await statusCache.set(taskId, {
-                message: this.#t('ERROR_PG_DUMP_LT_17'),
-              });
-            }
-          }
-          if (!skipRevertOnError) {
-            await this.#revertDbRestore();
-          }
-          await this.ctx.app.runCommand('upgrade');
-        }
-      } catch (err) {
-        this.ctx.logger.error(`Error handling restore failure: ${err.message}`, { module: BACKUPS });
+    let dbFile: string;
+    let uploadsExist: boolean;
+    let metadata: Metadata;
+    try {
+      const backupFiles = await fsPromises.readdir(extractedDir);
+      const foundDbFile = backupFiles.find((file) => file === 'data');
+      const metadataFile = backupFiles.find((file) => file === '_metadata.json');
+      uploadsExist = backupFiles.includes('uploads');
+      if (!foundDbFile || !metadataFile) {
+        this.ctx.logger.error('Not a valid backup file', { module: BACKUPS });
+        throw new Error(this.#t('Not a valid backup file'));
       }
-    });
+      dbFile = foundDbFile;
+      // check the metadata file
+      metadata = await this.#parseMetadataFile(path.join(extractedDir, metadataFile), tolerentMode, options);
+    } catch (error) {
+      await this.#cleanupExtractedDir(extractedDir);
+      throw error;
+    }
+
+    this.#restoreData(extractedDir, dbFile, uploadsExist, taskId, metadata, options)
+      .catch(async (error) => {
+        const restoreError = error instanceof RestoreDataError ? error : new RestoreDataError(error, undefined);
+        const dbVersion = await this.#logRestoreError(restoreError, metadata);
+        try {
+          if (tolerentMode && restoreError.message.includes('ignored')) {
+            // if the error was ignored by db client
+            this.ctx.logger.warn('Tolerent mode enabled, ignoring the error and continue the upgrade.', {
+              module: BACKUPS,
+            });
+            const encryptionFieldKeysRestore = await this.#restoreFilesForTolerentMode(
+              uploadsExist,
+              extractedDir,
+              restoreError.encryptionFieldKeysRestore,
+            );
+            // await sleep(5000); // wait for the client to show the error message, for debug
+            await this.ctx.app.runCommand('upgrade');
+            await this.#commitEncryptionFieldKeysRestore(encryptionFieldKeysRestore);
+          } else {
+            if (!tolerentMode && dbVersion && this.#isPostgresLikeDialect(this.#dbAdapter.dbOpts.dialect)) {
+              const backupClientVersion = Number(toMajorVersion(metadata.database.backupClientVersion));
+              const dbServerVersion = Number(toMajorVersion(dbVersion));
+              if (backupClientVersion > 16 && dbServerVersion <= 16) {
+                // pg_dump 17 introduced some incompatible options, give user a friendly message
+                const statusCache = await this.getStatusCache();
+                await statusCache.set(taskId, {
+                  message: this.#t('ERROR_PG_DUMP_LT_17'),
+                });
+              }
+            }
+            let databaseReverted = false;
+            if (!skipRevertOnError) {
+              databaseReverted = await this.#revertDbRestore();
+            }
+            if (databaseReverted) {
+              const encryptionFieldKeysReverted = await this.#rollbackEncryptionFieldKeysRestore(
+                restoreError.encryptionFieldKeysRestore,
+              );
+              if (!encryptionFieldKeysReverted) {
+                return;
+              }
+            } else {
+              const encryptionFieldKeysActivated = await this.#activateRestoredEncryptionFieldKeys(
+                restoreError.encryptionFieldKeysRestore,
+              );
+              if (!encryptionFieldKeysActivated) {
+                return;
+              }
+            }
+            await this.ctx.app.runCommand('upgrade');
+          }
+        } catch (err) {
+          this.ctx.logger.error(`Error handling restore failure: ${err.message}`, { module: BACKUPS });
+        }
+      })
+      .finally(async () => {
+        await this.#cleanupExtractedDir(extractedDir);
+      })
+      .catch((error) => {
+        this.ctx.logger.error(`Error finalizing restore: ${error.message}`, { module: BACKUPS });
+      });
   }
 
   async #parseMetadataFile(filePath: string, tolerentMode: boolean, options?: RestoreOptions) {
@@ -389,12 +480,12 @@ export class RestoreManager {
 
   async #decompressFiles(filePath: string, password?: string): Promise<string> {
     const fileBaseName = path.basename(filePath, `.${BACKUP_EXTENSION}`);
-    const outputDir = path.join(this.#tempDir, fileBaseName);
+    await fsPromises.mkdir(this.#tempDir, { recursive: true });
+    const outputDir = await fsPromises.mkdtemp(path.join(this.#tempDir, `${fileBaseName}-`));
     const inputFileStream = fs.createReadStream(filePath);
     let inputStream: Readable | null = null;
 
     try {
-      await fsPromises.mkdir(outputDir, { recursive: true });
       // Assign inputStream within the try block after creating the stream
       inputStream = await this.#createDecryptedStream(inputFileStream, password);
       const extractor = new Extractor({ path: outputDir });
@@ -408,6 +499,7 @@ export class RestoreManager {
       this.ctx.logger.error(`Error decrypting file: ${error.message}. Please confirm your password.`, {
         module: BACKUPS,
       });
+      await this.#cleanupExtractedDir(outputDir);
       throw new Error(this.#t('ERROR_DECRYPTING_PLS_CHECK_PASSWORD', error.message));
     } finally {
       // Ensure input file stream is always closed
@@ -491,6 +583,7 @@ export class RestoreManager {
     this.#notify(RESTORE_STEPS.DATABASE);
     const statusCache = await this.getStatusCache();
     const tmpBackupDir = path.join(this.#tempDir, 'before-restore');
+    let encryptionFieldKeysRestore: EncryptionFieldKeysRestoreState | undefined;
     try {
       await fsPromises.mkdir(tmpBackupDir, { recursive: true });
       await this.#dbAdapter.backup({ dir: tmpBackupDir });
@@ -511,26 +604,46 @@ export class RestoreManager {
       if (restoreUploads) {
         this.#notify(RESTORE_STEPS.UPLOADS);
       }
-      await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
-    } catch (error) {
+      encryptionFieldKeysRestore = await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
       await statusCache.set(taskId, {
         inProgress: false,
-        message: error.message,
       });
-      this.ctx.logger.error(`Error restoring backup: ${error.message}. Trying to revert the backup process`, {
+      await this.ctx.app.runCommand('upgrade');
+      await this.#commitEncryptionFieldKeysRestore(encryptionFieldKeysRestore);
+    } catch (error) {
+      const restoreError =
+        error instanceof RestoreDataError ? error : new RestoreDataError(error, encryptionFieldKeysRestore);
+      try {
+        await statusCache.set(taskId, {
+          inProgress: false,
+          message: restoreError.message,
+        });
+      } catch (statusError) {
+        this.ctx.logger.error(`Error updating restore task status: ${statusError.message}`, { module: BACKUPS });
+      }
+      this.ctx.logger.error(`Error restoring backup: ${restoreError.message}. Trying to revert the backup process`, {
         module: BACKUPS,
       });
-      throw error;
+      throw restoreError;
     } finally {
       this.#notify(RESTORE_STEPS.END);
     }
-    await statusCache.set(taskId, {
-      inProgress: false,
-    });
-    await this.ctx.app.runCommand('upgrade');
   }
 
-  async #restoreFilesAndCleanup(restoreUploads: boolean, extractedDir: string) {
+  async #restoreFilesAndCleanup(
+    restoreUploads: boolean,
+    extractedDir: string,
+  ): Promise<EncryptionFieldKeysRestoreState | undefined> {
+    const encryptionFieldKeysRestore = await this.#restoreEncryptionFieldKeys(extractedDir);
+    try {
+      await this.#restoreUploadsAndAesKey(restoreUploads, extractedDir);
+    } catch (error) {
+      throw new RestoreDataError(error, encryptionFieldKeysRestore);
+    }
+    return encryptionFieldKeysRestore;
+  }
+
+  async #restoreUploadsAndAesKey(restoreUploads: boolean, extractedDir: string): Promise<void> {
     if (restoreUploads) {
       const uploadsDir = path.join(extractedDir, 'uploads');
       await fsPromises.mkdir(this.#uploadDir, { recursive: true });
@@ -542,24 +655,385 @@ export class RestoreManager {
     if (await fs.pathExists(aesKeyPath)) {
       await fs.copy(aesKeyPath, this.#aesKeyPath, { overwrite: true });
     }
-    // cleanup the temp directory
-    fs.rm(extractedDir, { recursive: true }).catch((e) => {
-      this.ctx.logger.error(`Error cleaning up the temp directory: ${e.message}`, { module: BACKUPS });
-    });
   }
 
-  async #revertDbRestore() {
+  async #restoreFilesForTolerentMode(
+    restoreUploads: boolean,
+    extractedDir: string,
+    restoreState: EncryptionFieldKeysRestoreState | undefined,
+  ): Promise<EncryptionFieldKeysRestoreState | undefined> {
+    let encryptionFieldKeysRestore = restoreState;
+    if (!encryptionFieldKeysRestore) {
+      try {
+        return await this.#restoreFilesAndCleanup(restoreUploads, extractedDir);
+      } catch (error) {
+        const restoreError = error instanceof RestoreDataError ? error : new RestoreDataError(error, undefined);
+        if (!restoreError.encryptionFieldKeysRestore?.restoreFailed) {
+          throw error;
+        }
+        encryptionFieldKeysRestore = restoreError.encryptionFieldKeysRestore;
+      }
+    }
+
+    if (encryptionFieldKeysRestore.restoreFailed) {
+      const encryptionFieldKeysActivated = await this.#activateRestoredEncryptionFieldKeys(encryptionFieldKeysRestore);
+      if (!encryptionFieldKeysActivated) {
+        throw new RestoreDataError('Failed to activate the restored encryption field keys', encryptionFieldKeysRestore);
+      }
+      try {
+        await this.#restoreUploadsAndAesKey(restoreUploads, extractedDir);
+      } catch (error) {
+        throw new RestoreDataError(error, encryptionFieldKeysRestore);
+      }
+    }
+    return encryptionFieldKeysRestore;
+  }
+
+  async #restoreEncryptionFieldKeys(extractedDir: string): Promise<EncryptionFieldKeysRestoreState | undefined> {
+    const sourcePath = path.join(extractedDir, ENCRYPTION_FIELD_KEYS_DIRECTORY);
+    let sourceStat: fs.Stats;
+    try {
+      sourceStat = await fsPromises.lstat(sourcePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        // Backups created before encryption field keys were included must keep the current keys.
+        return undefined;
+      }
+      throw new RestoreDataError(error, { restoreFailed: true });
+    }
+    if (!sourceStat.isDirectory()) {
+      throw new RestoreDataError(this.#t('Not a valid backup file'), { restoreFailed: true });
+    }
+
+    let keyEntries: fs.Dirent[];
+    try {
+      keyEntries = (await fsPromises.readdir(sourcePath, { withFileTypes: true }))
+        .filter((entry) => entry.isFile() && path.extname(entry.name) === '.key')
+        .sort((left, right) => left.name.localeCompare(right.name));
+    } catch (error) {
+      throw new RestoreDataError(error, { restoreFailed: true });
+    }
+
+    const parentPath = path.dirname(this.#encryptionFieldKeysPath);
+    let stagingPath: string | undefined;
+    try {
+      await fsPromises.mkdir(parentPath, { recursive: true });
+      stagingPath = await fsPromises.mkdtemp(path.join(parentPath, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-`));
+      if (process.platform !== 'win32') {
+        await fsPromises.chmod(stagingPath, 0o700);
+      }
+      for (const entry of keyEntries) {
+        const sourceKeyPath = path.join(sourcePath, entry.name);
+        const stagedKeyPath = path.join(stagingPath, entry.name);
+        await fsPromises.copyFile(sourceKeyPath, stagedKeyPath);
+        if (process.platform !== 'win32') {
+          await fsPromises.chmod(stagedKeyPath, 0o600);
+        }
+      }
+    } catch (error) {
+      await this.#cleanupEncryptionFieldKeysDirectory(stagingPath, 'incomplete staged');
+      throw new RestoreDataError(error, { restoreFailed: true });
+    }
+    if (!stagingPath) {
+      throw new RestoreDataError('Failed to prepare the encryption field keys', { restoreFailed: true });
+    }
+
+    const previousPath = path.join(parentPath, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-${crypto.randomUUID()}`);
+    let hadPreviousKeys = false;
+    let previousMoved = false;
+
+    try {
+      try {
+        await fsPromises.lstat(this.#encryptionFieldKeysPath);
+        hadPreviousKeys = true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw new RestoreDataError(error, {
+            restoredPath: stagingPath,
+            previousKeysActive: true,
+            restoreFailed: true,
+          });
+        }
+      }
+
+      if (hadPreviousKeys) {
+        try {
+          await fsPromises.rename(this.#encryptionFieldKeysPath, previousPath);
+          previousMoved = true;
+        } catch (error) {
+          throw new RestoreDataError(error, {
+            restoredPath: stagingPath,
+            previousKeysActive: true,
+            restoreFailed: true,
+          });
+        }
+      }
+
+      try {
+        await fsPromises.rename(stagingPath, this.#encryptionFieldKeysPath);
+      } catch (installError) {
+        if (previousMoved) {
+          try {
+            await fsPromises.rename(previousPath, this.#encryptionFieldKeysPath);
+            previousMoved = false;
+          } catch (rollbackError) {
+            this.ctx.logger.error(
+              `Failed to restore the previous encryption field keys. The keys were preserved at "${previousPath}": ${rollbackError.message}`,
+              { module: BACKUPS },
+            );
+            throw new RestoreDataError(
+              new Error(
+                `Failed to install encryption field keys: ${installError.message}. Failed to restore the previous keys; they were preserved at "${previousPath}": ${rollbackError.message}`,
+              ),
+              {
+                previousPath,
+                restoredPath: stagingPath,
+                restoreFailed: true,
+              },
+            );
+          }
+        }
+        throw new RestoreDataError(installError, {
+          restoredPath: stagingPath,
+          previousKeysActive: hadPreviousKeys,
+          restoreFailed: true,
+        });
+      }
+      return {
+        previousPath: previousMoved ? previousPath : undefined,
+      };
+    } catch (error) {
+      const preserveStagingPath =
+        error instanceof RestoreDataError && error.encryptionFieldKeysRestore?.restoredPath === stagingPath;
+      if (!preserveStagingPath) {
+        await this.#cleanupEncryptionFieldKeysDirectory(stagingPath, 'staged');
+      }
+      throw error instanceof RestoreDataError ? error : new RestoreDataError(error, { restoreFailed: true });
+    }
+  }
+
+  async #commitEncryptionFieldKeysRestore(restoreState: EncryptionFieldKeysRestoreState | undefined): Promise<void> {
+    if (!restoreState?.previousPath) {
+      return;
+    }
+    try {
+      await fsPromises.rm(restoreState.previousPath, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    } catch (error) {
+      this.ctx.logger.error(
+        `Error cleaning up previous encryption field keys directory "${restoreState.previousPath}": ${error.message}`,
+        { module: BACKUPS },
+      );
+    }
+  }
+
+  async #rollbackEncryptionFieldKeysRestore(
+    restoreState: EncryptionFieldKeysRestoreState | undefined,
+  ): Promise<boolean> {
+    if (!restoreState) {
+      return true;
+    }
+
+    if (restoreState.restoreFailed) {
+      if (!restoreState.previousKeysActive && restoreState.previousPath) {
+        try {
+          await fsPromises.rename(restoreState.previousPath, this.#encryptionFieldKeysPath);
+        } catch (rollbackError) {
+          const restoredKeysLocation = restoreState.restoredPath
+            ? ` The restored keys were preserved at "${restoreState.restoredPath}".`
+            : '';
+          this.ctx.logger.error(
+            `Failed to roll back encryption field keys. The previous keys were preserved at "${restoreState.previousPath}".${restoredKeysLocation} ${rollbackError.message}`,
+            { module: BACKUPS },
+          );
+          return false;
+        }
+      }
+      await this.#cleanupEncryptionFieldKeysDirectory(restoreState.restoredPath, 'staged restored');
+      return true;
+    }
+
+    const parentPath = path.dirname(this.#encryptionFieldKeysPath);
+    const discardedPath = path.join(parentPath, `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-discarded-${crypto.randomUUID()}`);
+    let installedKeysMoved = false;
+
+    try {
+      await fsPromises.rename(this.#encryptionFieldKeysPath, discardedPath);
+      installedKeysMoved = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        const previousKeysLocation = restoreState.previousPath
+          ? ` The previous keys were preserved at "${restoreState.previousPath}".`
+          : '';
+        this.ctx.logger.error(
+          `Failed to remove the restored encryption field keys while rolling back.${previousKeysLocation} ${error.message}`,
+          { module: BACKUPS },
+        );
+        return false;
+      }
+    }
+
+    if (restoreState.previousPath) {
+      try {
+        await fsPromises.rename(restoreState.previousPath, this.#encryptionFieldKeysPath);
+      } catch (rollbackError) {
+        let restoredKeysLocation = installedKeysMoved ? ` The restored keys remain at "${discardedPath}".` : '';
+        if (installedKeysMoved) {
+          try {
+            await fsPromises.rename(discardedPath, this.#encryptionFieldKeysPath);
+            installedKeysMoved = false;
+            restoredKeysLocation = ' The restored keys remain active.';
+          } catch (reinstallError) {
+            restoredKeysLocation = ` The restored keys were preserved at "${discardedPath}" but could not be reinstalled: ${reinstallError.message}.`;
+          }
+        }
+        this.ctx.logger.error(
+          `Failed to roll back encryption field keys. The previous keys were preserved at "${restoreState.previousPath}".${restoredKeysLocation} ${rollbackError.message}`,
+          { module: BACKUPS },
+        );
+        return false;
+      }
+    }
+
+    if (installedKeysMoved) {
+      try {
+        await fsPromises.rm(discardedPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      } catch (error) {
+        this.ctx.logger.error(
+          `Error cleaning up rolled back encryption field keys directory "${discardedPath}": ${error.message}`,
+          { module: BACKUPS },
+        );
+      }
+    }
+    return true;
+  }
+
+  async #activateRestoredEncryptionFieldKeys(
+    restoreState: EncryptionFieldKeysRestoreState | undefined,
+  ): Promise<boolean> {
+    if (!restoreState?.restoreFailed) {
+      return true;
+    }
+    if (!restoreState.restoredPath) {
+      this.ctx.logger.error('Restored encryption field keys are unavailable; stopping the restore process.', {
+        module: BACKUPS,
+      });
+      return false;
+    }
+
+    let previousPath = restoreState.previousPath;
+    let previousKeysMoved = false;
+    if (restoreState.previousKeysActive) {
+      previousPath =
+        previousPath ??
+        path.join(
+          path.dirname(this.#encryptionFieldKeysPath),
+          `.${ENCRYPTION_FIELD_KEYS_DIRECTORY}-previous-${crypto.randomUUID()}`,
+        );
+      try {
+        await fsPromises.rename(this.#encryptionFieldKeysPath, previousPath);
+        previousKeysMoved = true;
+        restoreState.previousPath = previousPath;
+        restoreState.previousKeysActive = false;
+      } catch (error) {
+        this.ctx.logger.error(
+          `Failed to preserve the active encryption field keys at "${previousPath}" before activating the restored keys. The restored keys were preserved at "${restoreState.restoredPath}": ${error.message}`,
+          { module: BACKUPS },
+        );
+        return false;
+      }
+    }
+
+    try {
+      await fsPromises.rename(restoreState.restoredPath, this.#encryptionFieldKeysPath);
+      return true;
+    } catch (activationError) {
+      let previousKeysLocation = previousPath ? ` The previous keys were preserved at "${previousPath}".` : '';
+      if (previousKeysMoved && previousPath) {
+        try {
+          await fsPromises.rename(previousPath, this.#encryptionFieldKeysPath);
+          previousKeysLocation = ' The previous keys remain active.';
+        } catch (rollbackError) {
+          previousKeysLocation = ` The previous keys were preserved at "${previousPath}" but could not be reactivated: ${rollbackError.message}.`;
+        }
+      }
+      this.ctx.logger.error(
+        `Failed to activate the restored encryption field keys. The restored keys were preserved at "${restoreState.restoredPath}".${previousKeysLocation} ${activationError.message}`,
+        { module: BACKUPS },
+      );
+      return false;
+    }
+  }
+
+  async #cleanupEncryptionFieldKeysDirectory(directoryPath: string | undefined, description: string): Promise<void> {
+    if (!directoryPath) {
+      return;
+    }
+    try {
+      await fsPromises.rm(directoryPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch (error) {
+      this.ctx.logger.error(
+        `Error cleaning up ${description} encryption field keys directory "${directoryPath}": ${error.message}`,
+        { module: BACKUPS },
+      );
+    }
+  }
+
+  async #cleanupExtractedDir(extractedDir: string): Promise<void> {
+    try {
+      await fsPromises.rm(extractedDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch (error) {
+      this.ctx.logger.error(`Error cleaning up temporary backup directory "${extractedDir}": ${error.message}`, {
+        module: BACKUPS,
+      });
+    }
+  }
+
+  async #logRestoreError(error: Error, metadata: Metadata): Promise<string | undefined> {
+    let dbVersion: string | undefined;
+    let restoreClientVersion: string | undefined;
+    try {
+      dbVersion = await getDBVersion(this.ctx.app.db);
+    } catch (diagnosticError) {
+      this.ctx.logger.error(`Error reading the current database version: ${diagnosticError.message}`, {
+        module: BACKUPS,
+      });
+    }
+    try {
+      restoreClientVersion = await this.#dbAdapter.clientVersion('restore');
+    } catch (diagnosticError) {
+      this.ctx.logger.error(`Error reading the restore client version: ${diagnosticError.message}`, {
+        module: BACKUPS,
+      });
+    }
+    this.ctx.logger.error(
+      `Error restoring backup: "${error.message}".
+      Database Version: backup[${metadata.database.version}], current[${dbVersion ?? 'unknown'}],
+      Client Version: backup[${metadata.database.backupClientVersion}], restore[${restoreClientVersion ?? 'unknown'}]
+      `,
+      { module: BACKUPS },
+    );
+    return dbVersion;
+  }
+
+  async #revertDbRestore(): Promise<boolean> {
     this.ctx.logger.info('Reverting the database restore process', { module: BACKUPS });
     const dbFile = path.join(this.#tempDir, 'before-restore', 'data');
     if (await fs.pathExists(dbFile)) {
       try {
         await this.#dbAdapter.restore({ filePath: dbFile, schema: this.#dbAdapter.dbOpts.schema });
+        return true;
       } catch (error) {
         this.ctx.logger.error('Error reverting the database restore process', { module: BACKUPS });
+        return false;
       }
-    } else {
-      this.ctx.logger.error('Database backup file for revert restore process not found', { module: BACKUPS });
     }
+    this.ctx.logger.error('Database backup file for revert restore process not found', { module: BACKUPS });
+    return false;
   }
 
   async #notify(step: string) {

--- a/packages/plugins/@nocobase/plugin-backups/src/server/utils.ts
+++ b/packages/plugins/@nocobase/plugin-backups/src/server/utils.ts
@@ -13,6 +13,7 @@ export const STORAGE_PATH = 'storage/uploads';
 export const SETTINGS = 'backupSettings';
 export const BACKUPS = 'backups';
 export const FILE_ENCRYPTION_SALT = 'backup salt';
+export const ENCRYPTION_FIELD_KEYS_DIRECTORY = 'encryption-field-keys';
 export const BACKUP_TASKS_CACHE_NAME = 'backup-task-results';
 export const RESTORE_TASKS_CACHE_NAME = 'restore-task-results';
 export const RESTORE_TASKS_CACHE_TTL = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
<!-- Please explain the reason of the changes made in this PR. -->

Backup archives did not include the key files used by the field encryption plugin, causing restored encrypted values to become unreadable.

### Description 
<!-- 
Please describe the key changes made in this PR clearly and concisely, 
mention any potential risks, 
and provide some testing suggestions. 
-->

- Include field encryption key files in backup archives.
- Restore the archived key set before running the application upgrade.
- Preserve existing keys when restoring legacy backups that do not contain field encryption keys.
- Roll back field encryption keys when the database restore is reverted.
- Use isolated extraction directories and clean up extracted sensitive files.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where encrypted field values became invalid after restoring a backup |
| 🇨🇳 Chinese | 修复备份还原后加密字段值异常问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
