### PR TITLE
fix(database): prevent cyclic parent loading crashes

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/ClickableFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/ClickableFieldModel.tsx
@@ -17,15 +17,21 @@ import { openViewFlow } from '../../flows/openViewFlow';
 import { FieldModel } from '../base/FieldModel';
 import { hasDisplayValue, normalizeDisplayValue } from '../utils/displayValueUtils';
 
-export function transformNestedData(inputData) {
-  const resultArray = [];
+export function transformNestedData(inputData: unknown) {
+  const resultArray: Record<string, unknown>[] = [];
+  const visited = new WeakSet<object>();
 
-  function recursiveTransform(data) {
-    if (data?.parent) {
-      const { parent } = data;
+  function recursiveTransform(data: unknown) {
+    if (!data || typeof data !== 'object' || visited.has(data)) {
+      return;
+    }
+    visited.add(data);
+    const record = data as Record<string, unknown>;
+    if (record.parent) {
+      const { parent } = record;
       recursiveTransform(parent);
     }
-    const { parent, ...other } = data;
+    const { parent, ...other } = record;
     resultArray.push(other);
   }
   if (inputData) {

--- a/packages/core/client-v2/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { FlowEngine, FlowModel } from '@nocobase/flow-engine';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ClickableFieldModel } from '../ClickableFieldModel';
+import { ClickableFieldModel, transformNestedData } from '../ClickableFieldModel';
 import { DisplayTitleFieldModel } from '../DisplayTitleFieldModel';
 import { DisplayTextFieldModel } from '../DisplayTextFieldModel';
 
@@ -51,6 +51,17 @@ function createRolesFieldModel(sourceRecord: Record<string, any>) {
 }
 
 describe('ClickableFieldModel', () => {
+  it('stops traversing when tree parents contain a cycle', () => {
+    const parent = { id: 1, title: 'Parent', parent: null };
+    const child = { id: 2, title: 'Child', parent };
+    parent.parent = child;
+
+    expect(transformNestedData(child)).toEqual([
+      { id: 1, title: 'Parent' },
+      { id: 2, title: 'Child' },
+    ]);
+  });
+
   it('opens an association display value as a normal target record when source record has no id', () => {
     const { model, dispatchEvent } = createRolesFieldModel({});
     const event = { type: 'click' };

--- a/packages/core/database/src/__tests__/eager-loading/eager-loading-tree-cycle.test.ts
+++ b/packages/core/database/src/__tests__/eager-loading/eager-loading-tree-cycle.test.ts
@@ -1,0 +1,68 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import type { Model } from 'sequelize';
+import type Database from '../../database';
+import type { Collection } from '../../collection';
+import { queryParentSQL, setRecursiveParent } from '../../eager-loading/eager-loading-tree';
+
+function createInstance(id: string, parentId: string | null) {
+  const dataValues: Record<string, unknown> = { id, parentId };
+  return {
+    dataValues,
+    get(key: string) {
+      return dataValues[key];
+    },
+  } as unknown as Model;
+}
+
+describe('recursive parent eager loading', () => {
+  it('keeps the complete parent chain when it is acyclic', () => {
+    const categoryA = createInstance('a', null);
+    const categoryB = createInstance('b', 'a');
+    const categoryC = createInstance('c', 'b');
+
+    setRecursiveParent(categoryC, [categoryA, categoryB, categoryC], 'id', 'parentId', 'parent');
+
+    expect(categoryC.dataValues.parent).toBe(categoryB);
+    expect(categoryB.dataValues.parent).toBe(categoryA);
+  });
+
+  it('stops linking parents when the relationship contains a cycle', () => {
+    const categoryA = createInstance('a', 'b');
+    const categoryB = createInstance('b', 'a');
+
+    expect(() => setRecursiveParent(categoryA, [categoryA, categoryB], 'id', 'parentId', 'parent')).not.toThrow();
+    expect(categoryA.dataValues.parent).toBe(categoryB);
+    expect(categoryB.dataValues.parent).toBeUndefined();
+    expect(() => JSON.stringify(categoryA)).not.toThrow();
+  });
+
+  it('uses a distinct recursive CTE so cyclic rows converge', () => {
+    const collection = {
+      quotedTableName: () => '"categories"',
+      model: {
+        rawAttributes: {
+          id: { field: 'id' },
+          parentId: { field: 'parent_id' },
+        },
+      },
+    } as unknown as Collection;
+    const db = {
+      sequelize: {
+        getQueryInterface: () => ({ quoteIdentifier: (value: string) => `"${value}"` }),
+      },
+    } as unknown as Database;
+
+    const { sql } = queryParentSQL({ db, collection, foreignKey: 'parentId', targetKey: 'id', nodeIds: ['a'] });
+
+    expect(sql).toContain('\n      UNION\n');
+    expect(sql).not.toContain('UNION ALL');
+  });
+});

--- a/packages/core/database/src/eager-loading/eager-loading-tree.ts
+++ b/packages/core/database/src/eager-loading/eager-loading-tree.ts
@@ -82,7 +82,7 @@ const EagerLoadingNodeProto = {
   },
 };
 
-const queryParentSQL = (options: {
+export const queryParentSQL = (options: {
   db: Database;
   nodeIds: any[];
   collection: Collection;
@@ -103,7 +103,7 @@ const queryParentSQL = (options: {
       SELECT ${q(targetKeyField)}, ${q(foreignKeyField)}
       FROM ${tableName}
       WHERE ${q(targetKeyField)} IN (${placeholders})
-      UNION ALL
+      UNION
       SELECT t.${q(targetKeyField)}, t.${q(foreignKeyField)}
       FROM ${tableName} AS t
       INNER JOIN cte ON t.${q(targetKeyField)} = cte.${q(foreignKeyField)}
@@ -112,6 +112,26 @@ const queryParentSQL = (options: {
     bind: nodeIds,
   };
 };
+
+export function setRecursiveParent(
+  instance: Model,
+  parentInstances: Model[],
+  targetKey: string,
+  foreignKey: string,
+  associationAs: string,
+  visited = new Set<unknown>(),
+) {
+  visited.add(instance.get(targetKey));
+  const parentInstance = parentInstances.find(
+    (parentInstance) => parentInstance.get(targetKey) == instance.get(foreignKey),
+  );
+  if (!parentInstance || visited.has(parentInstance.get(targetKey))) {
+    return;
+  }
+
+  setRecursiveParent(parentInstance, parentInstances, targetKey, foreignKey, associationAs, visited);
+  instance[associationAs] = instance.dataValues[associationAs] = parentInstance;
+}
 
 export class EagerLoadingTree {
   public root: EagerLoadingNode;
@@ -441,20 +461,8 @@ export class EagerLoadingTree {
               attributes: node.attributes,
             });
 
-            const setInstanceParent = (instance) => {
-              const parentInstance = parentInstances.find(
-                (parentInstance) => parentInstance.get(targetKey) == instance.get(foreignKey),
-              );
-              if (!parentInstance) {
-                return;
-              }
-
-              setInstanceParent(parentInstance);
-              instance[association.as] = instance.dataValues[association.as] = parentInstance;
-            };
-
             for (const instance of instances) {
-              setInstanceParent(instance);
+              setRecursiveParent(instance, parentInstances, targetKey, foreignKey, association.as);
             }
           }
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Tree collection records can contain invalid cyclic parent relationships. Loading a parent display field with recursive appends could make the recursive CTE continuously produce duplicate rows and could also overflow the Node.js call stack while rebuilding the parent chain, causing the backend request or process to crash.

### Description 
- Use a distinct recursive CTE so repeated cyclic parent rows converge.
- Track visited target keys while rebuilding recursive parent associations and stop before creating an object cycle.
- Guard modern-client tree parent display traversal against cyclic object references.
- Add regression coverage for acyclic parent chains, cyclic parent chains, JSON serialization, recursive SQL generation, and client display traversal.

Potential risk: recursive parent loading now truncates an invalid cyclic chain at the first repeated record. Valid acyclic parent chains retain their complete hierarchy.

Testing:
- `yarn test packages/core/database/src/__tests__/eager-loading/eager-loading-tree-cycle.test.ts --run --reporter=verbose`
- `yarn test packages/core/client-v2/src/flow/models/fields/__tests__/ClickableFieldModel.test.ts --run --reporter=verbose`
- ESLint and commit hooks passed for all changed files.

### Related issues

None.

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed backend crashes when recursively loading parent fields from tree collections containing cyclic parent relationships |
| 🇨🇳 Chinese | 修复树集合存在循环父级关系时递归加载父级字段导致后台崩溃的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
