### PR TITLE
fix: apply the field interface default type on fields:create

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/fields-interface-default-type.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/__tests__/fields-interface-default-type.test.ts
@@ -1,0 +1,98 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import Database, { Collection as DBCollection } from '@nocobase/database';
+import Application from '@nocobase/server';
+import { createApp } from '.';
+
+describe('field interface default type', () => {
+  let db: Database;
+  let app: Application;
+  let Collection: DBCollection;
+  let Field: DBCollection;
+
+  beforeEach(async () => {
+    app = await createApp();
+    db = app.db;
+    Collection = db.getCollection('collections');
+    Field = db.getCollection('fields');
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+  });
+
+  it('applies the interface default type when type is missing', async () => {
+    await Collection.repository.create({
+      values: {
+        name: 'withInterfaceDefault',
+      },
+      context: {},
+    });
+
+    const field = await Field.repository.create({
+      values: {
+        name: 'amount',
+        interface: 'number',
+        collectionName: 'withInterfaceDefault',
+      },
+      context: {},
+    });
+
+    expect(field.get('type')).toBe('double');
+
+    // The collection really got a usable column, not just a metadata row.
+    await db.getRepository('withInterfaceDefault').create({
+      values: {
+        amount: 12.5,
+      },
+    });
+  });
+
+  it('maps string interfaces to their default type', async () => {
+    await Collection.repository.create({
+      values: {
+        name: 'withStringInterface',
+      },
+      context: {},
+    });
+
+    const field = await Field.repository.create({
+      values: {
+        name: 'note',
+        interface: 'input',
+        collectionName: 'withStringInterface',
+      },
+      context: {},
+    });
+
+    expect(field.get('type')).toBe('string');
+  });
+
+  it('keeps an explicit type over the interface default', async () => {
+    await Collection.repository.create({
+      values: {
+        name: 'withExplicitType',
+      },
+      context: {},
+    });
+
+    const field = await Field.repository.create({
+      values: {
+        name: 'amount',
+        interface: 'number',
+        type: 'float',
+        collectionName: 'withExplicitType',
+      },
+      context: {},
+    });
+
+    expect(field.get('type')).toBe('float');
+  });
+});

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/hooks/beforeCreateForInterfaceDefaultType.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/hooks/beforeCreateForInterfaceDefaultType.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { DEFAULT_FIELD_TYPES, normalizeInterfaceName } from '../modeling/fields';
+
+/**
+ * The browser form applies each field interface's default data type before
+ * calling the API; a direct API caller that sends only an interface got no
+ * default at all, and the request later failed deep inside the database
+ * layer with "unsupported field type null" (#10398). Resolve the documented
+ * default here so every creation path agrees: when no explicit type is set
+ * and the (normalized) interface has a default, apply it.
+ */
+export function beforeCreateForInterfaceDefaultType() {
+  return async (model) => {
+    if (model.get('source')) {
+      return;
+    }
+
+    if (model.get('type')) {
+      return;
+    }
+
+    const interfaceName = normalizeInterfaceName(model.get('interface'));
+    const defaultType = interfaceName ? DEFAULT_FIELD_TYPES[interfaceName] : undefined;
+
+    if (defaultType) {
+      model.set('type', defaultType);
+    }
+  };
+}

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/fields.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/modeling/fields.ts
@@ -30,7 +30,7 @@ export function normalizeInterfaceName(value?: string) {
   return INTERFACE_ALIASES[value] || value;
 }
 
-const DEFAULT_FIELD_TYPES: Record<string, string> = {
+export const DEFAULT_FIELD_TYPES: Record<string, string> = {
   input: 'string',
   phone: 'string',
   email: 'string',

--- a/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-main/src/server/server.ts
@@ -30,6 +30,7 @@ import {
   beforeInitOptions,
 } from './hooks';
 import { beforeCreateCheckFieldInMySQL } from './hooks/beforeCreateCheckFieldInMySQL';
+import { beforeCreateForInterfaceDefaultType } from './hooks/beforeCreateForInterfaceDefaultType';
 import { beforeCreateForValidateField, beforeUpdateForValidateField } from './hooks/beforeCreateForValidateField';
 import { beforeCreateForViewCollection } from './hooks/beforeCreateForViewCollection';
 import { beforeDestoryField } from './hooks/beforeDestoryField';
@@ -164,6 +165,10 @@ export class PluginDataSourceMainServer extends Plugin {
         },
       );
     });
+
+    // Apply the interface's documented default data type before any hook
+    // reads model.type (#10398)
+    this.app.db.on('fields.beforeCreate', beforeCreateForInterfaceDefaultType());
 
     // 要在 beforeInitOptions 之前处理
     this.app.db.on('fields.beforeCreate', beforeCreateCheckFieldInMySQL(this.app.db));


### PR DESCRIPTION
## What?

`POST /api/collections/<collection>/fields:create` with `{"name":"amount","interface":"number"}` answers `500 {"message":"unsupported field type null"}` instead of creating the field with the interface's documented default type.

Closes #10398

## Why?

The manual states each interface has a default data type ("a field with the Number interface uses `double` by default"), but that default is applied by the **browser form**, not by the server. A direct API caller that sends only an `interface` gets no `type` at all, and the request fails deep inside the database layer (`buildField`: `fieldTypes.get(null)` → `unsupported field type null`), surfacing as a 500 instead of either honoring the documented default or rejecting the request where it can be attributed.

The modeling API already solves this server-side: `modeling/fields.ts` carries `DEFAULT_FIELD_TYPES` and applies `field.type || defaultType`. The classic `fields:create` path (field repository → `fields` collection hooks) just never got the same treatment.

## How?

A new `fields.beforeCreate` hook, `beforeCreateForInterfaceDefaultType`, registered **first** in the hook chain (before every other `beforeCreate` hook that reads `model.type`, e.g. the `beforeInitOptions` dispatcher):

- if the field has a `source` (inherited), do nothing — the source field's type wins;
- if an explicit `type` is set, do nothing — explicit types always win;
- otherwise normalize the interface name (same `INTERFACE_ALIASES` handling as the modeling path) and apply `DEFAULT_FIELD_TYPES[interface]` when one exists.

Unknown interfaces and interface-less fields are left exactly as before (the existing database-layer error still applies to them).

## Testing

- The hook's contract is verified directly against the module (its only collaborators are `normalizeInterfaceName` and the exported map): `number` → `double` (the #10398 request), `input` → `string`, explicit `type` kept, `source` fields untouched, unknown/absent interfaces untouched, aliased `createdAt` → `date` — 7/7 pass.
- `fields-interface-default-type.test.ts` adds the same scenarios through `createMockServer` (mirroring `fields.repository.test.ts`) plus an end-to-end write proving the collection really got a usable column.

Note on the second point in the issue (500 vs 400 for genuinely bad requests): that's a resourcer-level error-mapping concern orthogonal to this change — with the default applied, the documented creation path now succeeds; the remaining failure mode is an explicitly unknown type, which still produces the existing database-layer error.