### PR TITLE
fix(workflow): allow task menu collapse

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx
@@ -234,7 +234,7 @@ describe('WorkflowTasksPage', () => {
     });
   });
 
-  it('collapses the current task type when its menu title is clicked again and keeps it selected', async () => {
+  it('toggles the current task type while keeping it selected', async () => {
     const { registry } = createTaskTypes();
     const demoTasks = {
       listMine: vi.fn().mockResolvedValue({ data: { data: [], meta: { count: 0 } } }),
@@ -259,6 +259,11 @@ describe('WorkflowTasksPage', () => {
     fireEvent.click(menuTitle);
 
     await waitFor(() => expect(submenu).not.toHaveClass('ant-menu-submenu-open'));
+    expect(submenu).toHaveClass('ant-menu-submenu-selected');
+
+    fireEvent.click(menuTitle);
+
+    await waitFor(() => expect(submenu).toHaveClass('ant-menu-submenu-open'));
     expect(submenu).toHaveClass('ant-menu-submenu-selected');
     expect(holder.navigate).not.toHaveBeenCalled();
   });

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx
@@ -234,6 +234,35 @@ describe('WorkflowTasksPage', () => {
     });
   });
 
+  it('collapses the current task type when its menu title is clicked again and keeps it selected', async () => {
+    const { registry } = createTaskTypes();
+    const demoTasks = {
+      listMine: vi.fn().mockResolvedValue({ data: { data: [], meta: { count: 0 } } }),
+    };
+    const userWorkflowTasks = {
+      listMine: vi.fn().mockResolvedValue({ data: [{ type: 'demo', stats: { pending: 1, all: 1 } }] }),
+    };
+    holder.ctx = makeCtx(registry, { demoTasks, userWorkflowTasks });
+
+    renderWithApp(<WorkflowTasksPage />);
+
+    await screen.findByTestId('workflow-task-navigation-menu');
+    const menuTitle = screen
+      .getByTestId('workflow-task-navigation-menu')
+      .querySelector<HTMLElement>('.ant-menu-submenu-title');
+    if (!menuTitle) {
+      throw new Error('Expected the task type submenu title to be rendered');
+    }
+    const submenu = menuTitle.closest('.ant-menu-submenu');
+    expect(submenu).toHaveClass('ant-menu-submenu-open', 'ant-menu-submenu-selected');
+
+    fireEvent.click(menuTitle);
+
+    await waitFor(() => expect(submenu).not.toHaveClass('ant-menu-submenu-open'));
+    expect(submenu).toHaveClass('ant-menu-submenu-selected');
+    expect(holder.navigate).not.toHaveBeenCalled();
+  });
+
   it('searches and incrementally loads workflow groups', async () => {
     const { registry } = createTaskTypes();
     const demoTasks = {

--- a/packages/plugins/@nocobase/plugin-workflow/src/shared/WorkflowTaskNavigation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/shared/WorkflowTaskNavigation.tsx
@@ -514,10 +514,15 @@ function WorkflowTaskNavigationMenu(props: {
   } = useWorkflowTaskFilterContext();
   const [searchValue, setSearchValue] = useState(search);
   const typeMenuKey = currentTypeKey ? `type:${currentTypeKey}` : undefined;
+  const [openKeys, setOpenKeys] = useState<string[]>(typeMenuKey ? [typeMenuKey] : []);
 
   useEffect(() => {
     setSearchValue(search);
   }, [search]);
+
+  useEffect(() => {
+    setOpenKeys(typeMenuKey ? [typeMenuKey] : []);
+  }, [typeMenuKey]);
 
   const handleWorkflowSelect = useCallback(
     (workflow: WorkflowTaskStatsItem | null) => {
@@ -554,18 +559,19 @@ function WorkflowTaskNavigationMenu(props: {
   );
 
   const handleOpenChange = useCallback<NonNullable<MenuProps['onOpenChange']>>(
-    (openKeys) => {
-      const nextTypeMenuKey = [...openKeys].reverse().find((key) => key.startsWith('type:') && key !== typeMenuKey);
+    (nextOpenKeys) => {
+      const nextTypeMenuKey = [...nextOpenKeys].reverse().find((key) => key.startsWith('type:') && key !== typeMenuKey);
       if (!nextTypeMenuKey) {
-        selectWorkflow(null);
+        setOpenKeys([]);
         return;
       }
+      setOpenKeys([nextTypeMenuKey]);
       const nextType = nextTypeMenuKey.slice('type:'.length);
       if (nextType !== currentTypeKey) {
         onTaskTypeSelect(nextType);
       }
     },
-    [currentTypeKey, onTaskTypeSelect, selectWorkflow, typeMenuKey],
+    [currentTypeKey, onTaskTypeSelect, typeMenuKey],
   );
 
   const workflowMenuItems: NonNullable<MenuProps['items']> = [
@@ -615,8 +621,11 @@ function WorkflowTaskNavigationMenu(props: {
       mode="inline"
       inlineIndent={token.padding}
       expandIcon={null}
-      openKeys={typeMenuKey ? [typeMenuKey] : []}
-      selectedKeys={[selectedWorkflow ? `workflow:${selectedWorkflow.workflowKey}` : 'workflow:all']}
+      openKeys={openKeys}
+      selectedKeys={[
+        ...(typeMenuKey ? [typeMenuKey] : []),
+        selectedWorkflow ? `workflow:${selectedWorkflow.workflowKey}` : 'workflow:all',
+      ]}
       onClick={handleMenuClick}
       onOpenChange={handleOpenChange}
       items={taskTypes.map((type) => ({

--- a/packages/plugins/@nocobase/plugin-workflow/src/shared/WorkflowTaskNavigation.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/shared/WorkflowTaskNavigation.tsx
@@ -560,7 +560,7 @@ function WorkflowTaskNavigationMenu(props: {
 
   const handleOpenChange = useCallback<NonNullable<MenuProps['onOpenChange']>>(
     (nextOpenKeys) => {
-      const nextTypeMenuKey = [...nextOpenKeys].reverse().find((key) => key.startsWith('type:') && key !== typeMenuKey);
+      const nextTypeMenuKey = [...nextOpenKeys].reverse().find((key) => key.startsWith('type:'));
       if (!nextTypeMenuKey) {
         setOpenKeys([]);
         return;
@@ -571,7 +571,7 @@ function WorkflowTaskNavigationMenu(props: {
         onTaskTypeSelect(nextType);
       }
     },
-    [currentTypeKey, onTaskTypeSelect, typeMenuKey],
+    [currentTypeKey, onTaskTypeSelect],
   );
 
   const workflowMenuItems: NonNullable<MenuProps['items']> = [


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The workflow task center forced the currently routed task menu to stay expanded. Clicking an expanded menu title could not collapse it, and the current parent menu did not consistently use the default selected style.

### Description

- Manage task menu expansion independently from the current route so the active menu can be collapsed by clicking its title again.
- Keep the current task type and workflow item selected so Ant Design applies its default highlight styles after the menu is collapsed.
- Preserve the current workflow filter when collapsing the parent menu.
- Add regression coverage for collapsing the active menu without navigation while retaining its selected state.

Testing suggestion: open the workflow task center, expand a task type such as My applications, click the same title again, and verify that it collapses while remaining highlighted.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed workflow task center menus so the active menu can be collapsed by clicking it again while retaining its selected highlight |
| 🇨🇳 Chinese | 修复工作流待办中心菜单，使当前菜单可再次点击折叠并保留选中高亮状态 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
