### PR TITLE
fix(plugin-workflow): load collection trigger data without appends

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -634,7 +634,7 @@ describe('workflow > triggers > collection', () => {
 
       const post = await PostRepo.create({ values: { title: 't1' } });
 
-      await plugin.execute(workflow, { data: post.id });
+      await plugin.execute(workflow, { data: post.id }, { manually: true });
 
       const [execution] = await workflow.getExecutions();
       expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/collection.test.ts
@@ -621,6 +621,26 @@ describe('workflow > triggers > collection', () => {
   });
 
   describe('config.appends', () => {
+    it('loads trigger data by record id when appends is omitted', async () => {
+      const workflow = await WorkflowModel.create({
+        enabled: false,
+        sync: true,
+        type: 'collection',
+        config: {
+          mode: 1,
+          collection: 'posts',
+        },
+      });
+
+      const post = await PostRepo.create({ values: { title: 't1' } });
+
+      await plugin.execute(workflow, { data: post.id });
+
+      const [execution] = await workflow.getExecutions();
+      expect(execution.status).toBe(EXECUTION_STATUS.RESOLVED);
+      expect(execution.context.data.title).toBe('t1');
+    });
+
     it('non-appended association could not be accessed', async () => {
       const workflow = await WorkflowModel.create({
         enabled: true,

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/CollectionTrigger.ts
@@ -170,7 +170,7 @@ export default class CollectionTrigger extends Trigger {
   }
 
   async prepare(workflow: WorkflowModel, data: Model | Record<string, any> | string | number, options) {
-    const { condition, changed, mode, appends } = workflow.config;
+    const { condition, changed, mode, appends = [] } = workflow.config;
     const [dataSourceName, collectionName] = parseCollectionName(workflow.config.collection);
     const { collectionManager } = this.workflow.app.dataSourceManager.dataSources.get(dataSourceName);
     const collection: Collection = (collectionManager as SequelizeCollectionManager).getCollection(collectionName);


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
Calling a collection-event sub-workflow with a record ID failed with `undefined.reduce` when Preload associations was left empty and the workflow configuration did not contain an `appends` property.

### Description
- Treat an omitted collection-trigger `appends` configuration as an empty array before preparing trigger data.
- Add a regression case that executes a collection workflow with only a record ID and verifies that the complete record is loaded successfully.

Risk is limited to collection-trigger context preparation when loading records by primary key. Existing configured association preloading behavior remains unchanged.

Testing note: lint-staged and ESLint passed. The server test suite could not start in the current environment because the `sqlite3` native package is unavailable (`Please install sqlite3 package manually`).

### Related issues

Task 6059

### Showcase

Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed collection event as sub-workflows failing when called with a record ID and no preload associations configured |
| 🇨🇳 Chinese | 修复子流程使用数据表事件未配置预加载关联字段且按记录 ID 调用时报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
