### PR TITLE
fix(plugin-ai): resolve internal file URLs without copying

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/workflow-ai-employee-fieldset.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/__tests__/workflow-ai-employee-fieldset.test.tsx
@@ -18,6 +18,7 @@ import { FeedbackSettings } from '../workflow/nodes/employee/components/Feedback
 import { SkillSettings } from '../workflow/nodes/employee/components/SkillSettings';
 import { StructuredOutput } from '../workflow/nodes/employee/components/StructuredOutput';
 import { UserInput } from '../workflow/nodes/employee/components/UserInput';
+import { FileInputs } from '../workflow/nodes/employee/components/FileInputs';
 
 const { useWorkflowVariableOptions } = vi.hoisted(() => ({
   useWorkflowVariableOptions: vi.fn((_options?: { types?: Array<(field: unknown) => boolean> }) => []),
@@ -162,6 +163,8 @@ type FormValues = {
       skills?: string[];
       tools?: string[];
     };
+    files?: Array<{ type: string; value?: string }>;
+    fileUrlOrigin?: string;
   };
 };
 
@@ -207,6 +210,28 @@ describe('AI employee workflow fieldset', () => {
 
     fireEvent.click(selector);
     expect(onChange).toHaveBeenCalledWith('{{$context.user.id}}');
+  });
+
+  it('submits the current browser origin for file URL same-origin checks', async () => {
+    const submitted: FormValues[] = [];
+
+    render(
+      <FormHarness
+        initialValues={{
+          config: {
+            files: [{ type: 'file_url', value: '{{$context.data.url}}' }],
+          },
+        }}
+        onFinish={(values) => submitted.push(values)}
+      >
+        <FileInputs />
+      </FormHarness>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(submitted).toHaveLength(1));
+    expect(submitted[0].config?.fileUrlOrigin).toBe(window.location.origin);
   });
 
   it('keeps structured output and normalized approval mode under config when submitted', async () => {

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/workflow/nodes/employee/components/FileInputs.tsx
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/workflow/nodes/employee/components/FileInputs.tsx
@@ -7,7 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { Form, Select } from 'antd';
 import { useFlowEngine } from '@nocobase/flow-engine';
 import { WorkflowVariableInput } from '@nocobase/plugin-workflow/client-v2';
@@ -79,6 +79,12 @@ export function FileInputs() {
     [flowEngine.context.dataSourceManager],
   );
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      form.setFieldValue(['config', 'fileUrlOrigin'], window.location.origin);
+    }
+  }, [form]);
+
   const updateFiles = useCallback(
     (next: AIEmployeeFileInput[]) => {
       form.setFieldValue(['config', 'files'], next);
@@ -95,6 +101,9 @@ export function FileInputs() {
 
   return (
     <>
+      <Form.Item name={['config', 'fileUrlOrigin']} noStyle>
+        <FormValueRegistry />
+      </Form.Item>
       <Form.Item name={['config', 'files']} noStyle>
         <FormValueRegistry />
       </Form.Item>

--- a/packages/plugins/@nocobase/plugin-ai/src/client-v2/workflow/types.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/client-v2/workflow/types.ts
@@ -124,6 +124,7 @@ export type AIEmployeeInstructionConfig = {
   userId?: string | number | Array<string | number>;
   message?: AIEmployeeTaskMessage;
   files?: AIEmployeeFileInput[];
+  fileUrlOrigin?: string;
   skillSettings?: SkillSettings;
   webSearch?: boolean;
   structuredOutput?: AIEmployeeStructuredOutputConfig;

--- a/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/workflow-files.test.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/__tests__/workflow-files.test.ts
@@ -9,7 +9,7 @@
 
 import axios from 'axios';
 import type { Plugin } from '@nocobase/server';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Files } from '../workflow/nodes/employee/files';
 
 vi.mock('axios', () => ({
@@ -17,6 +17,22 @@ vi.mock('axios', () => ({
     get: vi.fn(),
   },
 }));
+
+const originalPublicPath = process.env.APP_PUBLIC_PATH;
+const originalPublicOrigin = process.env.APP_PUBLIC_ORIGIN;
+
+afterEach(() => {
+  if (originalPublicPath === undefined) {
+    delete process.env.APP_PUBLIC_PATH;
+  } else {
+    process.env.APP_PUBLIC_PATH = originalPublicPath;
+  }
+  if (originalPublicOrigin === undefined) {
+    delete process.env.APP_PUBLIC_ORIGIN;
+  } else {
+    process.env.APP_PUBLIC_ORIGIN = originalPublicOrigin;
+  }
+});
 
 describe('workflow AI employee files', () => {
   it('preserves external data source metadata for attachment fields', async () => {
@@ -48,6 +64,69 @@ describe('workflow AI employee files', () => {
           collectionName: 'attachments',
           field: 'orders.files',
           documentCache: false,
+          trustworthy: true,
+        },
+      },
+    ]);
+  });
+
+  it('uses the original attachment for NocoBase permanent file urls', async () => {
+    process.env.APP_PUBLIC_PATH = '/nocobase';
+    delete process.env.APP_PUBLIC_ORIGIN;
+    vi.mocked(axios.get).mockClear();
+    const attachment = {
+      id: 24,
+      filename: 'report.pdf',
+      extname: '.pdf',
+      storageId: 1,
+    };
+    const findOne = vi.fn(async () => ({
+      toJSON: () => attachment,
+    }));
+    const collection = {
+      name: 'attachments',
+      options: { template: 'file' },
+    };
+    const createFileRecord = vi.fn();
+    const plugin = {
+      app: {
+        name: 'main',
+        dataSourceManager: {
+          get: () => ({
+            collectionManager: {
+              getCollection: () => collection,
+              getRepository: () => ({ findOne }),
+            },
+          }),
+        },
+      },
+      db: {
+        getRepository: () => ({
+          findOne: async () => ({ options: { storage: 'local' } }),
+        }),
+      },
+      pm: {
+        get: () => ({ createFileRecord }),
+      },
+    } as unknown as Plugin;
+    const attachmentPart: { attachments?: unknown[] } = {};
+
+    await Files.resolvers(plugin, attachmentPart, 'https://pr-10408.v2.test.nocobase.com').resolveUrls([
+      {
+        type: 'file_url',
+        value: 'https://pr-10408.v2.test.nocobase.com/nocobase/files/main/main/attachments/24.pdf',
+      },
+    ]);
+
+    expect(findOne).toHaveBeenCalledWith(expect.objectContaining({ filter: { id: '24' } }));
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(createFileRecord).not.toHaveBeenCalled();
+    expect(attachmentPart.attachments).toEqual([
+      {
+        ...attachment,
+        source: {
+          dataSourceKey: 'main',
+          collectionName: 'attachments',
           trustworthy: true,
         },
       },

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/files.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/files.ts
@@ -13,7 +13,7 @@ import path from 'node:path';
 import { AIEmployeeInstructionFiles } from './types';
 import _ from 'lodash';
 import axios from 'axios';
-import PluginFileManagerServer from '@nocobase/plugin-file-manager';
+import { parsePermanentFileReference, type PluginFileManagerServer } from '@nocobase/plugin-file-manager';
 import { Plugin } from '@nocobase/server';
 import { resolveContentType, resolveFileIdentity } from '../../utils';
 import { getAttachmentSource, type AttachmentSource } from '../../../attachments';
@@ -28,8 +28,53 @@ function appendSource(record: unknown, source: AttachmentSource) {
   };
 }
 
+type FileRecord = Record<string, unknown> & {
+  toJSON?: () => unknown;
+};
+
+function toFilePlainObject(record: FileRecord) {
+  const value = typeof record.toJSON === 'function' ? record.toJSON() : record;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid file record');
+  }
+  return value as Record<string, unknown>;
+}
+
+async function resolveInternalFileURL(plugin: Plugin, url: string, origin?: string) {
+  const reference = parsePermanentFileReference(url, origin);
+  if (!reference) {
+    return null;
+  }
+  if (reference.appName !== (plugin.app.name || 'main')) {
+    throw new Error('File not found');
+  }
+
+  const dataSource = plugin.app.dataSourceManager.get(reference.dataSourceKey);
+  const collection = dataSource?.collectionManager.getCollection(reference.collectionName);
+  if (!dataSource || !collection || (collection.name !== 'attachments' && collection.options?.template !== 'file')) {
+    throw new Error('File not found');
+  }
+
+  const record = (await dataSource.collectionManager.getRepository(collection.name).findOne({
+    filter: { id: reference.id },
+  })) as FileRecord | null;
+  if (!record) {
+    throw new Error('File not found');
+  }
+  const file = toFilePlainObject(record);
+  if (file.storageId == null || (reference.extname && reference.extname !== file.extname)) {
+    throw new Error('File not found');
+  }
+
+  return appendSource(file, {
+    dataSourceKey: reference.dataSourceKey,
+    collectionName: collection.name,
+    trustworthy: true,
+  });
+}
+
 export abstract class Files {
-  static resolvers(plugin: Plugin, attachmentPart: { attachments?: unknown[] }) {
+  static resolvers(plugin: Plugin, attachmentPart: { attachments?: unknown[] }, fileUrlOrigin?: string) {
     const resolveAttachments = async (files: AIEmployeeInstructionFiles[]) => {
       const attachments = files
         .filter((it) => it.type === 'attachments')
@@ -90,6 +135,15 @@ export abstract class Files {
         const storageName = settings?.options?.storage;
         const attachments = await Promise.all(
           urls.map(async (url) => {
+            const internalFile = await resolveInternalFileURL(plugin, url, fileUrlOrigin);
+            if (internalFile) {
+              return internalFile;
+            }
+            try {
+              new URL(url);
+            } catch (error) {
+              throw new Error(`File URL must be an absolute URL or a NocoBase permanent file URL: ${url}`);
+            }
             const response = await axios.get(url, {
               responseType: 'arraybuffer',
             });

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/index.ts
@@ -35,6 +35,7 @@ export class AIEmployeeInstruction extends Instruction {
       requiresApproval = REQUIRES_APPROVAL.NO_REQUIRED,
       userId,
       files,
+      fileUrlOrigin,
     }: AIEmployeeInstructionConfig = processor.getParsedValue(node.config, node.id);
 
     const toolName = SYSTEM_TOOLS.WORK_FLOW_TASK_OUTPUT;
@@ -137,7 +138,11 @@ Do not treat **${toolName}** as optional, and do not finish the task without cal
 
         const attachmentPart: Record<string, any> = {};
         if (files?.length) {
-          const { resolveAttachments, resolveFileIds, resolveUrls } = Files.resolvers(this.workflow, attachmentPart);
+          const { resolveAttachments, resolveFileIds, resolveUrls } = Files.resolvers(
+            this.workflow,
+            attachmentPart,
+            fileUrlOrigin,
+          );
           await resolveAttachments(files);
           await resolveFileIds(files);
           await resolveUrls(files);

--- a/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/types.ts
+++ b/packages/plugins/@nocobase/plugin-ai/src/server/workflow/nodes/employee/types.ts
@@ -29,6 +29,7 @@ export type AIEmployeeInstructionConfig = {
   assignees?: string[];
   userId: string;
   files: AIEmployeeInstructionFiles[];
+  fileUrlOrigin?: string;
 };
 
 export type AIEmployeeInstructionFiles = {

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/file-reference.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/__tests__/file-reference.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { parsePermanentFileReference } from '../file-reference';
+
+const originalPublicPath = process.env.APP_PUBLIC_PATH;
+const originalPublicOrigin = process.env.APP_PUBLIC_ORIGIN;
+
+afterEach(() => {
+  if (originalPublicPath === undefined) {
+    delete process.env.APP_PUBLIC_PATH;
+  } else {
+    process.env.APP_PUBLIC_PATH = originalPublicPath;
+  }
+  if (originalPublicOrigin === undefined) {
+    delete process.env.APP_PUBLIC_ORIGIN;
+  } else {
+    process.env.APP_PUBLIC_ORIGIN = originalPublicOrigin;
+  }
+});
+
+describe('permanent file references', () => {
+  it('parses relative permanent file paths with APP_PUBLIC_PATH', () => {
+    process.env.APP_PUBLIC_PATH = '/nocobase';
+
+    expect(parsePermanentFileReference('/nocobase/files/main/another/reports/42.xlsx')).toEqual({
+      appName: 'main',
+      dataSourceKey: 'another',
+      collectionName: 'reports',
+      id: '42',
+      extname: '.xlsx',
+    });
+  });
+
+  it('parses same-origin absolute permanent file urls using the submitted browser origin', () => {
+    process.env.APP_PUBLIC_PATH = '/nocobase';
+    const origin = 'https://nocobase.example.com';
+
+    expect(
+      parsePermanentFileReference('https://nocobase.example.com/nocobase/files/main/main/attachments/24.pdf', origin),
+    ).toEqual({
+      appName: 'main',
+      dataSourceKey: 'main',
+      collectionName: 'attachments',
+      id: '24',
+      extname: '.pdf',
+    });
+    expect(
+      parsePermanentFileReference('https://cdn.example.com/nocobase/files/main/main/attachments/24.pdf', origin),
+    ).toBeNull();
+  });
+
+  it('prefers APP_PUBLIC_ORIGIN over the submitted browser origin', () => {
+    process.env.APP_PUBLIC_PATH = '/nocobase';
+    process.env.APP_PUBLIC_ORIGIN = 'https://public.example.com';
+
+    expect(
+      parsePermanentFileReference(
+        'https://public.example.com/nocobase/files/main/main/attachments/24.pdf',
+        'https://editor.example.com',
+      ),
+    ).toEqual({
+      appName: 'main',
+      dataSourceKey: 'main',
+      collectionName: 'attachments',
+      id: '24',
+      extname: '.pdf',
+    });
+    expect(
+      parsePermanentFileReference(
+        'https://editor.example.com/nocobase/files/main/main/attachments/24.pdf',
+        'https://editor.example.com',
+      ),
+    ).toBeNull();
+  });
+
+  it('does not treat temporary access urls as permanent file references', () => {
+    expect(
+      parsePermanentFileReference('/files/main/main/attachments/24.pdf?temporaryAccessToken=temporary-token'),
+    ).toBeNull();
+  });
+
+  it('rejects malformed permanent file paths', () => {
+    expect(() => parsePermanentFileReference('/files/main/main/attachments')).toThrow('Invalid file URL');
+    expect(() => parsePermanentFileReference('/files/main/main/attachments/%2Fetc%2Fpasswd')).toThrow(
+      'Invalid file URL',
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/file-reference.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/file-reference.ts
@@ -1,0 +1,109 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { normalizeFileAccessExtname, trimPublicPath } from './utils';
+
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9_-]*$/;
+
+export type PermanentFileReference = {
+  appName: string;
+  dataSourceKey: string;
+  collectionName: string;
+  id: string;
+  extname?: string;
+};
+
+function invalidFileURL() {
+  return Object.assign(new Error('Invalid file URL'), { status: 404 });
+}
+
+function stripPublicPath(pathname: string) {
+  const publicPath = trimPublicPath(process.env.APP_PUBLIC_PATH);
+  if (publicPath && (pathname === publicPath || pathname.startsWith(`${publicPath}/`))) {
+    return pathname.slice(publicPath.length) || '/';
+  }
+  return pathname;
+}
+
+function getURLOrigin(value: unknown) {
+  if (typeof value !== 'string' || !value) {
+    return null;
+  }
+  try {
+    return new URL(value).origin;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function parsePermanentFileReference(value: unknown, origin?: string): PermanentFileReference | null {
+  if (typeof value !== 'string' || !value || value.startsWith('//')) {
+    return null;
+  }
+
+  let url: URL;
+  if (value.startsWith('/')) {
+    url = new URL(value, 'http://localhost');
+  } else {
+    try {
+      url = new URL(value);
+    } catch (error) {
+      return null;
+    }
+    const configuredOrigin = process.env.APP_PUBLIC_ORIGIN;
+    const trustedOrigin = configuredOrigin ? getURLOrigin(configuredOrigin) : getURLOrigin(origin);
+    if (!trustedOrigin || url.origin !== trustedOrigin) {
+      return null;
+    }
+  }
+
+  if (url.searchParams.has('temporaryAccessToken')) {
+    return null;
+  }
+
+  const segments = stripPublicPath(url.pathname).split('/').filter(Boolean);
+  if (segments[0] !== 'files') {
+    return null;
+  }
+  if (segments.length !== 5) {
+    throw invalidFileURL();
+  }
+
+  try {
+    const appName = decodeURIComponent(segments[1]);
+    const dataSourceKey = decodeURIComponent(segments[2]);
+    const collectionName = decodeURIComponent(segments[3]);
+    const fileIdSegment = decodeURIComponent(segments[4]);
+    const extnameIndex = fileIdSegment.lastIndexOf('.');
+    const extname = extnameIndex > 0 ? normalizeFileAccessExtname(fileIdSegment.slice(extnameIndex)) : '';
+    const id = extname ? fileIdSegment.slice(0, extnameIndex) : fileIdSegment;
+
+    if (
+      !IDENTIFIER_PATTERN.test(appName) ||
+      !IDENTIFIER_PATTERN.test(dataSourceKey) ||
+      !IDENTIFIER_PATTERN.test(collectionName) ||
+      !id ||
+      id.includes('/') ||
+      id.includes('\\') ||
+      id.includes('\0')
+    ) {
+      throw invalidFileURL();
+    }
+
+    return {
+      appName,
+      dataSourceKey,
+      collectionName,
+      id,
+      extname: extname || undefined,
+    };
+  } catch (error) {
+    throw invalidFileURL();
+  }
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/server/index.ts
@@ -12,6 +12,8 @@ import { StorageEngine } from 'multer';
 export * from '../constants';
 export { AttachmentModel, default, PluginFileManagerServer, StorageModel } from './server';
 export type { FileAccessAuthorizeParams, FileAccessAuthorizer } from './server';
+export { parsePermanentFileReference } from './file-reference';
+export type { PermanentFileReference } from './file-reference';
 export { cloudFilenameGetter } from './utils';
 export {
   appendDownloadResponse,


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
AI employee workflow nodes currently download every file URL through Axios and copy the result into `aiFiles`. NocoBase permanent file URLs may be relative or require the task operator's access permissions, so direct server-side HTTP requests can fail. Internal files are also unnecessarily duplicated.

### Description
- Add and export a reusable File Manager parser and result type for NocoBase permanent file URLs.
- Store the node editor's `location.origin` in the node config for same-origin absolute permanent file URLs, while preferring `APP_PUBLIC_ORIGIN` when it is configured.
- Keep file record lookup in the AI plugin, validate the application, data source, file collection, record ID, storage ID, and file extension, then attach trusted source metadata.
- Let AI employee workflow URL inputs use the original attachment record for internal files without Axios downloads or `aiFiles` copies.
- Preserve the existing download-and-copy behavior for external absolute URLs and return a clear error for unsupported relative URLs.

Potential risks:
- Existing nodes saved before this change do not contain `fileUrlOrigin`; re-saving the node is required for same-origin absolute URLs when `APP_PUBLIC_ORIGIN` is not configured. Relative permanent file URLs remain compatible.
- This change intentionally does not alter the existing `file_id` or attachment input resolution paths.

Testing suggestions:
- Use relative NocoBase attachment URLs with and without `APP_PUBLIC_PATH`, plus absolute URLs matching or differing from the node editor origin.
- Verify custom file collections are resolved from their original data source and passed to the AI employee without creating an `aiFiles` copy.
- Verify external HTTPS URLs are still downloaded into `aiFiles`.
- Verify temporary access URLs continue to use the existing token flow.

### Related issues

N/A

### Showcase

N/A (server-side workflow behavior)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed AI employee workflow nodes failing to access NocoBase permanent file URLs and unnecessarily copying internal files to AI storage. |
| 🇨🇳 Chinese | 修复 AI 员工工作流节点无法访问 NocoBase 永久文件 URL，以及内部文件被不必要复制到 AI 存储的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary



