### PR TITLE
feat(ci): support maintenance releases for version branches

### DIFF
--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -48,7 +48,8 @@ jobs:
             echo "Main stable version is invalid: $MAIN_VERSION" >&2
             exit 1
           fi
-          MAIN_BASE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          MAIN_MAJOR="${BASH_REMATCH[1]}"
+          MAIN_MINOR="${BASH_REMATCH[2]}"
 
           if [[ "$INPUT_BASE_VERSION" =~ ^([0-9]+)$ ]]; then
             INPUT_MAJOR="${BASH_REMATCH[1]}"
@@ -62,12 +63,6 @@ jobs:
             TAG_REGEX="^v($BASE_VERSION\.[0-9]+)$"
           else
             echo "Base version must be a major or major.minor line, for example 1 or 2.1." >&2
-            exit 1
-          fi
-
-          if [[ -n "${BASE_VERSION:-}" && "$BASE_VERSION" == "$MAIN_BASE_VERSION" ]]; then
-            echo "Maintenance line $BASE_VERSION matches Main version $MAIN_VERSION." >&2
-            echo "Use the Main release workflow for the current stable line." >&2
             exit 1
           fi
 
@@ -96,9 +91,15 @@ jobs:
             BASE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
           fi
 
-          if [[ "$BASE_VERSION" == "$MAIN_BASE_VERSION" ]]; then
-            echo "Maintenance line $BASE_VERSION matches Main version $MAIN_VERSION." >&2
-            echo "Use the Main release workflow for the current stable line." >&2
+          if [[ ! "$BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Failed to parse maintenance line $BASE_VERSION." >&2
+            exit 1
+          fi
+          BASE_MAJOR="${BASH_REMATCH[1]}"
+          BASE_MINOR="${BASH_REMATCH[2]}"
+          if (( BASE_MAJOR > MAIN_MAJOR || (BASE_MAJOR == MAIN_MAJOR && BASE_MINOR >= MAIN_MINOR) )); then
+            echo "Maintenance line $BASE_VERSION is not older than Main version $MAIN_VERSION." >&2
+            echo "Only release lines older than Main may use the maintenance release workflow." >&2
             exit 1
           fi
 
@@ -130,7 +131,7 @@ jobs:
     outputs:
       plugins: ${{ steps.select.outputs.plugins }}
     steps:
-      - name: Select plugins for release channel
+      - name: Select all plugins on the maintenance branch
         id: select
         env:
           ALL_PLUGINS: ${{ needs.get-plugins.outputs.all-plugins }}
@@ -296,8 +297,12 @@ jobs:
             repo="${repo_names[$i]}"
             repo_dir="${repo_dirs[$i]}"
             if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/$TAG^{commit}" >/dev/null; then
-              if ! git -C "$repo_dir" merge-base --is-ancestor "refs/tags/$TAG^{commit}" "$MAINTENANCE_BRANCH"; then
-                echo "ERROR: Existing tag $TAG in nocobase/$repo is not part of branch $MAINTENANCE_BRANCH." >&2
+              tag_commit=$(git -C "$repo_dir" rev-parse "refs/tags/$TAG^{commit}")
+              branch_commit=$(git -C "$repo_dir" rev-parse "refs/heads/$MAINTENANCE_BRANCH^{commit}")
+              if [[ "$tag_commit" != "$branch_commit" ]]; then
+                echo "ERROR: Existing tag $TAG in nocobase/$repo does not point to the current head of branch $MAINTENANCE_BRANCH." >&2
+                echo "Tag commit: $tag_commit" >&2
+                echo "Branch head: $branch_commit" >&2
                 exit 1
               fi
               exist+=("$repo")

--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -1,19 +1,15 @@
-name: Manual release v1.x
+name: Manual maintenance release
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.base_version || 'current' }}
   cancel-in-progress: true
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'specify a version (e.g. 1.9.48)'
+      base_version:
+        description: 'Optional major.minor line; 2.1 uses branch v2.1. Empty uses main.'
         type: string
-        required: false
-      is_feat:
-        description: 'is feat (minor bump behavior, see release.sh)'
-        type: boolean
         required: false
       dry_run:
         description: 'If true, do not build, commit, tag, or push. Only compute version + validate tag conflicts and print a plan.'
@@ -27,15 +23,156 @@ on:
         default: false
 
 jobs:
+  resolve-release:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.resolve.outputs.branch }}
+      version: ${{ steps.resolve.outputs.version }}
+      base_version: ${{ steps.resolve.outputs.baseVersion }}
+      highest_version: ${{ steps.resolve.outputs.highestVersion }}
+      is_current: ${{ steps.resolve.outputs.isCurrent }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Resolve maintenance branch and next patch version
+        id: resolve
+        shell: bash
+        env:
+          INPUT_BASE_VERSION: ${{ inputs.base_version }}
+        run: |
+          set -euo pipefail
+
+          BASE_VERSION="$INPUT_BASE_VERSION"
+          IS_CURRENT=false
+          if [[ -z "$BASE_VERSION" ]]; then
+            CURRENT_VERSION=$(jq -r '.version' lerna.json)
+            if [[ ! "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "Current stable version is invalid: $CURRENT_VERSION" >&2
+              exit 1
+            fi
+            BASE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            HIGHEST_VERSION="$CURRENT_VERSION"
+            MAINTENANCE_BRANCH=main
+            IS_CURRENT=true
+          else
+            if [[ ! "$BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+              echo "Base version must contain only major.minor, for example 1.9 or 2.1." >&2
+              exit 1
+            fi
+            MAINTENANCE_BRANCH="v$BASE_VERSION"
+            if ! git ls-remote --exit-code --heads origin "$MAINTENANCE_BRANCH" >/dev/null 2>&1; then
+              echo "Required maintenance branch $MAINTENANCE_BRANCH does not exist." >&2
+              exit 1
+            fi
+            git fetch origin "+refs/heads/$MAINTENANCE_BRANCH:refs/remotes/origin/$MAINTENANCE_BRANCH" --tags
+
+            HIGHEST_VERSION=$(
+              git tag --merged "origin/$MAINTENANCE_BRANCH" --list "v$BASE_VERSION.*" \
+                | sed -nE "s/^v($BASE_VERSION\.[0-9]+)$/\1/p" \
+                | sort -V \
+                | tail -1
+            )
+            if [[ -z "$HIGHEST_VERSION" ]]; then
+              echo "No stable $BASE_VERSION.x tag found on $MAINTENANCE_BRANCH." >&2
+              exit 1
+            fi
+          fi
+
+          HIGHEST_PATCH="${HIGHEST_VERSION##*.}"
+          NEXT_VERSION="$BASE_VERSION.$((HIGHEST_PATCH + 1))"
+
+          echo "branch=$MAINTENANCE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "baseVersion=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "highestVersion=$HIGHEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "isCurrent=$IS_CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Highest stable tag: v$HIGHEST_VERSION"
+          echo "Maintenance branch: $MAINTENANCE_BRANCH"
+          echo "Next patch version: $NEXT_VERSION"
+
   get-plugins:
+    needs:
+      - resolve-release
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
     with:
-      require_branch: v1
+      require_branch: ${{ needs.resolve-release.outputs.branch }}
     secrets: inherit
+
+  select-plugins:
+    needs:
+      - resolve-release
+      - get-plugins
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.select.outputs.plugins }}
+    steps:
+      - name: Select plugins for release channel
+        id: select
+        env:
+          ALL_PLUGINS: ${{ needs.get-plugins.outputs.all-plugins }}
+          CUSTOM_PLUGINS: ${{ needs.get-plugins.outputs.custom-plugins }}
+          IS_CURRENT: ${{ needs.resolve-release.outputs.is_current }}
+          RC_PLUGINS: ${{ needs.get-plugins.outputs.rc-plugins }}
+        run: |
+          set -euo pipefail
+          if [[ "$IS_CURRENT" == "true" ]]; then
+            PLUGINS=$(jq -cn --argjson rc "$RC_PLUGINS" --argjson custom "$CUSTOM_PLUGINS" '$rc + $custom | unique')
+          else
+            PLUGINS="$ALL_PLUGINS"
+          fi
+          echo "plugins=$PLUGINS" >> "$GITHUB_OUTPUT"
+          echo "Selected plugins: $PLUGINS"
+
+  pre-merge-current:
+    needs:
+      - resolve-release
+      - select-plugins
+    if: ${{ needs.resolve-release.outputs.is_current == 'true' && !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - nocobase
+          - pro-plugins
+          - ${{ fromJSON(needs.select-plugins.outputs.plugins) }}
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.NOCOBASE_APP_ID }}
+          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
+          repositories: nocobase,pro-plugins,${{ join(fromJSON(needs.select-plugins.outputs.plugins), ',') }}
+          skip-token-revoke: true
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api /users/${{ steps.app-token.outputs.app-slug }}[bot] --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - uses: actions/checkout@v4
+        with:
+          repository: nocobase/${{ matrix.repo }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Merge main into next
+        run: |
+          set -euo pipefail
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git checkout main
+          git pull origin main
+          git checkout next
+          git merge main
+          git push origin next --tags --atomic
 
   update-version:
     needs:
+      - resolve-release
       - get-plugins
+      - select-plugins
+      - pre-merge-current
+    if: ${{ always() && needs.resolve-release.result == 'success' && needs.get-plugins.result == 'success' && needs.select-plugins.result == 'success' && (needs.pre-merge-current.result == 'success' || needs.pre-merge-current.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -43,7 +180,7 @@ jobs:
         with:
           app-id: ${{ vars.NOCOBASE_APP_ID }}
           private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
-          repositories: nocobase,pro-plugins,${{ join(fromJSON(needs.get-plugins.outputs.all-plugins), ',') }}
+          repositories: nocobase,pro-plugins,${{ join(fromJSON(needs.select-plugins.outputs.plugins), ',') }}
           skip-token-revoke: true
 
       - name: Get GitHub App User ID
@@ -52,31 +189,34 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Checkout (v1)
+      - name: Checkout maintenance branch
         uses: actions/checkout@v4
         with:
           repository: nocobase/nocobase
-          ref: v1
+          ref: ${{ needs.resolve-release.outputs.branch }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
           fetch-depth: 0
 
-      - name: Checkout pro-plugins (v1)
+      - name: Checkout pro-plugins maintenance branch
         uses: actions/checkout@v4
         with:
           repository: nocobase/pro-plugins
-          ref: v1
+          ref: ${{ needs.resolve-release.outputs.branch }}
           path: packages/pro-plugins
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
-      - name: Clone pro repos (v1)
+      - name: Clone pro repos maintenance branches
+        env:
+          MAINTENANCE_BRANCH: ${{ needs.resolve-release.outputs.branch }}
         shell: bash
         run: |
-          for repo in ${{ join(fromJSON(needs.get-plugins.outputs.all-plugins), ' ') }}
+          set -euo pipefail
+          for repo in ${{ join(fromJSON(needs.select-plugins.outputs.plugins), ' ') }}
           do
-            git clone -b v1 https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
+            git clone -b "$MAINTENANCE_BRANCH" https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
 
       - name: Set Node.js 22
@@ -85,72 +225,114 @@ jobs:
           node-version: 22
 
       - name: Prepare git excludes + identity
+        env:
+          MAINTENANCE_BRANCH: ${{ needs.resolve-release.outputs.branch }}
         shell: bash
         run: |
+          set -euo pipefail
           cd ./packages/pro-plugins
-          git checkout v1
-          for repo in ${{ join(fromJSON(needs.get-plugins.outputs.all-plugins), ' ') }}
+          git checkout "$MAINTENANCE_BRANCH"
+          for repo in ${{ join(fromJSON(needs.select-plugins.outputs.plugins), ' ') }}
           do
             echo "@nocobase/$repo" >> .git/info/exclude
           done
           cd ./../..
 
-          git checkout v1
+          git checkout "$MAINTENANCE_BRANCH"
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
           echo "packages/pro-plugins" >> .git/info/exclude
 
-      - name: Compute version (v1.x)
-        id: compute-version
+      - name: Validate maintenance release
         shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -n "${{ inputs.version }}" ]]; then
-            v=$(bash release.sh --only-version --version "${{ inputs.version }}")
-          else
-            v=$(bash release.sh --only-version $IS_FEAT)
-          fi
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-          echo "Computed version: $v"
         env:
-          IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
-
-      - name: Check tag status (v1.x)
-        shell: bash
+          BASE_VERSION: ${{ needs.resolve-release.outputs.base_version }}
+          HIGHEST_VERSION: ${{ needs.resolve-release.outputs.highest_version }}
+          MAINTENANCE_BRANCH: ${{ needs.resolve-release.outputs.branch }}
+          TARGET_VERSION: ${{ needs.resolve-release.outputs.version }}
         run: |
           set -euo pipefail
-          TAG="v${{ steps.compute-version.outputs.version }}"
+          if ! git check-ref-format "refs/heads/$MAINTENANCE_BRANCH" >/dev/null; then
+            echo "Invalid maintenance branch: $MAINTENANCE_BRANCH" >&2
+            exit 1
+          fi
+          if [[ ! "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must be an exact stable semantic version such as 2.1.19." >&2
+            exit 1
+          fi
+
+          CURRENT_VERSION=$(jq -r '.version' lerna.json)
+          if [[ ! "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Maintenance branch version is not a stable semantic version: $CURRENT_VERSION" >&2
+            exit 1
+          fi
+          CURRENT_MAJOR="${BASH_REMATCH[1]}"
+          CURRENT_MINOR="${BASH_REMATCH[2]}"
+          CURRENT_PATCH="${BASH_REMATCH[3]}"
+
+          if [[ "$CURRENT_VERSION" != "$HIGHEST_VERSION" ]]; then
+            echo "Branch $MAINTENANCE_BRANCH is at $CURRENT_VERSION, but its highest stable tag is v$HIGHEST_VERSION." >&2
+            echo "Update the maintenance branch to its latest release before publishing the next patch." >&2
+            exit 1
+          fi
+
+          [[ "$TARGET_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]
+          TARGET_MAJOR="${BASH_REMATCH[1]}"
+          TARGET_MINOR="${BASH_REMATCH[2]}"
+          TARGET_PATCH="${BASH_REMATCH[3]}"
+
+          if (( TARGET_MAJOR != CURRENT_MAJOR || TARGET_MINOR != CURRENT_MINOR )); then
+            echo "Target version $TARGET_VERSION is outside maintenance line $CURRENT_MAJOR.$CURRENT_MINOR.x." >&2
+            exit 1
+          fi
+          if (( TARGET_PATCH < CURRENT_PATCH )); then
+            echo "Target version $TARGET_VERSION must not be older than branch version $CURRENT_VERSION." >&2
+            exit 1
+          fi
+
+          echo "Maintenance branch: $MAINTENANCE_BRANCH"
+          echo "Current version: $CURRENT_VERSION"
+          echo "Target version: $TARGET_VERSION"
+
+          if [[ "$BASE_VERSION" != 1.* ]] && ! grep -q 'publish_floating_docker_tag:' .github/workflows/release.yml; then
+            echo "The maintenance branch does not contain the maintenance-safe release workflow." >&2
+            echo "Merge or cherry-pick the release workflow update before creating $TARGET_VERSION." >&2
+            exit 1
+          fi
+
+      - name: Check tag status
+        shell: bash
+        env:
+          MAINTENANCE_BRANCH: ${{ needs.resolve-release.outputs.branch }}
+          TARGET_VERSION: ${{ needs.resolve-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v$TARGET_VERSION"
           echo "Checking tag across repos (supports resume): $TAG"
 
           exist=()
           missing=()
-          shas=()
 
-          repos=("nocobase" "pro-plugins")
-          for r in $(echo '${{ needs.get-plugins.outputs.all-plugins }}' | jq -r '.[]'); do repos+=("$r"); done
+          repo_names=("nocobase" "pro-plugins")
+          repo_dirs=("." "packages/pro-plugins")
+          for repo in $(echo '${{ needs.select-plugins.outputs.plugins }}' | jq -r '.[]'); do
+            repo_names+=("$repo")
+            repo_dirs+=("packages/pro-plugins/@nocobase/$repo")
+          done
 
-          for repo in "${repos[@]}"; do
-            if sha=$(gh api -H "Accept: application/vnd.github+json" "/repos/nocobase/$repo/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null); then
+          for i in "${!repo_names[@]}"; do
+            repo="${repo_names[$i]}"
+            repo_dir="${repo_dirs[$i]}"
+            if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/$TAG^{commit}" >/dev/null; then
+              if ! git -C "$repo_dir" merge-base --is-ancestor "refs/tags/$TAG^{commit}" "$MAINTENANCE_BRANCH"; then
+                echo "ERROR: Existing tag $TAG in nocobase/$repo is not part of branch $MAINTENANCE_BRANCH." >&2
+                exit 1
+              fi
               exist+=("$repo")
-              shas+=("$sha")
             else
               missing+=("$repo")
             fi
           done
-
-          # If the tag exists, ensure it points to the same object everywhere it exists.
-          if [[ ${#shas[@]} -gt 0 ]]; then
-            uniq_shas=$(printf '%s\n' "${shas[@]}" | sort -u)
-            uniq_count=$(printf '%s\n' "$uniq_shas" | sed '/^$/d' | wc -l | tr -d ' ')
-            if [[ "$uniq_count" -gt 1 ]]; then
-              echo "ERROR: Tag $TAG exists but points to different objects across repos (unsafe to continue)." >&2
-              echo "Distinct tag object SHAs:" >&2
-              printf '%s\n' "$uniq_shas" >&2
-              echo "Repos where tag exists:" >&2
-              printf '%s\n' "${exist[@]}" >&2
-              exit 1
-            fi
-          fi
 
           if [[ ${#exist[@]} -gt 0 && ${#missing[@]} -gt 0 ]]; then
             echo "WARNING: Tag $TAG already exists in some repos. Treating as resume and continuing." >&2
@@ -163,38 +345,28 @@ jobs:
           else
             echo "OK: Tag $TAG does not exist in any repo."
           fi
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Dry run plan (v1.x)
+      - name: Dry run plan
         if: ${{ inputs.dry_run }}
         shell: bash
+        env:
+          PRO_PLUGIN_REPOS: ${{ needs.select-plugins.outputs.plugins }}
+          TARGET_VERSION: ${{ needs.resolve-release.outputs.version }}
         run: |
           set -euo pipefail
-          if [[ -n "${{ inputs.version }}" ]]; then
-            bash release.sh --dry-run --version "${{ inputs.version }}"
-          else
-            bash release.sh --dry-run $IS_FEAT
-          fi
-        env:
-          PRO_PLUGIN_REPOS: ${{ needs.get-plugins.outputs.all-plugins }}
-          IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
+          bash release.sh --dry-run --version "$TARGET_VERSION"
 
       - name: Install Lerna
         if: ${{ !inputs.dry_run }}
         run: npm install -g lerna@4
 
-      - name: Apply version with release.sh (v1.x)
+      - name: Apply version with release.sh
         if: ${{ !inputs.dry_run }}
         shell: bash
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            bash release.sh --lerna-version-only --version "${{ inputs.version }}"
-          else
-            bash release.sh --lerna-version-only $IS_FEAT
-          fi
         env:
-          IS_FEAT: ${{ inputs.is_feat && '--is-feat' || '' }}
+          TARGET_VERSION: ${{ needs.resolve-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          bash release.sh --lerna-version-only --version "$TARGET_VERSION"
 
       - name: yarn install and build
         if: ${{ !inputs.dry_run && !inputs.skip_install_build }}
@@ -203,34 +375,62 @@ jobs:
           yarn install
           yarn build
 
-      - name: Run release.sh (v1.x)
+      - name: Run release.sh
         if: ${{ !inputs.dry_run }}
         shell: bash
         run: |
           bash release.sh --commit-tag-only
         env:
-          PRO_PLUGIN_REPOS: ${{ needs.get-plugins.outputs.all-plugins }}
+          PRO_PLUGIN_REPOS: ${{ needs.select-plugins.outputs.plugins }}
 
-      - name: Push tags/commits (v1)
+      - name: Push tags and commits
         if: ${{ !inputs.dry_run }}
+        env:
+          MAINTENANCE_BRANCH: ${{ needs.resolve-release.outputs.branch }}
         run: |
-          for repo in ${{ join(fromJSON(needs.get-plugins.outputs.all-plugins), ' ') }}
+          set -euo pipefail
+          for repo in ${{ join(fromJSON(needs.select-plugins.outputs.plugins), ' ') }}
           do
             cd ./packages/pro-plugins/@nocobase/$repo
-            git push origin v1 --atomic --tags
+            git push origin "$MAINTENANCE_BRANCH" --atomic --tags
             cd ../../../../
           done
 
           cd ./packages/pro-plugins
-          git push origin v1 --atomic --tags
+          git push origin "$MAINTENANCE_BRANCH" --atomic --tags
           cd ../../
-          git push origin v1 --atomic --tags
+          git push origin "$MAINTENANCE_BRANCH" --atomic --tags
+
+      - name: Merge current stable release into next
+        if: ${{ !inputs.dry_run && needs.resolve-release.outputs.is_current == 'true' }}
+        run: |
+          set -euo pipefail
+          for repo in ${{ join(fromJSON(needs.select-plugins.outputs.plugins), ' ') }}
+          do
+            cd ./packages/pro-plugins/@nocobase/$repo
+            git checkout next
+            git merge -X ours main --no-edit
+            git push origin next --tags --atomic
+            cd ../../../../
+          done
+
+          cd ./packages/pro-plugins
+          git checkout next
+          git merge -X ours main --no-edit
+          git push origin next --tags --atomic
+          cd ../../
+          git checkout next
+          git merge -X ours main --no-edit
+          git push origin next --tags --atomic
 
   feishu-notify:
     runs-on: ubuntu-latest
     if: failure()
     needs:
+      - resolve-release
       - get-plugins
+      - select-plugins
+      - pre-merge-current
       - update-version
     steps:
       - name: Checkout
@@ -243,7 +443,7 @@ jobs:
         shell: bash
         env:
           WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
-          TITLE: "NocoBase ${{ github.workflow }} 失败通知"
+          TITLE: 'NocoBase ${{ github.workflow }} 失败通知'
           STATUS: failure
           CONTENT: "**触发者：**${{ github.actor }}\n**时间：**${{ env.CURRENT_DATE }}\n**状态：**❌ 构建失败"
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/manual-release-v1.yml
+++ b/.github/workflows/manual-release-v1.yml
@@ -1,16 +1,16 @@
 name: Manual maintenance release
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.base_version || 'current' }}
+  group: ${{ github.workflow }}-${{ inputs.base_version }}
   cancel-in-progress: true
 
 on:
   workflow_dispatch:
     inputs:
       base_version:
-        description: 'Optional major.minor line; 2.1 uses branch v2.1. Empty uses main.'
+        description: 'Maintenance line: 2.1 uses v2.1; 1 uses v1 and resolves its latest minor line.'
         type: string
-        required: false
+        required: true
       dry_run:
         description: 'If true, do not build, commit, tag, or push. Only compute version + validate tag conflicts and print a plan.'
         type: boolean
@@ -30,7 +30,6 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       base_version: ${{ steps.resolve.outputs.baseVersion }}
       highest_version: ${{ steps.resolve.outputs.highestVersion }}
-      is_current: ${{ steps.resolve.outputs.isCurrent }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,40 +43,63 @@ jobs:
         run: |
           set -euo pipefail
 
-          BASE_VERSION="$INPUT_BASE_VERSION"
-          IS_CURRENT=false
-          if [[ -z "$BASE_VERSION" ]]; then
-            CURRENT_VERSION=$(jq -r '.version' lerna.json)
-            if [[ ! "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-              echo "Current stable version is invalid: $CURRENT_VERSION" >&2
+          MAIN_VERSION=$(jq -r '.version' lerna.json)
+          if [[ ! "$MAIN_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Main stable version is invalid: $MAIN_VERSION" >&2
+            exit 1
+          fi
+          MAIN_BASE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+          if [[ "$INPUT_BASE_VERSION" =~ ^([0-9]+)$ ]]; then
+            INPUT_MAJOR="${BASH_REMATCH[1]}"
+            MAINTENANCE_BRANCH="v$INPUT_MAJOR"
+            TAG_PATTERN="v$INPUT_MAJOR.*.*"
+            TAG_REGEX="^v($INPUT_MAJOR\.[0-9]+\.[0-9]+)$"
+          elif [[ "$INPUT_BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+            BASE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            MAINTENANCE_BRANCH="v$BASE_VERSION"
+            TAG_PATTERN="v$BASE_VERSION.*"
+            TAG_REGEX="^v($BASE_VERSION\.[0-9]+)$"
+          else
+            echo "Base version must be a major or major.minor line, for example 1 or 2.1." >&2
+            exit 1
+          fi
+
+          if [[ -n "${BASE_VERSION:-}" && "$BASE_VERSION" == "$MAIN_BASE_VERSION" ]]; then
+            echo "Maintenance line $BASE_VERSION matches Main version $MAIN_VERSION." >&2
+            echo "Use the Main release workflow for the current stable line." >&2
+            exit 1
+          fi
+
+          if ! git ls-remote --exit-code --heads origin "$MAINTENANCE_BRANCH" >/dev/null 2>&1; then
+            echo "Required maintenance branch $MAINTENANCE_BRANCH does not exist." >&2
+            exit 1
+          fi
+          git fetch origin "+refs/heads/$MAINTENANCE_BRANCH:refs/remotes/origin/$MAINTENANCE_BRANCH" --tags
+
+          HIGHEST_VERSION=$(
+            git tag --merged "origin/$MAINTENANCE_BRANCH" --list "$TAG_PATTERN" \
+              | sed -nE "s/$TAG_REGEX/\1/p" \
+              | sort -V \
+              | tail -1
+          )
+          if [[ -z "$HIGHEST_VERSION" ]]; then
+            echo "No stable release tag matching $TAG_PATTERN found on $MAINTENANCE_BRANCH." >&2
+            exit 1
+          fi
+
+          if [[ "$INPUT_BASE_VERSION" =~ ^[0-9]+$ ]]; then
+            if [[ ! "$HIGHEST_VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+              echo "Failed to resolve the maintenance line from $HIGHEST_VERSION." >&2
               exit 1
             fi
             BASE_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-            HIGHEST_VERSION="$CURRENT_VERSION"
-            MAINTENANCE_BRANCH=main
-            IS_CURRENT=true
-          else
-            if [[ ! "$BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
-              echo "Base version must contain only major.minor, for example 1.9 or 2.1." >&2
-              exit 1
-            fi
-            MAINTENANCE_BRANCH="v$BASE_VERSION"
-            if ! git ls-remote --exit-code --heads origin "$MAINTENANCE_BRANCH" >/dev/null 2>&1; then
-              echo "Required maintenance branch $MAINTENANCE_BRANCH does not exist." >&2
-              exit 1
-            fi
-            git fetch origin "+refs/heads/$MAINTENANCE_BRANCH:refs/remotes/origin/$MAINTENANCE_BRANCH" --tags
+          fi
 
-            HIGHEST_VERSION=$(
-              git tag --merged "origin/$MAINTENANCE_BRANCH" --list "v$BASE_VERSION.*" \
-                | sed -nE "s/^v($BASE_VERSION\.[0-9]+)$/\1/p" \
-                | sort -V \
-                | tail -1
-            )
-            if [[ -z "$HIGHEST_VERSION" ]]; then
-              echo "No stable $BASE_VERSION.x tag found on $MAINTENANCE_BRANCH." >&2
-              exit 1
-            fi
+          if [[ "$BASE_VERSION" == "$MAIN_BASE_VERSION" ]]; then
+            echo "Maintenance line $BASE_VERSION matches Main version $MAIN_VERSION." >&2
+            echo "Use the Main release workflow for the current stable line." >&2
+            exit 1
           fi
 
           HIGHEST_PATCH="${HIGHEST_VERSION##*.}"
@@ -87,7 +109,7 @@ jobs:
           echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "baseVersion=$BASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "highestVersion=$HIGHEST_VERSION" >> "$GITHUB_OUTPUT"
-          echo "isCurrent=$IS_CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Main stable version: $MAIN_VERSION"
           echo "Highest stable tag: v$HIGHEST_VERSION"
           echo "Maintenance branch: $MAINTENANCE_BRANCH"
           echo "Next patch version: $NEXT_VERSION"
@@ -112,67 +134,17 @@ jobs:
         id: select
         env:
           ALL_PLUGINS: ${{ needs.get-plugins.outputs.all-plugins }}
-          CUSTOM_PLUGINS: ${{ needs.get-plugins.outputs.custom-plugins }}
-          IS_CURRENT: ${{ needs.resolve-release.outputs.is_current }}
-          RC_PLUGINS: ${{ needs.get-plugins.outputs.rc-plugins }}
         run: |
           set -euo pipefail
-          if [[ "$IS_CURRENT" == "true" ]]; then
-            PLUGINS=$(jq -cn --argjson rc "$RC_PLUGINS" --argjson custom "$CUSTOM_PLUGINS" '$rc + $custom | unique')
-          else
-            PLUGINS="$ALL_PLUGINS"
-          fi
+          PLUGINS="$ALL_PLUGINS"
           echo "plugins=$PLUGINS" >> "$GITHUB_OUTPUT"
           echo "Selected plugins: $PLUGINS"
-
-  pre-merge-current:
-    needs:
-      - resolve-release
-      - select-plugins
-    if: ${{ needs.resolve-release.outputs.is_current == 'true' && !inputs.dry_run }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        repo:
-          - nocobase
-          - pro-plugins
-          - ${{ fromJSON(needs.select-plugins.outputs.plugins) }}
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.NOCOBASE_APP_ID }}
-          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
-          repositories: nocobase,pro-plugins,${{ join(fromJSON(needs.select-plugins.outputs.plugins), ',') }}
-          skip-token-revoke: true
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api /users/${{ steps.app-token.outputs.app-slug }}[bot] --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      - uses: actions/checkout@v4
-        with:
-          repository: nocobase/${{ matrix.repo }}
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Merge main into next
-        run: |
-          set -euo pipefail
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git checkout main
-          git pull origin main
-          git checkout next
-          git merge main
-          git push origin next --tags --atomic
 
   update-version:
     needs:
       - resolve-release
       - get-plugins
       - select-plugins
-      - pre-merge-current
-    if: ${{ always() && needs.resolve-release.result == 'success' && needs.get-plugins.result == 'success' && needs.select-plugins.result == 'success' && (needs.pre-merge-current.result == 'success' || needs.pre-merge-current.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -401,28 +373,6 @@ jobs:
           cd ../../
           git push origin "$MAINTENANCE_BRANCH" --atomic --tags
 
-      - name: Merge current stable release into next
-        if: ${{ !inputs.dry_run && needs.resolve-release.outputs.is_current == 'true' }}
-        run: |
-          set -euo pipefail
-          for repo in ${{ join(fromJSON(needs.select-plugins.outputs.plugins), ' ') }}
-          do
-            cd ./packages/pro-plugins/@nocobase/$repo
-            git checkout next
-            git merge -X ours main --no-edit
-            git push origin next --tags --atomic
-            cd ../../../../
-          done
-
-          cd ./packages/pro-plugins
-          git checkout next
-          git merge -X ours main --no-edit
-          git push origin next --tags --atomic
-          cd ../../
-          git checkout next
-          git merge -X ours main --no-edit
-          git push origin next --tags --atomic
-
   feishu-notify:
     runs-on: ubuntu-latest
     if: failure()
@@ -430,7 +380,6 @@ jobs:
       - resolve-release
       - get-plugins
       - select-plugins
-      - pre-merge-current
       - update-version
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,26 +116,44 @@ jobs:
             exit 1
           fi
 
-          DEFAULT_BRANCH=$(gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY" --jq '.default_branch')
-          STABLE_VERSION=$(
-            gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY/contents/lerna.json?ref=$DEFAULT_BRANCH" --jq '.content' \
-              | tr -d '\n' \
-              | base64 --decode \
-              | jq -r '.version'
-          )
-          if [[ ! "$STABLE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            echo "Failed to parse stable version from $STABLE_VERSION on $DEFAULT_BRANCH." >&2
-            exit 1
-          fi
-          STABLE_MAJOR="${BASH_REMATCH[1]}"
-          STABLE_MINOR="${BASH_REMATCH[2]}"
-          STABLE_PATCH="${BASH_REMATCH[3]}"
-
           IS_MAINTENANCE_RELEASE=false
-          if (( RELEASE_MAJOR < STABLE_MAJOR \
-            || (RELEASE_MAJOR == STABLE_MAJOR && RELEASE_MINOR < STABLE_MINOR) \
-            || (RELEASE_MAJOR == STABLE_MAJOR && RELEASE_MINOR == STABLE_MINOR && RELEASE_PATCH < STABLE_PATCH) )); then
-            IS_MAINTENANCE_RELEASE=true
+          DEFAULT_BRANCH=unknown
+          STABLE_VERSION=unavailable
+          if [[ "$TARGET_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            github_api_with_retry() {
+              local attempt
+              local output
+              for attempt in 1 2 3; do
+                if output=$(gh api -H "Accept: application/vnd.github+json" "$@" 2>&1); then
+                  printf '%s\n' "$output"
+                  return 0
+                fi
+                echo "GitHub API request failed (attempt $attempt/3): $output" >&2
+                if (( attempt < 3 )); then
+                  sleep $((attempt * 2))
+                fi
+              done
+              return 1
+            }
+
+            if DEFAULT_BRANCH=$(github_api_with_retry "/repos/$GITHUB_REPOSITORY" --jq '.default_branch') \
+              && STABLE_CONTENT=$(github_api_with_retry "/repos/$GITHUB_REPOSITORY/contents/lerna.json?ref=$DEFAULT_BRANCH" --jq '.content') \
+              && STABLE_VERSION=$(printf '%s' "$STABLE_CONTENT" | tr -d '\n' | base64 --decode | jq -r '.version') \
+              && [[ "$STABLE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              STABLE_MAJOR="${BASH_REMATCH[1]}"
+              STABLE_MINOR="${BASH_REMATCH[2]}"
+              STABLE_PATCH="${BASH_REMATCH[3]}"
+
+              if (( RELEASE_MAJOR < STABLE_MAJOR \
+                || (RELEASE_MAJOR == STABLE_MAJOR && RELEASE_MINOR < STABLE_MINOR) \
+                || (RELEASE_MAJOR == STABLE_MAJOR && RELEASE_MINOR == STABLE_MINOR && RELEASE_PATCH < STABLE_PATCH) )); then
+                IS_MAINTENANCE_RELEASE=true
+              fi
+            else
+              echo "Unable to determine the stable version from the default branch; treating $TARGET_REF as a non-maintenance release." >&2
+            fi
+          else
+            echo "Prerelease tag $TARGET_REF is not considered a maintenance release."
           fi
 
           PUBLISH_FLOATING_DOCKER_TAG=true
@@ -205,10 +223,17 @@ jobs:
       - prepare-release
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
     with:
-      # Maintenance releases may predate newer plugin repositories, so only select repos that carry the release tag.
+      # Ad-hoc non-maintenance reruns select existing tags. Maintenance releases select the whole maintenance branch,
+      # then validate below that every selected repository has the tag.
       require_tag: >-
-        ${{ (github.event_name == 'workflow_dispatch' || needs.prepare-release.outputs.is_maintenance_release == 'true')
-          && needs.prepare-release.outputs.target_ref || '' }}
+        ${{ github.event_name == 'workflow_dispatch'
+        && needs.prepare-release.outputs.is_v1 != 'true'
+        && needs.prepare-release.outputs.is_maintenance_release != 'true'
+        && needs.prepare-release.outputs.target_ref || '' }}
+      require_branch: >-
+        ${{ needs.prepare-release.outputs.is_v1 == 'true' && 'v1'
+        || needs.prepare-release.outputs.is_maintenance_release == 'true' && format('v{0}', needs.prepare-release.outputs.major_minor_version)
+        || '' }}
     secrets: inherit
 
   publish-packages:
@@ -227,7 +252,11 @@ jobs:
       - name: Get info
         id: get-info
         shell: bash
+        env:
+          ALL_PLUGINS: ${{ needs.get-plugins.outputs.all-plugins }}
+          CUSTOM_PLUGINS: ${{ needs.get-plugins.outputs.custom-plugins }}
         run: |
+          set -euo pipefail
           echo "defaultTag=${{ needs.prepare-release.outputs.default_tag }}" >> "$GITHUB_OUTPUT"
 
           if [[ "${{ needs.prepare-release.outputs.run_pro_package_release }}" != 'true' ]]; then
@@ -235,8 +264,9 @@ jobs:
             exit 0
           fi
 
-          if [[ "$TARGET_REF" =~ ^v1\. ]]; then
-            echo "proRepos=$(echo '${{ needs.get-plugins.outputs.all-plugins }}')" >> "$GITHUB_OUTPUT"
+          if [[ "${{ needs.prepare-release.outputs.is_maintenance_release }}" == 'true' || "$TARGET_REF" =~ ^v1\. ]]; then
+            PRO_REPOS=$(jq -cn --argjson all "$ALL_PLUGINS" --argjson custom "$CUSTOM_PLUGINS" '$all - $custom')
+            echo "proRepos=$PRO_REPOS" >> "$GITHUB_OUTPUT"
           elif [[ "$TARGET_REF" =~ beta ]]; then
             echo "proRepos=$(echo '${{ needs.get-plugins.outputs.beta-plugins }}')" >> "$GITHUB_OUTPUT"
           elif [[ "$TARGET_REF" =~ alpha ]]; then
@@ -247,7 +277,7 @@ jobs:
           fi
       - uses: actions/create-github-app-token@v1
         id: validate-token
-        if: ${{ needs.prepare-release.outputs.is_v1 == 'true' && needs.prepare-release.outputs.run_pro_package_release == 'true' }}
+        if: ${{ (needs.prepare-release.outputs.is_v1 == 'true' || needs.prepare-release.outputs.is_maintenance_release == 'true') && needs.prepare-release.outputs.run_pro_package_release == 'true' }}
         with:
           app-id: ${{ vars.NOCOBASE_APP_ID }}
           private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
@@ -267,8 +297,8 @@ jobs:
             echo "NPM_TAG_ARG=" >> "$GITHUB_ENV"
           fi
 
-      - name: Validate v1 tag exists in all selected repos
-        if: ${{ needs.prepare-release.outputs.is_v1 == 'true' && needs.prepare-release.outputs.run_pro_package_release == 'true' }}
+      - name: Validate maintenance tag exists in all selected repos
+        if: ${{ (needs.prepare-release.outputs.is_v1 == 'true' || needs.prepare-release.outputs.is_maintenance_release == 'true') && needs.prepare-release.outputs.run_pro_package_release == 'true' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
       major_minor_version: ${{ steps.prepare.outputs.majorMinorVersion }}
       default_tag: ${{ steps.prepare.outputs.defaultTag }}
       is_v1: ${{ steps.prepare.outputs.isV1 }}
+      is_maintenance_release: ${{ steps.prepare.outputs.isMaintenanceRelease }}
+      publish_floating_docker_tag: ${{ steps.prepare.outputs.publishFloatingDockerTag }}
       run_npm_release: ${{ steps.prepare.outputs.runNpmRelease }}
       run_pro_package_release: ${{ steps.prepare.outputs.runProPackageRelease }}
       run_docker_release: ${{ steps.prepare.outputs.runDockerRelease }}
@@ -103,9 +105,54 @@ jobs:
             fi
           fi
 
+          RELEASE_VERSION="${TARGET_REF#v}"
+          if [[ "$RELEASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            RELEASE_MAJOR="${BASH_REMATCH[1]}"
+            RELEASE_MINOR="${BASH_REMATCH[2]}"
+            RELEASE_PATCH="${BASH_REMATCH[3]}"
+            MAJOR_MINOR_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          else
+            echo "Failed to parse major.minor version from $TARGET_REF." >&2
+            exit 1
+          fi
+
+          DEFAULT_BRANCH=$(gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY" --jq '.default_branch')
+          STABLE_VERSION=$(
+            gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY/contents/lerna.json?ref=$DEFAULT_BRANCH" --jq '.content' \
+              | tr -d '\n' \
+              | base64 --decode \
+              | jq -r '.version'
+          )
+          if [[ ! "$STABLE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            echo "Failed to parse stable version from $STABLE_VERSION on $DEFAULT_BRANCH." >&2
+            exit 1
+          fi
+          STABLE_MAJOR="${BASH_REMATCH[1]}"
+          STABLE_MINOR="${BASH_REMATCH[2]}"
+          STABLE_PATCH="${BASH_REMATCH[3]}"
+
+          IS_MAINTENANCE_RELEASE=false
+          if (( RELEASE_MAJOR < STABLE_MAJOR \
+            || (RELEASE_MAJOR == STABLE_MAJOR && RELEASE_MINOR < STABLE_MINOR) \
+            || (RELEASE_MAJOR == STABLE_MAJOR && RELEASE_MINOR == STABLE_MINOR && RELEASE_PATCH < STABLE_PATCH) )); then
+            IS_MAINTENANCE_RELEASE=true
+          fi
+
+          PUBLISH_FLOATING_DOCKER_TAG=true
           if [[ "$TARGET_REF" =~ ^v1\. ]]; then
             DEFAULT_TAG=v1
             IS_V1=true
+            PUBLISH_FLOATING_DOCKER_TAG=false
+          elif [[ "$IS_MAINTENANCE_RELEASE" == "true" ]]; then
+            IS_V1=false
+            PUBLISH_FLOATING_DOCKER_TAG=false
+            if [[ "$TARGET_REF" =~ beta ]]; then
+              DEFAULT_TAG="maintenance-${MAJOR_MINOR_VERSION}-beta"
+            elif [[ "$TARGET_REF" =~ alpha ]]; then
+              DEFAULT_TAG="maintenance-${MAJOR_MINOR_VERSION}-alpha"
+            else
+              DEFAULT_TAG="maintenance-${MAJOR_MINOR_VERSION}"
+            fi
           elif [[ "$TARGET_REF" =~ beta ]]; then
             DEFAULT_TAG=beta
             IS_V1=false
@@ -115,14 +162,6 @@ jobs:
           else
             DEFAULT_TAG=latest
             IS_V1=false
-          fi
-
-          RELEASE_VERSION="${TARGET_REF#v}"
-          if [[ "$RELEASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\. ]]; then
-            MAJOR_MINOR_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-          else
-            echo "Failed to parse major.minor version from $TARGET_REF." >&2
-            exit 1
           fi
 
           RUN_NPM_RELEASE=true
@@ -145,6 +184,8 @@ jobs:
           echo "majorMinorVersion=$MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "defaultTag=$DEFAULT_TAG" >> "$GITHUB_OUTPUT"
           echo "isV1=$IS_V1" >> "$GITHUB_OUTPUT"
+          echo "isMaintenanceRelease=$IS_MAINTENANCE_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "publishFloatingDockerTag=$PUBLISH_FLOATING_DOCKER_TAG" >> "$GITHUB_OUTPUT"
           echo "runNpmRelease=$RUN_NPM_RELEASE" >> "$GITHUB_OUTPUT"
           echo "runProPackageRelease=$RUN_PRO_PACKAGE_RELEASE" >> "$GITHUB_OUTPUT"
           echo "runDockerRelease=$RUN_DOCKER_RELEASE" >> "$GITHUB_OUTPUT"
@@ -153,16 +194,21 @@ jobs:
           echo "skipPublishPkgSrc=$SKIP_PUBLISH_PKG_SRC" >> "$GITHUB_OUTPUT"
           echo "skipPublishDocker=$SKIP_PUBLISH_DOCKER" >> "$GITHUB_OUTPUT"
 
+          echo "Stable version on $DEFAULT_BRANCH: $STABLE_VERSION"
+          echo "Maintenance release: $IS_MAINTENANCE_RELEASE"
+          echo "Package dist-tag: $DEFAULT_TAG"
+          echo "Publish floating Docker tag: $PUBLISH_FLOATING_DOCKER_TAG"
+
   get-plugins:
     if: ${{ needs.prepare-release.outputs.run_pro_package_release == 'true' }}
     needs:
       - prepare-release
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
     with:
-      require_tag: ${{ github.event_name == 'workflow_dispatch' && needs.prepare-release.outputs.target_ref || '' }}
-      # For v1.x maintenance releases, only include repos that have the v1 branch.
-      # For v2+ we keep the original behavior (no filtering at this stage).
-      require_branch: ${{ needs.prepare-release.outputs.is_v1 == 'true' && 'v1' || '' }}
+      # Maintenance releases may predate newer plugin repositories, so only select repos that carry the release tag.
+      require_tag: >-
+        ${{ (github.event_name == 'workflow_dispatch' || needs.prepare-release.outputs.is_maintenance_release == 'true')
+          && needs.prepare-release.outputs.target_ref || '' }}
     secrets: inherit
 
   publish-packages:
@@ -489,8 +535,10 @@ jobs:
           SUFFIX="${{ matrix.variant.suffix }}"
           ALI_REG="${{ secrets.ALI_DOCKER_PUBLIC_REGISTRY }}"
           MINOR_TAG="$MAJOR_MINOR_VERSION"
-          if [[ "$DEFAULT_TAG" == "alpha" || "$DEFAULT_TAG" == "beta" ]]; then
-            MINOR_TAG="$MAJOR_MINOR_VERSION-$DEFAULT_TAG"
+          if [[ "$RELEASE_VERSION" =~ alpha ]]; then
+            MINOR_TAG="$MAJOR_MINOR_VERSION-alpha"
+          elif [[ "$RELEASE_VERSION" =~ beta ]]; then
+            MINOR_TAG="$MAJOR_MINOR_VERSION-beta"
           fi
 
           RELEASE_TAG="${RELEASE_VERSION}${SUFFIX}"
@@ -504,8 +552,8 @@ jobs:
             "$ALI_REG/nocobase/nocobase:$MINOR_RELEASE_TAG"
           )
 
-          # For v1 maintenance tags, do not push a floating default tag (for example `latest` or `latest-no-nginx`).
-          if [[ "${{ needs.prepare-release.outputs.is_v1 }}" != 'true' ]]; then
+          # Maintenance releases keep their exact and major.minor tags without moving a global floating tag.
+          if [[ "${{ needs.prepare-release.outputs.publish_floating_docker_tag }}" == 'true' ]]; then
             TAGS+=("nocobase/nocobase:$DEFAULT_RELEASE_TAG")
             TAGS+=("$ALI_REG/nocobase/nocobase:$DEFAULT_RELEASE_TAG")
           fi
@@ -577,7 +625,7 @@ jobs:
         shell: bash
         env:
           WEBHOOK_URL: ${{ secrets.RELEASE_RESULT_FEISHU_WEBHOOK_URL }}
-          TITLE: "NocoBase 版本 ${{ needs.prepare-release.outputs.target_ref }} Release 结果通知"
+          TITLE: 'NocoBase 版本 ${{ needs.prepare-release.outputs.target_ref }} Release 结果通知'
           STATUS: ${{ steps.result.outputs.status }}
           CONTENT: "**版本：**${{ needs.prepare-release.outputs.target_ref }}\n**时间：**${{ env.CURRENT_DATE }}\n**状态：**${{ steps.result.outputs.status == 'success' && '✅ 构建成功' || '❌ 构建失败' }}"
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Others

### Motivation

The v1-only maintenance workflow cannot publish fixes for older v2 release lines after the stable branch has advanced. Publishing such a tag through the current release workflow would also move global `latest` tags back to the older version.

### Description 

- Generalize the existing v1 manual workflow into a maintenance release workflow.
- Accept an optional `major.minor` base version and map it exactly to the `v<major.minor>` branch, such as `2.1` to `v2.1`; an empty value keeps the current stable release flow on `main`.
- Calculate the next patch version from the highest stable tag on the selected version branch.
- Preserve dry-run, cross-repository tagging, partial-run recovery, and current stable `main` to `next` synchronization.
- Detect releases older than the current stable version and publish packages under an isolated `maintenance-<major.minor>` dist-tag.
- Keep exact and `major.minor` Docker tags for maintenance releases without moving global `latest` tags.
- Select Pro plugin repositories by the target release tag so repositories introduced after an older release line do not block publishing.

Potential risks are limited to release automation. Before the first production maintenance release, run the workflow with `dry_run` enabled and verify the resolved branch, version, and plugin list.

Validation performed locally:

- Parsed both modified workflow files as YAML.
- Ran Prettier checks.
- Ran `git diff --check`.
- `actionlint` and `shellcheck` were unavailable locally.

### Related issues

N/A

### Showcase

N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added maintenance release support for version branches without changing global latest package and Docker tags |
| 🇨🇳 Chinese | 支持从版本分支发布维护版本，且不会更新全局 latest 软件包及 Docker 标签 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
