### PR TITLE
fix(plugin-workflow): avoid extra trigger at startsOn for cron based schedule

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
@@ -190,6 +190,60 @@ describe('workflow > triggers > schedule > static mode', () => {
       expect(date.getTime()).toBe(now.getTime());
     });
 
+    it('start in future should not trigger on a time not matching cron', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      // starts 2 seconds later, while the cron only matches 4 seconds later
+      const start = new Date(base.getTime() + 2000);
+      const cronTime = new Date(base.getTime() + 4000);
+
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: start.toISOString(),
+            repeat: `${cronTime.getSeconds()} * * * * *`,
+          },
+        },
+      });
+
+      await sleep(6000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(new Date(executions[0].context.date).getTime()).toBe(cronTime.getTime());
+    });
+
+    it('start in future should trigger when it matches cron', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      const start = new Date(base.getTime() + 2000);
+
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: start.toISOString(),
+            repeat: `${start.getSeconds()} * * * * *`,
+          },
+        },
+      });
+
+      await sleep(3000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(new Date(executions[0].context.date).getTime()).toBe(start.getTime());
+    });
+
     it('no repeat triggered then update to repeat', async () => {
       const start = await sleepToEvenSecond();
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
@@ -63,7 +63,11 @@ export default class StaticScheduleTrigger {
     currentDate.setMilliseconds(nextSecond ? 1000 : 0);
     const timestamp = currentDate.getTime();
     const startTime = parseDateWithoutMs(config.startsOn);
-    if (startTime > timestamp) {
+    // NOTE: a cron expression fully defines its own trigger moments, so `startsOn` only acts as a lower bound for them.
+    // Returning `startTime` here would fire once at `startsOn` even when it does not match the expression. When
+    // `repeat` is a number the period is `startsOn + n * repeat`, which makes `startsOn` the very first occurrence, so
+    // that case keeps returning it.
+    if (startTime > timestamp && typeof config.repeat !== 'string') {
       return startTime;
     }
     if (config.repeat) {
@@ -72,7 +76,10 @@ export default class StaticScheduleTrigger {
         return null;
       }
       if (typeof config.repeat === 'string') {
-        const interval = parser.parseExpression(config.repeat, { currentDate });
+        // NOTE: `next()` is exclusive, so step back a second to keep `startsOn` itself eligible when it happens to
+        // match the expression.
+        const base = startTime > timestamp ? new Date(startTime - 1000) : currentDate;
+        const interval = parser.parseExpression(config.repeat, { currentDate: base });
         const next = interval.next();
         return next.getTime();
       } else if (typeof config.repeat === 'number') {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

A schedule workflow in static mode with a **cron** `repeat` fires one extra time at `startsOn`, even when that moment does not match the cron expression.

In `StaticScheduleTrigger.getNextTime()`, when `startsOn` is still in the future the method returns `startTime` immediately and never looks at `repeat`:

```ts
const startTime = parseDateWithoutMs(config.startsOn);
if (startTime > timestamp) {
  return startTime;   // cron is not consulted at all
}
if (config.repeat) { /* cron / interval */ }
```

`trigger()` only re-computes the next time afterwards, so the sequence becomes "fire at `startsOn`, then follow the cron".

This is correct when `repeat` is a **number** (milliseconds): the period is `startsOn + n * repeat`, so `startsOn` genuinely is occurrence #0 — the `(timestamp - startTime) % config.repeat` line right below relies on it.

It is not correct when `repeat` is a **cron string**: a cron expression already defines its own moments, so `startsOn` should only act as a lower bound, and the first trigger should be the first cron match at or after `startsOn`.

The field is labelled just "Starts on" in the UI, with no hint that it fires on its own. And because the configuration form fills `startsOn` with the current date by default, **every newly created cron schedule fires one unexpected time**.

Real-world impact: a workflow configured as `0 30 10 * * 2,5` (18:30 on Tue/Fri, local) with `startsOn: 2026-08-25T00:00:00+08:00` sent its DingTalk notification at 00:00 — midnight — to every recipient.

### Description

`getNextTime()` now keeps returning `startTime` for a future `startsOn` **only when `repeat` is not a cron string**, so the number/no-repeat behaviour is untouched. For a cron string it falls through to the cron branch, which computes the next match starting from `startsOn` instead of "now".

`parser.parseExpression().next()` is exclusive, so the base date is `startsOn - 1s`; that keeps `startsOn` itself eligible when it does match the expression.

Risks: low. The change is scoped to `typeof config.repeat === 'string'` with a future `startsOn`. Existing behaviours that depend on `startsOn` being occurrence #0 (numeric `repeat`, and no `repeat` at all) take exactly the same code path as before. Users who unknowingly relied on the extra fire will simply stop receiving a trigger that never matched their expression.

Testing suggestions: `mode-static.test.ts` had no case combining a cron `repeat` with a future `startsOn` — every cron case used `startsOn: now`, which is why this went unnoticed. Two cases are added:

- `start in future should not trigger on a time not matching cron` — `startsOn` at +2s, cron matching +4s only; expects exactly one execution, at +4s (currently two executions).
- `start in future should trigger when it matches cron` — `startsOn` at +2s, cron matching that same second; expects one execution at `startsOn`, guarding the `-1s` boundary.

### Related issues

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the extra trigger at `startsOn` for schedule workflows repeating on a cron expression |
| 🇨🇳 Chinese | 修复定时任务按 cron 重复时，会在「开始于」时刻额外触发一次的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
