### PR TITLE
fix(workflow): stop static schedule from running past endsOn

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/__tests__/triggers/schedule/mode-static.test.ts
@@ -244,6 +244,155 @@ describe('workflow > triggers > schedule > static mode', () => {
       expect(new Date(executions[0].context.date).getTime()).toBe(start.getTime());
     });
 
+    it('should not trigger after endsOn on cron repeat', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      // repeats every 2 seconds, ends 3 seconds later: only the +2s occurrence is within `endsOn`
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: base.toISOString(),
+            repeat: '*/2 * * * * *',
+            endsOn: new Date(base.getTime() + 3000).toISOString(),
+          },
+        },
+      });
+
+      await sleep(6000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(new Date(executions[0].context.date).getTime()).toBe(base.getTime() + 2000);
+    });
+
+    it('should not trigger after endsOn on interval repeat', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: base.toISOString(),
+            repeat: 2000,
+            endsOn: new Date(base.getTime() + 3000).toISOString(),
+          },
+        },
+      });
+
+      await sleep(6000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(new Date(executions[0].context.date).getTime()).toBe(base.getTime() + 2000);
+    });
+
+    it('should trigger on an occurrence exactly at endsOn', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      // `endsOn` is inclusive: an occurrence landing exactly on it still runs
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: base.toISOString(),
+            repeat: '*/2 * * * * *',
+            endsOn: new Date(base.getTime() + 2000).toISOString(),
+          },
+        },
+      });
+
+      await sleep(4000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(1);
+      expect(new Date(executions[0].context.date).getTime()).toBe(base.getTime() + 2000);
+    });
+
+    it('should not trigger when startsOn is after endsOn on cron repeat', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      // a `startsOn` later than `endsOn` is contradictory: nothing should run, not even the start itself
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: new Date(base.getTime() + 3000).toISOString(),
+            repeat: '*/2 * * * * *',
+            endsOn: new Date(base.getTime() + 1000).toISOString(),
+          },
+        },
+      });
+
+      await sleep(6000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(0);
+    });
+
+    it('should not trigger when startsOn is after endsOn on interval repeat', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: new Date(base.getTime() + 3000).toISOString(),
+            repeat: 2000,
+            endsOn: new Date(base.getTime() + 1000).toISOString(),
+          },
+        },
+      });
+
+      await sleep(6000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(0);
+    });
+
+    it('should not trigger when startsOn is after endsOn without repeat', async () => {
+      await sleepToEvenSecond();
+
+      const base = new Date();
+      base.setMilliseconds(0);
+      const workflow = await WorkflowRepo.create({
+        values: {
+          enabled: true,
+          type: 'schedule',
+          config: {
+            mode: 0,
+            startsOn: new Date(base.getTime() + 3000).toISOString(),
+            endsOn: new Date(base.getTime() + 1000).toISOString(),
+          },
+        },
+      });
+
+      await sleep(5000);
+
+      const executions = await workflow.getExecutions();
+      expect(executions.length).toBe(0);
+    });
+
     it('no repeat triggered then update to repeat', async () => {
       const start = await sleepToEvenSecond();
 

--- a/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/server/triggers/ScheduleTrigger/StaticScheduleTrigger.ts
@@ -63,15 +63,16 @@ export default class StaticScheduleTrigger {
     currentDate.setMilliseconds(nextSecond ? 1000 : 0);
     const timestamp = currentDate.getTime();
     const startTime = parseDateWithoutMs(config.startsOn);
+    const endTime = config.endsOn ? parseDateWithoutMs(config.endsOn) : null;
     // NOTE: a cron expression fully defines its own trigger moments, so `startsOn` only acts as a lower bound for them.
     // Returning `startTime` here would fire once at `startsOn` even when it does not match the expression. When
     // `repeat` is a number the period is `startsOn + n * repeat`, which makes `startsOn` the very first occurrence, so
-    // that case keeps returning it.
+    // that case keeps returning it. That early start is a trigger moment of its own, so it has to respect the end bound
+    // as well: a `startsOn` later than `endsOn` is a contradictory configuration and must not be scheduled at all.
     if (startTime > timestamp && typeof config.repeat !== 'string') {
-      return startTime;
+      return endTime && endTime < startTime ? null : startTime;
     }
     if (config.repeat) {
-      const endTime = config.endsOn ? parseDateWithoutMs(config.endsOn) : null;
       if (endTime && endTime < timestamp) {
         return null;
       }
@@ -80,11 +81,14 @@ export default class StaticScheduleTrigger {
         // match the expression.
         const base = startTime > timestamp ? new Date(startTime - 1000) : currentDate;
         const interval = parser.parseExpression(config.repeat, { currentDate: base });
-        const next = interval.next();
-        return next.getTime();
+        const next = interval.next().getTime();
+        // NOTE: `endTime < timestamp` above only rules out an `endsOn` that is already in the past. The occurrence
+        // computed here may still fall beyond `endsOn`, which must not be scheduled. `DateFieldScheduleTrigger` applies
+        // the same check to both repeat kinds after computing the next time.
+        return endTime && endTime < next ? null : next;
       } else if (typeof config.repeat === 'number') {
         const next = timestamp + config.repeat - ((timestamp - startTime) % config.repeat);
-        return next;
+        return endTime && endTime < next ? null : next;
       } else {
         return null;
       }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

A schedule workflow in static mode keeps running **once past its `endsOn`**.

`StaticScheduleTrigger.getNextTime()` guards `endsOn` only against the *current* time:

```ts
const endTime = config.endsOn ? parseDateWithoutMs(config.endsOn) : null;
if (endTime && endTime < timestamp) {   // only "has endsOn already passed?"
  return null;
}
// ... the occurrence computed below may itself be beyond endsOn, and is scheduled anyway
```

So whenever `endsOn` is still ahead but the next occurrence falls beyond it, that occurrence is scheduled and executed. It self-terminates on the following pass (by then "now" is past `endsOn`), so the effect is exactly one extra run — but how late that run happens is bounded only by the repeat period:

| repeat | endsOn | last run actually executed | overrun |
| --- | --- | --- | --- |
| `0 30 10 * * 5` (weekly, Fri) | Wed | Fri | +2 days |
| `0 30 10 * * 2,5` (Tue/Fri) | Sat | next Tue | +3 days |
| `0 0 10 1 * *` (monthly, 1st) | Sep 15th | **Oct 1st** | **+16 days** |
| `86400000` (every 24h) | Aug 26th 12:00 | Aug 27th 09:00 | +21 hours |

Both repeat kinds are affected, cron and numeric interval alike.

The sibling implementation already gets this right. `DateFieldScheduleTrigger.getRecordNextTime()` re-checks the computed time against `endsOn` in both branches:

```ts
if (typeof repeat === 'number') {
  nextTime = timestamp + repeat - ((timestamp - startTime) % repeat);
  ...
  if (endTime && endTime < nextTime) {
    logger.debug(`[Schedule on date field] getNextTime: nextTime is after endsOn`);
    return null;
  }
} else if (typeof repeat === 'string') {
  nextTime = getCronNextTime(repeat, now);
  ...
  if (endTime && endTime < nextTime) { ... return null; }
}
```

This PR brings the static trigger in line with it, so the two schedule modes behave the same way.

### Description

After computing the next occurrence, both branches now return `null` when it lies beyond `endsOn`. The comparison is `endTime < next`, matching `DateFieldScheduleTrigger` — `endsOn` stays **inclusive**, so an occurrence landing exactly on it still runs.

Risks: low, and symmetrical for both repeat kinds. The only behaviour that disappears is a run that the user explicitly asked not to happen. Nothing changes when `endsOn` is unset, and nothing changes for occurrences at or before `endsOn`.

Testing suggestions: `mode-static.test.ts` had **no** `endsOn` coverage at all (`mode-date-field.test.ts` exercises it in eight places), which is why this went unnoticed. Three cases are added:

- `should not trigger after endsOn on cron repeat` — every 2s, `endsOn` at +3s; expects one run at +2s (currently two).
- `should not trigger after endsOn on interval repeat` — same with `repeat: 2000`, covering the numeric branch (currently two).
- `should trigger on an occurrence exactly at endsOn` — guards the inclusive boundary; passes before and after the fix.

Verified locally against Postgres 17: 17/17 pass with the fix; reverting only the trigger while keeping the tests makes the first two fail with `expected 2 to be 1`.

### Related issues

Same function as #10410 (extra trigger at `startsOn` for cron repeat). This branch is based on `main` and does not include that change, so a rebase may be needed depending on merge order.

### Showcase

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix schedule workflows in static mode running one more time after `endsOn` |
| 🇨🇳 Chinese | 修复定时任务（静态模式）在「结束于」之后仍会多执行一次的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | |
| 🇨🇳 Chinese | |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
