### PR TITLE
fix(acl): backport compound action authorization to v2.1

### DIFF
--- a/packages/core/acl/src/acl.ts
+++ b/packages/core/acl/src/acl.ts
@@ -72,6 +72,24 @@ interface CanArgs {
   roles?: string[];
 }
 
+export interface ResolveActionParamsOptions {
+  resourceName: string;
+  actionName: string;
+  rawResourceName?: string;
+  params?: any;
+  useCurrentRepository?: boolean;
+}
+
+export interface ResolvedActionParams {
+  actionName: string;
+  resourceName: string;
+  rawResourceName: string;
+  can: CanResult | null;
+  rawParams: any;
+  parsedParams?: any;
+  mergedParams: any;
+}
+
 export class ACL extends EventEmitter {
   /**
    * @internal
@@ -442,6 +460,58 @@ export class ACL extends EventEmitter {
     await compose(this.middlewares.nodes)(ctx, async () => {});
   }
 
+  async resolveActionParams(ctx, options: ResolveActionParamsOptions): Promise<ResolvedActionParams> {
+    const rawResourceName = options.rawResourceName || options.resourceName;
+    const resourceName = resolveResourceName(ctx, options.resourceName, options.useCurrentRepository === true);
+    const can = ctx.can({
+      resource: resourceName,
+      action: options.actionName,
+      rawResourceName,
+    });
+    const rawParams = lodash.cloneDeep(options.params || {});
+
+    if (!can || typeof can !== 'object') {
+      throw new NoPermissionError('No permissions');
+    }
+
+    const params = can.params || this.fixedParamsManager.getParams(resourceName, options.actionName);
+    ctx.log?.debug && ctx.log.debug('acl params', params);
+
+    if (!params) {
+      return {
+        actionName: options.actionName,
+        can,
+        mergedParams: rawParams,
+        rawParams,
+        rawResourceName,
+        resourceName,
+      };
+    }
+
+    const db = ctx.database ?? ctx.db;
+    const collection = db?.getCollection?.(resourceName);
+    checkFilterParams(collection, params?.filter);
+    const parsedFilter = await parseJsonTemplate(params.filter, {
+      state: ctx.state,
+      timezone: getTimezone(ctx),
+      userProvider: createUserProvider({
+        db: ctx.db,
+        currentUser: ctx.state?.currentUser,
+      }),
+    });
+    const parsedParams = params.filter ? { ...params, filter: parsedFilter ?? params.filter } : params;
+
+    return {
+      actionName: options.actionName,
+      can,
+      mergedParams: mergeActionParams(rawParams, parsedParams),
+      parsedParams,
+      rawParams,
+      rawResourceName,
+      resourceName,
+    };
+  }
+
   addGeneralFixedParams(merger: GeneralMerger) {
     this.fixedParamsManager.addGeneralParams(merger);
   }
@@ -465,6 +535,12 @@ export class ACL extends EventEmitter {
         const permission = ctx.permission;
 
         ctx.log?.debug && ctx.log.debug('ctx permission', permission);
+
+        if (['firstOrCreate', 'updateOrCreate'].includes(actionName)) {
+          permission.deferred = true;
+          await next();
+          return;
+        }
 
         if ((!permission.can || typeof permission.can !== 'object') && !permission.skip) {
           ctx.throw(403, 'No permissions');
@@ -524,7 +600,6 @@ export class ACL extends EventEmitter {
             if (isEmptyFields) {
               resourcerAction.params.fields = [];
             }
-
             ctx.permission.mergedParams = lodash.cloneDeep(resourcerAction.params);
           }
         } catch (e) {
@@ -548,6 +623,60 @@ export class ACL extends EventEmitter {
   protected isAvailableAction(actionName: string) {
     return this.availableActions.has(this.resolveActionAlias(actionName));
   }
+}
+
+function resolveResourceName(ctx: any, rawResourceName: string, useCurrentRepository: boolean) {
+  if (useCurrentRepository && ctx.getCurrentRepository) {
+    const repository = ctx.getCurrentRepository();
+    const collection = repository?.targetCollection || repository?.collection;
+    if (collection?.name) {
+      return collection.name;
+    }
+  }
+
+  return rawResourceName.includes('.') ? rawResourceName.split('.').pop() : rawResourceName;
+}
+
+function mergeActionParams(rawParams: any, parsedParams: any) {
+  const mergedParams = lodash.cloneDeep(rawParams || {});
+
+  if (parsedParams.appends && mergedParams.fields) {
+    for (const queryField of mergedParams.fields) {
+      if (parsedParams.appends.indexOf(queryField) !== -1) {
+        if (!mergedParams.appends) {
+          mergedParams.appends = [];
+        }
+        mergedParams.appends.push(queryField);
+        mergedParams.fields = mergedParams.fields.filter((f) => f !== queryField);
+      }
+    }
+  }
+
+  const isEmptyFields = mergedParams.fields && mergedParams.fields.length === 0;
+
+  assign(mergedParams, parsedParams, {
+    appends: (x, y) => {
+      if (!x) {
+        return [];
+      }
+      if (!y) {
+        return x;
+      }
+      return (x as any[]).filter((i) => y.includes(i.split('.').shift()));
+    },
+    blacklist: 'intersect',
+    except: 'union',
+    fields: 'intersect',
+    filter: 'andMerge',
+    sort: 'overwrite',
+    whitelist: 'intersect',
+  });
+
+  if (isEmptyFields) {
+    mergedParams.fields = [];
+  }
+
+  return mergedParams;
 }
 
 function getTimezone(ctx: any) {

--- a/packages/core/actions/src/actions/compound-action.ts
+++ b/packages/core/actions/src/actions/compound-action.ts
@@ -1,0 +1,168 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { CreateOptions, FirstOrCreateOptions, Repository, Transaction } from '@nocobase/database';
+import lodash from 'lodash';
+import { Context } from '..';
+import { getRepositoryFromParams } from '../utils';
+
+type CompoundActionName = 'firstOrCreate' | 'updateOrCreate';
+type ActualActionName = 'get' | 'create' | 'update';
+type CompoundRepositoryOptions = FirstOrCreateOptions &
+  Pick<CreateOptions, 'whitelist' | 'blacklist'> & { targetCollection?: string };
+
+const findParamKeys = ['fields', 'appends', 'except', 'filter', 'targetCollection'];
+const createParamKeys = ['values', 'whitelist', 'blacklist', 'updateAssociationValues', 'targetCollection'];
+const updateParamKeys = [
+  'values',
+  'whitelist',
+  'blacklist',
+  'filter',
+  'updateAssociationValues',
+  'forceUpdate',
+  'targetCollection',
+];
+
+function getTargetCollection(repository: Repository & { targetCollection?: Repository['collection'] }) {
+  return repository.targetCollection || repository.collection;
+}
+
+function getCompoundActionRepository(ctx: Context): Repository {
+  return ctx.getCurrentRepository ? ctx.getCurrentRepository() : getRepositoryFromParams(ctx);
+}
+
+async function withCurrentTransaction<T>(
+  ctx: Context,
+  callback: (transaction?: Transaction) => Promise<T>,
+): Promise<T> {
+  const database = ctx.database ?? ctx.db;
+  if (!database?.sequelize) {
+    return callback();
+  }
+  return database.sequelize.transaction(callback);
+}
+
+async function applyActualActionPermission(ctx: Context, actionName: ActualActionName, originalParams) {
+  if (ctx.permission?.deferred !== true || !['firstOrCreate', 'updateOrCreate'].includes(ctx.action.actionName)) {
+    ctx.throw(403, 'No permissions');
+  }
+
+  const { resourceName } = ctx.permission;
+  const can = ctx.can({
+    resource: resourceName,
+    action: actionName,
+    rawResourceName: ctx.action.resourceName,
+  });
+  if (!can || typeof can !== 'object') {
+    ctx.throw(403, 'No permissions');
+  }
+
+  const resolved = await ctx.acl.resolveActionParams(ctx, {
+    actionName,
+    params: originalParams,
+    resourceName: ctx.action.resourceName,
+    useCurrentRepository: true,
+  });
+  ctx.action.params = resolved.mergedParams;
+  ctx.permission.can = can;
+  ctx.permission.parsedParams = resolved.parsedParams;
+  ctx.permission.rawParams = resolved.rawParams;
+  ctx.permission.mergedParams = lodash.cloneDeep(resolved.mergedParams);
+  ctx.permission.actualActionName = actionName;
+  ctx.permission.deferred = false;
+}
+
+export function compoundAction(actionName: CompoundActionName) {
+  return async function compoundActionHandler(ctx: Context, next) {
+    const repository = getCompoundActionRepository(ctx);
+
+    // The actions package can be used without ACL middleware. In that case,
+    // preserve the repository action behavior; once ACL is present, the
+    // server-generated deferred marker is mandatory.
+    if (!ctx.acl) {
+      const compoundParams: CompoundRepositoryOptions = {
+        filterKeys: ctx.action.params.filterKeys,
+        values: ctx.action.params.values,
+        whitelist: ctx.action.params.whitelist,
+        blacklist: ctx.action.params.blacklist,
+        updateAssociationValues: ctx.action.params.updateAssociationValues,
+        targetCollection: ctx.action.params.targetCollection,
+        context: ctx,
+      };
+      ctx.body =
+        actionName === 'firstOrCreate'
+          ? await repository.firstOrCreate(compoundParams)
+          : await repository.updateOrCreate(compoundParams);
+      ctx.status = 200;
+      await next();
+      return;
+    }
+
+    if (ctx.permission?.deferred !== true || ctx.action.actionName !== actionName) {
+      ctx.throw(403, 'No permissions');
+    }
+
+    const originalParams = lodash.cloneDeep(ctx.action.params);
+    const { filterKeys, values } = originalParams;
+    const filter = Repository.valuesToFilter(values, filterKeys);
+    ctx.body = await withCurrentTransaction(ctx, async (transaction) => {
+      const instance = await repository.findOne({ filter, transaction, context: ctx });
+
+      if (!instance) {
+        await applyActualActionPermission(ctx, 'create', originalParams);
+        return repository.create({
+          values: ctx.action.params.values,
+          ...lodash.pick(
+            ctx.action.params,
+            createParamKeys.filter((key) => key !== 'values'),
+          ),
+          transaction,
+          context: ctx,
+        });
+      }
+
+      const targetCollection = getTargetCollection(repository);
+      const targetKey = targetCollection.filterTargetKey || targetCollection.model.primaryKeyAttribute;
+      const filterByTk = instance.get(targetKey);
+
+      if (actionName === 'firstOrCreate') {
+        await applyActualActionPermission(ctx, 'get', originalParams);
+        const result = await repository.findOne({
+          ...lodash.pick(ctx.action.params, findParamKeys),
+          filterByTk,
+          transaction,
+          context: ctx,
+        });
+        if (!result) {
+          ctx.throw(403, 'No permissions');
+        }
+        return result;
+      }
+
+      await applyActualActionPermission(ctx, 'update', originalParams);
+      const result = await repository.update({
+        values: ctx.action.params.values,
+        ...lodash.pick(
+          ctx.action.params,
+          updateParamKeys.filter((key) => key !== 'values'),
+        ),
+        filterByTk,
+        transaction,
+        context: ctx,
+      });
+      if (!result || (Array.isArray(result) && result.length === 0)) {
+        ctx.throw(403, 'No permissions');
+      }
+      return result;
+    });
+
+    ctx.status = 200;
+    await next();
+  };
+}

--- a/packages/core/actions/src/actions/first-or-create.ts
+++ b/packages/core/actions/src/actions/first-or-create.ts
@@ -7,9 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { proxyToRepository } from './proxy-to-repository';
+import { compoundAction } from './compound-action';
 
-export const firstOrCreate = proxyToRepository(
-  ['values', 'filterKeys', 'whitelist', 'blacklist', 'updateAssociationValues', 'targetCollection'],
-  'firstOrCreate',
-);
+export const firstOrCreate = compoundAction('firstOrCreate');

--- a/packages/core/actions/src/actions/update-or-create.ts
+++ b/packages/core/actions/src/actions/update-or-create.ts
@@ -7,9 +7,6 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { proxyToRepository } from './proxy-to-repository';
+import { compoundAction } from './compound-action';
 
-export const updateOrCreate = proxyToRepository(
-  ['values', 'filterKeys', 'whitelist', 'blacklist', 'updateAssociationValues', 'targetCollection'],
-  'updateOrCreate',
-);
+export const updateOrCreate = compoundAction('updateOrCreate');

--- a/packages/core/data-source-manager/src/load-default-actions.ts
+++ b/packages/core/data-source-manager/src/load-default-actions.ts
@@ -45,14 +45,6 @@ const actions: Actions = {
     params: ['filterByTk', 'filter'],
     method: 'destroy',
   },
-  firstOrCreate: {
-    params: ['values', 'filterKeys', 'whitelist', 'blacklist', 'updateAssociationValues', 'targetCollection'],
-    method: 'firstOrCreate',
-  },
-  updateOrCreate: {
-    params: ['values', 'filterKeys', 'whitelist', 'blacklist', 'updateAssociationValues', 'targetCollection'],
-    method: 'updateOrCreate',
-  },
   remove: {
     params(ctx) {
       return ctx.action.params.filterByTk || ctx.action.params.filterByTks || ctx.action.params.values;
@@ -79,6 +71,8 @@ export function loadDefaultActions() {
       carry[key] = proxyToRepository(actions[key].params, actions[key].method);
       return carry;
     }, {}),
+    firstOrCreate: coreActions.firstOrCreate,
+    updateOrCreate: coreActions.updateOrCreate,
     list,
     query: coreActions.query,
   };

--- a/packages/core/server/src/acl/available-action.ts
+++ b/packages/core/server/src/acl/available-action.ts
@@ -16,7 +16,7 @@ const availableActions: {
     displayName: '{{t("Add new")}}',
     type: 'new-data',
     onNewRecord: true,
-    aliases: ['create', 'firstOrCreate', 'updateOrCreate'],
+    aliases: ['create'],
     allowConfigureFields: true,
   },
   // import: {

--- a/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/compound-actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-acl/src/server/__tests__/compound-actions.test.ts
@@ -1,0 +1,230 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { SequelizeDataSource } from '@nocobase/data-source-manager';
+import { createMockDatabase, MockServer } from '@nocobase/test';
+import { prepareApp } from './prepare';
+
+describe('compound actions with ACL', () => {
+  let app: MockServer;
+  let userId: number;
+
+  beforeEach(async () => {
+    app = await prepareApp();
+
+    app.collection({
+      name: 'posts',
+      fields: [
+        { type: 'string', name: 'slug', unique: true },
+        { type: 'string', name: 'title' },
+        { type: 'string', name: 'secret' },
+      ],
+    });
+
+    await app.db.sync();
+
+    const user = await app.db.getRepository('users').findOne();
+    userId = user.get('id');
+
+    const role = app.acl.define({ role: 'create-only' });
+    role.grantAction('posts:create', {});
+
+    app.resourcer.use(
+      (ctx, next) => {
+        ctx.state.currentRole = 'create-only';
+        ctx.state.currentRoles = ['create-only'];
+        return next();
+      },
+      {
+        before: 'acl',
+        after: 'auth',
+      },
+    );
+  });
+
+  afterEach(async () => {
+    await app.destroy();
+  });
+
+  it('rejects firstOrCreate when an existing record lacks view permission', async () => {
+    await app.db.getRepository('posts').create({
+      values: {
+        slug: 'existing-post',
+        title: 'private title',
+      },
+    });
+
+    const viewResponse = await (await app.agent().login(userId)).resource('posts').get({
+      filter: {
+        slug: 'existing-post',
+      },
+    });
+    expect(viewResponse.statusCode).toBe(403);
+
+    const response = await (await app.agent().login(userId)).resource('posts').firstOrCreate({
+      filterKeys: ['slug'],
+      values: {
+        slug: 'existing-post',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+
+    const created = await (await app.agent().login(userId)).resource('posts').firstOrCreate({
+      filterKeys: ['slug'],
+      values: { slug: 'created-post', title: 'created title' },
+    });
+    expect(created.statusCode).toBe(200);
+
+    app.acl.getRole('create-only').grantAction('posts:view', {
+      filter: { slug: 'existing-post' },
+      fields: ['slug'],
+    });
+    const allowed = await (await app.agent().login(userId)).resource('posts').firstOrCreate({
+      filterKeys: ['slug'],
+      fields: ['slug', 'title'],
+      values: { slug: 'existing-post' },
+    });
+    expect(allowed.statusCode).toBe(200);
+    expect(allowed.body.data.slug).toBe('existing-post');
+    expect(allowed.body.data).not.toHaveProperty('title');
+
+    await app.db.getRepository('posts').create({ values: { slug: 'outside-scope' } });
+    const outsideScope = await (await app.agent().login(userId)).resource('posts').firstOrCreate({
+      filterKeys: ['slug'],
+      values: { slug: 'outside-scope' },
+    });
+    expect(outsideScope.statusCode).toBe(403);
+    expect(await app.db.getRepository('posts').count({ filter: { slug: 'outside-scope' } })).toBe(1);
+  });
+
+  it('rejects updateOrCreate when an existing record lacks update permission', async () => {
+    const post = await app.db.getRepository('posts').create({
+      values: {
+        slug: 'existing-post',
+        title: 'original title',
+      },
+    });
+
+    const updateResponse = await (await app.agent().login(userId)).resource('posts').update({
+      filterByTk: post.get('id'),
+      values: {
+        title: 'updated directly',
+      },
+    });
+    expect(updateResponse.statusCode).toBe(403);
+
+    const response = await (await app.agent().login(userId)).resource('posts').updateOrCreate({
+      filterKeys: ['slug'],
+      values: {
+        slug: 'existing-post',
+        title: 'updated through compound action',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    await post.reload();
+    expect(post.get('title')).toBe('original title');
+
+    const created = await (await app.agent().login(userId)).resource('posts').updateOrCreate({
+      filterKeys: ['slug'],
+      values: { slug: 'created-post', title: 'created title' },
+    });
+    expect(created.statusCode).toBe(200);
+
+    app.acl.getRole('create-only').grantAction('posts:update', {
+      filter: { slug: 'existing-post' },
+      fields: ['title'],
+    });
+    const allowed = await (await app.agent().login(userId)).resource('posts').updateOrCreate({
+      filterKeys: ['slug'],
+      values: {
+        slug: 'existing-post',
+        title: 'allowed title',
+        secret: 'forbidden secret',
+      },
+    });
+    expect(allowed.statusCode).toBe(200);
+    await post.reload();
+    expect(post.get('title')).toBe('allowed title');
+    expect(post.get('secret')).toBeNull();
+
+    await app.db.getRepository('posts').create({ values: { slug: 'outside-scope', title: 'original' } });
+    const outsideScope = await (await app.agent().login(userId)).resource('posts').updateOrCreate({
+      filterKeys: ['slug'],
+      values: { slug: 'outside-scope', title: 'forbidden' },
+    });
+    expect(outsideScope.statusCode).toBe(403);
+    const unchanged = await app.db.getRepository('posts').findOne({ filter: { slug: 'outside-scope' } });
+    expect(unchanged.get('title')).toBe('original');
+  });
+
+  it('enforces actual action permissions for external data sources', async () => {
+    const database = await createMockDatabase({ tablePrefix: 'compound_acl_ds_' });
+    const dataSource = new SequelizeDataSource({
+      name: 'compound-acl-ds',
+      resourceManager: { prefix: app.resourcer.options.prefix },
+      collectionManager: { database },
+    });
+    dataSource.collectionManager.defineCollection({
+      name: 'externalPosts',
+      fields: [
+        { type: 'string', name: 'slug', unique: true },
+        { type: 'string', name: 'title' },
+      ],
+    });
+    await dataSource.collectionManager.sync();
+    await app.dataSourceManager.add(dataSource);
+
+    const role = dataSource.acl.define({ role: 'external-create-only' });
+    role.grantAction('externalPosts:create', {});
+    let externalRoleName = 'external-create-only';
+    dataSource.resourceManager.use(
+      (ctx, next) => {
+        ctx.state.currentRole = externalRoleName;
+        ctx.state.currentRoles = [externalRoleName];
+        return next();
+      },
+      { before: 'acl', after: 'auth' },
+    );
+
+    const repository = dataSource.collectionManager.getRepository('externalPosts');
+    const existing = await repository.create({ values: { slug: 'existing', title: 'private' } });
+    const agent = await app.agent().login(userId);
+
+    const readResponse = await agent
+      .resource('externalPosts')
+      .firstOrCreate({ filterKeys: ['slug'], values: { slug: 'existing' } })
+      .set('x-data-source', 'compound-acl-ds');
+    expect(readResponse.statusCode).toBe(403);
+
+    const updateResponse = await agent
+      .resource('externalPosts')
+      .updateOrCreate({ filterKeys: ['slug'], values: { slug: 'existing', title: 'overwritten' } })
+      .set('x-data-source', 'compound-acl-ds');
+    expect(updateResponse.statusCode).toBe(403);
+    await existing.reload();
+    expect(existing.get('title')).toBe('private');
+
+    const created = await agent
+      .resource('externalPosts')
+      .updateOrCreate({ filterKeys: ['slug'], values: { slug: 'created', title: 'allowed' } })
+      .set('x-data-source', 'compound-acl-ds');
+    expect(created.statusCode).toBe(200);
+
+    dataSource.acl.define({ role: 'external-no-access' });
+    externalRoleName = 'external-no-access';
+    const deniedCreate = await agent
+      .resource('externalPosts')
+      .updateOrCreate({ filterKeys: ['slug'], values: { slug: 'denied', title: 'forbidden' } })
+      .set('x-data-source', 'compound-acl-ds');
+    expect(deniedCreate.statusCode).toBe(403);
+    expect(await repository.count({ filter: { slug: 'denied' } })).toBe(0);
+  });
+});


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Backport #10403 to v2.1. `firstOrCreate` and `updateOrCreate` were statically aliased to `create` in ACL. A role with create permission but without view or update permission could therefore return or modify an existing record through these compound actions.

### Description

- Remove `firstOrCreate` and `updateOrCreate` from the `create` ACL aliases.
- Defer ACL authorization for these built-in compound actions until the handler determines whether the target record exists.
- Authorize and execute the actual operation (`get`, `create`, or `update`) while applying its data scope and field permissions.
- Execute the probe and final repository operation in one transaction and fail closed when an existing record is outside the authorized scope.
- Add regression tests for unauthorized access and external data sources.
- Adapt ACL parameter resolution to the v2.1 implementation.

Potential risk: this changes authorization dispatch for the two compound actions. Testing should cover both existing and missing records for roles with create, view, and update permissions, including scoped and field-limited permissions.

Validation:

- ESLint passed for all touched files.
- `git diff --check` passed.
- The targeted server test could not reach its assertions in the isolated worktree because the available dependencies are from `main`: SQLite lacks the native `sqlite3` package, while PostgreSQL fails during Commander initialization because its version does not match v2.1.

### Related issues

Backport of #10403

### Showcase

N/A (server-side security fix)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an ACL bypass that allowed `firstOrCreate` or `updateOrCreate` to read or modify existing records without the required view or update permission. |
| 🇨🇳 Chinese | 修复 `firstOrCreate` 或 `updateOrCreate` 可在缺少查看或编辑权限时读取或修改已有记录的 ACL 绕过漏洞。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 无需更新 |

### Checklists
- [ ] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
