### PR TITLE
fix(plugin-workflow): restore option field selectors in v2 nodes

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx
@@ -35,6 +35,12 @@ type WorkflowVariableTree = ReturnType<typeof useWorkflowVariableOptions>;
 export type AssignedFieldFilter = (field: AssignedField) => boolean;
 
 const VARIABLE_EXPRESSION_FIELD_TYPES: ReadonlySet<string> = new Set(['string', 'text']);
+const OPTION_FIELD_INTERFACES: ReadonlySet<string> = new Set([
+  'select',
+  'multipleSelect',
+  'radioGroup',
+  'checkboxGroup',
+]);
 
 const fieldItemClassName = css`
   position: relative;
@@ -93,6 +99,10 @@ function normalizeAssignedValues(values: AssignedValues | undefined): AssignedVa
 
 function normalizeVariableExpressionValue(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function supportsVariableExpression(field: AssignedField): boolean {
+  return VARIABLE_EXPRESSION_FIELD_TYPES.has(field.type ?? '') && !OPTION_FIELD_INTERFACES.has(field.interface ?? '');
 }
 
 function getFieldTitle(field: AssignedField, t: (key: string) => string) {
@@ -215,7 +225,7 @@ export function AssignedFieldsEditor({
               layout="vertical"
               colon
             >
-              {VARIABLE_EXPRESSION_FIELD_TYPES.has(field.type ?? '') ? (
+              {supportsVariableExpression(field) ? (
                 <VariableHybridInput
                   value={normalizeVariableExpressionValue(normalizedValue[field.name])}
                   onChange={(nextValue) => updateValue(field.name, nextValue)}

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx
@@ -28,6 +28,9 @@ const {
     getFields: vi.fn(() => [
       { name: 'title', type: 'string', uiSchema: { title: 'Title' }, interface: 'input' },
       { name: 'status', type: 'string', uiSchema: { title: 'Status' }, interface: 'select' },
+      { name: 'priority', type: 'string', uiSchema: { title: 'Priority' }, interface: 'radioGroup' },
+      { name: 'categories', type: 'array', uiSchema: { title: 'Categories' }, interface: 'multipleSelect' },
+      { name: 'features', type: 'array', uiSchema: { title: 'Features' }, interface: 'checkboxGroup' },
       { name: 'body', type: 'text', uiSchema: { title: 'Body' }, interface: 'textarea' },
       { name: 'website', type: 'text', uiSchema: { title: 'Website' }, interface: 'url' },
       { name: 'metadata', type: 'json', uiSchema: { title: 'Metadata' }, interface: 'textarea' },
@@ -175,6 +178,31 @@ describe('AssignedFieldsEditor', () => {
         expect.anything(),
       );
     });
+  });
+
+  it('keeps field-aware selectors for option fields regardless of their storage type', async () => {
+    render(
+      <AssignedFieldsEditor
+        collection="posts"
+        value={{ status: 'open', priority: 'high', categories: ['news'], features: ['featured'] }}
+        onChange={() => undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      for (const [targetPath, value] of [
+        ['status', 'open'],
+        ['priority', 'high'],
+        ['categories', ['news']],
+        ['features', ['featured']],
+      ]) {
+        expect(mockFieldAssignValueInput).toHaveBeenCalledWith(
+          expect.objectContaining({ targetPath, value }),
+          expect.anything(),
+        );
+      }
+    });
+    expect(mockVariableHybridInput).not.toHaveBeenCalled();
   });
 
   it('adds unassigned collection fields with constant empty values', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
In v2 workflow Create record and Update record nodes, option fields backed by string storage were rendered as variable-expression text inputs. As a result, users could not select the options configured for select and radio fields.

This bug-fix branch is based on `main`.

### Description
- Keep `select`, `multipleSelect`, `radioGroup`, and `checkboxGroup` fields on the field-aware assignment editor so their configured options remain selectable.
- Preserve variable-expression editing for ordinary string and text fields.
- Add regression coverage for all four option-field interfaces.
- Limit the change to the shared v2 workflow assigned-fields editor; there are no API, database, migration, ACL, or saved workflow format changes.

Risk is low. The main review focus is the interface-based editor routing. Suggested manual testing is to configure each option-field type in both Create record and Update record nodes and verify that configured values can be selected and saved.

Local verification:
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx --run --reporter=verbose` — 7 passed.
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/createFieldset.test.tsx --run --reporter=verbose` — 2 passed.
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/nodes/__tests__/updateFieldset.test.tsx --run --reporter=verbose` — 5 passed.
- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/AssignedFieldsEditor.tsx packages/plugins/@nocobase/plugin-workflow/src/client-v2/components/collection/__tests__/AssignedFieldsEditor.test.tsx` — passed.
- `git diff --check` — passed.

Remote CI is tracked separately and is not represented by the local verification above.

### Related issues
Task 6075

### Showcase
N/A

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix option fields being unable to select configured values in v2 workflow Create record and Update record nodes. |
| 🇨🇳 Chinese | 修复 v2 工作流新增数据、更新数据节点中的选项字段无法选择配置值的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A — no documentation changes required. |
| 🇨🇳 Chinese | N/A — 无需修改文档。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
