### PR TITLE
fix(ui-templates): avoid reference close error

### DIFF
--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/models/__tests__/referenceShared.test.ts
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/models/__tests__/referenceShared.test.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { FlowContext, FlowEngine } from '@nocobase/flow-engine';
+import { describe, expect, it } from 'vitest';
+import { ensureBlockScopedEngine, ensureScopedEngineView } from '../referenceShared';
+
+describe('referenceShared', () => {
+  it('keeps the bridged view lookup local after the host view delegate is removed', () => {
+    const parentEngine = new FlowEngine();
+    const hostModel = parentEngine.createModel({ use: 'FlowModel', uid: 'host-model' });
+    const hostViewContext = new FlowContext();
+    const hostView = { uid: 'host-view' };
+    hostViewContext.defineProperty('view', { value: hostView });
+    hostModel.context.addDelegate(hostViewContext);
+
+    const scopedEngine = ensureBlockScopedEngine(parentEngine);
+    ensureScopedEngineView(scopedEngine, hostModel.context);
+
+    expect(scopedEngine.context).not.toBe(parentEngine.context);
+    expect(scopedEngine.context.engine).toBe(scopedEngine);
+    expect(scopedEngine.context.view).toBe(hostView);
+    expect(parentEngine.context.getPropertyOptions('view')).toBeUndefined();
+
+    const nextHostView = { uid: 'next-host-view' };
+    hostViewContext.defineProperty('view', { value: nextHostView });
+    expect(scopedEngine.context.view).toBe(nextHostView);
+
+    hostModel.context.removeDelegate(hostViewContext);
+
+    expect(() => scopedEngine.context.view).not.toThrow();
+    expect(scopedEngine.context.view).toBeUndefined();
+    expect(parentEngine.context.getPropertyOptions('view')).toBeUndefined();
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/models/referenceShared.tsx
+++ b/packages/plugins/@nocobase/plugin-ui-templates/src/client-v2/models/referenceShared.tsx
@@ -22,7 +22,19 @@ import {
 import { NAMESPACE } from '../locale';
 
 export function ensureBlockScopedEngine(flowEngine: FlowEngine, scopedEngine?: FlowEngine): FlowEngine {
-  return scopedEngine ?? createBlockScopedEngine(flowEngine);
+  if (scopedEngine) return scopedEngine;
+
+  const engine = createBlockScopedEngine(flowEngine);
+  // BlockScopedFlowEngine shares the parent engine context. Add a reference-local overlay so view bridging stays local while other context values still delegate to the parent.
+  const parentContext = engine.context;
+  const context = new FlowContext();
+  context.defineProperty('engine', { value: engine });
+  context.addDelegate(parentContext);
+  Object.defineProperty(engine, 'context', {
+    configurable: true,
+    value: context,
+  });
+  return engine;
 }
 
 export function ensureScopedEngineView(engine: FlowEngine, hostContext?: FlowContext): void {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

审批任务包含引用区块时，打开任务详情后再关闭会触发递归读取，导致页面报错，任务列表无法正常继续使用。

### Description

- 将引用区块使用的视图上下文限制在引用区块内部，避免影响共享上下文
- 关闭任务详情后，已卸载的视图可以安全解除关联，不再产生递归错误
- 增加回归测试，覆盖视图更新、上下文隔离以及关闭后的安全读取
- 修改仅限 Client V2 引用区块，不修改 core 或 API

测试建议：打开包含引用区块的审批任务并连续关闭、重新打开，确认页面正常返回任务列表且不再出现栈溢出错误。

### Showcase

无

### Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix the error when closing an approval task containing a referenced block |
| 🇨🇳 Chinese | 修复关闭包含引用区块的审批任务时报错的问题 |

### Docs

| Language | Link |
| --- | --- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
