### PR TITLE
fix(plugin-public-forms): hide duplicate v2 submit action

### DIFF
--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormSubmitActionModel.test.ts
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormSubmitActionModel.test.ts
@@ -8,10 +8,30 @@
  */
 
 import { FlowEngine } from '@nocobase/flow-engine';
+import { FormActionGroupModel, FormActionModel, FormSubmitActionModel } from '@nocobase/client-v2';
 import { describe, expect, it, vi } from 'vitest';
+import { PUBLIC_FORM_SUBMIT_ACTION_MODEL } from '../constants';
 import { PublicFormSubmitActionModel } from '../models/PublicFormSubmitActionModel';
 
 describe('PublicFormSubmitActionModel', () => {
+  it('is addable only within public forms', async () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ FormActionModel, FormSubmitActionModel, PublicFormSubmitActionModel });
+
+    const regularFormActionNames = (await FormActionGroupModel.defineChildren(engine.context)).map(
+      (item) => item.useModel,
+    );
+    expect(regularFormActionNames).toContain('FormSubmitActionModel');
+    expect(regularFormActionNames).not.toContain(PUBLIC_FORM_SUBMIT_ACTION_MODEL);
+
+    engine.context.defineProperty('allowedFormActionModelNames', {
+      value: [PUBLIC_FORM_SUBMIT_ACTION_MODEL],
+    });
+
+    const publicFormActions = await FormActionGroupModel.defineChildren(engine.context);
+    expect(publicFormActions.map((item) => item.useModel)).toEqual([PUBLIC_FORM_SUBMIT_ACTION_MODEL]);
+  });
+
   it('does not read record filterByTk when submitting a public create form', () => {
     const engine = new FlowEngine();
     engine.registerModels({ PublicFormSubmitActionModel });

--- a/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormSubmitActionModel.tsx
+++ b/packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormSubmitActionModel.tsx
@@ -8,6 +8,7 @@
  */
 
 import { FormSubmitActionModel } from '@nocobase/client-v2';
+import { PUBLIC_FORM_SUBMIT_ACTION_MODEL } from '../constants';
 import { tExpr } from '../locale';
 
 export class PublicFormSubmitActionModel extends FormSubmitActionModel {
@@ -41,6 +42,9 @@ export class PublicFormSubmitActionModel extends FormSubmitActionModel {
 
 PublicFormSubmitActionModel.define({
   label: tExpr('Submit'),
+  hide: (context) =>
+    !Array.isArray(context.allowedFormActionModelNames) ||
+    !context.allowedFormActionModelNames.includes(PUBLIC_FORM_SUBMIT_ACTION_MODEL),
 });
 
 PublicFormSubmitActionModel.registerFlow({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

When the Public Forms plugin was enabled, V2 regular form action configuration displayed two actions labeled `Submit`. Both the core `FormSubmitActionModel` and the public-form-specific `PublicFormSubmitActionModel` were discovered as form actions because the specialized action did not have a context visibility guard.

### Description

- Target base: `main`.
- Hide `PublicFormSubmitActionModel` unless the current form context explicitly allows that model through `allowedFormActionModelNames`.
- Add regression coverage proving that regular forms expose the core submit action without the public-form-specific duplicate, while public forms expose only their specialized submit action.
- Keep existing persisted model trees, submit execution, and the `publicSubmit` request behavior unchanged.
- No API, database, migration, permission, localization, documentation, or component demo changes are included.

Risk is low and limited to candidate discovery in the V2 add-action menu. Review should focus on the existing `allowedFormActionModelNames` context contract used by embedded public-form configuration pages.

Verification performed locally:

- All 7 Public Forms V2 test files passed: 30 tests total.
- `yarn test packages/core/client-v2/src/flow/models/blocks/form/__tests__/FormActionGroupModel.test.ts --run --reporter=verbose` passed: 1 test.
- `yarn eslint --fix packages/plugins/@nocobase/plugin-public-forms/src/client-v2/models/PublicFormSubmitActionModel.tsx packages/plugins/@nocobase/plugin-public-forms/src/client-v2/__tests__/PublicFormSubmitActionModel.test.ts` passed.
- Commit-time `lint-staged` passed.
- `git diff --check` passed.
- The directory-level test shortcut returned `No test files found` because of the repository test wrapper's directory matching; all 7 test files were then invoked explicitly and passed.
- No live browser verification was performed.

### Related issues

Task 6086

### Showcase

- Before: regular V2 form configuration showed both the core submit action and the public-form-specific submit action with the same `Submit` label.
- After: regular V2 forms show one core submit action; public forms retain their dedicated submit action.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicate Submit actions in V2 regular form configuration when Public Forms is enabled. |
| 🇨🇳 Chinese | 修复启用公开表单后，V2 普通表单配置中显示两个“提交”操作的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
