### PR TITLE
fix(plugin-ai-gigachat): defer model settings form creation

### DIFF
--- a/packages/plugins/@nocobase/plugin-ai-gigachat/src/client-v2/__tests__/model-settings.test.tsx
+++ b/packages/plugins/@nocobase/plugin-ai-gigachat/src/client-v2/__tests__/model-settings.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createModelSettingsForm: vi.fn(() => () => <div>GigaChat model settings</div>),
+}));
+
+vi.mock('@nocobase/plugin-ai/client-v2', () => ({
+  createModelSettingsForm: mocks.createModelSettingsForm,
+}));
+
+import { ModelSettingsForm } from '../llm-providers/gigachat/ModelSettings';
+
+describe('GigaChat ModelSettingsForm', () => {
+  it('creates the settings form lazily when the component renders', () => {
+    expect(mocks.createModelSettingsForm).not.toHaveBeenCalled();
+
+    const { rerender } = render(<ModelSettingsForm />);
+
+    expect(screen.getByText('GigaChat model settings')).toBeInTheDocument();
+    expect(mocks.createModelSettingsForm).toHaveBeenCalledTimes(1);
+
+    rerender(<ModelSettingsForm />);
+
+    expect(mocks.createModelSettingsForm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-ai-gigachat/src/client-v2/llm-providers/gigachat/ModelSettings.tsx
+++ b/packages/plugins/@nocobase/plugin-ai-gigachat/src/client-v2/llm-providers/gigachat/ModelSettings.tsx
@@ -7,6 +7,7 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
+import React, { useMemo } from 'react';
 import { createModelSettingsForm, type OptionField } from '@nocobase/plugin-ai/client-v2';
 
 const gigachatCompletionFields: OptionField[] = [
@@ -80,4 +81,8 @@ const gigachatCompletionFields: OptionField[] = [
   },
 ];
 
-export const ModelSettingsForm = createModelSettingsForm(gigachatCompletionFields);
+export const ModelSettingsForm: React.FC = () => {
+  const SettingsForm = useMemo(() => createModelSettingsForm(gigachatCompletionFields), []);
+
+  return <SettingsForm />;
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

On iOS 15.6 and earlier, loading NocoBase 2.2.1 with the GigaChat AI provider enabled could fail during application startup with `undefined is not an object (evaluating '...createModelSettingsForm')`. The GigaChat client-v2 module created its model settings component eagerly while the module was being evaluated.

### Description 

- Defer `createModelSettingsForm()` until the GigaChat model settings component is actually rendered.
- Memoize the generated component so ordinary React re-renders do not recreate it.
- Add a regression test confirming that the form factory is not called during module initialization and is called only once while rendering and re-rendering the component.

Risk is limited to the GigaChat model settings form initialization timing. The form fields and provider registration remain unchanged.

Testing suggestions:

1. Start the application with both `@nocobase/plugin-ai` and `@nocobase/plugin-ai-gigachat` enabled.
2. Confirm the application loads on iOS 15.6 Safari or an equivalent WebKit environment.
3. Open the GigaChat LLM service settings and confirm the model and option fields render normally.

### Related issues

- CRM ticket `202608241369`

### Showcase

Not applicable. This change preserves the existing UI.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an application startup error on iOS 15.6 and earlier when the GigaChat AI provider is enabled |
| 🇨🇳 Chinese | 修复启用 GigaChat AI 服务后应用在 iOS 15.6 及更早版本上启动报错的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
