### PR TITLE
fix(client-v2): guard popup record picker field names

### DIFF
--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx
@@ -35,6 +35,7 @@ import {
 import {
   buildOpenerUids,
   LabelByField,
+  normalizeAssociationFieldNames,
   type AssociationFieldNames,
   useAssociationValueHydration,
 } from './recordSelectShared';
@@ -331,6 +332,7 @@ function RecordPickerField(props) {
   const { fieldNames, onClick, disabled } = props;
   const ctx = useFlowContext();
   const allowMultiple = canRecordPickerSelectMultiple(ctx.collectionField, props.allowMultiple);
+  const normalizedFieldNames = normalizeAssociationFieldNames(fieldNames, ctx.collectionField?.targetCollection);
   useEffect(() => {
     ctx.model.selectedRows.value = props.value;
   }, [ctx.model.selectedRows, props.value]);
@@ -338,22 +340,23 @@ function RecordPickerField(props) {
     model: ctx.model,
     value: props.value,
     isMultiple: allowMultiple,
-    fieldNames,
+    fieldNames: normalizedFieldNames,
     onChange: props.onChange,
   });
 
   return (
     <Select
       {...props}
+      fieldNames={normalizedFieldNames}
       open={false}
       onClick={(e) => {
         if (!disabled) {
           onClick(e);
         }
       }}
-      value={normalizeRecordPickerValue(props.value, fieldNames, allowMultiple)}
+      value={normalizeRecordPickerValue(props.value, normalizedFieldNames, allowMultiple)}
       labelRender={(item) => {
-        return <LabelByField option={item} fieldNames={fieldNames} />;
+        return <LabelByField option={item} fieldNames={normalizedFieldNames} />;
       }}
       labelInValue
       mode={allowMultiple ? 'multiple' : undefined}

--- a/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/RecordPickerFieldModel.itemContext.test.ts
+++ b/packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/RecordPickerFieldModel.itemContext.test.ts
@@ -7,8 +7,9 @@
  * For more information, please refer to: https://www.nocobase.com/agreement.
  */
 
-import { FlowContext, FlowEngine, FlowModel } from '@nocobase/flow-engine';
-import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { FlowContext, FlowEngine, FlowModel, FlowModelProvider } from '@nocobase/flow-engine';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildCurrentItemTitle,
@@ -82,6 +83,29 @@ describe('RecordPickerFieldModel item context', () => {
     expect(normalizeRecordPickerValue(rows, fieldNames, false)).toEqual({ id: 1, name: 'A', label: 'A', value: 1 });
     expect(normalizeRecordPickerValue(undefined, fieldNames, true)).toEqual([]);
     expect(normalizeRecordPickerValue(undefined, fieldNames, false)).toBeUndefined();
+  });
+
+  it('renders existing values before field names are initialized', () => {
+    const engine = new FlowEngine();
+    engine.registerModels({ RecordPickerFieldModel });
+    const field = engine.createModel<RecordPickerFieldModel>({
+      use: 'RecordPickerFieldModel',
+      uid: 'record-picker-without-field-names',
+    });
+    field.context.defineProperty('collectionField', {
+      value: {
+        type: 'hasMany',
+        targetCollection: {
+          filterTargetKey: 'id',
+          titleCollectionField: { name: 'name' },
+        },
+      },
+    });
+    field.setProps({ value: [{ id: 1, name: 'Alice' }], onClick: vi.fn(), onChange: vi.fn() });
+
+    const result = render(React.createElement(FlowModelProvider, { model: field }, field.render()));
+
+    expect(result.getByRole('combobox')).toBeTruthy();
   });
 
   it('queues ID-only picker values for association label hydration', () => {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

Switching a v2 association field to the popup record picker can render the new `RecordPickerFieldModel` before its title-field flow initializes `fieldNames`. The relation-label hydration hook then dereferences `fieldNames.label` and the field falls into the render error boundary.

This PR targets `main` and fixes task 6092.

### Description

- Normalize popup record picker field names at the component boundary using the target collection title field and filter target key as fallbacks.
- Reuse the normalized names consistently for Ant Design Select, value conversion, label rendering, and relation-label hydration.
- Add a regression test that renders an existing relation value while `fieldNames` is still uninitialized.

Current behavior and boundaries:

- Existing explicit `fieldNames` remain unchanged.
- Only the temporary uninitialized state gains fallback behavior.
- No API, database, permission, migration, or persistence format changes are included.
- No automation is changed; first-run and repeated-run behavior are therefore unaffected.

Risk and review focus:

- Risk is low and limited to v2 popup record picker rendering.
- Review the fallback selection and consistent use of normalized field names.

### Related issues

Task 6092

### Showcase

Not included. The regression is covered by an automated render test.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix a render error when switching a v2 association field to popup record selection. |
| 🇨🇳 Chinese | 修复 v2 关系字段切换为弹窗选择时的渲染错误。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed; bug fix only. |
| 🇨🇳 Chinese | 无需更新，仅修复缺陷。 |

### Verification

Local verification:

- `yarn test packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/RecordPickerFieldModel.itemContext.test.ts --run --reporter=verbose` — passed, 18/18 tests.
- `yarn test packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/recordSelectShared.fieldNames.test.ts --run --reporter=verbose` — passed, 4/4 tests.
- `yarn eslint --fix packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/RecordPickerFieldModel.tsx packages/core/client-v2/src/flow/models/fields/AssociationFieldModel/__tests__/RecordPickerFieldModel.itemContext.test.ts` — passed.
- `git diff --check` — passed.

Remote CI has not yet completed. No runtime deployment was performed.

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
