### PR TITLE
fix(plugin-users): use current user profile action

### DIFF
--- a/packages/plugins/@nocobase/plugin-users/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/__tests__/actions.test.ts
@@ -64,6 +64,24 @@ describe('actions', () => {
     expect(res2.status).toBe(200);
   });
 
+  it('get current user profile', async () => {
+    const unauthorized = await agent.resource('users').getProfile();
+    expect(unauthorized.status).toBe(401);
+
+    const res = await adminAgent.resource('users').getProfile({
+      filterByTk: adminUser.id + 1,
+      fields: ['id', 'nickname', 'username', 'password', 'resetToken'],
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: adminUser.id,
+      nickname: adminUser.nickname,
+      username: adminUser.username,
+    });
+    expect(res.body.data).not.toHaveProperty('password');
+    expect(res.body.data).not.toHaveProperty('resetToken');
+  });
+
   it('update profile not allowed', async () => {
     await db.getRepository('systemSettings').update({
       filterByTk: 1,

--- a/packages/plugins/@nocobase/plugin-users/src/server/__tests__/actions.test.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/__tests__/actions.test.ts
@@ -71,6 +71,7 @@ describe('actions', () => {
     const res = await adminAgent.resource('users').getProfile({
       filterByTk: adminUser.id + 1,
       fields: ['id', 'nickname', 'username', 'password', 'resetToken'],
+      appends: ['roles'],
     });
     expect(res.status).toBe(200);
     expect(res.body.data).toMatchObject({
@@ -80,6 +81,9 @@ describe('actions', () => {
     });
     expect(res.body.data).not.toHaveProperty('password');
     expect(res.body.data).not.toHaveProperty('resetToken');
+    expect(res.body.data.roles).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: adminUser.roles[0].name })]),
+    );
   });
 
   it('update profile not allowed', async () => {

--- a/packages/plugins/@nocobase/plugin-users/src/server/actions/users.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/actions/users.ts
@@ -120,7 +120,7 @@ export async function getProfile(ctx: Context, next: Next) {
     except,
     context: ctx,
   });
-  ctx.body = user?.desensitize();
+  ctx.body = user?.toJSON();
   await next();
 }
 

--- a/packages/plugins/@nocobase/plugin-users/src/server/actions/users.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/actions/users.ts
@@ -101,6 +101,29 @@ export async function updateProfile(ctx: Context, next: Next) {
   await next();
 }
 
+/**
+ * Returns the authenticated user's profile without requiring the generic users:get permission.
+ * The profile form is intentionally scoped to the current session user.
+ */
+export async function getProfile(ctx: Context, next: Next) {
+  const { currentUser } = ctx.state;
+  if (!currentUser) {
+    ctx.throw(401);
+  }
+
+  const userRepo = ctx.db.getRepository('users');
+  const { fields, appends, except } = ctx.action.params;
+  const user = await userRepo.findOne({
+    filterByTk: currentUser.id,
+    fields,
+    appends,
+    except,
+    context: ctx,
+  });
+  ctx.body = user?.desensitize();
+  await next();
+}
+
 export async function updateLang(ctx: Context, next: Next) {
   const { appLang } = ctx.action.params.values || {};
   const { currentUser } = ctx.state;

--- a/packages/plugins/@nocobase/plugin-users/src/server/migrations/20260828000000-use-get-profile-action.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/migrations/20260828000000-use-get-profile-action.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { UiSchemaRepository } from '@nocobase/plugin-ui-schema-storage';
+import { Migration } from '@nocobase/server';
+
+export default class extends Migration {
+  on = 'afterLoad';
+
+  async up() {
+    const repo = this.db.getRepository<UiSchemaRepository>('uiSchemas');
+    const schema = await repo.getJsonSchema('nocobase-user-profile-edit-form');
+    const formBlock = schema?.properties?.form;
+    if (!formBlock?.['x-uid']) {
+      return;
+    }
+
+    await repo.patch({
+      'x-uid': formBlock['x-uid'],
+      'x-decorator-props': {
+        ...formBlock['x-decorator-props'],
+        action: 'getProfile',
+      },
+    });
+  }
+}

--- a/packages/plugins/@nocobase/plugin-users/src/server/profile/edit-form-schema.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/profile/edit-form-schema.ts
@@ -362,7 +362,7 @@ export const userProfileEditFormSchema = {
       'x-decorator-props': {
         collection: 'users',
         dataSource: 'main',
-        action: 'get',
+        action: 'getProfile',
       },
       'x-use-decorator-props': 'useEditFormBlockDecoratorProps',
       properties: {

--- a/packages/plugins/@nocobase/plugin-users/src/server/server.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/server/server.ts
@@ -149,7 +149,7 @@ export default class PluginUsersServer extends Plugin {
       };
     });
 
-    const loggedInActions = ['updateProfile', 'updateLang'];
+    const loggedInActions = ['getProfile', 'updateProfile', 'updateLang'];
     loggedInActions.forEach((action) => this.app.acl.allow('users', action, 'loggedIn'));
 
     this.app.acl.registerSnippet({

--- a/packages/plugins/@nocobase/plugin-users/src/swagger/index.ts
+++ b/packages/plugins/@nocobase/plugin-users/src/swagger/index.ts
@@ -64,6 +64,25 @@ export default {
         },
       },
     },
+    '/users:getProfile': {
+      get: {
+        tags: ['users'],
+        description: 'Get the current authenticated user profile',
+        parameters: [],
+        responses: {
+          200: {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/user',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     '/users:create': {
       post: {
         tags: ['users'],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch. 
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The personal profile form used the generic user detail action, which unnecessarily depended on user collection detail permissions and accepted an arbitrary record identifier.

### Description 
Use a dedicated authenticated action to load only the current user's profile. Existing profile form schemas are upgraded by migration, hidden user fields remain filtered from the response, and the API documentation is updated.

The main risk is compatibility with customized profile forms. The dedicated action preserves requested fields and associations while always scoping the query to the authenticated user.

Test by signing in with a role that can edit its own profile but cannot view generic user details, then open and submit the personal profile form.

### Related issues

### Showcase
<!-- Including any screenshots of the changes. -->

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed personal profile loading for users without user detail permissions |
| 🇨🇳 Chinese | 修复无用户详情权限时个人资料无法加载的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English |  <!-- [Title](link) -->    |
| 🇨🇳 Chinese |  <!-- [标题](link) -->  |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [ ] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
