### PR TITLE
fix(plugin-workflow): add index for pending job recovery

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts
@@ -65,4 +65,5 @@ export default {
       name: 'log',
     },
   ],
+  indexes: [{ fields: ['status', 'id'] }],
 };


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The JavaScript workflow worker periodically recovers pending jobs with a query that filters `jobs` by `status`, orders by `id`, and reads a limited batch. Without a matching index, the query can scan and sort a large number of job records and become slow as the workflow job table grows.

### Description

- Add a composite `(status, id)` index to the workflow `jobs` collection.
- Allow the JavaScript worker recovery query to filter pending jobs and scan them in ID order through the same index.
- Define the index in the collection schema so existing installations create it when running `yarn nocobase upgrade`; no standalone migration is required.

Potential risk is limited to the additional database storage and write overhead of maintaining one index on `jobs`. Test the upgrade against a database with an existing, populated `jobs` table, then use `EXPLAIN` or `EXPLAIN ANALYZE` to confirm that pending-job recovery uses the new index.

Validation performed:

- `yarn eslint --fix packages/plugins/@nocobase/plugin-workflow/src/common/collections/jobs.ts`
- `yarn test packages/plugins/@nocobase/plugin-workflow-javascript/src/server/__tests__/worker-queue.test.ts --run --reporter=verbose` (7 tests passed)

### Related issues

N/A

### Showcase

N/A (database index change only)

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimized pending workflow job recovery by adding a composite index on job status and ID. |
| 🇨🇳 Chinese | 为工作流任务状态和 ID 添加联合索引，优化待处理任务的恢复查询。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary