### PR TITLE
fix(plugin-workflow): adapt task details on mobile

### DIFF
--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowTasksPage.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/WorkflowTasksPage.tsx
@@ -54,6 +54,37 @@ interface PendingWorkflowTaskPopupRecord {
   taskTypeKey: string;
 }
 
+const WORKFLOW_TASKS_MOBILE_MEDIA_QUERY = '(max-width: 768px)';
+
+/**
+ * Keep the task detail experience usable when the task center is opened from the desktop route on a narrow viewport.
+ * The mobile layout context is not always available (for example when the page is embedded), so use the viewport too.
+ */
+function useWorkflowTasksViewportMobile() {
+  const getMatches = () =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(WORKFLOW_TASKS_MOBILE_MEDIA_QUERY).matches
+      : false;
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mediaQuery = window.matchMedia(WORKFLOW_TASKS_MOBILE_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+    setMatches(mediaQuery.matches);
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return matches;
+}
+
 let pendingWorkflowTaskPopupRecord: PendingWorkflowTaskPopupRecord | null = null;
 
 function getPendingWorkflowTaskPopupRecord(taskTypeKey?: string, popupId?: string) {
@@ -461,7 +492,8 @@ function WorkflowTasksPageContent(props: {
   const { counts, reload: reloadCounts } = countsState;
   const route = useWorkflowTasksRoute();
   const { isMobileLayout } = useMobileLayout();
-  const mobile = route.isMobileRoute || isMobileLayout;
+  const viewportMobile = useWorkflowTasksViewportMobile();
+  const mobile = route.isMobileRoute || isMobileLayout || viewportMobile;
   const navigate = useNavigate();
   const { message } = App.useApp();
   const t = useT();

--- a/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx
@@ -164,6 +164,17 @@ describe('WorkflowTasksPage', () => {
     holder.location = { pathname: '/admin/workflow/tasks/demo/pending', search: '', hash: '' };
     holder.isMobileLayout = false;
     holder.detailModalRecords = [];
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
   });
 
   it('loads the selected task type with v1-compatible action params', async () => {
@@ -492,6 +503,37 @@ describe('WorkflowTasksPage', () => {
     expect(document.body.querySelector('.ant-modal')).toBeInTheDocument();
     expect(document.body.querySelector('.ant-drawer')).not.toBeInTheDocument();
     expect(holder.navigate).toHaveBeenCalledWith('/admin/workflow/tasks/demo/pending/9');
+  });
+
+  it('uses the mobile detail page when the desktop route is viewed on a narrow viewport', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(max-width: 768px)',
+        media: query,
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    const { registry } = createTaskTypes();
+    const demoTasks = {
+      listMine: vi.fn().mockResolvedValue({
+        data: { data: [{ id: 9, title: 'Open me' }], meta: { count: 1 } },
+      }),
+    };
+    const userWorkflowTasks = {
+      listMine: vi.fn().mockResolvedValue({ data: [{ type: 'demo', stats: { pending: 1, all: 1 } }] }),
+    };
+    holder.ctx = makeCtx(registry, { demoTasks, userWorkflowTasks });
+
+    renderWithApp(<WorkflowTasksPage />);
+    fireEvent.click(await screen.findByText('Open me'));
+
+    expect(holder.navigate).toHaveBeenCalledWith('/admin/workflow/tasks/demo/pending/9');
+    expect(await screen.findByTestId('workflow-task-mobile-detail-page')).toBeInTheDocument();
+    expect(document.body.querySelector('.ant-modal')).not.toBeInTheDocument();
   });
 
   it('renders clicked task details as an inline mobile subpage instead of a modal', async () => {

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowTasks.tsx
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/WorkflowTasks.tsx
@@ -9,7 +9,7 @@
 import { CheckCircleOutlined } from '@ant-design/icons';
 import { PageHeader } from '@ant-design/pro-layout';
 import { observer } from '@nocobase/flow-engine';
-import { App, Badge, Button, Flex, Layout, Result, Segmented, Tabs, theme, Tooltip } from 'antd';
+import { App, Badge, Button, Flex, Grid, Layout, Result, Segmented, Tabs, theme, Tooltip } from 'antd';
 import { NavBar, Toast } from 'antd-mobile';
 import classnames from 'classnames';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
@@ -53,6 +53,7 @@ import {
   useWorkflowTaskFilterContext,
 } from '../shared/WorkflowTaskNavigation';
 import { lang, NAMESPACE } from './locale';
+import { shouldUseWorkflowTasksMobilePresentation } from './workflowTasksResponsive';
 
 export { useWorkflowTaskFilterContext } from '../shared/WorkflowTaskNavigation';
 
@@ -220,11 +221,25 @@ function useCurrentTaskType() {
   );
 }
 
+function useWorkflowTasksMobilePresentation() {
+  const { isMobileLayout } = useMobileLayout();
+  const mobilePage = Boolean(useMobilePage());
+  const screens = Grid.useBreakpoint();
+
+  return shouldUseWorkflowTasksMobilePresentation({
+    isMobileLayout,
+    md: screens.md,
+    mobilePage,
+    viewportWidth: typeof window === 'undefined' ? undefined : window.innerWidth,
+  });
+}
+
 function PopupContext(props: any) {
   const { taskType, status = TASK_STATUS.PENDING, popupId } = useParams();
   const { record } = usePopupRecordContext();
   const navigate = useNavigate();
   const mobilePage = useMobilePage();
+  const mobile = useWorkflowTasksMobilePresentation();
   const setVisible = useCallback(
     (visible: boolean) => {
       if (!visible) {
@@ -244,7 +259,13 @@ function PopupContext(props: any) {
   }
 
   return record ? (
-    <ActionContextProvider visible={Boolean(popupId)} setVisible={setVisible} openMode="modal" openSize="large">
+    <ActionContextProvider
+      visible={Boolean(popupId)}
+      setVisible={setVisible}
+      openMode={mobile ? 'drawer' : 'modal'}
+      openSize="large"
+      drawerProps={mobile ? { width: '100%' } : undefined}
+    >
       <CollectionRecordProvider record={record}>{props.children}</CollectionRecordProvider>
     </ActionContextProvider>
   ) : null;

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/__tests__/workflowTasksResponsive.test.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/__tests__/workflowTasksResponsive.test.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldUseWorkflowTasksMobilePresentation } from '../workflowTasksResponsive';
+
+describe('workflow tasks responsive presentation', () => {
+  it.each([
+    [{ mobilePage: true, isMobileLayout: false, md: true, viewportWidth: 1280 }, true],
+    [{ mobilePage: false, isMobileLayout: true, md: true, viewportWidth: 1280 }, true],
+    [{ mobilePage: false, isMobileLayout: false, md: false, viewportWidth: 1280 }, true],
+    [{ mobilePage: false, isMobileLayout: false, md: true, viewportWidth: 640 }, false],
+    [{ mobilePage: false, isMobileLayout: false, md: undefined, viewportWidth: 767 }, true],
+    [{ mobilePage: false, isMobileLayout: false, md: undefined, viewportWidth: 768 }, false],
+  ])('returns %s for %o', (input, expected) => {
+    expect(shouldUseWorkflowTasksMobilePresentation(input)).toBe(expected);
+  });
+});

--- a/packages/plugins/@nocobase/plugin-workflow/src/client/workflowTasksResponsive.ts
+++ b/packages/plugins/@nocobase/plugin-workflow/src/client/workflowTasksResponsive.ts
@@ -1,0 +1,23 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+const MOBILE_BREAKPOINT = 768;
+
+export function shouldUseWorkflowTasksMobilePresentation(options: {
+  isMobileLayout: boolean;
+  md?: boolean;
+  mobilePage: boolean;
+  viewportWidth?: number;
+}) {
+  const { isMobileLayout, md, mobilePage, viewportWidth } = options;
+  const isNarrowViewport =
+    md === false || (md === undefined && viewportWidth !== undefined && viewportWidth < MOBILE_BREAKPOINT);
+
+  return mobilePage || isMobileLayout || isNarrowViewport;
+}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

The workflow task center still opened task details with a standard dialog on narrow screens. The approval application and approval todo detail URLs were difficult to use on mobile because the dialog width and desktop-oriented content layout did not fit the viewport.

### Description

- Detect mobile task-center presentation from the mobile route, mobile layout context, Ant Design breakpoints, and narrow viewport width.
- Render legacy task-center details as a full-width Drawer on mobile while preserving the existing Modal on desktop.
- Keep v2 task-center detail presentation responsive for narrow embedded or desktop-route viewports.

The mobile container is scoped to the workflow task detail popup. Desktop behavior remains unchanged. The main additional risk is layout variation on viewports at or below the 768px breakpoint; the Drawer is constrained to the viewport width to avoid horizontal overflow.

Validation performed:

- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client/__tests__/workflowTasksResponsive.test.ts --run --reporter=verbose` (6 tests passed)
- `yarn test packages/plugins/@nocobase/plugin-workflow/src/client-v2/pages/__tests__/WorkflowTasksPage.test.tsx --run --reporter=dot` (41 tests passed)
- `yarn eslint --fix` on all touched files
- Local Playwright verification at 390px: both approval detail URLs rendered `modalCount: 0`, `drawerCount: 1`, Drawer width 390px, and no horizontal overflow.
- Local Playwright verification at 1024px: both URLs retained `modalCount: 1`, `drawerCount: 0`.

### Related issues

N/A

### Showcase

Mobile workflow task detail now opens as a full-width Drawer for approval applications and approval todos.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve workflow task detail handling on mobile by using a full-width Drawer and responsive task-center presentation. |
| 🇨🇳 Chinese | 优化工作流待办中心移动端详情处理：使用全宽抽屉并适配审批内容布局。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A |
| 🇨🇳 Chinese | N/A |

### Checklists

- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
