### PR TITLE
docs: fix typo seperately -> separately

### DIFF
--- a/packages/core/logger/src/system-logger.ts
+++ b/packages/core/logger/src/system-logger.ts
@@ -15,7 +15,7 @@ import { getFormat } from './format';
 import { createLogger, levels, Logger, LoggerOptions } from './logger';
 
 export interface SystemLoggerOptions extends LoggerOptions {
-  seperateError?: boolean; // print error seperately, default true
+  seperateError?: boolean; // print error separately, default true
 }
 
 export type logMethod = (


### PR DESCRIPTION
Corrects the misspelling `seperately` -> `separately` in `packages/core/logger/src/system-logger.ts`.

Documentation only, no behaviour change.