### PR TITLE
fix(field-attachment-url): allow private custom file collections

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/__tests__/AttachmentURLFieldInterface.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/__tests__/AttachmentURLFieldInterface.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { AttachmentURLFieldModel, PluginFieldAttachmentUrlClient } from '../index';
-import { AttachmentURLFieldInterface } from '../interfaces/attachment-url';
+import { AttachmentURLFieldInterface, isAttachmentURLFileCollection } from '../interfaces/attachment-url';
 
 describe('AttachmentURLFieldInterface', () => {
   it('registers the attachment URL interface and field model loader', async () => {
@@ -76,7 +76,9 @@ describe('AttachmentURLFieldInterface', () => {
         name: 'target',
         component: 'Select',
         required: true,
-        defaultValue: 'attachments',
+        componentProps: {
+          filter: isAttachmentURLFileCollection,
+        },
         schema: {
           enum: '{{fileCollections}}',
         },
@@ -87,5 +89,12 @@ describe('AttachmentURLFieldInterface', () => {
         hidden: true,
       }),
     ]);
+  });
+
+  it('only allows custom file collections as upload targets', () => {
+    expect(isAttachmentURLFileCollection({ name: 'attachments', template: 'file' })).toBe(false);
+    expect(isAttachmentURLFileCollection({ name: 'documents', template: 'file' })).toBe(true);
+    expect(isAttachmentURLFileCollection({ name: 'images', options: { template: 'file' } })).toBe(true);
+    expect(isAttachmentURLFileCollection({ name: 'users', template: 'general' })).toBe(false);
   });
 });

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/interfaces/attachment-url.tsx
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/interfaces/attachment-url.tsx
@@ -9,6 +9,18 @@
 
 import { CollectionFieldInterface } from '@nocobase/client-v2';
 
+type CollectionOption = {
+  name?: string;
+  template?: string;
+  options?: {
+    template?: string;
+  };
+};
+
+export function isAttachmentURLFileCollection(collection?: CollectionOption) {
+  return collection?.name !== 'attachments' && (collection?.template || collection?.options?.template) === 'file';
+}
+
 export class AttachmentURLFieldInterface extends CollectionFieldInterface {
   name = 'attachmentURL';
   type = 'object';
@@ -32,7 +44,9 @@ export class AttachmentURLFieldInterface extends CollectionFieldInterface {
         title: '{{t("Which file collection should it be uploaded to")}}',
         component: 'Select',
         required: true,
-        defaultValue: 'attachments',
+        componentProps: {
+          filter: isAttachmentURLFileCollection,
+        },
         schema: {
           enum: '{{fileCollections}}',
         },

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/__tests__/plugin.test.ts
@@ -41,23 +41,16 @@ describe('attachment URL file collection options', () => {
     await app?.destroy();
   });
 
-  it('includes file collections whose storage does not allow public access', async () => {
+  it('includes private custom file collections and excludes the built-in attachments collection', async () => {
     const response = await app.agent().resource('collections').listFileCollectionsWithPublicStorage({
       paginate: false,
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.data).toEqual(
-      expect.arrayContaining([
-        {
-          title: '{{t("Attachments")}}',
-          name: 'attachments',
-        },
-        {
-          title: 'Private files',
-          name: 'privateFiles',
-        },
-      ]),
-    );
+    expect(response.body.data).toContainEqual({
+      title: 'Private files',
+      name: 'privateFiles',
+    });
+    expect(response.body.data).not.toContainEqual(expect.objectContaining({ name: 'attachments' }));
   });
 });

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/__tests__/plugin.test.ts
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/__tests__/plugin.test.ts
@@ -1,0 +1,63 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { createMockServer, MockServer } from '@nocobase/test';
+
+describe('attachment URL file collection options', () => {
+  let app: MockServer;
+
+  beforeEach(async () => {
+    app = await createMockServer({
+      plugins: [
+        'error-handler',
+        'field-sort',
+        'users',
+        'auth',
+        'data-source-main',
+        'file-manager',
+        'field-attachment-url',
+      ],
+    });
+
+    await app.db.getCollection('collections').repository.create({
+      values: {
+        name: 'privateFiles',
+        title: 'Private files',
+        template: 'file',
+        options: {
+          template: 'file',
+        },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app?.destroy();
+  });
+
+  it('includes file collections whose storage does not allow public access', async () => {
+    const response = await app.agent().resource('collections').listFileCollectionsWithPublicStorage({
+      paginate: false,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data).toEqual(
+      expect.arrayContaining([
+        {
+          title: '{{t("Attachments")}}',
+          name: 'attachments',
+        },
+        {
+          title: 'Private files',
+          name: 'privateFiles',
+        },
+      ]),
+    );
+  });
+});

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/plugin.ts
@@ -23,14 +23,12 @@ export class PluginFieldAttachmentUrlServer extends Plugin {
           },
         });
 
-        const options = [
-          {
-            title: '{{t("Attachments")}}',
-            name: 'attachments',
-          },
-        ];
+        const options = [];
 
         for (const fileCollection of fileCollections) {
+          if (fileCollection.name === 'attachments') {
+            continue;
+          }
           options.push({
             name: fileCollection.name,
             title: fileCollection.title,

--- a/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-field-attachment-url/src/server/plugin.ts
@@ -8,7 +8,6 @@
  */
 
 import { Plugin } from '@nocobase/server';
-import PluginFileManagerServer from '@nocobase/plugin-file-manager';
 
 export class PluginFieldAttachmentUrlServer extends Plugin {
   async afterAdd() {}
@@ -24,26 +23,18 @@ export class PluginFieldAttachmentUrlServer extends Plugin {
           },
         });
 
-        const filePlugin = this.pm.get('file-manager') as PluginFileManagerServer | any;
-
-        const options = [];
-
-        const fileCollection = this.db.getCollection('attachments');
-
-        if (await filePlugin.isPublicAccessStorage(fileCollection?.options?.storage)) {
-          options.push({
+        const options = [
+          {
             title: '{{t("Attachments")}}',
             name: 'attachments',
-          });
-        }
+          },
+        ];
 
         for (const fileCollection of fileCollections) {
-          if (await filePlugin.isPublicAccessStorage(fileCollection?.options?.storage)) {
-            options.push({
-              name: fileCollection.name,
-              title: fileCollection.title,
-            });
-          }
+          options.push({
+            name: fileCollection.name,
+            title: fileCollection.title,
+          });
         }
 
         ctx.body = options;


### PR DESCRIPTION
## Summary

- allow the Attachment (URL) field to target custom file collections whose storage is private
- exclude the built-in `attachments` collection from Attachment (URL) upload targets
- restrict the `/v` field configuration dropdown to custom collections using the `file` template
- keep the existing server action name for client compatibility
- add server and client-v2 regression coverage

## Test plan

- `yarn test packages/plugins/@nocobase/plugin-field-attachment-url/src/server/__tests__/plugin.test.ts --run --reporter=verbose`
- `yarn test packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/__tests__/AttachmentURLFieldInterface.test.ts --run --reporter=verbose`
- `yarn eslint --fix packages/plugins/@nocobase/plugin-field-attachment-url/src/server/plugin.ts packages/plugins/@nocobase/plugin-field-attachment-url/src/server/__tests__/plugin.test.ts packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/interfaces/attachment-url.tsx packages/plugins/@nocobase/plugin-field-attachment-url/src/client-v2/__tests__/AttachmentURLFieldInterface.test.ts`
- `git diff --check`