### PR TITLE
fix(database): escape SQL Server LIKE wildcards

### DIFF
--- a/packages/core/database/src/operators/__tests__/string.test.ts
+++ b/packages/core/database/src/operators/__tests__/string.test.ts
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { Op } from 'sequelize';
+import stringOperators from '../string';
+
+describe('SQL Server string operator', () => {
+  const ctx = {
+    db: {
+      sequelize: {
+        getDialect: () => 'mssql',
+      },
+    },
+  };
+
+  it('should escape LIKE wildcard characters', () => {
+    const condition = stringOperators.$includes('[2026]%_010', ctx);
+
+    expect(condition[Op.like]).toBe('%[[]2026][%][_]010%');
+  });
+});

--- a/packages/core/database/src/operators/__tests__/string.test.ts
+++ b/packages/core/database/src/operators/__tests__/string.test.ts
@@ -24,4 +24,12 @@ describe('SQL Server string operator', () => {
 
     expect(condition[Op.like]).toBe('%[[]2026][%][_]010%');
   });
+
+  it('should escape LIKE wildcard characters in array values', () => {
+    const includesCondition = stringOperators.$includes(['[2026]010', '30%_'], ctx);
+    const notIncludesCondition = stringOperators.$notIncludes(['[2026]010', '30%_'], ctx);
+
+    expect(includesCondition[Op.or]).toEqual([{ [Op.like]: '%[[]2026]010%' }, { [Op.like]: '%30[%][_]%' }]);
+    expect(notIncludesCondition[Op.and]).toEqual([{ [Op.notLike]: '%[[]2026]010%' }, { [Op.notLike]: '%30[%][_]%' }]);
+  });
 });

--- a/packages/core/database/src/operators/string.ts
+++ b/packages/core/database/src/operators/string.ts
@@ -10,7 +10,20 @@
 import { Op, cast, where, col, Sequelize } from 'sequelize';
 import { isPg } from './utils';
 
-function escapeLike(value: string) {
+type LikeOperatorContext = {
+  db: {
+    sequelize: {
+      getDialect(): string;
+    };
+  };
+};
+
+function escapeLike(value: string, ctx: LikeOperatorContext) {
+  if (ctx.db.sequelize.getDialect() === 'mssql') {
+    const escapedValue = value.replaceAll('[', '[[]');
+    return escapedValue.replace(/[%_]/g, (character) => `[${character}]`);
+  }
+
   return value.replace(/[_%]/g, '\\$&');
 }
 
@@ -85,7 +98,7 @@ export default {
     }
     if (Array.isArray(value)) {
       const conditions = value.map((item) =>
-        getFieldExpression(`%${escapeLike(item)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE'),
+        getFieldExpression(`%${escapeLike(item, ctx)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE'),
       );
 
       return {
@@ -93,7 +106,7 @@ export default {
       };
     }
 
-    return getFieldExpression(`%${escapeLike(value)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE');
+    return getFieldExpression(`%${escapeLike(value, ctx)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE');
   },
 
   $notIncludes(value, ctx) {
@@ -104,7 +117,7 @@ export default {
     }
     if (Array.isArray(value)) {
       const conditions = value.map((item) =>
-        getFieldExpression(`%${escapeLike(item)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE'),
+        getFieldExpression(`%${escapeLike(item, ctx)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE'),
       );
 
       return {
@@ -112,13 +125,13 @@ export default {
       };
     }
 
-    return getFieldExpression(`%${escapeLike(value)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE');
+    return getFieldExpression(`%${escapeLike(value, ctx)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE');
   },
 
   $startsWith(value, ctx) {
     if (Array.isArray(value)) {
       const conditions = value.map((item) =>
-        getFieldExpression(`${escapeLike(item)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE'),
+        getFieldExpression(`${escapeLike(item, ctx)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE'),
       );
 
       return {
@@ -126,13 +139,13 @@ export default {
       };
     }
 
-    return getFieldExpression(`${escapeLike(value)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE');
+    return getFieldExpression(`${escapeLike(value, ctx)}%`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE');
   },
 
   $notStartsWith(value, ctx) {
     if (Array.isArray(value)) {
       const conditions = value.map((item) =>
-        getFieldExpression(`${escapeLike(item)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE'),
+        getFieldExpression(`${escapeLike(item, ctx)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE'),
       );
 
       return {
@@ -140,13 +153,13 @@ export default {
       };
     }
 
-    return getFieldExpression(`${escapeLike(value)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE');
+    return getFieldExpression(`${escapeLike(value, ctx)}%`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE');
   },
 
   $endWith(value, ctx) {
     if (Array.isArray(value)) {
       const conditions = value.map((item) =>
-        getFieldExpression(`%${escapeLike(item)}`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE'),
+        getFieldExpression(`%${escapeLike(item, ctx)}`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE'),
       );
 
       return {
@@ -154,13 +167,13 @@ export default {
       };
     }
 
-    return getFieldExpression(`%${escapeLike(value)}`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE');
+    return getFieldExpression(`%${escapeLike(value, ctx)}`, ctx, isPg(ctx) ? 'ILIKE' : 'LIKE');
   },
 
   $notEndWith(value, ctx) {
     if (Array.isArray(value)) {
       const conditions = value.map((item) =>
-        getFieldExpression(`%${escapeLike(item)}`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE'),
+        getFieldExpression(`%${escapeLike(item, ctx)}`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE'),
       );
 
       return {
@@ -168,6 +181,6 @@ export default {
       };
     }
 
-    return getFieldExpression(`%${escapeLike(value)}`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE');
+    return getFieldExpression(`%${escapeLike(value, ctx)}`, ctx, isPg(ctx) ? 'NOT ILIKE' : 'NOT LIKE');
   },
 } as Record<string, any>;


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
SQL Server treats square brackets as `LIKE` wildcard syntax. String filters containing literal bracketed text, such as `[2026]010`, therefore failed to match records containing the same literal value.

### Description 
- Escape SQL Server `LIKE` wildcard characters with bracket-delimited literals.
- Keep the existing escaping behavior unchanged for other database dialects.
- Add a focused regression test for bracket, percent, and underscore characters.

Testing:
- `vitest packages/core/database/src/operators/__tests__/string.test.ts --run --poolOptions.threads.singleThread=true`
- ESLint on the changed source and test files

### Related issues
NocoBase support ticket 384039318781952

### Showcase
Not applicable.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed SQL Server string filters failing to match literal square brackets and other `LIKE` wildcard characters |
| 🇨🇳 Chinese | 修复 SQL Server 字符串筛选无法匹配字面方括号及其他 `LIKE` 通配符的问题 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [x] Request a code review if it is necessary
