### PR TITLE
fix(plugin-workflow): ensure global request-interception workflows are triggered after restart

### DIFF
--- a/packages/core/data-source-manager/src/data-source-manager.ts
+++ b/packages/core/data-source-manager/src/data-source-manager.ts
@@ -87,6 +87,11 @@ export class DataSourceManager {
 
   use(fn: any, options?: ToposortOptions) {
     this.middlewares.push([fn, options]);
+    for (const ds of this.dataSources.values()) {
+      if ((ds as any)._used && ds.resourceManager) {
+        ds.resourceManager.use(fn, options);
+      }
+    }
   }
 
   middleware() {

--- a/packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/Plugin.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/Plugin.ts
@@ -17,6 +17,16 @@ export class PluginWorkflowRequestInterceptorServer extends Plugin {
     const workflowPlugin = this.app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
     workflowPlugin.registerTrigger('request-interception', RequestInterceptionTrigger);
   }
+
+  async afterStart() {
+    const workflowPlugin = this.app.pm.get(PluginWorkflowServer) as PluginWorkflowServer;
+    const workflows = await this.db.getRepository('workflows').find({
+      filter: { type: 'request-interception', enabled: true, current: true },
+    });
+    for (const workflow of workflows) {
+      workflowPlugin.toggle(workflow, true, { silent: true });
+    }
+  }
 }
 
 export default PluginWorkflowRequestInterceptorServer;

--- a/packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/RequestInterceptionTrigger.ts
+++ b/packages/plugins/@nocobase/plugin-workflow-request-interceptor/src/server/RequestInterceptionTrigger.ts
@@ -274,6 +274,7 @@ export default class RequestInterceptionTrigger extends Trigger {
     if (loadNeeded) {
       target = await repository.findOne({
         filterByTk,
+        transaction: (options as any)?.httpContext?.state?.transaction ?? (options as any)?.transaction,
       });
     }
     const params = values.action === INTERCEPTABLE_ACTIONS.DESTROY ? { filterByTk } : { values: target };


### PR DESCRIPTION
Fixes #10435

Global sync `request-interception` workflows never intercepted the request after a restart — the DELETE reached Postgres and exposed the raw FK error (`violates foreign key`).

Two timing bugs:

1. **enabledCache empty after restart** — `PluginWorkflowServer.onAfterStart` hydrates `enabledCache` before `plugin-workflow-request-interceptor` registers the trigger via `load()`, so workflows with `type=request-interception` never enter the cache. `PluginWorkflowRequestInterceptorServer.afterStart()` now re-hydrates enabled `request-interception` workflows with `toggle(..., silent:true)`.

2. **Middleware not bound when datasource already _used** — `RequestInterceptionTrigger` does `dataSourceManager.use(middleware)` after `main` is already `_used=true`, so `DataSource.middleware()` never flushes it to `resourceManager`. `DataSourceManager.use()` now also binds the middleware to already-`_used` datasources.

3. Forward the request `transaction` in `RequestInterceptionTrigger.execute()` (`httpContext.state.transaction`) to keep the read inside the request transaction.

Verified: `clientes:destroy` with movimientos → `400` with `response-message`; without movimientos → success. Previously returned `500 violates foreign key`.