### PR TITLE
fix(plugin-field-markdown-vditor): restore v2 table actions

### DIFF
--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx
@@ -31,6 +31,7 @@ type MockVditorInstance = {
 type MockVditorOptions = {
   value: string;
   after: () => void;
+  customWysiwygToolbar: (type: string, element: HTMLElement) => void;
   input: (value: string) => void;
   upload: {
     handler: (files: File[]) => Promise<unknown>;
@@ -184,6 +185,7 @@ describe('Edit', () => {
       cdn: 'https://cdn.example/vditor',
       minHeight: 200,
       mode: 'wysiwyg',
+      customWysiwygToolbar: expect.any(Function),
       after: expect.any(Function),
       input: expect.any(Function),
       upload: {
@@ -192,6 +194,8 @@ describe('Edit', () => {
         handler: expect.any(Function),
       },
     });
+
+    expect(() => instance.options.customWysiwygToolbar('table', document.createElement('div'))).not.toThrow();
 
     act(() => {
       instance.options.after();

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/Edit.test.tsx
@@ -183,7 +183,7 @@ describe('Edit', () => {
       },
       cdn: 'https://cdn.example/vditor',
       minHeight: 200,
-      mode: 'ir',
+      mode: 'wysiwyg',
       after: expect.any(Function),
       input: expect.any(Function),
       upload: {

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/VditorFieldModels.test.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/__tests__/VditorFieldModels.test.tsx
@@ -100,7 +100,7 @@ describe('VditorFieldModel', () => {
       .map(([config]) => config)
       .find((config) => config.key === 'markdownVditorEditSettings');
     const setProps = vi.fn();
-    expect(flow.steps.editMode.defaultParams({ model: { props: {} } })).toEqual({ editMode: 'ir' });
+    expect(flow.steps.editMode.defaultParams({ model: { props: {} } })).toEqual({ editMode: 'wysiwyg' });
     expect(flow.steps.editMode.defaultParams({ model: { props: { mode: 'wysiwyg' } } })).toEqual({
       editMode: 'wysiwyg',
     });

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Edit.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Edit.tsx
@@ -19,7 +19,7 @@ import useStyle from './style';
 const locales = ['en_US', 'fr_FR', 'pt_BR', 'ja_JP', 'ko_KR', 'ru_RU', 'sv_SE', 'zh_CN', 'zh_TW'];
 
 export const Edit = (props) => {
-  const { disabled, onChange, value, fileCollection, toolbar, editMode = 'ir', mode } = props;
+  const { disabled, onChange, value, fileCollection, toolbar, editMode = 'wysiwyg', mode } = props;
   const flowCtx = useFlowContext();
   const t = useT();
   const [editorReady, setEditorReady] = useState(false);

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Edit.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/components/Edit.tsx
@@ -69,6 +69,7 @@ export const Edit = (props) => {
       cdn,
       minHeight: 200,
       mode: editorMode,
+      customWysiwygToolbar() {},
       after: () => {
         vdRef.current = vditor;
         setEditorReady(true);

--- a/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/models/VditorFieldModel.tsx
+++ b/packages/plugins/@nocobase/plugin-field-markdown-vditor/src/client-v2/models/VditorFieldModel.tsx
@@ -46,7 +46,7 @@ VditorFieldModel.registerFlow({
       },
       defaultParams(ctx) {
         return {
-          editMode: ctx.model.props.editMode || ctx.model.props.mode || 'ir',
+          editMode: ctx.model.props.editMode || ctx.model.props.mode || 'wysiwyg',
         };
       },
       handler(ctx, params) {


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation

V2 Markdown Vditor fields did not expose table row, column, alignment, and size actions. Browser reproduction confirmed that Vditor generated the table popover controls, then threw `customWysiwygToolbar is not a function` before positioning and displaying the popover.

### Description

- Target base: `main`.
- Default unconfigured V2 Markdown Vditor fields to WYSIWYG mode, where Vditor provides table actions.
- Provide the optional `customWysiwygToolbar` callback expected unconditionally by Vditor 3.11.2, preventing the runtime exception.
- Keep the flow setting default consistent with the runtime default.
- Preserve explicitly configured `ir` and `sv` modes.
- Update focused unit-test coverage for the default mode and callback.

### Current behavior and boundaries

Only V2 Markdown Vditor fields without a saved edit mode change their default mode. Existing fields with an explicit mode keep that mode. The callback is a no-op and does not customize or replace Vditor's built-in toolbar controls. There are no database, migration, server API, permission, content-format, or dependency changes.

### Related issues

Task 6112

### Showcase

The PR deployment was reproduced in a signed-in browser before the callback fix: inserting a table generated all 12 table controls, but the popover remained hidden because the Vditor callback threw. After deployment of commit `4300d55f1c`, the table popover displayed all 12 controls and an insert-row action changed the table from 3 to 4 rows.

### Verification

- Browser reproduction on the PR deployment: confirmed the missing callback exception and hidden table popover before the fix.
- Post-deployment browser verification on build `2.2.5-rc.20260901060524`: the popover was visible with 12 controls, insert-row worked, and no new console errors occurred.
- Focused `Edit` tests: 8 passed.
- All V2 plugin client tests: 30 passed across 8 test files.
- `yarn eslint --fix` on all 4 branch-touched files: passed.
- `git diff --check` and `git diff --cached --check`: passed.
- Remote CI: all 7 PR checks passed for commit `4300d55f1c`.

### Risks and review focus

Risk is low. The callback fix adds one no-op initialization option and directly prevents the observed exception. The deliberate default-mode change affects only unconfigured V2 fields; explicitly configured modes remain compatible. Review whether any product surface intentionally relies on the old implicit `ir` fallback.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Restore table actions in V2 Markdown Vditor fields. |
| 🇨🇳 Chinese | 恢复 V2 Markdown Vditor 字段的表格操作。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | Not needed |
| 🇨🇳 Chinese | 不需要 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
