### PR TITLE
fix(plugin-file-manager): restore v2 file storage selection

### DIFF
--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/CollectionsPage.tsx
@@ -75,6 +75,7 @@ type CollectionCategoryRecord = {
 };
 
 type CollectionFormValues = {
+  [key: string]: unknown;
   title: string;
   name: string;
   template: string;
@@ -536,7 +537,7 @@ const CollectionTemplatePreview: FC<{ template?: CollectionTemplateOptions }> = 
   );
 };
 
-function buildCollectionCreateValues(options: {
+export function buildCollectionCreateValues(options: {
   template: CollectionTemplateOptions;
   formValues: CollectionFormValues;
   selectedPresetFields: React.Key[];
@@ -1014,6 +1015,7 @@ function CollectionEditDrawer(props: {
           : undefined,
       category: Array.isArray(collection.category) ? collection.category.map((item) => String(item.id)) : [],
       description: collection.description,
+      storage: collection.storage,
       simplePaginate: collection.simplePaginate,
       filterTargetKey: getCollectionRecordUniqueKey(collection, collection.fields),
       databaseView: getDatabaseViewFormValue(collection),

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPage.test.ts
@@ -9,7 +9,7 @@
 
 import { compileLegacyTemplate } from '../../../utils/compileLegacyTemplate';
 import { getInheritedFieldGroups, isFieldDeleteDisabled, isInheritedFieldOverridden } from '../FieldsPage';
-import { getPresetFieldRows } from '../CollectionsPage';
+import { buildCollectionCreateValues, getPresetFieldRows } from '../CollectionsPage';
 import {
   collectionNeedsRecordUniqueKey,
   getCollectionRecordUniqueKey,
@@ -51,6 +51,38 @@ describe('getPresetFieldRows', () => {
     };
 
     expect(compileLegacyTemplate(rows[0].field, t)).toBe('空间');
+  });
+});
+
+describe('buildCollectionCreateValues', () => {
+  it('preserves file storage selected by a template configure item', () => {
+    const values = buildCollectionCreateValues({
+      template: {
+        name: 'file',
+        title: 'File collection',
+        collection: {
+          options: {
+            template: 'file',
+          },
+          fields: [],
+        },
+      },
+      formValues: {
+        title: 'Documents',
+        name: 'documents',
+        template: 'file',
+        storage: 'archive',
+      },
+      selectedPresetFields: [],
+      presetFields: [],
+    });
+
+    expect(values).toMatchObject({
+      name: 'documents',
+      storage: 'archive',
+      template: 'file',
+      title: 'Documents',
+    });
   });
 });
 

--- a/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPageComponent.test.tsx
+++ b/packages/plugins/@nocobase/plugin-data-source-manager/src/client-v2/pages/components/__tests__/CollectionsPageComponent.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { App } from 'antd';
+import { App, Form, Input } from 'antd';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -44,6 +44,7 @@ const apiRequest = vi.fn((options: { url: string }) => {
             title: '{{t("Orders")}}',
             template: 'general',
             description: 'Order records',
+            storage: 'archive',
             category: [{ id: 1, name: 'Business', color: 'blue' }],
             fields: [{ name: 'id', primaryKey: true }],
           },
@@ -119,6 +120,18 @@ const plugin = {
     title: '{{t("General collection")}}',
     collection: {
       fields: [],
+    },
+    configure: {
+      items: [
+        {
+          name: 'storage',
+          Component: ({ item }: { item: { name: string } }) => (
+            <Form.Item name={item.name} label="Storage">
+              <Input />
+            </Form.Item>
+          ),
+        },
+      ],
     },
   })),
   getCollectionTemplates: vi.fn(() => [
@@ -415,6 +428,7 @@ describe('CollectionsPage', () => {
         values: expect.objectContaining({
           title: '{{t("Orders")}}',
           category: ['1'],
+          storage: 'archive',
         }),
       }),
     );

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/FileCollectionConfigure.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/FileCollectionConfigure.tsx
@@ -1,0 +1,84 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { useFlowContext } from '@nocobase/flow-engine';
+import type { CollectionTemplateConfigureItemProps } from '@nocobase/plugin-data-source-manager/client-v2';
+import { useRequest } from 'ahooks';
+import { Form, Select } from 'antd';
+import React, { useMemo } from 'react';
+import { useT } from './locale';
+
+type StorageRecord = {
+  name: string;
+  title?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normalizeStorageRecords(response: unknown): StorageRecord[] {
+  const body = isRecord(response) ? response.data : undefined;
+  const payload = isRecord(body) ? body.data : undefined;
+  const records = Array.isArray(payload)
+    ? payload
+    : isRecord(payload) && Array.isArray(payload.data)
+      ? payload.data
+      : [];
+
+  return records
+    .filter(
+      (record): record is Record<string, unknown> & { name: string } =>
+        isRecord(record) && typeof record.name === 'string',
+    )
+    .map((record) => ({
+      name: record.name,
+      title: typeof record.title === 'string' ? record.title : undefined,
+    }))
+    .filter((record) => !!record.name);
+}
+
+export function FileCollectionStorageConfigureItem({ item }: CollectionTemplateConfigureItemProps) {
+  const t = useT();
+  const ctx = useFlowContext();
+  const storageRequest = useRequest(async () => {
+    const response = await ctx.api.resource('storages').list({
+      paginate: false,
+      sort: ['id'],
+      appends: [],
+    });
+    return normalizeStorageRecords(response);
+  });
+  const options = useMemo(
+    () =>
+      (storageRequest.data || []).map((storage) => ({
+        label: storage.title || storage.name,
+        value: storage.name,
+      })),
+    [storageRequest.data],
+  );
+
+  return (
+    <Form.Item
+      name={item.name || 'storage'}
+      label={t('File storage')}
+      extra={t('Default storage will be used when not selected')}
+      getValueFromEvent={(value: string | undefined) => value ?? null}
+    >
+      <Select
+        aria-label={t('File storage')}
+        allowClear
+        showSearch
+        optionFilterProp="label"
+        loading={storageRequest.loading}
+        options={options}
+      />
+    </Form.Item>
+  );
+}

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/FileCollectionConfigure.test.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/FileCollectionConfigure.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
+import type { FormInstance } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+
+const listStorages = vi.fn().mockResolvedValue({
+  data: {
+    data: {
+      data: [
+        { name: 'local', title: 'Local files' },
+        { name: 'archive', title: 'Archive files' },
+      ],
+    },
+  },
+});
+
+vi.mock('@nocobase/flow-engine', () => ({
+  useFlowContext: () => ({
+    api: {
+      resource: () => ({
+        list: listStorages,
+      }),
+    },
+  }),
+}));
+
+vi.mock('../locale', () => ({
+  useT: () => (value: string) => value,
+}));
+
+import { FileCollectionStorageConfigureItem, normalizeStorageRecords } from '../FileCollectionConfigure';
+
+describe('FileCollectionStorageConfigureItem', () => {
+  it('normalizes flat and paginated storage list responses', () => {
+    expect(normalizeStorageRecords({ data: { data: [{ name: 'local', title: 'Local files' }] } })).toEqual([
+      { name: 'local', title: 'Local files' },
+    ]);
+    expect(
+      normalizeStorageRecords({ data: { data: { data: [{ name: 'archive', title: 'Archive files' }] } } }),
+    ).toEqual([{ name: 'archive', title: 'Archive files' }]);
+    expect(normalizeStorageRecords({ data: { data: [{ name: '' }, null, { title: 'Missing name' }] } })).toEqual([]);
+  });
+
+  it('loads storage options and preserves the selected storage name', async () => {
+    let formInstance: FormInstance | undefined;
+
+    function FormHarness() {
+      const [form] = Form.useForm();
+      formInstance = form;
+
+      return (
+        <Form form={form} initialValues={{ storage: 'archive' }}>
+          <FileCollectionStorageConfigureItem
+            mode="edit"
+            template={{ name: 'file', title: 'File collection' }}
+            form={form}
+            item={{ name: 'storage' }}
+          />
+        </Form>
+      );
+    }
+
+    render(<FormHarness />);
+
+    expect(screen.getByText('Default storage will be used when not selected')).toBeInTheDocument();
+    await waitFor(() => expect(listStorages).toHaveBeenCalledWith({ paginate: false, sort: ['id'], appends: [] }));
+    expect(formInstance?.getFieldValue('storage')).toBe('archive');
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'File storage' }));
+    expect(await screen.findByText('Local files')).toBeInTheDocument();
+    expect(screen.getAllByText('Archive files').length).toBeGreaterThan(0);
+
+    const clearButton = document.querySelector<HTMLElement>('.ant-select-clear');
+    expect(clearButton).not.toBeNull();
+    if (!clearButton) {
+      throw new Error('Storage clear action is missing');
+    }
+    fireEvent.mouseDown(clearButton);
+    fireEvent.click(clearButton);
+    await waitFor(() => expect(formInstance?.getFieldValue('storage')).toBeNull());
+  });
+});

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/PluginFileManagerClientV2.test.ts
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/__tests__/PluginFileManagerClientV2.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { FileCollectionStorageConfigureItem } from '../FileCollectionConfigure';
 import { PluginFileManagerClientV2 } from '../plugin';
 
 vi.mock('@nocobase/client-v2', () => ({
@@ -90,6 +91,14 @@ describe('PluginFileManagerClientV2', () => {
         collection: expect.objectContaining({
           options: expect.objectContaining({ template: 'file' }),
         }),
+        configure: {
+          items: [
+            {
+              name: 'storage',
+              Component: FileCollectionStorageConfigureItem,
+            },
+          ],
+        },
       }),
     );
     expect(addMenuItem).toHaveBeenCalledWith(

--- a/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
+++ b/packages/plugins/@nocobase/plugin-file-manager/src/client-v2/plugin.tsx
@@ -18,6 +18,7 @@ import {
   STORAGE_TYPE_TX_COS,
 } from '../constants';
 import { NAMESPACE } from '../common/constants';
+import { FileCollectionStorageConfigureItem } from './FileCollectionConfigure';
 import { AttachmentFieldInterface } from './interfaces/attachment';
 import { tExpr } from './locale';
 
@@ -237,6 +238,14 @@ export class PluginFileManagerClientV2 extends Plugin<Record<string, never>, App
       },
       presetFields: {
         disabled: true,
+      },
+      configure: {
+        items: [
+          {
+            name: 'storage',
+            Component: FileCollectionStorageConfigureItem,
+          },
+        ],
       },
     });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution!
For bug fixes or other non-feature modifications, please base your branch on the main branch.
For new features or API modifications, please make sure your branch is based on the next branch.
Thank you!
-->

### This is a ...
- [ ] New feature
- [ ] Improvement
- [x] Bug fix
- [ ] Others

### Motivation
The v2 data source manager did not expose the file storage setting when creating or editing a file collection. Users therefore could not choose a non-default storage from the form.

### Description
- Register a file-template configure item in the v2 file manager client.
- Load available storages and render a searchable, clearable selector using storage titles while persisting storage names.
- Preserve template-specific values when creating a collection and initialize the current storage when editing one.
- Clearing the selector submits `null`, preserving the existing server-side fallback to the default storage.
- Add focused coverage for loading, selecting, clearing, template registration, creation, and editing.

This branch is based on `main`. The risk is low because the change is limited to the v2 client and does not alter v1 behavior, storage APIs, server logic, schemas, migrations, or ACL rules. Review should focus on response normalization, persisting the storage `name`, and the `null` clear behavior.

Local verification:
- ESLint passed for all seven touched files.
- Four targeted test files passed: 23 tests in total.
- `git diff --check` and the staged diff audit passed.

Remote CI is still running and is not included in the local verification result above.

### Related issues
Task: 6190

### Showcase
N/A — no screenshot was captured for this fix.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the missing file storage selector in v2 file collection create and edit forms. |
| 🇨🇳 Chinese | 修复 v2 文件表新建和编辑表单中缺少文件存储器选择项的问题。 |

### Docs

| Language   | Link |
| ---------- | --------- |
| 🇺🇸 English | N/A — no documentation changes are required. |
| 🇨🇳 Chinese | 不适用——无需更新文档。 |

### Checklists
- [x] All changes have been self-tested and work as expected
- [x] Test cases are updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] If documentation was changed, the corresponding files in all other languages have been updated to keep them in sync (or this change does not affect docs)
- [x] Component demo is updated/provided or not needed
- [x] Changelog is provided or not needed
- [ ] Request a code review if it is necessary
